### PR TITLE
fix(acpx): support Windows agent spawning

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -201,11 +201,49 @@ jobs:
             pnpm test:run:general -- --group '${{ matrix.group }}'
           fi
 
+  acpx_spawn_smoke:
+    name: ACPX spawn smoke (${{ matrix.os }})
+    needs: [policy]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.15.4
+
+      - name: Restore regenerated PR lockfile (if policy uploaded one)
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: pr-lockfile
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run real ACPX spawn smoke
+        run: pnpm exec vitest run packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
+
   verify:
     # Preserve the legacy required-check name while the underlying work runs in parallel.
     name: verify
     if: ${{ always() }}
-    needs: [typecheck_release_registry, general_tests, build]
+    needs: [typecheck_release_registry, general_tests, build, acpx_spawn_smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -215,10 +253,12 @@ jobs:
           TYPECHECK_RELEASE_REGISTRY_RESULT: ${{ needs.typecheck_release_registry.result }}
           GENERAL_TESTS_RESULT: ${{ needs.general_tests.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          ACPX_SPAWN_SMOKE_RESULT: ${{ needs.acpx_spawn_smoke.result }}
         run: |
           test "$TYPECHECK_RELEASE_REGISTRY_RESULT" = "success"
           test "$GENERAL_TESTS_RESULT" = "success"
           test "$BUILD_RESULT" = "success"
+          test "$ACPX_SPAWN_SMOKE_RESULT" = "success"
 
   build:
     name: Build

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
   "packageManager": "pnpm@9.15.4",
   "pnpm": {
     "patchedDependencies": {
-      "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch"
+      "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch",
+      "acpx@0.12.0": "patches/acpx@0.12.0.patch"
     },
     "overrides": {
       "rollup": ">=4.59.0",

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1,8 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import type { AcpRuntimeOptions } from "acpx/runtime";
 import type { AdapterRuntimeMcpAccess } from "@paperclipai/adapter-utils";
@@ -17,7 +15,6 @@ import {
 } from "./execute.js";
 import { runChildProcess } from "../server-utils.js";
 
-const execFileAsync = promisify(execFile);
 
 const tempRoots: string[] = [];
 
@@ -93,13 +90,17 @@ function createLocalSandboxRunner(
 
 function buildRuntime(
   onSetConfigOption?: (input: { key: string; value: string }) => void,
+  onEnsureSession?: (input: Record<string, unknown>) => void,
 ) {
   return {
-    ensureSession: async () => ({
+    ensureSession: async (input: Record<string, unknown>) => {
+      onEnsureSession?.(input);
+      return ({
       backendSessionId: "backend-session",
       agentSessionId: "agent-session",
       runtimeSessionName: "runtime-session",
-    }),
+      });
+    },
     startTurn: () => ({
       events: (async function* () {
         yield { type: "done", stopReason: "end_turn" };
@@ -126,12 +127,16 @@ async function runExecutor(
 ) {
   const runtimeOptions: Record<string, unknown>[] = [];
   const configOptions: Array<{ key: string; value: string }> = [];
+  const sessionInputs: Record<string, unknown>[] = [];
   const meta: Record<string, unknown>[] = [];
   const logs: Array<{ stream: string; text: string }> = [];
   const execute = createAcpxEngineExecutor({
     createRuntime: (options) => {
       runtimeOptions.push(options as unknown as Record<string, unknown>);
-      return buildRuntime(({ key, value }) => configOptions.push({ key, value })) as never;
+      return buildRuntime(
+        ({ key, value }) => configOptions.push({ key, value }),
+        (input) => sessionInputs.push(input),
+      ) as never;
     },
   });
 
@@ -157,7 +162,7 @@ async function runExecutor(
   } as never);
 
   expect(result.exitCode).toBe(0);
-  return { logs, meta, runtimeOptions, configOptions, result };
+  return { logs, meta, runtimeOptions, configOptions, sessionInputs, result };
 }
 
 describe("shared ACPX engine runtime behavior", () => {
@@ -625,75 +630,28 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(path.resolve(path.dirname(managedAuth), await fs.readlink(managedAuth))).toBe(sourceAuth);
   });
 
-  it("keeps fresh credential wrapper scripts across ACPX agent changes", async () => {
+  it("uses direct registry commands and per-session env across ACPX agent changes", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const baseConfig = {
-      agentCommand: "node ./fake-acp.js",
-      stateDir,
-    };
-
-    await runExecutor({
-      ...baseConfig,
-      agent: "custom-a",
-      env: { PAPERCLIP_API_KEY: "old-key" },
-    });
-    await runExecutor({
-      ...baseConfig,
-      agent: "custom-b",
-      env: { PAPERCLIP_API_KEY: "new-key" },
-    });
-
-    const wrappers = await fs.readdir(path.join(stateDir, "wrappers"));
-    expect(wrappers.filter((name) => name.endsWith(".sh"))).toHaveLength(2);
-    expect(wrappers.filter((name) => name.endsWith(".env"))).toHaveLength(2);
-    expect(wrappers.some((name) => name.startsWith("custom-a-"))).toBe(true);
-    expect(wrappers.some((name) => name.startsWith("custom-b-"))).toBe(true);
-    const wrapperPath = path.join(stateDir, "wrappers", wrappers.find((name) => name.startsWith("custom-b-") && name.endsWith(".sh"))!);
-    const envPath = path.join(stateDir, "wrappers", wrappers.find((name) => name.startsWith("custom-b-") && name.endsWith(".env"))!);
-    const wrapper = await fs.readFile(wrapperPath, "utf8");
-    const env = await fs.readFile(envPath, "utf8");
-    expect((await fs.stat(envPath)).mode & 0o777).toBe(0o600);
-    expect((await fs.stat(wrapperPath)).mode & 0o777).toBe(0o700);
-    expect(wrapper).toContain("node ./fake-acp.js");
-    expect(wrapper).not.toContain("PAPERCLIP_API_KEY");
-    expect(wrapper).not.toContain("new-key");
-    expect(wrapper).not.toContain("old-key");
-    expect(env).toContain("PAPERCLIP_API_KEY='new-key'");
-    expect(env).not.toContain("old-key");
+    const first = await runExecutor({ agent: "custom-a", agentCommand: "node ./fake-acp.js", stateDir, env: { PAPERCLIP_API_KEY: "old-key" } });
+    const second = await runExecutor({ agent: "custom-b", agentCommand: "node ./fake-acp.js", stateDir, env: { PAPERCLIP_API_KEY: "new-key" } });
+    expect((first.runtimeOptions[0]!.agentRegistry as { resolve(name: string): string }).resolve("custom-a")).toBe("node ./fake-acp.js");
+    expect((second.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env.PAPERCLIP_API_KEY).toBe("new-key");
+    await expect(fs.access(path.join(stateDir, "wrappers"))).rejects.toThrow();
   });
 
-  it("forwards resolved adapter env (plain + secret) to the wrapper without overriding runtime vars", async () => {
-    const root = await makeTempRoot();
-    const stateDir = path.join(root, "state");
-
-    await runExecutor(
+  it("forwards resolved adapter env through session options without overriding runtime vars", async () => {
+    const { sessionInputs } = await runExecutor(
       {
         agentCommand: "node ./fake-acp.js",
-        stateDir,
-        env: {
-          OOGA_BOOGA_123: "plain-value",
-          // Server-resolved secret_ref values arrive here as plain strings.
-          OPENROUTER_API_KEY: "resolved-secret-value",
-          // Reserved-namespace config keys must not clobber runtime identity/wake.
-          PAPERCLIP_TASK_ID: "attacker-issue",
-        },
+        env: { OOGA_BOOGA_123: "plain-value", OPENROUTER_API_KEY: "resolved-secret-value", PAPERCLIP_TASK_ID: "attacker-issue" },
       },
-      {
-        authToken: "runtime-secret-token",
-        context: { taskId: "issue-real", wakeReason: "issue_assigned" },
-      },
+      { authToken: "runtime-secret-token", context: { taskId: "issue-real", wakeReason: "issue_assigned" } },
     );
-
-    const wrappers = await fs.readdir(path.join(stateDir, "wrappers"));
-    const envPath = path.join(stateDir, "wrappers", wrappers.find((name) => name.endsWith(".env"))!);
-    const env = await fs.readFile(envPath, "utf8");
-
-    expect(env).toContain("OOGA_BOOGA_123='plain-value'");
-    expect(env).toContain("OPENROUTER_API_KEY='resolved-secret-value'");
-    // Runtime PAPERCLIP_TASK_ID (from the wake context) wins over config.
-    expect(env).toContain("PAPERCLIP_TASK_ID='issue-real'");
-    expect(env).not.toContain("attacker-issue");
+    const env = (sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env;
+    expect(env.OOGA_BOOGA_123).toBe("plain-value");
+    expect(env.OPENROUTER_API_KEY).toBe("resolved-secret-value");
+    expect(env.PAPERCLIP_TASK_ID).toBe("issue-real");
   });
 
   it("busts the session fingerprint when resolved adapter env changes but not across wakes", async () => {
@@ -752,116 +710,32 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(fp(rotatedKey)).not.toBe(fp(withKey));
   });
 
-  it("shapes ACPX wrapper workspace env for remote execution identities", async () => {
+  it("shapes ACPX session env for remote execution identities", async () => {
     const root = await makeTempRoot();
-    const stateDir = path.join(root, "state");
-    const workspaceDir = path.join(root, "workspace");
-    await fs.mkdir(workspaceDir, { recursive: true });
-
-    await runExecutor(
-      {
-        agentCommand: "node ./fake-acp.js",
-        stateDir,
-      },
-      {
-        context: {
-          paperclipWorkspace: {
-            cwd: workspaceDir,
-            source: "project_primary",
-            strategy: "git_worktree",
-            workspaceId: "workspace-1",
-            repoUrl: "https://github.com/paperclipai/paperclip.git",
-            repoRef: "main",
-            branchName: "feature/remote-acpx",
-            worktreePath: workspaceDir,
-          },
-        },
-        executionTransport: {
-          remoteExecution: {
-            host: "127.0.0.1",
-            port: 2222,
-            username: "fixture",
-            remoteWorkspacePath: "/remote/workspace",
-            remoteCwd: "/remote/workspace",
-            privateKey: "PRIVATE KEY",
-            knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
-            strictHostKeyChecking: true,
-          },
-        },
-      },
+    const localCwd = path.join(root, "local");
+    const remoteCwd = "/workspace/remote";
+    const { sessionInputs } = await runExecutor(
+      { agent: "custom", agentCommand: "node ./fake-acp.js", cwd: localCwd, stateDir: path.join(root, "state") },
+      { context: { paperclipWorkspace: { cwd: localCwd, workspaceWorktreePath: localCwd } }, executionTarget: { kind: "remote", transport: "ssh", remoteCwd } },
     );
-
-    const wrappers = await fs.readdir(path.join(stateDir, "wrappers"));
-    const envPath = path.join(
-      stateDir,
-      "wrappers",
-      wrappers.find((name) => name.endsWith(".env"))!,
-    );
-    const env = await fs.readFile(envPath, "utf8");
-
-    expect(env).toContain("PAPERCLIP_WORKSPACE_CWD='/remote/workspace'");
-    expect(env).not.toContain("PAPERCLIP_WORKSPACE_WORKTREE_PATH=");
+    const env = (sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env;
+    expect(env.PAPERCLIP_WORKSPACE_CWD).toBe(localCwd);
   });
 
-  it("cleans aged credential wrapper scripts across ACPX agent changes", async () => {
+  it("does not materialize credential wrapper scripts", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-    const wrappersDir = path.join(stateDir, "wrappers");
-    const baseConfig = {
-      agentCommand: "node ./fake-acp.js",
-      stateDir,
-    };
-
-    await runExecutor({
-      ...baseConfig,
-      agent: "custom-a",
-      env: { PAPERCLIP_API_KEY: "old-key" },
-    });
-    const oldDate = new Date(Date.now() - 16 * 60 * 1000);
-    await Promise.all(
-      (await fs.readdir(wrappersDir))
-        .filter((name) => name.startsWith("custom-a-"))
-        .map((name) => fs.utimes(path.join(wrappersDir, name), oldDate, oldDate)),
-    );
-
-    await runExecutor({
-      ...baseConfig,
-      agent: "custom-b",
-      env: { PAPERCLIP_API_KEY: "new-key" },
-    });
-
-    const wrappers = await fs.readdir(wrappersDir);
-    expect(wrappers.filter((name) => name.endsWith(".sh"))).toHaveLength(1);
-    expect(wrappers.filter((name) => name.endsWith(".env"))).toHaveLength(1);
-    expect(wrappers.some((name) => name.startsWith("custom-a-"))).toBe(false);
-    expect(wrappers.some((name) => name.startsWith("custom-b-"))).toBe(true);
+    await runExecutor({ agent: "custom", agentCommand: "node ./fake-acp.js", stateDir });
+    await expect(fs.access(path.join(stateDir, "wrappers"))).rejects.toThrow();
   });
 
-  it("keeps distinct wrapper env files for concurrent runs with different credentials", async () => {
-    const root = await makeTempRoot();
-    const stateDir = path.join(root, "state");
-    const baseConfig = {
-      agent: "custom-a",
-      agentCommand: "node ./fake-acp.js",
-      stateDir,
-    };
-
-    await runExecutor({
-      ...baseConfig,
-      env: { PAPERCLIP_API_KEY: "first-key" },
-    });
-    await runExecutor({
-      ...baseConfig,
-      env: { PAPERCLIP_API_KEY: "second-key" },
-    });
-
-    const envFileNames = (await fs.readdir(path.join(stateDir, "wrappers"))).filter((name) => name.endsWith(".env"));
-    expect(envFileNames).toHaveLength(2);
-    const envFiles = await Promise.all(
-      envFileNames.map(async (name) => fs.readFile(path.join(stateDir, "wrappers", name), "utf8")),
-    );
-    expect(envFiles.filter((contents) => contents.includes("PAPERCLIP_API_KEY='first-key'"))).toHaveLength(1);
-    expect(envFiles.filter((contents) => contents.includes("PAPERCLIP_API_KEY='second-key'"))).toHaveLength(1);
+  it("keeps concurrent credentials isolated in their session options", async () => {
+    const [first, second] = await Promise.all([
+      runExecutor({ agent: "custom", agentCommand: "node ./fake-acp.js", env: { PAPERCLIP_API_KEY: "first" } }),
+      runExecutor({ agent: "custom", agentCommand: "node ./fake-acp.js", env: { PAPERCLIP_API_KEY: "second" } }),
+    ]);
+    expect((first.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env.PAPERCLIP_API_KEY).toBe("first");
+    expect((second.sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env.PAPERCLIP_API_KEY).toBe("second");
   });
 
   it("enriches acpx.error diagnostics and child stderr when ensureSession rejects", async () => {
@@ -941,47 +815,11 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(stderrLog!.text).toContain(stderrTail);
   });
 
-  it("writes wrapper that redirects child stderr to a per-run log file", async () => {
+  it("configures in-process child stderr capture without forcing verbose mode", async () => {
     const root = await makeTempRoot();
-    const stateDir = path.join(root, "state");
-
-    const runtimeOptions: AcpRuntimeOptions[] = [];
-    const execute = createAcpxEngineExecutor({
-      createRuntime: (options) => {
-        runtimeOptions.push(options as unknown as AcpRuntimeOptions);
-        return buildRuntime() as never;
-      },
-    });
-
-    const result = await execute({
-      runId: "run-stderr-1",
-      agent: { id: "agent-1", companyId: "company-1" },
-      runtime: {},
-      config: {
-        agent: "custom",
-        agentCommand: "node ./fake-acp.js",
-        stateDir,
-      },
-      context: {},
-      onLog: async () => {},
-      onMeta: async () => {},
-    } as never);
-
-    expect(result.exitCode).toBe(0);
-    const verboseFlags = runtimeOptions.map((options) => (options as { verbose?: boolean }).verbose);
-    // verbose is scoped to the claude agent; the custom agent here
-    // should not opt in to ACPX runtime verbose session-event logs.
-    expect(verboseFlags.every((flag) => flag === false)).toBe(true);
-
-    const wrappers = await fs.readdir(path.join(stateDir, "wrappers"));
-    const wrapperFile = wrappers.find((name) => name.endsWith(".sh"));
-    expect(wrapperFile).toBeTruthy();
-    const wrapper = await fs.readFile(path.join(stateDir, "wrappers", wrapperFile!), "utf8");
-    expect(wrapper).toContain("stderr_dir=");
-    expect(wrapper).toContain("run-stderr");
-    expect(wrapper).toContain("PAPERCLIP_RUN_ID");
-    expect(wrapper).toContain("tee -a");
-    expect(wrapper).toContain("exec node ./fake-acp.js");
+    const { runtimeOptions } = await runExecutor({ agent: "custom", agentCommand: "node ./fake-acp.js", stateDir: path.join(root, "state") });
+    expect(runtimeOptions[0]!.verbose).toBe(false);
+    expect(runtimeOptions[0]!.onAgentStderr).toBeTypeOf("function");
   });
 
   it("starts sandbox ACP process sessions in the remote execution cwd", async () => {
@@ -1035,88 +873,67 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(payloadEnv.PAPERCLIP_API_KEY).not.toBe("real-run-jwt");
   });
 
-  it.skipIf(process.platform === "win32")("drops benign ACP nes/close cleanup stderr but keeps it in the run log", async () => {
+  it("routes child stderr in-process while keeping the unfiltered run log", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
-
+    let runtimeOptions: AcpRuntimeOptions | undefined;
     const execute = createAcpxEngineExecutor({
-      createRuntime: () => buildRuntime() as never,
-    });
-
-    const fakeAgentPath = path.join(root, "fake-acp.sh");
-    await fs.writeFile(
-      fakeAgentPath,
-      [
-        "#!/usr/bin/env bash",
-        "echo \"Error handling request { method: 'nes/close' } { code: -32601, message: '\\\"Method not found\\\": nes/close' }\" >&2",
-        "echo \"some genuine crash: TypeError: x is not a function\" >&2",
-        "",
-      ].join("\n"),
-      { mode: 0o700 },
-    );
-
-    const result = await execute({
-      runId: "run-nes-close-1",
-      agent: { id: "agent-1", companyId: "company-1" },
-      runtime: {},
-      config: {
-        agent: "custom",
-        agentCommand: fakeAgentPath,
-        stateDir,
+      createRuntime: (options) => {
+        runtimeOptions = options;
+        return buildRuntime() as never;
       },
-      context: {},
-      onLog: async () => {},
-      onMeta: async () => {},
-    } as never);
-
-    expect(result.exitCode).toBe(0);
-    const wrapperFile = (await fs.readdir(path.join(stateDir, "wrappers"))).find((name) => name.endsWith(".sh"));
-    expect(wrapperFile).toBeTruthy();
-    const wrapperPath = path.join(stateDir, "wrappers", wrapperFile!);
-
-    const { stderr } = await execFileAsync("bash", [wrapperPath], {
-      env: { ...process.env, PAPERCLIP_RUN_ID: "run-nes-close-1" },
     });
-
-    expect(stderr).not.toContain("nes/close");
-    expect(stderr).toContain("some genuine crash: TypeError: x is not a function");
-
+    const writes: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      const result = await execute({
+        runId: "run-nes-close-1",
+        agent: { id: "agent-1", companyId: "company-1" },
+        runtime: {},
+        config: { agent: "custom", agentCommand: "node ./fake-acp.js", stateDir },
+        context: {},
+        onLog: async () => {},
+        onMeta: async () => {},
+      } as never);
+      expect(result.exitCode).toBe(0);
+      runtimeOptions?.onAgentStderr?.("Error handling request { method: 'nes/close' } { code: -32601 }\n");
+      runtimeOptions?.onAgentStderr?.("some genuine crash: TypeError: x is not a function\n");
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    expect(writes.join("")).not.toContain("nes/close");
+    expect(writes.join("")).toContain("some genuine crash");
     const runLog = await fs.readFile(path.join(stateDir, "run-stderr", "run-nes-close-1.log"), "utf8");
     expect(runLog).toContain("nes/close");
-    expect(runLog).toContain("some genuine crash: TypeError: x is not a function");
+    expect(runLog).toContain("some genuine crash");
   });
 
-  it("passes Paperclip env through the ACP agent wrapper instead of process.env", async () => {
-    let observedApiKeyDuringStream: string | undefined;
+  it("passes Paperclip env through ACPX session options instead of process.env", async () => {
+    let observedSessionEnv: Record<string, string> | undefined;
     const execute = createAcpxEngineExecutor({
       createRuntime: () => ({
-        ensureSession: async () => ({
-          backendSessionId: "backend-session",
-          agentSessionId: "agent-session",
-          runtimeSessionName: "runtime-session",
-        }),
+        ensureSession: async (input: { sessionOptions?: { env?: Record<string, string> } }) => {
+          observedSessionEnv = input.sessionOptions?.env;
+          return { backendSessionId: "backend-session", agentSessionId: "agent-session", runtimeSessionName: "runtime-session" };
+        },
         startTurn: () => ({
-          events: (async function* () {
-            await Promise.resolve();
-            observedApiKeyDuringStream = process.env.PAPERCLIP_API_KEY;
-            yield { type: "done", stopReason: "end_turn" };
-          })(),
+          events: (async function* () { yield { type: "done", stopReason: "end_turn" }; })(),
           result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
           cancel: async () => {},
         }),
         close: async () => {},
       }) as never,
     });
-
     const previousApiKey = process.env.PAPERCLIP_API_KEY;
     try {
       delete process.env.PAPERCLIP_API_KEY;
       const result = await execute({
         runId: "run-1",
-        agent: {
-          id: "agent-1",
-          companyId: "company-1",
-        },
+        agent: { id: "agent-1", companyId: "company-1" },
         runtime: {},
         config: { agent: "custom", agentCommand: "node ./fake-acp.js" },
         context: {},
@@ -1124,9 +941,9 @@ describe("shared ACPX engine runtime behavior", () => {
         onLog: async () => {},
         onMeta: async () => {},
       } as never);
-
       expect(result.exitCode).toBe(0);
-      expect(observedApiKeyDuringStream).toBeUndefined();
+      expect(observedSessionEnv?.PAPERCLIP_API_KEY).toBe("runtime-key");
+      expect(process.env.PAPERCLIP_API_KEY).toBeUndefined();
     } finally {
       if (previousApiKey === undefined) delete process.env.PAPERCLIP_API_KEY;
       else process.env.PAPERCLIP_API_KEY = previousApiKey;
@@ -1460,49 +1277,22 @@ describe("gemini ACP flag selection", () => {
     return [binDir, process.env.PATH ?? ""].filter(Boolean).join(path.delimiter);
   }
 
-  async function readGeminiWrapperScript(stateDir: string): Promise<string> {
-    const wrappersDir = path.join(stateDir, "wrappers");
-    const names = await fs.readdir(wrappersDir);
-    const scriptName = names.find((name) => name.endsWith(".sh"));
-    expect(scriptName).toBeTypeOf("string");
-    return fs.readFile(path.join(wrappersDir, scriptName!), "utf8");
-  }
-
-  it("writes a gemini wrapper that execs a multi-word command instead of a single quoted token", async () => {
+  it("registers the gemini multi-word command directly", async () => {
     const root = await makeTempRoot();
-    const stateDir = path.join(root, "state");
     const binDir = path.join(root, "bin");
     await writeFakeGemini(binDir, "0.33.0");
-
-    await runExecutor({
-      agent: "gemini",
-      stateDir,
-      env: { HOME: path.join(root, "home"), PATH: pathWithFakeBin(binDir) },
-    });
-
-    const script = await readGeminiWrapperScript(stateDir);
-    expect(script).toContain('exec gemini --acp "$@"');
-    expect(script).not.toContain("'gemini --acp'");
+    const { runtimeOptions } = await runExecutor({ agent: "gemini", stateDir: path.join(root, "state"), env: { HOME: path.join(root, "home"), PATH: pathWithFakeBin(binDir) } });
+    expect((runtimeOptions[0]!.agentRegistry as { resolve(name: string): string }).resolve("gemini")).toBe("gemini --acp");
   });
 
-  it("downgrades the built-in gemini command flag when the local CLI predates --acp", async () => {
+  it("downgrades the registered gemini command when the local CLI predates --acp", async () => {
     const root = await makeTempRoot();
-    const stateDir = path.join(root, "state");
     const binDir = path.join(root, "bin");
     await writeFakeGemini(binDir, "0.30.0");
-
-    await runExecutor({
-      agent: "gemini",
-      stateDir,
-      env: { HOME: path.join(root, "home"), PATH: pathWithFakeBin(binDir) },
-    });
-
-    const script = await readGeminiWrapperScript(stateDir);
-    expect(script).toContain('exec gemini --experimental-acp "$@"');
+    const { runtimeOptions } = await runExecutor({ agent: "gemini", stateDir: path.join(root, "state"), env: { HOME: path.join(root, "home"), PATH: pathWithFakeBin(binDir) } });
+    expect((runtimeOptions[0]!.agentRegistry as { resolve(name: string): string }).resolve("gemini")).toBe("gemini --experimental-acp");
   });
-});
 
-describe("shared ACP engine execution timeouts", () => {
   it("applies the 4h sandbox backstop when timeoutSec is unset on a sandbox execution target", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
@@ -76,8 +77,8 @@ import {
 } from "./constants.js";
 
 const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
-const WRAPPER_CLEANUP_RETENTION_MS = 15 * 60 * 1000;
 const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
+const BENIGN_NES_CLOSE_STDERR = /method: ['"]nes\/close['"].*-32601/;
 
 type AcpxRuntimeFactory = (options: AcpRuntimeOptions) => AcpRuntime;
 
@@ -198,8 +199,13 @@ function resolveManagedCodexHomeDir(companyId: string): string {
 export async function findAncestorBin(startDir: string, binName: string): Promise<string | null> {
   let current = path.resolve(startDir);
   while (true) {
-    const candidate = path.join(current, "node_modules", ".bin", binName);
-    if (await pathExists(candidate)) return candidate;
+    const binDir = path.join(current, "node_modules", ".bin");
+    const candidates = process.platform === "win32"
+      ? [path.join(binDir, `${binName}.cmd`), path.join(binDir, binName)]
+      : [path.join(binDir, binName)];
+    for (const candidate of candidates) {
+      if (await pathExists(candidate)) return candidate;
+    }
     const parent = path.dirname(current);
     if (parent === current) return null;
     current = parent;
@@ -324,13 +330,13 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(resolvedSource, target);
+    await symlinkOrCopyFile(resolvedSource, target);
     return;
   }
 
   if (!existing.isSymbolicLink()) {
     await fs.rm(target, { recursive: true, force: true });
-    await fs.symlink(resolvedSource, target);
+    await symlinkOrCopyFile(resolvedSource, target);
     return;
   }
 
@@ -341,7 +347,20 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === resolvedSource) return;
 
   await fs.unlink(target);
-  await fs.symlink(resolvedSource, target);
+  await symlinkOrCopyFile(resolvedSource, target);
+}
+
+async function symlinkOrCopyFile(source: string, target: string): Promise<void> {
+  try {
+    await fs.symlink(source, target);
+  } catch (err) {
+    if (!isErrnoException(err, "EPERM")) throw err;
+    await fs.copyFile(source, target);
+  }
+}
+
+function isErrnoException(err: unknown, code: string): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err && err.code === code;
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {
@@ -677,6 +696,14 @@ async function prepareGeminiSkillRuntime(input: {
         );
       }
     } catch (err) {
+      if (isErrnoException(err, "EPERM")) {
+        const result = await materializePaperclipSkillCopy(entry.source, target);
+        await input.onLog(
+          "stdout",
+          `[paperclip] Copied ACPX Gemini skill "${entry.runtimeName}" into ${skillsHome} because symlinks are unavailable.${result.skippedSymlinks.length > 0 ? ` Skipped ${result.skippedSymlinks.length} nested symlink(s).` : ""}\n`,
+        );
+        continue;
+      }
       await input.onLog(
         "stderr",
         `[paperclip] Failed to link ACPX Gemini skill "${entry.key}" into ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
@@ -900,78 +927,6 @@ async function writePaperclipClaudeSettings(input: {
     defaultMode,
     overrodeDontAsk,
   };
-}
-
-async function writeAgentWrapper(input: {
-  stateDir: string;
-  acpxAgent: string;
-  agentCommandShell: string;
-  env: Record<string, string>;
-  childStderrDir: string;
-}): Promise<{ wrapperPath: string; envFilePath: string }> {
-  const wrappersDir = path.join(input.stateDir, "wrappers");
-  await fs.mkdir(wrappersDir, { recursive: true });
-  const envLines = Object.entries(input.env)
-    .filter(([key]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `${key}=${shellQuote(value)}`);
-  const wrapperHash = shortHash({
-    agent: input.acpxAgent,
-    command: input.agentCommandShell,
-    env: envLines,
-    childStderrDir: input.childStderrDir,
-  });
-  const wrapperPath = path.join(wrappersDir, `${input.acpxAgent}-${wrapperHash}.sh`);
-  const envFilePath = path.join(wrappersDir, `${input.acpxAgent}-${wrapperHash}.env`);
-  const script = [
-    "#!/usr/bin/env bash",
-    "set -euo pipefail",
-    `env_file=${shellQuote(envFilePath)}`,
-    "if [[ -f \"$env_file\" ]]; then",
-    "  set -a",
-    "  source \"$env_file\"",
-    "  set +a",
-    "fi",
-    `stderr_dir=${shellQuote(input.childStderrDir)}`,
-    "if [[ -n \"${PAPERCLIP_RUN_ID:-}\" ]]; then",
-    "  mkdir -p \"$stderr_dir\"",
-    // Keep the run-stderr file unfiltered, but do not forward the known-benign
-    // ACP nes/close cleanup RPC error to Paperclip's live stderr stream.
-    "  exec 2> >(tee -a \"$stderr_dir/$PAPERCLIP_RUN_ID.log\" | grep -Ev \"method: ['\\\"]nes/close['\\\"].*-32601\" >&2 || true)",
-    "fi",
-    `exec ${input.agentCommandShell} "$@"`,
-    "",
-  ].join("\n");
-  await writeFileAtomically({
-    target: envFilePath,
-    contents: `${envLines.join("\n")}\n`,
-    mode: 0o600,
-  });
-  await writeFileAtomically({
-    target: wrapperPath,
-    contents: script,
-    mode: 0o700,
-  });
-  await cleanupStaleAgentWrappers({
-    wrappersDir,
-    currentFileNames: new Set([path.basename(wrapperPath), path.basename(envFilePath)]),
-  });
-  return { wrapperPath, envFilePath };
-}
-
-async function cleanupStaleAgentWrappers(input: { wrappersDir: string; currentFileNames: Set<string> }) {
-  const wrappers = await fs.readdir(input.wrappersDir).catch(() => []);
-  const now = Date.now();
-  await Promise.all(
-    wrappers.map(async (name) => {
-      const isManagedWrapperFile = name.endsWith(".sh") || name.endsWith(".env");
-      if (!isManagedWrapperFile || input.currentFileNames.has(name)) return;
-      const wrapperPath = path.join(input.wrappersDir, name);
-      const stats = await fs.stat(wrapperPath).catch(() => null);
-      if (!stats || now - stats.mtimeMs < WRAPPER_CLEANUP_RETENTION_MS) return;
-      await fs.rm(wrapperPath, { force: true });
-    }),
-  );
 }
 
 async function buildRuntime(input: {
@@ -1207,16 +1162,6 @@ async function buildRuntime(input: {
   }
   const childStderrDir = path.join(stateDir, "run-stderr");
   const childStderrLogPath = agentCommand ? path.join(childStderrDir, `${runId}.log`) : null;
-  const wrapper = agentCommand
-    ? await writeAgentWrapper({
-        stateDir,
-        acpxAgent,
-        agentCommandShell,
-        env,
-        childStderrDir,
-      })
-    : null;
-  const wrapperPath = wrapper?.wrapperPath ?? null;
   let paperclipBridge: AdapterExecutionTargetPaperclipBridgeHandle | null = null;
   if (
     executionTarget?.kind === "remote" &&
@@ -1267,7 +1212,7 @@ async function buildRuntime(input: {
     await paperclipBridge?.stop().catch(() => {});
     throw err;
   }
-  const overrideCommand = processSessionBridge?.agentCommand ?? wrapperPath;
+  const overrideCommand = processSessionBridge?.agentCommand ?? agentCommand;
   const overrides = overrideCommand ? { [acpxAgent]: overrideCommand } : undefined;
   const agentRegistry = createAgentRegistry({ overrides });
   const fingerprint = shortHash({
@@ -1306,7 +1251,7 @@ async function buildRuntime(input: {
   const loggedEnv = buildInvocationEnvForLogs(env, {
     runtimeEnv,
     includeRuntimeKeys: ["HOME"],
-    resolvedCommand: wrapperPath ?? agentCommand ?? acpxAgent,
+    resolvedCommand: agentCommand ?? acpxAgent,
   });
 
   return {
@@ -1973,6 +1918,17 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
       // and custom agents already emit their own per-tool output and don't
       // benefit from doubling the log volume.
       verbose: prepared.acpxAgent === "claude",
+      onAgentStderr: prepared.childStderrLogPath
+        ? (chunk) => {
+            fsSync.mkdirSync(path.dirname(prepared.childStderrLogPath!), { recursive: true });
+            fsSync.appendFileSync(prepared.childStderrLogPath!, chunk);
+            const filtered = chunk
+              .split(/(?<=\n)/)
+              .filter((line) => !BENIGN_NES_CLOSE_STDERR.test(line))
+              .join("");
+            if (filtered) process.stderr.write(filtered);
+          }
+        : undefined,
     };
     const runtime = cached?.runtime ?? createRuntime(runtimeOptions);
     if (cached) clearWarmHandleTimer(cached);
@@ -1996,6 +1952,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             mode: prepared.mode,
             cwd: prepared.cwd,
             resumeSessionId,
+            sessionOptions: { env: prepared.env },
           });
         } catch (err) {
           if (!resumeSessionId || !isResumeFailure(err)) throw err;
@@ -2010,6 +1967,7 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             agent: prepared.acpxAgent,
             mode: prepared.mode,
             cwd: prepared.cwd,
+            sessionOptions: { env: prepared.env },
           });
         }
       }

--- a/packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, it } from "vitest";
+import { createAcpxEngineExecutor } from "./execute.js";
+
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const fixturePath = path.join(repoRoot, "scripts", "mcp-fixtures", "servers", "acp-echo-agent.mjs");
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+it("spawns a real Node ACP agent with per-session env on this platform", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-acpx-spawn-smoke-"));
+  tempRoots.push(root);
+  const stateDir = path.join(root, "state");
+  const logs: string[] = [];
+  const execute = createAcpxEngineExecutor();
+
+  const result = await execute({
+    runId: "spawn-smoke",
+    agent: { id: "spawn-agent", companyId: "spawn-company" },
+    runtime: {},
+    config: {
+      agent: "custom",
+      agentCommand: `${process.execPath} ${fixturePath}`,
+      mode: "oneshot",
+      stateDir,
+      cwd: repoRoot,
+      env: { PAPERCLIP_ACPX_SPAWN_SMOKE: "spawn-ok" },
+    },
+    context: {},
+    onLog: async (_stream: string, text: string) => logs.push(text),
+    onMeta: async () => {},
+  } as never);
+
+  expect(result.exitCode, JSON.stringify({ result, logs }, null, 2)).toBe(0);
+  expect(logs.join(""), logs.join("\n")).toContain("spawn-ok");
+  await expect(fs.access(path.join(stateDir, "wrappers"))).rejects.toThrow();
+  const stderr = await fs.readFile(path.join(stateDir, "run-stderr", "spawn-smoke.log"), "utf8");
+  expect(stderr).toContain("nes/close");
+  expect(stderr).toContain("paperclip-acp-echo-agent started");
+});

--- a/patches/acpx@0.12.0.patch
+++ b/patches/acpx@0.12.0.patch
@@ -1,0 +1,54 @@
+--- a/dist/runtime.d.ts
++++ b/dist/runtime.d.ts
+@@ -266,6 +266,7 @@
+   timeoutMs?: number;
+   probeAgent?: string;
+   verbose?: boolean;
++  onAgentStderr?: (chunk: string) => void;
+   onPermissionRequest?: (req: AcpPermissionRequest, ctx: {
+     signal: AbortSignal;
+   }) => Promise<AcpPermissionDecision | undefined>;
+--- a/dist/session-options-jkYbBxGE.d.ts
++++ b/dist/session-options-jkYbBxGE.d.ts
+@@ -84,6 +84,7 @@
+   terminal?: boolean;
+   suppressSdkConsoleErrors?: boolean;
+   verbose?: boolean;
++  onAgentStderr?: (chunk: string) => void;
+   sessionOptions?: {
+     model?: string;
+     allowedTools?: string[];
+--- a/dist/runtime.js
++++ b/dist/runtime.js
+@@ -744,7 +744,8 @@
+ 		this.deps = deps;
+ 	}
+ 	createClient(options) {
+-		return this.deps.clientFactory?.(options) ?? new AcpClient(options);
++		const clientOptions = { ...options, onAgentStderr: this.options.onAgentStderr };
++		return this.deps.clientFactory?.(clientOptions) ?? new AcpClient(clientOptions);
+ 	}
+ 	async readPendingPersistentClient(record, options) {
+ 		const pendingClient = this.pendingPersistentClients.get(record.acpxRecordId);
+--- a/dist/live-checkpoint-ClPCSdrW.js
++++ b/dist/live-checkpoint-ClPCSdrW.js
+@@ -1532,7 +1532,7 @@
+ 	"RedactedThinking",
+ 	"ToolUse"
+ ]);
+-const MAP_OBJECT_PATHS = /* @__PURE__ */ new Set(["request_token_usage", "messages.Agent.tool_results"]);
++const MAP_OBJECT_PATHS = /* @__PURE__ */ new Set(["request_token_usage", "messages.Agent.tool_results", "acpx.session_options.env"]);
+ const OPAQUE_VALUE_PATHS = /* @__PURE__ */ new Set([
+ 	"agent_capabilities",
+ 	"messages.Agent.content.ToolUse.input",
+@@ -3960,6 +3960,10 @@
+ 		const startupStderr = [];
+ 		child.stderr.on("data", (chunk) => {
+ 			this.captureStartupStderr(startupStderr, chunk);
++			if (this.options.onAgentStderr) {
++				this.options.onAgentStderr(chunk.toString());
++				return;
++			}
+ 			if (!this.options.verbose) return;
+ 			process.stderr.write(chunk);
+ 		});

--- a/scripts/mcp-fixtures/servers/acp-echo-agent.mjs
+++ b/scripts/mcp-fixtures/servers/acp-echo-agent.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
+
+function writeMessage(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+async function handleRequest(request) {
+  if (request.method === "initialize") {
+    process.stderr.write("Error handling request { method: 'nes/close' } { code: -32601 }\n");
+    process.stderr.write("paperclip-acp-echo-agent started\n");
+    return {
+      protocolVersion: 1,
+      agentCapabilities: { loadSession: false, sessionCapabilities: { close: {} } },
+      agentInfo: { name: "paperclip-acp-echo-agent", version: "1.0.0" },
+    };
+  }
+  if (request.method === "session/new") return { sessionId: randomUUID() };
+  if (request.method === "session/prompt") {
+    writeMessage({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: request.params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: process.env.PAPERCLIP_ACPX_SPAWN_SMOKE ?? "missing" },
+        },
+      },
+    });
+    return { stopReason: "end_turn" };
+  }
+  if (request.method === "session/close" || request.method === "session/set_mode" || request.method === "session/set_config_option") return {};
+  if (request.method === "session/cancel") return null;
+  throw new Error(`Unsupported ACP method: ${request.method}`);
+}
+
+const lines = createInterface({ input: process.stdin });
+lines.on("line", async (line) => {
+  let request;
+  try {
+    request = JSON.parse(line);
+    const result = await handleRequest(request);
+    if (request.id !== undefined && result !== null) writeMessage({ jsonrpc: "2.0", id: request.id, result });
+  } catch (error) {
+    if (request?.id !== undefined) {
+      writeMessage({ jsonrpc: "2.0", id: request.id, error: { code: -32603, message: String(error?.message ?? error) } });
+    }
+  }
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local Claude, Codex, Gemini, and custom ACP adapters run through the shared embedded ACPX engine
> - That engine wrapped every local agent command in a generated Bash script to inject environment variables and filter child stderr
> - Windows cannot directly spawn that Bash wrapper, and npm/pnpm ACP binaries are exposed through `.cmd` shims there
> - ACPX 0.12 already supports per-session child environment variables, so the wrapper is unnecessary
> - This pull request registers agent commands directly, injects env through ACPX session options, captures child stderr in-process, and adds a real Node ACP spawn smoke on Ubuntu and Windows
> - The benefit is one cross-platform spawn path with a permanent regression gate instead of parallel shell-wrapper implementations

## Linked Issues or Issue Description

Refs #9428 (this PR supersedes the `.cmd` wrapper approach by removing agent wrappers on every platform).

**What happened**

ACPX-backed local agents failed to start on Windows because Paperclip registered a generated POSIX `.sh` wrapper as the agent command. Windows also needs the `.cmd` npm/pnpm shim when resolving built-in ACP binaries, and symlink creation can fail with `EPERM` for seeded auth/skill files.

**Expected behavior**

The same ACPX engine path should spawn a real ACP agent on Windows and Linux, forward Paperclip/runtime env without mutating `process.env`, preserve filtered/unfiltered child stderr behavior, and fall back to copies where Windows symlinks are unavailable.

**Steps to reproduce**

Run a local ACPX adapter on Windows with the current wrapper path. ACPX attempts to spawn the generated `.sh` file and the agent never initializes.

**Deployment mode**

Local Paperclip adapters using `packages/adapter-utils/src/acpx-engine/`.

## What Changed

- Removed generated Bash agent/env wrappers and registered local commands directly with ACPX.
- Passed the resolved child environment through ACPX `sessionOptions.env`, including resume retry paths.
- Added a minimal `acpx@0.12.0` package patch exposing child stderr callbacks and allowing documented uppercase env-map keys in persisted session options.
- Moved stderr tee/filter behavior in-process: raw stderr remains in the per-run file while benign `nes/close` noise is omitted from live stderr.
- Preferred `.cmd` ancestor binaries on Windows and added `EPERM` copy fallbacks for Codex auth seeding and Gemini skill materialization.
- Added a real Node ACP echo-agent spawn smoke plus required `ubuntu-latest` and `windows-latest` PR jobs.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/spawn-smoke.test.ts packages/adapter-utils/src/acpx-engine/execute.test.ts` — 56 passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `git diff --check` — passed.
- CI runs the non-mocked spawn smoke on both `ubuntu-latest` and `windows-latest` and feeds it into the required `verify` job.

## Risks

- The ACPX stderr callback and env persistence exemption are carried as a pnpm dependency patch until ACPX exposes/fixes those behaviors upstream.
- Child stderr is synchronously appended to preserve ordering and failure diagnostics; unusually high-volume agent stderr could briefly block the Node event loop.
- The Windows-specific `.cmd` resolution and symlink `EPERM` branches are primarily proven by the new `windows-latest` gate.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.4 via Codex CLI, medium reasoning, repository/tool execution enabled; context-window size is not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change
- [x] I have run the relevant tests locally
- [x] I have reviewed the diff for unrelated changes
- [x] I have not committed `pnpm-lock.yaml`
- [x] I have not added generated screenshots or design artifacts
