### PR TITLE
fix(codex-local): use gpt-5.4-mini for the cheap model profile (spark is subscription-auth-only)

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -59,8 +59,11 @@ export const modelProfiles: AdapterModelProfileDefinition[] = [
     label: "Cheap",
     description: "Use the lowest-cost known Codex local model lane without changing the primary model.",
     adapterConfig: {
-      model: "gpt-5.3-codex-spark",
-      // Spark is the cheap lane by model price; high effort keeps Codex coding behavior usable for delegated work.
+      model: "gpt-5.4-mini",
+      // gpt-5.4-mini is the cheap lane that works on both auth modes. gpt-5.3-codex-spark is
+      // cheaper but only available with ChatGPT subscription auth; on OPENAI_API_KEY runs the
+      // platform API rejects it with model_not_found. High effort keeps Codex coding behavior
+      // usable for delegated work.
       modelReasoningEffort: "high",
     },
     source: "adapter_default",

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -268,7 +268,7 @@ describe("server adapter registry", () => {
     await expect(listAdapterModelProfiles("codex_local")).resolves.toEqual([
       expect.objectContaining({
         key: "cheap",
-        adapterConfig: expect.objectContaining({ model: "gpt-5.3-codex-spark" }),
+        adapterConfig: expect.objectContaining({ model: "gpt-5.4-mini" }),
         source: "adapter_default",
       }),
     ]);

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -36,7 +36,7 @@ describe("heartbeat model profile application", () => {
       configSource: "adapter_default",
       fallbackReason: null,
       adapterConfig: {
-        model: "gpt-5.3-codex-spark",
+        model: "gpt-5.4-mini",
         modelReasoningEffort: "high",
       },
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents execute through adapters; the codex_local adapter runs the Codex CLI against OpenAI models, and its `modelProfiles` export declares a built-in "cheap" lane that issues and heartbeats can request without changing the agent's primary model
> - The cheap profile pins `model: "gpt-5.3-codex-spark"`, a model OpenAI only serves to ChatGPT-subscription auth; the OpenAI platform API does not offer it
> - Any cheap-profile run authenticated with an `OPENAI_API_KEY` therefore fails with HTTP 400 `model_not_found` before doing any work
> - Since the profile is an adapter default, every API-key deployment inherits this broken lane out of the box
> - This pull request points the cheap profile at `gpt-5.4-mini`, which is available on both auth modes and already present in the adapter's `models` list, while keeping `gpt-5.3-codex-spark` selectable for subscription-auth users
> - The benefit is that the built-in cheap lane works regardless of how Codex is authenticated

## Linked Issues or Issue Description

No public issue exists. Refs #8032 proposes the same cheap-profile default change; it additionally removes `gpt-5.3-codex-spark` from the `models` list, which this PR deliberately does not do because the model remains valid for ChatGPT-subscription auth. Related prior art for the same bug class in another adapter: Refs #8735, Refs #6101 (making the claude_local cheap profile aware of the active platform).

**What happened?**
On a multi-tenant cloud deployment of Paperclip, codex_local runs that requested the built-in "cheap" model profile while authenticated with a bound `OPENAI_API_KEY` failed with:

```
HTTP 400: {"code":"model_not_found","message":"The requested model 'gpt-5.3-codex-spark' does not exist."}
```

**Expected behavior**
The adapter's built-in cheap profile should resolve to a model the active credentials can actually use, so requesting the cheap lane never turns a runnable task into an immediate API error.

**Steps to reproduce**
1. Configure a codex_local agent with an `OPENAI_API_KEY` (no ChatGPT subscription login).
2. Run an issue with the `cheap` model profile requested (issue override or wake context).
3. The run fails immediately with HTTP 400 `model_not_found` for `gpt-5.3-codex-spark`.

## What Changed

- Changed the codex_local `cheap` model profile in `packages/adapters/codex-local/src/index.ts` from `gpt-5.3-codex-spark` to `gpt-5.4-mini`, and updated the profile comment to record that spark is subscription-auth-only and fails API-key runs with `model_not_found`.
- Kept `gpt-5.3-codex-spark` in the `models` list; it remains a valid explicit choice for subscription-auth users.
- Updated the two tests asserting the profile default (`server/src/__tests__/adapter-registry.test.ts`, `server/src/__tests__/heartbeat-model-profile.test.ts`); both were changed first and confirmed failing before the fix. Other `gpt-5.3-codex-spark` occurrences (fast-mode arg tests, validator fixtures) use it as an arbitrary valid model id and are unchanged.

Kept deliberately minimal. A possible follow-up: the adapter already distinguishes auth modes at execution time (`evaluateCodexCredentialReadiness` reports `authMode: "api" | "subscription"`), so the cheap lane could resolve to spark for subscription auth and `gpt-5.4-mini` for API keys. Today `modelProfiles` is a static per-adapter export, so that would need a small mechanism change; happy to do it as a separate PR if wanted.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-model-profile.test.ts server/src/__tests__/adapter-registry.test.ts packages/adapters/codex-local` (22 files, 201 tests pass; the two updated assertions failed before the fix as expected)
- `pnpm run typecheck` in `packages/adapters/codex-local` (clean)

## Risks

Low risk. One adapter-default constant plus its comment and two test assertions. Subscription-auth users who relied on the cheap lane resolving to spark will now get `gpt-5.4-mini` (slightly pricier, works on both auth modes); they can restore spark per agent via `runtimeConfig.modelProfiles.cheap.adapterConfig` or by selecting it explicitly. No migrations, no API changes.

## Model Used

Claude Fable 5 (claude-fable-5), extended thinking, via Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
