### PR TITLE
chore(lockfile): register ACPX package patch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ overrides:
   '@lexical/utils': 0.46.0
 
 patchedDependencies:
+  acpx@0.12.0:
+    hash: 6rtgor3dogxkfotm4jopwanvmu
+    path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
@@ -120,8 +123,8 @@ importers:
   packages/adapter-utils:
     dependencies:
       acpx:
-        specifier: ^0.12.0
-        version: 0.12.0
+        specifier: 0.12.0
+        version: 0.12.0(patch_hash=6rtgor3dogxkfotm4jopwanvmu)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -13045,7 +13048,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  acpx@0.12.0:
+  acpx@0.12.0(patch_hash=6rtgor3dogxkfotm4jopwanvmu):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Its dependency lockfile must remain synchronized with root `patchedDependencies` so CI and contributors can perform frozen installs.
> - PR #9980 added the packaged ACPX Windows-spawn patch and pinned `acpx` to `0.12.0`.
> - The merged commit updated `package.json` and added `patches/acpx@0.12.0.patch`, but did not update `pnpm-lock.yaml`.
> - Current `master` therefore fails every `pnpm install --frozen-lockfile` before typecheck, tests, or build can start.
> - This pull request records the ACPX patch hash and patched package snapshot in the lockfile.
> - The benefit is restoring deterministic installs and unblocking the full PR pipeline without changing runtime behavior beyond what #9980 already merged.

## Linked Issues or Issue Description

Refs #9980

### What happened?

After #9980 merged, `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because root `patchedDependencies` contains `acpx@0.12.0`, while `pnpm-lock.yaml` still describes unpatched `acpx@0.12.0` with the previous range specifier.

### Expected behavior

A clean checkout of current `master` should accept a frozen install and resolve `acpx@0.12.0` through `patches/acpx@0.12.0.patch` using the deterministic patch hash.

### Steps to reproduce

1. Check out `master` at or after `d31a28828`.
2. Run `pnpm install --frozen-lockfile`.
3. Observe `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` before this change.
4. Apply this lockfile update and rerun the command; installation completes.

## What Changed

- Added the `acpx@0.12.0` patch hash and patch path to lockfile `patchedDependencies`.
- Synchronized the adapter-utils importer from `^0.12.0` to the pinned patched `0.12.0` resolution.
- Updated the ACPX snapshot key with the patch hash.

## Verification

- `pnpm install --frozen-lockfile` — completed successfully from a fresh isolated worktree; lockfile resolution was skipped as up to date.
- `git diff --check` — passed.
- A Windows-local optional `cpu-features` native build reported that no compiler could be detected, but pnpm treated it as optional and the frozen install completed with exit code 0.

## Risks

- Low risk: lockfile-only synchronization generated by pnpm 9.15.4, matching the repository `packageManager` and CI setup version.
- The patch hash is tied to `patches/acpx@0.12.0.patch`; future patch edits must regenerate the lockfile.

> This is a dependency-integrity repair for already-merged core work and does not introduce a new roadmap capability.

## Model Used

OpenAI GPT-5.6 (`gpt-5.6-sol`) with reasoning, tool use, and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked the related public PR and described the regression in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run the relevant local verification and it passes
- [x] No test-code update is required for this lockfile-only synchronization
- [x] No documentation update is required beyond this PR description
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
