### PR TITLE
docs(release): add v2026.722.0 changelog

### DIFF
--- a/releases/v2026.722.0.md
+++ b/releases/v2026.722.0.md
@@ -1,0 +1,49 @@
+# Paperclip v2026.722.0
+
+> Released: 2026-07-22
+
+## Highlights
+
+- **Run-bound agent secret access** — Agents can now fetch the secrets they've been granted on demand through a run-bound API, instead of relying only on ambient environment injection. A new `access.*` delivery mode exposes API-only secrets, `GET /api/agents/me/secrets` lists just the aliases an agent is granted, and `POST /api/agents/me/secrets/:key/value` returns a value with `Cache-Control: no-store`. Every value read is written to both the security audit trail and the operator activity log, low-trust review/skill-test tokens stay denied, and a new **Secret access** editor lets you manage per-agent grants from agent settings. ([#9921](https://github.com/paperclipai/paperclip/pull/9921))
+- **Local agents run on Windows** — The embedded ACPX engine no longer wraps local agent commands in a generated Bash script, so Claude, Codex, Gemini, and custom ACP adapters now spawn natively on Windows as well as Linux. Environment variables are injected through ACPX session options, child stderr is captured in-process, `.cmd` npm/pnpm shims are preferred on Windows, and symlink `EPERM` failures fall back to copies. A real Node ACP spawn smoke now runs on both Ubuntu and Windows. ([#9980](https://github.com/paperclipai/paperclip/pull/9980))
+
+## Improvements
+
+- **User-named `PAPERCLIP_*` bindings now reach your agents** — The heartbeat previously stripped *every* `PAPERCLIP_`-prefixed env binding before resolution, so a secret you deliberately named something like `PAPERCLIP_CLOUD_PROD_PROVIDER_RAILWAY_TOKEN` was silently dropped. Now only `PAPERCLIP_API_KEY` is categorically rejected, harness-assigned runtime vars always win, and every other `PAPERCLIP_*` binding flows through to the run environment. ([#9974](https://github.com/paperclipai/paperclip/pull/9974))
+- **Sturdier telemetry client** — The telemetry client now matches the wire contract: payloads are chunked, batch IDs are deterministic, retries are batched with backoff, and the local store is bounded. A silent-drop baseline is pinned and caps/backoff are now a configurable surface. Telemetry remains anonymized and can be disabled with `DO_NOT_TRACK=1` or `PAPERCLIP_TELEMETRY_DISABLED=1`. ([#9946](https://github.com/paperclipai/paperclip/pull/9946), [#9906](https://github.com/paperclipai/paperclip/pull/9906), @nickyleach)
+- **Slash-named secrets browse as folders** — Secrets whose names contain slashes now navigate as nested folders in the UI. ([#9913](https://github.com/paperclipai/paperclip/pull/9913))
+- **Searchable agent picker for secret access** — Granting per-agent secret access now uses a searchable agent picker instead of a long flat list. ([#9918](https://github.com/paperclipai/paperclip/pull/9918))
+- **Cleaner external object labels and star controls** — External object labels and the star controls that sit next to them were simplified for less visual noise. ([#9929](https://github.com/paperclipai/paperclip/pull/9929))
+- **Safer sandbox `CODEX_HOME` sync** — The `codex-local` adapter now stages an explicit allowlist when syncing `CODEX_HOME` into the sandbox, rather than copying the whole home directory. ([#9972](https://github.com/paperclipai/paperclip/pull/9972), @nickyleach)
+
+## Experimental
+
+These features ship gated behind experimental settings — enable Apps under experimental settings to try them out.
+
+- **Connections v3 foundation** — The groundwork for one-click Connected Apps landed: a v3 schema core adds a stable company-scoped connection UID, explicit ownership/auth/transport fields, a subject-aware `connection_grants` table, and multi-key credentials (with the legacy `remote_http` transport renamed to `mcp_remote`). On top of that, a generated **AppDefinition** Wave 1 catalog gives browse and setup a single typed contract, and a runtime layer adds subject-aware authorization state, scoped key handling, and OpenAPI-registered grant routes that fail closed for unknown scopes. ([#9958](https://github.com/paperclipai/paperclip/pull/9958), [#9981](https://github.com/paperclipai/paperclip/pull/9981), [#9982](https://github.com/paperclipai/paperclip/pull/9982))
+
+## Fixes
+
+- **Archived inbox items stay archived** — Items you've archived no longer resurface in the inbox. ([#9931](https://github.com/paperclipai/paperclip/pull/9931))
+- **Execution-policy final approval finishes cleanly** — Approving the final stage of an execution policy now terminates the policy instead of rewinding it back to stage 1. ([#7936](https://github.com/paperclipai/paperclip/pull/7936), @HKTITAN)
+- **Accept Office issue attachments** — Office document attachments (Word, Excel, PowerPoint) are now accepted on issues. ([#8562](https://github.com/paperclipai/paperclip/pull/8562), @samrusani)
+- **Redact HTTP cookies from server logs** — Cookie headers are now redacted from server logs so session material doesn't leak into log output. ([#7977](https://github.com/paperclipai/paperclip/pull/7977), @nosolosoft)
+- **No more 500s from run-authored comments** — `createdByRunId` is sanitized on comment insert, fixing a class of 500 errors. ([#9489](https://github.com/paperclipai/paperclip/pull/9489), @digitalflanker-ux)
+- **Preserve terminal status on issue release** — Releasing an issue no longer clobbers a terminal (done/cancelled) status. ([#7524](https://github.com/paperclipai/paperclip/pull/7524), @harshkotak)
+- **Fail loudly on invalid config files** — An invalid config file now surfaces a clear error instead of being silently ignored. ([#9041](https://github.com/paperclipai/paperclip/pull/9041), @lesbass)
+- **Non-clickable pending-approval guidance** — The pending-approval admin guidance on the invite screen is no longer a misleading clickable element. ([#6786](https://github.com/paperclipai/paperclip/pull/6786), @le-czs)
+- **Cron validity settles with radix-ui 1.6.4** — Cron validity handling and a settle-branch test were synced for radix-ui 1.6.4. ([#9966](https://github.com/paperclipai/paperclip/pull/9966), @nickyleach)
+- **CLI import selection fixes** — Cleared import selections no longer drop the extension file, and missing company-manifest fields were added to the import-selection test fixture. ([#2379](https://github.com/paperclipai/paperclip/pull/2379), @kevinmanase, [#9978](https://github.com/paperclipai/paperclip/pull/9978), @aaymeloglu)
+- **Cloud-managed instances pass the health gate** — Cloud-managed instances are now treated as bootstrapped in the health gate so they don't stall on startup. ([#9912](https://github.com/paperclipai/paperclip/pull/9912))
+
+## Upgrade Guide
+
+- This release adds two additive database migrations for the Connections v3 foundation (`0182_connections_v3_schema_core`, `0183_connection_user_authorization_state`), which backfill stable connection UIDs, create default workspace grants, and rename the `remote_http` transport to `mcp_remote`. Migrations run automatically on startup — no manual action is required.
+- If you previously set a static `PAPERCLIP_API_KEY` in adapter/config env to override the run token, that override no longer applies — the harness-minted run token is now the only source of the run API key. All other `PAPERCLIP_*`-named bindings now flow through to the run environment as expected.
+- Connections/Apps remain gated behind experimental settings. Enable **Apps** under experimental settings to try the Connections v3 surfaces.
+
+## Contributors
+
+This release has 44 commits from 13 contributors. Thank you to everyone who contributed to this release!
+
+@aaymeloglu, @digitalflanker-ux, @harshkotak, @HKTITAN, @kevinmanase, @le-czs, @lesbass, @MindSyncHub, @nickyleach, @nosolosoft, @samrusani


### PR DESCRIPTION
## Release changelog: Paperclip v2026.722.0

Adds `releases/v2026.722.0.md`, the user-facing stable changelog for the
`v2026.722.0` release, generated per `.agents/skills/release-changelog/SKILL.md`.

- **Range:** `v2026.720.0..origin/master` — 44 commits from 13 contributors.
- **Version:** confirmed via `scripts/release.sh stable --date 2026-07-22 --print-version` → `2026.722.0`.
- **Breaking changes:** none. Two additive DB migrations (Connections v3 schema core + connection user authorization state); no destructive migrations.
- **Sections:** Highlights (run-bound agent secret access; Windows local-agent spawning), Improvements, Experimental (Connections v3 foundation, gated behind the Apps experimental setting), Fixes, Upgrade Guide, Contributors.

Contributor count/names follow the skill rules (bots and Paperclip founders excluded from the listed names but counted in the total).

Related issue: PAP-14983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
