### PR TITLE
fix(task-watchdogs): ignore system comments in stopped fingerprints

### DIFF
--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -248,6 +248,74 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdog?.triggerCount).toBe(1);
   });
 
+  it("does not re-arm when the source receives only system no-op comments", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-SYS-COMMENT", status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const first = await service.reconcileTaskWatchdogs({ companyId });
+    expect(first).toMatchObject({ checked: 1, triggered: 1 });
+
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+
+    const commentAt = new Date(Date.now() + 60_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "system",
+      body: "No-op heartbeat transcript retained for audit.",
+      createdAt: commentAt,
+      updatedAt: commentAt,
+    });
+
+    const second = await service.reconcileTaskWatchdogs({ companyId });
+    expect(second).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(1);
+    const watchdogComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, watchdogIssueId));
+    expect(watchdogComments).toHaveLength(1);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.triggerCount).toBe(1);
+  });
+
+  it("re-arms when a user comment changes the source stopped fingerprint", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-USER-COMMENT", status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    const first = await service.reconcileTaskWatchdogs({ companyId });
+    expect(first).toMatchObject({ checked: 1, triggered: 1 });
+
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+
+    const commentAt = new Date(Date.now() + 60_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "user",
+      authorUserId: "user-1",
+      body: "Manual follow-up note from work.",
+      createdAt: commentAt,
+      updatedAt: commentAt,
+    });
+
+    const second = await service.reconcileTaskWatchdogs({ companyId });
+    expect(second).toMatchObject({ checked: 1, triggered: 1 });
+    const watchdogComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, watchdogIssueId));
+    expect(watchdogComments).toHaveLength(2);
+  });
+
   it("re-wakes a same-fingerprint watchdog review stuck in stale in_review", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-STALE", status: "done" });

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { and, asc, eq, gte, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agentWakeupRequests,
@@ -909,6 +909,12 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           eq(issueComments.companyId, companyId),
           inArray(issueComments.issueId, subtreeIssueIds),
           isNull(issueComments.deletedAt),
+          // Ignore watchdog/system housekeeping comments when computing stopped-subtree
+          // fingerprint signals; no-op heartbeat transcripts should not re-arm watchdogs.
+          or(
+            isNull(issueComments.authorType),
+            ne(issueComments.authorType, "system"),
+          ),
         ))
         .groupBy(issueComments.issueId),
       db


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work and uses task watchdogs to detect stopped issue subtrees.
> - A stopped-subtree fingerprint includes the latest issue activity so meaningful follow-up work can re-arm a reusable watchdog.
> - System-authored housekeeping comments, including no-op heartbeat audit transcripts, were counted as meaningful comment activity.
> - Saving those comments changed the fingerprint even when task status, blockers, monitors, approvals, and execution paths were unchanged.
> - This pull request excludes system-authored comments from the comment-activity portion of the stopped fingerprint while preserving user and agent comments.
> - The benefit is that repeated no-op heartbeats no longer reopen the same watchdog review, while real work still triggers reevaluation.

## Linked Issues or Issue Description

- **What happened:** A reusable task-watchdog review re-armed after a source issue received only a system-authored no-op heartbeat comment. The task's liveness state was otherwise unchanged.
- **Expected behavior:** System housekeeping comments should not change the stopped-subtree fingerprint. User or agent work comments and meaningful state changes should continue to trigger reevaluation.
- **Steps to reproduce:**
  1. Create a terminal source issue with a task watchdog.
  2. Reconcile once so the stopped-subtree review is created.
  3. Add a system-authored comment without changing task state.
  4. Reconcile again and observe the review re-arm on the prior implementation.
- **Paperclip version or commit:** Reproduced from `bf6365637a3341d775a0a5b1834a4c04a99861dd`.
- **Deployment mode:** Built from source with embedded PGlite tests.
- **Adapter involvement:** Not adapter-specific; this is core watchdog behavior.

## What Changed

- Filter `authorType = system` comments out of the latest-comment activity query used by stopped-subtree classification.
- Keep comments with a null author type for backward compatibility and continue counting user/agent comments.
- Add scheduler regressions proving system comments do not re-arm and user comments still do.

## Verification

- `pnpm exec vitest run server/src/__tests__/task-watchdogs-scheduler.test.ts server/src/__tests__/task-watchdogs-classifier.test.ts` — 2 files passed, 28 tests passed.

## Risks

- Low risk. The change is limited to fingerprint activity collection. A system-authored comment by itself will no longer re-arm a stopped review; actual issue state, blockers, monitors, approvals, runs, documents, work products, and non-system comments remain fingerprint inputs.

## Model Used

- OpenAI Codex `gpt-5.6-sol`, medium reasoning, with repository tools and code execution. The runtime does not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
