### PR TITLE
feat(cli): add managed per-user install command

### DIFF
--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -4,7 +4,16 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installCommand, resolveNpmInstallRequest } from "../commands/install.js";
 import { uninstallCommand } from "../commands/uninstall.js";
-import { readInstallManifest, resolveInstallStorePaths } from "../install-store.js";
+import {
+  INSTALL_MANIFEST_VERSION,
+  flipCurrentAtomic,
+  initializeInstallStore,
+  payloadPathFor,
+  readInstallManifest,
+  resolveInstallStorePaths,
+  withInstallStoreLock,
+  writeInstallManifestAtomic,
+} from "../install-store.js";
 import { resolveCliVersion } from "../version.js";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -107,5 +116,30 @@ describe("managed install commands", () => {
 
     await expect(uninstallCommand()).rejects.toThrow("unverified install store");
     expect(fs.readFileSync(unrelatedFile, "utf8")).toBe("keep");
+  });
+
+  it("refuses to uninstall while another store mutation holds the lock", async () => {
+    const paths = resolveInstallStorePaths();
+    const payloadPath = payloadPathFor(paths, "npm", "2026.720.0");
+    initializeInstallStore(paths);
+    fs.mkdirSync(payloadPath, { recursive: true });
+    flipCurrentAtomic(payloadPath, paths);
+    writeInstallManifestAtomic({
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      source: "npm",
+      version: "2026.720.0",
+      channel: "latest",
+      payloadPath,
+      installedAt: "2026-07-22T18:00:00.000Z",
+      previous: [],
+    }, paths);
+
+    await withInstallStoreLock(
+      async () => {
+        await expect(uninstallCommand()).rejects.toThrow("already running");
+      },
+      paths,
+    );
+    expect(fs.existsSync(paths.lockPath)).toBe(false);
   });
 });

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -85,4 +85,27 @@ describe("managed install commands", () => {
     expect(fs.existsSync(paths.shimPath)).toBe(false);
     expect(fs.readFileSync(userData, "utf8")).toBe("keep");
   });
+
+  it("rejects a symlinked installs root before npm writes outside the store", async () => {
+    const paths = resolveInstallStorePaths();
+    const outside = path.join(root, "outside");
+    fs.mkdirSync(paths.cliRoot, { recursive: true });
+    fs.mkdirSync(outside);
+    fs.symlinkSync(outside, paths.installsRoot, "dir");
+    const runCommand = vi.fn(async () => ({ stdout: JSON.stringify("2026.720.0"), stderr: "" }));
+
+    await expect(installCommand({}, { runCommand })).rejects.toThrow("non-directory install-store path");
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expect(fs.readdirSync(outside)).toEqual([]);
+  });
+
+  it("refuses to uninstall an unverified cli directory", async () => {
+    const paths = resolveInstallStorePaths();
+    const unrelatedFile = path.join(paths.cliRoot, "keep.txt");
+    fs.mkdirSync(paths.cliRoot, { recursive: true });
+    fs.writeFileSync(unrelatedFile, "keep");
+
+    await expect(uninstallCommand()).rejects.toThrow("unverified install store");
+    expect(fs.readFileSync(unrelatedFile, "utf8")).toBe("keep");
+  });
 });

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installCommand, resolveNpmInstallRequest } from "../commands/install.js";
+import { uninstallCommand } from "../commands/uninstall.js";
+import { readInstallManifest, resolveInstallStorePaths } from "../install-store.js";
+import { resolveCliVersion } from "../version.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("managed install commands", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-command-"));
+    process.env = {
+      ...ORIGINAL_ENV,
+      HOME: path.join(root, "home"),
+      PAPERCLIP_HOME: path.join(root, "home", ".paperclip"),
+      PATH: "/usr/bin:/bin",
+      SHELL: "/bin/bash",
+    };
+    fs.mkdirSync(process.env.HOME!, { recursive: true });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("selects stable, canary, and exact-version npm sources", () => {
+    expect(resolveNpmInstallRequest({})).toEqual({ spec: "latest", channel: "latest" });
+    expect(resolveNpmInstallRequest({ canary: true })).toEqual({ spec: "canary", channel: "canary" });
+    expect(resolveNpmInstallRequest({ version: "2026.720.0" })).toEqual({
+      spec: "2026.720.0",
+      channel: "pinned",
+    });
+    expect(() => resolveNpmInstallRequest({ canary: true, version: "1.2.3" })).toThrow();
+    expect(() => resolveNpmInstallRequest({ version: "latest" })).toThrow();
+  });
+
+  it("installs through the shim, reports provenance, and uninstalls without deleting user data", async () => {
+    const version = "2026.720.0";
+    const runCommand = vi.fn(async (file: string, args: string[], _options?: unknown) => {
+      if (file === "npm" && args[0] === "view") return { stdout: JSON.stringify(version), stderr: "" };
+      if (file === "npm" && args[0] === "install") {
+        const prefix = args[args.indexOf("--prefix") + 1];
+        const entrypoint = path.join(prefix, "node_modules", "paperclipai", "dist", "index.js");
+        fs.mkdirSync(path.dirname(entrypoint), { recursive: true });
+        fs.writeFileSync(entrypoint, "#!/usr/bin/env node\n");
+        return { stdout: "", stderr: "" };
+      }
+      if (file === process.execPath && args.at(-1) === "--version") {
+        return { stdout: `${version}\n`, stderr: "" };
+      }
+      throw new Error(`Unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    await installCommand({}, { runCommand, now: () => new Date("2026-07-22T18:00:00.000Z") });
+
+    const paths = resolveInstallStorePaths();
+    const manifest = readInstallManifest(paths);
+    expect(manifest?.version).toBe(version);
+    expect(manifest?.channel).toBe("latest");
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(manifest!.payloadPath));
+    expect(fs.existsSync(paths.shimPath)).toBe(true);
+    const installCall = runCommand.mock.calls.find(
+      ([file, args]) => file === "npm" && args[0] === "install",
+    );
+    expect(installCall?.[1]).toContain("--@paperclipai:registry=https://registry.npmjs.org");
+    const installOptions = installCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(installOptions?.env?.npm_config_userconfig).toContain(".npmrc-");
+    const entrypoint = path.join(manifest!.payloadPath, "node_modules", "paperclipai", "dist", "index.js");
+    expect(resolveCliVersion(entrypoint)).toContain(`managed npm latest; payload ${manifest!.payloadPath}`);
+
+    const userData = path.join(process.env.PAPERCLIP_HOME!, "instances", "default", "keep.txt");
+    fs.mkdirSync(path.dirname(userData), { recursive: true });
+    fs.writeFileSync(userData, "keep");
+    await uninstallCommand();
+
+    expect(fs.existsSync(paths.cliRoot)).toBe(false);
+    expect(fs.existsSync(paths.shimPath)).toBe(false);
+    expect(fs.readFileSync(userData, "utf8")).toBe("keep");
+  });
+});

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   INSTALL_MANIFEST_VERSION,
+  MANAGED_SHIM_MARKER,
   addManagedPathBlock,
   buildNextManifest,
   flipCurrentAtomic,
@@ -125,5 +126,29 @@ describe("managed install store", () => {
     fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
     fs.writeFileSync(paths.shimPath, "#!/bin/sh\necho other-command\n");
     expect(() => writeManagedShim(paths)).toThrow("non-managed command");
+  });
+
+  it("refuses symlinked rc files, unsafe shim parents, and multiply linked shims", () => {
+    const outsideRc = path.join(root, "outside-rc");
+    fs.writeFileSync(outsideRc, "keep\n");
+    const rcPath = path.join(root, "home", ".bashrc");
+    fs.mkdirSync(path.dirname(rcPath), { recursive: true });
+    fs.symlinkSync(outsideRc, rcPath);
+    expect(() => addManagedPathBlock(rcPath)).toThrow("non-regular shell rc file");
+    expect(() => removeManagedPathBlock(rcPath)).toThrow("non-regular shell rc file");
+    expect(fs.readFileSync(outsideRc, "utf8")).toBe("keep\n");
+
+    fs.rmSync(rcPath);
+    const localDir = path.join(root, "home", ".local");
+    const outsideBin = path.join(root, "outside-bin");
+    fs.mkdirSync(outsideBin);
+    fs.symlinkSync(outsideBin, localDir, "dir");
+    expect(() => writeManagedShim(paths)).toThrow("unsafe shim directory");
+
+    fs.rmSync(localDir);
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, `# ${MANAGED_SHIM_MARKER}\n`);
+    fs.linkSync(paths.shimPath, path.join(root, "linked-shim"));
+    expect(() => writeManagedShim(paths)).toThrow("multiply linked shim");
   });
 });

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  INSTALL_MANIFEST_VERSION,
+  addManagedPathBlock,
+  buildNextManifest,
+  flipCurrentAtomic,
+  payloadPathFor,
+  pruneInstallPayloads,
+  readInstallManifest,
+  removeManagedPathBlock,
+  resolveInstallStorePaths,
+  writeInstallManifestAtomic,
+  writeManagedShim,
+  type InstallManifest,
+  type InstallRecord,
+} from "../install-store.js";
+
+function record(payloadPath: string, version: string): InstallRecord {
+  return {
+    source: "npm",
+    version,
+    channel: "latest",
+    payloadPath,
+    installedAt: `2026-07-${version.padStart(2, "0")}T00:00:00.000Z`,
+  };
+}
+
+describe("managed install store", () => {
+  let root: string;
+  let paths: ReturnType<typeof resolveInstallStorePaths>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-store-"));
+    paths = resolveInstallStorePaths({
+      homeDir: path.join(root, "home"),
+      paperclipHome: path.join(root, "home", ".paperclip"),
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves the documented npm and git payload layout", () => {
+    expect(payloadPathFor(paths, "npm", "2026.720.0")).toBe(
+      path.join(paths.cliRoot, "installs", "npm", "2026.720.0"),
+    );
+    expect(payloadPathFor(paths, "git", "ab12cd34ef56")).toBe(
+      path.join(paths.cliRoot, "installs", "git", "ab12cd34ef56"),
+    );
+  });
+
+  it("writes and reads the manifest atomically with private permissions", () => {
+    const payloadPath = payloadPathFor(paths, "npm", "1.2.3");
+    const manifest: InstallManifest = {
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      ...record(payloadPath, "1.2.3"),
+      previous: [],
+    };
+    writeInstallManifestAtomic(manifest, paths);
+    expect(readInstallManifest(paths)).toEqual(manifest);
+    expect(fs.statSync(paths.manifestPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("leaves the old current payload working when interrupted before rename", () => {
+    const oldPayload = payloadPathFor(paths, "npm", "1.0.0");
+    const newPayload = payloadPathFor(paths, "npm", "2.0.0");
+    fs.mkdirSync(oldPayload, { recursive: true });
+    fs.mkdirSync(newPayload, { recursive: true });
+    flipCurrentAtomic(oldPayload, paths);
+
+    expect(() =>
+      flipCurrentAtomic(newPayload, paths, {
+        beforeRename: () => {
+          throw new Error("simulated crash");
+        },
+      }),
+    ).toThrow("simulated crash");
+
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(oldPayload));
+    expect(fs.readdirSync(paths.cliRoot).filter((entry) => entry.startsWith(".current-"))).toEqual([]);
+  });
+
+  it("retains current plus two previous payloads and prunes older entries", () => {
+    const payloads = ["1", "2", "3", "4"].map((version) => payloadPathFor(paths, "npm", version));
+    for (const payload of payloads) fs.mkdirSync(payload, { recursive: true });
+    const previousManifest: InstallManifest = {
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      ...record(payloads[2], "3"),
+      previous: [record(payloads[1], "2"), record(payloads[0], "1")],
+    };
+    const next = buildNextManifest(record(payloads[3], "4"), previousManifest);
+
+    expect(next.previous.map((entry) => entry.version)).toEqual(["3", "2"]);
+    expect(pruneInstallPayloads(next, paths)).toEqual([payloads[0]]);
+    expect(fs.existsSync(payloads[0])).toBe(false);
+    expect(payloads.slice(1).every((payload) => fs.existsSync(payload))).toBe(true);
+  });
+
+  it("writes a stable shim and manages an idempotent shell PATH block", () => {
+    writeManagedShim(paths);
+    const shim = fs.readFileSync(paths.shimPath, "utf8");
+    expect(shim).toContain("$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js");
+    expect(fs.statSync(paths.shimPath).mode & 0o777).toBe(0o755);
+
+    const rcPath = path.join(root, "home", ".bashrc");
+    expect(addManagedPathBlock(rcPath)).toBe(true);
+    expect(addManagedPathBlock(rcPath)).toBe(false);
+    expect(removeManagedPathBlock(rcPath)).toBe(true);
+    expect(fs.readFileSync(rcPath, "utf8")).not.toContain("paperclipai managed PATH");
+  });
+
+  it("refuses symlinked payload roots and pre-existing non-managed shims", () => {
+    const outside = path.join(root, "outside");
+    fs.mkdirSync(outside, { recursive: true });
+    fs.mkdirSync(paths.installsRoot, { recursive: true });
+    fs.symlinkSync(outside, path.join(paths.installsRoot, "npm"), "dir");
+    const escapedPayload = path.join(paths.installsRoot, "npm", "1.2.3");
+    fs.mkdirSync(path.join(outside, "1.2.3"));
+    expect(() => flipCurrentAtomic(escapedPayload, paths)).toThrow("resolves outside");
+
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, "#!/bin/sh\necho other-command\n");
+    expect(() => writeManagedShim(paths)).toThrow("non-managed command");
+  });
+});

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -138,6 +138,15 @@ describe("managed install store", () => {
     expect(fs.existsSync(paths.lockPath)).toBe(false);
   });
 
+  it("fails closed without replacing a stale-looking lock", async () => {
+    const staleToken = "999999:stale";
+    await withInstallStoreLock(async () => undefined, paths);
+    fs.writeFileSync(paths.lockPath, `${staleToken}\n`, { mode: 0o600 });
+
+    await expect(withInstallStoreLock(async () => undefined, paths)).rejects.toThrow("stale lock");
+    expect(fs.readFileSync(paths.lockPath, "utf8")).toBe(`${staleToken}\n`);
+  });
+
   it("reports managed provenance only for the payload selected by current", () => {
     const manifestPayload = payloadPathFor(paths, "npm", "1.0.0");
     const currentPayload = payloadPathFor(paths, "npm", "2.0.0");

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -8,11 +8,14 @@ import {
   addManagedPathBlock,
   buildNextManifest,
   flipCurrentAtomic,
+  isManagedExecutable,
   payloadPathFor,
   pruneInstallPayloads,
   readInstallManifest,
   removeManagedPathBlock,
+  removeManagedShim,
   resolveInstallStorePaths,
+  withInstallStoreLock,
   writeInstallManifestAtomic,
   writeManagedShim,
   type InstallManifest,
@@ -101,10 +104,12 @@ describe("managed install store", () => {
     expect(payloads.slice(1).every((payload) => fs.existsSync(payload))).toBe(true);
   });
 
-  it("writes a stable shim and manages an idempotent shell PATH block", () => {
+  it("writes a stable shim with the validated runtime and custom store path", () => {
     writeManagedShim(paths);
     const shim = fs.readFileSync(paths.shimPath, "utf8");
-    expect(shim).toContain("$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js");
+    expect(shim).toContain(process.execPath);
+    expect(shim).toContain(paths.currentPath);
+    expect(shim).not.toContain("PAPERCLIP_HOME");
     expect(fs.statSync(paths.shimPath).mode & 0o777).toBe(0o755);
 
     const rcPath = path.join(root, "home", ".bashrc");
@@ -112,6 +117,42 @@ describe("managed install store", () => {
     expect(addManagedPathBlock(rcPath)).toBe(false);
     expect(removeManagedPathBlock(rcPath)).toBe(true);
     expect(fs.readFileSync(rcPath, "utf8")).not.toContain("paperclipai managed PATH");
+  });
+
+  it("rejects marker substrings that are not the exact managed shim format", () => {
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, `#!/bin/sh\necho '${MANAGED_SHIM_MARKER}'\n`);
+
+    expect(removeManagedShim(paths)).toBe(false);
+    expect(fs.existsSync(paths.shimPath)).toBe(true);
+    expect(() => writeManagedShim(paths)).toThrow("non-managed command");
+  });
+
+  it("serializes install-store mutations with an exclusive lock", async () => {
+    await expect(
+      withInstallStoreLock(
+        () => withInstallStoreLock(async () => undefined, paths),
+        paths,
+      ),
+    ).rejects.toThrow("already running");
+    expect(fs.existsSync(paths.lockPath)).toBe(false);
+  });
+
+  it("reports managed provenance only for the payload selected by current", () => {
+    const manifestPayload = payloadPathFor(paths, "npm", "1.0.0");
+    const currentPayload = payloadPathFor(paths, "npm", "2.0.0");
+    const executable = path.join(manifestPayload, "node_modules", "paperclipai", "dist", "index.js");
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(executable, "");
+    fs.mkdirSync(currentPayload, { recursive: true });
+    flipCurrentAtomic(currentPayload, paths);
+    const manifest: InstallManifest = {
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      ...record(manifestPayload, "1.0.0"),
+      previous: [],
+    };
+
+    expect(isManagedExecutable(executable, manifest, paths)).toBe(false);
   });
 
   it("refuses symlinked payload roots and pre-existing non-managed shims", () => {

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -13,6 +13,7 @@ import {
   pruneInstallPayloads,
   readInstallManifest,
   resolveInstallStorePaths,
+  withInstallStoreLock,
   writeInstallManifestAtomic,
   writeManagedShim,
   type InstallChannel,
@@ -88,8 +89,11 @@ async function smokePayload(payloadPath: string, expectedVersion: string, runCom
   }
 }
 
-async function installNpmPayload(version: string, runCommand: CommandRunner): Promise<{ payloadPath: string; reused: boolean }> {
-  const paths = resolveInstallStorePaths();
+async function installNpmPayload(
+  version: string,
+  runCommand: CommandRunner,
+  paths = resolveInstallStorePaths(),
+): Promise<{ payloadPath: string; reused: boolean }> {
   const payloadPath = payloadPathFor(paths, "npm", version);
   if (fs.existsSync(payloadPath)) {
     await smokePayload(payloadPath, version, runCommand);
@@ -185,28 +189,31 @@ export async function installCommand(
   console.log(`Installing paperclipai@${version}...`);
 
   const paths = resolveInstallStorePaths();
-  assertManagedShimWritable(paths);
-  const currentManifest = readInstallManifest(paths);
-  const installed = await installNpmPayload(version, runCommand);
-  const record: InstallRecord = {
-    source: "npm",
-    version,
-    channel: request.channel,
-    payloadPath: installed.payloadPath,
-    installedAt: (dependencies.now?.() ?? new Date()).toISOString(),
-  };
-  const nextManifest = buildNextManifest(record, currentManifest);
-  const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
-  flipCurrentAtomic(installed.payloadPath, paths);
-  try {
-    writeInstallManifestAtomic(nextManifest, paths);
-  } catch (error) {
-    if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths);
-    else fs.rmSync(paths.currentPath, { force: true });
-    throw error;
-  }
-  writeManagedShim(paths);
-  pruneInstallPayloads(nextManifest, paths);
+  const installed = await withInstallStoreLock(async () => {
+    assertManagedShimWritable(paths);
+    const currentManifest = readInstallManifest(paths);
+    const payload = await installNpmPayload(version, runCommand, paths);
+    const record: InstallRecord = {
+      source: "npm",
+      version,
+      channel: request.channel,
+      payloadPath: payload.payloadPath,
+      installedAt: (dependencies.now?.() ?? new Date()).toISOString(),
+    };
+    const nextManifest = buildNextManifest(record, currentManifest);
+    const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
+    flipCurrentAtomic(payload.payloadPath, paths);
+    try {
+      writeInstallManifestAtomic(nextManifest, paths);
+    } catch (error) {
+      if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths);
+      else fs.rmSync(paths.currentPath, { force: true });
+      throw error;
+    }
+    writeManagedShim(paths);
+    pruneInstallPayloads(nextManifest, paths);
+    return payload;
+  }, paths);
   await ensureShimOnPath(options);
 
   console.log(pc.green(`${installed.reused ? "Activated cached" : "Installed"} paperclipai ${version} (${request.channel}).`));

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -1,0 +1,215 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  addManagedPathBlock,
+  assertManagedShimWritable,
+  buildNextManifest,
+  flipCurrentAtomic,
+  payloadPathFor,
+  pruneInstallPayloads,
+  readInstallManifest,
+  resolveInstallStorePaths,
+  writeInstallManifestAtomic,
+  writeManagedShim,
+  type InstallChannel,
+  type InstallRecord,
+} from "../install-store.js";
+
+const execFileAsync = promisify(execFile);
+const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org";
+const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export type InstallOptions = { canary?: boolean; version?: string; yes?: boolean };
+
+type CommandRunner = (
+  file: string,
+  args: string[],
+  options?: Parameters<typeof execFileAsync>[2],
+) => Promise<{ stdout: string; stderr: string }>;
+
+function assertSupportedNodeVersion(): void {
+  const major = Number(process.versions.node.split(".")[0]);
+  if (!Number.isFinite(major) || major < 20) {
+    throw new Error(`Managed installs require Node.js 20 or newer (found ${process.version}).`);
+  }
+}
+
+export function resolveNpmInstallRequest(options: InstallOptions): {
+  spec: string;
+  channel: InstallChannel;
+} {
+  if (options.canary && options.version) throw new Error("Choose either --canary or --version, not both.");
+  if (options.version) {
+    const version = options.version.trim();
+    if (!EXACT_VERSION_PATTERN.test(version)) {
+      throw new Error(`--version requires an exact published version, received '${options.version}'.`);
+    }
+    return { spec: version, channel: "pinned" };
+  }
+  return options.canary ? { spec: "canary", channel: "canary" } : { spec: "latest", channel: "latest" };
+}
+
+function parseResolvedVersion(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error("npm returned an empty version response.");
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    if (EXACT_VERSION_PATTERN.test(trimmed)) return trimmed;
+  }
+  throw new Error(`npm returned an unexpected version response: ${trimmed}`);
+}
+
+async function resolvePublishedVersion(spec: string, runCommand: CommandRunner): Promise<string> {
+  const result = await runCommand(
+    "npm",
+    ["view", `paperclipai@${spec}`, "version", "--json", `--registry=${PUBLIC_NPM_REGISTRY}`],
+    { maxBuffer: 1024 * 1024 },
+  );
+  return parseResolvedVersion(result.stdout);
+}
+
+function payloadEntrypoint(payloadPath: string): string {
+  return path.join(payloadPath, "node_modules", "paperclipai", "dist", "index.js");
+}
+
+async function smokePayload(payloadPath: string, expectedVersion: string, runCommand: CommandRunner): Promise<void> {
+  const entrypoint = payloadEntrypoint(payloadPath);
+  if (!fs.existsSync(entrypoint)) throw new Error(`Installed package is missing its CLI entrypoint: ${entrypoint}`);
+  const result = await runCommand(process.execPath, [entrypoint, "--version"], { maxBuffer: 1024 * 1024 });
+  const reportedVersion = result.stdout.trim().split(/\s+/)[0];
+  if (reportedVersion !== expectedVersion) {
+    throw new Error(`Installed CLI smoke check reported ${reportedVersion || "no version"}; expected ${expectedVersion}.`);
+  }
+}
+
+async function installNpmPayload(version: string, runCommand: CommandRunner): Promise<{ payloadPath: string; reused: boolean }> {
+  const paths = resolveInstallStorePaths();
+  const payloadPath = payloadPathFor(paths, "npm", version);
+  if (fs.existsSync(payloadPath)) {
+    await smokePayload(payloadPath, version, runCommand);
+    return { payloadPath, reused: true };
+  }
+  const sourceRoot = path.dirname(payloadPath);
+  fs.mkdirSync(sourceRoot, { recursive: true, mode: 0o700 });
+  const sourceStat = fs.lstatSync(sourceRoot);
+  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+    throw new Error(`Refusing to install into unsafe payload root ${sourceRoot}.`);
+  }
+  fs.chmodSync(paths.cliRoot, 0o700);
+  fs.chmodSync(paths.installsRoot, 0o700);
+  fs.chmodSync(sourceRoot, 0o700);
+  const stagingPath = path.join(sourceRoot, `.${version}.tmp-${process.pid}-${Date.now()}`);
+  const npmUserConfigPath = path.join(sourceRoot, `.npmrc-${process.pid}-${Date.now()}`);
+  fs.rmSync(stagingPath, { recursive: true, force: true });
+  try {
+    fs.writeFileSync(
+      npmUserConfigPath,
+      `registry=${PUBLIC_NPM_REGISTRY}\n@paperclipai:registry=${PUBLIC_NPM_REGISTRY}\n`,
+      { mode: 0o600 },
+    );
+    await runCommand(
+      "npm",
+      [
+        "install",
+        "--prefix",
+        stagingPath,
+        `paperclipai@${version}`,
+        `--registry=${PUBLIC_NPM_REGISTRY}`,
+        `--@paperclipai:registry=${PUBLIC_NPM_REGISTRY}`,
+        "--no-audit",
+        "--no-fund",
+      ],
+      {
+        cwd: sourceRoot,
+        env: { ...process.env, npm_config_userconfig: npmUserConfigPath },
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    );
+    await smokePayload(stagingPath, version, runCommand);
+    fs.renameSync(stagingPath, payloadPath);
+    return { payloadPath, reused: false };
+  } finally {
+    fs.rmSync(stagingPath, { recursive: true, force: true });
+    fs.rmSync(npmUserConfigPath, { force: true });
+  }
+}
+
+function pathContains(directory: string): boolean {
+  const normalized = path.resolve(directory);
+  return (process.env.PATH ?? "").split(path.delimiter).filter(Boolean).some((entry) => path.resolve(entry) === normalized);
+}
+
+function shellRcPath(): string | null {
+  const home = process.env.HOME;
+  if (!home) return null;
+  const shell = path.basename(process.env.SHELL ?? "");
+  if (shell === "bash") return path.join(home, ".bashrc");
+  if (shell === "zsh") return path.join(home, ".zshrc");
+  return null;
+}
+
+async function ensureShimOnPath(options: InstallOptions): Promise<void> {
+  const paths = resolveInstallStorePaths();
+  const binDir = path.dirname(paths.shimPath);
+  if (pathContains(binDir)) return;
+  const manualInstruction = `export PATH="$HOME/.local/bin:$PATH"`;
+  const rcPath = shellRcPath();
+  if (!process.stdin.isTTY || !process.stdout.isTTY || !rcPath) {
+    console.log(pc.yellow(`Add Paperclip to PATH for this shell:\n  ${manualInstruction}`));
+    return;
+  }
+  const confirmed = options.yes === true ? true : await p.confirm({ message: `Add ~/.local/bin to PATH in ${rcPath}?`, initialValue: true });
+  if (p.isCancel(confirmed) || !confirmed) {
+    console.log(pc.yellow(`PATH was not changed. Run:\n  ${manualInstruction}`));
+    return;
+  }
+  const changed = addManagedPathBlock(rcPath);
+  console.log(changed ? pc.green(`Updated ${rcPath}.`) : pc.dim(`${rcPath} already contains the PATH block.`));
+}
+
+export async function installCommand(
+  options: InstallOptions,
+  dependencies: { runCommand?: CommandRunner; now?: () => Date } = {},
+): Promise<void> {
+  assertSupportedNodeVersion();
+  const runCommand = dependencies.runCommand ?? execFileAsync;
+  const request = resolveNpmInstallRequest(options);
+  console.log(`Resolving paperclipai@${request.spec} from ${PUBLIC_NPM_REGISTRY}...`);
+  const version = await resolvePublishedVersion(request.spec, runCommand);
+  console.log(`Installing paperclipai@${version}...`);
+
+  const paths = resolveInstallStorePaths();
+  assertManagedShimWritable(paths);
+  const currentManifest = readInstallManifest(paths);
+  const installed = await installNpmPayload(version, runCommand);
+  const record: InstallRecord = {
+    source: "npm",
+    version,
+    channel: request.channel,
+    payloadPath: installed.payloadPath,
+    installedAt: (dependencies.now?.() ?? new Date()).toISOString(),
+  };
+  const nextManifest = buildNextManifest(record, currentManifest);
+  const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
+  flipCurrentAtomic(installed.payloadPath, paths);
+  try {
+    writeInstallManifestAtomic(nextManifest, paths);
+  } catch (error) {
+    if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths);
+    else fs.rmSync(paths.currentPath, { force: true });
+    throw error;
+  }
+  writeManagedShim(paths);
+  pruneInstallPayloads(nextManifest, paths);
+  await ensureShimOnPath(options);
+
+  console.log(pc.green(`${installed.reused ? "Activated cached" : "Installed"} paperclipai ${version} (${request.channel}).`));
+  console.log(pc.dim(`Payload: ${installed.payloadPath}`));
+  console.log(`Run ${pc.cyan("paperclipai --version")} to verify the managed install.`);
+}

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -6,18 +6,24 @@ import {
   removeManagedPathBlock,
   removeManagedShim,
   resolveInstallStorePaths,
+  withInstallStoreLock,
 } from "../install-store.js";
 
 export async function uninstallCommand(): Promise<void> {
   const paths = resolveInstallStorePaths();
-  if (fs.existsSync(paths.cliRoot)) assertManagedInstallStore(paths);
-  const shimRemoved = removeManagedShim(paths);
-  fs.rmSync(paths.cliRoot, { recursive: true, force: true });
+  const hadStore = fs.existsSync(paths.cliRoot);
+  if (hadStore) assertManagedInstallStore(paths);
+  const shimRemoved = await withInstallStoreLock(async () => {
+    if (hadStore) assertManagedInstallStore(paths);
+    const removed = removeManagedShim(paths);
 
-  const home = process.env.HOME;
-  for (const rcFile of home ? [path.join(home, ".bashrc"), path.join(home, ".zshrc")] : []) {
-    removeManagedPathBlock(rcFile);
-  }
+    const home = process.env.HOME;
+    for (const rcFile of home ? [path.join(home, ".bashrc"), path.join(home, ".zshrc")] : []) {
+      removeManagedPathBlock(rcFile);
+    }
+    fs.rmSync(paths.cliRoot, { recursive: true, force: true });
+    return removed;
+  }, paths, { initialize: !hadStore });
 
   if (!shimRemoved) {
     console.log(pc.yellow(`Left ${paths.shimPath} unchanged because it is not a Paperclip-managed shim.`));

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 import {
+  assertManagedInstallStore,
   removeManagedPathBlock,
   removeManagedShim,
   resolveInstallStorePaths,
@@ -9,6 +10,7 @@ import {
 
 export async function uninstallCommand(): Promise<void> {
   const paths = resolveInstallStorePaths();
+  if (fs.existsSync(paths.cliRoot)) assertManagedInstallStore(paths);
   const shimRemoved = removeManagedShim(paths);
   fs.rmSync(paths.cliRoot, { recursive: true, force: true });
 

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import pc from "picocolors";
+import {
+  removeManagedPathBlock,
+  removeManagedShim,
+  resolveInstallStorePaths,
+} from "../install-store.js";
+
+export async function uninstallCommand(): Promise<void> {
+  const paths = resolveInstallStorePaths();
+  const shimRemoved = removeManagedShim(paths);
+  fs.rmSync(paths.cliRoot, { recursive: true, force: true });
+
+  const home = process.env.HOME;
+  for (const rcFile of home ? [path.join(home, ".bashrc"), path.join(home, ".zshrc")] : []) {
+    removeManagedPathBlock(rcFile);
+  }
+
+  if (!shimRemoved) {
+    console.log(pc.yellow(`Left ${paths.shimPath} unchanged because it is not a Paperclip-managed shim.`));
+  }
+  console.log(pc.green("Removed the managed Paperclip CLI install."));
+  console.log(pc.dim(`User data was left untouched under ${paths.paperclipHome}.`));
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -43,15 +43,32 @@ import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerAssetCommands } from "./commands/client/asset.js";
 import { registerSkillCommands } from "./commands/client/skill.js";
 import { cliVersion } from "./version.js";
+import { installCommand } from "./commands/install.js";
+import { uninstallCommand } from "./commands/uninstall.js";
 
 const program = new Command();
 const DATA_DIR_OPTION_HELP =
   "Paperclip data directory root (isolates state from ~/.paperclip)";
 
+program.enablePositionalOptions();
+
 program
   .name("paperclipai")
   .description("Paperclip CLI — setup, diagnose, and configure your instance")
   .version(cliVersion);
+
+program
+  .command("install")
+  .description("Install Paperclip into a managed per-user CLI store")
+  .option("--canary", "Install the npm canary channel")
+  .option("--version <version>", "Install an exact published npm version")
+  .option("-y, --yes", "Consent to the supported shell PATH update without prompting")
+  .action(installCommand);
+
+program
+  .command("uninstall")
+  .description("Remove the managed CLI install while preserving user data")
+  .action(uninstallCommand);
 
 program.hook("preAction", (_thisCommand, actionCommand) => {
   const options = actionCommand.optsWithGlobals() as DataDirOptionLike;

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -144,15 +144,6 @@ export function assertManagedInstallStore(paths = resolveInstallStorePaths()): I
   return manifest;
 }
 
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
-  }
-}
-
 export async function withInstallStoreLock<T>(
   callback: () => Promise<T>,
   paths = resolveInstallStorePaths(),
@@ -172,18 +163,11 @@ export async function withInstallStoreLock<T>(
       }
       const owner = fs.readFileSync(paths.lockPath, "utf8").trim();
       const ownerPid = Number.parseInt(owner.split(":", 1)[0] ?? "", 10);
-      if (Number.isInteger(ownerPid) && ownerPid > 0 && processIsAlive(ownerPid)) {
-        throw new Error(`Another managed install is already running (pid ${ownerPid}).`);
-      }
-      fs.rmSync(paths.lockPath, { force: true });
-      try {
-        fs.linkSync(temporaryPath, paths.lockPath);
-      } catch (retryError) {
-        if ((retryError as NodeJS.ErrnoException).code === "EEXIST") {
-          throw new Error("Another managed install started while recovering a stale lock.");
-        }
-        throw retryError;
-      }
+      const ownerLabel = Number.isInteger(ownerPid) && ownerPid > 0 ? ` (pid ${ownerPid})` : "";
+      throw new Error(
+        `Another managed install is already running${ownerLabel}. ` +
+        `If no install process is active, remove the stale lock at ${paths.lockPath} and retry.`,
+      );
     } finally {
       fs.rmSync(temporaryPath, { force: true });
     }

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 import { resolvePaperclipHomeDir } from "./config/home.js";
 
 export const INSTALL_MANIFEST_VERSION = 1;
-export const MANAGED_SHIM_MARKER = "paperclipai managed install shim";
+export const MANAGED_SHIM_MARKER = "paperclipai managed install shim v1";
+export const MANAGED_STORE_MARKER = "paperclipai managed install store v1\n";
 export const PATH_BLOCK_START = "# >>> paperclipai managed PATH >>>";
 export const PATH_BLOCK_END = "# <<< paperclipai managed PATH <<<";
 
@@ -31,6 +32,8 @@ export type InstallStorePaths = {
   cliRoot: string;
   installsRoot: string;
   manifestPath: string;
+  markerPath: string;
+  lockPath: string;
   currentPath: string;
   shimPath: string;
 };
@@ -76,9 +79,127 @@ export function resolveInstallStorePaths(options: {
     cliRoot,
     installsRoot: path.join(cliRoot, "installs"),
     manifestPath: path.join(cliRoot, "install.json"),
+    markerPath: path.join(cliRoot, ".managed-install"),
+    lockPath: path.join(cliRoot, ".install.lock"),
     currentPath: path.join(cliRoot, "current"),
     shimPath: path.join(homeDir, ".local", "bin", "paperclipai"),
   };
+}
+
+export function initializeInstallStore(paths = resolveInstallStorePaths()): void {
+  ensurePrivateDirectory(paths.cliRoot);
+  ensurePrivateDirectory(paths.installsRoot);
+  try {
+    const markerStat = fs.lstatSync(paths.markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink() || markerStat.nlink > 1) {
+      throw new Error(`Refusing to use unsafe install-store marker ${paths.markerPath}.`);
+    }
+    assertOwnedByCurrentUser(markerStat, paths.markerPath);
+    if (fs.readFileSync(paths.markerPath, "utf8") !== MANAGED_STORE_MARKER) {
+      throw new Error(`Refusing to use unrecognized install store ${paths.cliRoot}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    try {
+      fs.writeFileSync(paths.markerPath, MANAGED_STORE_MARKER, { mode: 0o600, flag: "wx" });
+    } catch (writeError) {
+      if (
+        (writeError as NodeJS.ErrnoException).code !== "EEXIST" ||
+        fs.readFileSync(paths.markerPath, "utf8") !== MANAGED_STORE_MARKER
+      ) {
+        throw writeError;
+      }
+    }
+  }
+}
+
+export function assertManagedInstallStore(paths = resolveInstallStorePaths()): InstallManifest {
+  const cliStat = fs.lstatSync(paths.cliRoot);
+  if (!cliStat.isDirectory() || cliStat.isSymbolicLink()) {
+    throw new Error(`Refusing to remove unsafe install-store path ${paths.cliRoot}.`);
+  }
+  assertOwnedByCurrentUser(cliStat, paths.cliRoot);
+  let markerStat: fs.Stats;
+  try {
+    markerStat = fs.lstatSync(paths.markerPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Refusing to remove unverified install store ${paths.cliRoot}.`);
+    }
+    throw error;
+  }
+  if (!markerStat.isFile() || markerStat.isSymbolicLink() || markerStat.nlink > 1) {
+    throw new Error(`Refusing to remove unverified install store ${paths.cliRoot}.`);
+  }
+  assertOwnedByCurrentUser(markerStat, paths.markerPath);
+  if (fs.readFileSync(paths.markerPath, "utf8") !== MANAGED_STORE_MARKER) {
+    throw new Error(`Refusing to remove unverified install store ${paths.cliRoot}.`);
+  }
+  const manifest = readInstallManifest(paths);
+  if (!manifest) throw new Error(`Refusing to remove install store without a manifest at ${paths.cliRoot}.`);
+  const relativePayload = path.relative(paths.installsRoot, path.resolve(manifest.payloadPath));
+  if (!relativePayload || relativePayload.startsWith("..") || path.isAbsolute(relativePayload)) {
+    throw new Error(`Refusing to remove install store with an invalid manifest at ${paths.cliRoot}.`);
+  }
+  return manifest;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export async function withInstallStoreLock<T>(
+  callback: () => Promise<T>,
+  paths = resolveInstallStorePaths(),
+): Promise<T> {
+  initializeInstallStore(paths);
+  const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  const acquire = (): void => {
+    const temporaryPath = `${paths.lockPath}.${token}.tmp`;
+    try {
+      fs.writeFileSync(temporaryPath, `${token}\n`, { mode: 0o600, flag: "wx" });
+      try {
+        fs.linkSync(temporaryPath, paths.lockPath);
+        return;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+      const owner = fs.readFileSync(paths.lockPath, "utf8").trim();
+      const ownerPid = Number.parseInt(owner.split(":", 1)[0] ?? "", 10);
+      if (Number.isInteger(ownerPid) && ownerPid > 0 && processIsAlive(ownerPid)) {
+        throw new Error(`Another managed install is already running (pid ${ownerPid}).`);
+      }
+      fs.rmSync(paths.lockPath, { force: true });
+      try {
+        fs.linkSync(temporaryPath, paths.lockPath);
+      } catch (retryError) {
+        if ((retryError as NodeJS.ErrnoException).code === "EEXIST") {
+          throw new Error("Another managed install started while recovering a stale lock.");
+        }
+        throw retryError;
+      }
+    } finally {
+      fs.rmSync(temporaryPath, { force: true });
+    }
+  };
+
+  acquire();
+  try {
+    return await callback();
+  } finally {
+    try {
+      if (fs.readFileSync(paths.lockPath, "utf8").trim() === token) {
+        fs.rmSync(paths.lockPath, { force: true });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
 }
 
 export function payloadPathFor(
@@ -246,12 +367,28 @@ export function assertManagedShimWritable(paths = resolveInstallStorePaths()): v
     assertOwnedByCurrentUser(stat, paths.shimPath);
     if (stat.nlink > 1) throw new Error(`Refusing to replace multiply linked shim ${paths.shimPath}.`);
     const existing = fs.readFileSync(paths.shimPath, "utf8");
-    if (!existing.includes(MANAGED_SHIM_MARKER)) {
+    if (!isManagedShimContents(existing)) {
       throw new Error(`Refusing to replace existing non-managed command ${paths.shimPath}.`);
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function isManagedShimContents(contents: string): boolean {
+  const lines = contents.split("\n");
+  return (
+    lines.length === 5 &&
+    lines[0] === "#!/bin/sh" &&
+    lines[1] === `# ${MANAGED_SHIM_MARKER}` &&
+    lines[2] === "set -eu" &&
+    /^exec '(?:[^']|'"'"')+' '(?:[^']|'"'"')+' "\$@"$/.test(lines[3]) &&
+    lines[4] === ""
+  );
 }
 
 export function writeManagedShim(paths = resolveInstallStorePaths()): void {
@@ -262,14 +399,15 @@ export function writeManagedShim(paths = resolveInstallStorePaths()): void {
   fs.mkdirSync(localDir, { mode: 0o755 });
   fs.mkdirSync(path.dirname(paths.shimPath), { mode: 0o755 });
   assertManagedShimWritable(paths);
-  const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nPAPERCLIP_HOME="\${PAPERCLIP_HOME:-\$HOME/.paperclip}"\nexec node "\$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js" "\$@"\n`;
+  const entrypoint = path.join(paths.currentPath, "node_modules", "paperclipai", "dist", "index.js");
+  const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nexec ${shellQuote(process.execPath)} ${shellQuote(entrypoint)} "\$@"\n`;
   writeFileAtomic(paths.shimPath, contents, 0o755);
 }
 
 export function removeManagedShim(paths = resolveInstallStorePaths()): boolean {
   try {
     const contents = fs.readFileSync(paths.shimPath, "utf8");
-    if (!contents.includes(MANAGED_SHIM_MARKER)) return false;
+    if (!isManagedShimContents(contents)) return false;
     fs.rmSync(paths.shimPath, { force: true });
     return true;
   } catch (error) {
@@ -333,7 +471,11 @@ export function isManagedExecutable(
   try {
     const executableRealPath = fs.realpathSync(executablePath);
     const payloadRealPath = fs.realpathSync(manifest.payloadPath);
-    return executableRealPath.startsWith(`${payloadRealPath}${path.sep}`) && fs.existsSync(paths.currentPath);
+    const currentRealPath = fs.realpathSync(paths.currentPath);
+    return (
+      currentRealPath === payloadRealPath &&
+      executableRealPath.startsWith(`${payloadRealPath}${path.sep}`)
+    );
   } catch {
     return false;
   }

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -1,0 +1,293 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePaperclipHomeDir } from "./config/home.js";
+
+export const INSTALL_MANIFEST_VERSION = 1;
+export const MANAGED_SHIM_MARKER = "paperclipai managed install shim";
+export const PATH_BLOCK_START = "# >>> paperclipai managed PATH >>>";
+export const PATH_BLOCK_END = "# <<< paperclipai managed PATH <<<";
+
+export type InstallSource = "npm" | "git";
+export type InstallChannel = "latest" | "canary" | "pinned";
+
+export type InstallRecord = {
+  source: InstallSource;
+  version: string;
+  channel: InstallChannel;
+  payloadPath: string;
+  repo?: string;
+  ref?: string;
+  sha?: string;
+  installedAt: string;
+};
+
+export type InstallManifest = InstallRecord & {
+  schemaVersion: typeof INSTALL_MANIFEST_VERSION;
+  previous: InstallRecord[];
+};
+
+export type InstallStorePaths = {
+  paperclipHome: string;
+  cliRoot: string;
+  installsRoot: string;
+  manifestPath: string;
+  currentPath: string;
+  shimPath: string;
+};
+
+function ensurePrivateDirectory(directoryPath: string): void {
+  fs.mkdirSync(directoryPath, { recursive: true, mode: 0o700 });
+  const stat = fs.lstatSync(directoryPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Refusing to use non-directory install-store path ${directoryPath}.`);
+  }
+  fs.chmodSync(directoryPath, 0o700);
+}
+
+export function resolveInstallStorePaths(options: {
+  paperclipHome?: string;
+  homeDir?: string;
+} = {}): InstallStorePaths {
+  const paperclipHome = path.resolve(options.paperclipHome ?? resolvePaperclipHomeDir());
+  const homeDir = path.resolve(options.homeDir ?? process.env.HOME ?? path.dirname(paperclipHome));
+  const cliRoot = path.join(paperclipHome, "cli");
+  return {
+    paperclipHome,
+    cliRoot,
+    installsRoot: path.join(cliRoot, "installs"),
+    manifestPath: path.join(cliRoot, "install.json"),
+    currentPath: path.join(cliRoot, "current"),
+    shimPath: path.join(homeDir, ".local", "bin", "paperclipai"),
+  };
+}
+
+export function payloadPathFor(
+  paths: InstallStorePaths,
+  source: InstallSource,
+  identifier: string,
+): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(identifier)) {
+    throw new Error(`Invalid install payload identifier '${identifier}'.`);
+  }
+  return path.join(paths.installsRoot, source, identifier);
+}
+
+export function readInstallManifest(paths = resolveInstallStorePaths()): InstallManifest | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(paths.manifestPath, "utf8")) as InstallManifest;
+    if (
+      value.schemaVersion !== INSTALL_MANIFEST_VERSION ||
+      (value.source !== "npm" && value.source !== "git") ||
+      !Array.isArray(value.previous) ||
+      typeof value.payloadPath !== "string"
+    ) {
+      throw new Error("unsupported manifest shape");
+    }
+    return value;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error(`Could not read managed install manifest at ${paths.manifestPath}: ${String(error)}`);
+  }
+}
+
+export function writeInstallManifestAtomic(
+  manifest: InstallManifest,
+  paths = resolveInstallStorePaths(),
+): void {
+  ensurePrivateDirectory(paths.cliRoot);
+  const temporaryPath = `${paths.manifestPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporaryPath, paths.manifestPath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function assertPayloadPath(payloadPath: string, paths: InstallStorePaths): void {
+  const relative = path.relative(paths.installsRoot, path.resolve(payloadPath));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to activate payload outside ${paths.installsRoot}.`);
+  }
+  const stat = fs.lstatSync(payloadPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Refusing to activate non-directory payload ${payloadPath}.`);
+  }
+  const installsRealPath = fs.realpathSync(paths.installsRoot);
+  const payloadRealPath = fs.realpathSync(payloadPath);
+  if (!payloadRealPath.startsWith(`${installsRealPath}${path.sep}`)) {
+    throw new Error(`Refusing to activate payload that resolves outside ${paths.installsRoot}.`);
+  }
+}
+
+export function flipCurrentAtomic(
+  payloadPath: string,
+  paths = resolveInstallStorePaths(),
+  hooks: { beforeRename?: () => void } = {},
+): void {
+  assertPayloadPath(payloadPath, paths);
+  ensurePrivateDirectory(paths.cliRoot);
+  try {
+    const currentStat = fs.lstatSync(paths.currentPath);
+    if (!currentStat.isSymbolicLink()) {
+      throw new Error(`Refusing to replace non-symlink ${paths.currentPath}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  const temporaryLink = path.join(
+    paths.cliRoot,
+    `.current-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  const relativeTarget = path.relative(paths.cliRoot, payloadPath);
+  try {
+    fs.symlinkSync(relativeTarget, temporaryLink, "dir");
+    hooks.beforeRename?.();
+    fs.renameSync(temporaryLink, paths.currentPath);
+  } finally {
+    fs.rmSync(temporaryLink, { force: true });
+  }
+}
+
+export function buildNextManifest(
+  record: InstallRecord,
+  current: InstallManifest | null,
+): InstallManifest {
+  const candidates: InstallRecord[] = current
+    ? [
+        {
+          source: current.source,
+          version: current.version,
+          channel: current.channel,
+          payloadPath: current.payloadPath,
+          repo: current.repo,
+          ref: current.ref,
+          sha: current.sha,
+          installedAt: current.installedAt,
+        },
+        ...current.previous,
+      ]
+    : [];
+  const previous = candidates
+    .filter((candidate) => path.resolve(candidate.payloadPath) !== path.resolve(record.payloadPath))
+    .filter(
+      (candidate, index, all) =>
+        all.findIndex((other) => path.resolve(other.payloadPath) === path.resolve(candidate.payloadPath)) ===
+        index,
+    )
+    .slice(0, 2);
+
+  return { schemaVersion: INSTALL_MANIFEST_VERSION, ...record, previous };
+}
+
+export function pruneInstallPayloads(
+  manifest: InstallManifest,
+  paths = resolveInstallStorePaths(),
+): string[] {
+  const retained = new Set(
+    [manifest, ...manifest.previous].map((record) => path.resolve(record.payloadPath)),
+  );
+  const removed: string[] = [];
+  for (const source of ["npm", "git"] as const) {
+    const sourceRoot = path.join(paths.installsRoot, source);
+    if (!fs.existsSync(sourceRoot)) continue;
+    const sourceStat = fs.lstatSync(sourceRoot);
+    if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+      throw new Error(`Refusing to prune unsafe install-store path ${sourceRoot}.`);
+    }
+    for (const entry of fs.readdirSync(sourceRoot)) {
+      if (entry.startsWith(".")) continue;
+      const candidate = path.join(sourceRoot, entry);
+      if (!retained.has(path.resolve(candidate))) {
+        fs.rmSync(candidate, { recursive: true, force: true });
+        removed.push(candidate);
+      }
+    }
+  }
+  return removed;
+}
+
+export function assertManagedShimWritable(paths = resolveInstallStorePaths()): void {
+  try {
+    const stat = fs.lstatSync(paths.shimPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to replace symlinked shim ${paths.shimPath}.`);
+    }
+    const existing = fs.readFileSync(paths.shimPath, "utf8");
+    if (!existing.includes(MANAGED_SHIM_MARKER)) {
+      throw new Error(`Refusing to replace existing non-managed command ${paths.shimPath}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+export function writeManagedShim(paths = resolveInstallStorePaths()): void {
+  assertManagedShimWritable(paths);
+  fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true, mode: 0o755 });
+  const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nPAPERCLIP_HOME="\${PAPERCLIP_HOME:-\$HOME/.paperclip}"\nexec node "\$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js" "\$@"\n`;
+  fs.writeFileSync(paths.shimPath, contents, { mode: 0o755 });
+  fs.chmodSync(paths.shimPath, 0o755);
+}
+
+export function removeManagedShim(paths = resolveInstallStorePaths()): boolean {
+  try {
+    const contents = fs.readFileSync(paths.shimPath, "utf8");
+    if (!contents.includes(MANAGED_SHIM_MARKER)) return false;
+    fs.rmSync(paths.shimPath, { force: true });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+export function managedPathBlock(): string {
+  return `${PATH_BLOCK_START}\nexport PATH="$HOME/.local/bin:$PATH"\n${PATH_BLOCK_END}`;
+}
+
+export function addManagedPathBlock(rcPath: string): boolean {
+  let existing = "";
+  try {
+    existing = fs.readFileSync(rcPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (existing.includes(PATH_BLOCK_START)) return false;
+  fs.mkdirSync(path.dirname(rcPath), { recursive: true });
+  const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  fs.appendFileSync(rcPath, `${prefix}${managedPathBlock()}\n`);
+  return true;
+}
+
+export function removeManagedPathBlock(rcPath: string): boolean {
+  let existing: string;
+  try {
+    existing = fs.readFileSync(rcPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+  const escapedStart = PATH_BLOCK_START.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedEnd = PATH_BLOCK_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const next = existing.replace(new RegExp(`(?:^|\\n)${escapedStart}\\n[\\s\\S]*?${escapedEnd}\\n?`), "\n");
+  if (next === existing) return false;
+  fs.writeFileSync(rcPath, next.replace(/^\n/, ""));
+  return true;
+}
+
+export function isManagedExecutable(
+  executablePath: string | undefined,
+  manifest: InstallManifest,
+  paths = resolveInstallStorePaths(),
+): boolean {
+  if (!executablePath) return false;
+  try {
+    const executableRealPath = fs.realpathSync(executablePath);
+    const payloadRealPath = fs.realpathSync(manifest.payloadPath);
+    return executableRealPath.startsWith(`${payloadRealPath}${path.sep}`) && fs.existsSync(paths.currentPath);
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -156,8 +156,9 @@ function processIsAlive(pid: number): boolean {
 export async function withInstallStoreLock<T>(
   callback: () => Promise<T>,
   paths = resolveInstallStorePaths(),
+  options: { initialize?: boolean } = {},
 ): Promise<T> {
-  initializeInstallStore(paths);
+  if (options.initialize !== false) initializeInstallStore(paths);
   const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
   const acquire = (): void => {
     const temporaryPath = `${paths.lockPath}.${token}.tmp`;

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -44,6 +44,26 @@ function ensurePrivateDirectory(directoryPath: string): void {
   fs.chmodSync(directoryPath, 0o700);
 }
 
+function assertOwnedByCurrentUser(stat: fs.Stats, targetPath: string): void {
+  const getuid = process.getuid;
+  if (typeof getuid === "function" && stat.uid !== getuid()) {
+    throw new Error(`Refusing to modify path not owned by the current user: ${targetPath}.`);
+  }
+}
+
+function writeFileAtomic(filePath: string, contents: string, mode: number): void {
+  const temporaryPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  try {
+    fs.writeFileSync(temporaryPath, contents, { mode, flag: "wx" });
+    fs.renameSync(temporaryPath, filePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
 export function resolveInstallStorePaths(options: {
   paperclipHome?: string;
   homeDir?: string;
@@ -209,11 +229,22 @@ export function pruneInstallPayloads(
 }
 
 export function assertManagedShimWritable(paths = resolveInstallStorePaths()): void {
+  const homeDir = path.dirname(path.dirname(path.dirname(paths.shimPath)));
+  for (const directoryPath of [homeDir, path.join(homeDir, ".local"), path.dirname(paths.shimPath)]) {
+    if (!fs.existsSync(directoryPath)) continue;
+    const directoryStat = fs.lstatSync(directoryPath);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      throw new Error(`Refusing to use unsafe shim directory ${directoryPath}.`);
+    }
+    assertOwnedByCurrentUser(directoryStat, directoryPath);
+  }
   try {
     const stat = fs.lstatSync(paths.shimPath);
-    if (stat.isSymbolicLink()) {
-      throw new Error(`Refusing to replace symlinked shim ${paths.shimPath}.`);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Refusing to replace non-regular shim ${paths.shimPath}.`);
     }
+    assertOwnedByCurrentUser(stat, paths.shimPath);
+    if (stat.nlink > 1) throw new Error(`Refusing to replace multiply linked shim ${paths.shimPath}.`);
     const existing = fs.readFileSync(paths.shimPath, "utf8");
     if (!existing.includes(MANAGED_SHIM_MARKER)) {
       throw new Error(`Refusing to replace existing non-managed command ${paths.shimPath}.`);
@@ -225,10 +256,14 @@ export function assertManagedShimWritable(paths = resolveInstallStorePaths()): v
 
 export function writeManagedShim(paths = resolveInstallStorePaths()): void {
   assertManagedShimWritable(paths);
-  fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true, mode: 0o755 });
+  const homeDir = path.dirname(path.dirname(path.dirname(paths.shimPath)));
+  const localDir = path.dirname(path.dirname(paths.shimPath));
+  fs.mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(localDir, { mode: 0o755 });
+  fs.mkdirSync(path.dirname(paths.shimPath), { mode: 0o755 });
+  assertManagedShimWritable(paths);
   const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nPAPERCLIP_HOME="\${PAPERCLIP_HOME:-\$HOME/.paperclip}"\nexec node "\$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js" "\$@"\n`;
-  fs.writeFileSync(paths.shimPath, contents, { mode: 0o755 });
-  fs.chmodSync(paths.shimPath, 0o755);
+  writeFileAtomic(paths.shimPath, contents, 0o755);
 }
 
 export function removeManagedShim(paths = resolveInstallStorePaths()): boolean {
@@ -249,7 +284,14 @@ export function managedPathBlock(): string {
 
 export function addManagedPathBlock(rcPath: string): boolean {
   let existing = "";
+  let mode = 0o600;
   try {
+    const stat = fs.lstatSync(rcPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Refusing to modify non-regular shell rc file ${rcPath}.`);
+    }
+    assertOwnedByCurrentUser(stat, rcPath);
+    mode = stat.mode & 0o777;
     existing = fs.readFileSync(rcPath, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -257,13 +299,18 @@ export function addManagedPathBlock(rcPath: string): boolean {
   if (existing.includes(PATH_BLOCK_START)) return false;
   fs.mkdirSync(path.dirname(rcPath), { recursive: true });
   const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-  fs.appendFileSync(rcPath, `${prefix}${managedPathBlock()}\n`);
+  writeFileAtomic(rcPath, `${existing}${prefix}${managedPathBlock()}\n`, mode);
   return true;
 }
 
 export function removeManagedPathBlock(rcPath: string): boolean {
   let existing: string;
   try {
+    const stat = fs.lstatSync(rcPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Refusing to modify non-regular shell rc file ${rcPath}.`);
+    }
+    assertOwnedByCurrentUser(stat, rcPath);
     existing = fs.readFileSync(rcPath, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
@@ -273,7 +320,7 @@ export function removeManagedPathBlock(rcPath: string): boolean {
   const escapedEnd = PATH_BLOCK_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const next = existing.replace(new RegExp(`(?:^|\\n)${escapedStart}\\n[\\s\\S]*?${escapedEnd}\\n?`), "\n");
   if (next === existing) return false;
-  fs.writeFileSync(rcPath, next.replace(/^\n/, ""));
+  writeFileAtomic(rcPath, next.replace(/^\n/, ""), fs.statSync(rcPath).mode & 0o777);
   return true;
 }
 

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,4 +1,9 @@
 import { createRequire } from "node:module";
+import {
+  isManagedExecutable,
+  readInstallManifest,
+  resolveInstallStorePaths,
+} from "./install-store.js";
 
 type PackageJson = {
   version?: string;
@@ -7,4 +12,21 @@ type PackageJson = {
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as PackageJson;
 
-export const cliVersion = pkg.version ?? "0.0.0";
+const packageVersion = pkg.version ?? "0.0.0";
+
+export function resolveCliVersion(executablePath = process.argv[1]): string {
+  try {
+    const paths = resolveInstallStorePaths();
+    const manifest = readInstallManifest(paths);
+    if (!manifest || !isManagedExecutable(executablePath, manifest, paths)) return packageVersion;
+    const provenance =
+      manifest.source === "git"
+        ? `managed git ${manifest.ref ?? manifest.sha ?? "unknown"}`
+        : `managed npm ${manifest.channel}`;
+    return `${packageVersion} (${provenance}; payload ${manifest.payloadPath})`;
+  } catch {
+    return packageVersion;
+  }
+}
+
+export const cliVersion = resolveCliVersion();

--- a/scripts/clean-install-npm.sh
+++ b/scripts/clean-install-npm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+PC_TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install.XXXXXX")"
+PC_HOME="$PC_TEST_ROOT/home"
+PC_CACHE="$PC_TEST_ROOT/npm-cache"
+mkdir -p "$PC_HOME" "$PC_CACHE"
+trap 'rm -rf "$PC_TEST_ROOT"' EXIT
+
+export HOME="$PC_HOME"
+export npm_config_cache="$PC_CACHE"
+export npm_config_userconfig="$PC_HOME/.npmrc"
+export PATH="$PC_HOME/.local/bin:$PATH"
+
+cd "$PC_TEST_ROOT"
+npx --yes --registry https://registry.npmjs.org paperclipai install
+
+test -x "$PC_HOME/.local/bin/paperclipai"
+test -L "$PC_HOME/.paperclip/cli/current"
+test -f "$PC_HOME/.paperclip/cli/install.json"
+paperclipai --version
+
+mkdir -p "$PC_HOME/.paperclip/instances/default"
+touch "$PC_HOME/.paperclip/instances/default/user-data-marker"
+paperclipai uninstall
+
+test ! -e "$PC_HOME/.paperclip/cli"
+test ! -e "$PC_HOME/.local/bin/paperclipai"
+test -f "$PC_HOME/.paperclip/instances/default/user-data-marker"

--- a/scripts/clean-install-npm.sh
+++ b/scripts/clean-install-npm.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PC_INSTALL_DRIVER="${PC_INSTALL_DRIVER:-source}"
+
 PC_TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install.XXXXXX")"
 PC_HOME="$PC_TEST_ROOT/home"
 PC_CACHE="$PC_TEST_ROOT/npm-cache"
@@ -8,22 +11,26 @@ mkdir -p "$PC_HOME" "$PC_CACHE"
 trap 'rm -rf "$PC_TEST_ROOT"' EXIT
 
 export HOME="$PC_HOME"
+export PAPERCLIP_HOME="$PC_HOME/.paperclip"
 export npm_config_cache="$PC_CACHE"
 export npm_config_userconfig="$PC_HOME/.npmrc"
 export PATH="$PC_HOME/.local/bin:$PATH"
 
-cd "$PC_TEST_ROOT"
-npx --yes --registry https://registry.npmjs.org paperclipai install
+if [ "$PC_INSTALL_DRIVER" = "published" ]; then
+  (cd "$PC_TEST_ROOT" && npx --yes --registry https://registry.npmjs.org paperclipai install)
+else
+  (cd "$REPO_ROOT" && pnpm paperclipai install --yes)
+fi
 
 test -x "$PC_HOME/.local/bin/paperclipai"
-test -L "$PC_HOME/.paperclip/cli/current"
-test -f "$PC_HOME/.paperclip/cli/install.json"
+test -L "$PAPERCLIP_HOME/cli/current"
+test -f "$PAPERCLIP_HOME/cli/install.json"
 paperclipai --version
 
-mkdir -p "$PC_HOME/.paperclip/instances/default"
-touch "$PC_HOME/.paperclip/instances/default/user-data-marker"
-paperclipai uninstall
+mkdir -p "$PAPERCLIP_HOME/instances/default"
+touch "$PAPERCLIP_HOME/instances/default/user-data-marker"
+(cd "$REPO_ROOT" && pnpm paperclipai uninstall)
 
-test ! -e "$PC_HOME/.paperclip/cli"
+test ! -e "$PAPERCLIP_HOME/cli"
 test ! -e "$PC_HOME/.local/bin/paperclipai"
-test -f "$PC_HOME/.paperclip/instances/default/user-data-marker"
+test -f "$PAPERCLIP_HOME/instances/default/user-data-marker"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies
> - The CLI is the entrypoint for onboarding, diagnostics, and running a local Paperclip instance
> - Today npm/npx can execute the CLI, but Paperclip has no durable, first-party per-user installation primitive
> - A managed store needs side-by-side payloads, an atomic activation pointer, and provenance so future update and rollback commands have a safe foundation
> - Installation also touches security-sensitive filesystem surfaces, especially shell PATH changes, symlinks, and executable shims
> - This pull request adds the npm-backed managed install core, uninstall flow, provenance reporting, and focused lifecycle tests
> - The benefit is a durable install that remains backward-compatible with existing npx and npm-global usage while making later update/rollback work safe

## Linked Issues or Issue Description

### Subsystem affected

`cli/` — command registration, package installation, executable shims, and version reporting.

### Problem or motivation

Users can run Paperclip through npx or install it globally themselves, but there is no supported durable install command, no stable per-user payload location, and no provenance foundation for safe updates or rollback. Private npm configuration can also redirect package resolution unexpectedly.

### Proposed solution

Add `paperclipai install` with stable, canary, and exact-version npm sources. Install into side-by-side payload directories, smoke-test before an atomic symlink activation, expose install provenance in `--version`, create a stable per-user shim with consent-gated PATH handling, retain two prior payloads, and add `paperclipai uninstall` that leaves user data intact.

### Alternatives considered

- Document only `npm install -g`: rejected because it does not provide atomic activation, retained payloads, provenance, or a Paperclip-owned update foundation.
- Keep npx as the only path: retained for backward compatibility, but rejected as the durable-install solution because the executable remains cache-dependent.
- Make the shim a symlink directly to a versioned payload: rejected because a stable script shim survives payload switches and allows consistent environment handling.

### Roadmap alignment

`ROADMAP.md` does not currently list a managed CLI installer. This is additive CLI infrastructure and does not overlap the listed roadmap initiatives.

### Additional context

The design follows the repository's existing npm release artifacts and keeps all instance state under `~/.paperclip` separate from managed code. The security-sensitive filesystem behavior is explicitly covered by focused tests and a dedicated security review request.

## What Changed

- Added a `~/.paperclip/cli` install store with npm/version payload layout, private manifest writes, atomic `current` symlink flips, and current-plus-two-previous retention.
- Added `paperclipai install`, including stable/canary/pinned source selection, public-registry isolation, Node 20 enforcement, staged npm installation, and pre-activation smoke checks.
- Added a marked `~/.local/bin/paperclipai` shim and consent-gated bash/zsh PATH blocks; non-interactive installs print manual PATH instructions.
- Added `paperclipai uninstall`, preserving instance data and refusing to overwrite or remove non-managed shims.
- Serialized install and uninstall store mutations with a fail-closed exclusive lock; existing locks are never removed automatically.
- Hardened store/shim ownership with a private store marker, exact versioned shim identity, pinned runtime/store paths, symlink-root checks, and current-target provenance validation.
- Added managed provenance to `paperclipai --version` and a clean-HOME npm smoke script.
- Added unit coverage for layout, manifest I/O, crash-before-flip safety, retention pruning, symlink defenses, shim ownership, source selection, provenance, and uninstall data preservation.

## Verification

- `pnpm --filter paperclipai exec vitest run src/__tests__/install-store.test.ts src/__tests__/install-command.test.ts`
- `pnpm --filter paperclipai typecheck`
- `pnpm --filter paperclipai build`
- `./scripts/clean-install-npm.sh` — fresh HOME → branch installer resolves and installs public `paperclipai@2026.720.0` → shim runs → branch uninstall removes managed code → user-data marker remains.
- The smoke defaults to the branch CLI as the install/uninstall driver, so it validates the unreleased commands while still exercising a real public-registry payload.
- Latest head `8828a8795f38b4207b165ddccb6d73fe79ee673c`: 16 focused tests passed, all 25 remote checks reached terminal success/neutral/skipped states, Greptile passed with zero new comments, and zero review threads remain unresolved.
- SecurityEngineer re-review approved the filesystem hardening with no blocking findings.

## Risks

- Shell startup files are sensitive: edits are limited to an idempotent marked block, require interactive confirmation (or explicit `--yes` consent), and are skipped in non-TTY contexts.
- Symlink replacement is sensitive: activation rejects payloads resolving outside the managed store, refuses non-symlink `current` paths, and refuses pre-existing non-managed or symlinked shims.
- Filesystem rename atomicity is POSIX-oriented; Windows support remains through WSL rather than native Windows shells.
- A crashed process can leave `.install.lock`; recovery intentionally fails closed and requires the user to confirm no installer is active before deleting that lock.
- The initial managed release must contain these commands for shim-driven provenance and uninstall; older already-published payloads naturally do not have unreleased behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI `gpt-5.5` via Codex CLI, with repository tools, shell execution, and code/test iteration. Context-window size is not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant command help and executable verification coverage to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge