### PR TITLE
fix(release): add npm publish crash diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,15 @@ jobs:
           GITHUB_ACTIONS: "true"
         run: ./scripts/release.sh canary --skip-verify
 
+      - name: Dump npm debug logs
+        if: failure()
+        run: |
+          shopt -s nullglob
+          for f in "$HOME"/.npm/_logs/*.log; do
+            echo "===== $f ====="
+            tail -n 300 "$f"
+          done
+
       - name: Push canary tag
         run: |
           tag="$(git tag --points-at HEAD | grep '^canary/v' | head -1)"
@@ -183,6 +192,15 @@ jobs:
             args+=(--date "${{ inputs.stable_date }}")
           fi
           ./scripts/release.sh "${args[@]}"
+
+      - name: Dump npm debug logs
+        if: failure()
+        run: |
+          shopt -s nullglob
+          for f in "$HOME"/.npm/_logs/*.log; do
+            echo "===== $f ====="
+            tail -n 300 "$f"
+          done
 
       - name: Push stable tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
           shopt -s nullglob
           for f in "$HOME"/.npm/_logs/*.log; do
             echo "===== $f ====="
-            tail -n 300 "$f"
+            tail -n 300 "$f" | sed -E \
+              -e 's#((authorization|_authToken|_auth|node_auth_token|npm_token)"?[[:space:]]*[:=][[:space:]]*"?)(Bearer[[:space:]]+)?[^",[:space:]]+#\1***REDACTED***#Ig'
           done
 
       - name: Push canary tag
@@ -199,7 +200,8 @@ jobs:
           shopt -s nullglob
           for f in "$HOME"/.npm/_logs/*.log; do
             echo "===== $f ====="
-            tail -n 300 "$f"
+            tail -n 300 "$f" | sed -E \
+              -e 's#((authorization|_authToken|_auth|node_auth_token|npm_token)"?[[:space:]]*[:=][[:space:]]*"?)(Bearer[[:space:]]+)?[^",[:space:]]+#\1***REDACTED***#Ig'
           done
 
       - name: Push stable tag

--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -36,7 +36,8 @@ test("bundled package staging materializes publishConfig entrypoints", () => {
 test("bundled package dry runs preview without querying published versions", () => {
   assert.match(releaseScript, /run_bundled_npm_pack pack --pack-destination "\$publish_dir"/);
   assert.match(releaseLib, /BUNDLED_NPM_PACK_VERSION="10\.9\.7"/);
-  assert.match(releaseLib, /BUNDLED_NPM_PUBLISH_VERSION="11\.16\.0"/);
+  assert.match(releaseLib, /BUNDLED_NPM_PUBLISH_VERSION="11\.18\.0"/);
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PACK_VERSION"/);
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PUBLISH_VERSION"/);
+  assert.match(releaseLib, /"\$@" --loglevel verbose/);
 });

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -311,14 +311,14 @@ package_publish_tool() {
 }
 
 BUNDLED_NPM_PACK_VERSION="10.9.7"
-BUNDLED_NPM_PUBLISH_VERSION="11.16.0"
+BUNDLED_NPM_PUBLISH_VERSION="11.18.0"
 
 run_bundled_npm_pack() {
   npx --yes "npm@$BUNDLED_NPM_PACK_VERSION" "$@"
 }
 
 run_bundled_npm_publish() {
-  npx --yes "npm@$BUNDLED_NPM_PUBLISH_VERSION" "$@"
+  npx --yes "npm@$BUNDLED_NPM_PUBLISH_VERSION" "$@" --loglevel verbose
 }
 
 run_package_publish() {

--- a/scripts/release-lib.test.mjs
+++ b/scripts/release-lib.test.mjs
@@ -91,7 +91,7 @@ exit 1
 set -euo pipefail
 printf 'npx %s\n' "$*" >> "$FAKE_CALL_LOG"
 [ "$1" = "--yes" ] && shift
-[ "$1" = "npm@11.16.0" ] && shift
+[ "$1" = "npm@11.18.0" ] && shift
 exec npm "$@"
 `,
   );
@@ -145,8 +145,11 @@ test("publish_package_to_npm uses trusted-publishing-capable npm for bundled dep
   const result = runPublishHelper({ pnpmMode: "success", publishTool: "npm" });
 
   assert.equal(result.status, 0);
-  assert.match(result.calls, /^npx --yes npm@11\.16\.0 publish --tag canary --access public$/m);
-  assert.match(result.calls, /^npm publish --tag canary --access public$/m);
+  assert.match(
+    result.calls,
+    /^npx --yes npm@11\.18\.0 publish --tag canary --access public --loglevel verbose$/m,
+  );
+  assert.match(result.calls, /^npm publish --tag canary --access public --loglevel verbose$/m);
   assert.doesNotMatch(result.calls, /^pnpm publish/m);
 });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip publishes a coordinated set of packages through its release workflows
> - Bundled packages use a pinned npm CLI so trusted publishing works consistently
> - The canary publisher now crashes deterministically inside npm before useful output reaches the workflow log
> - The npm debug log that contains the underlying failure disappears with the hosted runner
> - This pull request upgrades the pinned publish CLI and preserves both verbose HTTP activity and npm debug logs on failure
> - The benefit is that the plausible HTTP-layer fix ships immediately, while any remaining CI-only failure becomes diagnosable

## Linked Issues or Issue Description

- **Problem:** The canary release workflow fails on the first bundled package with `npm error Exit handler never called!` and no preceding diagnostic output.
- **Expected behavior:** Bundled packages publish through trusted publishing, or the workflow retains enough npm diagnostics to identify the actual failure.
- **Reproduction:** Run the canary release workflow in GitHub Actions; the failure reproduced on both attempts of run 29948506814.
- **Version/commit:** Current `master` after #10024 and #10030.
- **Deployment mode:** GitHub-hosted release workflow using Node.js 24 and npm trusted publishing.
- Related: #10024, #10030.

## What Changed

- Bumped the bundled publish CLI from npm 11.16.0 to npm 11.18.0.
- Added `--loglevel verbose` to bundled npm publish invocations.
- Dumped the last 300 lines of every npm debug log after failed canary or stable publishes, with common registry credential forms redacted.
- Updated release assertions to pin npm 11.18.0 and verify verbose logging.

## Verification

- `pnpm test:release-registry` — 66 tests passed.
- `bash -n scripts/release-lib.sh`.
- Parsed `.github/workflows/release.yml` with Python/PyYAML.
- Smoke-tested npm log redaction with representative Authorization, `_authToken`, and token environment values.
- Smoke-tested npm debug-log redaction against Authorization, `_authToken`, and `npm_token` examples.
- `git diff --check origin/master...HEAD`.
- The merge-triggered canary workflow remains the live trusted-publishing verification.

## Risks

- Low code risk: changes are isolated to the release publisher and its workflow diagnostics.
- npm 11.18.0 could expose a different registry/runtime regression; failure-time debug log dumping makes that actionable.
- Verbose npm output increases release log volume but does not change package contents or dist-tags; common credential forms are redacted before debug logs are printed.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.3 Codex, tool-enabled coding agent with repository and shell execution; context window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge



