### PR TITLE
test(heartbeat): await execution drain before cleanup

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -100,17 +100,6 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
   }, 20_000);
 
   afterEach(async () => {
-    mockAdapterExecute.mockReset();
-    mockAdapterExecute.mockImplementation(async () => ({
-      exitCode: 0,
-      signal: null,
-      timedOut: false,
-      errorMessage: null,
-      summary: "Dependency-aware heartbeat test run.",
-      provider: "test",
-      model: "test-model",
-    }));
-    runningProcesses.clear();
     let idlePolls = 0;
     for (let attempt = 0; attempt < 100; attempt += 1) {
       const runs = await db
@@ -125,7 +114,22 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       }
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    const runIds = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .then((runs) => runs.map((run) => run.id));
+    await Promise.all(runIds.map((runId) => heartbeat.waitForRunExecutionDrain(runId)));
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Dependency-aware heartbeat test run.",
+      provider: "test",
+      model: "test-model",
+    }));
+    runningProcesses.clear();
     await db.delete(environmentLeases);
     await db.delete(activityLog);
     await db.delete(companySkills);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Release publishing is gated on the server test suite completing reliably
> - Heartbeat runs persist terminal status before their full execution cleanup path has drained
> - The dependency-scheduling test teardown treated terminal status as full completion and could delete referenced rows while late environment/event writes were still running
> - This pull request waits on the heartbeat service's execution-drain primitive before resetting mocks and deleting fixture data
> - The benefit is deterministic serialized release verification without changing production heartbeat behavior

## Linked Issues or Issue Description

- **Bug:** The stable release workflow can fail intermittently in `heartbeat-dependency-scheduling.test.ts` with foreign-key violations while deleting `heartbeat_runs`. The test waits for terminal run statuses, but terminal persistence precedes final environment lease release and lifecycle event writes. Teardown can therefore remove issues/runs while the heartbeat execution `finally` path is still active.
- **Expected:** Test teardown waits until all heartbeat execution work has drained before deleting fixture rows.

## What Changed

- Await `waitForRunExecutionDrain` for every heartbeat run before fixture deletion.
- Delay mock reset and `runningProcesses` cleanup until executions have fully drained.
- Remove the arbitrary 50 ms teardown delay.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-dependency-scheduling.test.ts --reporter=dot`
- Repeated the exact test file nine consecutive times; all 54 test executions passed.

## Risks

- Low risk: test-only cleanup sequencing; production heartbeat behavior is unchanged.
- A genuinely stuck execution now fails with the existing drain timeout instead of surfacing as a misleading foreign-key teardown error.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, tool use and code execution enabled; repository context and focused test execution used for verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
