### PR TITLE
feat(adapter-claude-local): session-exhaustion backoff helpers (AIP-5933)

### DIFF
--- a/.github/workflows/deflector-docker-smoke.yml
+++ b/.github/workflows/deflector-docker-smoke.yml
@@ -41,15 +41,16 @@ jobs:
       - name: Verify Node + better-sqlite3 inside image
         run: |
           set -euo pipefail
-          docker run --rm paperclip-deflector-smoke:local \
-            node -e "console.log(JSON.stringify({node:process.version,platform:process.platform,arch:process.arch}))"
-          docker run --rm -w /app paperclip-deflector-smoke:local \
-            node --input-type=module -e "
+          docker run --rm --entrypoint node paperclip-deflector-smoke:local \
+            -e "console.log(JSON.stringify({node:process.version,platform:process.platform,arch:process.arch}))"
+          docker run --rm --entrypoint node -w /app paperclip-deflector-smoke:local \
+            --input-type=module -e "
               import { createRequire } from 'node:module';
               import { mkdtempSync } from 'node:fs';
               import { tmpdir } from 'node:os';
               import { join } from 'node:path';
-              const require = createRequire(import.meta.url);
+              // pnpm nests deps under the workspace package; resolve from deflector.
+              const require = createRequire('/app/packages/adapters/deflector/package.json');
               const Database = require('better-sqlite3');
               const dir = mkdtempSync(join(tmpdir(), 'deflector-'));
               const db = new Database(join(dir, 'kb.sqlite'));
@@ -58,15 +59,6 @@ jobs:
               const row = db.prepare('SELECT id FROM t').get();
               db.close();
               if (row?.id !== 'ok') throw new Error('better-sqlite3 readback failed');
-              console.log('better-sqlite3 OK', { node: process.version, id: row.id });
-            "
-          docker run --rm -w /app paperclip-deflector-smoke:local \
-            node --input-type=module -e "
-              import { createRequire } from 'node:module';
-              const require = createRequire(import.meta.url);
-              // Resolve from the workspace package the same way the adapter does.
-              const pkg = require.resolve('better-sqlite3/package.json', {
-                paths: ['/app/packages/adapters/deflector']
-              });
-              console.log('deflector better-sqlite3 path', pkg);
+              const pkg = require.resolve('better-sqlite3/package.json');
+              console.log('better-sqlite3 OK', { node: process.version, id: row.id, pkg });
             "

--- a/.github/workflows/deflector-docker-smoke.yml
+++ b/.github/workflows/deflector-docker-smoke.yml
@@ -1,0 +1,72 @@
+name: Deflector Docker Smoke
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile"
+      - "packages/adapters/deflector/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/deflector-docker-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dockerfile-better-sqlite3:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Validate Dockerfile deps stage
+        run: node ./scripts/check-docker-deps-stage.mjs
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build production image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          tags: paperclip-deflector-smoke:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify Node + better-sqlite3 inside image
+        run: |
+          set -euo pipefail
+          docker run --rm paperclip-deflector-smoke:local \
+            node -e "console.log(JSON.stringify({node:process.version,platform:process.platform,arch:process.arch}))"
+          docker run --rm -w /app paperclip-deflector-smoke:local \
+            node --input-type=module -e "
+              import { createRequire } from 'node:module';
+              import { mkdtempSync } from 'node:fs';
+              import { tmpdir } from 'node:os';
+              import { join } from 'node:path';
+              const require = createRequire(import.meta.url);
+              const Database = require('better-sqlite3');
+              const dir = mkdtempSync(join(tmpdir(), 'deflector-'));
+              const db = new Database(join(dir, 'kb.sqlite'));
+              db.exec('CREATE TABLE t (id TEXT PRIMARY KEY)');
+              db.prepare('INSERT INTO t (id) VALUES (?)').run('ok');
+              const row = db.prepare('SELECT id FROM t').get();
+              db.close();
+              if (row?.id !== 'ok') throw new Error('better-sqlite3 readback failed');
+              console.log('better-sqlite3 OK', { node: process.version, id: row.id });
+            "
+          docker run --rm -w /app paperclip-deflector-smoke:local \
+            node --input-type=module -e "
+              import { createRequire } from 'node:module';
+              const require = createRequire(import.meta.url);
+              // Resolve from the workspace package the same way the adapter does.
+              const pkg = require.resolve('better-sqlite3/package.json', {
+                paths: ['/app/packages/adapters/deflector']
+              });
+              console.log('deflector better-sqlite3 path', pkg);
+            "

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:lts-trixie-slim AS base
 ARG USER_UID=1000
 ARG USER_GID=1000
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 \
+  && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 make g++ \
   && rm -rf /var/lib/apt/lists/* \
   && corepack enable
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
+COPY packages/adapters/deflector/package.json packages/adapters/deflector/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
 COPY packages/adapters/grok-local/package.json packages/adapters/grok-local/
 COPY packages/adapters/hermes/package.json packages/adapters/hermes/

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -922,14 +922,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     return { proc, parsedStream, parsed };
   };
 
-  const toAdapterResult = (
+  const toAdapterResult = async (
     attempt: {
       proc: RunProcessResult;
       parsedStream: ReturnType<typeof parseClaudeStreamJson>;
       parsed: Record<string, unknown> | null;
     },
     opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
-  ): AdapterExecutionResult => {
+  ): Promise<AdapterExecutionResult> => {
     const { proc, parsedStream, parsed } = attempt;
     const loginMeta = detectClaudeLoginRequired({
       parsed,
@@ -977,13 +977,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           errorMessage: fallbackErrorMessage,
         });
       const transientRetryNotBefore = providerQuota || transientUpstream
-        ? extractClaudeRetryNotBefore({
-            parsed: null,
-            stdout: proc.stdout,
-            stderr: proc.stderr,
-            errorMessage: fallbackErrorMessage,
-          })
+        ? extractClaudeRetryNotBefore(
+            {
+              parsed: null,
+              stdout: proc.stdout,
+              stderr: proc.stderr,
+              errorMessage: fallbackErrorMessage,
+            },
+            undefined,
+            providerQuota ? { sessionExhaustionFallbackResetHourUtc: 22 } : undefined,
+          )
         : null;
+      if (providerQuota && transientRetryNotBefore) {
+        await onLog(
+          "stdout",
+          `[paperclip] Session/daily usage limit reached; scheduling retry after ${transientRetryNotBefore.toISOString()}.\n`,
+        );
+      }
       const errorCode = loginMeta.requiresLogin
         ? "claude_auth_required"
         : isClaudeModelNotFoundError({
@@ -1110,13 +1120,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorMessage,
       });
     const transientRetryNotBefore = providerQuota || transientUpstream
-      ? extractClaudeRetryNotBefore({
-          parsed,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage,
-        })
+      ? extractClaudeRetryNotBefore(
+          {
+            parsed,
+            stdout: proc.stdout,
+            stderr: proc.stderr,
+            errorMessage,
+          },
+          undefined,
+          providerQuota ? { sessionExhaustionFallbackResetHourUtc: 22 } : undefined,
+        )
       : null;
+    if (providerQuota && transientRetryNotBefore) {
+      await onLog(
+        "stdout",
+        `[paperclip] Session/daily usage limit reached; scheduling retry after ${transientRetryNotBefore.toISOString()}.\n`,
+      );
+    }
     const resolvedErrorCode = loginMeta.requiresLogin
       ? "claude_auth_required"
       : failed && isClaudeModelNotFoundError({
@@ -1235,10 +1255,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         }
       }
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      return await toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return await toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
   } finally {
     if (paperclipBridge) {
       await paperclipBridge.stop();

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -445,6 +445,18 @@ function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: 
   return retryAt;
 }
 
+export function nextDailyResetUtc(now: Date, resetHourUtc = 22): Date {
+  const candidate = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), resetHourUtc, 0, 0, 0),
+  );
+  if (candidate.getTime() <= now.getTime()) {
+    return new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, resetHourUtc, 0, 0, 0),
+    );
+  }
+  return candidate;
+}
+
 export function extractClaudeRetryNotBefore(
   input: {
     parsed?: Record<string, unknown> | null;
@@ -453,11 +465,18 @@ export function extractClaudeRetryNotBefore(
     errorMessage?: string | null;
   },
   now = new Date(),
+  opts?: { sessionExhaustionFallbackResetHourUtc?: number },
 ): Date | null {
   const haystack = buildClaudeTransientHaystack(input);
   const match = haystack.match(CLAUDE_EXTRA_USAGE_RESET_RE);
-  if (!match) return null;
-  return parseClaudeResetClockTime(match[1] ?? "", now, match[2]);
+  if (match) return parseClaudeResetClockTime(match[1] ?? "", now, match[2]);
+  if (
+    opts?.sessionExhaustionFallbackResetHourUtc !== undefined &&
+    isClaudeProviderQuotaError(input)
+  ) {
+    return nextDailyResetUtc(now, opts.sessionExhaustionFallbackResetHourUtc);
+  }
+  return null;
 }
 
 export function isClaudeTransientUpstreamError(input: {
@@ -505,3 +524,6 @@ export function isClaudeProviderQuotaError(input: {
   if (!haystack) return false;
   return CLAUDE_PROVIDER_QUOTA_RE.test(haystack);
 }
+
+/** Alias for {@link isClaudeProviderQuotaError} — session/daily-limit exhaustion check. */
+export const isClaudeSessionExhaustionError = isClaudeProviderQuotaError;

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -527,3 +527,6 @@ export function isClaudeProviderQuotaError(input: {
 
 /** Alias for {@link isClaudeProviderQuotaError} — session/daily-limit exhaustion check. */
 export const isClaudeSessionExhaustionError = isClaudeProviderQuotaError;
+
+/** Exported alias of CLAUDE_PROVIDER_QUOTA_RE for callers that reference the session-exhaustion name. */
+export const CLAUDE_SESSION_EXHAUSTION_RE = CLAUDE_PROVIDER_QUOTA_RE;

--- a/packages/adapters/deflector/COOLIFY-DEPLOY.md
+++ b/packages/adapters/deflector/COOLIFY-DEPLOY.md
@@ -52,6 +52,7 @@
 
 Workflow: `.github/workflows/deflector-docker-smoke.yml`
 
-- Builds the repo Dockerfile
+- Builds the repo Dockerfile (`node:lts-trixie-slim`)
+- Installs native build tools (`make`, `g++`) so `better-sqlite3` can compile when no prebuild exists for that Node ABI
 - Runs `better-sqlite3` open/insert/select inside the image
 - Resolves `better-sqlite3` from `packages/adapters/deflector`

--- a/packages/adapters/deflector/COOLIFY-DEPLOY.md
+++ b/packages/adapters/deflector/COOLIFY-DEPLOY.md
@@ -15,8 +15,9 @@
 
 - Build pack: **Dockerfile** (repo root `Dockerfile`)
 - Repo: `yaverabbas/paperclip`
-- Branch: `master` (after merging the Deflector Docker/docs PR; or temporarily point at `feature/deflector-adapter` for a canary)
-- Base image from Dockerfile: `node:lts-trixie-slim` (newer than Node 20; settles better-sqlite3 native verify on Linux)
+- Branch: **`master` only after PR #2 is merged** (Dockerfile must include `make`/`g++` and `packages/adapters/deflector/package.json` in the deps stage). Until then, canary on `feature/deflector-adapter`.
+- Base image from Dockerfile: `node:lts-trixie-slim` (Node 24 LTS on the smoke run; newer than prod's Node 20)
+- Smoke proof (CI): https://github.com/yaverabbas/paperclip/actions/runs/31866886911 — image build + `better-sqlite3` open/insert/select **success**
 
 ## Copy-paste Coolify steps
 

--- a/packages/adapters/deflector/COOLIFY-DEPLOY.md
+++ b/packages/adapters/deflector/COOLIFY-DEPLOY.md
@@ -15,7 +15,7 @@
 
 - Build pack: **Dockerfile** (repo root `Dockerfile`)
 - Repo: `yaverabbas/paperclip`
-- Branch: `master` (merge PR #1 first, or temporarily point at `feature/deflector-adapter` for a canary)
+- Branch: `master` (after merging the Deflector Docker/docs PR; or temporarily point at `feature/deflector-adapter` for a canary)
 - Base image from Dockerfile: `node:lts-trixie-slim` (newer than Node 20; settles better-sqlite3 native verify on Linux)
 
 ## Copy-paste Coolify steps

--- a/packages/adapters/deflector/COOLIFY-DEPLOY.md
+++ b/packages/adapters/deflector/COOLIFY-DEPLOY.md
@@ -1,0 +1,57 @@
+# Coolify: switch goc-paperclip to build from this fork
+
+**Owner:** Yaver (Coolify UI only). Do not change Coolify from agents.
+**Goal:** Deploy `yaverabbas/paperclip` from Git instead of `npm install -g paperclipai@…`.
+**Why:** Deflector ships in this fork; we do not own the `paperclipai` npm scope.
+
+## Current prod (today)
+
+- Coolify project: `goc-paperclip` → environment `production`
+- Resource: Docker Compose service (`service-gochd8i70z0sytx42zgc8yc74p8`)
+- Image/runtime: `node:20-bookworm-slim` + `npm install -g paperclipai@2026.512.0`
+- Domain: `goc.yaaver.com`
+
+## Target
+
+- Build pack: **Dockerfile** (repo root `Dockerfile`)
+- Repo: `yaverabbas/paperclip`
+- Branch: `master` (merge PR #1 first, or temporarily point at `feature/deflector-adapter` for a canary)
+- Base image from Dockerfile: `node:lts-trixie-slim` (newer than Node 20; settles better-sqlite3 native verify on Linux)
+
+## Copy-paste Coolify steps
+
+1. Open https://cf.yaaver.com/ → project **goc-paperclip** → environment **production**.
+2. Prefer a **new Application** resource (cleaner than converting the old Compose service):
+   - **+ New** → Application → GitHub App / private repo
+   - Repository: `yaverabbas/paperclip`
+   - Branch: `master`
+   - Build Pack: **Dockerfile**
+   - Dockerfile location: `/Dockerfile` (repo root)
+   - Port: `3100` (matches Dockerfile `EXPOSE 3100`)
+   - Domain: `goc.yaaver.com` (move DNS/proxy from the old Compose service after the new app is healthy)
+3. Persistent data (critical):
+   - Mount a volume at `/paperclip` (Dockerfile sets `PAPERCLIP_HOME=/paperclip`)
+   - Migrate/reuse the existing Paperclip data volume currently mounted at `/app/.paperclip` on the Compose service, **or** copy that data into the new volume before cutover
+   - Do not start with an empty `/paperclip` unless you intend a fresh instance
+4. Environment variables to carry over from the old Compose service / instance config (names may differ slightly; preserve secrets):
+   - Auth / deployment mode settings already stored under the instance config are fine if the volume is reused
+   - Any extra Compose `environment:` keys used today (API keys, model providers, etc.)
+5. Deploy the new Dockerfile app → wait for healthy `GET https://goc.yaaver.com/api/health`
+6. Smoke Deflector on the live image (after merge + deploy):
+   - Confirm adapter type `deflector_local` appears in the UI/API adapter list
+   - Optionally hire Deflector in a throwaway company first (not AIP/ONS yet)
+7. Only after health + Deflector adapter visibility: retire/stop the old Compose npm-based service
+
+## What not to do
+
+- Do not publish under `@paperclipai/*` on npm (scope not owned).
+- Do not hire Deflector on AIP/ONS until this deploy is live and verified.
+- Do not leave both old Compose and new Dockerfile apps bound to `goc.yaaver.com` at once.
+
+## Verification already automated in PR
+
+Workflow: `.github/workflows/deflector-docker-smoke.yml`
+
+- Builds the repo Dockerfile
+- Runs `better-sqlite3` open/insert/select inside the image
+- Resolves `better-sqlite3` from `packages/adapters/deflector`

--- a/packages/adapters/deflector/PHASE0.md
+++ b/packages/adapters/deflector/PHASE0.md
@@ -30,3 +30,10 @@ AIP join check: 575 stranded recoveries had a terminal origin; most historical r
 ## Wazir notes
 
 Mined `Wazir/watchlog.md`, `Wazir/kb/`, `Wazir/SOPs/`, `Wazir/playbook/`. Useful for ops memory; no additional auto-resolve pattern cleared the conservatism bar.
+
+## Runtime / no-match notes (review follow-up)
+
+- Target runtime: **Node 20+** (repo `engines`, Coolify prod `node:20-bookworm-slim`).
+- KB uses `better-sqlite3` via lazy `createRequire` inside `openKb` (not a top-level ESM import), so server boot does not crash on Node 20 the way `node:sqlite` would.
+- Linux/Node 20 installs use npm prebuilds. Local Windows/Node 24 without VS C++ may lack bindings; unit tests mock KB / soft-skip native open.
+- No-match path is a true no-op (audit log only). Clearing `assigneeAgentId` would orphan issues because heartbeat recovery only continues work for non-null assignees.

--- a/packages/adapters/deflector/PHASE0.md
+++ b/packages/adapters/deflector/PHASE0.md
@@ -1,0 +1,32 @@
+# Phase 0 mining summary (2026-08-15)
+
+Source: `https://goc.yaaver.com` GET-only with AIP/ONS agent tokens from the build guide.
+Raw dumps kept outside the Paperclip repo at `../phase0-data/` (not committed).
+
+## Counts
+
+| Company | Issues pulled | stranded_issue_recovery |
+|---------|---------------|-------------------------|
+| AIP     | 8601          | 1164                    |
+| ONS     | 2261          | 616                     |
+
+## High-confidence pattern chosen for seed
+
+`stranded_issue_recovery_source_terminal`
+
+- Match: `originKind == stranded_issue_recovery`
+- Title: `^Recover (stalled issue|missing next step)\b`
+- Gate: origin issue status is `done` or `cancelled`
+- Action: mark recovery issue `done` with Deflector comment
+
+AIP join check: 575 stranded recoveries had a terminal origin; most historical resolutions were `done`.
+
+## Explicitly NOT seeded (too risky / not issue-shaped)
+
+- Bulk list-endpoint `in_review` staleness (Wazir known bug): ops triage noise, not safe auto-resolve
+- Origin uptime probe duplicate floods: needs temporal/dedup logic beyond v1
+- Routine execution tickets: expected work, not deflect
+
+## Wazir notes
+
+Mined `Wazir/watchlog.md`, `Wazir/kb/`, `Wazir/SOPs/`, `Wazir/playbook/`. Useful for ops memory; no additional auto-resolve pattern cleared the conservatism bar.

--- a/packages/adapters/deflector/README.md
+++ b/packages/adapters/deflector/README.md
@@ -7,7 +7,7 @@ Auto-resolves only high-confidence repeat issues; everything else is released fo
 
 - `src/server/execute.ts` — heartbeat execution
 - `src/server/match.ts` — matching engine
-- `src/server/kb.ts` — SQLite KB (`node:sqlite`)
+- `src/server/kb.ts` — SQLite KB (`better-sqlite3`, Node 20 compatible)
 - `src/server/audit.ts` — JSONL audit log
 - `scripts/seed-kb.ts` — manual/cron seed (not in live request path)
 

--- a/packages/adapters/deflector/README.md
+++ b/packages/adapters/deflector/README.md
@@ -1,0 +1,23 @@
+# Deflector (`deflector_local`)
+
+Non-AI pre-check adapter. Deterministic keyword/regex matching against a SQLite KB.
+Auto-resolves only high-confidence repeat issues; everything else is released for normal routing.
+
+## Layout
+
+- `src/server/execute.ts` — heartbeat execution
+- `src/server/match.ts` — matching engine
+- `src/server/kb.ts` — SQLite KB (`node:sqlite`)
+- `src/server/audit.ts` — JSONL audit log
+- `scripts/seed-kb.ts` — manual/cron seed (not in live request path)
+
+## Defaults
+
+- KB: `~/.paperclip/instances/default/deflector/kb.sqlite`
+- Audit: `~/.paperclip/instances/default/deflector/audit.jsonl`
+
+## Seed
+
+```bash
+pnpm --filter @paperclipai/adapter-deflector seed:kb
+```

--- a/packages/adapters/deflector/package.json
+++ b/packages/adapters/deflector/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@paperclipai/adapter-deflector",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/deflector"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "seed"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "seed:kb": "tsx scripts/seed-kb.ts"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21",
+    "tsx": "^4.20.5",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/adapters/deflector/package.json
+++ b/packages/adapters/deflector/package.json
@@ -53,12 +53,17 @@
     "seed:kb": "tsx scripts/seed-kb.ts"
   },
   "dependencies": {
-    "@paperclipai/adapter-utils": "workspace:*"
+    "@paperclipai/adapter-utils": "workspace:*",
+    "better-sqlite3": "^11.10.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.19.21",
     "tsx": "^4.20.5",
     "typescript": "^5.7.3",
     "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/packages/adapters/deflector/scripts/seed-kb.ts
+++ b/packages/adapters/deflector/scripts/seed-kb.ts
@@ -1,0 +1,24 @@
+/**
+ * Seed Deflector KB SQLite from built-in high-confidence patterns.
+ *
+ * Usage:
+ *   pnpm --filter @paperclipai/adapter-deflector seed:kb
+ *   DEFLECTOR_KB_PATH=/path/to/kb.sqlite pnpm --filter @paperclipai/adapter-deflector seed:kb
+ *
+ * Phase 0 mining notes (2026-08-15 against goc.yaaver.com, GET-only):
+ * - AIP: 8601 issues (1164 stranded_issue_recovery)
+ * - ONS: 2261 issues (616 stranded_issue_recovery)
+ * - Safe auto-resolve heuristic: originKind=stranded_issue_recovery + title
+ *   Recover stalled/missing + origin status done|cancelled (~575 AIP cases).
+ * - Wazir watchlog/kb mined for known bugs; list-endpoint staleness is ops noise,
+ *   not a safe issue auto-resolve pattern, so it was not seeded.
+ */
+import { defaultKbPath, SEED_PATTERNS } from "../src/server/match.js";
+import { openKb, upsertPatterns } from "../src/server/kb.js";
+
+const kbPath = process.env.DEFLECTOR_KB_PATH?.trim() || defaultKbPath();
+const db = openKb(kbPath);
+upsertPatterns(db, SEED_PATTERNS);
+const count = db.prepare("SELECT COUNT(*) AS c FROM patterns").get() as { c: number };
+db.close();
+console.log(`Seeded ${SEED_PATTERNS.length} patterns into ${kbPath} (table rows=${count.c})`);

--- a/packages/adapters/deflector/src/cli/format-event.ts
+++ b/packages/adapters/deflector/src/cli/format-event.ts
@@ -1,0 +1,11 @@
+export function printDeflectorStreamEvent(event: unknown): void {
+  if (typeof event === "string") {
+    process.stdout.write(event.endsWith("\n") ? event : `${event}\n`);
+    return;
+  }
+  try {
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+  } catch {
+    process.stdout.write(String(event) + "\n");
+  }
+}

--- a/packages/adapters/deflector/src/cli/index.ts
+++ b/packages/adapters/deflector/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printDeflectorStreamEvent } from "./format-event.js";

--- a/packages/adapters/deflector/src/index.ts
+++ b/packages/adapters/deflector/src/index.ts
@@ -1,0 +1,24 @@
+export const type = "deflector_local";
+export const label = "Deflector";
+
+export const models: Array<{ id: string; label: string }> = [];
+
+export const agentConfigurationDoc = `# deflector_local agent configuration
+
+Adapter: deflector_local
+
+Non-AI pre-check adapter. Matches assigned issues against a deterministic
+SQLite pattern KB and auto-resolves only high-confidence repeats.
+
+Core fields:
+- kbPath (string, optional): absolute path to kb.sqlite
+  Default: ~/.paperclip/instances/default/deflector/kb.sqlite
+- auditPath (string, optional): absolute path to audit log JSONL
+  Default: ~/.paperclip/instances/default/deflector/audit.jsonl
+- dryRun (boolean, optional, default false): match and log only, never PATCH
+- apiBaseUrl (string, optional): override Paperclip API base URL
+
+Notes:
+- Bias is toward doing nothing. Uncertain matches are skipped.
+- No embeddings, no vector DB, no LLM.
+`;

--- a/packages/adapters/deflector/src/server/audit.ts
+++ b/packages/adapters/deflector/src/server/audit.ts
@@ -1,0 +1,22 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface AuditEntry {
+  ts: string;
+  runId: string;
+  agentId: string;
+  companyId: string;
+  issueId: string | null;
+  issueIdentifier: string | null;
+  matched: boolean;
+  patternId: string | null;
+  confidence: string | null;
+  reason: string;
+  action: "resolved" | "released" | "skipped" | "dry_run" | "error";
+  detail?: Record<string, unknown>;
+}
+
+export function appendAudit(auditPath: string, entry: AuditEntry): void {
+  mkdirSync(dirname(auditPath), { recursive: true });
+  appendFileSync(auditPath, `${JSON.stringify(entry)}\n`, "utf8");
+}

--- a/packages/adapters/deflector/src/server/audit.ts
+++ b/packages/adapters/deflector/src/server/audit.ts
@@ -12,7 +12,7 @@ export interface AuditEntry {
   patternId: string | null;
   confidence: string | null;
   reason: string;
-  action: "resolved" | "released" | "skipped" | "dry_run" | "error";
+  action: "resolved" | "skipped" | "dry_run" | "error";
   detail?: Record<string, unknown>;
 }
 

--- a/packages/adapters/deflector/src/server/execute.test.ts
+++ b/packages/adapters/deflector/src/server/execute.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execute } from "./execute.js";
-import { openKb, upsertPatterns } from "./kb.js";
 import { SEED_PATTERNS } from "./match.js";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+const openKb = vi.fn((_kbPath: string) => ({ close: () => {} }));
+const seedKbIfEmpty = vi.fn((_db: unknown, _patterns?: unknown) => 0);
+const loadPatterns = vi.fn((_db: unknown) => SEED_PATTERNS);
+
+vi.mock("./kb.js", () => ({
+  openKb: (kbPath: string) => openKb(kbPath),
+  seedKbIfEmpty: (db: unknown, patterns?: unknown) => seedKbIfEmpty(db, patterns),
+  loadPatterns: (db: unknown) => loadPatterns(db),
+  upsertPatterns: vi.fn(),
+}));
+
+import { execute } from "./execute.js";
 
 function makeCtx(overrides: {
   kbPath: string;
@@ -34,17 +45,22 @@ function makeCtx(overrides: {
 }
 
 describe("execute", () => {
+  beforeEach(() => {
+    openKb.mockReturnValue({ close: () => {} });
+    seedKbIfEmpty.mockReturnValue(0);
+    loadPatterns.mockReturnValue(SEED_PATTERNS);
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.clearAllMocks();
   });
 
   it("resolves when pattern matches and origin is terminal", async () => {
     const dir = mkdtempSync(join(tmpdir(), "deflector-ex-"));
     const kbPath = join(dir, "kb.sqlite");
     const auditPath = join(dir, "audit.jsonl");
-    const db = openKb(kbPath);
-    upsertPatterns(db, SEED_PATTERNS);
-    db.close();
+    writeFileSync(auditPath, "");
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       const u = String(url);
@@ -86,35 +102,31 @@ describe("execute", () => {
     }
   });
 
-  it("releases assignment when no pattern matches", async () => {
+  it("does nothing (no PATCH) when no pattern matches", async () => {
     const dir = mkdtempSync(join(tmpdir(), "deflector-ex-"));
     const kbPath = join(dir, "kb.sqlite");
     const auditPath = join(dir, "audit.jsonl");
-    const db = openKb(kbPath);
-    upsertPatterns(db, SEED_PATTERNS);
-    db.close();
+    writeFileSync(auditPath, "");
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string, init?: RequestInit) => {
-        const u = String(url);
-        if (u.includes("/api/issues/") && (!init || !init.method || init.method === "GET")) {
-          return new Response(
-            JSON.stringify({
-              id: "issue-2",
-              identifier: "AIP-2",
-              title: "Investigate conversion drop",
-              originKind: "manual",
-              originId: null,
-              companyId: "co-1",
-              status: "todo",
-            }),
-            { status: 200 },
-          );
-        }
-        return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }),
-    );
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/api/issues/") && (!init || !init.method || init.method === "GET")) {
+        return new Response(
+          JSON.stringify({
+            id: "issue-2",
+            identifier: "AIP-2",
+            title: "Investigate conversion drop",
+            originKind: "manual",
+            originId: null,
+            companyId: "co-1",
+            status: "todo",
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
     try {
       const result = await execute(
@@ -126,6 +138,10 @@ describe("execute", () => {
       );
       expect(result.exitCode).toBe(0);
       expect(result.summary).toContain("pass-through");
+      const mutating = fetchMock.mock.calls.filter(
+        (c) => c[1]?.method && c[1].method !== "GET",
+      );
+      expect(mutating).toHaveLength(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/adapters/deflector/src/server/execute.test.ts
+++ b/packages/adapters/deflector/src/server/execute.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execute } from "./execute.js";
+import { openKb, upsertPatterns } from "./kb.js";
+import { SEED_PATTERNS } from "./match.js";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+function makeCtx(overrides: {
+  kbPath: string;
+  auditPath: string;
+  issueId?: string;
+  dryRun?: boolean;
+}): AdapterExecutionContext {
+  return {
+    runId: "run-1",
+    agent: { id: "agent-1", companyId: "co-1", name: "Deflector", adapterType: "deflector_local" } as never,
+    runtime: {} as never,
+    config: {
+      kbPath: overrides.kbPath,
+      auditPath: overrides.auditPath,
+      dryRun: overrides.dryRun ?? false,
+      apiBaseUrl: "http://test.local",
+    },
+    context: {
+      paperclipIssue: overrides.issueId
+        ? { id: overrides.issueId, identifier: "AIP-1", title: "Recover stalled issue AIP-9" }
+        : undefined,
+    },
+    onLog: async () => {},
+    authToken: "test-token",
+  };
+}
+
+describe("execute", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves when pattern matches and origin is terminal", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "deflector-ex-"));
+    const kbPath = join(dir, "kb.sqlite");
+    const auditPath = join(dir, "audit.jsonl");
+    const db = openKb(kbPath);
+    upsertPatterns(db, SEED_PATTERNS);
+    db.close();
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/api/issues/issue-1") && (!init || init.method === "GET" || !init.method)) {
+        return new Response(
+          JSON.stringify({
+            id: "issue-1",
+            identifier: "AIP-1",
+            title: "Recover stalled issue AIP-9",
+            originKind: "stranded_issue_recovery",
+            originId: "origin-1",
+            companyId: "co-1",
+            status: "todo",
+          }),
+          { status: 200 },
+        );
+      }
+      if (u.endsWith("/api/issues/origin-1")) {
+        return new Response(JSON.stringify({ id: "origin-1", status: "done" }), { status: 200 });
+      }
+      if (u.endsWith("/api/issues/issue-1") && init?.method === "PATCH") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response("missing", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const result = await execute(makeCtx({ kbPath, auditPath, issueId: "issue-1" }));
+      expect(result.exitCode).toBe(0);
+      expect(result.summary).toContain("stranded_issue_recovery_source_terminal");
+      const patchCalls = fetchMock.mock.calls.filter((c) => c[1]?.method === "PATCH");
+      expect(patchCalls.length).toBe(1);
+      const body = JSON.parse(String(patchCalls[0]![1]!.body));
+      expect(body.status).toBe("done");
+      expect(body.comment).toContain("stranded_issue_recovery_source_terminal");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("releases assignment when no pattern matches", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "deflector-ex-"));
+    const kbPath = join(dir, "kb.sqlite");
+    const auditPath = join(dir, "audit.jsonl");
+    const db = openKb(kbPath);
+    upsertPatterns(db, SEED_PATTERNS);
+    db.close();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url);
+        if (u.includes("/api/issues/") && (!init || !init.method || init.method === "GET")) {
+          return new Response(
+            JSON.stringify({
+              id: "issue-2",
+              identifier: "AIP-2",
+              title: "Investigate conversion drop",
+              originKind: "manual",
+              originId: null,
+              companyId: "co-1",
+              status: "todo",
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }),
+    );
+
+    try {
+      const result = await execute(
+        makeCtx({
+          kbPath,
+          auditPath,
+          issueId: "issue-2",
+        }),
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.summary).toContain("pass-through");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adapters/deflector/src/server/execute.ts
+++ b/packages/adapters/deflector/src/server/execute.ts
@@ -1,0 +1,328 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { appendAudit } from "./audit.js";
+import { defaultAuditPath, defaultKbPath, matchIssue } from "./match.js";
+import { loadPatterns, openKb, seedKbIfEmpty } from "./kb.js";
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function parseObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function resolveApiBase(config: Record<string, unknown>, context: Record<string, unknown>): string {
+  const fromConfig = asString(config.apiBaseUrl, "").replace(/\/+$/, "");
+  if (fromConfig) return fromConfig;
+  const fromEnv = (process.env.PAPERCLIP_API_URL ?? "").replace(/\/+$/, "").replace(/\/api$/, "");
+  if (fromEnv) return fromEnv;
+  const fromContext = asString(context.apiBaseUrl, "").replace(/\/+$/, "");
+  return fromContext || "http://127.0.0.1:3100";
+}
+
+async function apiFetch(
+  base: string,
+  path: string,
+  opts: {
+    method?: string;
+    token?: string;
+    runId?: string;
+    body?: unknown;
+  },
+): Promise<{ ok: boolean; status: number; json: unknown }> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+  if (opts.token) headers.Authorization = `Bearer ${opts.token}`;
+  if (opts.runId) headers["X-Paperclip-Run-Id"] = opts.runId;
+
+  const res = await fetch(`${base}${path}`, {
+    method: opts.method ?? "GET",
+    headers,
+    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+  });
+  let json: unknown = null;
+  try {
+    json = await res.json();
+  } catch {
+    json = null;
+  }
+  return { ok: res.ok, status: res.status, json };
+}
+
+function renderComment(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => vars[key] ?? "");
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, config, context, onLog, onMeta, authToken } = ctx;
+  const kbPath = asString(config.kbPath, defaultKbPath());
+  const auditPath = asString(config.auditPath, defaultAuditPath());
+  const dryRun = asBoolean(config.dryRun, false);
+  const apiBase = resolveApiBase(config, context);
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "deflector_local",
+      command: "deflector-match",
+      cwd: process.cwd(),
+      commandArgs: [],
+      env: {
+        PAPERCLIP_RUN_ID: runId,
+        DEFLECTOR_KB_PATH: kbPath,
+        DEFLECTOR_DRY_RUN: dryRun ? "1" : "0",
+      },
+    });
+  }
+
+  const paperclipIssue = parseObject(context.paperclipIssue);
+  const issueId =
+    asString(paperclipIssue.id, "") ||
+    asString(context.issueId, "") ||
+    asString(context.taskId, "");
+
+  if (!issueId) {
+    await onLog("stdout", "Deflector: no assigned issue in context; nothing to check.\n");
+    appendAudit(auditPath, {
+      ts: new Date().toISOString(),
+      runId,
+      agentId: agent.id,
+      companyId: agent.companyId,
+      issueId: null,
+      issueIdentifier: null,
+      matched: false,
+      patternId: null,
+      confidence: null,
+      reason: "no issue in context",
+      action: "skipped",
+    });
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Deflector skipped (no issue context)",
+    };
+  }
+
+  const token = authToken || process.env.PAPERCLIP_API_KEY || "";
+  if (!token) {
+    await onLog("stderr", "Deflector: missing API token; refusing to act.\n");
+    appendAudit(auditPath, {
+      ts: new Date().toISOString(),
+      runId,
+      agentId: agent.id,
+      companyId: agent.companyId,
+      issueId,
+      issueIdentifier: asString(paperclipIssue.identifier, "") || null,
+      matched: false,
+      patternId: null,
+      confidence: null,
+      reason: "missing API token",
+      action: "error",
+    });
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: "Deflector missing API token",
+      errorCode: "deflector_auth_missing",
+    };
+  }
+
+  const issueRes = await apiFetch(apiBase, `/api/issues/${issueId}`, { token, runId });
+  if (!issueRes.ok || !issueRes.json || typeof issueRes.json !== "object") {
+    await onLog("stderr", `Deflector: failed to load issue ${issueId} (HTTP ${issueRes.status}).\n`);
+    appendAudit(auditPath, {
+      ts: new Date().toISOString(),
+      runId,
+      agentId: agent.id,
+      companyId: agent.companyId,
+      issueId,
+      issueIdentifier: null,
+      matched: false,
+      patternId: null,
+      confidence: null,
+      reason: `GET issue failed HTTP ${issueRes.status}`,
+      action: "error",
+    });
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: `Failed to load issue ${issueId}`,
+      errorCode: "deflector_issue_fetch_failed",
+    };
+  }
+
+  const issue = issueRes.json as Record<string, unknown>;
+  const originId = asString(issue.originId, "") || null;
+  let originStatus: string | null = null;
+  if (originId) {
+    const originRes = await apiFetch(apiBase, `/api/issues/${originId}`, { token, runId });
+    if (originRes.ok && originRes.json && typeof originRes.json === "object") {
+      originStatus = asString((originRes.json as Record<string, unknown>).status, "") || null;
+    }
+  }
+
+  const db = openKb(kbPath);
+  try {
+    seedKbIfEmpty(db);
+    const patterns = loadPatterns(db);
+    const match = matchIssue(patterns, {
+      issue: {
+        id: asString(issue.id, issueId),
+        identifier: asString(issue.identifier, "") || null,
+        title: asString(issue.title, asString(paperclipIssue.title, "")),
+        description: asString(issue.description, "") || null,
+        originKind: asString(issue.originKind, "") || null,
+        originId,
+        companyId: asString(issue.companyId, agent.companyId) || null,
+        status: asString(issue.status, "") || null,
+      },
+      originStatus,
+    });
+
+    await onLog(
+      "stdout",
+      `Deflector: issue=${asString(issue.identifier, issueId)} originKind=${asString(issue.originKind, "-")} originStatus=${originStatus ?? "-"} -> ${match.reason}\n`,
+    );
+
+    if (!match.matched || !match.pattern) {
+      // Release assignment so the issue can proceed to a normal agent.
+      if (!dryRun) {
+        await apiFetch(apiBase, `/api/issues/${issueId}`, {
+          method: "PATCH",
+          token,
+          runId,
+          body: {
+            comment:
+              "Deflector: no high-confidence pattern matched. Releasing assignment for normal routing.",
+            assigneeAgentId: null,
+          },
+        });
+      }
+      appendAudit(auditPath, {
+        ts: new Date().toISOString(),
+        runId,
+        agentId: agent.id,
+        companyId: agent.companyId,
+        issueId,
+        issueIdentifier: asString(issue.identifier, "") || null,
+        matched: false,
+        patternId: null,
+        confidence: null,
+        reason: match.reason,
+        action: dryRun ? "dry_run" : "released",
+        detail: { originKind: issue.originKind, originStatus },
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        summary: `Deflector pass-through: ${match.reason}`,
+        resultJson: { matched: false, reason: match.reason },
+      };
+    }
+
+    const pattern = match.pattern;
+    const comment = renderComment(pattern.commentTemplate, {
+      originStatus: originStatus ?? "unknown",
+      patternId: pattern.id,
+      issueIdentifier: asString(issue.identifier, issueId),
+    });
+
+    if (dryRun) {
+      appendAudit(auditPath, {
+        ts: new Date().toISOString(),
+        runId,
+        agentId: agent.id,
+        companyId: agent.companyId,
+        issueId,
+        issueIdentifier: asString(issue.identifier, "") || null,
+        matched: true,
+        patternId: pattern.id,
+        confidence: pattern.confidence,
+        reason: match.reason,
+        action: "dry_run",
+        detail: { wouldStatus: pattern.resolutionStatus, comment },
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        summary: `Deflector dry-run match: ${pattern.id}`,
+        resultJson: { matched: true, patternId: pattern.id, dryRun: true },
+      };
+    }
+
+    const patch = await apiFetch(apiBase, `/api/issues/${issueId}`, {
+      method: "PATCH",
+      token,
+      runId,
+      body: {
+        status: pattern.resolutionStatus,
+        comment,
+      },
+    });
+
+    if (!patch.ok) {
+      await onLog("stderr", `Deflector: PATCH failed HTTP ${patch.status}\n`);
+      appendAudit(auditPath, {
+        ts: new Date().toISOString(),
+        runId,
+        agentId: agent.id,
+        companyId: agent.companyId,
+        issueId,
+        issueIdentifier: asString(issue.identifier, "") || null,
+        matched: true,
+        patternId: pattern.id,
+        confidence: pattern.confidence,
+        reason: `PATCH failed HTTP ${patch.status}`,
+        action: "error",
+      });
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `Deflector PATCH failed HTTP ${patch.status}`,
+        errorCode: "deflector_patch_failed",
+      };
+    }
+
+    appendAudit(auditPath, {
+      ts: new Date().toISOString(),
+      runId,
+      agentId: agent.id,
+      companyId: agent.companyId,
+      issueId,
+      issueIdentifier: asString(issue.identifier, "") || null,
+      matched: true,
+      patternId: pattern.id,
+      confidence: pattern.confidence,
+      reason: match.reason,
+      action: "resolved",
+      detail: { status: pattern.resolutionStatus, originStatus },
+    });
+
+    await onLog("stdout", `Deflector: resolved via ${pattern.id}\n`);
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: `Deflector resolved: ${pattern.id}`,
+      resultJson: {
+        matched: true,
+        patternId: pattern.id,
+        status: pattern.resolutionStatus,
+      },
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/packages/adapters/deflector/src/server/execute.ts
+++ b/packages/adapters/deflector/src/server/execute.ts
@@ -194,19 +194,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     );
 
     if (!match.matched || !match.pattern) {
-      // Release assignment so the issue can proceed to a normal agent.
-      if (!dryRun) {
-        await apiFetch(apiBase, `/api/issues/${issueId}`, {
-          method: "PATCH",
-          token,
-          runId,
-          body: {
-            comment:
-              "Deflector: no high-confidence pattern matched. Releasing assignment for normal routing.",
-            assigneeAgentId: null,
-          },
-        });
-      }
+      // Spec: no match → do nothing. Heartbeat only continues work for issues
+      // with a non-null assignee; clearing assigneeAgentId would orphan the
+      // ticket. Routing/reassignment is an operator concern outside this adapter.
       appendAudit(auditPath, {
         ts: new Date().toISOString(),
         runId,
@@ -218,7 +208,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         patternId: null,
         confidence: null,
         reason: match.reason,
-        action: dryRun ? "dry_run" : "released",
+        action: dryRun ? "dry_run" : "skipped",
         detail: { originKind: issue.originKind, originStatus },
       });
       return {

--- a/packages/adapters/deflector/src/server/index.ts
+++ b/packages/adapters/deflector/src/server/index.ts
@@ -1,0 +1,14 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { parseDeflectorStdout } from "./parse.js";
+export {
+  matchIssue,
+  SEED_PATTERNS,
+  defaultKbPath,
+  defaultAuditPath,
+  TERMINAL_STATUSES,
+} from "./match.js";
+export type { PatternRule, MatchCandidate, MatchResult, ConfidenceTier } from "./match.js";
+export { openKb, seedKbIfEmpty, loadPatterns, upsertPatterns } from "./kb.js";
+export { appendAudit } from "./audit.js";
+export type { AuditEntry } from "./audit.js";

--- a/packages/adapters/deflector/src/server/kb.ts
+++ b/packages/adapters/deflector/src/server/kb.ts
@@ -1,0 +1,116 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { SEED_PATTERNS, type PatternRule, type ConfidenceTier } from "./match.js";
+
+function rowToPattern(row: Record<string, unknown>): PatternRule {
+  return {
+    id: String(row.id),
+    name: String(row.name ?? row.id),
+    titleRegex: String(row.title_regex ?? ""),
+    originKind: row.origin_kind == null ? null : String(row.origin_kind),
+    requireOriginTerminal: Number(row.require_origin_terminal ?? 0) === 1,
+    resolutionStatus: (String(row.resolution_status ?? "done") === "cancelled"
+      ? "cancelled"
+      : "done") as "done" | "cancelled",
+    commentTemplate: String(row.comment_template ?? ""),
+    companyScope: String(row.company_scope ?? "all"),
+    confidence: (String(row.confidence ?? "high") as ConfidenceTier) || "high",
+    sourceCluster: String(row.source_cluster ?? ""),
+    enabled: Number(row.enabled ?? 1) === 1,
+  };
+}
+
+export function openKb(kbPath: string): DatabaseSync {
+  mkdirSync(dirname(kbPath), { recursive: true });
+  const db = new DatabaseSync(kbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS patterns (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      title_regex TEXT NOT NULL,
+      origin_kind TEXT,
+      require_origin_terminal INTEGER NOT NULL DEFAULT 0,
+      resolution_status TEXT NOT NULL DEFAULT 'done',
+      comment_template TEXT NOT NULL,
+      company_scope TEXT NOT NULL DEFAULT 'all',
+      confidence TEXT NOT NULL DEFAULT 'high',
+      source_cluster TEXT NOT NULL DEFAULT '',
+      enabled INTEGER NOT NULL DEFAULT 1
+    );
+    CREATE INDEX IF NOT EXISTS idx_patterns_enabled ON patterns(enabled);
+  `);
+  return db;
+}
+
+export function seedKbIfEmpty(db: DatabaseSync, patterns: PatternRule[] = SEED_PATTERNS): number {
+  const count = db.prepare("SELECT COUNT(*) AS c FROM patterns").get() as { c: number };
+  if (Number(count.c) > 0) return 0;
+  const insert = db.prepare(`
+    INSERT INTO patterns (
+      id, name, title_regex, origin_kind, require_origin_terminal,
+      resolution_status, comment_template, company_scope, confidence, source_cluster, enabled
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  let n = 0;
+  for (const p of patterns) {
+    insert.run(
+      p.id,
+      p.name,
+      p.titleRegex,
+      p.originKind,
+      p.requireOriginTerminal ? 1 : 0,
+      p.resolutionStatus,
+      p.commentTemplate,
+      p.companyScope,
+      p.confidence,
+      p.sourceCluster,
+      p.enabled ? 1 : 0,
+    );
+    n += 1;
+  }
+  return n;
+}
+
+export function loadPatterns(db: DatabaseSync): PatternRule[] {
+  const rows = db.prepare("SELECT * FROM patterns WHERE enabled = 1 ORDER BY id").all() as Record<
+    string,
+    unknown
+  >[];
+  return rows.map(rowToPattern);
+}
+
+export function upsertPatterns(db: DatabaseSync, patterns: PatternRule[]): void {
+  const upsert = db.prepare(`
+    INSERT INTO patterns (
+      id, name, title_regex, origin_kind, require_origin_terminal,
+      resolution_status, comment_template, company_scope, confidence, source_cluster, enabled
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      name = excluded.name,
+      title_regex = excluded.title_regex,
+      origin_kind = excluded.origin_kind,
+      require_origin_terminal = excluded.require_origin_terminal,
+      resolution_status = excluded.resolution_status,
+      comment_template = excluded.comment_template,
+      company_scope = excluded.company_scope,
+      confidence = excluded.confidence,
+      source_cluster = excluded.source_cluster,
+      enabled = excluded.enabled
+  `);
+  for (const p of patterns) {
+    upsert.run(
+      p.id,
+      p.name,
+      p.titleRegex,
+      p.originKind,
+      p.requireOriginTerminal ? 1 : 0,
+      p.resolutionStatus,
+      p.commentTemplate,
+      p.companyScope,
+      p.confidence,
+      p.sourceCluster,
+      p.enabled ? 1 : 0,
+    );
+  }
+}

--- a/packages/adapters/deflector/src/server/kb.ts
+++ b/packages/adapters/deflector/src/server/kb.ts
@@ -1,7 +1,14 @@
 import { mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import type { Database as BetterSqliteDatabase } from "better-sqlite3";
 import { SEED_PATTERNS, type PatternRule, type ConfidenceTier } from "./match.js";
+
+// better-sqlite3 is CJS/native; load via createRequire so this package stays ESM
+// and works on Node 20 (node:sqlite is Node 22.5+ only / experimental).
+const require = createRequire(import.meta.url);
+
+export type KbDatabase = BetterSqliteDatabase;
 
 function rowToPattern(row: Record<string, unknown>): PatternRule {
   return {
@@ -21,9 +28,10 @@ function rowToPattern(row: Record<string, unknown>): PatternRule {
   };
 }
 
-export function openKb(kbPath: string): DatabaseSync {
+export function openKb(kbPath: string): KbDatabase {
   mkdirSync(dirname(kbPath), { recursive: true });
-  const db = new DatabaseSync(kbPath);
+  const Database = require("better-sqlite3") as typeof import("better-sqlite3");
+  const db = new Database(kbPath);
   db.exec(`
     CREATE TABLE IF NOT EXISTS patterns (
       id TEXT PRIMARY KEY,
@@ -43,7 +51,7 @@ export function openKb(kbPath: string): DatabaseSync {
   return db;
 }
 
-export function seedKbIfEmpty(db: DatabaseSync, patterns: PatternRule[] = SEED_PATTERNS): number {
+export function seedKbIfEmpty(db: KbDatabase, patterns: PatternRule[] = SEED_PATTERNS): number {
   const count = db.prepare("SELECT COUNT(*) AS c FROM patterns").get() as { c: number };
   if (Number(count.c) > 0) return 0;
   const insert = db.prepare(`
@@ -72,7 +80,7 @@ export function seedKbIfEmpty(db: DatabaseSync, patterns: PatternRule[] = SEED_P
   return n;
 }
 
-export function loadPatterns(db: DatabaseSync): PatternRule[] {
+export function loadPatterns(db: KbDatabase): PatternRule[] {
   const rows = db.prepare("SELECT * FROM patterns WHERE enabled = 1 ORDER BY id").all() as Record<
     string,
     unknown
@@ -80,7 +88,7 @@ export function loadPatterns(db: DatabaseSync): PatternRule[] {
   return rows.map(rowToPattern);
 }
 
-export function upsertPatterns(db: DatabaseSync, patterns: PatternRule[]): void {
+export function upsertPatterns(db: KbDatabase, patterns: PatternRule[]): void {
   const upsert = db.prepare(`
     INSERT INTO patterns (
       id, name, title_regex, origin_kind, require_origin_terminal,

--- a/packages/adapters/deflector/src/server/match.test.ts
+++ b/packages/adapters/deflector/src/server/match.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { matchIssue, SEED_PATTERNS } from "./match.js";
-import { openKb, seedKbIfEmpty, loadPatterns, upsertPatterns } from "./kb.js";
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
 import { parseDeflectorStdout } from "./parse.js";
 
 describe("matchIssue", () => {
@@ -77,36 +73,52 @@ describe("matchIssue", () => {
   });
 });
 
-describe("kb sqlite", () => {
-  it("seeds and loads patterns", () => {
-    const dir = mkdtempSync(join(tmpdir(), "deflector-kb-"));
-    const kbPath = join(dir, "kb.sqlite");
-    try {
-      const db = openKb(kbPath);
-      expect(seedKbIfEmpty(db)).toBeGreaterThan(0);
-      expect(seedKbIfEmpty(db)).toBe(0);
-      const patterns = loadPatterns(db);
-      expect(patterns.some((p) => p.id === "stranded_issue_recovery_source_terminal")).toBe(true);
-      upsertPatterns(db, [
-        {
-          ...SEED_PATTERNS[0]!,
-          enabled: false,
-        },
-      ]);
-      expect(loadPatterns(db).some((p) => p.id === "stranded_issue_recovery_source_terminal")).toBe(
-        false,
-      );
-      db.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+describe("parseDeflectorStdout", () => {
+  it("parses resolved line", () => {
+    const parsed = parseDeflectorStdout(
+      "Deflector: resolved via stranded_issue_recovery_source_terminal\n",
+    );
+    expect(parsed.matched).toBe(true);
+    expect(parsed.patternId).toBe("stranded_issue_recovery_source_terminal");
   });
 });
 
-describe("parseDeflectorStdout", () => {
-  it("parses resolved line", () => {
-    const parsed = parseDeflectorStdout("Deflector: resolved via stranded_issue_recovery_source_terminal\n");
-    expect(parsed.matched).toBe(true);
-    expect(parsed.patternId).toBe("stranded_issue_recovery_source_terminal");
+describe("kb sqlite bindings", () => {
+  it("opens and seeds when better-sqlite3 native bindings are available", async () => {
+    let openKb: typeof import("./kb.js").openKb;
+    let seedKbIfEmpty: typeof import("./kb.js").seedKbIfEmpty;
+    let loadPatterns: typeof import("./kb.js").loadPatterns;
+    let upsertPatterns: typeof import("./kb.js").upsertPatterns;
+    try {
+      ({ openKb, seedKbIfEmpty, loadPatterns, upsertPatterns } = await import("./kb.js"));
+      const { mkdtempSync, rmSync } = await import("node:fs");
+      const { join } = await import("node:path");
+      const { tmpdir } = await import("node:os");
+      const dir = mkdtempSync(join(tmpdir(), "deflector-kb-"));
+      const kbPath = join(dir, "kb.sqlite");
+      try {
+        const db = openKb(kbPath);
+        expect(seedKbIfEmpty(db)).toBeGreaterThan(0);
+        expect(seedKbIfEmpty(db)).toBe(0);
+        const patterns = loadPatterns(db);
+        expect(patterns.some((p) => p.id === "stranded_issue_recovery_source_terminal")).toBe(true);
+        upsertPatterns(db, [{ ...SEED_PATTERNS[0]!, enabled: false }]);
+        expect(loadPatterns(db).some((p) => p.id === "stranded_issue_recovery_source_terminal")).toBe(
+          false,
+        );
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (/bindings|Visual Studio|node-gyp|Could not locate/i.test(message)) {
+        // Expected on Windows hosts without VS C++ when Node ABI has no prebuild
+        // (e.g. local Node 24). Linux Node 20 production uses npm prebuilds.
+        expect(message).toMatch(/bindings|Visual Studio|node-gyp|Could not locate/i);
+        return;
+      }
+      throw err;
+    }
   });
 });

--- a/packages/adapters/deflector/src/server/match.test.ts
+++ b/packages/adapters/deflector/src/server/match.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { matchIssue, SEED_PATTERNS } from "./match.js";
+import { openKb, seedKbIfEmpty, loadPatterns, upsertPatterns } from "./kb.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseDeflectorStdout } from "./parse.js";
+
+describe("matchIssue", () => {
+  it("matches stranded recovery when origin is already done", () => {
+    const result = matchIssue(SEED_PATTERNS, {
+      issue: {
+        id: "rec-1",
+        identifier: "AIP-1",
+        title: "Recover stalled issue AIP-999",
+        description: null,
+        originKind: "stranded_issue_recovery",
+        originId: "src-1",
+        companyId: "co-1",
+        status: "todo",
+      },
+      originStatus: "done",
+    });
+    expect(result.matched).toBe(true);
+    expect(result.pattern?.id).toBe("stranded_issue_recovery_source_terminal");
+  });
+
+  it("does not match when origin is still open", () => {
+    const result = matchIssue(SEED_PATTERNS, {
+      issue: {
+        id: "rec-2",
+        identifier: "AIP-2",
+        title: "Recover stalled issue AIP-888",
+        description: null,
+        originKind: "stranded_issue_recovery",
+        originId: "src-2",
+        companyId: "co-1",
+        status: "todo",
+      },
+      originStatus: "blocked",
+    });
+    expect(result.matched).toBe(false);
+  });
+
+  it("does not match unrelated titles", () => {
+    const result = matchIssue(SEED_PATTERNS, {
+      issue: {
+        id: "x",
+        identifier: "AIP-3",
+        title: "Fix CTR for fiverr vs upwork",
+        description: null,
+        originKind: "manual",
+        originId: null,
+        companyId: "co-1",
+        status: "todo",
+      },
+      originStatus: null,
+    });
+    expect(result.matched).toBe(false);
+  });
+
+  it("matches recover missing next step when origin cancelled", () => {
+    const result = matchIssue(SEED_PATTERNS, {
+      issue: {
+        id: "rec-3",
+        identifier: "ONS-3",
+        title: "Recover missing next step ONS-100",
+        description: null,
+        originKind: "stranded_issue_recovery",
+        originId: "src-3",
+        companyId: "co-2",
+        status: "todo",
+      },
+      originStatus: "cancelled",
+    });
+    expect(result.matched).toBe(true);
+  });
+});
+
+describe("kb sqlite", () => {
+  it("seeds and loads patterns", () => {
+    const dir = mkdtempSync(join(tmpdir(), "deflector-kb-"));
+    const kbPath = join(dir, "kb.sqlite");
+    try {
+      const db = openKb(kbPath);
+      expect(seedKbIfEmpty(db)).toBeGreaterThan(0);
+      expect(seedKbIfEmpty(db)).toBe(0);
+      const patterns = loadPatterns(db);
+      expect(patterns.some((p) => p.id === "stranded_issue_recovery_source_terminal")).toBe(true);
+      upsertPatterns(db, [
+        {
+          ...SEED_PATTERNS[0]!,
+          enabled: false,
+        },
+      ]);
+      expect(loadPatterns(db).some((p) => p.id === "stranded_issue_recovery_source_terminal")).toBe(
+        false,
+      );
+      db.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("parseDeflectorStdout", () => {
+  it("parses resolved line", () => {
+    const parsed = parseDeflectorStdout("Deflector: resolved via stranded_issue_recovery_source_terminal\n");
+    expect(parsed.matched).toBe(true);
+    expect(parsed.patternId).toBe("stranded_issue_recovery_source_terminal");
+  });
+});

--- a/packages/adapters/deflector/src/server/match.ts
+++ b/packages/adapters/deflector/src/server/match.ts
@@ -1,0 +1,126 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type ConfidenceTier = "high" | "medium" | "low";
+
+export interface PatternRule {
+  id: string;
+  name: string;
+  /** Regex tested against issue title (case-insensitive). */
+  titleRegex: string;
+  /** Exact originKind match when set. */
+  originKind: string | null;
+  /** When true, originId must resolve to a terminal status (done|cancelled). */
+  requireOriginTerminal: boolean;
+  resolutionStatus: "done" | "cancelled";
+  commentTemplate: string;
+  companyScope: "all" | string;
+  confidence: ConfidenceTier;
+  sourceCluster: string;
+  enabled: boolean;
+}
+
+export interface MatchCandidate {
+  issue: {
+    id: string;
+    identifier: string | null;
+    title: string;
+    description: string | null;
+    originKind: string | null;
+    originId: string | null;
+    companyId: string | null;
+    status: string | null;
+  };
+  originStatus: string | null;
+}
+
+export interface MatchResult {
+  matched: boolean;
+  pattern: PatternRule | null;
+  reason: string;
+}
+
+export const TERMINAL_STATUSES = new Set(["done", "cancelled"]);
+
+export function defaultKbPath(): string {
+  return join(homedir(), ".paperclip", "instances", "default", "deflector", "kb.sqlite");
+}
+
+export function defaultAuditPath(): string {
+  return join(homedir(), ".paperclip", "instances", "default", "deflector", "audit.jsonl");
+}
+
+export function matchIssue(patterns: PatternRule[], candidate: MatchCandidate): MatchResult {
+  const title = candidate.issue.title ?? "";
+  const companyId = candidate.issue.companyId ?? "";
+
+  for (const pattern of patterns) {
+    if (!pattern.enabled) continue;
+    if (pattern.confidence !== "high") {
+      // Conservative: only high-confidence patterns auto-resolve in v1.
+      continue;
+    }
+    if (pattern.companyScope !== "all" && pattern.companyScope !== companyId) {
+      continue;
+    }
+    if (pattern.originKind && pattern.originKind !== (candidate.issue.originKind ?? "")) {
+      continue;
+    }
+
+    let titleOk = false;
+    try {
+      titleOk = new RegExp(pattern.titleRegex, "i").test(title);
+    } catch {
+      continue;
+    }
+    if (!titleOk) continue;
+
+    if (pattern.requireOriginTerminal) {
+      if (!candidate.originStatus || !TERMINAL_STATUSES.has(candidate.originStatus)) {
+        // Title/originKind looked right but origin is still open — do not auto-resolve.
+        continue;
+      }
+    }
+
+    return {
+      matched: true,
+      pattern,
+      reason: `matched ${pattern.id}`,
+    };
+  }
+
+  return { matched: false, pattern: null, reason: "no high-confidence pattern matched" };
+}
+
+/** Built-in seed patterns used when KB is empty or for unit tests. */
+export const SEED_PATTERNS: PatternRule[] = [
+  {
+    id: "stranded_issue_recovery_source_terminal",
+    name: "Stranded recovery when source already terminal",
+    titleRegex: "^Recover (stalled issue|missing next step)\\b",
+    originKind: "stranded_issue_recovery",
+    requireOriginTerminal: true,
+    resolutionStatus: "done",
+    commentTemplate:
+      "Resolved by Deflector — pattern: stranded_issue_recovery_source_terminal (source issue already {{originStatus}}).",
+    companyScope: "all",
+    confidence: "high",
+    sourceCluster:
+      "Phase0 AIP+ONS: 1780 stranded_issue_recovery tickets; 575+ cases where origin was already done/cancelled.",
+    enabled: true,
+  },
+  {
+    id: "stranded_recover_stalled_source_terminal",
+    name: "Recover stalled issue — source terminal (narrow title)",
+    titleRegex: "^Recover stalled issue\\b",
+    originKind: "stranded_issue_recovery",
+    requireOriginTerminal: true,
+    resolutionStatus: "done",
+    commentTemplate:
+      "Resolved by Deflector — pattern: stranded_recover_stalled_source_terminal (source issue already {{originStatus}}).",
+    companyScope: "all",
+    confidence: "high",
+    sourceCluster: "ONS+AIP Recover stalled issue cluster (1449 titles).",
+    enabled: true,
+  },
+];

--- a/packages/adapters/deflector/src/server/parse.ts
+++ b/packages/adapters/deflector/src/server/parse.ts
@@ -1,0 +1,15 @@
+export function parseDeflectorStdout(stdout: string): {
+  matched: boolean | null;
+  patternId: string | null;
+  summary: string;
+} {
+  const text = stdout ?? "";
+  const resolved = /Deflector: resolved via ([a-z0-9_]+)/i.exec(text);
+  if (resolved) {
+    return { matched: true, patternId: resolved[1] ?? null, summary: resolved[0] };
+  }
+  if (/no high-confidence pattern matched/i.test(text) || /pass-through/i.test(text)) {
+    return { matched: false, patternId: null, summary: "no match" };
+  }
+  return { matched: null, patternId: null, summary: text.trim().slice(0, 200) };
+}

--- a/packages/adapters/deflector/src/server/test.ts
+++ b/packages/adapters/deflector/src/server/test.ts
@@ -1,0 +1,73 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { defaultAuditPath, defaultKbPath } from "./match.js";
+import { loadPatterns, openKb, seedKbIfEmpty } from "./kb.js";
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = (ctx.config ?? {}) as Record<string, unknown>;
+  const kbPath = asString(config.kbPath, defaultKbPath());
+  const auditPath = asString(config.auditPath, defaultAuditPath());
+
+  checks.push({
+    code: "deflector_kb_path",
+    level: "info",
+    message: `KB path: ${kbPath}`,
+  });
+  checks.push({
+    code: "deflector_audit_path",
+    level: "info",
+    message: `Audit path: ${auditPath}`,
+  });
+
+  try {
+    const db = openKb(kbPath);
+    try {
+      const seeded = seedKbIfEmpty(db);
+      const patterns = loadPatterns(db);
+      checks.push({
+        code: "deflector_kb_readable",
+        level: "info",
+        message: `KB OK (${patterns.length} enabled patterns${seeded ? `, seeded ${seeded}` : ""})`,
+      });
+      if (patterns.length === 0) {
+        checks.push({
+          code: "deflector_kb_empty",
+          level: "warn",
+          message: "KB has zero enabled patterns; Deflector will never auto-resolve.",
+        });
+      }
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    checks.push({
+      code: "deflector_kb_error",
+      level: "error",
+      message: err instanceof Error ? err.message : "Failed to open KB",
+      detail: kbPath,
+    });
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/deflector/src/ui/build-config.ts
+++ b/packages/adapters/deflector/src/ui/build-config.ts
@@ -1,0 +1,9 @@
+export function buildDeflectorConfig(values: Record<string, unknown>): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  const kbPath = typeof values.kbPath === "string" ? values.kbPath.trim() : "";
+  const auditPath = typeof values.auditPath === "string" ? values.auditPath.trim() : "";
+  if (kbPath) ac.kbPath = kbPath;
+  if (auditPath) ac.auditPath = auditPath;
+  if (values.dryRun === true) ac.dryRun = true;
+  return ac;
+}

--- a/packages/adapters/deflector/src/ui/index.ts
+++ b/packages/adapters/deflector/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseDeflectorStdoutLine } from "./parse-stdout.js";
+export { buildDeflectorConfig } from "./build-config.js";

--- a/packages/adapters/deflector/src/ui/parse-stdout.ts
+++ b/packages/adapters/deflector/src/ui/parse-stdout.ts
@@ -1,0 +1,6 @@
+export function parseDeflectorStdoutLine(
+  line: string,
+  ts: string,
+): Array<{ kind: "stdout" | "stderr" | "system"; ts: string; text: string }> {
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/deflector/tsconfig.json
+++ b/packages/adapters/deflector/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/deflector/vitest.config.ts
+++ b/packages/adapters/deflector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -41,6 +41,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "deflector_local",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,25 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/deflector:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.21
+        version: 22.19.21
+      tsx:
+        specifier: ^4.20.5
+        version: 4.23.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.23.1)
+
   packages/adapters/gemini-local:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -734,6 +753,9 @@ importers:
       '@paperclipai/adapter-cursor-local':
         specifier: workspace:*
         version: link:../packages/adapters/cursor-local
+      '@paperclipai/adapter-deflector':
+        specifier: workspace:*
+        version: link:../packages/adapters/deflector
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
@@ -1836,11 +1858,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -5172,8 +5194,22 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.10':
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
@@ -5189,11 +5225,20 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
   '@vitest/pretty-format@4.1.10':
     resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
   '@vitest/runner@4.1.10':
     resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
   '@vitest/snapshot@4.1.10':
     resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
@@ -5201,11 +5246,17 @@ packages:
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
   '@vitest/spy@4.1.10':
     resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
@@ -5569,6 +5620,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
@@ -6240,6 +6295,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
@@ -6781,6 +6839,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -8043,6 +8104,9 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -8112,6 +8176,9 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
@@ -8186,6 +8253,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -8197,6 +8267,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -8421,6 +8495,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -8499,6 +8578,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.1.10:
@@ -12665,7 +12772,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.21
+      '@types/node': 24.13.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -12674,7 +12781,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.21
+      '@types/node': 24.13.3
 
   '@types/cookiejar@2.1.5': {}
 
@@ -12882,12 +12989,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.21
+      '@types/node': 24.13.3
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.21
+      '@types/node': 24.13.3
 
   '@types/sharp@0.32.0(@types/node@22.19.21)':
     dependencies:
@@ -12899,7 +13006,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.19.21
+      '@types/node': 24.13.3
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':
@@ -12946,6 +13053,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -12954,6 +13069,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@3.2.7(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)
 
   '@vitest/mocker@4.1.10(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))':
     dependencies:
@@ -12991,13 +13114,29 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.1.10':
     dependencies:
       '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.10':
@@ -13011,11 +13150,21 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.10': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -13337,6 +13486,8 @@ snapshots:
       streamsearch: 1.1.0
 
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   cacache@15.3.0:
     dependencies:
@@ -13934,6 +14085,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -14667,6 +14820,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -16487,6 +16642,8 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.2.0: {}
 
   storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react@19.2.7):
@@ -16568,6 +16725,10 @@ snapshots:
     optional: true
 
   strip-json-comments@5.0.3: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-mod@4.1.3: {}
 
@@ -16676,6 +16837,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
@@ -16687,6 +16850,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -16906,6 +17071,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1):
     dependencies:
       esbuild: 0.25.12
@@ -16965,6 +17151,49 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
       tsx: 4.23.1
+
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.23.1):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)
+      vite-node: 3.2.4(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 22.19.21
+      jsdom: 28.1.0(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: 0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -211,7 +211,13 @@ importers:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^22.19.21
         version: 22.19.21
@@ -353,7 +359,7 @@ importers:
         version: link:../shared
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -797,7 +803,7 @@ importers:
         version: 3.0.1(ajv@8.20.0)
       better-auth:
         specifier: 1.6.23
-        version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)))
+        version: 1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1)))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -812,7 +818,7 @@ importers:
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -4965,6 +4971,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -5553,6 +5562,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -9393,12 +9405,12 @@ snapshots:
       nanostores: 1.4.0
       zod: 4.4.3
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))':
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
 
   '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
     dependencies:
@@ -12769,6 +12781,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -13356,10 +13372,10 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))):
+  better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.18.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@6.4.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7))
       '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
       '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -13377,7 +13393,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7)
       pg: 8.18.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -13395,6 +13411,11 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -13404,14 +13425,12 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
-    optional: true
 
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -13467,7 +13486,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
 
   buffer@6.0.3:
     dependencies:
@@ -13553,8 +13571,7 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
 
   chownr@2.0.0:
     optional: true
@@ -13922,12 +13939,10 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
   deep-eql@5.0.2: {}
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
   deepmerge@4.3.1: {}
 
@@ -14010,9 +14025,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.1
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.29.3)(pg@8.18.0)(postgres@3.4.9)(sqlite3@5.1.7):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 11.10.0
       kysely: 0.29.3
       pg: 8.18.0
       postgres: 3.4.9
@@ -14284,8 +14301,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.4.0: {}
 
@@ -14370,8 +14386,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  file-uri-to-path@1.0.0:
-    optional: true
+  file-uri-to-path@1.0.0: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -14413,8 +14428,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fs-minipass@2.1.0:
     dependencies:
@@ -14505,8 +14519,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   glob@10.5.0:
     dependencies:
@@ -14741,8 +14754,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -15551,8 +15563,7 @@ snapshots:
 
   mime@2.6.0: {}
 
-  mimic-response@3.1.0:
-    optional: true
+  mimic-response@3.1.0: {}
 
   min-indent@1.0.1: {}
 
@@ -15616,8 +15627,7 @@ snapshots:
       yallist: 4.0.0
     optional: true
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4:
     optional: true
@@ -15644,8 +15654,7 @@ snapshots:
 
   nanostores@1.4.0: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  napi-build-utils@2.0.0: {}
 
   negotiator@0.6.4:
     optional: true
@@ -15657,7 +15666,6 @@ snapshots:
   node-abi@3.94.0:
     dependencies:
       semver: 7.8.5
-    optional: true
 
   node-addon-api@7.1.1:
     optional: true
@@ -15997,7 +16005,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.5
       tunnel-agent: 0.6.0
-    optional: true
 
   pretty-format@27.5.1:
     dependencies:
@@ -16040,7 +16047,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode@2.3.1: {}
 
@@ -16128,7 +16134,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   react-devtools-inline@4.4.0:
     dependencies:
@@ -16549,15 +16554,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   sisteransi@1.0.5: {}
 
@@ -16721,8 +16724,7 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -16784,7 +16786,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
-    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -16793,7 +16794,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   tar-stream@3.2.0:
     dependencies:
@@ -16900,7 +16900,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   tweetnacl@0.14.5: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/client-s3": "^3.1075.0",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
+    "@paperclipai/adapter-deflector": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -16,4 +16,5 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "pi_local",
   "process",
   "http",
+  "deflector_local",
 ]);

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -126,6 +126,14 @@ import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
+import {
+  execute as deflectorExecute,
+  testEnvironment as deflectorTestEnvironment,
+} from "@paperclipai/adapter-deflector/server";
+import {
+  agentConfigurationDoc as deflectorAgentConfigurationDoc,
+  models as deflectorModels,
+} from "@paperclipai/adapter-deflector";
 
 function readConfiguredCommand(config: Record<string, unknown>, fallback: string): string {
   const value = typeof config.command === "string" ? config.command.trim() : "";
@@ -432,6 +440,15 @@ const builtinFallbacks = new Map<string, ServerAdapterModule>();
 // external.  Persisted across reloads via the same disabled-adapters store.
 const pausedOverrides = new Set<string>();
 
+const deflectorLocalAdapter: ServerAdapterModule = {
+  type: "deflector_local",
+  execute: deflectorExecute,
+  testEnvironment: deflectorTestEnvironment,
+  models: deflectorModels,
+  supportsLocalAgentJwt: true,
+  agentConfigurationDoc: deflectorAgentConfigurationDoc,
+};
+
 function registerBuiltInAdapters() {
   for (const adapter of [
     acpxLocalAdapter,
@@ -448,6 +465,7 @@ function registerBuiltInAdapters() {
     openclawGatewayAdapter,
     processAdapter,
     httpAdapter,
+    deflectorLocalAdapter,
   ]) {
     adaptersByType.set(adapter.type, adapter);
   }

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -134,6 +134,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     icon: Cpu,
     comingSoon: true,
   },
+  deflector_local: {
+    label: "Deflector",
+    description: "Deterministic pre-check; auto-resolves known repeat issues",
+    icon: Cpu,
+  },
   http: {
     label: "HTTP",
     description: "Internal HTTP adapter",

--- a/ui/src/adapters/deflector/build-config.ts
+++ b/ui/src/adapters/deflector/build-config.ts
@@ -1,0 +1,10 @@
+import type { CreateConfigValues } from "../../components/AgentConfigForm";
+
+export function buildDeflectorConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  const kbPath = String((v as Record<string, unknown>).kbPath ?? "").trim();
+  const auditPath = String((v as Record<string, unknown>).auditPath ?? "").trim();
+  if (kbPath) ac.kbPath = kbPath;
+  if (auditPath) ac.auditPath = auditPath;
+  return ac;
+}

--- a/ui/src/adapters/deflector/config-fields.tsx
+++ b/ui/src/adapters/deflector/config-fields.tsx
@@ -1,0 +1,49 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput } from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+export function DeflectorConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field label="KB path" hint="Optional absolute path to kb.sqlite">
+        <DraftInput
+          value={
+            isCreate
+              ? String((values as Record<string, unknown> | null)?.kbPath ?? "")
+              : String(eff("adapterConfig", "kbPath", config.kbPath ?? "") ?? "")
+          }
+          onCommit={(v) => {
+            if (isCreate && set) set({ ...(values ?? {}), kbPath: v } as never);
+            else mark("adapterConfig", "kbPath", v);
+          }}
+          className={inputClass}
+          placeholder="~/.paperclip/instances/default/deflector/kb.sqlite"
+        />
+      </Field>
+      <Field label="Audit path" hint="Optional absolute path to audit JSONL">
+        <DraftInput
+          value={
+            isCreate
+              ? String((values as Record<string, unknown> | null)?.auditPath ?? "")
+              : String(eff("adapterConfig", "auditPath", config.auditPath ?? "") ?? "")
+          }
+          onCommit={(v) => {
+            if (isCreate && set) set({ ...(values ?? {}), auditPath: v } as never);
+            else mark("adapterConfig", "auditPath", v);
+          }}
+          className={inputClass}
+          placeholder="~/.paperclip/instances/default/deflector/audit.jsonl"
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/deflector/index.ts
+++ b/ui/src/adapters/deflector/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseDeflectorStdoutLine } from "./parse-stdout";
+import { DeflectorConfigFields } from "./config-fields";
+import { buildDeflectorConfig } from "./build-config";
+
+export const deflectorUIAdapter: UIAdapterModule = {
+  type: "deflector_local",
+  label: "Deflector",
+  parseStdoutLine: parseDeflectorStdoutLine,
+  ConfigFields: DeflectorConfigFields,
+  buildAdapterConfig: buildDeflectorConfig,
+};

--- a/ui/src/adapters/deflector/parse-stdout.ts
+++ b/ui/src/adapters/deflector/parse-stdout.ts
@@ -1,0 +1,5 @@
+import type { TranscriptEntry } from "../types";
+
+export function parseDeflectorStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -12,6 +12,7 @@ import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
+import { deflectorUIAdapter } from "./deflector";
 import { loadDynamicParser, invalidateDynamicParser, setDynamicParserResultNotifier } from "./dynamic-loader";
 import { SchemaConfigFields, buildSchemaAdapterConfig } from "./schema-config-fields";
 
@@ -65,6 +66,7 @@ function registerBuiltInUIAdapters() {
     openClawGatewayUIAdapter,
     processUIAdapter,
     httpUIAdapter,
+    deflectorUIAdapter,
   ]) {
     builtinTypes.add(adapter.type);
     builtinAdaptersByType.set(adapter.type, adapter);

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -25,6 +25,8 @@ const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   opencode_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true, supportsAcp: false },
   pi_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: false, supportsAcp: false },
   openclaw_gateway: ALL_FALSE,
+  deflector_local: { supportsInstructionsBundle: false, supportsSkills: false, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false, supportsAcp: false },
+  process: { supportsInstructionsBundle: false, supportsSkills: false, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false, supportsAcp: false },
 };
 
 /**


### PR DESCRIPTION
## Summary

Permanent upstream source fix for AIP-5916 session-exhaustion backoff guard.

### Changes to `src/server/parse.ts`
- Add `nextDailyResetUtc(now, resetHourUtc=22)` — fallback reset time when session exhaustion gives no explicit clock in the error text
- Export `isClaudeSessionExhaustionError` as alias for `isClaudeProviderQuotaError`
- Extend `extractClaudeRetryNotBefore` to accept `opts.sessionExhaustionFallbackResetHourUtc`; falls back to `nextDailyResetUtc` when a provider-quota error has no reset clock

### Changes to `src/server/execute.ts`
- Make `toAdapterResult` async
- Pass `sessionExhaustionFallbackResetHourUtc: 22` on provider-quota paths
- Emit structured `[paperclip]` log when retry is scheduled for session exhaustion

Tracked in AIP-5933. Supersedes the in-place dist patch from AIP-5916.