### PR TITLE
fix(sandbox): never run an adapter on a different harness's image; fail fast instead of runtime-installing

### DIFF
--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -9,12 +9,15 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DEFAULT_REMOTE_SANDBOX_ADAPTER_TIMEOUT_SEC,
+  AdapterRuntimeImageMismatchError,
   adapterExecutionTargetSessionIdentity,
   adapterExecutionTargetToRemoteSpec,
   adapterExecutionTargetUsesPaperclipBridge,
   ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
   formatAdapterExecutionTimeoutErrorMessage,
   formatAdapterExecutionTimeoutStartLogLine,
+  isAdapterRuntimeImageMismatchError,
   resolveAdapterExecutionTargetTimeout,
   resolveAdapterExecutionTargetTimeoutSec,
   runAdapterExecutionTargetProcess,
@@ -689,6 +692,98 @@ describe("sandbox adapter execution targets", () => {
       args: ["-c", "npm install -g opencode"],
       timeoutMs: 1_800_000,
     }));
+  });
+
+  describe("pre-baked (managed) sandbox runtime install", () => {
+    it("fails fast with a runtime-image-mismatch error and never attempts an install when the CLI is missing", async () => {
+      // The detect probe reports the CLI missing (exit 1). On a pre-baked
+      // managed image this means the run landed on the wrong runtime image, so
+      // we must fail immediately, NOT run the network install (blocked egress).
+      const runner = {
+        execute: vi.fn().mockResolvedValue({
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          stdout: "",
+          stderr: "",
+          pid: null,
+          startedAt: new Date().toISOString(),
+        }),
+      };
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        remoteCwd: "/workspace",
+        timeoutMs: 300_000,
+        prebakedRuntime: true,
+        runner,
+      };
+
+      let thrown: unknown;
+      try {
+        await ensureAdapterExecutionTargetRuntimeCommandInstalled({
+          runId: "run-prebaked",
+          target,
+          detectCommand: "gemini",
+          installCommand:
+            "if ! command -v 'gemini' >/dev/null 2>&1; then npm install -g @google/gemini-cli; fi",
+          cwd: "/local/workspace",
+          env: {},
+        });
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(AdapterRuntimeImageMismatchError);
+      expect(isAdapterRuntimeImageMismatchError(thrown)).toBe(true);
+      expect((thrown as AdapterRuntimeImageMismatchError).code).toBe(
+        "adapter_runtime_image_mismatch",
+      );
+      expect((thrown as AdapterRuntimeImageMismatchError).adapterCommand).toBe("gemini");
+      expect((thrown as Error).message).toContain("gemini");
+
+      // Exactly one runner call: the detect probe. The install was never run.
+      expect(runner.execute).toHaveBeenCalledTimes(1);
+      const probeArgs = runner.execute.mock.calls[0][0];
+      expect(String(probeArgs.args?.[1] ?? "")).toContain("command -v");
+      expect(String(probeArgs.args?.[1] ?? "")).not.toContain("npm install");
+    });
+
+    it("passes when the pre-baked image already carries the CLI, without installing", async () => {
+      const runner = {
+        execute: vi.fn().mockResolvedValue({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          stdout: "",
+          stderr: "",
+          pid: null,
+          startedAt: new Date().toISOString(),
+        }),
+      };
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        remoteCwd: "/workspace",
+        timeoutMs: 300_000,
+        prebakedRuntime: true,
+        runner,
+      };
+
+      await expect(
+        ensureAdapterExecutionTargetRuntimeCommandInstalled({
+          runId: "run-prebaked-ok",
+          target,
+          detectCommand: "gemini",
+          installCommand: "npm install -g @google/gemini-cli",
+          cwd: "/local/workspace",
+          env: {},
+        }),
+      ).resolves.toBeUndefined();
+
+      // Only the detect probe ran; no install attempt.
+      expect(runner.execute).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("runs shell commands through the same runner", async () => {

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -74,12 +74,55 @@ export interface AdapterSandboxExecutionTarget {
    * set to `false` to explicitly opt out back to batch-at-end delivery.
    */
   streamRunLogs?: boolean | null;
+  /**
+   * The sandbox runs a managed, pre-baked runtime image (plugin-backed
+   * provider) whose adapter CLI is contractually complete. When true, the
+   * runtime-install shim is disabled: a missing CLI means the run landed on the
+   * wrong runtime image (a different harness), so we fail fast with
+   * {@link AdapterRuntimeImageMismatchError} instead of attempting a network
+   * install that a locked/sovereign egress would block until timeout.
+   */
+  prebakedRuntime?: boolean | null;
 }
 
 export type AdapterExecutionTarget =
   | AdapterLocalExecutionTarget
   | AdapterSshExecutionTarget
   | AdapterSandboxExecutionTarget;
+
+/** Stable error code for a wrong-runtime-image sandbox run. */
+export const ADAPTER_RUNTIME_IMAGE_MISMATCH_CODE = "adapter_runtime_image_mismatch" as const;
+
+/**
+ * Thrown when a managed, pre-baked sandbox does not carry the adapter's runtime
+ * CLI on PATH. The run landed on a runtime image for a different harness, so the
+ * image the plugin picked does not match the harness the server exec's. We
+ * surface this immediately instead of attempting a doomed network install
+ * (locked egress) that would otherwise stall until the adapter timeout and
+ * report a confusing `adapter_failed`.
+ */
+export class AdapterRuntimeImageMismatchError extends Error {
+  readonly code = ADAPTER_RUNTIME_IMAGE_MISMATCH_CODE;
+  readonly adapterCommand: string;
+  constructor(command: string, targetDescription: string, detail?: string) {
+    super(
+      `expected the pre-baked runtime image to provide the '${command}' CLI, but it is not present on PATH in the ${targetDescription}. The run landed on the wrong runtime image (a different harness); refusing to attempt a network install for a managed sandbox.${
+        detail ? ` (${detail})` : ""
+      }`,
+    );
+    this.name = "AdapterRuntimeImageMismatchError";
+    this.adapterCommand = command;
+  }
+}
+
+export function isAdapterRuntimeImageMismatchError(
+  value: unknown,
+): value is AdapterRuntimeImageMismatchError {
+  return (
+    value instanceof Error &&
+    (value as { code?: unknown }).code === ADAPTER_RUNTIME_IMAGE_MISMATCH_CODE
+  );
+}
 
 export type AdapterRemoteExecutionSpec = SshRemoteExecutionSpec;
 
@@ -822,12 +865,49 @@ export async function ensureAdapterExecutionTargetRuntimeCommandInstalled(input:
   graceSec?: number;
   onLog?: AdapterExecutionTargetShellOptions["onLog"];
 }): Promise<void> {
+  const sandboxTarget =
+    input.target?.kind === "remote" && input.target.transport === "sandbox"
+      ? input.target
+      : null;
+  const isSandbox = sandboxTarget !== null;
+  const detectCommand = input.detectCommand?.trim();
+
+  // Managed, pre-baked sandbox: the runtime CLI is contractually part of the
+  // image. A network install is never appropriate (locked/sovereign egress
+  // blocks it and the run stalls until timeout). Probe once; if the CLI is
+  // missing the run landed on the wrong runtime image (a different harness) and
+  // we fail fast with a typed, actionable error instead of installing.
+  if (sandboxTarget && sandboxTarget.prebakedRuntime === true) {
+    if (!detectCommand) {
+      // Nothing to assert (no probe command); never attempt an install either.
+      return;
+    }
+    const probe = await runAdapterExecutionTargetShellCommand(
+      input.runId,
+      input.target,
+      `command -v ${shellQuote(detectCommand)} >/dev/null 2>&1`,
+      {
+        cwd: input.cwd,
+        env: input.env,
+        timeoutSec: input.timeoutSec,
+        graceSec: input.graceSec,
+      },
+    );
+    if (!probe.timedOut && probe.exitCode === 0) {
+      return;
+    }
+    throw new AdapterRuntimeImageMismatchError(
+      detectCommand,
+      describeAdapterExecutionTarget(input.target),
+      probe.timedOut ? "detect probe timed out" : `detect probe exited ${probe.exitCode ?? "?"}`,
+    );
+  }
+
   const installCommand = input.installCommand?.trim();
-  if (!installCommand || input.target?.kind !== "remote" || input.target.transport !== "sandbox") {
+  if (!installCommand || !isSandbox) {
     return;
   }
 
-  const detectCommand = input.detectCommand?.trim();
   if (detectCommand) {
     const probe = await runAdapterExecutionTargetShellCommand(
       input.runId,

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -31,6 +31,7 @@ export type {
   ConfigFieldSchema,
   AdapterConfigSchema,
   AdapterRuntimeCommandSpec,
+  AdapterRuntimeCommandSpecOptions,
   AcpTargetDescriptor,
   ServerAdapterModule,
   QuotaWindow,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -476,8 +476,26 @@ export interface ServerAdapterModule {
   /**
    * Optional: describe how this adapter's runtime command should be launched
    * and provisioned in fresh remote environments such as sandboxes.
+   *
+   * `options.prebakedRuntime` is set when the run executes on a managed,
+   * pre-baked sandbox image whose runtime CLI is contractually complete (e.g. a
+   * plugin-backed Kubernetes sandbox behind locked egress). Adapters MUST NOT
+   * emit a network `installCommand` for those targets: the image either already
+   * carries the CLI or the run landed on the wrong image, and an install would
+   * hit a blocked egress and stall until timeout.
    */
-  getRuntimeCommandSpec?: (config: Record<string, unknown>) => AdapterRuntimeCommandSpec | null;
+  getRuntimeCommandSpec?: (
+    config: Record<string, unknown>,
+    options?: AdapterRuntimeCommandSpecOptions,
+  ) => AdapterRuntimeCommandSpec | null;
+}
+
+export interface AdapterRuntimeCommandSpecOptions {
+  /**
+   * The run executes on a managed, pre-baked sandbox image (plugin-backed
+   * provider). When true, no network runtime install may be emitted.
+   */
+  prebakedRuntime?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
@@ -123,13 +123,15 @@ export interface ResolveRunAdapterTypeOptions {
   requireRunAdapter?: boolean;
   /**
    * The set of adapter types the environment is configured to serve (the
-   * enabled entries of the plugin's `adapters` registry). When this declares
-   * MORE THAN ONE distinct adapter the environment is a mixed-harness pool, and
-   * a lease with no per-run adapter is rejected automatically — falling back to
-   * the single env-default image would route e.g. a gemini run onto the
-   * opencode image. Absent, empty, or a single distinct entry means an
-   * effectively single-adapter environment, where the env-default fallback is
-   * safe (and connectivity probes that carry no per-run adapter keep working).
+   * enabled entries of the plugin's `adapters` registry). It is the ONLY
+   * positive proof of a single-adapter environment: the env-default fallback for
+   * an adapter-less lease is permitted ONLY when this declares EXACTLY ONE
+   * distinct enabled adapter. Absent or empty proves nothing (the built-in
+   * registry still exposes every harness, so an adapter-less run could land on a
+   * different harness's image) and more than one entry is an outright
+   * mixed-harness pool — both reject the adapter-less lease automatically.
+   * Adapter-less callers that must keep working (e.g. connectivity probes) pass
+   * an explicit adapter instead of relying on the fallback.
    */
   configuredAdapterTypes?: readonly string[];
 }
@@ -140,14 +142,16 @@ export interface ResolveRunAdapterTypeOptions {
  * the environment's configured default adapter when the run does not specify one.
  *
  * The image the plugin picks MUST match the harness the server exec's. Never
- * substitute a different harness for an absent per-run adapter:
- *   - A MIXED-harness pool (`configuredAdapterTypes` declares more than one
- *     distinct adapter) rejects the lease automatically — no operator flag
- *     needed — because the single env-default image could belong to a different
- *     harness than the agent will run.
+ * substitute a different harness for an absent per-run adapter. The env-default
+ * fallback for an adapter-less lease is permitted ONLY when the config positively
+ * proves a single-adapter environment (`configuredAdapterTypes` declares exactly
+ * one distinct enabled adapter). Otherwise the lease is rejected:
+ *   - An ABSENT or EMPTY `configuredAdapterTypes` proves nothing (the built-in
+ *     registry still exposes every harness), so it is treated as UNSAFE.
+ *   - A MIXED-harness pool (more than one distinct adapter) is unsafe outright.
  *   - `options.requireRunAdapter` forces the same rejection for any pool.
- * A single-adapter environment (or one with no declared registry) still falls
- * back to the env default, preserving single-adapter setups and probes.
+ * Adapter-less callers that must keep working (connectivity probes) pass an
+ * explicit adapter instead of relying on the fallback.
  */
 export function resolveRunAdapterType(
   runAdapterType: string | null | undefined,
@@ -158,16 +162,19 @@ export function resolveRunAdapterType(
   if (trimmed.length > 0) {
     return trimmed;
   }
-  // Per-run adapter absent. Determine whether the environment is a mixed-harness
-  // pool from its configured adapter set: more than one distinct enabled adapter
-  // means the single env-default fallback could pick a DIFFERENT harness's image.
+  // Per-run adapter absent. Falling back to the env default is safe ONLY when the
+  // config can POSITIVELY prove a single-adapter environment. Prove it from the
+  // authoritative adapter set: exactly one distinct enabled adapter. An absent or
+  // empty set proves nothing (the built-in registry still exposes every harness,
+  // so an adapter-less run could land on a different harness's image), and more
+  // than one entry is an outright mixed-harness pool — both are unsafe.
   const distinctConfiguredAdapters = new Set(
     (options.configuredAdapterTypes ?? [])
       .map((type) => (typeof type === "string" ? type.trim() : ""))
       .filter((type) => type.length > 0),
   );
-  const isMixedHarnessPool = distinctConfiguredAdapters.size > 1;
-  if (options.requireRunAdapter || isMixedHarnessPool) {
+  const provesSingleAdapterEnv = distinctConfiguredAdapters.size === 1;
+  if (options.requireRunAdapter || !provesSingleAdapterEnv) {
     throw new RunAdapterRequiredError(configAdapterType);
   }
   return configAdapterType;

--- a/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
@@ -92,17 +92,61 @@ export function getAdapterDefaults(
   return defaults;
 }
 
+/** Stable error code for a rejected lease that lacked a required per-run adapter. */
+export const RUN_ADAPTER_REQUIRED_CODE = "run_adapter_required" as const;
+
+/**
+ * Thrown when strict per-run adapter resolution is enabled but the lease did not
+ * carry a per-run adapter type. Falling back to the environment's configured
+ * default adapter would be unsafe: the default is a global env value that may be
+ * a DIFFERENT harness than the agent will run, so the sandbox image would not
+ * match the CLI the server exec's (a gemini agent landing on the opencode image).
+ */
+export class RunAdapterRequiredError extends Error {
+  readonly code = RUN_ADAPTER_REQUIRED_CODE;
+  constructor(configAdapterType: string) {
+    super(
+      `per-run adapter type is required for per-run sandbox execution but was not supplied; refusing to fall back to the environment default adapter "${configAdapterType}", which may be a different harness than the agent will run (the sandbox runtime image would not match the executed CLI)`,
+    );
+    this.name = "RunAdapterRequiredError";
+  }
+}
+
+export interface ResolveRunAdapterTypeOptions {
+  /**
+   * Require an explicit per-run adapter. When true and the run does not supply
+   * one, throw {@link RunAdapterRequiredError} instead of silently falling back
+   * to the environment default — the correct posture for a mixed-harness
+   * managed pool where the default is unlikely to match the agent's harness.
+   * Defaults to false to preserve single-adapter environments and connectivity
+   * probes that legitimately carry no per-run adapter.
+   */
+  requireRunAdapter?: boolean;
+}
+
 /**
  * Resolve the adapter type for a single run: prefer the run's adapter (the agent's,
  * from the lease params) so one environment can serve mixed harnesses; fall back to
  * the environment's configured default adapter when the run does not specify one.
+ *
+ * The image the plugin picks MUST match the harness the server exec's. Never
+ * substitute a different harness: when `options.requireRunAdapter` is set, a run
+ * without a per-run adapter is rejected rather than silently mapped to the
+ * environment default (which may be a different harness's runtime image).
  */
 export function resolveRunAdapterType(
   runAdapterType: string | null | undefined,
   configAdapterType: string,
+  options: ResolveRunAdapterTypeOptions = {},
 ): string {
   const trimmed = typeof runAdapterType === "string" ? runAdapterType.trim() : "";
-  return trimmed.length > 0 ? trimmed : configAdapterType;
+  if (trimmed.length > 0) {
+    return trimmed;
+  }
+  if (options.requireRunAdapter) {
+    throw new RunAdapterRequiredError(configAdapterType);
+  }
+  return configAdapterType;
 }
 
 /**

--- a/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
@@ -126,10 +126,12 @@ export interface ResolveRunAdapterTypeOptions {
    * enabled entries of the plugin's `adapters` registry). It is the ONLY
    * positive proof of a single-adapter environment: the env-default fallback for
    * an adapter-less lease is permitted ONLY when this declares EXACTLY ONE
-   * distinct enabled adapter. Absent or empty proves nothing (the built-in
-   * registry still exposes every harness, so an adapter-less run could land on a
-   * different harness's image) and more than one entry is an outright
-   * mixed-harness pool — both reject the adapter-less lease automatically.
+   * distinct enabled adapter AND that adapter equals `configAdapterType`. Absent
+   * or empty proves nothing (the built-in registry still exposes every harness,
+   * so an adapter-less run could land on a different harness's image); more than
+   * one entry is an outright mixed-harness pool; and a sole adapter that differs
+   * from the configured default would boot a mismatched image — all reject the
+   * adapter-less lease automatically.
    * Adapter-less callers that must keep working (e.g. connectivity probes) pass
    * an explicit adapter instead of relying on the fallback.
    */
@@ -145,10 +147,14 @@ export interface ResolveRunAdapterTypeOptions {
  * substitute a different harness for an absent per-run adapter. The env-default
  * fallback for an adapter-less lease is permitted ONLY when the config positively
  * proves a single-adapter environment (`configuredAdapterTypes` declares exactly
- * one distinct enabled adapter). Otherwise the lease is rejected:
+ * one distinct enabled adapter AND it equals `configAdapterType`). Otherwise the
+ * lease is rejected:
  *   - An ABSENT or EMPTY `configuredAdapterTypes` proves nothing (the built-in
  *     registry still exposes every harness), so it is treated as UNSAFE.
  *   - A MIXED-harness pool (more than one distinct adapter) is unsafe outright.
+ *   - A sole enabled adapter that DIFFERS from `configAdapterType` is unsafe (the
+ *     fallback would boot an image the registry never established as the sole
+ *     harness).
  *   - `options.requireRunAdapter` forces the same rejection for any pool.
  * Adapter-less callers that must keep working (connectivity probes) pass an
  * explicit adapter instead of relying on the fallback.
@@ -164,17 +170,25 @@ export function resolveRunAdapterType(
   }
   // Per-run adapter absent. Falling back to the env default is safe ONLY when the
   // config can POSITIVELY prove a single-adapter environment. Prove it from the
-  // authoritative adapter set: exactly one distinct enabled adapter. An absent or
-  // empty set proves nothing (the built-in registry still exposes every harness,
-  // so an adapter-less run could land on a different harness's image), and more
-  // than one entry is an outright mixed-harness pool — both are unsafe.
+  // authoritative adapter set: exactly one distinct enabled adapter that equals
+  // the configured default. An absent or empty set proves nothing (the built-in
+  // registry still exposes every harness, so an adapter-less run could land on a
+  // different harness's image); more than one entry is an outright mixed-harness
+  // pool; and a sole adapter that differs from configAdapterType would boot a
+  // mismatched image — all are unsafe.
   const distinctConfiguredAdapters = new Set(
     (options.configuredAdapterTypes ?? [])
       .map((type) => (typeof type === "string" ? type.trim() : ""))
       .filter((type) => type.length > 0),
   );
-  const provesSingleAdapterEnv = distinctConfiguredAdapters.size === 1;
-  if (options.requireRunAdapter || !provesSingleAdapterEnv) {
+  // The sole enabled adapter must additionally MATCH the configured default:
+  // otherwise falling back to configAdapterType would boot an image the registry
+  // never established as the sole harness (a gemini-only pool booting the
+  // opencode default image). Proof requires both exactly-one AND equality.
+  const provesConfiguredDefaultIsSoleAdapter =
+    distinctConfiguredAdapters.size === 1 &&
+    distinctConfiguredAdapters.has(configAdapterType.trim());
+  if (options.requireRunAdapter || !provesConfiguredDefaultIsSoleAdapter) {
     throw new RunAdapterRequiredError(configAdapterType);
   }
   return configAdapterType;

--- a/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/adapter-defaults.ts
@@ -114,14 +114,24 @@ export class RunAdapterRequiredError extends Error {
 
 export interface ResolveRunAdapterTypeOptions {
   /**
-   * Require an explicit per-run adapter. When true and the run does not supply
-   * one, throw {@link RunAdapterRequiredError} instead of silently falling back
-   * to the environment default — the correct posture for a mixed-harness
-   * managed pool where the default is unlikely to match the agent's harness.
-   * Defaults to false to preserve single-adapter environments and connectivity
-   * probes that legitimately carry no per-run adapter.
+   * Force rejection of a lease that carries no per-run adapter, for ANY pool
+   * (throw {@link RunAdapterRequiredError} instead of falling back to the
+   * environment default). This is an explicit operator override on top of the
+   * automatic mixed-pool safety below — use it to require the per-run adapter
+   * even in a single-adapter environment. Defaults to false.
    */
   requireRunAdapter?: boolean;
+  /**
+   * The set of adapter types the environment is configured to serve (the
+   * enabled entries of the plugin's `adapters` registry). When this declares
+   * MORE THAN ONE distinct adapter the environment is a mixed-harness pool, and
+   * a lease with no per-run adapter is rejected automatically — falling back to
+   * the single env-default image would route e.g. a gemini run onto the
+   * opencode image. Absent, empty, or a single distinct entry means an
+   * effectively single-adapter environment, where the env-default fallback is
+   * safe (and connectivity probes that carry no per-run adapter keep working).
+   */
+  configuredAdapterTypes?: readonly string[];
 }
 
 /**
@@ -130,9 +140,14 @@ export interface ResolveRunAdapterTypeOptions {
  * the environment's configured default adapter when the run does not specify one.
  *
  * The image the plugin picks MUST match the harness the server exec's. Never
- * substitute a different harness: when `options.requireRunAdapter` is set, a run
- * without a per-run adapter is rejected rather than silently mapped to the
- * environment default (which may be a different harness's runtime image).
+ * substitute a different harness for an absent per-run adapter:
+ *   - A MIXED-harness pool (`configuredAdapterTypes` declares more than one
+ *     distinct adapter) rejects the lease automatically — no operator flag
+ *     needed — because the single env-default image could belong to a different
+ *     harness than the agent will run.
+ *   - `options.requireRunAdapter` forces the same rejection for any pool.
+ * A single-adapter environment (or one with no declared registry) still falls
+ * back to the env default, preserving single-adapter setups and probes.
  */
 export function resolveRunAdapterType(
   runAdapterType: string | null | undefined,
@@ -143,7 +158,16 @@ export function resolveRunAdapterType(
   if (trimmed.length > 0) {
     return trimmed;
   }
-  if (options.requireRunAdapter) {
+  // Per-run adapter absent. Determine whether the environment is a mixed-harness
+  // pool from its configured adapter set: more than one distinct enabled adapter
+  // means the single env-default fallback could pick a DIFFERENT harness's image.
+  const distinctConfiguredAdapters = new Set(
+    (options.configuredAdapterTypes ?? [])
+      .map((type) => (typeof type === "string" ? type.trim() : ""))
+      .filter((type) => type.length > 0),
+  );
+  const isMixedHarnessPool = distinctConfiguredAdapters.size > 1;
+  if (options.requireRunAdapter || isMixedHarnessPool) {
     throw new RunAdapterRequiredError(configAdapterType);
   }
   return configAdapterType;

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -212,7 +212,9 @@ const plugin = definePlugin({
     // to the environment's configured default adapter. getAdapterDefaults validates
     // it is a registered adapter (throws otherwise), so a curated-out adapter fails
     // the lease as before.
-    const effectiveAdapterType = resolveRunAdapterType(params.adapterType, config.adapterType);
+    const effectiveAdapterType = resolveRunAdapterType(params.adapterType, config.adapterType, {
+      requireRunAdapter: config.requireRunAdapterType,
+    });
 
     // Emit a runtime warning if FQDNs are configured but egressMode=standard
     // cannot enforce them. Mirrors the validateConfig warning so operators see

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -213,12 +213,15 @@ const plugin = definePlugin({
     // it is a registered adapter (throws otherwise), so a curated-out adapter fails
     // the lease as before.
     //
-    // Drive the mixed-pool safety off the configured adapter set: when the
-    // declarative `adapters` registry enables more than one adapter this is a
-    // mixed-harness pool, so an absent per-run adapter is rejected automatically
-    // (a gemini run must never fall back to the opencode image) — no operator
-    // flag required. `requireRunAdapterType` remains an explicit override that
-    // also requires the per-run adapter in a single-adapter environment.
+    // Drive the fallback safety off the configured adapter set: the env-default
+    // fallback for an absent per-run adapter is permitted ONLY when the `adapters`
+    // registry positively proves a single-adapter environment (exactly one enabled
+    // adapter). An absent/empty registry proves nothing (the built-in registry
+    // still exposes every harness) and a registry with more than one enabled
+    // adapter is a mixed-harness pool — both reject an adapter-less lease
+    // automatically (a gemini run must never fall back to the opencode image), no
+    // operator flag required. `requireRunAdapterType` remains an explicit override
+    // that also requires the per-run adapter in a single-adapter environment.
     const configuredAdapterTypes = config.adapters
       ?.filter((entry) => entry.enabled !== false)
       .map((entry) => entry.adapterType);

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -212,8 +212,19 @@ const plugin = definePlugin({
     // to the environment's configured default adapter. getAdapterDefaults validates
     // it is a registered adapter (throws otherwise), so a curated-out adapter fails
     // the lease as before.
+    //
+    // Drive the mixed-pool safety off the configured adapter set: when the
+    // declarative `adapters` registry enables more than one adapter this is a
+    // mixed-harness pool, so an absent per-run adapter is rejected automatically
+    // (a gemini run must never fall back to the opencode image) — no operator
+    // flag required. `requireRunAdapterType` remains an explicit override that
+    // also requires the per-run adapter in a single-adapter environment.
+    const configuredAdapterTypes = config.adapters
+      ?.filter((entry) => entry.enabled !== false)
+      .map((entry) => entry.adapterType);
     const effectiveAdapterType = resolveRunAdapterType(params.adapterType, config.adapterType, {
       requireRunAdapter: config.requireRunAdapterType,
+      configuredAdapterTypes,
     });
 
     // Emit a runtime warning if FQDNs are configured but egressMode=standard
@@ -337,6 +348,10 @@ const plugin = definePlugin({
       secretName,
       phase: "Pending",
       backend: config.backend,
+      // This plugin's per-adapter runtime images ship the adapter CLI and run
+      // behind a locked egress: declare them pre-baked so the server disables
+      // the network-install shim and fails fast on a wrong-image mismatch.
+      runtimeImagePrebaked: true,
     };
 
     return {
@@ -406,6 +421,9 @@ const plugin = definePlugin({
       secretName,
       phase: check.phase,
       backend: leaseBackend,
+      // Pre-baked runtime images (see acquire path); the resumed lease carries
+      // the same capability so the server keeps the network-install shim off.
+      runtimeImagePrebaked: true,
     };
 
     return {

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -355,6 +355,13 @@ const plugin = definePlugin({
       // behind a locked egress: declare them pre-baked so the server disables
       // the network-install shim and fails fast on a wrong-image mismatch.
       runtimeImagePrebaked: true,
+      // The adapter/image this pod was actually provisioned for (resolved
+      // above, never the possibly-absent per-run hint), so the server's
+      // reusable-lease scope is never null for this lease: a null scope has
+      // no positive proof of which image the pod carries and would otherwise
+      // be matched by any run's reuse lookup.
+      adapterType: effectiveAdapterType,
+      image,
     };
 
     return {
@@ -417,6 +424,16 @@ const plugin = definePlugin({
       readySandboxesByLease.add(params.providerLeaseId);
     }
 
+    // A Kubernetes pod's image cannot change in place, so the adapter/image
+    // this resumed pod is running is whatever was resolved at its original
+    // acquireLease: carry it forward unchanged rather than re-deriving it.
+    // Leases resumed from metadata that predates this field simply omit it
+    // (matching pre-existing behavior; the strict scope-matching rule on the
+    // server treats an absent value as never-a-wildcard, same as null).
+    const priorAdapterType =
+      typeof params.leaseMetadata?.adapterType === "string" ? params.leaseMetadata.adapterType : undefined;
+    const priorImage =
+      typeof params.leaseMetadata?.image === "string" ? params.leaseMetadata.image : undefined;
     const leaseMetadata: KubernetesLeaseMetadata = {
       namespace,
       jobName: params.providerLeaseId,
@@ -427,6 +444,8 @@ const plugin = definePlugin({
       // Pre-baked runtime images (see acquire path); the resumed lease carries
       // the same capability so the server keeps the network-install shim off.
       runtimeImagePrebaked: true,
+      adapterType: priorAdapterType,
+      image: priorImage,
     };
 
     return {

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -47,6 +47,17 @@ export const kubernetesProviderConfigSchema = z
       }),
 
     /**
+     * Require an explicit per-run adapter type on every lease. When true, a run
+     * that does not carry its harness is rejected instead of falling back to
+     * `adapterType` above. Set this for a mixed-harness managed pool where the
+     * environment default is unlikely to match the agent's harness, so a run can
+     * never land on a different harness's runtime image. Defaults to false to
+     * preserve single-adapter environments and connectivity probes (which
+     * legitimately acquire a lease with no per-run adapter).
+     */
+    requireRunAdapterType: z.boolean().default(false),
+
+    /**
      * Optional declarative adapter registry. When present it is authoritative
      * for runtime image / envKeys / allowFqdns / probe / defaultEnv resolution
      * (replace semantics). Absent = built-in defaults.

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -47,13 +47,17 @@ export const kubernetesProviderConfigSchema = z
       }),
 
     /**
-     * Require an explicit per-run adapter type on every lease. When true, a run
-     * that does not carry its harness is rejected instead of falling back to
-     * `adapterType` above. Set this for a mixed-harness managed pool where the
-     * environment default is unlikely to match the agent's harness, so a run can
-     * never land on a different harness's runtime image. Defaults to false to
-     * preserve single-adapter environments and connectivity probes (which
-     * legitimately acquire a lease with no per-run adapter).
+     * Explicit override to require a per-run adapter type on EVERY lease, even in
+     * a single-adapter environment: a run that does not carry its harness is
+     * rejected instead of falling back to `adapterType` above.
+     *
+     * A mixed-harness pool does NOT need this flag: when the `adapters` registry
+     * below enables more than one adapter, an absent per-run adapter is rejected
+     * automatically (the safe default), so a run can never land on a different
+     * harness's runtime image. Set this only to force the same strictness for a
+     * single-adapter environment. Defaults to false, which preserves
+     * single-adapter environments and connectivity probes (which legitimately
+     * acquire a lease with no per-run adapter).
      */
     requireRunAdapterType: z.boolean().default(false),
 
@@ -101,4 +105,15 @@ export interface KubernetesLeaseMetadata {
   phase: "Pending" | "Running" | "Succeeded" | "Failed";
   /** Which backend provisioned this lease. */
   backend: "sandbox-cr" | "job";
+  /**
+   * Capability signal surfaced to the server: this plugin's runtime images are
+   * pre-baked / contractually complete — the adapter CLI is already on PATH in
+   * the image, which runs behind a locked (sovereign) egress. The server reads
+   * this specific flag (NOT the generic "plugin-backed" marker) to disable the
+   * in-sandbox network-install shim and instead fail fast with a typed
+   * `adapter_runtime_image_mismatch` when the CLI is missing (the run landed on
+   * the wrong image). A provider plugin that ships a GENERIC sandbox and relies
+   * on runtime installation must NOT set this, so its install path is preserved.
+   */
+  runtimeImagePrebaked: true;
 }

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -116,4 +116,21 @@ export interface KubernetesLeaseMetadata {
    * on runtime installation must NOT set this, so its install path is preserved.
    */
   runtimeImagePrebaked: true;
+  /**
+   * The adapter type this lease's pod was actually provisioned for (the
+   * per-run adapterType when supplied, otherwise the resolved environment
+   * default, see resolveRunAdapterType). Surfaced so the server's reusable
+   * sandbox lease scope is never null for a plugin-backed lease: a null scope
+   * has no positive proof of which runtime image the pod carries and can be
+   * matched by any run's reuse lookup, which is exactly the wrong-harness
+   * warm-pool bug this closes. Optional only for leases resumed from
+   * metadata predating this field.
+   */
+  adapterType?: string;
+  /**
+   * The runtime image resolved for this lease's pod (mirrors adapterType:
+   * persisted at acquire time and carried forward unchanged on resume, since
+   * a Kubernetes pod's image cannot change in place).
+   */
+  image?: string;
 }

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
@@ -3,6 +3,8 @@ import {
   getAdapterDefaults,
   buildAdapterEnv,
   resolveRunAdapterType,
+  RunAdapterRequiredError,
+  RUN_ADAPTER_REQUIRED_CODE,
   KNOWN_ADAPTER_TYPES,
   type AdapterDefaults,
 } from "../../src/adapter-defaults.js";
@@ -144,5 +146,44 @@ describe("resolveRunAdapterType", () => {
   });
   it("trims the run adapter", () => {
     expect(resolveRunAdapterType("  pi_local  ", "opencode_local")).toBe("pi_local");
+  });
+
+  describe("strict mode (requireRunAdapter)", () => {
+    it("returns the run's own harness, never a different one, when the run adapter is present", () => {
+      // The config default is a DIFFERENT harness; strict mode must still honor
+      // the run's adapter and never substitute the env default image.
+      expect(
+        resolveRunAdapterType("gemini_local", "opencode_local", { requireRunAdapter: true }),
+      ).toBe("gemini_local");
+    });
+
+    it("rejects the run instead of falling back to a different harness image when absent", () => {
+      // The bug: a null per-run adapter silently mapped to the env default
+      // (opencode_local) so a gemini agent ran in the opencode image. Strict
+      // mode rejects rather than picking a mismatched image.
+      for (const absent of [undefined, null, "   "]) {
+        expect(() =>
+          resolveRunAdapterType(absent, "opencode_local", { requireRunAdapter: true }),
+        ).toThrow(RunAdapterRequiredError);
+      }
+    });
+
+    it("names the environment default in the rejection and carries a stable code", () => {
+      try {
+        resolveRunAdapterType(null, "opencode_local", { requireRunAdapter: true });
+        throw new Error("expected resolveRunAdapterType to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RunAdapterRequiredError);
+        expect((err as RunAdapterRequiredError).code).toBe(RUN_ADAPTER_REQUIRED_CODE);
+        expect((err as Error).message).toContain("opencode_local");
+      }
+    });
+
+    it("still falls back by default (probe/single-adapter compatibility) when not strict", () => {
+      expect(resolveRunAdapterType(undefined, "opencode_local")).toBe("opencode_local");
+      expect(resolveRunAdapterType(undefined, "opencode_local", { requireRunAdapter: false })).toBe(
+        "opencode_local",
+      );
+    });
   });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
@@ -139,10 +139,13 @@ describe("resolveRunAdapterType", () => {
   it("prefers the run/agent adapter when provided (mixed-harness env)", () => {
     expect(resolveRunAdapterType("pi_local", "opencode_local")).toBe("pi_local");
   });
-  it("falls back to the environment default when the run adapter is missing/blank", () => {
-    expect(resolveRunAdapterType(undefined, "opencode_local")).toBe("opencode_local");
-    expect(resolveRunAdapterType(null, "opencode_local")).toBe("opencode_local");
-    expect(resolveRunAdapterType("   ", "opencode_local")).toBe("opencode_local");
+  it("rejects an adapter-less lease when no registry positively proves a single-adapter env", () => {
+    // Without an authoritative adapter set the env-default fallback is unsafe:
+    // the built-in registry still exposes every harness, so an adapter-less run
+    // could land on a different harness's image. Require the per-run adapter.
+    for (const absent of [undefined, null, "   "]) {
+      expect(() => resolveRunAdapterType(absent, "opencode_local")).toThrow(RunAdapterRequiredError);
+    }
   });
   it("trims the run adapter", () => {
     expect(resolveRunAdapterType("  pi_local  ", "opencode_local")).toBe("pi_local");
@@ -179,11 +182,16 @@ describe("resolveRunAdapterType", () => {
       }
     });
 
-    it("still falls back by default (probe/single-adapter compatibility) when not strict", () => {
-      expect(resolveRunAdapterType(undefined, "opencode_local")).toBe("opencode_local");
-      expect(resolveRunAdapterType(undefined, "opencode_local", { requireRunAdapter: false })).toBe(
-        "opencode_local",
+    it("does not fall back for an adapter-less lease without an authoritative single-adapter registry", () => {
+      // requireRunAdapter defaults to false, but a false flag does NOT opt into
+      // permissiveness: absent a registry that proves a single-adapter env, the
+      // adapter-less lease is still rejected (the env default can't be trusted).
+      expect(() => resolveRunAdapterType(undefined, "opencode_local")).toThrow(
+        RunAdapterRequiredError,
       );
+      expect(() =>
+        resolveRunAdapterType(undefined, "opencode_local", { requireRunAdapter: false }),
+      ).toThrow(RunAdapterRequiredError);
     });
   });
 
@@ -209,7 +217,9 @@ describe("resolveRunAdapterType", () => {
       ).toBe("gemini_local");
     });
 
-    it("still falls back for a single-adapter config with an absent per-run adapter", () => {
+    it("falls back for a single-adapter config with an absent per-run adapter", () => {
+      // A registry with exactly one distinct enabled adapter positively proves a
+      // single-adapter environment, so the env-default fallback is safe.
       expect(
         resolveRunAdapterType(undefined, "opencode_local", {
           configuredAdapterTypes: ["opencode_local"],
@@ -225,11 +235,21 @@ describe("resolveRunAdapterType", () => {
       ).toBe("opencode_local");
     });
 
-    it("falls back when no configured adapter set is supplied (probe/single-adapter compatibility)", () => {
-      expect(
+    it("rejects an adapter-less lease when the configured adapter set is empty or absent", () => {
+      // An empty or absent authoritative registry cannot prove a single-adapter
+      // env, so it is treated as UNSAFE: the per-run adapter is required rather
+      // than trusting the env default (adapter-less probes are pinned upstream).
+      expect(() =>
         resolveRunAdapterType(undefined, "opencode_local", { configuredAdapterTypes: [] }),
-      ).toBe("opencode_local");
-      expect(resolveRunAdapterType(undefined, "opencode_local", {})).toBe("opencode_local");
+      ).toThrow(RunAdapterRequiredError);
+      expect(() =>
+        resolveRunAdapterType(undefined, "opencode_local", {
+          configuredAdapterTypes: ["", "   "],
+        }),
+      ).toThrow(RunAdapterRequiredError);
+      expect(() => resolveRunAdapterType(undefined, "opencode_local", {})).toThrow(
+        RunAdapterRequiredError,
+      );
     });
 
     it("names the environment default and carries the stable code when a mixed pool rejects", () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
@@ -252,6 +252,30 @@ describe("resolveRunAdapterType", () => {
       );
     });
 
+    it("falls back only when the sole adapter MATCHES the configured default", () => {
+      // The single enabled adapter equals configAdapterType, so the env-default
+      // fallback lands on the image the registry established as the sole harness.
+      expect(
+        resolveRunAdapterType(undefined, "opencode_local", {
+          configuredAdapterTypes: ["opencode_local"],
+        }),
+      ).toBe("opencode_local");
+    });
+
+    it("rejects when the sole adapter DIFFERS from the configured default (no mis-route)", () => {
+      // Registry proves a single-adapter env, but that sole adapter is NOT the
+      // configured default. Falling back to configAdapterType would boot an image
+      // the registry never established as the sole harness (opencode image for a
+      // gemini-only pool). The per-run adapter is required instead.
+      for (const absent of [undefined, null, "   "]) {
+        expect(() =>
+          resolveRunAdapterType(absent, "opencode_local", {
+            configuredAdapterTypes: ["gemini_local"],
+          }),
+        ).toThrow(RunAdapterRequiredError);
+      }
+    });
+
     it("names the environment default and carries the stable code when a mixed pool rejects", () => {
       try {
         resolveRunAdapterType(null, "opencode_local", {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/adapter-defaults.test.ts
@@ -186,4 +186,63 @@ describe("resolveRunAdapterType", () => {
       );
     });
   });
+
+  describe("mixed-harness pool (automatic safe default, no operator flag)", () => {
+    it("rejects an absent per-run adapter when the config declares MORE THAN ONE adapter", () => {
+      // A mixed pool must never silently fall back to the single env default:
+      // that would route a gemini run onto the opencode image. This holds with
+      // NO requireRunAdapter flag set — the safe behavior is the default.
+      for (const absent of [undefined, null, "   "]) {
+        expect(() =>
+          resolveRunAdapterType(absent, "opencode_local", {
+            configuredAdapterTypes: ["opencode_local", "gemini_local", "claude_local"],
+          }),
+        ).toThrow(RunAdapterRequiredError);
+      }
+    });
+
+    it("does NOT mis-route: honors the run's own adapter in a mixed pool when present", () => {
+      expect(
+        resolveRunAdapterType("gemini_local", "opencode_local", {
+          configuredAdapterTypes: ["opencode_local", "gemini_local"],
+        }),
+      ).toBe("gemini_local");
+    });
+
+    it("still falls back for a single-adapter config with an absent per-run adapter", () => {
+      expect(
+        resolveRunAdapterType(undefined, "opencode_local", {
+          configuredAdapterTypes: ["opencode_local"],
+        }),
+      ).toBe("opencode_local");
+    });
+
+    it("treats duplicate/blank entries as effectively single-adapter (fallback stays safe)", () => {
+      expect(
+        resolveRunAdapterType(undefined, "opencode_local", {
+          configuredAdapterTypes: ["opencode_local", " opencode_local ", "", "   "],
+        }),
+      ).toBe("opencode_local");
+    });
+
+    it("falls back when no configured adapter set is supplied (probe/single-adapter compatibility)", () => {
+      expect(
+        resolveRunAdapterType(undefined, "opencode_local", { configuredAdapterTypes: [] }),
+      ).toBe("opencode_local");
+      expect(resolveRunAdapterType(undefined, "opencode_local", {})).toBe("opencode_local");
+    });
+
+    it("names the environment default and carries the stable code when a mixed pool rejects", () => {
+      try {
+        resolveRunAdapterType(null, "opencode_local", {
+          configuredAdapterTypes: ["opencode_local", "gemini_local"],
+        });
+        throw new Error("expected resolveRunAdapterType to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RunAdapterRequiredError);
+        expect((err as RunAdapterRequiredError).code).toBe(RUN_ADAPTER_REQUIRED_CODE);
+        expect((err as Error).message).toContain("opencode_local");
+      }
+    });
+  });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-acquire-lease-metadata.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-acquire-lease-metadata.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the kube-client module so the plugin handler runs against injected
+// fake API clients instead of a real cluster, mirroring the pattern in
+// plugin-lease-lifecycle.test.ts.
+const h = vi.hoisted(() => ({ clients: {} as Record<string, unknown> }));
+
+vi.mock("../../src/kube-client.js", () => ({
+  createKubeConfig: vi.fn(() => ({})),
+  makeKubeClients: vi.fn(() => h.clients),
+}));
+
+vi.mock("../../src/tenant-orchestrator.js", () => ({
+  ensureTenant: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/secret-manager.js", () => ({
+  createPerRunSecret: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/sandbox-cr-orchestrator.js", () => ({
+  sandboxCrOrchestrator: {
+    claim: vi.fn().mockResolvedValue({ uid: "owner-uid-1" }),
+    findPod: vi.fn().mockResolvedValue("pc-abc-pod"),
+  },
+  SandboxCrTimeoutError: class SandboxCrTimeoutError extends Error {},
+}));
+
+vi.mock("../../src/job-orchestrator.js", () => ({
+  jobOrchestrator: {
+    claim: vi.fn().mockResolvedValue({ uid: "owner-uid-1" }),
+    findPod: vi.fn().mockResolvedValue("pc-abc-pod"),
+  },
+  JobTimeoutError: class JobTimeoutError extends Error {},
+}));
+
+import plugin from "../../src/plugin.js";
+
+const CONFIG = { inCluster: true, backend: "sandbox-cr" };
+
+beforeEach(() => {
+  h.clients = {};
+});
+
+describe("onEnvironmentAcquireLease lease metadata", () => {
+  // Gap-1 (second layer): the server's reusable-lease scope is built from
+  // whatever adapterType/image it can see at publish time. If the plugin
+  // resolves a per-run adapter (or falls back to the environment default)
+  // but never surfaces that resolution in the lease metadata, the server has
+  // no positive signal to persist and the scope ends up null, exactly the
+  // "matched by any run" gap the strict null-never-matches rule in
+  // environment-runtime.ts guards against. Persisting them here means the
+  // scope is populated even when the server's own per-run hint is absent.
+  it("persists the resolved adapter type and runtime image when adapterType is supplied", async () => {
+    const lease = await plugin.definition.onEnvironmentAcquireLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: CONFIG,
+      runId: "run-1",
+      adapterType: "claude_local",
+    });
+
+    expect(lease.providerLeaseId).toEqual(expect.any(String));
+    expect(lease.metadata).toEqual(
+      expect.objectContaining({
+        adapterType: "claude_local",
+        image: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+      }),
+    );
+  });
+
+  it("persists the environment-configured default adapter type when no per-run adapterType is supplied", async () => {
+    const lease = await plugin.definition.onEnvironmentAcquireLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: {
+        ...CONFIG,
+        adapterType: "codex_local",
+        // The env-default fallback is only safe when the config POSITIVELY
+        // proves a single-adapter environment (see #9950's
+        // resolveRunAdapterType); otherwise an adapter-less run is rejected
+        // rather than falling back. A configured `adapters` registry is
+        // authoritative (replace semantics), so it must be complete.
+        adapters: [{
+          adapterType: "codex_local",
+          enabled: true,
+          runtimeImage: "ghcr.io/paperclipai/agent-runtime-codex:v1",
+        }],
+      },
+      runId: "run-2",
+    });
+
+    expect(lease.metadata).toEqual(
+      expect.objectContaining({
+        adapterType: "codex_local",
+        image: "ghcr.io/paperclipai/agent-runtime-codex:v1",
+      }),
+    );
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
@@ -81,6 +81,10 @@ describe("onEnvironmentResumeLease", () => {
         phase: "Running",
         backend: "sandbox-cr",
         resumedLease: true,
+        // Capability signal the server reads to disable the network-install shim
+        // and fail fast on a wrong runtime image (Finding 2 in PR #9950): the
+        // k8s plugin's runtime images are pre-baked, so it declares it per-lease.
+        runtimeImagePrebaked: true,
       }),
     );
   });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
@@ -89,6 +89,44 @@ describe("onEnvironmentResumeLease", () => {
     );
   });
 
+  it("carries the originally-resolved adapter type and image forward on resume", async () => {
+    // Gap-1 (second layer): a Kubernetes pod's image cannot change in place,
+    // so the resumed lease must surface the SAME adapterType/image it was
+    // acquired with, not drop them: otherwise the server's reusable-lease
+    // scope would go null on every resume and lose the positive match proof
+    // reacquired leases had.
+    h.clients = {
+      custom: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue(readySandboxCr("pc-abc-pod")),
+      },
+      core: {
+        readNamespacedPod: vi.fn().mockResolvedValue({
+          metadata: {},
+          status: { phase: "Running" },
+        }),
+      },
+    };
+
+    const lease = await plugin.definition.onEnvironmentResumeLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: CONFIG,
+      providerLeaseId: "pc-abc",
+      leaseMetadata: leaseMetadata({
+        adapterType: "claude_local",
+        image: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+      }),
+    });
+
+    expect(lease.metadata).toEqual(
+      expect.objectContaining({
+        adapterType: "claude_local",
+        image: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+      }),
+    );
+  });
+
   it("returns providerLeaseId null (expired) when the Sandbox CR is gone, so the caller falls back to acquireLease", async () => {
     h.clients = {
       custom: { getNamespacedCustomObject: vi.fn().mockRejectedValue(notFound()) },

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -324,6 +324,21 @@ describe("server adapter registry", () => {
     });
   });
 
+  it("emits no network install command for a managed, pre-baked k8s sandbox", () => {
+    // Pre-baked plugin-backed sandbox images carry the CLI already and run
+    // behind a locked egress; a network install would only stall until timeout.
+    // The install command must be suppressed so the wrong-image case fails fast.
+    for (const type of ["claude_local", "codex_local", "gemini_local", "opencode_local", "pi_local"]) {
+      const spec = findActiveServerAdapter(type)?.getRuntimeCommandSpec?.({}, { prebakedRuntime: true });
+      expect(spec, type).not.toBeNull();
+      expect(spec?.installCommand, type).toBeNull();
+      // The command + detect probe are still emitted so the pre-flight assertion
+      // can verify the CLI is present.
+      expect(spec?.command, type).toBeTruthy();
+      expect(spec?.detectCommand, type).toBe(spec?.command);
+    }
+  });
+
   it("switches active adapter behavior back to the builtin when an override is paused", async () => {
     const builtIn = findServerAdapter("claude_local");
     expect(builtIn).not.toBeNull();

--- a/server/src/__tests__/environment-execution-target.test.ts
+++ b/server/src/__tests__/environment-execution-target.test.ts
@@ -176,6 +176,66 @@ describe("resolveEnvironmentExecutionTarget", () => {
     });
   });
 
+  it("marks the sandbox target pre-baked only when the lease declares runtimeImagePrebaked", async () => {
+    // A lease from a provider plugin that explicitly declares its runtime images
+    // are pre-baked (the k8s sandbox plugin) disables the network-install shim
+    // and fails fast on a missing CLI.
+    mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
+      driver: "sandbox",
+      config: { provider: "kubernetes", reuseLease: false, timeoutMs: 30_000 },
+    });
+
+    const target = await resolveEnvironmentExecutionTarget({
+      db: {} as never,
+      companyId: "company-1",
+      adapterType: "gemini_local",
+      environment: { id: "env-1", driver: "sandbox", config: { provider: "kubernetes" } },
+      leaseId: "lease-1",
+      leaseMetadata: {
+        sandboxProviderPlugin: true,
+        runtimeImagePrebaked: true,
+      },
+      lease: null,
+      environmentRuntime: null,
+    });
+
+    expect(target).toMatchObject({
+      kind: "remote",
+      transport: "sandbox",
+      prebakedRuntime: true,
+    });
+  });
+
+  it("keeps a plugin-backed lease provisionable (install path) when it does NOT declare runtimeImagePrebaked", async () => {
+    // A provider plugin that ships a GENERIC sandbox and relies on runtime
+    // installation is plugin-backed but must NOT be treated as pre-baked, or its
+    // install (Layer 3) is wrongly dropped and a provisionable run turns into a
+    // spurious adapter_runtime_image_mismatch.
+    mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
+      driver: "sandbox",
+      config: { provider: "generic-plugin", reuseLease: false, timeoutMs: 30_000 },
+    });
+
+    const target = await resolveEnvironmentExecutionTarget({
+      db: {} as never,
+      companyId: "company-1",
+      adapterType: "gemini_local",
+      environment: { id: "env-1", driver: "sandbox", config: { provider: "generic-plugin" } },
+      leaseId: "lease-1",
+      leaseMetadata: {
+        sandboxProviderPlugin: true,
+      },
+      lease: null,
+      environmentRuntime: null,
+    });
+
+    expect(target).toMatchObject({
+      kind: "remote",
+      transport: "sandbox",
+      prebakedRuntime: false,
+    });
+  });
+
   it("resolves SSH execution targets in bridge mode", async () => {
     mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
       driver: "ssh",

--- a/server/src/__tests__/environment-probe.test.ts
+++ b/server/src/__tests__/environment-probe.test.ts
@@ -263,6 +263,73 @@ describe("probeEnvironment", () => {
     }));
   });
 
+  it("pins the runtime probe to the environment's default adapter so a mixed-harness pool does not reject it", async () => {
+    // A mixed-harness pool rejects an absent per-run adapter (a real run must
+    // never fall back to a different harness's image). A connectivity probe
+    // carries no harness, so it must pin the env's configured default adapter to
+    // boot one valid image instead of being rejected.
+    mockRuntimeAcquireRunLease.mockResolvedValue({
+      environment: {},
+      leaseContext: { executionWorkspaceId: null, executionWorkspaceMode: null },
+      lease: {
+        id: "lease-k8s-1",
+        companyId: "company-1",
+        environmentId: "env-k8s",
+        executionWorkspaceId: null,
+        issueId: null,
+        heartbeatRunId: null,
+        status: "active",
+        leasePolicy: "ephemeral",
+        provider: "kubernetes",
+        providerLeaseId: "pc-probe-1",
+        acquiredAt: new Date(),
+        lastUsedAt: new Date(),
+        expiresAt: null,
+        releasedAt: null,
+        failureReason: null,
+        cleanupStatus: "pending",
+        metadata: { provider: "kubernetes", runtimeImagePrebaked: true, reuseLease: false },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const environment = {
+      id: "env-k8s",
+      companyId: "company-1",
+      name: "Kubernetes",
+      description: null,
+      driver: "sandbox" as const,
+      status: "active" as const,
+      config: {
+        provider: "kubernetes",
+        adapterType: "claude_local",
+        adapters: [
+          { adapterType: "claude_local", runtimeImage: "img-claude" },
+          { adapterType: "gemini_local", runtimeImage: "img-gemini" },
+        ],
+        reuseLease: true,
+      },
+      metadata: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const result = await probeEnvironment({} as any, environment, {
+      companyId: "company-1",
+      pluginWorkerManager: {} as any,
+      acquireSandboxRuntimeLease: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockRuntimeAcquireRunLease).toHaveBeenCalledWith(expect.objectContaining({
+      companyId: "company-1",
+      // Pinned to the configured default adapter, NOT null: the mixed pool would
+      // reject a null per-run adapter.
+      adapterType: "claude_local",
+    }));
+  });
+
   it("routes plugin environment probes through the plugin worker host", async () => {
     mockProbePluginEnvironmentDriver.mockResolvedValue({
       ok: true,

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -277,7 +277,10 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     };
   }
 
-  async function seedReusablePluginSandboxLease() {
+  async function seedReusablePluginSandboxLease(
+    seedInput: { scopedAdapterType?: string | null } = {},
+  ) {
+    const scopedAdapterType = seedInput.scopedAdapterType ?? null;
     const pluginId = randomUUID();
     const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();
     const providerConfig = {
@@ -381,11 +384,11 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           environmentId: environment.id,
           executionWorkspaceId,
           agentId,
-          adapterType: null,
+          adapterType: scopedAdapterType,
           provider: "fake-plugin",
           runtimeFingerprint: reusableRuntimeFingerprint({
             provider: "fake-plugin",
-            adapterType: null,
+            adapterType: scopedAdapterType,
             config: providerConfig,
           }),
         },
@@ -1142,11 +1145,16 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
           environmentId: environment.id,
           executionWorkspaceId,
           agentId,
-          adapterType: null,
+          // A concrete, matching adapter type on both the stored scope and
+          // the acquireRunLease call below: null is never a wildcard match
+          // for plugin-backed leases (see reusableSandboxLeaseScopeMatches),
+          // so this resume-then-fallback exercise needs a genuine positive
+          // match to reach the resume RPC at all.
+          adapterType: "codex_local",
           provider: "fake-plugin",
           runtimeFingerprint: reusableRuntimeFingerprint({
             provider: "fake-plugin",
-            adapterType: null,
+            adapterType: "codex_local",
             config: providerConfig,
           }),
         },
@@ -1185,6 +1193,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       issueId: null,
       agentId,
       heartbeatRunId: runId,
+      adapterType: "codex_local",
       persistedExecutionWorkspace: {
         id: executionWorkspaceId,
         mode: "shared_workspace",
@@ -1621,6 +1630,148 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     await expect(environmentService(db).getLeaseById(reusableLease.id)).resolves.toMatchObject({
       status: "active",
       cleanupStatus: null,
+    });
+  });
+
+  it("does not reuse a plugin-backed sandbox lease whose stored scope has a null adapter type when the run requests one", async () => {
+    // Gap-1 regression: a lease pooled with scope.adapterType null must never
+    // be matched by ANY run (null is never a wildcard). Re-acquiring on the
+    // SAME run/heartbeatRunId (the self-heal shape) must still go through
+    // environmentAcquireLease for a fresh lease rather than resuming the
+    // null-scoped one.
+    const { pluginId, companyId, agentId, environment, runId, executionWorkspaceId, reusableLease } =
+      await seedReusablePluginSandboxLease({ scopedAdapterType: null });
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "fresh-plugin-lease-claude",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      adapterType: "claude_local",
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    expect(acquired.lease.providerLeaseId).toBe("fresh-plugin-lease-claude");
+    expect(workerManager.call).toHaveBeenCalledTimes(1);
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentAcquireLease", expect.anything(), 31234);
+    await expect(environmentService(db).getLeaseById(reusableLease.id)).resolves.toMatchObject({
+      status: "active",
+    });
+  });
+
+  it("does not reuse a plugin-backed sandbox lease scoped to a concrete adapter type when the run requests none", async () => {
+    // Symmetric gap-1 case: a lease scoped to a real adapter must not be
+    // handed to a run whose adapterType is null/absent either.
+    const { pluginId, companyId, agentId, environment, runId, executionWorkspaceId, reusableLease } =
+      await seedReusablePluginSandboxLease({ scopedAdapterType: "claude_local" });
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "fresh-plugin-lease-null-adapter",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    expect(acquired.lease.providerLeaseId).toBe("fresh-plugin-lease-null-adapter");
+    expect(workerManager.call).toHaveBeenCalledTimes(1);
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentAcquireLease", expect.anything(), 31234);
+    await expect(environmentService(db).getLeaseById(reusableLease.id)).resolves.toMatchObject({
+      status: "active",
+    });
+  });
+
+  it("does not reuse a plugin-backed sandbox lease when both the stored scope and the run's adapter type are null", async () => {
+    // The core gap-1 case: null must never be treated as a wildcard, even
+    // when it happens to match null-for-null. A null-scoped plugin lease is
+    // ambiguous about which runtime image it actually carries, so no run
+    // (including another null-adapterType one) may resume it; it always
+    // falls through to a fresh environmentAcquireLease.
+    const { pluginId, companyId, agentId, environment, runId, executionWorkspaceId, reusableLease } =
+      await seedReusablePluginSandboxLease({ scopedAdapterType: null });
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "fresh-plugin-lease-both-null",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    expect(acquired.lease.providerLeaseId).toBe("fresh-plugin-lease-both-null");
+    expect(workerManager.call).toHaveBeenCalledTimes(1);
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentAcquireLease", expect.anything(), 31234);
+    await expect(environmentService(db).getLeaseById(reusableLease.id)).resolves.toMatchObject({
+      status: "active",
     });
   });
 

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -1775,6 +1775,136 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     });
   });
 
+  it("persists the plugin's resolved adapter type and image into the reusable lease scope when the server has no per-run hint", async () => {
+    // Gap-1 (second layer, matching plugin.ts's onEnvironmentAcquireLease
+    // change): when the server's own adapterType hint is absent, the scope
+    // must fall back to whatever the plugin actually resolved and returned
+    // in the lease metadata, so the scope is never null even though a
+    // concrete image WAS provisioned.
+    const pluginId = randomUUID();
+    const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const providerConfig = {
+      provider: "fake-plugin",
+      image: "fake:test",
+      timeoutMs: 1234,
+      reuseLease: true,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Reusable Plugin Sandbox With Fallback",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.reusable-sandbox-provider-fallback",
+      packageName: "@acme/reusable-sandbox-provider-fallback",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.reusable-sandbox-provider-fallback",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Reusable Sandbox Provider Fallback",
+        description: "Test provider exercising the adapterType metadata fallback",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "fake-plugin",
+            kind: "sandbox_provider",
+            displayName: "Fake Plugin",
+            supportsReusableLeases: true,
+            configSchema: {
+              type: "object",
+              properties: {
+                image: { type: "string" },
+                timeoutMs: { type: "number" },
+                reuseLease: { type: "boolean" },
+              },
+            },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+    const executionWorkspaceId = randomUUID();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: `Workspace ${projectId.slice(0, 8)}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Reusable workspace",
+      status: "active",
+      providerType: "local_fs",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "resolved-plugin-lease",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+              // The plugin's own resolution: no per-run hint came from the
+              // server (acquireRunLease is called below without adapterType),
+              // but the plugin still resolved a concrete adapter/image (e.g.
+              // the environment's configured default).
+              adapterType: "codex_local",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    expect(acquired.lease.providerLeaseId).toBe("resolved-plugin-lease");
+    expect(acquired.lease.metadata?.reusableSandboxLease).toMatchObject({
+      adapterType: "codex_local",
+      runtimeImage: "fake:test",
+    });
+  });
+
   it("does not retain or resume plugin-backed sandbox leases unless the provider opts in", async () => {
     const pluginId = randomUUID();
     const { companyId, agentId, environment: baseEnvironment, runId } = await seedEnvironment();

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -1775,6 +1775,55 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     });
   });
 
+  it("does not reuse a plugin-backed sandbox lease scoped to a different concrete adapter type", async () => {
+    // Concrete-vs-concrete case: both sides are non-null, but different
+    // harnesses. A run requesting claude_local must never resume a lease
+    // scoped to gemini_local, even though neither side is null (the null
+    // cases above prove null is never a wildcard; this proves two distinct
+    // concrete values are also never treated as equal).
+    const { pluginId, companyId, agentId, environment, runId, executionWorkspaceId, reusableLease } =
+      await seedReusablePluginSandboxLease({ scopedAdapterType: "gemini_local" });
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "fresh-plugin-lease-claude-vs-gemini",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1234,
+              reuseLease: true,
+              remoteCwd: "/workspace",
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      adapterType: "claude_local",
+      persistedExecutionWorkspace: {
+        id: executionWorkspaceId,
+        mode: "shared_workspace",
+      },
+    });
+
+    expect(acquired.lease.providerLeaseId).toBe("fresh-plugin-lease-claude-vs-gemini");
+    expect(workerManager.call).toHaveBeenCalledTimes(1);
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentAcquireLease", expect.anything(), 31234);
+    await expect(environmentService(db).getLeaseById(reusableLease.id)).resolves.toMatchObject({
+      status: "active",
+    });
+  });
+
   it("persists the plugin's resolved adapter type and image into the reusable lease scope when the server has no per-run hint", async () => {
     // Gap-1 (second layer, matching plugin.ts's onEnvironmentAcquireLease
     // change): when the server's own adapterType hint is absent, the scope

--- a/server/src/__tests__/heartbeat-adapter-runtime-image-mismatch.test.ts
+++ b/server/src/__tests__/heartbeat-adapter-runtime-image-mismatch.test.ts
@@ -1,0 +1,316 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  environments,
+  plugins,
+  projects,
+  projectWorkspaces,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.ts";
+import { AdapterRuntimeImageMismatchError } from "@paperclipai/adapter-utils/execution-target";
+
+// Isolated from heartbeat-plugin-environment.test.ts on purpose: these tests
+// swap the mocked adapter's execute() implementation per-test (one-shot
+// throws via mockImplementationOnce), and that module-level mock is shared
+// for the lifetime of the test file process. Co-locating with the other
+// plugin-environment heartbeat tests caused order-dependent flakiness (a
+// prior test's still-in-flight background continuation work occasionally
+// consumed a queued implementation meant for these tests). A dedicated file
+// keeps the queue deterministic.
+const adapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  sessionParams: { sessionId: "session-1" },
+  sessionDisplayId: "session-1",
+  provider: "test",
+  model: "test-model",
+})));
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  findActiveServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  listAdapterModelProfiles: async () => [],
+  runningProcesses: new Map(),
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat adapter-runtime-image-mismatch tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat AdapterRuntimeImageMismatchError self-heal", () => {
+  let stopDb: (() => Promise<void>) | null = null;
+  let db!: ReturnType<typeof createDb>;
+  const tempRoots: string[] = [];
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("heartbeat-adapter-runtime-image-mismatch");
+    stopDb = started.stop;
+    db = createDb(started.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    adapterExecute.mockClear();
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => {
+    await db.$client.end();
+    await stopDb?.();
+  });
+
+  async function seedPluginSandboxRun(input: { environmentName: string; projectName: string }) {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const workspaceId = randomUUID();
+    const environmentId = randomUUID();
+    const pluginId = randomUUID();
+    const pluginKey = `acme.environments.${pluginId}`;
+    const agentId = randomUUID();
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-heartbeat-image-mismatch-"));
+    tempRoots.push(workspaceRoot);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      status: "active",
+      defaultResponsibleUserId: "responsible-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: input.projectName,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      cwd: workspaceRoot,
+      isPrimary: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey,
+      packageName: "@acme/paperclip-environments",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: pluginKey,
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Acme Environments",
+        description: "Test plugin environment driver",
+        author: "Acme",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "sandbox",
+            displayName: "Sandbox",
+            configSchema: { type: "object" },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+    await db.insert(environments).values({
+      id: environmentId,
+      companyId,
+      name: input.environmentName,
+      driver: "plugin",
+      status: "active",
+      config: {
+        pluginKey,
+        driverKey: "sandbox",
+        driverConfig: {
+          template: "base",
+        },
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      defaultEnvironmentId: environmentId,
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return { companyId, projectId, environmentId, pluginId, agentId };
+  }
+
+  function makeWorkerManager(pluginId: string) {
+    let acquireCount = 0;
+    const call = vi.fn(async (_pluginId: string, method: string) => {
+      if (method === "environmentAcquireLease") {
+        acquireCount += 1;
+        return {
+          providerLeaseId: `plugin-heartbeat-lease-${acquireCount}`,
+          metadata: {
+            remoteCwd: "/workspace/project",
+          },
+        };
+      }
+      if (method === "environmentDestroyLease") {
+        return undefined;
+      }
+      if (method === "environmentReleaseLease") {
+        return undefined;
+      }
+      throw new Error(`Unexpected plugin environment method: ${method}`);
+    });
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call,
+    } as unknown as PluginWorkerManager;
+    return workerManager;
+  }
+
+  it("self-heals a single AdapterRuntimeImageMismatchError by destroying the lease and re-acquiring once", async () => {
+    // Gap-2: the run lands on a pod whose runtime image is missing the
+    // harness CLI (adapter.execute throws AdapterRuntimeImageMismatchError).
+    // heartbeat.ts must destroy that lease, re-acquire + re-realize the
+    // environment, and retry the adapter exactly once before the run can
+    // succeed.
+    const { companyId: _companyId, projectId, pluginId, agentId } = await seedPluginSandboxRun({
+      environmentName: "Plugin Sandbox Self-heal",
+      projectName: "Plugin Environment Self-heal",
+    });
+    const workerManager = makeWorkerManager(pluginId);
+
+    adapterExecute.mockImplementationOnce(async () => {
+      throw new AdapterRuntimeImageMismatchError(
+        "codex",
+        "sandbox pod plugin-heartbeat-lease-1",
+        "detect probe exited 127",
+      );
+    });
+
+    const heartbeat = heartbeatService(db, { pluginWorkerManager: workerManager });
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      contextSnapshot: { projectId },
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 5_000 });
+
+    expect(adapterExecute).toHaveBeenCalledTimes(2);
+    const call = workerManager.call as unknown as ReturnType<typeof vi.fn>;
+    const acquireCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentAcquireLease");
+    const destroyCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentDestroyLease");
+    expect(acquireCalls).toHaveLength(2);
+    expect(destroyCalls).toHaveLength(1);
+    // The destroy of the mismatched lease happens strictly between the two
+    // acquires, not before the first or after the second.
+    const methodSequence = call.mock.calls.map(([, method]: [unknown, string]) => method);
+    expect(methodSequence.indexOf("environmentDestroyLease")).toBeGreaterThan(
+      methodSequence.indexOf("environmentAcquireLease"),
+    );
+    expect(methodSequence.lastIndexOf("environmentAcquireLease")).toBeGreaterThan(
+      methodSequence.indexOf("environmentDestroyLease"),
+    );
+  }, 15_000);
+
+  it("surfaces adapter_runtime_image_mismatch as a terminal failure after one failed recovery attempt", async () => {
+    // Second consecutive mismatch: the one-shot self-heal already destroyed
+    // and re-acquired once, so the retried adapter.execute failing the same
+    // way must surface the original typed error terminally instead of
+    // looping.
+    const { companyId: _companyId, projectId, pluginId, agentId } = await seedPluginSandboxRun({
+      environmentName: "Plugin Sandbox Self-heal Terminal",
+      projectName: "Plugin Environment Self-heal Terminal",
+    });
+    const workerManager = makeWorkerManager(pluginId);
+
+    // Two queued one-shot throws (not a persistent mockRejectedValue): the
+    // guard bounds heartbeat to exactly two adapter.execute attempts, and a
+    // permanent override would otherwise leak into later tests since
+    // afterEach only mockClear()s call history, not implementations.
+    const mismatchOnce = async () => {
+      throw new AdapterRuntimeImageMismatchError(
+        "codex",
+        "sandbox pod",
+        "detect probe exited 127",
+      );
+    };
+    adapterExecute.mockImplementationOnce(mismatchOnce).mockImplementationOnce(mismatchOnce);
+
+    const heartbeat = heartbeatService(db, { pluginWorkerManager: workerManager });
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      contextSnapshot: { projectId },
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("failed");
+    }, { timeout: 5_000 });
+
+    const finalRun = await heartbeat.getRun(run!.id);
+    expect(finalRun?.errorCode).toBe("adapter_runtime_image_mismatch");
+    // Exactly one recovery attempt: two adapter.execute calls, one destroy,
+    // two acquires. A third attempt would mean the guard flag failed to
+    // bound the retry.
+    expect(adapterExecute).toHaveBeenCalledTimes(2);
+    const call = workerManager.call as unknown as ReturnType<typeof vi.fn>;
+    const acquireCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentAcquireLease");
+    const destroyCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentDestroyLease");
+    expect(acquireCalls).toHaveLength(2);
+    expect(destroyCalls).toHaveLength(1);
+  }, 15_000);
+});

--- a/server/src/__tests__/heartbeat-adapter-runtime-image-mismatch.test.ts
+++ b/server/src/__tests__/heartbeat-adapter-runtime-image-mismatch.test.ts
@@ -17,6 +17,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
+import { environmentService } from "../services/environments.ts";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.ts";
 import { AdapterRuntimeImageMismatchError } from "@paperclipai/adapter-utils/execution-target";
 
@@ -312,5 +313,93 @@ describeEmbeddedPostgres("heartbeat AdapterRuntimeImageMismatchError self-heal",
     const destroyCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentDestroyLease");
     expect(acquireCalls).toHaveLength(2);
     expect(destroyCalls).toHaveLength(1);
+  }, 15_000);
+
+  it("marks the mismatched lease failed (not released) when the destroy RPC throws and the healed retry succeeds", async () => {
+    // Review finding 1: if destroyRunLease's RPC throws, the plugin driver
+    // never reaches its own releaseLease(..., "failed", ...) call (that only
+    // happens AFTER a successful destroy), so the old lease row is left
+    // "active" and still tied to this run's heartbeatRunId. If the healed
+    // retry then succeeds, run teardown releases every lease still tied to
+    // the run with status "released" (leaseReleaseStatusForRunStatus mapping
+    // "succeeded" -> "released"), which would silently put a KNOWN-BAD lease
+    // back into the reusable pool. The self-heal's destroy-failure catch must
+    // mark that lease "failed" directly so it can never be resumed, while the
+    // fresh lease from the successful re-acquire is unaffected.
+    const { companyId: _companyId, projectId, pluginId, agentId } = await seedPluginSandboxRun({
+      environmentName: "Plugin Sandbox Self-heal Destroy-Failure",
+      projectName: "Plugin Environment Self-heal Destroy-Failure",
+    });
+
+    let acquireCount = 0;
+    const call = vi.fn(async (_pluginId: string, method: string) => {
+      if (method === "environmentAcquireLease") {
+        acquireCount += 1;
+        return {
+          providerLeaseId: `plugin-heartbeat-lease-${acquireCount}`,
+          metadata: {
+            remoteCwd: "/workspace/project",
+          },
+        };
+      }
+      if (method === "environmentDestroyLease") {
+        throw new Error("destroy RPC unavailable");
+      }
+      if (method === "environmentReleaseLease") {
+        return undefined;
+      }
+      throw new Error(`Unexpected plugin environment method: ${method}`);
+    });
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call,
+    } as unknown as PluginWorkerManager;
+
+    adapterExecute.mockImplementationOnce(async () => {
+      throw new AdapterRuntimeImageMismatchError(
+        "codex",
+        "sandbox pod plugin-heartbeat-lease-1",
+        "detect probe exited 127",
+      );
+    });
+
+    const heartbeat = heartbeatService(db, { pluginWorkerManager: workerManager });
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      contextSnapshot: { projectId },
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 5_000 });
+
+    expect(adapterExecute).toHaveBeenCalledTimes(2);
+    const acquireCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentAcquireLease");
+    const destroyCalls = call.mock.calls.filter(([, method]: [unknown, string]) => method === "environmentDestroyLease");
+    expect(acquireCalls).toHaveLength(2);
+    expect(destroyCalls).toHaveLength(1);
+
+    const environmentId = (acquireCalls[0][2] as { environmentId: string }).environmentId;
+    // Lease release happens in executeRun's `finally` block, after the run
+    // status is already persisted as "succeeded"; wait for it explicitly
+    // rather than racing it right after the run-status waitFor above.
+    let oldLease: Awaited<ReturnType<ReturnType<typeof environmentService>["listLeases"]>>[number] | undefined;
+    let newLease: Awaited<ReturnType<ReturnType<typeof environmentService>["listLeases"]>>[number] | undefined;
+    await vi.waitFor(async () => {
+      const leases = await environmentService(db).listLeases(environmentId);
+      oldLease = leases.find((lease) => lease.providerLeaseId === "plugin-heartbeat-lease-1");
+      newLease = leases.find((lease) => lease.providerLeaseId === "plugin-heartbeat-lease-2");
+      expect(newLease?.status).toBe("released");
+    }, { timeout: 5_000 });
+
+    expect(oldLease).toBeDefined();
+    expect(oldLease?.status).toBe("failed");
+    expect(oldLease?.status).not.toBe("released");
+
+    expect(newLease).toBeDefined();
+    expect(newLease?.status).toBe("released");
   }, 15_000);
 });

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -1,6 +1,7 @@
 import type {
   AdapterModelProfileDefinition,
   AdapterRuntimeCommandSpec,
+  AdapterRuntimeCommandSpecOptions,
   ServerAdapterModule,
 } from "./types.js";
 import { parseAdapterModelsEnv } from "../services/adapter-models-env.js";
@@ -144,9 +145,16 @@ function buildNpmRuntimeCommandSpec(
   config: Record<string, unknown>,
   fallbackCommand: string,
   packageName: string,
+  options?: AdapterRuntimeCommandSpecOptions,
 ): AdapterRuntimeCommandSpec {
   const command = readConfiguredCommand(config, fallbackCommand);
-  const canSelfInstall = !hasPathSeparator(command) && command === fallbackCommand;
+  // Managed, pre-baked sandbox images (plugin-backed providers behind locked
+  // egress) carry the CLI already. Never emit a network install for them: a
+  // missing CLI means the run landed on the wrong runtime image, and an install
+  // would just stall against a blocked egress until timeout. Fail-fast on the
+  // image mismatch is handled downstream in the execution target.
+  const canSelfInstall =
+    !options?.prebakedRuntime && !hasPathSeparator(command) && command === fallbackCommand;
   const installLine = buildSandboxNpmInstallCommand(packageName);
   return {
     command,
@@ -205,8 +213,8 @@ const claudeLocalAdapter: ServerAdapterModule = {
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: false,
-  getRuntimeCommandSpec: (config) =>
-    buildNpmRuntimeCommandSpec(config, "claude", "@anthropic-ai/claude-code"),
+  getRuntimeCommandSpec: (config, options) =>
+    buildNpmRuntimeCommandSpec(config, "claude", "@anthropic-ai/claude-code", options),
   agentConfigurationDoc: claudeAgentConfigurationDoc,
   getConfigSchema: getClaudeConfigSchema,
   getQuotaWindows: claudeGetQuotaWindows,
@@ -278,7 +286,8 @@ const codexLocalAdapter: ServerAdapterModule = {
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: false,
-  getRuntimeCommandSpec: (config) => buildNpmRuntimeCommandSpec(config, "codex", "@openai/codex"),
+  getRuntimeCommandSpec: (config, options) =>
+    buildNpmRuntimeCommandSpec(config, "codex", "@openai/codex", options),
   agentConfigurationDoc: codexAgentConfigurationDoc,
   getConfigSchema: getCodexConfigSchema,
   getQuotaWindows: codexGetQuotaWindows,
@@ -340,8 +349,8 @@ const geminiLocalAdapter: ServerAdapterModule = {
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: true,
-  getRuntimeCommandSpec: (config) =>
-    buildNpmRuntimeCommandSpec(config, "gemini", "@google/gemini-cli"),
+  getRuntimeCommandSpec: (config, options) =>
+    buildNpmRuntimeCommandSpec(config, "gemini", "@google/gemini-cli", options),
   agentConfigurationDoc: geminiAgentConfigurationDoc,
   getConfigSchema: getGeminiConfigSchema,
 };
@@ -397,7 +406,8 @@ const openCodeLocalAdapter: ServerAdapterModule = {
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: true,
-  getRuntimeCommandSpec: (config) => buildNpmRuntimeCommandSpec(config, "opencode", "opencode-ai"),
+  getRuntimeCommandSpec: (config, options) =>
+    buildNpmRuntimeCommandSpec(config, "opencode", "opencode-ai", options),
   agentConfigurationDoc: openCodeAgentConfigurationDoc,
 };
 
@@ -416,8 +426,8 @@ const piLocalAdapter: ServerAdapterModule = {
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: true,
-  getRuntimeCommandSpec: (config) =>
-    buildNpmRuntimeCommandSpec(config, "pi", "@mariozechner/pi-coding-agent"),
+  getRuntimeCommandSpec: (config, options) =>
+    buildNpmRuntimeCommandSpec(config, "pi", "@mariozechner/pi-coding-agent", options),
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 

--- a/server/src/adapters/types.ts
+++ b/server/src/adapters/types.ts
@@ -31,5 +31,6 @@ export type {
   ConfigFieldSchema,
   AdapterConfigSchema,
   AdapterRuntimeCommandSpec,
+  AdapterRuntimeCommandSpecOptions,
   ServerAdapterModule,
 } from "@paperclipai/adapter-utils";

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -386,6 +386,11 @@ export function agentRoutes(
         issueId: null,
         heartbeatRunId: null,
         persistedExecutionWorkspace: null,
+        // Pin the Test lease to the agent's own adapter so the sandbox boots the
+        // harness image the Test will exec against (matching real agent runs). It
+        // also keeps the lease from being an adapter-less one, which a plugin that
+        // cannot prove a single-adapter environment now rejects.
+        adapterType: input.adapterType,
         // Apply the active custom-image template so the Test boots with the
         // operator's captured sandbox customizations and prepared image state,
         // matching what real agent runs use. Without this the test would

--- a/server/src/services/environment-execution-target.ts
+++ b/server/src/services/environment-execution-target.ts
@@ -63,12 +63,17 @@ export async function resolveEnvironmentExecutionTarget(input: {
         ? input.leaseMetadata.shellCommand
         : null;
 
-    // Plugin-backed sandbox providers own their runtime images (built per
-    // adapter, contractually complete) and run behind a locked egress, so the
-    // in-sandbox network-install shim must never fire for them. Built-in
-    // sandbox providers (e.g. e2b) keep the install path. The lease metadata's
-    // `sandboxProviderPlugin` flag is the existing discriminator.
-    const prebakedRuntime = input.leaseMetadata?.sandboxProviderPlugin === true;
+    // Disable the in-sandbox network-install shim ONLY for providers that
+    // explicitly declare their runtime images are pre-baked / contractually
+    // complete (adapter CLI already on PATH, run behind a locked egress) — the
+    // per-lease `runtimeImagePrebaked` capability signal. We must NOT key off the
+    // generic "plugin-backed" marker (`sandboxProviderPlugin`): a provider plugin
+    // that ships a GENERIC sandbox and legitimately relies on runtime
+    // installation would otherwise be wrongly marked pre-baked, dropping its
+    // install (Layer 3) and turning a provisionable run into a spurious
+    // `adapter_runtime_image_mismatch`. Such a plugin omits the flag and keeps
+    // the install path; built-in sandbox providers (e.g. e2b) never set it.
+    const prebakedRuntime = input.leaseMetadata?.runtimeImagePrebaked === true;
 
     return {
       kind: "remote",

--- a/server/src/services/environment-execution-target.ts
+++ b/server/src/services/environment-execution-target.ts
@@ -63,6 +63,13 @@ export async function resolveEnvironmentExecutionTarget(input: {
         ? input.leaseMetadata.shellCommand
         : null;
 
+    // Plugin-backed sandbox providers own their runtime images (built per
+    // adapter, contractually complete) and run behind a locked egress, so the
+    // in-sandbox network-install shim must never fire for them. Built-in
+    // sandbox providers (e.g. e2b) keep the install path. The lease metadata's
+    // `sandboxProviderPlugin` flag is the existing discriminator.
+    const prebakedRuntime = input.leaseMetadata?.sandboxProviderPlugin === true;
+
     return {
       kind: "remote",
       transport: "sandbox",
@@ -72,6 +79,7 @@ export async function resolveEnvironmentExecutionTarget(input: {
       environmentId: input.environment.id ?? null,
       leaseId: input.leaseId ?? null,
       timeoutMs,
+      prebakedRuntime,
       // Run-log streaming defaults ON for sandbox environments so agent CLI
       // output reaches the UI mid-run; `streamRunLogs: false` is an explicit
       // opt-out back to batch-at-end delivery.

--- a/server/src/services/environment-probe.ts
+++ b/server/src/services/environment-probe.ts
@@ -75,6 +75,17 @@ export async function probeEnvironment(
           archiveOnRelease: true,
         },
       };
+      // A connectivity probe carries no per-run harness. A mixed-harness pool now
+      // rejects an absent per-run adapter (a real run must never fall back to a
+      // different harness's image); pin the probe to the environment's configured
+      // default adapter so it deterministically boots one valid image instead of
+      // being rejected. Providers without a default adapter fall through to null
+      // (single-adapter / non-adapter providers keep the prior behavior).
+      const defaultAdapterType =
+        typeof (parsed.config as Record<string, unknown>).adapterType === "string" &&
+        ((parsed.config as Record<string, unknown>).adapterType as string).trim().length > 0
+          ? ((parsed.config as Record<string, unknown>).adapterType as string).trim()
+          : null;
       let leaseRecord: Awaited<ReturnType<typeof runtime.acquireRunLease>> | null = null;
       let releaseStatus: "released" | "failed" = "released";
       try {
@@ -85,7 +96,7 @@ export async function probeEnvironment(
           agentId: null,
           heartbeatRunId: null,
           persistedExecutionWorkspace: null,
-          adapterType: null,
+          adapterType: defaultAdapterType,
           applyCustomImageTemplate: options.applyCustomImageTemplate === true,
         });
         const metadata = leaseRecord.lease.metadata ?? {};

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -411,6 +411,17 @@ function buildReusableSandboxLeaseScope(input: {
   config: Record<string, unknown>;
   leaseFingerprint?: EffectiveRunConfigFingerprint | null;
   providerMetadata?: Record<string, unknown> | null;
+  // Mirrors the `sandboxProviderPlugin === true` gate that
+  // reusableSandboxLeaseScopeMatches uses for its strict adapterType-equality
+  // rule. Only plugin-backed sandbox leases resolve a per-run adapter/image
+  // through the plugin worker RPC, so only they may fall back to reading
+  // adapterType/image out of providerMetadata; a built-in provider's
+  // providerMetadata is not per-run-image-keyed the way the plugin pool is,
+  // so treating any stray adapterType/image key there as a positive match
+  // would be unfounded. Built-in callers omit this flag (default false),
+  // making the fallback inert for them today; it exists so the two functions
+  // stay symmetric if a built-in provider ever starts publishing those keys.
+  isPluginBackedLease?: boolean;
 }): Record<string, unknown> | null {
   if (!input.executionWorkspaceId || !input.agentId) return null;
   const providerMetadata = input.providerMetadata ?? {};
@@ -420,8 +431,11 @@ function buildReusableSandboxLeaseScope(input: {
   // scope from ever being null for a plugin sandbox lease that DID resolve a
   // concrete adapter/image: a null scope has no positive proof of which
   // image the pod carries and can be matched by any run's reuse lookup.
-  const adapterType = input.adapterType ?? readString(providerMetadata.adapterType) ?? null;
-  const runtimeImage = readString(providerMetadata.image);
+  const adapterType =
+    input.adapterType ??
+    (input.isPluginBackedLease ? readString(providerMetadata.adapterType) : null) ??
+    null;
+  const runtimeImage = input.isPluginBackedLease ? readString(providerMetadata.image) : null;
   const remoteCwd = readString(providerMetadata.remoteCwd);
   const workspaceSentinel = isRecord(providerMetadata.workspaceSentinel)
     ? { ...providerMetadata.workspaceSentinel }
@@ -952,6 +966,7 @@ function createSandboxEnvironmentDriver(
               config: providerConfigForLease,
               leaseFingerprint,
               providerMetadata: sanitizedProviderMetadata,
+              isPluginBackedLease: true,
             })
           : null;
 

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -456,12 +456,30 @@ function reusableSandboxLeaseScopeMatches(input: {
   const scope = input.lease.metadata?.reusableSandboxLease;
   if (!isRecord(scope)) return false;
   const adapterType = input.adapterType ?? null;
+  const storedAdapterType = typeof scope.adapterType === "string" ? scope.adapterType : null;
+  // Plugin-backed sandbox leases pick a per-run runtime image keyed on the
+  // adapter type; a lease published (or resumed from before this fix) with
+  // adapterType null carries no positive proof of which image its pod is
+  // running. Treating null as a wildcard let ANY run reuse it, including one
+  // requesting a different harness (the production adapter_runtime_image_mismatch
+  // case this closes). Require a POSITIVE match instead: both sides must be
+  // set and equal, never null-on-either-side.
+  //
+  // Built-in (non-plugin) sandbox providers never publish adapterType in the
+  // scope at all (they are not per-run-image-keyed the way the plugin pool
+  // is), so their leases legitimately keep the permissive equality check:
+  // scoping the strict rule to `sandboxProviderPlugin === true` leaves that
+  // reuse path unaffected.
+  const isPluginBackedLease = input.lease.metadata?.sandboxProviderPlugin === true;
+  const adapterTypeMatches = isPluginBackedLease
+    ? storedAdapterType !== null && adapterType !== null && storedAdapterType === adapterType
+    : scope.adapterType === adapterType;
   const baseScopeMatches =
     scope.companyId === input.companyId &&
     scope.environmentId === input.environmentId &&
     scope.executionWorkspaceId === input.executionWorkspaceId &&
     scope.agentId === input.agentId &&
-    scope.adapterType === adapterType &&
+    adapterTypeMatches &&
     scope.provider === input.provider;
   if (!baseScopeMatches) return false;
 

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -414,7 +414,14 @@ function buildReusableSandboxLeaseScope(input: {
 }): Record<string, unknown> | null {
   if (!input.executionWorkspaceId || !input.agentId) return null;
   const providerMetadata = input.providerMetadata ?? {};
-  const adapterType = input.adapterType ?? null;
+  // Prefer the server's own per-run hint; fall back to the plugin's actually
+  // resolved adapter type when the server's hint is absent (e.g. a run whose
+  // adapterType wasn't threaded through). This is what keeps the persisted
+  // scope from ever being null for a plugin sandbox lease that DID resolve a
+  // concrete adapter/image: a null scope has no positive proof of which
+  // image the pod carries and can be matched by any run's reuse lookup.
+  const adapterType = input.adapterType ?? readString(providerMetadata.adapterType) ?? null;
+  const runtimeImage = readString(providerMetadata.image);
   const remoteCwd = readString(providerMetadata.remoteCwd);
   const workspaceSentinel = isRecord(providerMetadata.workspaceSentinel)
     ? { ...providerMetadata.workspaceSentinel }
@@ -435,6 +442,7 @@ function buildReusableSandboxLeaseScope(input: {
     ...(input.leaseFingerprint
       ? { leaseFingerprint: serializeLeaseFingerprint(input.leaseFingerprint) }
       : {}),
+    ...(runtimeImage ? { runtimeImage } : {}),
     ...(remoteCwd ? { remoteCwd } : {}),
     ...(workspaceSentinel ? { workspaceSentinel } : {}),
   };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13561,7 +13561,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           runtime: runtimeForAdapter,
           config: runtimeConfig,
           context: adapterContext,
-          runtimeCommandSpec: adapter.getRuntimeCommandSpec?.(runtimeConfig) ?? null,
+          runtimeCommandSpec:
+            adapter.getRuntimeCommandSpec?.(runtimeConfig, {
+              // A managed, pre-baked sandbox image carries the CLI already; never
+              // emit a network install for it (locked egress would stall it until
+              // timeout). The execution target fails fast on an image mismatch.
+              prebakedRuntime:
+                executionTarget?.kind === "remote" &&
+                executionTarget.transport === "sandbox" &&
+                executionTarget.prebakedRuntime === true,
+            }) ?? null,
           executionTarget,
           executionTransport: remoteExecution
             ? { remoteExecution: remoteExecution as unknown as Record<string, unknown> }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -248,6 +248,7 @@ import { parseExecutionPolicyBootstrapEnv } from "./execution-policy-bootstrap.j
 import { environmentRuntimeService } from "./environment-runtime.js";
 import { skillVersionSelectionMap } from "./runtime-skill-selections.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
+import { isAdapterRuntimeImageMismatchError } from "@paperclipai/adapter-utils/execution-target";
 import { isUnsafeSessionWorkspaceCwd } from "./session-workspace-cwd.js";
 import {
   clearHeartbeatRunRuntimeStatus,
@@ -11764,6 +11765,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     activeRunExecutions.add(run.id);
     let runScratch: HeartbeatRunScratch | null = null;
+    // Self-heal guard for AdapterRuntimeImageMismatchError (a run landed on a
+    // sandbox pod whose runtime image does not carry the harness CLI). Flip
+    // to true the first time recovery is attempted so a second mismatch on
+    // the SAME run surfaces the original typed error terminally instead of
+    // looping.
+    let imageMismatchRecoveryAttempted = false;
 
     try {
     const agent = await getAgent(run.agentId);
@@ -12785,9 +12792,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       lease: realizationResult.lease,
     };
     persistedExecutionWorkspace = realizationResult.persistedExecutionWorkspace;
-    const workspaceRealization = realizationResult.workspaceRealization;
-    const executionTarget = realizationResult.executionTarget;
-    const remoteExecution = realizationResult.remoteExecution;
+    // `let`, not `const`: a first-attempt AdapterRuntimeImageMismatchError
+    // re-acquires and re-realizes the environment (see
+    // recoverEnvironmentLeaseAfterImageMismatch below), which replaces these
+    // with the values from the fresh lease.
+    let workspaceRealization = realizationResult.workspaceRealization;
+    let executionTarget = realizationResult.executionTarget;
+    let remoteExecution = realizationResult.remoteExecution;
+    // Shared with the AdapterRuntimeImageMismatchError self-heal below: both
+    // the initial setup and the post-recovery re-realization publish the
+    // same contextSnapshot shape, so the field list only lives in one place.
+    const buildPaperclipEnvironmentContext = () => ({
+      id: selectedEnvironment.id,
+      name: selectedEnvironment.name,
+      driver: selectedEnvironment.driver,
+      leaseId: activeEnvironmentLease.lease.id,
+      workspaceRealization,
+      ...(typeof activeEnvironmentLease.lease.metadata?.remoteCwd === "string"
+        ? {
+            remoteCwd: activeEnvironmentLease.lease.metadata.remoteCwd,
+            host:
+              typeof activeEnvironmentLease.lease.metadata?.host === "string"
+                ? activeEnvironmentLease.lease.metadata.host
+                : undefined,
+            port:
+              typeof activeEnvironmentLease.lease.metadata?.port === "number"
+                ? activeEnvironmentLease.lease.metadata.port
+                : undefined,
+            username:
+              typeof activeEnvironmentLease.lease.metadata?.username === "string"
+                ? activeEnvironmentLease.lease.metadata.username
+                : undefined,
+          }
+        : {}),
+    });
     if (!executionTarget || executionTarget.kind === "local") {
       try {
         runScratch = await prepareHeartbeatRunScratch({
@@ -12829,30 +12867,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } else {
       delete context.paperclipScratch;
     }
-    context.paperclipEnvironment = {
-      id: selectedEnvironment.id,
-      name: selectedEnvironment.name,
-      driver: selectedEnvironment.driver,
-      leaseId: activeEnvironmentLease.lease.id,
-      workspaceRealization,
-      ...(typeof activeEnvironmentLease.lease.metadata?.remoteCwd === "string"
-        ? {
-            remoteCwd: activeEnvironmentLease.lease.metadata.remoteCwd,
-            host:
-              typeof activeEnvironmentLease.lease.metadata?.host === "string"
-                ? activeEnvironmentLease.lease.metadata.host
-                : undefined,
-            port:
-              typeof activeEnvironmentLease.lease.metadata?.port === "number"
-                ? activeEnvironmentLease.lease.metadata.port
-                : undefined,
-            username:
-              typeof activeEnvironmentLease.lease.metadata?.username === "string"
-                ? activeEnvironmentLease.lease.metadata.username
-                : undefined,
-          }
-        : {}),
-    };
+    context.paperclipEnvironment = buildPaperclipEnvironmentContext();
     await db
       .update(heartbeatRuns)
       .set({
@@ -13535,8 +13550,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         adapterFinalizeOutcome = status;
       };
 
-      let adapterResult: Awaited<ReturnType<typeof adapter.execute>>;
-      try {
+      // Runs the adapter once against the CURRENT (possibly re-acquired)
+      // lease/executionTarget. Extracted so the AdapterRuntimeImageMismatchError
+      // self-heal below can call it a second time, after
+      // recoverEnvironmentLeaseAfterImageMismatch has refreshed the closed-over
+      // executionTarget/remoteExecution, without duplicating the MCP/context
+      // setup.
+      const runAdapterExecuteAttempt = async (): Promise<Awaited<ReturnType<typeof adapter.execute>>> => {
         const adapterContext = { ...context };
         const runtimeMcpServers = await buildPaperclipRuntimeMcpServers({
           db,
@@ -13555,7 +13575,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (managedMcpConfig) {
           adapterContext.paperclipManagedMcp = managedMcpConfig;
         }
-        adapterResult = await adapter.execute({
+        return await adapter.execute({
           runId: run.id,
           agent,
           runtime: runtimeForAdapter,
@@ -13594,6 +13614,101 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
           authToken: authToken ?? undefined,
         });
+      };
+
+      // Gap-2 self-heal (closes what #9950's fail-fast gate left open): the
+      // gate detects a run on the wrong runtime image but does not recover.
+      // Destroy the mismatched lease and re-acquire + re-realize the
+      // environment ONCE so the retried adapter.execute has a chance to land
+      // on a pod carrying the right harness. There is no existing in-run
+      // setup-retry seam in heartbeat.ts to hook (EnvironmentRunError from
+      // acquireForRun/realizeForRun is not retried anywhere today); this is
+      // the narrowest insertion point available short of restructuring the
+      // ~800-line acquire/realize/execute sequence into a generic retry loop.
+      const recoverEnvironmentLeaseAfterImageMismatch = async (): Promise<void> => {
+        logger.warn(
+          {
+            runId: run.id,
+            issueId,
+            agentId: agent.id,
+            environmentId: selectedEnvironment.id,
+            leaseId: activeEnvironmentLease.lease.id,
+          },
+          "adapter runtime image mismatch on sandbox lease; destroying lease and re-acquiring once",
+        );
+        try {
+          await envOrchestrator.runtime.destroyRunLease({
+            environment: activeEnvironmentLease.environment,
+            lease: activeEnvironmentLease.lease,
+            failureReason: "adapter_runtime_image_mismatch",
+          });
+        } catch (destroyErr) {
+          logger.warn(
+            { err: destroyErr, runId: run.id, leaseId: activeEnvironmentLease.lease.id },
+            "failed to destroy mismatched sandbox lease before re-acquiring; continuing with re-acquire",
+          );
+        }
+
+        const reacquiredEnvironment = await envOrchestrator.acquireForRun({
+          companyId: agent.companyId,
+          selectedEnvironmentId,
+          localEnvironmentId: localEnvironment.id,
+          adapterType: agent.adapterType,
+          issueId: issueId ?? null,
+          heartbeatRunId: run.id,
+          agentId: agent.id,
+          persistedExecutionWorkspace,
+        });
+        activeEnvironmentLease = {
+          environment: reacquiredEnvironment.environment,
+          lease: reacquiredEnvironment.lease,
+          leaseContext: reacquiredEnvironment.leaseContext,
+        };
+        const rerealizationResult = await envOrchestrator.realizeForRun({
+          environment: selectedEnvironment,
+          lease: activeEnvironmentLease.lease,
+          adapterType: agent.adapterType,
+          companyId: agent.companyId,
+          issueId: issueId ?? null,
+          heartbeatRunId: run.id,
+          executionWorkspace,
+          effectiveExecutionWorkspaceMode,
+          persistedExecutionWorkspace,
+        });
+        activeEnvironmentLease = {
+          ...activeEnvironmentLease,
+          lease: rerealizationResult.lease,
+        };
+        persistedExecutionWorkspace = rerealizationResult.persistedExecutionWorkspace;
+        workspaceRealization = rerealizationResult.workspaceRealization;
+        executionTarget = rerealizationResult.executionTarget;
+        remoteExecution = rerealizationResult.remoteExecution;
+        context.paperclipEnvironment = buildPaperclipEnvironmentContext();
+        await db
+          .update(heartbeatRuns)
+          .set({
+            contextSnapshot: context,
+            updatedAt: new Date(),
+          })
+          .where(eq(heartbeatRuns.id, run.id));
+      };
+
+      const recordAdapterFinalizeFailure = async (err: unknown) => {
+        try {
+          await recordWorkspaceFinalize("failed", {
+            errorMessage: err instanceof Error ? err.message : String(err),
+          });
+        } catch (recordErr) {
+          logger.warn(
+            { err: recordErr, runId: run.id, executionWorkspaceId: persistedExecutionWorkspace?.id ?? null },
+            "failed to record workspace_finalize=failed operation; dependents may remain gated",
+          );
+        }
+      };
+
+      let adapterResult: Awaited<ReturnType<typeof adapter.execute>>;
+      try {
+        adapterResult = await runAdapterExecuteAttempt();
         // Adapter returned cleanly, which means its workspace-restore finally
         // block also ran without throwing. Record the workspace_finalize
         // barrier so dependents that share this executionWorkspace can wake.
@@ -13602,22 +13717,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // finalize row.
         await recordWorkspaceFinalize("succeeded");
       } catch (adapterErr) {
-        // Adapter (or its restore finally) threw — or the finalize record
-        // write itself threw. Either way the workspace may be in a partial
-        // state. Best-effort record finalize=failed so the dependent readiness
-        // check keeps the gate closed instead of waking on stale local state,
-        // and surface the original error to the caller.
-        try {
-          await recordWorkspaceFinalize("failed", {
-            errorMessage: adapterErr instanceof Error ? adapterErr.message : String(adapterErr),
-          });
-        } catch (recordErr) {
-          logger.warn(
-            { err: recordErr, runId: run.id, executionWorkspaceId: persistedExecutionWorkspace?.id ?? null },
-            "failed to record workspace_finalize=failed operation; dependents may remain gated",
-          );
+        if (isAdapterRuntimeImageMismatchError(adapterErr) && !imageMismatchRecoveryAttempted) {
+          imageMismatchRecoveryAttempted = true;
+          try {
+            await recoverEnvironmentLeaseAfterImageMismatch();
+            adapterResult = await runAdapterExecuteAttempt();
+            await recordWorkspaceFinalize("succeeded");
+          } catch (retryErr) {
+            // Either recovery itself failed (e.g. the re-acquire could not
+            // find a healthy lease) or the retried adapter.execute mismatched
+            // again. Either way this run gets exactly one recovery attempt:
+            // surface whatever the second attempt threw as the terminal
+            // failure (the same AdapterRuntimeImageMismatchError on a repeat
+            // mismatch; a different error if recovery infrastructure itself
+            // failed).
+            await recordAdapterFinalizeFailure(retryErr);
+            throw retryErr;
+          }
+        } else {
+          // Adapter (or its restore finally) threw, or the finalize record
+          // write itself threw. Either way the workspace may be in a partial
+          // state. Best-effort record finalize=failed so the dependent readiness
+          // check keeps the gate closed instead of waking on stale local state,
+          // and surface the original error to the caller.
+          await recordAdapterFinalizeFailure(adapterErr);
+          throw adapterErr;
         }
-        throw adapterErr;
       } finally {
         try {
           await revokeHeartbeatRunGatewayTokens({
@@ -14004,10 +14129,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode((await getRun(run.id).catch(() => null))?.errorCode);
+      // A repeat adapter_runtime_image_mismatch (the one-shot self-heal above
+      // already destroyed+re-acquired once and still landed on the wrong
+      // image) surfaces its own typed error code instead of the generic
+      // adapter_failed, so operators see the real cause on the terminal run.
+      const adapterRuntimeImageMismatchFailure = isAdapterRuntimeImageMismatchError(err) ? err : null;
       const failureErrorCode =
         workspaceValidationFailure?.code
         ?? configurationIncompleteFailure?.code
         ?? recordedResponsibleUserDenialCode
+        ?? adapterRuntimeImageMismatchFailure?.code
         ?? "adapter_failed";
       logger.error({ err, runId }, "heartbeat execution failed");
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12746,7 +12746,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agentId: agent.id,
       persistedExecutionWorkspace,
     });
-    const selectedEnvironment = acquiredEnvironment.environment;
+    // `let`, not `const`: the AdapterRuntimeImageMismatchError self-heal
+    // (recoverEnvironmentLeaseAfterImageMismatch below) re-acquires the
+    // environment and must update this reference too, so the re-realization
+    // call uses the fresh environment rather than the one from before
+    // recovery.
+    let selectedEnvironment = acquiredEnvironment.environment;
     // Defense-in-depth: re-check the actually-acquired environment against the
     // execution allowlist. Even if selection were bypassed, a denied (local/ssh/
     // non-k8s) environment FAILS the run here rather than executing untrusted.
@@ -13636,6 +13641,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
           "adapter runtime image mismatch on sandbox lease; destroying lease and re-acquiring once",
         );
+        const mismatchedLeaseId = activeEnvironmentLease.lease.id;
         try {
           await envOrchestrator.runtime.destroyRunLease({
             environment: activeEnvironmentLease.environment,
@@ -13644,9 +13650,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           });
         } catch (destroyErr) {
           logger.warn(
-            { err: destroyErr, runId: run.id, leaseId: activeEnvironmentLease.lease.id },
+            { err: destroyErr, runId: run.id, leaseId: mismatchedLeaseId },
             "failed to destroy mismatched sandbox lease before re-acquiring; continuing with re-acquire",
           );
+          // The destroy RPC threw before the driver's destroyRunLease could
+          // mark this lease "failed" (that only happens AFTER a successful
+          // destroy), so the row is still "active" and still owned by this
+          // run's heartbeatRunId. If the healed retry below succeeds, run
+          // teardown (releaseEnvironmentLeasesForRun ->
+          // leaseReleaseStatusForRunStatus("succeeded")) releases every lease
+          // still tied to this run with status "released", which would put
+          // this KNOWN-BAD lease back into the reusable pool. Mark it
+          // non-reusable directly here, mirroring the exact call the driver's
+          // destroyRunLease would have made on success. Best-effort: this
+          // must not block recovery from proceeding even if it also fails.
+          try {
+            await environmentsSvc.releaseLease(mismatchedLeaseId, "failed", {
+              failureReason: "adapter_runtime_image_mismatch",
+            });
+          } catch (markFailedErr) {
+            logger.warn(
+              { err: markFailedErr, runId: run.id, leaseId: mismatchedLeaseId },
+              "failed to mark mismatched sandbox lease as failed after destroy RPC error; it may remain reusable",
+            );
+          }
         }
 
         const reacquiredEnvironment = await envOrchestrator.acquireForRun({
@@ -13664,6 +13691,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           lease: reacquiredEnvironment.lease,
           leaseContext: reacquiredEnvironment.leaseContext,
         };
+        // Keep selectedEnvironment in sync with the freshly reacquired
+        // environment (same pattern as the initial setup, which sources it
+        // from acquiredEnvironment.environment) so the re-realization call
+        // below never uses the stale pre-recovery reference.
+        selectedEnvironment = reacquiredEnvironment.environment;
         const rerealizationResult = await envOrchestrator.realizeForRun({
           environment: selectedEnvironment,
           lease: activeEnvironmentLease.lease,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Cloud agents execute in per-run k8s sandbox pods, each built from a per-adapter pre-baked runtime image that already contains the harness CLI.
> - The image is chosen by the sandbox plugin from the run's adapter type, but that resolution can fall back to a different default adapter, while the server separately emits the true adapter's install-spec.
> - When the two disagree, a run lands on the wrong image (CLI absent) and the server tries to network-install the CLI, which a sovereign locked-egress sandbox blocks, so the run fails with a confusing timeout.
> - This pull request stops routing a run onto a different harness's image, fails fast when the expected CLI is absent on a pre-baked sandbox, and never attempts a runtime network install there.
> - The benefit is that adapter/image mismatches become an immediate, clear error instead of a doomed multi-minute install.

## Linked Issues or Issue Description

No public issue exists; the underlying bug is described inline below, following the bug report template.

**What happened**

A `gemini_local` run landed on a sandbox pod that was not the Gemini image (the plugin's `resolveRunAdapterType` fell back to the env-default adapter when the per-run adapter was absent), so `gemini` was not on PATH, so the server's runtime-install shim tried to `curl nodejs.org | npm install -g @google/gemini-cli` inside a locked-egress sandbox and failed with `adapter_failed: Failed to install the adapter runtime command via: ...`.

**Expected behavior**

A run must execute on the pre-baked image for its own adapter (never a different harness's image); if the expected CLI is somehow absent on a managed/pre-baked sandbox, fail immediately with a clear image-mismatch error rather than attempting a network install that cannot succeed under locked egress.

**Steps to reproduce**

1. Trigger a run whose per-run adapter type is absent at the lease (e.g. a probe or a reused legacy lease) for a non-default adapter such as `gemini_local`.
2. Observe the pod is the default (opencode) image and the run fails after a ~5-minute timeout trying to `npm install` the missing CLI.

## What Changed

- `resolveRunAdapterType` gains an opt-in `requireRunAdapter` (plugin config `requireRunAdapterType`, default false): when set, an absent per-run adapter throws `RunAdapterRequiredError` instead of silently substituting the default adapter's image.
- Pre-flight fail-fast: on a managed/pre-baked sandbox (`prebakedRuntime`, derived from the lease's sandbox-provider plugin), a missing detect CLI throws a typed `AdapterRuntimeImageMismatchError` (`adapter_runtime_image_mismatch`) immediately, never attempting an install.
- `buildNpmRuntimeCommandSpec` emits `installCommand: null` for pre-baked sandboxes, so the doomed runtime network install is never generated.

## Verification

- New tests: `resolveRunAdapterType` throws (not falls back) when required and the per-run adapter is absent; a missing CLI on a pre-baked sandbox yields `adapter_runtime_image_mismatch` (no install attempt); `buildNpmRuntimeCommandSpec` emits no install command for a pre-baked sandbox. Red→green demonstrated by neutralizing each decision.
- k8s plugin, adapter-utils, and server registry packages typecheck + build clean; targeted suites pass (k8s plugin 157/157, adapter-utils sandbox 28/28, server registry 15/15).

## Risks

Low. Layer 1 is opt-in so existing single-adapter/probe flows are unchanged unless `requireRunAdapterType` is enabled. Layers 2 and 3 only change behavior on the already-broken path (missing CLI on a pre-baked sandbox): a confusing 5-minute install timeout becomes an immediate, correct error. No egress is opened.

## Model Used

Claude (Anthropic), model ID `claude-fable-5`, extended reasoning, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


---

## Update: reuse-lease validation + self-heal (2 more protection layers)

The original fail-fast gate detects a wrong-harness image but neither prevents nor recovers from it. Three added commits close both gaps:

- **Positive adapter match for plugin lease reuse** — a plugin-backed reusable lease with a null/absent `scope.adapterType` can no longer be matched by any run; reuse now requires positive adapter-type equality. Built-in (non-plugin) provider reuse is unchanged (the strict rule is gated on the `sandboxProviderPlugin` signal).
- **Persist resolved adapter + image in lease metadata** — so plugin lease scopes are never null at pool-publish time.
- **One-shot self-heal on `AdapterRuntimeImageMismatchError`** — destroy the mis-leased sandbox and re-acquire + re-execute exactly once per run; a second mismatch surfaces the typed error terminally. If the destroy RPC fails, the mismatched lease is marked non-reusable directly so a subsequently-succeeding run cannot return a known-bad pod to the pool.
