### PR TITLE
Fix heartbeat dependency test teardown race

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -100,17 +100,6 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
   }, 20_000);
 
   afterEach(async () => {
-    mockAdapterExecute.mockReset();
-    mockAdapterExecute.mockImplementation(async () => ({
-      exitCode: 0,
-      signal: null,
-      timedOut: false,
-      errorMessage: null,
-      summary: "Dependency-aware heartbeat test run.",
-      provider: "test",
-      model: "test-model",
-    }));
-    runningProcesses.clear();
     let idlePolls = 0;
     for (let attempt = 0; attempt < 100; attempt += 1) {
       const runs = await db
@@ -125,7 +114,22 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       }
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    const runIds = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .then((runs) => runs.map((run) => run.id));
+    await Promise.all(runIds.map((runId) => heartbeat.waitForRunExecutionDrain(runId)));
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Dependency-aware heartbeat test run.",
+      provider: "test",
+      model: "test-model",
+    }));
+    runningProcesses.clear();
     await db.delete(environmentLeases);
     await db.delete(activityLog);
     await db.delete(companySkills);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents and their work
> - Heartbeat scheduling tests protect orchestration rules that serialize an agent's runs
> - The dependency scheduling suite waits for run rows to become terminal before deleting shared database fixtures
> - A terminal row is persisted before asynchronous execution finalization and successful-run handoff work fully drain
> - The test could delete heartbeat rows while finalization was still releasing leases and appending lifecycle events
> - This pull request waits for each tracked run's execution promise to drain before resetting mocks or deleting fixtures
> - The benefit is deterministic release verification without changing production heartbeat behavior

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched existing open and closed issues and found no public duplicate.
- [x] I reproduced this on `master` in the stable release workflow.
- [x] The error originates in Paperclip's server test teardown, not an adapter or provider.

### What happened?

The stable release workflow intermittently fails in `heartbeat-dependency-scheduling.test.ts` while deleting `heartbeat_runs`. The test waits for terminal run statuses, but terminal persistence precedes final environment lease release and lifecycle event writes. Teardown can therefore remove issues and runs while the heartbeat execution `finally` path is still active, producing a foreign-key violation from `heartbeat_run_events`.

### Expected behavior

Test teardown waits until all asynchronous heartbeat execution work has drained before deleting fixture rows.

### Steps to reproduce

1. Run `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-dependency-scheduling.test.ts` repeatedly.
2. Exercise the suite under serialized CI timing.
3. Observe that release run `29936031931` failed while deleting `heartbeat_runs` because a late `heartbeat_run_events` row still referenced the run.

### Paperclip version or commit

`2aef4641b48e88f5ce7e75ce69fbe3bf6bbfc60d`

### Deployment mode

GitHub Actions release verification, built from source.

### Installation method

Built from source with pnpm.

### Agent adapter(s) involved

Not adapter-specific; this is a core server test teardown race.

### Database mode

External PostgreSQL-backed embedded test database.

### Access context

Not applicable.

### Relevant logs or output

`delete from "heartbeat_runs"` failed because `heartbeat_run_events_run_id_heartbeat_runs_id_fk` still referenced the run.

### Additional context

The production lifecycle ordering is intentional. The test already has access to `waitForRunExecutionDrain`, which is the correct completion boundary.

### Privacy checklist

- [x] The included output contains no credentials, usernames, paths, API keys, tokens, company data, or task content.

## What Changed

- Collect heartbeat run IDs after queued and running rows settle, then await `heartbeat.waitForRunExecutionDrain()` for each run.
- Reset the adapter mock and clear process tracking only after asynchronous heartbeat finalization completes.
- Remove the arbitrary 50 ms teardown delay.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts --reporter=dot`
- The exact six-test file passed ten consecutive runs, totaling 60 test executions.

## Risks

- Low risk: test-only cleanup ordering using an existing heartbeat service drain API. Production behavior is unchanged.
- A genuinely stuck execution now surfaces through the existing drain timeout instead of a misleading teardown foreign-key error.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with `gpt-5.5` in the initial run and `gpt-5.6-sol` in the continuation; tool-enabled code inspection, GitHub diagnostics, and shell test execution. Runtime context-window sizes were not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
