### PR TITLE
fix(authz): reject paused agents as assignment targets and execution-policy stage participants

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   agents,
   authUsers,
@@ -525,6 +526,60 @@ describeEmbeddedPostgres("authorization service", () => {
       reason: "allow_simple_company_member",
     });
     expect(decision.explanation).toContain("simple mode");
+  });
+
+  it("denies tasks:assign when the target agent is paused", async () => {
+    const company = await createCompany(db, "PausedTarget");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, targetAgent.id));
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "agent",
+      principalId: actorAgent.id,
+      status: "active",
+      membershipRole: "member",
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: targetAgent.id },
+      scope: { assigneeAgentId: targetAgent.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_company_boundary",
+    });
+  });
+
+  it("allows a paused agent to call tasks:assign as the actor", async () => {
+    // Paused service identities holding long-lived keys must remain able to create and
+    // route issues; only the assignment TARGET check rejects paused, not the actor check.
+    const company = await createCompany(db, "PausedActor");
+    const pausedActor = await createAgent(db, company.id, { role: "engineer" });
+    const activeTarget = await createAgent(db, company.id, { role: "engineer" });
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, pausedActor.id));
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "agent",
+      principalId: pausedActor.id,
+      status: "active",
+      membershipRole: "member",
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: pausedActor.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: activeTarget.id },
+      scope: { assigneeAgentId: activeTarget.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_simple_company_member",
+    });
   });
 
   it("denies delegated protected assignment when the responsible user lacks matching authority", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -153,6 +153,7 @@ import {
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 import { executionWorkspaceService as executionWorkspaceServiceDirect } from "../services/execution-workspaces.js";
 import { decisionTrainingService } from "../services/decision-training.js";
+import { assertExecutionPolicyParticipantAgentsInvokable } from "../services/agent-assignability.js";
 import { feedbackService } from "../services/feedback.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import {
@@ -7052,6 +7053,9 @@ export function issueRoutes(
       actor.actorType,
     );
     await assertCanManageIssueMonitor(access, req, companyId, createBody.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+    if (executionPolicy?.stages?.length) {
+      await assertExecutionPolicyParticipantAgentsInvokable(db, companyId, executionPolicy.stages);
+    }
     const issueId = randomUUID();
     const sourceTrust = await sourceTrustForActorWrite({
       id: issueId,
@@ -7839,6 +7843,9 @@ export function issueRoutes(
       existing.assigneeAgentId,
       req.body.executionPolicy !== undefined && monitorChanged,
     );
+    if (req.body.executionPolicy !== undefined && nextExecutionPolicy?.stages?.length) {
+      await assertExecutionPolicyParticipantAgentsInvokable(db, existing.companyId, nextExecutionPolicy.stages);
+    }
 
     const transition = applyIssueExecutionPolicyTransition({
       issue: existing,

--- a/server/src/services/agent-assignability.ts
+++ b/server/src/services/agent-assignability.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { agents } from "@paperclipai/db";
 import {
   getAgentWorkEligibility,
+  isAgentStatusInvokable,
   type AgentEligibilityAgent,
   type AgentOrgChainHealth,
 } from "@paperclipai/shared";
@@ -168,4 +169,39 @@ export async function assertAssignableAgent(
         ? firstInvalidAncestor.id
         : null,
   }));
+}
+
+// Validates that every agent-type participant in a set of execution policy stages is
+// invokable (i.e. not paused, terminated, or pending_approval). This must be called at
+// write time because the execution-policy participant transition bypasses the authorization
+// layer via workflowControlledAssignment, so assignmentTargetIsInCompany is never reached
+// for stage-driven assignee changes.
+export async function assertExecutionPolicyParticipantAgentsInvokable(
+  db: Db,
+  companyId: string,
+  stages: Array<{ participants: Array<{ type: string; agentId?: string | null }> }>,
+): Promise<void> {
+  const agentIds = new Set<string>(
+    stages
+      .flatMap((s) => s.participants)
+      .filter((p): p is { type: string; agentId: string } => p.type === "agent" && typeof p.agentId === "string")
+      .map((p) => p.agentId),
+  );
+  for (const agentId of agentIds) {
+    const agent = await getAgent(db, agentId);
+    if (!agent || agent.companyId !== companyId) {
+      throw notFound("Execution policy stage participant agent not found in company");
+    }
+    if (!isAgentStatusInvokable(agent.status)) {
+      throw conflict(
+        `Agent with status "${agent.status}" cannot be set as an execution policy stage participant — only active agents can fulfill review stages`,
+        conflictDetails({
+          companyId,
+          assigneeAgentId: agentId,
+          reason: "assignee_unknown_status",
+          chain: [{ id: agent.id, companyId: agent.companyId, name: agent.name, status: agent.status, reportsTo: agent.reportsTo }],
+        }),
+      );
+    }
+  }
 }

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -188,6 +188,15 @@ function isSimpleAssignableAgentStatus(status: string | null | undefined) {
   return status !== "pending_approval" && status !== "terminated";
 }
 
+// Used for assignment TARGET checks only. Extends isSimpleAssignableAgentStatus by also
+// rejecting "paused", because a paused agent never runs a heartbeat and work routed to one
+// will strand permanently. isSimpleAssignableAgentStatus is deliberately kept separate for
+// ACTOR checks (e.g. tasks:assign caller, inbox:manage) where paused service identities that
+// hold long-lived API keys must remain able to take action without running a heartbeat.
+function isAssignableTargetAgentStatus(status: string | null | undefined) {
+  return isSimpleAssignableAgentStatus(status) && status !== "paused";
+}
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -1176,7 +1185,7 @@ export function authorizationService(db: Db) {
       return Boolean(
         target &&
         target.companyId === resource.companyId &&
-        isSimpleAssignableAgentStatus(target.status),
+        isAssignableTargetAgentStatus(target.status),
       );
     }
     if (resource.assigneeUserId) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source platform for managing AI agents and routing work between them
> - Authorization of issue assignment is centralized in `server/src/services/authorization.ts`, which guards the `tasks:assign` action
> - When an agent is `paused`, it stops running heartbeats but retains its identity and can still hold long-lived API keys
> - `isSimpleAssignableAgentStatus` only excludes `terminated` and `pending_approval`, letting `paused` pass the assignment-target check at `assignmentTargetIsInCompany` (`:1179`)
> - A paused agent accepted as an assignment target (or execution-policy stage participant) will never run a heartbeat, so the issue strands permanently
> - This PR fixes both paths through which a paused agent could be accepted, while deliberately leaving the actor-side checks unchanged so paused service identities can keep calling `tasks:assign` and `inbox:manage` as actors
> - The benefit is that the API now rejects these assignments at write time rather than letting them silently strand

## Linked Issues

Closes #9963

## What Changed

- **`server/src/services/authorization.ts`** — Added `isAssignableTargetAgentStatus`, which extends `isSimpleAssignableAgentStatus` by also rejecting `"paused"`. Used at the target check inside `assignmentTargetIsInCompany` (`:1179`) only. The actor checks at `:1714` (`inbox:manage`) and `:1847` (`tasks:assign`) deliberately continue to use `isSimpleAssignableAgentStatus` — see *Why the actor checks are left alone* below.

- **`server/src/services/agent-assignability.ts`** — Added `assertExecutionPolicyParticipantAgentsInvokable`, which loads each unique agent-type participant from execution-policy stages and rejects any whose status is not invokable (uses `isAgentStatusInvokable` from `@paperclipai/shared`, which already treats `paused`, `terminated`, and `pending_approval` as non-invokable).

- **`server/src/routes/issues.ts`** — Calls `assertExecutionPolicyParticipantAgentsInvokable` in both the issue-create and issue-update paths, immediately after the execution policy is normalized and before any database write.

- **`server/src/__tests__/authorization-service.test.ts`** — Two regression tests: one asserts that `tasks:assign` to a paused target is denied; the other asserts that a paused actor can still call `tasks:assign` to an active target (the actor check must remain permissive).

### Why the actor checks are left alone

Paused service identities are a real deployment pattern: an agent whose sole purpose is to hold a long-lived API key and create/update issues on behalf of an external system (alerting pipelines, monitoring probes, CI webhooks). These agents are deliberately `paused` so they never consume a heartbeat slot. Their API calls act as the *caller* of `tasks:assign`, not the *target*. Changing the actor checks to also reject `paused` would break these call sites silently — exactly the same class of mistake as the original defect.

### Why the execution-policy participant path needs a separate fix

Issue #9963 noted that execution-policy stage participants "inherit the same permissiveness" as direct assignees. After verifying against master, this is not the case: execution-policy transitions set `workflowControlledAssignment: true` in `applyIssueExecutionPolicyTransition` (see `issue-execution-policy.ts`), which causes the route to skip the `assertCanAssignTasks` call entirely. The `assignmentTargetIsInCompany` check at `:1179` is never reached for stage-driven assignee changes. The write-time validation in the routes addresses this gap directly.

## Verification

```bash
# Authorization unit tests (includes the two new regression tests)
pnpm --filter server test authorization-service

# Full server test suite
pnpm --filter server test
```

Both new tests are deterministic and do not require external services (they use the embedded Postgres test harness already in use for the rest of the authorization test suite).

## Risks

- **Targeted scope.** Only the assignment-target path (`assignmentTargetIsInCompany`) and write-time execution-policy validation are changed. Actor checks are untouched. No migration needed — existing stranded issues are not affected by this change; it only prevents new ones.
- **Paused-as-target is now rejected.** Any client that deliberately assigns issues to a paused agent (e.g., to queue work for later resumption) will now receive a `409 Conflict`. If upstream wants to support that workflow, a follow-up could add an explicit `allow_paused_target` flag or use a different status (e.g., `idle`) for "temporarily halted but will resume."
- **Execution-policy participants.** Existing policies that already have a paused participant stored in the database are not re-validated; the check only fires on new writes. The liveness sweep (`invalid_review_participant`) continues to detect and recover those.

## Model Used

- **Claude Sonnet 4.6** (Anthropic, `claude-sonnet-4-6`)
  - Context window: 200k tokens
  - Extended reasoning used for tracing the `workflowControlledAssignment` bypass
  - Tool use: filesystem reads, grep across the monorepo

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/paused-agent-assignment-target`) and contains no internal Paperclip ticket id
- [ ] I have run tests locally and they pass *(CI will verify — local test infra requires the embedded Postgres binary)*
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green *(pending CI run)*
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups *(pending Greptile run)*
- [ ] I will address all Greptile and reviewer comments before requesting merge
