### PR TITLE
fix(secrets): include AWS client request tokens

### DIFF
--- a/server/src/__tests__/aws-secrets-manager-provider.test.ts
+++ b/server/src/__tests__/aws-secrets-manager-provider.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAwsSecretsManagerProvider } from "../secrets/aws-secrets-manager-provider.js";
 import { SecretProviderClientError } from "../secrets/types.js";
 
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 describe("awsSecretsManagerProvider", () => {
   const previousEnv = {
     PAPERCLIP_SECRETS_AWS_REGION: process.env.PAPERCLIP_SECRETS_AWS_REGION,
@@ -229,6 +231,8 @@ describe("awsSecretsManagerProvider", () => {
     expect(headers.authorization).toContain("SignedHeaders=");
     expect(headers.authorization).toContain("Signature=");
     expect(init?.signal).toBeInstanceOf(AbortSignal);
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.ClientRequestToken).toEqual(expect.stringMatching(UUID_V4_PATTERN));
   });
 
   it("creates new AWS secret versions against a namespace-valid existing secret reference", async () => {
@@ -284,6 +288,7 @@ describe("awsSecretsManagerProvider", () => {
             "arn:aws:secretsmanager:us-east-1:123456789012:secret:paperclip/prod-use1/company-1/openai-api-key",
           SecretString: "rotated-secret-value",
           VersionStages: ["PAPERCLIP_PENDING"],
+          ClientRequestToken: expect.stringMatching(UUID_V4_PATTERN),
         },
       },
     ]);

--- a/server/src/secrets/aws-secrets-manager-provider.ts
+++ b/server/src/secrets/aws-secrets-manager-provider.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac } from "node:crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 import { S3Client } from "@aws-sdk/client-s3";
 import type { DeploymentMode, SecretProviderConfigDiscoveryPreviewResult } from "@paperclipai/shared";
 import { unprocessable } from "../errors.js";
@@ -87,6 +87,7 @@ interface AwsSecretsManagerGateway {
   createSecret(input: {
     Name: string;
     SecretString: string;
+    ClientRequestToken: string;
     KmsKeyId?: string;
     Description?: string;
     Tags: AwsSecretsManagerTag[];
@@ -98,6 +99,7 @@ interface AwsSecretsManagerGateway {
   putSecretValue(input: {
     SecretId: string;
     SecretString: string;
+    ClientRequestToken: string;
     VersionStages?: string[];
   }): Promise<{
     ARN?: string;
@@ -889,6 +891,7 @@ class AwsSecretsManagerJsonGateway implements AwsSecretsManagerGateway {
   createSecret(input: {
     Name: string;
     SecretString: string;
+    ClientRequestToken: string;
     KmsKeyId?: string;
     Description?: string;
     Tags: AwsSecretsManagerTag[];
@@ -903,6 +906,7 @@ class AwsSecretsManagerJsonGateway implements AwsSecretsManagerGateway {
   putSecretValue(input: {
     SecretId: string;
     SecretString: string;
+    ClientRequestToken: string;
     VersionStages?: string[];
   }) {
     return this.call<{
@@ -1127,6 +1131,7 @@ export function createAwsSecretsManagerProvider(
         const createInput = {
           Name: secretId,
           SecretString: input.value,
+          ClientRequestToken: randomUUID(),
           ...(config.kmsKeyId ? { KmsKeyId: config.kmsKeyId } : {}),
           Description: input.context ? `Paperclip secret ${input.context.secretName}` : undefined,
           Tags: buildManagedSecretTags(config, input.context),
@@ -1160,6 +1165,7 @@ export function createAwsSecretsManagerProvider(
         const created = await gateway.putSecretValue({
           SecretId: secretId,
           SecretString: input.value,
+          ClientRequestToken: randomUUID(),
           VersionStages: [PAPERCLIP_PENDING_VERSION_STAGE],
         });
         const normalizedSecretId = created.ARN ?? created.Name ?? secretId;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its secrets subsystem supports AWS Secrets Manager as a remote provider for managed values such as routine-trigger signing secrets
> - The AWS provider constructs and signs raw Secrets Manager JSON requests instead of using the Secrets Manager SDK client
> - AWS requires raw HTTP callers that supply a secret value to include a UUID-like `ClientRequestToken`, while the CLI and SDK normally generate it automatically
> - Paperclip omitted that field from `CreateSecret` and `PutSecretValue`, causing AWS to reject managed secret creation before a public routine trigger could be created
> - This pull request generates and sends a UUID for both write operations and locks the behavior in with regression tests
> - The benefit is that AWS-backed managed secret creation and rotation follow the AWS API contract and public routine triggers can be created successfully

## Linked Issues or Issue Description

- Fixes: #9970

## What Changed

- Require `ClientRequestToken` in the internal AWS Secrets Manager gateway contract for `CreateSecret` and `PutSecretValue`.
- Generate a UUID v4 for every managed secret creation and version-write operation using Node.js `crypto.randomUUID()`.
- Assert that the serialized raw `CreateSecret` request and `PutSecretValue` gateway input contain UUID v4 request tokens.

## Verification

- TDD RED: the two new assertions failed before the implementation because `ClientRequestToken` was `undefined` for both operations.
- `pnpm exec vitest run server/src/__tests__/aws-secrets-manager-provider.test.ts` — passed, 15/15 tests.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.
- `pnpm build` — passed.
- Executed the compiled `server/dist` provider against a captured HTTP transport; the emitted `secretsmanager.CreateSecret` request contained a 36-character UUID v4 `ClientRequestToken`.
- `pnpm -r typecheck` reached and passed the server package, then failed in the unrelated existing `cli/src/__tests__/company.test.ts` fixture because it lacks newly required `CompanyPortabilityCompanyManifestEntry` fields. This same failure is present on the current upstream `master` (`f4b65c122`) and is not caused by this PR.
- The broad `pnpm test:run` suite exposed unrelated failures in workspace-runtime, monitor-scheduler, adapter-registry, and cursor-local suites on the current `master` snapshot; the run was stopped after those baseline failures made a green result impossible. The focused AWS provider suite remained green.

## Risks

- Low risk. The change affects only AWS Secrets Manager write request construction and adds the idempotency metadata AWS requires.
- No database, API, configuration, credential, or migration changes.
- Each distinct secret write receives a fresh UUID; retries of the same constructed gateway request retain that request's token.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5. The host does not expose the exact runtime model ID or context-window size to this session. Reasoning, tool use, local code execution, GitHub operations, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: this restores the existing documented AWS provider behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
