### PR TITLE
fix(codex-local): skip auth copy-back when no shared host credential store exists

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -289,6 +289,42 @@ describe("copyBackCodexAuth", () => {
     expect(combined).not.toContain("SENTINEL");
   });
 
+  it("treats a missing ANCESTOR of the host directory (ENOENT on lock acquisition) as a keep-host no-op and never creates it", async () => {
+    // Variant of the missing-host-dir case: the merge lock lives in a SIBLING
+    // of the host directory (`${hostDir}.paperclip-restore.lock`), so when the
+    // host dir itself is the missing leaf the lock still acquires and the
+    // staging `open` is the first ENOENT. But when an ANCESTOR of the host dir
+    // is missing too, the lock `mkdir` itself throws ENOENT before staging ever
+    // runs. Both shapes mean the same thing (no shared store to merge into) and
+    // must resolve to the same benign kept-host outcome without creating any
+    // part of the missing tree.
+    const parentDir = await makeHostDir();
+    const hostDir = path.join(parentDir, "missing-ancestor", "missing-codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    const sandboxAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: NEWER,
+      marker: "sandbox-SENTINEL",
+    });
+
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      log: (line) => {
+        logs.push(line);
+      },
+    });
+
+    expect(outcome).toBe("kept-host");
+    // Neither the missing ancestor nor anything below it may be created.
+    await expect(stat(path.join(parentDir, "missing-ancestor"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readdir(parentDir)).toEqual([]);
+    const combined = logs.join("\n");
+    expect(combined).toContain("no shared host credential store");
+    expect(combined).not.toContain("SENTINEL");
+  });
+
   it("fails loud when the sandbox read errors and leaves the host untouched", async () => {
     const hostDir = await makeHostDir();
     const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -253,6 +253,42 @@ describe("copyBackCodexAuth", () => {
     expect(result.logs.join("\n")).toContain("no sandbox credential to copy back");
   });
 
+  it("treats a missing host credential directory (ENOENT on staging) as a keep-host no-op and never creates it", async () => {
+    // The prod shape: on a multi-tenant cloud server the shared host codex home
+    // (`~/.codex`) never existed, so staging the copy-back temp file fails with
+    // ENOENT on the missing parent directory. That must be a benign "nothing to
+    // merge into" outcome, not a teardown failure that marks a completed run
+    // failed. Crucially the directory must NOT be created either: on a
+    // multi-tenant server that would leak this run's credential into the store
+    // every other tenant's managed home is seeded from.
+    const parentDir = await makeHostDir();
+    const hostDir = path.join(parentDir, "missing-codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    const sandboxAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: NEWER,
+      marker: "sandbox-SENTINEL",
+    });
+
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      log: (line) => {
+        logs.push(line);
+      },
+    });
+
+    expect(outcome).toBe("kept-host");
+    // The shared host directory must stay absent.
+    await expect(stat(hostDir)).rejects.toMatchObject({ code: "ENOENT" });
+    // No leftover artifacts (the merge-lock sibling dir must be cleaned up too).
+    expect(await readdir(parentDir)).toEqual([]);
+    const combined = logs.join("\n");
+    expect(combined).toContain("no shared host credential store");
+    expect(combined).not.toContain("SENTINEL");
+  });
+
   it("fails loud when the sandbox read errors and leaves the host untouched", async () => {
     const hostDir = await makeHostDir();
     const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -84,10 +84,12 @@ async function decideExitCode(sourcePath: string, destinationPath: string): Prom
  *      error stays fail-loud.
  *   2. Stage them to a `0600` temp file on the **same filesystem** as the host
  *      target (its directory), which doubles as the predicate `source`. A host
- *      directory that is missing outright (ENOENT) resolves to `kept-host`:
- *      there is no shared store to merge into, and the directory is never
- *      created here (on a multi-tenant server that would leak one tenant's
- *      credential into the store every other managed home is seeded from).
+ *      directory whose path is missing at any depth (ENOENT from the lock
+ *      acquisition when an ancestor is absent, or from staging when the host
+ *      directory itself is) resolves to `kept-host`: there is no shared store
+ *      to merge into, and no part of the missing tree is ever created here (on
+ *      a multi-tenant server that would leak one tenant's credential into the
+ *      store every other managed home is seeded from).
  *   3. Run the Phase-3 decision predicate (`source` = sandbox temp, `destination`
  *      = host). Exit 10 → adopt the sandbox copy; exit 20 → keep the host copy.
  *   4. On exit 10, `rename` the staged temp over the host target — an atomic
@@ -119,58 +121,65 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
   }
 
   const hostDir = path.dirname(hostAuthPath);
-  return withDirectoryMergeLock(hostDir, async () => {
-    // Stage on the same filesystem as the host target so both the predicate read
-    // and the final rename stay device-local (rename across devices is not
-    // atomic and would fail with EXDEV).
-    const stagedTempPath = path.join(hostDir, `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`);
-    // `wx` + explicit mode create the temp private (0600) and fail if it somehow
-    // already exists, so we never write through a pre-existing symlink. ENOENT
-    // here means the host directory itself is missing (a shared codex home that
-    // never existed, e.g. a multi-tenant cloud server whose credentials live
-    // only in managed per-company homes, or one deleted between the caller's
-    // launch-time check and teardown): there is nothing to merge into, so treat
-    // it exactly like the absent-sandbox-auth branch above and keep the host.
-    // Deliberately NOT `mkdir`: creating the shared directory here would leak
-    // this run's credential into the store every other tenant's managed home is
-    // seeded from. Every other staging error stays fail-loud.
-    let handle;
-    try {
-      handle = await open(stagedTempPath, "wx", 0o600);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+  try {
+    return await withDirectoryMergeLock(hostDir, async () => {
+      // Stage on the same filesystem as the host target so both the predicate read
+      // and the final rename stay device-local (rename across devices is not
+      // atomic and would fail with EXDEV).
+      const stagedTempPath = path.join(hostDir, `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`);
+      // `wx` + explicit mode create the temp private (0600) and fail if it somehow
+      // already exists, so we never write through a pre-existing symlink.
+      const handle = await open(stagedTempPath, "wx", 0o600);
+      try {
+        await handle.writeFile(sandboxAuthBytes);
+        await handle.close();
+
+        const decision = await decideExitCode(stagedTempPath, hostAuthPath);
+        if (decision === USE_SOURCE_EXIT) {
+          // Atomic same-directory swap; rename preserves the temp's 0600 mode.
+          await rename(stagedTempPath, hostAuthPath);
+          await log(
+            "[paperclip] Codex auth copy-back: sandbox credential is strictly newer for the same subscription identity; installed to the host at mode 0600.",
+          );
+          return "copied";
+        }
+
         await log(
-          "[paperclip] Codex auth copy-back: no shared host credential store (host codex home directory is absent); nothing to merge into, host left untouched.",
+          "[paperclip] Codex auth copy-back: host credential kept (sandbox copy is not a strictly-newer same-identity subscription credential).",
         );
         return "kept-host";
+      } finally {
+        // Close is idempotent-safe to skip after an explicit close; the temp is the
+        // thing that must never linger. On the copy path rename already consumed it
+        // (force makes the removal a no-op); on every other path this deletes the
+        // staged credential bytes.
+        await handle.close().catch(() => undefined);
+        await rm(stagedTempPath, { force: true }).catch(() => undefined);
       }
-      throw error;
-    }
-    try {
-      await handle.writeFile(sandboxAuthBytes);
-      await handle.close();
-
-      const decision = await decideExitCode(stagedTempPath, hostAuthPath);
-      if (decision === USE_SOURCE_EXIT) {
-        // Atomic same-directory swap; rename preserves the temp's 0600 mode.
-        await rename(stagedTempPath, hostAuthPath);
-        await log(
-          "[paperclip] Codex auth copy-back: sandbox credential is strictly newer for the same subscription identity; installed to the host at mode 0600.",
-        );
-        return "copied";
-      }
-
+    });
+  } catch (error) {
+    // ENOENT anywhere in the locked host-side sequence means some part of the
+    // shared host store's path is missing: the lock `mkdir` when an ANCESTOR of
+    // the host directory is absent (the lock lives in a sibling of `hostDir`,
+    // so a missing ancestor fails lock acquisition before staging even runs),
+    // the staging `open` when the host directory itself is the missing leaf, or
+    // the writeFile/rename if the directory vanishes mid-sequence. All shapes
+    // mean the same thing: a shared codex home that never existed (e.g. a
+    // multi-tenant cloud server whose credentials live only in managed
+    // per-company homes) or one deleted between the caller's launch-time check
+    // and teardown. There is nothing to merge into, so treat it exactly like
+    // the absent-sandbox-auth branch above and keep the host. Deliberately NOT
+    // `mkdir`: creating the shared directory here would leak this run's
+    // credential into the store every other tenant's managed home is seeded
+    // from. The decision predicate never surfaces a coded ENOENT (it rewraps
+    // spawn failures into plain Errors), so every non-ENOENT failure stays
+    // fail-loud.
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       await log(
-        "[paperclip] Codex auth copy-back: host credential kept (sandbox copy is not a strictly-newer same-identity subscription credential).",
+        "[paperclip] Codex auth copy-back: no shared host credential store (host codex home path is absent); nothing to merge into, host left untouched.",
       );
       return "kept-host";
-    } finally {
-      // Close is idempotent-safe to skip after an explicit close; the temp is the
-      // thing that must never linger. On the copy path rename already consumed it
-      // (force makes the removal a no-op); on every other path this deletes the
-      // staged credential bytes.
-      await handle.close().catch(() => undefined);
-      await rm(stagedTempPath, { force: true }).catch(() => undefined);
     }
-  });
+    throw error;
+  }
 }

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -83,7 +83,11 @@ async function decideExitCode(sourcePath: string, destinationPath: string): Prom
  *      resolves to `kept-host` (benign no-op, host untouched); every other read
  *      error stays fail-loud.
  *   2. Stage them to a `0600` temp file on the **same filesystem** as the host
- *      target (its directory), which doubles as the predicate `source`.
+ *      target (its directory), which doubles as the predicate `source`. A host
+ *      directory that is missing outright (ENOENT) resolves to `kept-host`:
+ *      there is no shared store to merge into, and the directory is never
+ *      created here (on a multi-tenant server that would leak one tenant's
+ *      credential into the store every other managed home is seeded from).
  *   3. Run the Phase-3 decision predicate (`source` = sandbox temp, `destination`
  *      = host). Exit 10 → adopt the sandbox copy; exit 20 → keep the host copy.
  *   4. On exit 10, `rename` the staged temp over the host target — an atomic
@@ -121,8 +125,27 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
     // atomic and would fail with EXDEV).
     const stagedTempPath = path.join(hostDir, `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`);
     // `wx` + explicit mode create the temp private (0600) and fail if it somehow
-    // already exists, so we never write through a pre-existing symlink.
-    const handle = await open(stagedTempPath, "wx", 0o600);
+    // already exists, so we never write through a pre-existing symlink. ENOENT
+    // here means the host directory itself is missing (a shared codex home that
+    // never existed, e.g. a multi-tenant cloud server whose credentials live
+    // only in managed per-company homes, or one deleted between the caller's
+    // launch-time check and teardown): there is nothing to merge into, so treat
+    // it exactly like the absent-sandbox-auth branch above and keep the host.
+    // Deliberately NOT `mkdir`: creating the shared directory here would leak
+    // this run's credential into the store every other tenant's managed home is
+    // seeded from. Every other staging error stays fail-loud.
+    let handle;
+    try {
+      handle = await open(stagedTempPath, "wx", 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+        await log(
+          "[paperclip] Codex auth copy-back: no shared host credential store (host codex home directory is absent); nothing to merge into, host left untouched.",
+        );
+        return "kept-host";
+      }
+      throw error;
+    }
     try {
       await handle.writeFile(sandboxAuthBytes);
       await handle.close();

--- a/packages/adapters/codex-local/src/server/execute.copyback-gate.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.copyback-gate.test.ts
@@ -1,0 +1,209 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+  prepareAdapterExecutionTargetRuntime,
+  startAdapterExecutionTargetPaperclipBridge,
+  copyBackCodexAuth,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr: "remote failure",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "/usr/bin/codex"),
+  // Captures the `assets` contract execute() hands to the sandbox runtime so
+  // each test can invoke the `home` asset's `restore` seam exactly the way the
+  // sandbox core does at teardown, without a real sandbox.
+  prepareAdapterExecutionTargetRuntime: vi.fn(
+    async (input: { target: unknown; runId: string }) => ({
+      target: input.target,
+      workspaceRemoteDir: `/remote/workspace/.paperclip-runtime/runs/${input.runId}/workspace`,
+      runtimeRootDir: `/remote/workspace/.paperclip-runtime/runs/${input.runId}/workspace/.paperclip-runtime/codex`,
+      assetDirs: {
+        home: `/remote/workspace/.paperclip-runtime/runs/${input.runId}/workspace/.paperclip-runtime/codex/home`,
+      },
+      restoreWorkspace: async () => {},
+    }),
+  ),
+  startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => ({
+    env: {
+      PAPERCLIP_API_URL: "http://127.0.0.1:4310",
+      PAPERCLIP_API_KEY: "bridge-token",
+      PAPERCLIP_API_BRIDGE_MODE: "queue_v1",
+    },
+    stop: async () => {},
+  })),
+  copyBackCodexAuth: vi.fn(async () => "kept-host" as const),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    prepareAdapterExecutionTargetRuntime,
+    startAdapterExecutionTargetPaperclipBridge,
+  };
+});
+
+vi.mock("./codex-auth-copyback.js", () => ({
+  copyBackCodexAuth,
+}));
+
+import { execute } from "./execute.js";
+
+type CapturedRestoreSeam = (ctx: {
+  assetDir: string;
+  readFile: (remotePath: string) => Promise<Buffer>;
+}) => Promise<void>;
+
+describe("codex auth copy-back call-site gate", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  // Runs execute() against the remote SSH transport (any remote target routes
+  // through prepareAdapterExecutionTargetRuntime, which is mocked above) and
+  // returns the captured `home` asset restore seam plus the collected logs.
+  async function runExecuteAndCaptureRestore(input: {
+    runId: string;
+  }): Promise<{ restore: CapturedRestoreSeam; logs: string[] }> {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-gate-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const codexHomeDir = path.join(rootDir, "codex-home");
+    await mkdir(workspaceDir, { recursive: true });
+    await mkdir(codexHomeDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+
+    const logs: string[] = [];
+    await execute({
+      runId: input.runId,
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        env: {
+          CODEX_HOME: codexHomeDir,
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+    });
+
+    expect(prepareAdapterExecutionTargetRuntime).toHaveBeenCalledTimes(1);
+    const prepareInput = prepareAdapterExecutionTargetRuntime.mock.calls[0]?.[0] as unknown as {
+      assets?: { key: string; restore?: CapturedRestoreSeam }[];
+    };
+    const homeAsset = (prepareInput.assets ?? []).find((asset) => asset.key === "home");
+    expect(homeAsset?.restore).toBeTypeOf("function");
+    return { restore: homeAsset?.restore as CapturedRestoreSeam, logs };
+  }
+
+  it("skips the copy-back with a single log line when the shared host home has no usable auth", async () => {
+    const sharedRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-shared-absent-"));
+    cleanupDirs.push(sharedRoot);
+    // The prod multi-tenant shape: the shared host codex home does not exist at
+    // all (credentials came from a managed per-company CODEX_HOME instead).
+    vi.stubEnv("CODEX_HOME", path.join(sharedRoot, "never-created-codex-home"));
+
+    const { restore, logs } = await runExecuteAndCaptureRestore({ runId: "run-gate-skip" });
+    await restore({
+      assetDir: "/remote/home",
+      readFile: async () => Buffer.from("{}", "utf8"),
+    });
+
+    expect(copyBackCodexAuth).not.toHaveBeenCalled();
+    const skipLines = logs.filter((line) =>
+      line.includes("Codex auth copy-back skipped: no shared host credential store"),
+    );
+    expect(skipLines).toHaveLength(1);
+  });
+
+  it("still runs the copy-back against the shared host credential when it exists", async () => {
+    const sharedHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-shared-present-"));
+    cleanupDirs.push(sharedHome);
+    await writeFile(
+      path.join(sharedHome, "auth.json"),
+      JSON.stringify({ OPENAI_API_KEY: "sk-shared" }),
+      "utf8",
+    );
+    vi.stubEnv("CODEX_HOME", sharedHome);
+
+    const { restore, logs } = await runExecuteAndCaptureRestore({ runId: "run-gate-copy" });
+    await restore({
+      assetDir: "/remote/home",
+      readFile: async () => Buffer.from("{}", "utf8"),
+    });
+
+    expect(copyBackCodexAuth).toHaveBeenCalledTimes(1);
+    expect(copyBackCodexAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostAuthPath: path.join(sharedHome, "auth.json"),
+      }),
+    );
+    expect(logs.join("")).not.toContain("Codex auth copy-back skipped");
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -630,6 +630,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           // large runtime state (`sessions/`, `*.sqlite`, `plugins/`, …) that the
           // 4-name denylist missed and that a sandbox run never needs.
           stagedCodexHomeDir = await stageCodexHomeForSync(effectiveCodexHome, { runId });
+          // Captured at launch time, before the sandbox runs: does the SHARED
+          // host credential store (the symlink source the managed homes point
+          // their `auth.json` at) hold usable auth? The teardown copy-back
+          // below gates on this instead of re-probing, so a run can never
+          // manufacture a copy-back target that did not exist at launch.
+          const sharedHostCodexHome = resolveSharedCodexHomeDir(process.env);
+          const sharedHostHasUsableAuth = await codexHomeHasUsableAuth(sharedHostCodexHome);
           return await prepareAdapterExecutionTargetRuntime({
             runId,
             target: executionTarget,
@@ -660,12 +667,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                 // generic `restore` seam per asset before destroying the sandbox.
                 // Target is the shared symlink SOURCE (what managed homes point
                 // `auth.json` at), not the in-sandbox symlink.
-                restore: async ({ assetDir, readFile }) =>
+                restore: async ({ assetDir, readFile }) => {
+                  // The copy-back exists to persist refreshed ChatGPT-subscription
+                  // tokens back to the credential the managed homes symlink to.
+                  // When no shared host credential store exists (cloud/multi-tenant
+                  // servers whose auth lives only in managed per-company homes, or
+                  // a host that never ran `codex login`) there is nothing to merge
+                  // into, and creating a shared `~/.codex` on a multi-tenant server
+                  // would leak one tenant's credential into the store every other
+                  // tenant's managed home is seeded from. Skip instead of letting
+                  // the ENOENT fail the teardown and mark a completed run failed.
+                  if (!sharedHostHasUsableAuth) {
+                    await onLog(
+                      "stdout",
+                      "[paperclip] Codex auth copy-back skipped: no shared host credential store.\n",
+                    );
+                    return;
+                  }
                   void (await copyBackCodexAuth({
                     readSandboxAuth: () => readFile(path.posix.join(assetDir, "auth.json")),
-                    hostAuthPath: path.join(resolveSharedCodexHomeDir(process.env), "auth.json"),
+                    hostAuthPath: path.join(sharedHostCodexHome, "auth.json"),
                     log: (line) => onLog("stdout", `${line}\n`),
-                  })),
+                  }));
+                },
                 // No `exclude` denylist: `stagedCodexHomeDir` already contains
                 // ONLY the allowlisted files (auth/config/skills), so there is
                 // nothing to filter out.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The codex-local adapter can run agents in remote sandboxes; it syncs a CODEX_HOME in, and at teardown a copy-back seam persists a refreshed ChatGPT-subscription `auth.json` from the sandbox onto the shared host credential store (`~/.codex`) that managed homes symlink to
> - On multi-tenant cloud deployments that shared host store legitimately never exists: each company's managed CODEX_HOME gets its `auth.json` materialized from a bound OPENAI_API_KEY secret, and nobody ever runs `codex login` on the host
> - The copy-back stages its temp file inside the shared home directory with `open(..., "wx")`; with the directory missing this throws ENOENT, the error propagates out of the `home` asset's `restore` seam, and the whole run is marked `adapter_failed` at teardown, after the agent's sandbox work already completed successfully
> - Simply creating the missing directory would be wrong: on a multi-tenant server it would leak one tenant's credential into the store every other tenant's managed home is seeded from
> - This pull request adds a launch-time gate at the call site (skip the copy-back entirely when the shared host store has no usable auth) plus defense-in-depth inside `copyBackCodexAuth` (ENOENT anywhere in the locked host-side sequence, including lock acquisition when an ancestor directory is missing, resolves to a benign `kept-host` instead of throwing)
> - The benefit is that completed runs are no longer marked failed on hosts without a shared credential store, while hosts that do have one keep the exact copy-back behavior they have today

## Linked Issues or Issue Description

No public issue exists; describing the bug per the bug report template:

**What happened**

On a multi-tenant cloud deployment of Paperclip, 20+ codex-local sandbox runs were marked failed with `error_code=adapter_failed` and `error: ENOENT: no such file or directory, open '/<home>/.codex/.auth.json.copyback-<pid>-<uuid>.tmp'`. Run timings show the sandbox agent work had completed (runs lasted 2 to 5.5 minutes doing real work) before the teardown copy-back crashed and failed the whole run.

Root cause: `copyBackCodexAuth` stages its temp file via `open(path.join(hostDir, '.auth.json.copyback-...'), "wx", 0o600)` where `hostDir` is the shared host codex home from `resolveSharedCodexHomeDir(process.env)`. With the shared home absent, `open()` throws ENOENT on the missing parent; the error escapes the `home` asset restore seam in `execute.ts` and fails the run. A variant exists one level earlier: `withDirectoryMergeLock` acquires its lock in a sibling directory of `hostDir`, so a missing ancestor makes the lock `mkdir` throw ENOENT before staging even runs.

**Expected behavior**

A missing shared host credential store should never fail a run at teardown. There is nothing to merge into, so the copy-back should be a benign logged no-op, and the shared directory must not be created (on a multi-tenant server that would leak one tenant's credential into the store every other tenant's managed home is seeded from).

**Steps to reproduce**

1. On a host where `~/.codex` does not exist, provision a codex-local agent whose managed CODEX_HOME carries an API-key `auth.json` (no host `codex login` ever ran).
2. Run the agent against a remote sandbox execution target.
3. The agent completes its work in the sandbox; at teardown the `home` asset restore seam throws the ENOENT above and the run is marked `adapter_failed`.

**Paperclip version**

Current `master` (any build containing the sandbox auth copy-back seam).

**Deployment mode**

Self-hosted multi-tenant server with remote sandbox execution targets.

## What Changed

- `execute.ts`: capture at launch time (before the sandbox runs) whether the shared host credential store has usable auth via the existing `codexHomeHasUsableAuth(resolveSharedCodexHomeDir(process.env))`. When it does not, the `home` asset restore seam logs a single non-leaking line (`[paperclip] Codex auth copy-back skipped: no shared host credential store.`) and returns without calling `copyBackCodexAuth`.
- `codex-auth-copyback.ts`: defense-in-depth for the race where the store disappears between the launch-time check and teardown. ENOENT anywhere in the locked host-side sequence (lock acquisition with a missing ancestor, staging `open` with the host directory as the missing leaf, or a mid-sequence writeFile/rename) resolves to `kept-host` with a benign non-leaking log line, mirroring the existing absent-sandbox-auth branch. Every other error stays fail-loud, and the decision predicate still cannot be confused with this path (its spawn failures are rewrapped into plain Errors).
- Neither layer ever creates the shared directory: on a multi-tenant server that would leak one tenant's credential into the store every other tenant's managed home is seeded from.
- Tests: new `execute.copyback-gate.test.ts` covering both sides of the call-site gate; `codex-auth-copyback.test.ts` extended with the missing-host-directory and missing-ancestor cases (kept-host, no throw, nothing created, lock sibling cleaned up, no token bytes logged).

## Verification

- `pnpm exec vitest run packages/adapters/codex-local` (21 files, 185 tests, all passing)
- `pnpm --filter @paperclipai/adapter-codex-local run typecheck` (clean)
- Targeted: `pnpm exec vitest run packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts packages/adapters/codex-local/src/server/execute.copyback-gate.test.ts`
- Manual: on a host without `~/.codex`, a remote-sandbox codex run now logs the single skip line at teardown and completes; on a host with a usable `~/.codex/auth.json`, the copy-back decision/install behavior is unchanged.

## Risks

- Low risk. Hosts with a usable shared credential store keep today's behavior byte for byte (the gate only short-circuits when `codexHomeHasUsableAuth` is false, and the existing suite covering copy/keep decisions still passes).
- The broadened ENOENT handling inside `copyBackCodexAuth` could in principle mask an exotic ENOENT from a concurrent deletion mid-sequence; that shape is exactly the "store vanished, nothing to merge into" case the branch is meant to absorb, the host file is left untouched, and the outcome is logged. Non-ENOENT errors still fail loud.
- No migrations, no API changes, no behavior change for local (non-remote) execution.

## Model Used

Claude Fable 5 (claude-fable-5), extended thinking, via Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
