### PR TITLE
feat(skills): authenticate GitHub skill imports via company secret token

### DIFF
--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -1,13 +1,14 @@
 import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   discoverProjectWorkspaceSkillDirectories,
   findMissingLocalSkillIds,
   normalizeGitHubSkillDirectory,
   parseSkillImportSourceInput,
   readLocalSkillImportFromDirectory,
+  readUrlSkillImports,
 } from "../services/company-skills.js";
 
 const cleanupDirs = new Set<string>();
@@ -406,5 +407,65 @@ describe("missing local skill reconciliation", () => {
     ]);
 
     expect(missingIds).toEqual(["skill-1"]);
+  });
+});
+
+describe("authenticated GitHub skill import", () => {
+  const commitSha = "a".repeat(40);
+  const source = `https://github.com/acme/private-skills/tree/${commitSha}/skills`;
+  let calls: Array<{ url: string; authorization: string | null }>;
+
+  function readHeader(init: RequestInit | undefined, name: string): string | null {
+    const headers = init?.headers;
+    if (!headers) return null;
+    if (headers instanceof Headers) return headers.get(name);
+    const record = headers as Record<string, string>;
+    return record[name] ?? record[name.toLowerCase()] ?? null;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubGitHub() {
+    calls = [];
+    vi.stubGlobal("fetch", async (url: string | URL, init?: RequestInit) => {
+      const target = String(url);
+      calls.push({ url: target, authorization: readHeader(init, "authorization") });
+      if (target.includes("/git/trees/")) {
+        return new Response(
+          JSON.stringify({ tree: [{ path: "skills/demo/SKILL.md", type: "blob" }] }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      // raw.githubusercontent.com file content
+      return new Response("---\nname: Demo Skill\n---\n\n# Demo\n", { status: 200 });
+    });
+  }
+
+  it("sends Authorization: Bearer on every GitHub call when a token is configured", async () => {
+    stubGitHub();
+    const result = await readUrlSkillImports("company-1", source, null, "secret-token");
+
+    expect(result.skills).toHaveLength(1);
+    // The pinned commit ref skips branch/commit resolution: expect the tree read
+    // and the raw SKILL.md fetch, both authenticated.
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls.some((call) => call.url.includes("/git/trees/"))).toBe(true);
+    expect(calls.some((call) => call.url.includes("raw.githubusercontent.com"))).toBe(true);
+    for (const call of calls) {
+      expect(call.authorization).toBe("Bearer secret-token");
+    }
+  });
+
+  it("omits Authorization when no token is configured (public repos unchanged)", async () => {
+    stubGitHub();
+    const result = await readUrlSkillImports("company-1", source, null);
+
+    expect(result.skills).toHaveLength(1);
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of calls) {
+      expect(call.authorization).toBeNull();
+    }
   });
 });

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -91,7 +91,8 @@ import type {
 import { isUuidLike, normalizeAgentUrlKey, parseFrontmatterMarkdown } from "@paperclipai/shared";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
-import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
+import { ghFetch, gitHubApiBase, gitHubAuthHeaders, resolveRawGitHubUrl } from "./github-fetch.js";
+import { resolveCompanyGitHubToken } from "./github-external-object-provider.js";
 import { agentService } from "./agents.js";
 import { issueDocumentSelect, mapIssueDocumentRow } from "./documents.js";
 import { toIssueWorkProduct } from "./work-products.js";
@@ -657,18 +658,19 @@ function deriveTrustLevel(fileInventory: CompanySkillFileInventoryEntry[]): Comp
   return "markdown_only";
 }
 
-async function fetchText(url: string) {
-  const response = await ghFetch(url);
+async function fetchText(url: string, token?: string | null) {
+  const response = await ghFetch(url, { headers: gitHubAuthHeaders(token) });
   if (!response.ok) {
     throw unprocessable(`Failed to fetch ${url}: ${response.status}`);
   }
   return response.text();
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+async function fetchJson<T>(url: string, token?: string | null): Promise<T> {
   const response = await ghFetch(url, {
     headers: {
       accept: "application/vnd.github+json",
+      ...gitHubAuthHeaders(token),
     },
   });
   if (!response.ok) {
@@ -678,16 +680,18 @@ async function fetchJson<T>(url: string): Promise<T> {
 }
 
 
-async function resolveGitHubDefaultBranch(owner: string, repo: string, apiBase: string) {
+async function resolveGitHubDefaultBranch(owner: string, repo: string, apiBase: string, token?: string | null) {
   const response = await fetchJson<{ default_branch?: string }>(
     `${apiBase}/repos/${owner}/${repo}`,
+    token,
   );
   return asString(response.default_branch) ?? "main";
 }
 
-async function resolveGitHubCommitSha(owner: string, repo: string, ref: string, apiBase: string) {
+async function resolveGitHubCommitSha(owner: string, repo: string, ref: string, apiBase: string, token?: string | null) {
   const response = await fetchJson<{ sha?: string }>(
     `${apiBase}/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
+    token,
   );
   const sha = asString(response.sha);
   if (!sha) {
@@ -753,7 +757,7 @@ function normalizeRemoteSkillImportSource(rawUrl: string) {
   return url.toString();
 }
 
-async function resolveGitHubPinnedRef(parsed: ReturnType<typeof parseGitHubSourceUrl>) {
+async function resolveGitHubPinnedRef(parsed: ReturnType<typeof parseGitHubSourceUrl>, token?: string | null) {
   const apiBase = gitHubApiBase(parsed.hostname);
   if (/^[0-9a-f]{40}$/i.test(parsed.ref.trim())) {
     return {
@@ -764,8 +768,8 @@ async function resolveGitHubPinnedRef(parsed: ReturnType<typeof parseGitHubSourc
 
   const trackingRef = parsed.explicitRef
     ? parsed.ref
-    : await resolveGitHubDefaultBranch(parsed.owner, parsed.repo, apiBase);
-  const pinnedRef = await resolveGitHubCommitSha(parsed.owner, parsed.repo, trackingRef, apiBase);
+    : await resolveGitHubDefaultBranch(parsed.owner, parsed.repo, apiBase, token);
+  const pinnedRef = await resolveGitHubCommitSha(parsed.owner, parsed.repo, trackingRef, apiBase, token);
   return { pinnedRef, trackingRef };
 }
 
@@ -1482,10 +1486,11 @@ async function readLocalSkillImports(companyId: string, sourcePath: string): Pro
   return imports;
 }
 
-async function readUrlSkillImports(
+export async function readUrlSkillImports(
   companyId: string,
   sourceUrl: string,
   requestedSkillSlug: string | null = null,
+  githubToken: string | null = null,
 ): Promise<{ skills: ImportedSkill[]; warnings: string[] }> {
   const url = sourceUrl.trim();
   const warnings: string[] = [];
@@ -1493,10 +1498,11 @@ async function readUrlSkillImports(
   if (looksLikeRepoUrl) {
     const parsed = parseGitHubSourceUrl(url);
     const apiBase = gitHubApiBase(parsed.hostname);
-    const { pinnedRef, trackingRef } = await resolveGitHubPinnedRef(parsed);
+    const { pinnedRef, trackingRef } = await resolveGitHubPinnedRef(parsed, githubToken);
     let ref = pinnedRef;
     const tree = await fetchJson<{ tree?: Array<{ path: string; type: string }> }>(
       `${apiBase}/repos/${parsed.owner}/${parsed.repo}/git/trees/${ref}?recursive=1`,
+      githubToken,
     ).catch(() => {
       throw unprocessable(`Failed to read GitHub tree for ${url}`);
     });
@@ -1523,7 +1529,7 @@ async function readUrlSkillImports(
     const skills: ImportedSkill[] = [];
     for (const relativeSkillPath of skillPaths) {
       const repoSkillPath = basePrefix ? `${basePrefix}${relativeSkillPath}` : relativeSkillPath;
-      const markdown = await fetchText(resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, repoSkillPath));
+      const markdown = await fetchText(resolveRawGitHubUrl(parsed.hostname, parsed.owner, parsed.repo, ref, repoSkillPath), githubToken);
       const parsedMarkdown = parseFrontmatterMarkdown(markdown);
       const skillDir = path.posix.dirname(relativeSkillPath);
       const slug = deriveImportedSkillSlug(parsedMarkdown.frontmatter, path.posix.basename(skillDir));
@@ -3873,7 +3879,8 @@ export function companySkillService(db: Db) {
 
     const hostname = asString(metadata.hostname) || "github.com";
     const apiBase = gitHubApiBase(hostname);
-    const latestRef = await resolveGitHubCommitSha(owner, repo, trackingRef, apiBase);
+    const githubToken = await resolveCompanyGitHubToken(db, companyId);
+    const latestRef = await resolveGitHubCommitSha(owner, repo, trackingRef, apiBase, githubToken);
     return {
       supported: true,
       reason: null,
@@ -3927,8 +3934,9 @@ export function companySkillService(db: Db) {
         throw unprocessable("Skill source metadata is incomplete.");
       }
       const repoPath = normalizePortablePath(path.posix.join(repoSkillDir, normalizedPath));
+      const githubToken = await resolveCompanyGitHubToken(db, companyId);
       try {
-        content = await fetchText(resolveRawGitHubUrl(hostname, owner, repo, ref, repoPath));
+        content = await fetchText(resolveRawGitHubUrl(hostname, owner, repo, ref, repoPath), githubToken);
       } catch (error) {
         if (normalizedPath === "SKILL.md" && skill.markdown) {
           content = skill.markdown;
@@ -4351,7 +4359,8 @@ export function companySkillService(db: Db) {
       throw unprocessable("Skill source locator is missing.");
     }
 
-    const result = await readUrlSkillImports(companyId, skill.sourceLocator, skill.slug);
+    const githubToken = await resolveCompanyGitHubToken(db, companyId);
+    const result = await readUrlSkillImports(companyId, skill.sourceLocator, skill.slug, githubToken);
     const matching = result.skills.find((entry) => entry.key === skill.key) ?? result.skills[0] ?? null;
     if (!matching) {
       throw unprocessable(`Skill ${skill.key} could not be re-imported from its source.`);
@@ -5611,13 +5620,14 @@ export function companySkillService(db: Db) {
     if (local) {
       await assertLocalImportSourceAllowed(companyId, parsed.resolvedSource);
     }
+    const githubToken = local ? null : await resolveCompanyGitHubToken(db, companyId);
     const { skills, warnings } = local
       ? {
         skills: (await readLocalSkillImports(companyId, parsed.resolvedSource))
           .filter((skill) => !parsed.requestedSkillSlug || skill.slug === parsed.requestedSkillSlug),
         warnings: parsed.warnings,
       }
-      : await readUrlSkillImports(companyId, parsed.resolvedSource, parsed.requestedSkillSlug)
+      : await readUrlSkillImports(companyId, parsed.resolvedSource, parsed.requestedSkillSlug, githubToken)
         .then((result) => ({
           skills: result.skills,
           warnings: [...parsed.warnings, ...result.warnings],

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -27,7 +27,7 @@ interface GitHubObjectIdentity {
   pathKind: "pull" | "issues";
 }
 
-const DEFAULT_GITHUB_TOKEN_SECRET_NAMES = ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"] as const;
+export const DEFAULT_GITHUB_TOKEN_SECRET_NAMES = ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"] as const;
 const GITHUB_OBJECT_TTL_SECONDS = 300;
 
 function isGitHubHost(host: string) {
@@ -305,7 +305,17 @@ async function safeJson(response: Response) {
   }
 }
 
-async function defaultTokenProvider(db: Db, companyId: string, secretNames: readonly string[]) {
+/**
+ * Resolve a company-scoped GitHub token from Paperclip secrets, trying the
+ * configured secret names in order. Returns null when none is set. Shared by the
+ * external-object liveness provider and the company skill importer so both use
+ * the same secret-name convention.
+ */
+export async function resolveCompanyGitHubToken(
+  db: Db,
+  companyId: string,
+  secretNames: readonly string[] = DEFAULT_GITHUB_TOKEN_SECRET_NAMES,
+) {
   const secrets = secretService(db);
   for (const secretName of secretNames) {
     const secret = await secrets.getByName(companyId, secretName);
@@ -325,7 +335,7 @@ export function createGitHubExternalObjectProvider(
   const secretNames = opts.secretNames ?? DEFAULT_GITHUB_TOKEN_SECRET_NAMES;
   const tokenProvider = Object.prototype.hasOwnProperty.call(opts, "tokenProvider") && opts.tokenProvider !== undefined
     ? opts.tokenProvider
-    : ((companyId: string) => defaultTokenProvider(db, companyId, secretNames));
+    : ((companyId: string) => resolveCompanyGitHubToken(db, companyId, secretNames));
 
   const detector: ExternalObjectDetector = {
     key: "github",

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -16,6 +16,17 @@ export function resolveRawGitHubUrl(hostname: string, owner: string, repo: strin
     : `https://${hostname}/raw/${owner}/${repo}/${ref}/${p}`;
 }
 
+/**
+ * Build the Authorization header for an authenticated GitHub request. Returns an
+ * empty object when no token is provided so callers can spread it unconditionally
+ * and preserve unauthenticated behavior for public repositories. The token is only
+ * ever placed in a header, never in a URL or error message.
+ */
+export function gitHubAuthHeaders(token?: string | null): Record<string, string> {
+  const trimmed = token?.trim();
+  return trimmed ? { authorization: `Bearer ${trimmed}` } : {};
+}
+
 export async function ghFetch(url: string, init?: RequestInit): Promise<Response> {
   try {
     return await fetch(url, init);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Skills are reusable Markdown bundles that a company imports into its catalog from external sources (skills.sh, GitHub repos, raw URLs); the importer lives in `server/src/services/company-skills.ts`.
> - To import from a GitHub repo the importer makes several GitHub HTTP calls: default-branch / commit-SHA resolution, a recursive `git/trees` read, and raw `SKILL.md` / file-content fetches — all routed through `ghFetch` in `server/src/services/github-fetch.ts`.
> - `ghFetch` sends no `Authorization` header, so every one of those calls is anonymous. GitHub answers requests for a **private** repository with `404`, so importing a skill from a private repo fails while public repos work.
> - The token-resolution logic already exists in the codebase — `github-external-object-provider.ts` reads a company-scoped Paperclip secret (`GITHUB_TOKEN` / `GH_TOKEN` / `PAPERCLIP_GITHUB_TOKEN`) — but it was only wired into external-object (link-liveness) refresh, never into the importer.
> - This pull request threads that same company-scoped token through every GitHub call the importer makes, reusing the existing provider rather than duplicating it.
> - The benefit is that companies can import skills from their private GitHub repositories, with public-repo imports completely unchanged when no token is configured.

## Linked Issues or Issue Description

No existing GitHub issue tracks this, so the underlying bug is described inline below following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**
Importing a company skill from a **private** GitHub repository (via `POST` skill import / `importFromSource`, re-import, or the skills.sh → GitHub resolution path) fails. The importer issues unauthenticated calls to `api.github.com` (default-branch, commit-SHA, `git/trees`) and `raw.githubusercontent.com` (SKILL.md / file content). GitHub returns `404` for a private repo to an anonymous caller, surfaced as `Failed to fetch <url>: 404` / `Failed to read GitHub tree for <url>`.

**Expected behavior:**
When the company has a GitHub token stored as a Paperclip secret (`GITHUB_TOKEN`, `GH_TOKEN`, or `PAPERCLIP_GITHUB_TOKEN`), the importer should authenticate its GitHub calls and successfully import the skill from a private repo. When no token is configured, behavior should be unchanged (public repos still import anonymously).

**Steps to reproduce:**
1. Create a private GitHub repo containing a `skills/<name>/SKILL.md`.
2. In a Paperclip company with no GitHub secret set, import the skill from that repo's URL.
3. Observe the import fail with a `404` from GitHub.
4. (After this change) store a token secret named `GITHUB_TOKEN` for the company and retry — the import succeeds.

**Paperclip version or commit:** built from source on `master` (branch based on upstream `master` @ `b247bf715`).
**Deployment mode:** Local dev (`pnpm dev`). **Access context:** Board (human operator) initiating an import. **Adapter:** Not adapter-specific (core skill importer).

### Related PRs (found via duplicate search — see note to reviewers)

Refs #4832 — "Authenticate skill-importer GitHub requests when GITHUB_TOKEN is set" (open): overlapping intent but scoped to anonymous **rate-limit 403** on skills.sh resolution using a global `GITHUB_TOKEN` env var.
Refs #5560 — "feat(skills): support optional GitHub token in skill import endpoint" (open): related optional-token support at the endpoint layer.
Refs #3237 — "GitHub PAT support for private skill repos + delete by source" (closed).

This PR differs by resolving a **company-scoped Paperclip secret** (not a process-wide env var) and by covering **all** importer GitHub calls including the raw file-content fetch and update-check, targeting the private-repo `404` case. Flagging these overlaps for a maintainer to decide on consolidation rather than assuming no duplicate exists.

## What Changed

- `server/src/services/github-external-object-provider.ts`: exported the existing token resolver as `resolveCompanyGitHubToken` (previously the private `defaultTokenProvider`) and exported `DEFAULT_GITHUB_TOKEN_SECRET_NAMES`. The link-liveness provider now calls the shared function — no duplication.
- `server/src/services/github-fetch.ts`: added `gitHubAuthHeaders(token)`, returning `{ authorization: "Bearer <token>" }` when a token is present and `{}` otherwise, so callers can spread it unconditionally.
- `server/src/services/company-skills.ts`: `fetchText` / `fetchJson` and the ref-resolution helpers (`resolveGitHubDefaultBranch`, `resolveGitHubCommitSha`, `resolveGitHubPinnedRef`) take an optional token; `readUrlSkillImports` resolves the token once and passes it into the `git/trees` read, ref resolution, and raw fetch. The import, re-import, update-check, and GitHub file-content read paths each resolve the token via `resolveCompanyGitHubToken(db, companyId)`. When a token is resolved it is sent as `Authorization: Bearer <token>` alongside the existing `accept: application/vnd.github+json`.
- The generic **arbitrary-URL** import branch (non-GitHub hosts) is intentionally left unauthenticated so a company GitHub token is never sent to a third-party host.
- `server/src/__tests__/company-skills.test.ts`: added two tests asserting the `Authorization: Bearer <token>` header is sent on every GitHub call when a token is configured, and omitted when it is not.

## Verification

- `pnpm --filter server run typecheck` → **0 errors**.
- `pnpm --filter server exec vitest run src/__tests__/company-skills.test.ts` → **20 passed** (18 pre-existing + 2 new). The new tests stub global `fetch`, import from a pinned-commit GitHub tree URL, and assert the auth header is present on the `git/trees` read and the `raw.githubusercontent.com` fetch when a token is set, and absent when it is not.
- **Not run:** the full monorepo build and the complete test suite (out of scope / heavy for this change); no runtime/live-server test against a real private repo.

## Risks

- **Low risk / backward compatible.** With no token secret configured, requests are byte-identical to today (unauthenticated), so public-repo imports are unaffected.
- **Token confidentiality:** the token is only ever placed in a request header — never in a URL or an error/log message (error strings contain the URL only). Sending is scoped to GitHub hosts; the arbitrary-URL branch stays anonymous to avoid leaking the token to non-GitHub hosts.
- **Blast radius:** changes are confined to the skill-import / GitHub-fetch path; the shared token resolver is the same function the link-liveness provider already used in production.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

(Checked `ROADMAP.md`: Skills Manager / Skill Studio / Skills Store are shipped items; this is a bug fix on the existing importer, not planned core feature work.)

## Model Used

Claude Opus 4.8 (model ID `claude-opus-4-8`), 1M-context variant, run via Claude Code with extended thinking and tool use (file edits, local typecheck + vitest execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — searched; related PRs (#4832, #5560, #3237) linked above for maintainers to adjudicate any overlap
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs change required for this fix
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending automated review
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
