### PR TITLE
feat(artifacts): star documents + Starred tab (PAP-14811)

### DIFF
--- a/packages/db/src/migrations/0182_document_memberships.sql
+++ b/packages/db/src/migrations/0182_document_memberships.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "document_memberships" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL REFERENCES "companies"("id") ON DELETE CASCADE,
+  "document_id" uuid NOT NULL REFERENCES "documents"("id") ON DELETE CASCADE,
+  "user_id" text NOT NULL,
+  "starred_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: Drizzle migrations run transactionally, so CONCURRENTLY is unavailable; this index is created with the new empty membership table for user-scoped starred ordering.
+CREATE INDEX IF NOT EXISTS "document_memberships_company_user_starred_idx"
+  ON "document_memberships" USING btree ("company_id", "user_id", "starred_at");--> statement-breakpoint
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: Drizzle migrations run transactionally, so CONCURRENTLY is unavailable; this uniqueness index is created with the new empty membership table to make star upserts idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS "document_memberships_company_user_document_uq"
+  ON "document_memberships" USING btree ("company_id", "user_id", "document_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1784231633059,
       "tag": "0181_decision_training_retention_policy",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1784640927793,
+      "tag": "0182_document_memberships",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/document_memberships.ts
+++ b/packages/db/src/schema/document_memberships.ts
@@ -1,0 +1,28 @@
+import { pgTable, uuid, text, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { documents } from "./documents.js";
+
+export const documentMemberships = pgTable(
+  "document_memberships",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    documentId: uuid("document_id").notNull().references(() => documents.id, { onDelete: "cascade" }),
+    userId: text("user_id").notNull(),
+    starredAt: timestamp("starred_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyUserStarredIdx: index("document_memberships_company_user_starred_idx").on(
+      table.companyId,
+      table.userId,
+      table.starredAt,
+    ),
+    companyUserDocumentUq: uniqueIndex("document_memberships_company_user_document_uq").on(
+      table.companyId,
+      table.userId,
+      table.documentId,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -25,6 +25,7 @@ export { agentTaskSessions } from "./agent_task_sessions.js";
 export { agentWakeupRequests } from "./agent_wakeup_requests.js";
 export { projects } from "./projects.js";
 export { projectMemberships } from "./project_memberships.js";
+export { documentMemberships } from "./document_memberships.js";
 export { projectWorkspaces } from "./project_workspaces.js";
 export { executionWorkspaces } from "./execution_workspaces.js";
 export { environments } from "./environments.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1305,7 +1305,9 @@ export {
 } from "./validators/sidebar-preferences.js";
 export {
   resourceMembershipStateSchema,
+  updateDocumentResourceMembershipSchema,
   updateResourceMembershipSchema,
+  type UpdateDocumentResourceMembership,
   type UpdateResourceMembership,
 } from "./validators/resource-memberships.js";
 export {

--- a/packages/shared/src/resource-memberships.test.ts
+++ b/packages/shared/src/resource-memberships.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { updateResourceMembershipSchema } from "./validators/resource-memberships.js";
+import {
+  updateDocumentResourceMembershipSchema,
+  updateResourceMembershipSchema,
+} from "./validators/resource-memberships.js";
 
 describe("resource membership contract", () => {
   it("accepts legacy state-only membership updates", () => {
@@ -17,5 +20,12 @@ describe("resource membership contract", () => {
     expect(() => updateResourceMembershipSchema.parse({ state: "left", starred: true })).toThrow(
       "starred resources must be joined",
     );
+  });
+
+  it("accepts document star updates without join state", () => {
+    expect(updateDocumentResourceMembershipSchema.parse({ starred: true })).toEqual({ starred: true });
+    expect(updateDocumentResourceMembershipSchema.parse({ starred: false })).toEqual({ starred: false });
+    expect(() => updateDocumentResourceMembershipSchema.parse({ state: "joined", starred: true })).toThrow();
+    expect(() => updateDocumentResourceMembershipSchema.parse({})).toThrow();
   });
 });

--- a/packages/shared/src/types/resource-memberships.ts
+++ b/packages/shared/src/types/resource-memberships.ts
@@ -1,15 +1,17 @@
 export const RESOURCE_MEMBERSHIP_STATES = ["joined", "left"] as const;
 
 export type ResourceMembershipState = (typeof RESOURCE_MEMBERSHIP_STATES)[number];
-export type ResourceMembershipResourceType = "project" | "agent";
+export type ResourceMembershipResourceType = "project" | "agent" | "document";
 
 export interface ResourceMemberships {
   projectMemberships: Record<string, ResourceMembershipState>;
   agentMemberships: Record<string, ResourceMembershipState>;
   starredProjectIds?: string[];
   starredAgentIds?: string[];
+  starredDocumentIds: string[];
   projectStarredAt?: Record<string, Date>;
   agentStarredAt?: Record<string, Date>;
+  documentStarredAt: Record<string, string>;
   updatedAt: Date | null;
 }
 

--- a/packages/shared/src/validators/artifact.ts
+++ b/packages/shared/src/validators/artifact.ts
@@ -16,6 +16,10 @@ export const companyArtifactsQuerySchema = z.object({
   q: z.string().trim().max(COMPANY_ARTIFACTS_MAX_QUERY_LENGTH).optional(),
   groupBy: companyArtifactGroupBySchema.optional().default("none"),
   groupIssueId: z.string().uuid().optional(),
+  starred: z.preprocess(
+    (value) => value === "true" ? true : value === "false" ? false : value,
+    z.boolean(),
+  ).optional().default(false),
   limit: z.coerce
     .number()
     .int()

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -91,7 +91,9 @@ export {
 } from "./sidebar-preferences.js";
 export {
   resourceMembershipStateSchema,
+  updateDocumentResourceMembershipSchema,
   updateResourceMembershipSchema,
+  type UpdateDocumentResourceMembership,
   type UpdateResourceMembership,
 } from "./resource-memberships.js";
 export {

--- a/packages/shared/src/validators/resource-memberships.ts
+++ b/packages/shared/src/validators/resource-memberships.ts
@@ -13,4 +13,9 @@ export const updateResourceMembershipSchema = z.object({
   path: ["starred"],
 });
 
+export const updateDocumentResourceMembershipSchema = z.object({
+  starred: z.boolean(),
+}).strict();
+
 export type UpdateResourceMembership = z.infer<typeof updateResourceMembershipSchema>;
+export type UpdateDocumentResourceMembership = z.infer<typeof updateDocumentResourceMembershipSchema>;

--- a/server/src/__tests__/company-artifacts-service.test.ts
+++ b/server/src/__tests__/company-artifacts-service.test.ts
@@ -8,6 +8,7 @@ import {
   assets,
   companies,
   createDb,
+  documentMemberships,
   documents,
   heartbeatRuns,
   issueAttachments,
@@ -65,6 +66,7 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(documentMemberships);
     await db.delete(issueWorkProducts);
     await db.delete(issueAttachments);
     await db.delete(assets);
@@ -172,6 +174,14 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
         updatedAt: new Date("2026-01-06T00:00:00.000Z"),
       },
       {
+        id: "20202020-2020-4020-8020-202020202020",
+        companyId,
+        title: "Plan",
+        latestBody: "Human-approved plan",
+        createdByUserId: "user-1",
+        updatedAt: new Date("2026-01-08T00:00:00.000Z"),
+      },
+      {
         id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
         companyId: otherCompanyId,
         title: "Other Company Plan",
@@ -198,6 +208,12 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
         issueId,
         documentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
         key: "user-notes",
+      },
+      {
+        companyId,
+        issueId: secondIssueId,
+        documentId: "20202020-2020-4020-8020-202020202020",
+        key: "plan",
       },
       {
         companyId: otherCompanyId,
@@ -332,6 +348,83 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
 
     return { companyId, otherCompanyId, projectId, issueId, secondIssueId, otherIssueId, otherRunId };
   }
+
+  it("returns only the caller's starred documents, including plan and human-authored documents, with cursor order", async () => {
+    const { companyId } = await seedArtifacts();
+    await db.insert(documentMemberships).values([
+      {
+        companyId,
+        documentId: "20202020-2020-4020-8020-202020202020",
+        userId: "user-1",
+        starredAt: new Date("2026-02-03T00:00:00.000Z"),
+      },
+      {
+        companyId,
+        documentId: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        userId: "user-1",
+        starredAt: new Date("2026-02-02T00:00:00.000Z"),
+      },
+      {
+        companyId,
+        documentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        userId: "other-user",
+        starredAt: new Date("2026-02-04T00:00:00.000Z"),
+      },
+    ]);
+
+    const app = express();
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "user-1",
+        source: "session",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "viewer", status: "active" }],
+      };
+      next();
+    });
+    app.use("/api/companies", companyRoutes(db, createStorageService()));
+    app.use(errorHandler);
+
+    const first = await request(app).get(`/api/companies/${companyId}/artifacts?starred=true&limit=1`);
+    expect(first.status).toBe(200);
+    expect(first.body.artifacts.map((artifact: { title: string }) => artifact.title)).toEqual(["Plan"]);
+    expect(first.body.nextCursor).toEqual(expect.any(String));
+
+    const second = await request(app).get(
+      `/api/companies/${companyId}/artifacts?starred=true&limit=10&cursor=${first.body.nextCursor}`,
+    );
+    expect(second.status).toBe(200);
+    expect(second.body.artifacts.map((artifact: { title: string }) => artifact.title)).toEqual(["User Upload Notes"]);
+    expect(second.body.artifacts.every((artifact: { source: string }) => artifact.source === "document")).toBe(true);
+  });
+
+  it("returns an empty starred view for agent callers", async () => {
+    const { companyId, otherRunId } = await seedArtifacts();
+    await db.insert(documentMemberships).values({
+      companyId,
+      documentId: "20202020-2020-4020-8020-202020202020",
+      userId: "user-1",
+    });
+    const app = express();
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "agent",
+        agentId: "33333333-3333-4333-8333-333333333333",
+        companyId,
+        runId: otherRunId,
+        source: "agent_key",
+      };
+      next();
+    });
+    app.use("/api/companies", companyRoutes(db, createStorageService()));
+    app.use(errorHandler);
+
+    const response = await request(app).get(`/api/companies/${companyId}/artifacts?starred=true`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ artifacts: [], nextCursor: null });
+  });
 
   it("projects agent-created documents, direct attachments, and work products while excluding noisy sources", async () => {
     const { companyId } = await seedArtifacts();

--- a/server/src/__tests__/company-artifacts-service.test.ts
+++ b/server/src/__tests__/company-artifacts-service.test.ts
@@ -397,6 +397,12 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
     expect(second.status).toBe(200);
     expect(second.body.artifacts.map((artifact: { title: string }) => artifact.title)).toEqual(["User Upload Notes"]);
     expect(second.body.artifacts.every((artifact: { source: string }) => artifact.source === "document")).toBe(true);
+
+    const incompatibleKind = await request(app).get(
+      `/api/companies/${companyId}/artifacts?starred=true&kind=image`,
+    );
+    expect(incompatibleKind.status).toBe(200);
+    expect(incompatibleKind.body).toEqual({ artifacts: [], nextCursor: null });
   });
 
   it("returns an empty starred view for agent callers", async () => {

--- a/server/src/__tests__/resource-memberships-routes.test.ts
+++ b/server/src/__tests__/resource-memberships-routes.test.ts
@@ -447,14 +447,15 @@ describeEmbeddedPostgres("resource membership routes", () => {
     expect(list.body.documentStarredAt[documentId]).toBe(first.body.starredAt);
     await expect(db.select().from(documentMemberships)).resolves.toHaveLength(1);
 
-    await request(app)
-      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
-      .send({ starred: false })
-      .expect(200);
-    await request(app)
-      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
-      .send({ starred: false })
-      .expect(200);
+    const unstars = await Promise.all([
+      request(app)
+        .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+        .send({ starred: false }),
+      request(app)
+        .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+        .send({ starred: false }),
+    ]);
+    expect(unstars.map((response) => response.status)).toEqual([200, 200]);
     await expect(db.select().from(documentMemberships)).resolves.toHaveLength(0);
 
     await request(app)

--- a/server/src/__tests__/resource-memberships-routes.test.ts
+++ b/server/src/__tests__/resource-memberships-routes.test.ts
@@ -429,12 +429,14 @@ describeEmbeddedPostgres("resource membership routes", () => {
     const { companyId, documentId } = await seed();
     const app = createApp(db, boardActor(companyId));
 
-    const first = await request(app)
-      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
-      .send({ starred: true });
-    const second = await request(app)
-      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
-      .send({ starred: true });
+    const [first, second] = await Promise.all([
+      request(app)
+        .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+        .send({ starred: true }),
+      request(app)
+        .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+        .send({ starred: true }),
+    ]);
     const list = await request(app).get(`/api/companies/${companyId}/resource-memberships/me`);
 
     expect(first.status).toBe(200);

--- a/server/src/__tests__/resource-memberships-routes.test.ts
+++ b/server/src/__tests__/resource-memberships-routes.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import express from "express";
+import { eq } from "drizzle-orm";
 import request from "supertest";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -8,6 +9,8 @@ import {
   agents,
   companies,
   createDb,
+  documentMemberships,
+  documents,
   projectMemberships,
   projects,
 } from "@paperclipai/db";
@@ -62,8 +65,10 @@ describeEmbeddedPostgres("resource membership routes", () => {
 
   afterEach(async () => {
     await db.delete(activityLog);
+    await db.delete(documentMemberships);
     await db.delete(projectMemberships);
     await db.delete(agentMemberships);
+    await db.delete(documents);
     await db.delete(projects);
     await db.delete(agents);
     await db.delete(companies);
@@ -82,6 +87,8 @@ describeEmbeddedPostgres("resource membership routes", () => {
     const agentId = randomUUID();
     const otherAgentId = randomUUID();
     const terminatedAgentId = randomUUID();
+    const documentId = randomUUID();
+    const otherDocumentId = randomUUID();
     await db.insert(companies).values([
       {
         id: companyId,
@@ -95,6 +102,10 @@ describeEmbeddedPostgres("resource membership routes", () => {
         issuePrefix: `T${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
         requireBoardApprovalForNewAgents: false,
       },
+    ]);
+    await db.insert(documents).values([
+      { id: documentId, companyId, title: "Plan", latestBody: "Plan body", createdByUserId: "user-1" },
+      { id: otherDocumentId, companyId: otherCompanyId, title: "Other", latestBody: "Other body" },
     ]);
     await db.insert(projects).values([
       { id: projectId, companyId, name: "Growth", status: "in_progress" },
@@ -136,7 +147,17 @@ describeEmbeddedPostgres("resource membership routes", () => {
         permissions: {},
       },
     ]);
-    return { archivedProjectId, companyId, otherAgentId, otherProjectId, projectId, agentId, terminatedAgentId };
+    return {
+      archivedProjectId,
+      companyId,
+      documentId,
+      otherAgentId,
+      otherDocumentId,
+      otherProjectId,
+      projectId,
+      agentId,
+      terminatedAgentId,
+    };
   }
 
   it("defaults missing membership rows to joined", async () => {
@@ -151,8 +172,10 @@ describeEmbeddedPostgres("resource membership routes", () => {
       agentMemberships: {},
       starredProjectIds: [],
       starredAgentIds: [],
+      starredDocumentIds: [],
       projectStarredAt: {},
       agentStarredAt: {},
+      documentStarredAt: {},
       updatedAt: null,
     });
   });
@@ -400,5 +423,64 @@ describeEmbeddedPostgres("resource membership routes", () => {
         actor: boardActor(companyId),
       }),
     ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("stars and unstars documents idempotently and cascades on document deletion", async () => {
+    const { companyId, documentId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const first = await request(app)
+      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+      .send({ starred: true });
+    const second = await request(app)
+      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+      .send({ starred: true });
+    const list = await request(app).get(`/api/companies/${companyId}/resource-memberships/me`);
+
+    expect(first.status).toBe(200);
+    expect(first.body).toMatchObject({ resourceType: "document", resourceId: documentId, starredAt: expect.any(String) });
+    expect(second.status).toBe(200);
+    expect(second.body.starredAt).toBe(first.body.starredAt);
+    expect(list.body.starredDocumentIds).toEqual([documentId]);
+    expect(list.body.documentStarredAt[documentId]).toBe(first.body.starredAt);
+    await expect(db.select().from(documentMemberships)).resolves.toHaveLength(1);
+
+    await request(app)
+      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+      .send({ starred: false })
+      .expect(200);
+    await request(app)
+      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+      .send({ starred: false })
+      .expect(200);
+    await expect(db.select().from(documentMemberships)).resolves.toHaveLength(0);
+
+    await request(app)
+      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${documentId}`)
+      .send({ starred: true })
+      .expect(200);
+    await db.delete(documents).where(eq(documents.id, documentId));
+    await expect(db.select().from(documentMemberships)).resolves.toHaveLength(0);
+
+    const activity = await db.select().from(activityLog);
+    expect(activity.map((entry) => entry.action)).toEqual([
+      "resource_membership.starred",
+      "resource_membership.unstarred",
+      "resource_membership.starred",
+    ]);
+    expect(activity[0]).toMatchObject({ entityType: "document", entityId: documentId });
+  });
+
+  it("returns identical 404s for cross-company documents", async () => {
+    const { companyId, otherDocumentId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const response = await request(app)
+      .put(`/api/companies/${companyId}/resource-memberships/me/documents/${otherDocumentId}`)
+      .send({ starred: true });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe("Document not found");
+    await expect(db.select().from(documentMemberships)).resolves.toHaveLength(0);
   });
 });

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -142,7 +142,9 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const query = companyArtifactsQuerySchema.parse(req.query);
-    res.json(await artifacts.list(companyId, query));
+    res.json(await artifacts.list(companyId, query, {
+      userId: query.starred && req.actor.type === "board" ? req.actor.userId : undefined,
+    }));
   });
 
   router.get("/:companyId/timeline", async (req, res) => {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -150,6 +150,7 @@ import {
   patchInstanceSettingsSchema,
   issueGraphLivenessAutoRecoveryRequestSchema,
   // Resource memberships
+  updateDocumentResourceMembershipSchema,
   updateResourceMembershipSchema,
   // Document annotations
   createDocumentAnnotationCommentSchema,
@@ -727,6 +728,7 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "POST /api/bootstrap/claim",
   "GET /api/companies/{companyId}/resource-memberships/me",
   "PUT /api/companies/{companyId}/resource-memberships/me/agents/{agentId}",
+  "PUT /api/companies/{companyId}/resource-memberships/me/documents/{documentId}",
   "PUT /api/companies/{companyId}/resource-memberships/me/projects/{projectId}",
   "GET /api/companies/{companyId}/secret-provider-configs",
   "POST /api/companies/{companyId}/secret-provider-configs",
@@ -5422,6 +5424,14 @@ registerCurrentRoute({
   path: "/api/issues/{id}/cost-summary",
   tags: ["costs"],
   summary: "Get issue cost summary",
+});
+
+registerCurrentRoute({
+  method: "put",
+  path: "/api/companies/{companyId}/resource-memberships/me/documents/{documentId}",
+  tags: ["resource-memberships"],
+  summary: "Star or unstar a document resource",
+  body: updateDocumentResourceMembershipSchema,
 });
 
 for (const route of [

--- a/server/src/routes/resource-memberships.ts
+++ b/server/src/routes/resource-memberships.ts
@@ -1,6 +1,9 @@
 import { Router, type Request, type Response } from "express";
 import type { Db } from "@paperclipai/db";
-import { updateResourceMembershipSchema } from "@paperclipai/shared";
+import {
+  updateDocumentResourceMembershipSchema,
+  updateResourceMembershipSchema,
+} from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { getActorInfo } from "./authz.js";
 import { logActivity, resourceMembershipService } from "../services/index.js";
@@ -19,7 +22,7 @@ async function logMembershipChange(
   input: {
     companyId: string;
     userId: string;
-    resourceType: "project" | "agent";
+    resourceType: "project" | "agent" | "document";
     resourceId: string;
     state: "joined" | "left";
     starredAt: Date | null;
@@ -116,6 +119,38 @@ export function resourceMembershipRoutes(db: Db) {
           userId,
           resourceType: "agent",
           resourceId: agentId,
+          state: result.state,
+          starredAt: result.starredAt,
+          changeKind: result.changeKind,
+          policySource: result.policySource,
+        });
+      }
+      const { changed: _changed, changeKind: _changeKind, policySource: _policySource, ...response } = result;
+      res.json(response);
+    },
+  );
+
+  router.put(
+    "/companies/:companyId/resource-memberships/me/documents/:documentId",
+    validate(updateDocumentResourceMembershipSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      const documentId = req.params.documentId as string;
+      const userId = requireBoardUserId(req, res);
+      if (!userId) return;
+      const result = await svc.updateDocument({
+        companyId,
+        documentId,
+        userId,
+        starred: req.body.starred,
+        actor: req.actor,
+      });
+      if (result.changed && result.changeKind) {
+        await logMembershipChange(db, req, {
+          companyId,
+          userId,
+          resourceType: "document",
+          resourceId: documentId,
           state: result.state,
           starredAt: result.starredAt,
           changeKind: result.changeKind,

--- a/server/src/services/company-artifacts.ts
+++ b/server/src/services/company-artifacts.ts
@@ -6,6 +6,7 @@ import {
   agents,
   assets,
   companies,
+  documentMemberships,
   documents,
   heartbeatRuns,
   issueAttachments,
@@ -171,9 +172,10 @@ async function readTextAttachmentPreview(
   }
 }
 
-function sortArtifacts(artifacts: CompanyArtifact[]) {
+function sortArtifacts(artifacts: CompanyArtifact[], sortDates = new Map<string, string>()) {
   return artifacts.sort((a, b) => {
-    const dateDiff = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+    const dateDiff = Date.parse(sortDates.get(b.id) ?? b.updatedAt)
+      - Date.parse(sortDates.get(a.id) ?? a.updatedAt);
     if (dateDiff !== 0) return dateDiff;
     return b.id.localeCompare(a.id);
   });
@@ -318,7 +320,7 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
     list: async (
       companyId: string,
       rawQuery: Partial<CompanyArtifactsQuery> = {},
-      options: { issueConditions?: SQL[] } = {},
+      options: { issueConditions?: SQL[]; userId?: string } = {},
     ): Promise<CompanyArtifactsResponse> => {
       const query = companyArtifactsQuerySchema.parse(rawQuery);
       const cursor = decodeCursor(query.cursor);
@@ -330,6 +332,10 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
         .then((rows) => rows[0] ?? null);
       if (!company) throw notFound("Company not found");
 
+      if (query.starred && !options.userId) {
+        return { artifacts: [], nextCursor: null };
+      }
+
       const fetchLimit = Math.min(query.limit + 1, COMPANY_ARTIFACTS_MAX_LIMIT + 1);
       const sourceFetchLimit = groupBy ? GROUPED_ARTIFACT_FETCH_LIMIT : fetchLimit;
       const q = query.q ? `%${escapeLikePattern(query.q)}%` : null;
@@ -339,20 +345,32 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
         ...(options.issueConditions ?? []),
       ];
       const artifacts: CompanyArtifact[] = [];
+      const artifactSortDates = new Map<string, string>();
       const workProductAttachmentIds = new Set<string>();
 
-      if (query.kind === "all" || query.kind === "document") {
+      if (query.starred || query.kind === "all" || query.kind === "document") {
         const createdAgent = alias(agents, "document_created_agent");
         const updatedAgent = alias(agents, "document_updated_agent");
         const documentArtifactId = sql<string>`concat('document:', ${documents.id})`;
         const documentConditions: SQL[] = [
           eq(issueDocuments.companyId, companyId),
           eq(documents.companyId, companyId),
-          or(isNotNull(documents.createdByAgentId), isNotNull(documents.updatedByAgentId))!,
-          notInArray(issueDocuments.key, [...SYSTEM_ISSUE_DOCUMENT_KEYS]),
           ...issueConditions,
+          ...(query.starred
+            ? [
+              eq(documentMemberships.companyId, companyId),
+              eq(documentMemberships.userId, options.userId!),
+              isNotNull(documentMemberships.starredAt),
+            ]
+            : [
+              or(isNotNull(documents.createdByAgentId), isNotNull(documents.updatedByAgentId))!,
+              notInArray(issueDocuments.key, [...SYSTEM_ISSUE_DOCUMENT_KEYS]),
+            ]),
         ];
-        const documentCursor = groupBy ? undefined : cursorCondition(sql<Date>`${documents.updatedAt}`, documentArtifactId, cursor);
+        const documentSortDate = query.starred
+          ? sql<Date>`${documentMemberships.starredAt}`
+          : sql<Date>`${documents.updatedAt}`;
+        const documentCursor = groupBy ? undefined : cursorCondition(documentSortDate, documentArtifactId, cursor);
         if (documentCursor) documentConditions.push(documentCursor);
         if (groupBy === "task" && query.groupIssueId) documentConditions.push(eq(issues.id, query.groupIssueId));
         if (query.projectId) documentConditions.push(eq(issues.projectId, query.projectId));
@@ -380,6 +398,7 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
             createdByAgentId: sql<string | null>`coalesce(${createdAgent.id}, ${updatedAgent.id})`,
             createdByAgentName: sql<string | null>`coalesce(${createdAgent.name}, ${updatedAgent.name})`,
             updatedAt: documents.updatedAt,
+            starredAt: documentMemberships.starredAt,
           })
           .from(issueDocuments)
           .innerJoin(
@@ -387,6 +406,14 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
             and(
               eq(issueDocuments.documentId, documents.id),
               eq(documents.companyId, issueDocuments.companyId),
+            ),
+          )
+          .leftJoin(
+            documentMemberships,
+            and(
+              eq(documentMemberships.documentId, documents.id),
+              eq(documentMemberships.companyId, documents.companyId),
+              eq(documentMemberships.userId, options.userId ?? ""),
             ),
           )
           .innerJoin(
@@ -418,11 +445,12 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
             ),
           )
           .where(and(...documentConditions))
-          .orderBy(desc(documents.updatedAt), desc(documentArtifactId));
+          .orderBy(desc(documentSortDate), desc(documentArtifactId));
         const documentRows = await documentRowsQuery.limit(sourceFetchLimit);
 
         for (const row of documentRows) {
           const identifier = row.issueIdentifier ?? row.issueId;
+          artifactSortDates.set(row.artifactId, (row.starredAt ?? row.updatedAt).toISOString());
           artifacts.push({
             id: row.artifactId,
             source: "document",
@@ -444,7 +472,7 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
         }
       }
 
-      if (query.kind !== "document") {
+      if (!query.starred && query.kind !== "document") {
         const workProductAgent = alias(agents, "work_product_agent");
         const workProductArtifactId = sql<string>`concat('work_product:', ${issueWorkProducts.id})`;
         const workProductContentType = sql<string>`coalesce(${issueWorkProducts.metadata}->>'contentType', '')`;
@@ -692,11 +720,15 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
         artifacts.push(...attachmentArtifacts.filter((artifact): artifact is CompanyArtifact => artifact !== null));
       }
 
-      const sorted = sortArtifacts(artifacts);
+      const sorted = sortArtifacts(artifacts, artifactSortDates);
       if (!groupBy) {
         const page = sorted.slice(0, query.limit);
+        const last = page[page.length - 1];
         const nextCursor = sorted.length > query.limit
-          ? encodeCursor({ id: page[page.length - 1]?.id ?? "", updatedAt: page[page.length - 1]?.updatedAt ?? new Date(0).toISOString() })
+          ? encodeCursor({
+            id: last?.id ?? "",
+            updatedAt: last ? artifactSortDates.get(last.id) ?? last.updatedAt : new Date(0).toISOString(),
+          })
           : null;
 
         return { artifacts: page, nextCursor };

--- a/server/src/services/company-artifacts.ts
+++ b/server/src/services/company-artifacts.ts
@@ -348,7 +348,7 @@ export function companyArtifactsService(db: Db, storage?: StorageService) {
       const artifactSortDates = new Map<string, string>();
       const workProductAttachmentIds = new Set<string>();
 
-      if (query.starred || query.kind === "all" || query.kind === "document") {
+      if (query.kind === "all" || query.kind === "document") {
         const createdAgent = alias(agents, "document_created_agent");
         const updatedAgent = alias(agents, "document_updated_agent");
         const documentArtifactId = sql<string>`concat('document:', ${documents.id})`;

--- a/server/src/services/resource-memberships.ts
+++ b/server/src/services/resource-memberships.ts
@@ -524,15 +524,19 @@ export function resourceMembershipService(db: Db, options: ResourceMembershipSer
           policySource: decision.source ?? "oss_default",
         };
       }
-      await db.delete(documentMemberships).where(eq(documentMemberships.id, existing.id));
+      const [deleted] = await db
+        .delete(documentMemberships)
+        .where(eq(documentMemberships.id, existing.id))
+        .returning({ id: documentMemberships.id });
+      const changed = deleted !== undefined;
       return {
         resourceType: "document",
         resourceId: input.documentId,
         state: "joined",
         starredAt: null,
         updatedAt: new Date(),
-        changed: true,
-        changeKind: "unstarred",
+        changed,
+        changeKind: changed ? "unstarred" : null,
         policySource: decision.source ?? "oss_default",
       };
     },

--- a/server/src/services/resource-memberships.ts
+++ b/server/src/services/resource-memberships.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agentMemberships,
@@ -491,19 +491,23 @@ export function resourceMembershipService(db: Db, options: ResourceMembershipSer
           .onConflictDoUpdate({
             target: [documentMemberships.companyId, documentMemberships.userId, documentMemberships.documentId],
             set: {
-              starredAt: now,
-              updatedAt: now,
+              starredAt: sql`${documentMemberships.starredAt}`,
+              updatedAt: sql`${documentMemberships.updatedAt}`,
             },
           })
-          .returning();
+          .returning({
+            starredAt: documentMemberships.starredAt,
+            updatedAt: documentMemberships.updatedAt,
+            inserted: sql<boolean>`xmax = 0`,
+          });
         return {
           resourceType: "document",
           resourceId: input.documentId,
           state: "joined",
           starredAt: row?.starredAt ?? now,
           updatedAt: row?.updatedAt ?? now,
-          changed: true,
-          changeKind: "starred",
+          changed: row?.inserted === true,
+          changeKind: row?.inserted === true ? "starred" : null,
           policySource: decision.source ?? "oss_default",
         };
       }

--- a/server/src/services/resource-memberships.ts
+++ b/server/src/services/resource-memberships.ts
@@ -3,6 +3,8 @@ import type { Db } from "@paperclipai/db";
 import {
   agentMemberships,
   agents,
+  documentMemberships,
+  documents,
   projectMemberships,
   projects,
 } from "@paperclipai/db";
@@ -173,7 +175,7 @@ export function resourceMembershipService(db: Db, options: ResourceMembershipSer
   return {
     async listForUser(companyId: string, userId: string, actor: BoardActor): Promise<ResourceMemberships> {
       assertBoardSelfMembershipAccess(actor, companyId, userId);
-      const [projectRows, agentRows] = await Promise.all([
+      const [projectRows, agentRows, documentRows] = await Promise.all([
         db
           .select({
             projectId: projectMemberships.projectId,
@@ -208,19 +210,42 @@ export function resourceMembershipService(db: Db, options: ResourceMembershipSer
             eq(agentMemberships.companyId, companyId),
             eq(agentMemberships.userId, userId),
           )),
+        db
+          .select({
+            documentId: documentMemberships.documentId,
+            starredAt: documentMemberships.starredAt,
+            updatedAt: documentMemberships.updatedAt,
+          })
+          .from(documentMemberships)
+          .innerJoin(documents, and(
+            eq(documents.id, documentMemberships.documentId),
+            eq(documents.companyId, documentMemberships.companyId),
+          ))
+          .where(and(
+            eq(documentMemberships.companyId, companyId),
+            eq(documentMemberships.userId, userId),
+          )),
       ]);
       const starEligibleProjectRows = projectRows.filter((row) => row.starredAt && !row.projectArchivedAt);
       const starEligibleAgentRows = agentRows.filter((row) => row.starredAt && row.agentStatus !== "terminated");
+      const starredDocumentRows = documentRows
+        .filter((row): row is typeof row & { starredAt: Date } => row.starredAt !== null)
+        .sort((a, b) => b.starredAt.getTime() - a.starredAt.getTime());
       return {
         projectMemberships: defaultJoinedMap(projectRows, "projectId"),
         agentMemberships: defaultJoinedMap(agentRows, "agentId"),
         starredProjectIds: starredIds(starEligibleProjectRows, "projectId"),
         starredAgentIds: starredIds(starEligibleAgentRows, "agentId"),
+        starredDocumentIds: starredDocumentRows.map((row) => row.documentId),
         projectStarredAt: starredAtMap(starEligibleProjectRows, "projectId"),
         agentStarredAt: starredAtMap(starEligibleAgentRows, "agentId"),
+        documentStarredAt: Object.fromEntries(
+          starredDocumentRows.map((row) => [row.documentId, row.starredAt.toISOString()]),
+        ),
         updatedAt: latestDate(
           ...projectRows.map((row) => row.updatedAt),
           ...agentRows.map((row) => row.updatedAt),
+          ...documentRows.map((row) => row.updatedAt),
         ),
       };
     },
@@ -407,6 +432,103 @@ export function resourceMembershipService(db: Db, options: ResourceMembershipSer
         changeKind: input.starred !== undefined && starredChanged
           ? input.starred ? "starred" : "unstarred"
           : stateChanged ? nextState : nextStarredAt ? "starred" : "unstarred",
+        policySource: decision.source ?? "oss_default",
+      };
+    },
+
+    async updateDocument(input: {
+      companyId: string;
+      userId: string;
+      documentId: string;
+      starred: boolean;
+      actor: BoardActor;
+    }): Promise<MembershipUpdateResult> {
+      const document = await db.query.documents.findFirst({
+        where: eq(documents.id, input.documentId),
+      });
+      if (!document || document.companyId !== input.companyId) throw notFound("Document not found");
+
+      const decision = await assertMutationAllowed({
+        actor: input.actor,
+        companyId: input.companyId,
+        userId: input.userId,
+        resourceType: "document",
+        resourceId: input.documentId,
+        state: "joined",
+        starred: input.starred,
+      });
+      const existing = await db.query.documentMemberships.findFirst({
+        where: and(
+          eq(documentMemberships.companyId, input.companyId),
+          eq(documentMemberships.userId, input.userId),
+          eq(documentMemberships.documentId, input.documentId),
+        ),
+      });
+
+      if (input.starred) {
+        if (existing?.starredAt) {
+          return {
+            resourceType: "document",
+            resourceId: input.documentId,
+            state: "joined",
+            starredAt: existing.starredAt,
+            updatedAt: existing.updatedAt,
+            changed: false,
+            changeKind: null,
+            policySource: decision.source ?? "oss_default",
+          };
+        }
+        const now = new Date();
+        const [row] = await db
+          .insert(documentMemberships)
+          .values({
+            companyId: input.companyId,
+            documentId: input.documentId,
+            userId: input.userId,
+            starredAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: [documentMemberships.companyId, documentMemberships.userId, documentMemberships.documentId],
+            set: {
+              starredAt: now,
+              updatedAt: now,
+            },
+          })
+          .returning();
+        return {
+          resourceType: "document",
+          resourceId: input.documentId,
+          state: "joined",
+          starredAt: row?.starredAt ?? now,
+          updatedAt: row?.updatedAt ?? now,
+          changed: true,
+          changeKind: "starred",
+          policySource: decision.source ?? "oss_default",
+        };
+      }
+
+      if (!existing) {
+        return {
+          resourceType: "document",
+          resourceId: input.documentId,
+          state: "joined",
+          starredAt: null,
+          updatedAt: new Date(),
+          changed: false,
+          changeKind: null,
+          policySource: decision.source ?? "oss_default",
+        };
+      }
+      await db.delete(documentMemberships).where(eq(documentMemberships.id, existing.id));
+      return {
+        resourceType: "document",
+        resourceId: input.documentId,
+        state: "joined",
+        starredAt: null,
+        updatedAt: new Date(),
+        changed: true,
+        changeKind: "unstarred",
         policySource: decision.source ?? "oss_default",
       };
     },

--- a/ui/src/api/artifacts.test.ts
+++ b/ui/src/api/artifacts.test.ts
@@ -75,6 +75,18 @@ describe("artifactsApi.list", () => {
     );
   });
 
+  it("omits the starred param when false", async () => {
+    await artifactsApi.list("company-1", { starred: false });
+    expect(mockApi.get).toHaveBeenCalledWith("/companies/company-1/artifacts");
+  });
+
+  it("serializes starred as the boolean-coercible string and composes with search", async () => {
+    await artifactsApi.list("company-1", { starred: true, q: "plan" });
+    expect(mockApi.get).toHaveBeenCalledWith(
+      "/companies/company-1/artifacts?q=plan&starred=true",
+    );
+  });
+
   it("preserves groups and selectedGroup from the envelope", async () => {
     const artifact = sampleArtifact();
     const group = {

--- a/ui/src/api/artifacts.ts
+++ b/ui/src/api/artifacts.ts
@@ -39,6 +39,11 @@ export interface ListArtifactsParams {
   groupBy?: CompanyArtifactGroupBy;
   /** When grouping, selects a single stack to expand into its artifacts. */
   groupIssueId?: string;
+  /**
+   * Restrict to artifacts the current viewer has starred (documents only in V1).
+   * Requires a board viewer server-side; other actors get an empty list.
+   */
+  starred?: boolean;
   limit?: number;
   cursor?: string;
 }
@@ -50,6 +55,10 @@ function buildArtifactsQuery(params?: ListArtifactsParams): string {
   if (params?.q) search.set("q", params.q);
   if (params?.groupBy && params.groupBy !== "none") search.set("groupBy", params.groupBy);
   if (params?.groupIssueId) search.set("groupIssueId", params.groupIssueId);
+  // Server coerces the string "true" into the boolean filter (see
+  // companyArtifactsQuerySchema); the page's shareable `?starred=1` param is
+  // translated here so the two encodings stay decoupled.
+  if (params?.starred) search.set("starred", "true");
   if (params?.limit != null) search.set("limit", String(params.limit));
   if (params?.cursor) search.set("cursor", params.cursor);
   const qs = search.toString();

--- a/ui/src/api/resourceMemberships.ts
+++ b/ui/src/api/resourceMemberships.ts
@@ -18,4 +18,9 @@ export const resourceMembershipsApi = {
       `/companies/${companyId}/resource-memberships/me/agents/${agentId}`,
       data,
     ),
+  updateDocument: (companyId: string, documentId: string, data: { starred: boolean }) =>
+    api.put<ResourceMembershipUpdateResult>(
+      `/companies/${companyId}/resource-memberships/me/documents/${documentId}`,
+      data,
+    ),
 };

--- a/ui/src/components/ArtifactsPanel.tsx
+++ b/ui/src/components/ArtifactsPanel.tsx
@@ -4,6 +4,8 @@ import type { IssueWorkProduct } from "@paperclipai/shared";
 import { issuesApi } from "../api/issues";
 import { queryKeys } from "../lib/queryKeys";
 import { MarkdownBody } from "./MarkdownBody";
+import { StarToggle } from "./StarToggle";
+import { isStarred, useDocumentStarMutation, useResourceMemberships } from "../hooks/useResourceMemberships";
 import { cn } from "../lib/utils";
 import {
   FileText,
@@ -264,6 +266,9 @@ function DocumentViewer({
     queryFn: () => issuesApi.getDocument(taskId, docKey),
   });
 
+  const membershipsQuery = useResourceMemberships(doc?.companyId ?? null);
+  const documentStarMutation = useDocumentStarMutation(doc?.companyId ?? null);
+
   const needsAction = status === "ready_for_review" || reviewState === "needs_board_review";
   const isApproved = status === "approved" || reviewState === "approved";
   const isRejected = status === "changes_requested" || reviewState === "changes_requested";
@@ -275,6 +280,25 @@ function DocumentViewer({
           <ArrowLeft className="h-4 w-4" />
         </button>
         <h3 className="text-sm font-semibold flex-1 truncate">{title}</h3>
+        {doc ? (
+          <StarToggle
+            size="row"
+            starred={isStarred(membershipsQuery.data, "document", doc.id)}
+            pending={
+              documentStarMutation.isPending &&
+              documentStarMutation.variables?.documentId === doc.id
+            }
+            error={
+              documentStarMutation.isError &&
+              documentStarMutation.variables?.documentId === doc.id
+            }
+            resourceName={title}
+            revealClassName="opacity-100"
+            onToggle={(next) =>
+              documentStarMutation.mutate({ documentId: doc.id, documentName: title, starred: next })
+            }
+          />
+        ) : null}
         <button onClick={onBack} className="text-muted-foreground hover:text-foreground">
           <X className="h-4 w-4" />
         </button>

--- a/ui/src/components/IssueDocumentsSection.test.tsx
+++ b/ui/src/components/IssueDocumentsSection.test.tsx
@@ -11,6 +11,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IssueDocumentsSection } from "./IssueDocumentsSection";
 import { queryKeys } from "../lib/queryKeys";
 
+// The document StarToggle uses the shared resource-membership mutation, which
+// pulls in toast feedback; stub the throwing hook so these provider-less renders
+// don't need a ToastProvider (all other real exports stay intact).
+vi.mock("../context/ToastContext", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../context/ToastContext")>()),
+  useToastActions: () => ({ pushToast: vi.fn(), dismissToast: vi.fn() }),
+}));
+
 const mockIssuesApi = vi.hoisted(() => ({
   listDocuments: vi.fn(),
   listDocumentRevisions: vi.fn(),

--- a/ui/src/components/IssueDocumentsSection.tsx
+++ b/ui/src/components/IssueDocumentsSection.tsx
@@ -38,6 +38,8 @@ import { Check, Copy, Diff, Download, FilePenLine, FileText, Lock, MoreHorizonta
 import { DocumentDiffModal } from "./DocumentDiffModal";
 import { DocumentFrameHeader, type DocumentFrameHeaderRevisionActor } from "./DocumentFrameHeader";
 import { SourceTrustBadge } from "./SourceTrustBadge";
+import { StarToggle } from "./StarToggle";
+import { isStarred, useDocumentStarMutation, useResourceMemberships } from "../hooks/useResourceMemberships";
 import { Badge } from "@/components/ui/badge";
 
 type DraftState = {
@@ -450,6 +452,12 @@ export function IssueDocumentsSection({
     }
     return map;
   }, [feedbackVotes]);
+
+  // Per-viewer document stars. All documents in a section share a company, so we
+  // derive it once and drive a single optimistic mutation keyed by document id.
+  const starCompanyId = sortedDocuments[0]?.companyId ?? null;
+  const membershipsQuery = useResourceMemberships(starCompanyId);
+  const documentStarMutation = useDocumentStarMutation(starCompanyId);
 
   const hasRealPlan = sortedDocuments.some((doc) => doc.key === "plan");
   const isEmpty = sortedDocuments.length === 0 && !documentSubject.legacyPlanDocument;
@@ -1058,6 +1066,27 @@ export function IssueDocumentsSection({
                 titleSlot={showTitle ? <p className="mt-2 text-sm font-medium">{displayedTitle}</p> : null}
                 actionsSlot={
                   <>
+                    <StarToggle
+                      size="row"
+                      starred={isStarred(membershipsQuery.data, "document", doc.id)}
+                      pending={
+                        documentStarMutation.isPending &&
+                        documentStarMutation.variables?.documentId === doc.id
+                      }
+                      error={
+                        documentStarMutation.isError &&
+                        documentStarMutation.variables?.documentId === doc.id
+                      }
+                      resourceName={displayedTitle.trim() || doc.key}
+                      revealClassName="opacity-100"
+                      onToggle={(next) =>
+                        documentStarMutation.mutate({
+                          documentId: doc.id,
+                          documentName: displayedTitle.trim() || doc.key,
+                          starred: next,
+                        })
+                      }
+                    />
                     {canManageDocumentLocks ? (
                     <Button
                       variant="ghost"

--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -230,6 +230,8 @@ describe("SidebarAgents", () => {
     memberships = {
       projectMemberships: {},
       agentMemberships: {},
+      starredDocumentIds: [],
+      documentStarredAt: {},
       updatedAt: null,
     };
     mockResourceMembershipsApi.listMine.mockImplementation(() => Promise.resolve(memberships));
@@ -368,8 +370,10 @@ describe("SidebarAgents", () => {
       agentMemberships: {},
       starredProjectIds: [],
       starredAgentIds: ["agent-b"],
+      starredDocumentIds: [],
       projectStarredAt: {},
       agentStarredAt: {},
+      documentStarredAt: {},
       updatedAt: new Date(),
     };
 
@@ -417,8 +421,10 @@ describe("SidebarAgents", () => {
       agentMemberships: { "agent-b": "joined" },
       starredProjectIds: [],
       starredAgentIds: ["agent-b"],
+      starredDocumentIds: [],
       projectStarredAt: {},
       agentStarredAt: {},
+      documentStarredAt: {},
       updatedAt: new Date(),
     };
     mockResourceMembershipsApi.updateAgent.mockRejectedValue(new Error("nope"));
@@ -544,6 +550,8 @@ describe("SidebarAgents", () => {
       resolveMemberships({
         projectMemberships: {},
         agentMemberships: { "agent-1": "left" },
+        starredDocumentIds: [],
+        documentStarredAt: {},
         updatedAt: null,
       });
     });

--- a/ui/src/components/SidebarProjects.test.tsx
+++ b/ui/src/components/SidebarProjects.test.tsx
@@ -297,6 +297,8 @@ describe("SidebarProjects", () => {
     memberships = {
       projectMemberships: {},
       agentMemberships: {},
+      starredDocumentIds: [],
+      documentStarredAt: {},
       updatedAt: null,
     };
     mockResourceMembershipsApi.listMine.mockImplementation(() => Promise.resolve(memberships));

--- a/ui/src/components/SidebarStarredProjects.test.tsx
+++ b/ui/src/components/SidebarStarredProjects.test.tsx
@@ -135,8 +135,10 @@ describe("SidebarStarredProjects", () => {
       agentMemberships: {},
       starredProjectIds: [],
       starredAgentIds: [],
+      starredDocumentIds: [],
       projectStarredAt: {},
       agentStarredAt: {},
+      documentStarredAt: {},
       updatedAt: null,
     };
     mockResourceMembershipsApi.listMine.mockImplementation(() => Promise.resolve(memberships));

--- a/ui/src/components/artifacts/ArtifactCard.tsx
+++ b/ui/src/components/artifacts/ArtifactCard.tsx
@@ -3,6 +3,20 @@ import { Download, ExternalLink, Paperclip, Play } from "lucide-react";
 import type { CompanyArtifact } from "@/api/artifacts";
 import { Link } from "@/lib/router";
 import { cn, formatDate } from "@/lib/utils";
+import { useCompany } from "@/context/CompanyContext";
+import {
+  isStarred,
+  useDocumentStarMutation,
+  useResourceMemberships,
+} from "@/hooks/useResourceMemberships";
+import { StarToggle } from "@/components/StarToggle";
+
+/** Document artifact ids are `document:<documents.id>`; other sources have no star. */
+function documentIdFromArtifactId(artifact: CompanyArtifact): string | null {
+  if (artifact.source !== "document") return null;
+  const prefix = "document:";
+  return artifact.id.startsWith(prefix) ? artifact.id.slice(prefix.length) : null;
+}
 
 interface ArtifactCardProps {
   artifact: CompanyArtifact;
@@ -190,7 +204,35 @@ function SecondaryAction({
   );
 }
 
+/**
+ * Star control for a document artifact card. Rendered only for `document`
+ * sources (mounted conditionally so the membership hooks stay off non-document
+ * cards). Reuses the shared row StarToggle + resource-membership optimistic
+ * machinery. Lives outside the hover-reveal group so a starred document stays
+ * visibly marked at rest while unstarred stars reveal on hover/focus.
+ */
+function ArtifactCardStar({ documentId, name }: { documentId: string; name: string }) {
+  const { selectedCompanyId } = useCompany();
+  const membershipsQuery = useResourceMemberships(selectedCompanyId);
+  const starMutation = useDocumentStarMutation(selectedCompanyId);
+  const starred = isStarred(membershipsQuery.data, "document", documentId);
+  const pending = starMutation.isPending && starMutation.variables?.documentId === documentId;
+  const error = starMutation.isError && starMutation.variables?.documentId === documentId;
+
+  return (
+    <StarToggle
+      size="row"
+      starred={starred}
+      pending={pending}
+      error={error}
+      resourceName={name}
+      onToggle={(next) => starMutation.mutate({ documentId, documentName: name, starred: next })}
+    />
+  );
+}
+
 export function ArtifactCard({ artifact }: ArtifactCardProps) {
+  const documentId = documentIdFromArtifactId(artifact);
   return (
     <Link
       // design-allow(card-pattern): navigation <Link> card; Card renders a div and would break anchor semantics (C5a Run 3)
@@ -210,17 +252,20 @@ export function ArtifactCard({ artifact }: ArtifactCardProps) {
           >
             {artifact.title}
           </h3>
-          <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-            {artifact.openPath ? (
-              <SecondaryAction href={artifact.openPath} title="Open file in new tab">
-                <ExternalLink className="h-3.5 w-3.5" />
-              </SecondaryAction>
-            ) : null}
-            {artifact.downloadPath ? (
-              <SecondaryAction href={artifact.downloadPath} download title="Download file">
-                <Download className="h-3.5 w-3.5" />
-              </SecondaryAction>
-            ) : null}
+          <div className="flex shrink-0 items-center gap-0.5">
+            {documentId ? <ArtifactCardStar documentId={documentId} name={artifact.title} /> : null}
+            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+              {artifact.openPath ? (
+                <SecondaryAction href={artifact.openPath} title="Open file in new tab">
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </SecondaryAction>
+              ) : null}
+              {artifact.downloadPath ? (
+                <SecondaryAction href={artifact.downloadPath} download title="Download file">
+                  <Download className="h-3.5 w-3.5" />
+                </SecondaryAction>
+              ) : null}
+            </div>
           </div>
         </div>
 

--- a/ui/src/hooks/useDocumentStarMutation.test.tsx
+++ b/ui/src/hooks/useDocumentStarMutation.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResourceMemberships } from "@paperclipai/shared";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const membershipsApiMock = vi.hoisted(() => ({
+  listMine: vi.fn(),
+  updateDocument: vi.fn(),
+}));
+
+const pushToast = vi.hoisted(() => vi.fn());
+
+vi.mock("../api/resourceMemberships", () => ({
+  resourceMembershipsApi: membershipsApiMock,
+}));
+
+vi.mock("../context/ToastContext", () => ({
+  useToastActions: () => ({ pushToast }),
+}));
+
+import { useDocumentStarMutation, useResourceMemberships } from "./useResourceMemberships";
+import { queryKeys } from "../lib/queryKeys";
+
+const MINE_KEY = queryKeys.resourceMemberships.mine("company-1");
+
+function emptyMemberships(): ResourceMemberships {
+  return {
+    projectMemberships: {},
+    agentMemberships: {},
+    starredProjectIds: [],
+    starredAgentIds: [],
+    starredDocumentIds: [],
+    projectStarredAt: {},
+    agentStarredAt: {},
+    documentStarredAt: {},
+    updatedAt: null,
+  };
+}
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flush() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+type HarnessHandle = { mutate: ReturnType<typeof useDocumentStarMutation>["mutate"] };
+
+function Harness({ onReady }: { onReady: (handle: HarnessHandle) => void }) {
+  useResourceMemberships("company-1");
+  const mutation = useDocumentStarMutation("company-1");
+  onReady({ mutate: mutation.mutate });
+  return <div data-testid="harness" />;
+}
+
+function starredIds(queryClient: QueryClient): string[] {
+  return queryClient.getQueryData<ResourceMemberships>(MINE_KEY)?.starredDocumentIds ?? [];
+}
+
+describe("useDocumentStarMutation", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+    membershipsApiMock.listMine.mockReset();
+    membershipsApiMock.updateDocument.mockReset();
+    pushToast.mockReset();
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => { root?.unmount(); });
+    }
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  async function render(onReady: (handle: HarnessHandle) => void) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <Harness onReady={onReady} />
+        </QueryClientProvider>,
+      );
+    });
+    // Let the initial memberships query settle into the cache.
+    await act(async () => { await flush(); });
+    return queryClient;
+  }
+
+  it("optimistically stars a document before the server responds and confirms on success", async () => {
+    membershipsApiMock.listMine.mockResolvedValue(emptyMemberships());
+    let resolveUpdate: (() => void) | null = null;
+    membershipsApiMock.updateDocument.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpdate = () =>
+          resolve({
+            resourceType: "document",
+            resourceId: "doc-1",
+            state: "joined",
+            starredAt: new Date(),
+            updatedAt: new Date(),
+          });
+      }),
+    );
+
+    let handle: HarnessHandle | null = null;
+    const queryClient = await render((h) => { handle = h; });
+    expect(starredIds(queryClient)).not.toContain("doc-1");
+
+    await act(async () => {
+      handle!.mutate({ documentId: "doc-1", documentName: "Launch Brief", starred: true });
+      await flush();
+    });
+
+    // Optimistic flip is applied to the cache while the request is still in flight.
+    expect(starredIds(queryClient)).toContain("doc-1");
+    expect(membershipsApiMock.updateDocument).toHaveBeenCalledWith("company-1", "doc-1", { starred: true });
+
+    // Server truth now reflects the star; the post-settle refetch stays consistent.
+    membershipsApiMock.listMine.mockResolvedValue({
+      ...emptyMemberships(),
+      starredDocumentIds: ["doc-1"],
+      documentStarredAt: { "doc-1": new Date().toISOString() },
+    });
+    await act(async () => {
+      resolveUpdate?.();
+      await flush();
+    });
+    // Server confirmation (starredAt set) keeps the star in place.
+    expect(starredIds(queryClient)).toContain("doc-1");
+  });
+
+  it("rolls back the optimistic unstar and toasts when the server rejects", async () => {
+    membershipsApiMock.listMine.mockResolvedValue({
+      ...emptyMemberships(),
+      starredDocumentIds: ["doc-1"],
+      documentStarredAt: { "doc-1": new Date().toISOString() },
+    });
+    membershipsApiMock.updateDocument.mockRejectedValue(new Error("nope"));
+
+    let handle: HarnessHandle | null = null;
+    const queryClient = await render((h) => { handle = h; });
+    expect(starredIds(queryClient)).toContain("doc-1");
+
+    await act(async () => {
+      handle!.mutate({ documentId: "doc-1", documentName: "Launch Brief", starred: false });
+      await flush();
+    });
+
+    // Rolled back to the pre-mutation (starred) snapshot after the rejection.
+    expect(starredIds(queryClient)).toContain("doc-1");
+    expect(pushToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Couldn't unstar Launch Brief.", tone: "error" }),
+    );
+  });
+});

--- a/ui/src/hooks/useDocumentStarMutation.test.tsx
+++ b/ui/src/hooks/useDocumentStarMutation.test.tsx
@@ -149,6 +149,32 @@ describe("useDocumentStarMutation", () => {
     expect(starredIds(queryClient)).toContain("doc-1");
   });
 
+  it("invalidates the Artifacts list on settle so an unstarred doc leaves the Starred tab", async () => {
+    membershipsApiMock.listMine.mockResolvedValue({
+      ...emptyMemberships(),
+      starredDocumentIds: ["doc-1"],
+      documentStarredAt: { "doc-1": new Date().toISOString() },
+    });
+    membershipsApiMock.updateDocument.mockResolvedValue({
+      resourceType: "document",
+      resourceId: "doc-1",
+      state: "left",
+      starredAt: null,
+      updatedAt: new Date(),
+    });
+
+    let handle: HarnessHandle | null = null;
+    const queryClient = await render((h) => { handle = h; });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await act(async () => {
+      handle!.mutate({ documentId: "doc-1", documentName: "Launch Brief", starred: false });
+      await flush();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["artifacts"] });
+  });
+
   it("rolls back the optimistic unstar and toasts when the server rejects", async () => {
     membershipsApiMock.listMine.mockResolvedValue({
       ...emptyMemberships(),

--- a/ui/src/hooks/useResourceMemberships.ts
+++ b/ui/src/hooks/useResourceMemberships.ts
@@ -259,16 +259,22 @@ export function useDocumentStarMutation(companyId: string | null | undefined) {
     onMutate: async (variables) => {
       await queryClient.cancelQueries({ queryKey });
       const previous = queryClient.getQueryData<ResourceMemberships>(queryKey);
+      // Capture only this document's prior star so a rollback reverts just this
+      // change and leaves any concurrent star mutation's optimistic state intact.
+      const previousStarred = isStarred(previous, "document", variables.documentId);
       queryClient.setQueryData<ResourceMemberships>(
         queryKey,
         applyDocumentStarChange(previous, variables.documentId, variables.starred),
       );
-      return { previous };
+      return { previousStarred };
     },
     onError: (error, variables, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(queryKey, context.previous);
-      }
+      // Targeted rollback: re-apply this document's prior star on top of the
+      // current cache, so we don't clobber a newer concurrent update.
+      queryClient.setQueryData<ResourceMemberships>(
+        queryKey,
+        (current) => applyDocumentStarChange(current, variables.documentId, context?.previousStarred ?? false),
+      );
       pushToast({
         title: `Couldn't ${variables.starred ? "star" : "unstar"} ${variables.documentName}.`,
         body: error instanceof Error ? error.message : "Try again.",
@@ -284,6 +290,10 @@ export function useDocumentStarMutation(companyId: string | null | undefined) {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey });
+      // The Artifacts "Starred" tab is a separate list query keyed by ["artifacts", ...],
+      // so refresh it too — otherwise an unstarred document lingers in the grid
+      // until the next natural refetch.
+      queryClient.invalidateQueries({ queryKey: ["artifacts"] });
     },
   });
 }

--- a/ui/src/hooks/useResourceMemberships.ts
+++ b/ui/src/hooks/useResourceMemberships.ts
@@ -9,7 +9,7 @@ import { useToastActions } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
 
 type MutationVariables = {
-  resourceType: ResourceMembershipResourceType;
+  resourceType: JoinableResourceType;
   resourceId: string;
   resourceName: string;
   /** Join / leave transition. Omit to only change the starred flag. */
@@ -18,19 +18,23 @@ type MutationVariables = {
   starred?: boolean;
 };
 
+type JoinableResourceType = Exclude<ResourceMembershipResourceType, "document">;
+
 function emptyMemberships(): ResourceMemberships {
   return {
     projectMemberships: {},
     agentMemberships: {},
     starredProjectIds: [],
     starredAgentIds: [],
+    starredDocumentIds: [],
     projectStarredAt: {},
     agentStarredAt: {},
+    documentStarredAt: {},
     updatedAt: null,
   };
 }
 
-function starKeys(resourceType: ResourceMembershipResourceType) {
+function starKeys(resourceType: JoinableResourceType) {
   return resourceType === "project"
     ? { ids: "starredProjectIds", at: "projectStarredAt", state: "projectMemberships" }
     : { ids: "starredAgentIds", at: "agentStarredAt", state: "agentMemberships" };
@@ -45,7 +49,7 @@ function starKeys(resourceType: ResourceMembershipResourceType) {
  */
 function applyMembershipChange(
   current: ResourceMemberships | undefined,
-  resourceType: ResourceMembershipResourceType,
+  resourceType: JoinableResourceType,
   resourceId: string,
   change: { state?: ResourceMembershipState; starred?: boolean },
 ): ResourceMemberships {
@@ -96,7 +100,7 @@ function applyMembershipChange(
 
 export function resourceMembershipState(
   memberships: ResourceMemberships | undefined,
-  resourceType: ResourceMembershipResourceType,
+  resourceType: JoinableResourceType,
   resourceId: string,
 ): ResourceMembershipState {
   const state = resourceType === "project"
@@ -113,7 +117,9 @@ export function isStarred(
 ): boolean {
   const ids = resourceType === "project"
     ? memberships?.starredProjectIds
-    : memberships?.starredAgentIds;
+    : resourceType === "agent"
+      ? memberships?.starredAgentIds
+      : memberships?.starredDocumentIds;
   return Array.isArray(ids) && ids.includes(resourceId);
 }
 
@@ -124,7 +130,9 @@ export function starredResourceIds(
 ): string[] {
   const ids = resourceType === "project"
     ? memberships?.starredProjectIds
-    : memberships?.starredAgentIds;
+    : resourceType === "agent"
+      ? memberships?.starredAgentIds
+      : memberships?.starredDocumentIds;
   return Array.isArray(ids) ? ids : [];
 }
 

--- a/ui/src/hooks/useResourceMemberships.ts
+++ b/ui/src/hooks/useResourceMemberships.ts
@@ -98,6 +98,40 @@ function applyMembershipChange(
   };
 }
 
+/**
+ * Apply an optimistic document star change to the cached memberships snapshot.
+ * Documents have no join/leave state — they only carry a per-viewer star, so
+ * this mirrors the `document` half of the server rules: starring prepends the id
+ * (newest-first, matching starredAt DESC) and stamps `documentStarredAt`;
+ * unstarring drops both.
+ */
+function applyDocumentStarChange(
+  current: ResourceMemberships | undefined,
+  documentId: string,
+  starred: boolean,
+): ResourceMemberships {
+  const base = current ?? emptyMemberships();
+  const currentIds = base.starredDocumentIds ?? [];
+  const nextStarredAt = { ...(base.documentStarredAt ?? {}) };
+  const previouslyStarred = currentIds.includes(documentId);
+
+  let starredIds = currentIds;
+  if (starred && !previouslyStarred) {
+    starredIds = [documentId, ...currentIds];
+    nextStarredAt[documentId] = new Date().toISOString();
+  } else if (!starred && previouslyStarred) {
+    starredIds = currentIds.filter((id) => id !== documentId);
+    delete nextStarredAt[documentId];
+  }
+
+  return {
+    ...base,
+    starredDocumentIds: starredIds,
+    documentStarredAt: nextStarredAt,
+    updatedAt: new Date(),
+  };
+}
+
 export function resourceMembershipState(
   memberships: ResourceMemberships | undefined,
   resourceType: JoinableResourceType,
@@ -190,6 +224,62 @@ export function useResourceMembershipMutation(companyId: string | null | undefin
           state: result.state,
           starred: result.starredAt != null,
         }),
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+}
+
+type DocumentStarVariables = {
+  documentId: string;
+  /** Human-readable document name, used for the error toast. */
+  documentName: string;
+  starred: boolean;
+};
+
+/**
+ * Optimistic star/unstar for documents. Mirrors {@link useResourceMembershipMutation}
+ * but talks to the document-only route (documents have no join/leave state) and
+ * touches the `starredDocumentIds` / `documentStarredAt` cache fields.
+ */
+export function useDocumentStarMutation(companyId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToastActions();
+  const queryKey = queryKeys.resourceMemberships.mine(companyId ?? "__none__");
+
+  return useMutation({
+    mutationFn: (variables: DocumentStarVariables) => {
+      if (!companyId) throw new Error("Select a company first.");
+      return resourceMembershipsApi.updateDocument(companyId, variables.documentId, {
+        starred: variables.starred,
+      });
+    },
+    onMutate: async (variables) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ResourceMemberships>(queryKey);
+      queryClient.setQueryData<ResourceMemberships>(
+        queryKey,
+        applyDocumentStarChange(previous, variables.documentId, variables.starred),
+      );
+      return { previous };
+    },
+    onError: (error, variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+      pushToast({
+        title: `Couldn't ${variables.starred ? "star" : "unstar"} ${variables.documentName}.`,
+        body: error instanceof Error ? error.message : "Try again.",
+        tone: "error",
+      });
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<ResourceMemberships>(
+        queryKey,
+        // Loose null-check: a missing or null starredAt both mean "not starred".
+        (current) => applyDocumentStarChange(current, result.resourceId, result.starredAt != null),
       );
     },
     onSettled: () => {

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -275,6 +275,7 @@ export const queryKeys = {
       q?: string,
       groupBy?: string,
       groupIssueId?: string,
+      starred?: boolean,
     ) =>
       [
         "artifacts",
@@ -283,6 +284,7 @@ export const queryKeys = {
         q ?? "",
         groupBy ?? "none",
         groupIssueId ?? "",
+        starred ? "starred" : "all",
       ] as const,
   },
   budgets: {

--- a/ui/src/pages/Artifacts.test.tsx
+++ b/ui/src/pages/Artifacts.test.tsx
@@ -182,6 +182,7 @@ describe("Artifacts page", () => {
         q: undefined,
         groupBy: "task",
         groupIssueId: undefined,
+        starred: false,
         limit: 30,
         cursor: undefined,
       });
@@ -228,6 +229,7 @@ describe("Artifacts page", () => {
         q: "launch",
         groupBy: "task",
         groupIssueId: undefined,
+        starred: false,
         limit: 30,
         cursor: undefined,
       });
@@ -285,6 +287,7 @@ describe("Artifacts page", () => {
         q: undefined,
         groupBy: "none",
         groupIssueId: undefined,
+        starred: false,
         limit: 30,
         cursor: "cursor-2",
       });
@@ -325,6 +328,7 @@ describe("Artifacts page", () => {
         q: undefined,
         groupBy: "none",
         groupIssueId: undefined,
+        starred: false,
         limit: 30,
         cursor: undefined,
       });
@@ -353,6 +357,7 @@ describe("Artifacts page", () => {
         q: undefined,
         groupBy: "task",
         groupIssueId: undefined,
+        starred: false,
         limit: 30,
         cursor: undefined,
       });
@@ -386,6 +391,7 @@ describe("Artifacts page", () => {
         q: undefined,
         groupBy: "task",
         groupIssueId: "issue-1",
+        starred: false,
         limit: 30,
         cursor: undefined,
       });
@@ -395,6 +401,95 @@ describe("Artifacts page", () => {
       ).toBe("/artifacts");
       expect(container.textContent).toContain("Stacked Artifact");
       expect(container.querySelector('[data-testid="artifact-card"]')).not.toBeNull();
+    });
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  it("requests starred documents from the ?starred=1 URL, ignoring kind and grouping", async () => {
+    artifactsApiMock.list.mockResolvedValue({
+      artifacts: [sampleArtifact({ id: "document:doc-1", title: "Starred Brief" })],
+      nextCursor: null,
+    });
+
+    const { root } = renderArtifacts(container, ["/artifacts?starred=1&kind=image&groupBy=task"]);
+
+    await waitForAssertion(() => {
+      expect(artifactsApiMock.list).toHaveBeenCalledWith("company-1", {
+        kind: "all",
+        q: undefined,
+        groupBy: "none",
+        groupIssueId: undefined,
+        starred: true,
+        limit: 30,
+        cursor: undefined,
+      });
+      const starredTab = container.querySelector('[data-testid="artifact-starred-tab"]') as HTMLElement;
+      expect(starredTab.getAttribute("aria-selected")).toBe("true");
+      // The grouping control is hidden in the documents-only Starred view.
+      expect(container.querySelector('[data-testid="artifact-group-control"]')).toBeNull();
+      expect(container.querySelector('[data-testid="artifact-card"]')).not.toBeNull();
+    });
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  it("composes the search query with the Starred filter", async () => {
+    artifactsApiMock.list.mockResolvedValue({ artifacts: [], nextCursor: null });
+
+    const { root } = renderArtifacts(container, ["/artifacts?starred=1&q=launch"]);
+
+    await waitForAssertion(() => {
+      expect(artifactsApiMock.list).toHaveBeenCalledWith("company-1", {
+        kind: "all",
+        q: "launch",
+        groupBy: "none",
+        groupIssueId: undefined,
+        starred: true,
+        limit: 30,
+        cursor: undefined,
+      });
+      // Empty state guides the user to star a document.
+      expect(container.textContent).toContain("No starred documents match this search.");
+    });
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  it("enters the Starred view when the Starred tab is clicked", async () => {
+    artifactsApiMock.list.mockResolvedValue({ artifacts: [], groups: [sampleGroup()], nextCursor: null });
+
+    const { root } = renderArtifacts(container);
+
+    const starredTab = await (async () => {
+      let tab: HTMLElement | null = null;
+      await waitForAssertion(() => {
+        tab = container.querySelector('[data-testid="artifact-starred-tab"]');
+        expect(tab).not.toBeNull();
+      });
+      return tab as unknown as HTMLElement;
+    })();
+
+    flushSync(() => {
+      starredTab.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(artifactsApiMock.list).toHaveBeenLastCalledWith("company-1", {
+        kind: "all",
+        q: undefined,
+        groupBy: "none",
+        groupIssueId: undefined,
+        starred: true,
+        limit: 30,
+        cursor: undefined,
+      });
     });
 
     flushSync(() => {
@@ -417,6 +512,7 @@ describe("Artifacts page", () => {
         q: undefined,
         groupBy: "task",
         groupIssueId: undefined,
+        starred: false,
         limit: 30,
         cursor: undefined,
       });

--- a/ui/src/pages/Artifacts.tsx
+++ b/ui/src/pages/Artifacts.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { ArrowLeft, Check, Layers, Package, Search, X } from "lucide-react";
+import { ArrowLeft, Check, Layers, Package, Search, Star, X } from "lucide-react";
 import type { To } from "react-router-dom";
 import {
   artifactsApi,
@@ -66,10 +66,13 @@ export function Artifacts() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const kind = parseKind(searchParams.get("kind"));
+  const starred = searchParams.get("starred") === "1";
+  // Starred is documents-only in V1: it ignores the kind filter and grouping so
+  // the tab always renders a flat list of the viewer's starred documents.
+  const kind = starred ? "all" : parseKind(searchParams.get("kind"));
   const query = searchParams.get("q") ?? "";
-  const groupBy = parseGroupBy(searchParams.get("groupBy"));
-  const groupIssueId = searchParams.get("groupIssueId") ?? undefined;
+  const groupBy = starred ? "none" : parseGroupBy(searchParams.get("groupBy"));
+  const groupIssueId = starred ? undefined : (searchParams.get("groupIssueId") ?? undefined);
 
   const [draftQuery, setDraftQuery] = useState(query);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -117,12 +120,26 @@ export function Artifacts() {
   const selectKind = useCallback(
     (value: ArtifactKindFilter) => {
       updateParams((next) => {
+        // Selecting any kind tab exits the Starred view (they are mutually
+        // exclusive: Starred resets the kind filter in V1).
+        next.delete("starred");
         if (value === "all") next.delete("kind");
         else next.set("kind", value);
       });
     },
     [updateParams],
   );
+
+  const selectStarred = useCallback(() => {
+    updateParams((next) => {
+      // Starred is documents-only: drop the kind filter and any grouping so the
+      // tab is a clean, shareable flat list (`?starred=1` composes with `q`).
+      next.set("starred", "1");
+      next.delete("kind");
+      next.delete("groupBy");
+      next.delete("groupIssueId");
+    });
+  }, [updateParams]);
 
   const selectGroupBy = useCallback(
     (value: ArtifactGroupBy) => {
@@ -177,13 +194,14 @@ export function Artifacts() {
     fetchNextPage,
     error,
   } = useInfiniteQuery({
-    queryKey: queryKeys.artifacts.list(selectedCompanyId!, kind, query, groupBy, groupIssueId),
+    queryKey: queryKeys.artifacts.list(selectedCompanyId!, kind, query, groupBy, groupIssueId, starred),
     queryFn: ({ pageParam }) =>
       artifactsApi.list(selectedCompanyId!, {
         kind,
         q: query || undefined,
         groupBy,
         groupIssueId,
+        starred,
         limit: ARTIFACTS_PAGE_SIZE,
         cursor: pageParam,
       }),
@@ -233,7 +251,11 @@ export function Artifacts() {
   const showGroupCards = viewingStackList;
   const items = showGroupCards ? groups : artifacts;
 
-  const emptyMessage = showGroupCards
+  const emptyMessage = starred
+    ? searching
+      ? "No starred documents match this search."
+      : "No starred documents yet — star a document from its header or card."
+    : showGroupCards
     ? searching
       ? "No artifact stacks match this search."
       : "No artifact stacks yet."
@@ -270,37 +292,40 @@ export function Artifacts() {
         </div>
 
         <div className="flex flex-wrap items-center gap-1.5">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                aria-label={`Group artifacts (currently ${artifactGroupByLabel(groupBy)})`}
-                title="Group artifacts"
-                data-testid="artifact-group-control"
-                data-group-by={groupBy}
-                className={cn("h-8 w-8 shrink-0", grouping && "bg-accent")}
-              >
-                <Layers className="h-3.5 w-3.5" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              <DropdownMenuLabel>Group by</DropdownMenuLabel>
-              {ARTIFACT_GROUP_OPTIONS.map((option) => (
-                <DropdownMenuItem
-                  key={option.value}
-                  data-testid={`artifact-group-option-${option.value}`}
-                  aria-selected={groupBy === option.value}
-                  onSelect={() => selectGroupBy(option.value)}
-                  className="justify-between"
+          {/* Grouping is meaningless in the documents-only Starred view. */}
+          {!starred ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={`Group artifacts (currently ${artifactGroupByLabel(groupBy)})`}
+                  title="Group artifacts"
+                  data-testid="artifact-group-control"
+                  data-group-by={groupBy}
+                  className={cn("h-8 w-8 shrink-0", grouping && "bg-accent")}
                 >
-                  {option.label}
-                  {groupBy === option.value ? <Check className="h-3.5 w-3.5" /> : null}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  <Layers className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuLabel>Group by</DropdownMenuLabel>
+                {ARTIFACT_GROUP_OPTIONS.map((option) => (
+                  <DropdownMenuItem
+                    key={option.value}
+                    data-testid={`artifact-group-option-${option.value}`}
+                    aria-selected={groupBy === option.value}
+                    onSelect={() => selectGroupBy(option.value)}
+                    className="justify-between"
+                  >
+                    {option.label}
+                    {groupBy === option.value ? <Check className="h-3.5 w-3.5" /> : null}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
 
           <div className="flex flex-wrap items-center gap-1.5" role="tablist" aria-label="Filter artifacts by type">
             {ARTIFACT_KIND_FILTERS.map((filter) => (
@@ -308,11 +333,11 @@ export function Artifacts() {
                 key={filter.value}
                 type="button"
                 role="tab"
-                aria-selected={kind === filter.value}
+                aria-selected={!starred && kind === filter.value}
                 onClick={() => selectKind(filter.value)}
                 className={cn(
                   "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                  kind === filter.value
+                  !starred && kind === filter.value
                     ? "bg-accent text-foreground"
                     : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                 )}
@@ -320,6 +345,25 @@ export function Artifacts() {
                 {filter.label}
               </button>
             ))}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={starred}
+              onClick={selectStarred}
+              data-testid="artifact-starred-tab"
+              className={cn(
+                "inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                starred
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+              )}
+            >
+              <Star
+                className={cn("h-3.5 w-3.5", starred && "fill-amber-500 text-amber-500")}
+                aria-hidden="true"
+              />
+              Starred
+            </button>
           </div>
         </div>
       </div>
@@ -348,7 +392,7 @@ export function Artifacts() {
       {isLoading ? (
         <PageSkeleton variant="list" />
       ) : items.length === 0 ? (
-        <EmptyState icon={showGroupCards ? Layers : Package} message={emptyMessage} />
+        <EmptyState icon={starred ? Star : showGroupCards ? Layers : Package} message={emptyMessage} />
       ) : (
         <>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Documents (plans, briefs, specs produced on issues) surface both inline on issue pages and as cards on the company-wide `/artifacts` page
> - Users can already star projects and agents to pin what matters, but there is no way to star a document or to find starred documents quickly
> - As document counts grow this gap makes it hard to return to the handful of documents you actually care about
> - This pull request adds per-user document stars everywhere a document is shown (issue header, artifact card, side-panel viewer) plus a URL-shareable **Starred** tab on `/artifacts`
> - The benefit is a consistent, optimistic starring affordance that reuses the existing `StarToggle` and resource-membership machinery, so pinning and finding key documents works the same way as projects/agents

## Linked Issues or Issue Description

This is the UI half of per-user document stars. It builds directly on the
server/data-model change in **#9952** (document memberships table, the
`PUT /companies/:id/resource-memberships/me/documents/:documentId { starred }`
route, the caller-scoped `starred` filter on the artifacts endpoint, and the
shared `starredDocumentIds` / `documentStarredAt` contract). This PR is stacked
on that branch and consumes those types/routes.

Refs #9952

**Problem (feature):** documents cannot be starred and there is no way to filter
`/artifacts` down to the documents a user has starred. This PR adds the star
affordances and the Starred tab.

> Note to maintainers: base branch is `feat/document-stars-server` (the #9952
> branch). Retarget to `master` once #9952 lands.

## What Changed

- **API / hooks:** `resourceMembershipsApi.updateDocument` and a new
  `useDocumentStarMutation` hook with an `applyDocumentStarChange` optimistic
  update over `starredDocumentIds` / `documentStarredAt`. Documents have no
  join/leave state, so this is a star-only sibling of the project/agent mutation.
- **Issue document header:** `StarToggle` in the `DocumentFrameHeader` actions,
  alongside Lock/Copy/⋯ (covers issue detail, case detail, and skill studio,
  which all render the shared documents section).
- **Artifacts grid:** star on cards whose source is `document` (the artifact id
  decodes to `document:<documentId>`); non-document cards get no star in this
  version. Starred cards stay marked at rest, unstarred reveal on hover/focus.
- **Issue side-panel viewer:** same toggle in the document-viewer header.
- **Starred tab:** URL-driven (`?starred=1`, shareable, composes with the search
  query) tab in the existing `/artifacts` filter row. Selecting it resets the
  kind filter and hides grouping (documents-only in this version) and shows a
  dedicated empty state.

## Verification

- `NODE_ENV=development pnpm --filter @paperclipai/ui exec vitest run src/api/artifacts.test.ts src/pages/Artifacts.test.tsx src/hooks/useDocumentStarMutation.test.tsx src/components/artifacts/ArtifactCard.test.tsx src/components/StarToggle.test.tsx src/components/IssueDocumentsSection.test.tsx` — all green (added: `starred` query serialization, Starred-tab param wiring, optimistic flip + rollback).
- `pnpm --filter @paperclipai/ui typecheck` — green.
- Visually verified all four states in a real Chromium via a seeded, no-backend
  Vite harness: document header (starred + default), Starred tab populated, and
  the empty state. Screenshots are attached to the tracking issue.

## Risks

- Low risk, additive UI. New optimistic mutation rolls back and toasts on server
  error. No migrations in this PR (they live in the base branch). The star
  route requires a board user server-side; non-board viewers get a graceful
  rollback rather than a persisted change.

## Model Used

Claude Opus 4.8 (model id `claude-opus-4-8`, 1M-context variant), with extended
thinking and tool use (code execution, browser-driven screenshot verification).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
