### PR TITLE
feat(i18n): add Chinese locale preference

### DIFF
--- a/ui/src/components/LocaleSwitcher.tsx
+++ b/ui/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,96 @@
+import { Globe } from "lucide-react";
+
+import {
+  operatorLocaleNames,
+  operatorLocales,
+  setOperatorLocale,
+  useTranslation,
+  type OperatorLocale,
+} from "@/i18n";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+type LocaleSwitcherVariant = "icon" | "menu-action";
+
+interface LocaleSwitcherProps {
+  className?: string;
+  variant?: LocaleSwitcherVariant;
+  onAfterSelect?: () => void;
+}
+
+export function LocaleSwitcher({ className, variant = "icon", onAfterSelect }: LocaleSwitcherProps) {
+  const { i18n } = useTranslation();
+  const currentLocale = operatorLocales.includes(i18n.resolvedLanguage as OperatorLocale)
+    ? (i18n.resolvedLanguage as OperatorLocale)
+    : "en";
+  const currentName = operatorLocaleNames[currentLocale];
+
+  async function selectLocale(locale: string) {
+    if (!operatorLocales.includes(locale as OperatorLocale)) return;
+    await setOperatorLocale(locale as OperatorLocale);
+    onAfterSelect?.();
+  }
+
+  const menu = (
+    <DropdownMenuContent align={variant === "icon" ? "end" : "start"}>
+      <DropdownMenuRadioGroup value={currentLocale} onValueChange={selectLocale}>
+        {operatorLocales.map((locale) => (
+          <DropdownMenuRadioItem key={locale} value={locale} className="flex items-center gap-2">
+            {operatorLocaleNames[locale]}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+    </DropdownMenuContent>
+  );
+
+  if (variant === "menu-action") {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/60",
+              className,
+            )}
+            aria-label={`Change interface language. Current: ${currentName}`}
+          >
+            <span className="mt-0.5 rounded-lg border border-border bg-background/70 p-2 text-muted-foreground">
+              <Globe className="size-4" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-medium text-foreground">{currentName}</span>
+              <span className="block text-xs text-muted-foreground">Interface language</span>
+            </span>
+          </button>
+        </DropdownMenuTrigger>
+        {menu}
+      </DropdownMenu>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={`Change interface language. Current: ${currentName}`}
+          title={`Language: ${currentName}`}
+          className={cn("text-muted-foreground", className)}
+        >
+          <Globe />
+        </Button>
+      </DropdownMenuTrigger>
+      {menu}
+    </DropdownMenu>
+  );
+}

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -16,6 +16,7 @@ import { useSidebar } from "../context/SidebarContext";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import { LocaleSwitcher } from "./LocaleSwitcher";
 import { ThemeToggle } from "./ThemeToggle";
 import { SidebarServerInfo } from "./SidebarServerInfo";
 import { Badge } from "@/components/ui/badge";
@@ -256,6 +257,7 @@ export function SidebarAccountMenu({
                 onClick={() => setOpen(false)}
               />
               <ThemeToggle variant="menu-action" onAfterToggle={() => setOpen(false)} />
+              <LocaleSwitcher variant="menu-action" onAfterSelect={() => setOpen(false)} />
               {deploymentMode === "authenticated" ? (
                 <button
                   type="button"

--- a/ui/src/i18n/index.test.ts
+++ b/ui/src/i18n/index.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { i18n, matchOperatorLocale, setOperatorLocale } from ".";
+
+describe("operator locale", () => {
+  afterEach(async () => {
+    await setOperatorLocale("en");
+  });
+
+  it("matches English and Chinese browser locales", () => {
+    expect(matchOperatorLocale("en-US")).toBe("en");
+    expect(matchOperatorLocale("zh")).toBe("zh-CN");
+    expect(matchOperatorLocale("zh-Hant-TW")).toBe("zh-CN");
+    expect(matchOperatorLocale("fr-FR")).toBeNull();
+  });
+
+  it("changes the active locale", async () => {
+    await setOperatorLocale("zh-CN");
+
+    expect(i18n.resolvedLanguage).toBe("zh-CN");
+  });
+});

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -3,9 +3,73 @@ import { initReactI18next, useTranslation as useReactI18nextTranslation } from "
 
 import { DEFAULT_LOCALE, i18nextResources, supportedLocales } from "./locales";
 
+export const UI_LOCALE_STORAGE_KEY = "paperclip.ui.locale";
+export const operatorLocales = ["en", "zh-CN"] as const;
+
+export type OperatorLocale = (typeof operatorLocales)[number];
+
+export const operatorLocaleNames: Record<OperatorLocale, string> = {
+  en: "English",
+  "zh-CN": "简体中文",
+};
+
+function isOperatorLocale(locale: string | null | undefined): locale is OperatorLocale {
+  return operatorLocales.includes(locale as OperatorLocale);
+}
+
+function readStoredLocale(): string | null {
+  try {
+    return window.localStorage.getItem(UI_LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function storeLocale(locale: OperatorLocale): void {
+  try {
+    window.localStorage.setItem(UI_LOCALE_STORAGE_KEY, locale);
+  } catch {
+    // A browser can deny storage in private or embedded contexts. The selected
+    // language still applies for the active session.
+  }
+}
+
+function applyDocumentLocale(locale: OperatorLocale): void {
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = locale;
+  }
+}
+
+export function matchOperatorLocale(locale: string | null | undefined): OperatorLocale | null {
+  if (!locale) return null;
+
+  const normalized = locale.toLowerCase();
+  if (normalized === "en" || normalized.startsWith("en-")) return "en";
+  if (normalized === "zh" || normalized.startsWith("zh-")) return "zh-CN";
+  return null;
+}
+
+function resolveInitialLocale(): OperatorLocale {
+  if (typeof window !== "undefined") {
+    const savedLocale = readStoredLocale();
+    if (isOperatorLocale(savedLocale)) return savedLocale;
+  }
+
+  if (typeof navigator !== "undefined") {
+    for (const locale of [navigator.language, ...(navigator.languages ?? [])]) {
+      const match = matchOperatorLocale(locale);
+      if (match) return match;
+    }
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+const initialLocale = resolveInitialLocale();
+
 const i18nextOptions: InitOptions = {
   resources: i18nextResources,
-  lng: DEFAULT_LOCALE,
+  lng: initialLocale,
   fallbackLng: DEFAULT_LOCALE,
   supportedLngs: supportedLocales,
   defaultNS: "translation",
@@ -17,6 +81,18 @@ const i18nextOptions: InitOptions = {
 void i18n.use(initReactI18next).init(i18nextOptions).catch((error: unknown) => {
   console.error("Failed to initialize i18next", error);
 });
+
+applyDocumentLocale(initialLocale);
+i18n.on("languageChanged", (locale) => {
+  applyDocumentLocale(isOperatorLocale(locale) ? locale : DEFAULT_LOCALE);
+});
+
+export async function setOperatorLocale(locale: OperatorLocale): Promise<void> {
+  if (typeof window !== "undefined") {
+    storeLocale(locale);
+  }
+  await i18n.changeLanguage(locale);
+}
 
 export function t(key: string, options: TOptions = {}) {
   return i18n.t(key, options);

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -6,6 +6,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
+import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { Sparkles } from "lucide-react";
 
@@ -77,7 +78,8 @@ export function AuthPage() {
 
   return (
     <div className="fixed inset-0 flex bg-background">
-      <div className="absolute top-4 right-4 z-10">
+      <div className="absolute top-4 right-4 z-10 flex items-center gap-1">
+        <LocaleSwitcher />
         <ThemeToggle />
       </div>
       {/* Left half — form */}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies, and its operator interface must remain understandable to the people running those companies.
> - The UI already bundles Simplified Chinese messages for the no-company screen, but the active locale is hard-coded to English and there is no supported way to choose Chinese.
> - A related large-scale localization PR (#8641) has been open since June and spans 207 files with unresolved review feedback.
> - This pull request intentionally contributes the smaller, independently useful foundation: a durable English/Simplified Chinese operator preference and discoverable controls.
> - The preference is browser-local and changes no company data, governance logic, or server API.
> - The benefit is that Chinese-capable UI messages can now be selected predictably while broader translation migration remains reviewable in later, focused PRs.

## Linked Issues or Issue Description

Refs #8641.

**Subsystem affected:** `ui/src/i18n` and operator chrome.

**Problem:** Simplified Chinese exists as a bundled locale but cannot be selected or persisted by an operator.

**Proposed solution:** Detect English/Chinese browser preference, persist an explicit browser-local choice, update the document language, and expose the selector on authentication and account-menu surfaces.

**Out of scope:** Bulk extraction or machine translation of every hard-coded UI string.

## What Changed

- Added a constrained English/Simplified Chinese locale preference with safe local-storage fallback and browser-locale detection.
- Added an accessible locale selector to the authentication page and account menu.
- Added tests for locale matching and active-language changes.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/i18n/locale-validation.test.ts src/i18n/index.test.ts` — 9 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm --filter @paperclipai/ui build` — passed.
- `git diff --check` — passed.

## Risks

- This is intentionally a preference and selection baseline, not a claim that every operator surface is translated. Unmigrated strings continue to render in English.
- The locale is stored only in the current browser and does not affect company data or other users.
- Full repository typecheck and test commands currently expose unrelated upstream-baseline failures in CLI fixtures and runtime/adapter suites; no failures reference these five UI files.

## Model Used

- OpenAI Codex, GPT-5, tool-assisted implementation and verification.

## Checklist

- [x] I have included a thinking path that traces from the top of the project down to this specific change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the underlying feature request in this PR
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id or instance-derived details
- [x] I have run targeted tests locally and they pass
- [x] I have added tests where applicable
- [ ] I have updated documentation to reflect this change (not needed: the UI control is self-contained)
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green (awaiting GitHub CI; unrelated local baseline failures documented)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (awaiting review)
- [x] I will address all Greptile and reviewer comments before requesting merge
