### PR TITLE
feat(ui): prompt to reload when a new build is deployed

### DIFF
--- a/ui/src/components/AppUpdateBanner.tsx
+++ b/ui/src/components/AppUpdateBanner.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { RefreshCw, X } from "lucide-react";
+import { getLoadedBundleId, startAppUpdateWatcher } from "../lib/app-update-check";
+
+/**
+ * Shows a persistent, dismissible banner when a newer frontend build has been
+ * deployed while this tab was open, so long-lived tabs don't keep running a
+ * stale (possibly buggy) bundle until they happen to reload. See
+ * `lib/app-update-check.ts` for how a new build is detected.
+ */
+export function AppUpdateBanner() {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const stop = startAppUpdateWatcher({
+      currentBundleId: getLoadedBundleId(),
+      onUpdateAvailable: () => setUpdateAvailable(true),
+    });
+    return stop;
+  }, []);
+
+  if (!updateAvailable || dismissed) return null;
+
+  return (
+    <aside
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-3 right-3 z-(--z-120) w-full max-w-sm px-1"
+    >
+      <div className="pointer-events-auto rounded-sm border border-sky-300 bg-sky-50 text-sky-900 shadow-lg backdrop-blur-xl dark:border-sky-500/25 dark:bg-sky-950/60 dark:text-sky-100">
+        <div className="flex items-start gap-3 px-3 py-2.5">
+          <RefreshCw className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold leading-5">A new version is available</p>
+            <p className="mt-1 text-xs leading-4 opacity-70">Reload to get the latest update.</p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-2 inline-flex text-xs font-medium underline underline-offset-4 hover:opacity-90"
+            >
+              Reload
+            </button>
+          </div>
+          <button
+            type="button"
+            aria-label="Dismiss update notice"
+            onClick={() => setDismissed(true)}
+            className="mt-0.5 shrink-0 rounded p-1 opacity-50 hover:bg-black/10 hover:opacity-100 dark:hover:bg-white/10"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/ui/src/components/AppUpdateBanner.tsx
+++ b/ui/src/components/AppUpdateBanner.tsx
@@ -26,7 +26,10 @@ export function AppUpdateBanner() {
     <aside
       role="status"
       aria-live="polite"
-      className="fixed bottom-3 right-3 z-(--z-120) w-full max-w-sm px-1"
+      // Below md the toast viewport (bottom-left, w-full) spans the width, so
+      // sit at the top to avoid overlapping it; from md up there is room for
+      // both bottom corners.
+      className="fixed right-3 top-3 z-(--z-120) w-full max-w-sm px-1 md:top-auto md:bottom-3"
     >
       <div className="pointer-events-auto rounded-sm border border-sky-300 bg-sky-50 text-sky-900 shadow-lg backdrop-blur-xl dark:border-sky-500/25 dark:bg-sky-950/60 dark:text-sky-100">
         <div className="flex items-start gap-3 px-3 py-2.5">

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -15,6 +15,7 @@ import { NewGoalDialog } from "./NewGoalDialog";
 import { NewAgentDialog } from "./NewAgentDialog";
 import { KeyboardShortcutsCheatsheet } from "./KeyboardShortcutsCheatsheet";
 import { ToastViewport } from "./ToastViewport";
+import { AppUpdateBanner } from "./AppUpdateBanner";
 import { MobileBottomNav } from "./MobileBottomNav";
 import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
@@ -658,6 +659,7 @@ export function Layout() {
       <NewAgentDialog />
       <KeyboardShortcutsCheatsheet open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
       <ToastViewport />
+      <AppUpdateBanner />
       </div>
     </GeneralSettingsProvider>
   );

--- a/ui/src/lib/app-update-check.test.ts
+++ b/ui/src/lib/app-update-check.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getLoadedBundleId,
+  parseBundleIdFromHtml,
+  startAppUpdateWatcher,
+} from "./app-update-check";
+
+describe("parseBundleIdFromHtml", () => {
+  it("extracts the hashed entry bundle from index.html", () => {
+    const html = `<!doctype html><html><head>
+      <script type="module" crossorigin src="/assets/index-B85r4qUa.js"></script>
+      <link rel="stylesheet" href="/assets/index-abc123.css"></head><body></body></html>`;
+    expect(parseBundleIdFromHtml(html)).toBe("index-B85r4qUa.js");
+  });
+
+  it("returns null when no entry bundle is present", () => {
+    expect(parseBundleIdFromHtml("<html><head></head><body></body></html>")).toBeNull();
+  });
+});
+
+describe("getLoadedBundleId", () => {
+  it("reads the bundle filename from a script tag", () => {
+    const doc = {
+      querySelectorAll: () => [
+        { getAttribute: () => "/assets/vendor-x.js" },
+        { getAttribute: () => "https://host/assets/index-CB24WRl4.js" },
+      ],
+    } as unknown as Document;
+    expect(getLoadedBundleId(doc)).toBe("index-CB24WRl4.js");
+  });
+});
+
+describe("startAppUpdateWatcher", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("fires once when the deployed bundle differs, then latches", async () => {
+    const onUpdate = vi.fn();
+    let deployed = "index-AAA.js";
+    const stop = startAppUpdateWatcher({
+      currentBundleId: "index-AAA.js",
+      onUpdateAvailable: onUpdate,
+      intervalMs: 1000,
+      getDeployedBundleId: () => Promise.resolve(deployed),
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onUpdate).not.toHaveBeenCalled(); // same bundle
+
+    deployed = "index-BBB.js";
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith("index-BBB.js");
+
+    // latched — does not fire again on subsequent polls
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("does nothing when the current bundle id is unknown", () => {
+    const onUpdate = vi.fn();
+    const stop = startAppUpdateWatcher({
+      currentBundleId: null,
+      onUpdateAvailable: onUpdate,
+      intervalMs: 1000,
+      getDeployedBundleId: () => Promise.resolve("index-BBB.js"),
+    });
+    vi.advanceTimersByTime(5000);
+    expect(onUpdate).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it("stop() halts polling", async () => {
+    const onUpdate = vi.fn();
+    const getter = vi.fn(() => Promise.resolve("index-AAA.js"));
+    const stop = startAppUpdateWatcher({
+      currentBundleId: "index-AAA.js",
+      onUpdateAvailable: onUpdate,
+      intervalMs: 1000,
+      getDeployedBundleId: getter,
+    });
+    stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(getter).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/app-update-check.ts
+++ b/ui/src/lib/app-update-check.ts
@@ -1,0 +1,91 @@
+/**
+ * Detects when a new frontend build has been deployed while a tab is still open.
+ *
+ * Long-lived tabs keep running the JS bundle they loaded at page-load, so a
+ * deployed fix (e.g. the React perf-measure memory fix) doesn't reach them until
+ * they happen to reload. The service worker (`public/sw.js`) is a static file
+ * that doesn't change between builds, so the normal SW `updatefound` flow never
+ * fires for a JS-only deploy. Instead we compare the *hashed bundle filename*
+ * (which Vite changes every build) against the freshly-served `index.html`.
+ */
+
+// Vite emits the entry as `assets/index-<hash>.js`. Match just the filename.
+const BUNDLE_FILENAME_RE = /(index-[A-Za-z0-9_-]+\.js)/;
+
+/** The bundle filename this page actually loaded, from its <script> tags. */
+export function getLoadedBundleId(doc: Document = document): string | null {
+  for (const script of Array.from(doc.querySelectorAll("script[src]"))) {
+    const src = script.getAttribute("src") ?? "";
+    const match = src.match(BUNDLE_FILENAME_RE);
+    if (match) return match[1]!;
+  }
+  return null;
+}
+
+/** The entry bundle filename referenced by a served index.html string. */
+export function parseBundleIdFromHtml(html: string): string | null {
+  const match = html.match(/<script[^>]+src=["'][^"']*?(index-[A-Za-z0-9_-]+\.js)["']/i);
+  return match ? match[1]! : null;
+}
+
+export async function fetchDeployedBundleId(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  try {
+    const res = await fetchImpl("/index.html", { cache: "no-store", credentials: "same-origin" });
+    if (!res.ok) return null;
+    return parseBundleIdFromHtml(await res.text());
+  } catch {
+    return null;
+  }
+}
+
+export interface AppUpdateWatcherOptions {
+  currentBundleId: string | null;
+  onUpdateAvailable: (deployedBundleId: string) => void;
+  /** Poll interval; also re-checks when the tab regains focus/visibility. */
+  intervalMs?: number;
+  /** Injectable for tests. */
+  getDeployedBundleId?: () => Promise<string | null>;
+}
+
+const DEFAULT_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * Poll for a newer deployed bundle. Fires `onUpdateAvailable` at most once
+ * (updates are latched), then keeps quiet until the caller reloads. Returns a
+ * stop function.
+ */
+export function startAppUpdateWatcher(opts: AppUpdateWatcherOptions): () => void {
+  const { currentBundleId, onUpdateAvailable, intervalMs = DEFAULT_INTERVAL_MS } = opts;
+  // If we can't identify our own bundle, we can't compare — do nothing.
+  if (!currentBundleId) return () => {};
+  const getDeployed = opts.getDeployedBundleId ?? (() => fetchDeployedBundleId());
+
+  let stopped = false;
+  let notified = false;
+
+  const check = async () => {
+    if (stopped || notified) return;
+    const deployed = await getDeployed();
+    if (stopped || notified) return;
+    if (deployed && deployed !== currentBundleId) {
+      notified = true;
+      onUpdateAvailable(deployed);
+    }
+  };
+
+  const interval = setInterval(() => void check(), intervalMs);
+  const onVisible = () => {
+    if (typeof document === "undefined" || document.visibilityState === "visible") void check();
+  };
+  if (typeof document !== "undefined") document.addEventListener("visibilitychange", onVisible);
+  if (typeof window !== "undefined") window.addEventListener("focus", onVisible);
+
+  return () => {
+    stopped = true;
+    clearInterval(interval);
+    if (typeof document !== "undefined") document.removeEventListener("visibilitychange", onVisible);
+    if (typeof window !== "undefined") window.removeEventListener("focus", onVisible);
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - It's a long-lived single-page app; users leave tabs open for hours or days
> - When a fix is deployed, an already-open tab keeps running the JS bundle it loaded at page-load until it happens to reload — so the fix never reaches it
> - This directly undermined the memory-leak fix (#9827): stale tabs kept leaking and looked like the fix "wasn't working", and a stale deploy earlier (#9701) caused the same confusion
> - The service worker (`public/sw.js`) is a static file that doesn't change between builds, so the browser's usual SW `updatefound` flow never fires for a JS-only deploy
> - This pull request detects a new build by comparing the hashed entry-bundle filename against a freshly-served `index.html`, and prompts the user to reload
> - The benefit is that deployed fixes actually reach long-lived tabs, without ever auto-reloading and interrupting someone's work

## Linked Issues or Issue Description

No public GitHub issue exists; describing inline per CONTRIBUTING.md → "Link Issues or Describe Them In-PR", following the bug report template. Follow-up to the memory-leak work (#9827) — it addresses the "stale tab keeps running the old build" problem surfaced during that investigation.

**What happened?**

After deploying a frontend fix, tabs that were already open kept running the old bundle and kept exhibiting the fixed bug (e.g. unbounded memory growth) until the user manually reloaded. There was no signal to the user that a new build existed.

**Expected behavior**

When a new build is deployed, a long-lived tab should surface a non-intrusive prompt to reload, so the fix takes effect without the user having to know to refresh — and without ever auto-reloading and losing in-progress work.

**Steps to reproduce**

Open the app, deploy a new frontend build (new `index-<hash>.js`), and leave the tab open. The tab keeps running the old bundle indefinitely; nothing tells the user a newer version is available.

**Paperclip version or commit**

Branch `feat/app-update-reload-banner`, off `master`.

**Deployment mode**

Local dev build served by the dev instance, web UI. Not adapter-specific.

## What Changed

- **`ui/src/lib/app-update-check.ts` (new)** — `getLoadedBundleId()` reads this page's `index-<hash>.js` from its script tags; `fetchDeployedBundleId()` fetches `/index.html` (`cache: no-store`) and parses the entry bundle; `startAppUpdateWatcher()` polls every 5 min (and on tab focus/visibility), fires `onUpdateAvailable` **at most once** (latched) when the deployed bundle differs, and returns a stop function. Detection is via the Vite content hash, since `public/sw.js` is static and can't signal JS-only deploys.
- **`ui/src/components/AppUpdateBanner.tsx` (new)** — a persistent, dismissible banner ("A new version is available — Reload"), styled like the existing info toast. **Reload is user-driven only** — it never auto-reloads, so it can't interrupt work or drop unsaved input. Mounted in `Layout` beside `ToastViewport`.

## Verification

- `vitest`: `app-update-check.test.ts` — `parseBundleIdFromHtml`, `getLoadedBundleId`, and the watcher (fires once on change, latches, no-op when bundle id unknown, `stop()` halts polling). All pass.
- `Layout.test.tsx` still passes (22) — the banner renders `null` until an update is detected.
- `tsc -b` clean.

## Risks

Low, client-only, additive UI.
- The banner only appears after a genuine bundle-hash change; it renders nothing otherwise. It never auto-reloads.
- The `/index.html` poll is every 5 min + on focus (negligible), goes through the SW's network-first path, and fails closed (any error → no prompt).
- If `index.html` ever stops referencing a hashed `index-*.js` entry (build-config change), detection simply no-ops rather than misfiring.

## Model Used

- **Provider:** Anthropic, via the Claude Code CLI.
- **Model:** Claude Opus 4.8 (`claude-opus-4-8`).
- **Reasoning mode:** Extended thinking enabled.
- **Capabilities used:** tool use (shell, file editing). (The memory investigation that motivated this used the Chrome DevTools MCP; this PR is a straightforward follow-up.)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (follow-up to #9827; no duplicates)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] I have updated relevant documentation to reflect my changes (N/A — no user-facing docs)
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

