### PR TITLE
feat(cli): add managed install, service, and update workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,16 @@ jobs:
           GITHUB_ACTIONS: "true"
         run: ./scripts/release.sh canary --skip-verify
 
+      - name: Dump npm debug logs
+        if: failure()
+        run: |
+          shopt -s nullglob
+          for f in "$HOME"/.npm/_logs/*.log; do
+            echo "===== $f ====="
+            tail -n 300 "$f" | sed -E \
+              -e 's#((authorization|_authToken|_auth|node_auth_token|npm_token)"?[[:space:]]*[:=][[:space:]]*"?)(Bearer[[:space:]]+)?[^",[:space:]]+#\1***REDACTED***#Ig'
+          done
+
       - name: Push canary tag
         run: |
           tag="$(git tag --points-at HEAD | grep '^canary/v' | head -1)"
@@ -183,6 +193,16 @@ jobs:
             args+=(--date "${{ inputs.stable_date }}")
           fi
           ./scripts/release.sh "${args[@]}"
+
+      - name: Dump npm debug logs
+        if: failure()
+        run: |
+          shopt -s nullglob
+          for f in "$HOME"/.npm/_logs/*.log; do
+            echo "===== $f ====="
+            tail -n 300 "$f" | sed -E \
+              -e 's#((authorization|_authToken|_auth|node_auth_token|npm_token)"?[[:space:]]*[:=][[:space:]]*"?)(Bearer[[:space:]]+)?[^",[:space:]]+#\1***REDACTED***#Ig'
+          done
 
       - name: Push stable tag
         run: |

--- a/README.md
+++ b/README.md
@@ -301,7 +301,14 @@ Paperclip is a full control plane, not a wrapper. Before you build any of this y
 Open source. Self-hosted. No Paperclip account required.
 
 ```bash
-curl -fsSL https://paperclip.ing/install.sh | bash
+curl -fsSLO https://paperclip.ing/install.sh
+curl -fsSLO https://paperclip.ing/install.sh.sha256
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c install.sh.sha256
+else
+  shasum -a 256 -c install.sh.sha256
+fi
+bash install.sh
 ```
 
 The installer ensures Node.js 20 or newer is available, installs a managed

--- a/README.md
+++ b/README.md
@@ -301,7 +301,25 @@ Paperclip is a full control plane, not a wrapper. Before you build any of this y
 Open source. Self-hosted. No Paperclip account required.
 
 ```bash
-npx paperclipai onboard --yes
+curl -fsSL https://paperclip.ing/install.sh | bash
+```
+
+The installer ensures Node.js 20 or newer is available, installs a managed
+Paperclip CLI under `~/.paperclip/cli`, and starts interactive onboarding. It
+can also install Paperclip as a background service on supported Linux and
+macOS systems.
+
+For a non-interactive managed install:
+
+```bash
+curl -fsSL https://paperclip.ing/install.sh | bash -s -- --no-prompt --no-onboard
+paperclipai onboard --yes
+```
+
+To try Paperclip without installing anything permanently:
+
+```bash
+npx --registry https://registry.npmjs.org paperclipai onboard --yes
 ```
 
 > **Troubleshooting: private npm registry `.npmrc`**
@@ -323,12 +341,15 @@ npx paperclipai onboard --yes
 That quickstart path now defaults to trusted local loopback mode for the fastest first run. To start in authenticated/private mode instead, choose a bind preset explicitly:
 
 ```bash
-npx paperclipai onboard --yes --bind lan
+paperclipai onboard --yes --bind lan
 # or:
-npx paperclipai onboard --yes --bind tailnet
+paperclipai onboard --yes --bind tailnet
 ```
 
 If you already have Paperclip configured, rerunning `onboard` keeps the existing config in place. Use `paperclipai configure` to edit settings.
+
+See [`doc/INSTALLING.md`](doc/INSTALLING.md) for pinned versions, canary and
+git-ref installs, updates, rollback, service management, and uninstalling.
 
 Or manually:
 

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -97,4 +97,27 @@ describe("managed install commands", () => {
     expect(fs.existsSync(paths.shimPath)).toBe(false);
     expect(fs.readFileSync(userData, "utf8")).toBe("keep");
   });
+
+  it("rejects a symlinked installs root before npm writes outside the store", async () => {
+    const paths = resolveInstallStorePaths();
+    const outside = path.join(root, "outside");
+    fs.mkdirSync(paths.cliRoot, { recursive: true });
+    fs.mkdirSync(outside);
+    fs.symlinkSync(outside, paths.installsRoot, "dir");
+    const runCommand = vi.fn(async () => ({ stdout: JSON.stringify("2026.720.0"), stderr: "" }));
+
+    await expect(installCommand({}, { runCommand })).rejects.toThrow("non-directory install-store path");
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expect(fs.readdirSync(outside)).toEqual([]);
+  });
+
+  it("refuses to uninstall an unverified cli directory", async () => {
+    const paths = resolveInstallStorePaths();
+    const unrelatedFile = path.join(paths.cliRoot, "keep.txt");
+    fs.mkdirSync(paths.cliRoot, { recursive: true });
+    fs.writeFileSync(unrelatedFile, "keep");
+
+    await expect(uninstallCommand()).rejects.toThrow("unverified install store");
+    expect(fs.readFileSync(unrelatedFile, "utf8")).toBe("keep");
+  });
 });

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -85,6 +85,27 @@ describe("managed install commands", () => {
     expect(runCommand.mock.calls[0]?.[0]).toBe(process.execPath);
   });
 
+  it("installs a GitHub branch through codeload and reuses the resolved SHA", async () => {
+    const sha = "c".repeat(40);
+    const runCommand = vi.fn(async (file: string, args: string[]) => {
+      if (file === "curl" && !args.includes("--output")) return { stdout: JSON.stringify({ sha }), stderr: "" };
+      if (file === "curl") { fs.writeFileSync(args[args.indexOf("--output") + 1], "archive"); return { stdout: "", stderr: "" }; }
+      if (file === "tar") { const checkout = args[args.indexOf("-C") + 1]; fs.mkdirSync(path.join(checkout, "cli"), { recursive: true }); fs.writeFileSync(path.join(checkout, "cli", "package.json"), JSON.stringify({ version: "0.3.1" })); return { stdout: "", stderr: "" }; }
+      if (file === "corepack" || file === "bash") return { stdout: "", stderr: "" };
+      if (file === "npm" && args[0] === "pack") { fs.writeFileSync(path.join(args[args.indexOf("--pack-destination") + 1], "paperclipai-0.3.1.tgz"), "package"); return { stdout: "", stderr: "" }; }
+      if (file === "npm" && args[0] === "install") { const prefix = args[args.indexOf("--prefix") + 1]; const packageRoot = path.join(prefix, "node_modules", "paperclipai"); fs.mkdirSync(path.join(packageRoot, "dist"), { recursive: true }); fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ version: "0.3.1" })); fs.writeFileSync(path.join(packageRoot, "dist", "index.js"), "#!/usr/bin/env node\n"); return { stdout: "", stderr: "" }; }
+      if (file === process.execPath) return { stdout: "0.3.1\n", stderr: "" };
+      throw new Error(`Unexpected command: ${file} ${args.join(" ")}`);
+    });
+    await installCommand({ ref: "master", repo: "HenkDz/paperclip" }, { runCommand });
+    await installCommand({ ref: "master", repo: "HenkDz/paperclip" }, { runCommand });
+    const manifest = readInstallManifest(resolveInstallStorePaths());
+    expect(manifest).toMatchObject({ source: "git", repo: "HenkDz/paperclip", ref: "master", sha });
+    expect(manifest?.payloadPath).toContain(path.join("git", sha.slice(0, 12)));
+    expect(runCommand.mock.calls.filter(([command, args]) => command === "curl" && args.includes("--output"))).toHaveLength(1);
+    expect(runCommand.mock.calls.filter(([command]) => command === "corepack")).toHaveLength(1);
+  });
+
   it("installs through the shim, reports provenance, and uninstalls without deleting user data", async () => {
     const version = "2026.720.0";
     const runCommand = vi.fn(async (file: string, args: string[], _options?: unknown) => {

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -79,8 +79,20 @@ describe("managed install commands", () => {
     const userData = path.join(process.env.PAPERCLIP_HOME!, "instances", "default", "keep.txt");
     fs.mkdirSync(path.dirname(userData), { recursive: true });
     fs.writeFileSync(userData, "keep");
-    await uninstallCommand();
+    const uninstallService = vi.fn(async () => {
+      expect(fs.existsSync(paths.shimPath)).toBe(true);
+    });
+    await uninstallCommand({
+      detectServiceManager: vi.fn(async () => ({
+        supported: true as const,
+        manager: {
+          status: vi.fn(async () => ({ installed: true, active: true })),
+          uninstall: uninstallService,
+        } as never,
+      })),
+    });
 
+    expect(uninstallService).toHaveBeenCalledOnce();
     expect(fs.existsSync(paths.cliRoot)).toBe(false);
     expect(fs.existsSync(paths.shimPath)).toBe(false);
     expect(fs.readFileSync(userData, "utf8")).toBe("keep");

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installCommand, resolveNpmInstallRequest } from "../commands/install.js";
+import { uninstallCommand } from "../commands/uninstall.js";
+import { readInstallManifest, resolveInstallStorePaths } from "../install-store.js";
+import { resolveCliVersion } from "../version.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("managed install commands", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-command-"));
+    process.env = {
+      ...ORIGINAL_ENV,
+      HOME: path.join(root, "home"),
+      PAPERCLIP_HOME: path.join(root, "home", ".paperclip"),
+      PATH: "/usr/bin:/bin",
+      SHELL: "/bin/bash",
+    };
+    fs.mkdirSync(process.env.HOME!, { recursive: true });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("selects stable, canary, and exact-version npm sources", () => {
+    expect(resolveNpmInstallRequest({})).toEqual({ spec: "latest", channel: "latest" });
+    expect(resolveNpmInstallRequest({ canary: true })).toEqual({ spec: "canary", channel: "canary" });
+    expect(resolveNpmInstallRequest({ version: "2026.720.0" })).toEqual({
+      spec: "2026.720.0",
+      channel: "pinned",
+    });
+    expect(() => resolveNpmInstallRequest({ canary: true, version: "1.2.3" })).toThrow();
+    expect(() => resolveNpmInstallRequest({ version: "latest" })).toThrow();
+  });
+
+  it("installs through the shim, reports provenance, and uninstalls without deleting user data", async () => {
+    const version = "2026.720.0";
+    const runCommand = vi.fn(async (file: string, args: string[], _options?: unknown) => {
+      if (file === "npm" && args[0] === "view") return { stdout: JSON.stringify(version), stderr: "" };
+      if (file === "npm" && args[0] === "install") {
+        const prefix = args[args.indexOf("--prefix") + 1];
+        const entrypoint = path.join(prefix, "node_modules", "paperclipai", "dist", "index.js");
+        fs.mkdirSync(path.dirname(entrypoint), { recursive: true });
+        fs.writeFileSync(entrypoint, "#!/usr/bin/env node\n");
+        return { stdout: "", stderr: "" };
+      }
+      if (file === process.execPath && args.at(-1) === "--version") {
+        return { stdout: `${version}\n`, stderr: "" };
+      }
+      throw new Error(`Unexpected command: ${file} ${args.join(" ")}`);
+    });
+
+    await installCommand({}, { runCommand, now: () => new Date("2026-07-22T18:00:00.000Z") });
+
+    const paths = resolveInstallStorePaths();
+    const manifest = readInstallManifest(paths);
+    expect(manifest?.version).toBe(version);
+    expect(manifest?.channel).toBe("latest");
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(manifest!.payloadPath));
+    expect(fs.existsSync(paths.shimPath)).toBe(true);
+    const installCall = runCommand.mock.calls.find(
+      ([file, args]) => file === "npm" && args[0] === "install",
+    );
+    expect(installCall?.[1]).toContain("--@paperclipai:registry=https://registry.npmjs.org");
+    const installOptions = installCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(installOptions?.env?.npm_config_userconfig).toContain(".npmrc-");
+    const entrypoint = path.join(manifest!.payloadPath, "node_modules", "paperclipai", "dist", "index.js");
+    expect(resolveCliVersion(entrypoint)).toContain(`managed npm latest; payload ${manifest!.payloadPath}`);
+
+    const userData = path.join(process.env.PAPERCLIP_HOME!, "instances", "default", "keep.txt");
+    fs.mkdirSync(path.dirname(userData), { recursive: true });
+    fs.writeFileSync(userData, "keep");
+    await uninstallCommand();
+
+    expect(fs.existsSync(paths.cliRoot)).toBe(false);
+    expect(fs.existsSync(paths.shimPath)).toBe(false);
+    expect(fs.readFileSync(userData, "utf8")).toBe("keep");
+  });
+});

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { installCommand, resolveNpmInstallRequest } from "../commands/install.js";
+import { installCommand, installGitPayload, resolveGitHubRef, resolveGitInstallRequest, resolveNpmInstallRequest } from "../commands/install.js";
 import { uninstallCommand } from "../commands/uninstall.js";
 import {
   INSTALL_MANIFEST_VERSION,
@@ -49,6 +49,40 @@ describe("managed install commands", () => {
     });
     expect(() => resolveNpmInstallRequest({ canary: true, version: "1.2.3" })).toThrow();
     expect(() => resolveNpmInstallRequest({ version: "latest" })).toThrow();
+  });
+
+  it("resolves branch, tag, full SHA, and short SHA refs through GitHub", async () => {
+    const sha = "a".repeat(40);
+    const runCommand = vi.fn(async (_file: string, _args: string[]) => ({ stdout: JSON.stringify({ sha }), stderr: "" }));
+    for (const ref of ["master", "v1.2.3", sha, sha.slice(0, 12)]) {
+      await expect(resolveGitHubRef("paperclipai/paperclip", ref, runCommand)).resolves.toBe(sha);
+    }
+    expect(runCommand.mock.calls.map((call) => call[1].at(-1))).toEqual([
+      "https://api.github.com/repos/paperclipai/paperclip/commits/master",
+      "https://api.github.com/repos/paperclipai/paperclip/commits/v1.2.3",
+      `https://api.github.com/repos/paperclipai/paperclip/commits/${sha}`,
+      `https://api.github.com/repos/paperclipai/paperclip/commits/${sha.slice(0, 12)}`,
+    ]);
+  });
+
+  it("supports fork overrides and classifies SHA refs as pinned", () => {
+    expect(resolveGitInstallRequest({ ref: "feature/test", repo: "HenkDz/paperclip" })).toEqual({ repo: "HenkDz/paperclip", ref: "feature/test", pinned: false });
+    expect(resolveGitInstallRequest({ ref: "abcdef1" })).toEqual({ repo: "paperclipai/paperclip", ref: "abcdef1", pinned: true });
+    expect(() => resolveGitInstallRequest({ repo: "HenkDz/paperclip" })).toThrow("requires --ref");
+  });
+
+  it("reuses a SHA-keyed git payload without downloading or rebuilding", async () => {
+    const sha = "b".repeat(40);
+    const paths = resolveInstallStorePaths();
+    const payloadPath = payloadPathFor(paths, "git", sha.slice(0, 12));
+    const packageRoot = path.join(payloadPath, "node_modules", "paperclipai");
+    fs.mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ version: "0.3.1" }));
+    fs.writeFileSync(path.join(packageRoot, "dist", "index.js"), "#!/usr/bin/env node\n");
+    const runCommand = vi.fn(async (_file: string, _args: string[]) => ({ stdout: "0.3.1\n", stderr: "" }));
+    await expect(installGitPayload("paperclipai/paperclip", sha, runCommand, paths)).resolves.toEqual({ payloadPath, reused: true, version: "0.3.1" });
+    expect(runCommand).toHaveBeenCalledOnce();
+    expect(runCommand.mock.calls[0]?.[0]).toBe(process.execPath);
   });
 
   it("installs through the shim, reports provenance, and uninstalls without deleting user data", async () => {

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -4,7 +4,16 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installCommand, resolveNpmInstallRequest } from "../commands/install.js";
 import { uninstallCommand } from "../commands/uninstall.js";
-import { readInstallManifest, resolveInstallStorePaths } from "../install-store.js";
+import {
+  INSTALL_MANIFEST_VERSION,
+  flipCurrentAtomic,
+  initializeInstallStore,
+  payloadPathFor,
+  readInstallManifest,
+  resolveInstallStorePaths,
+  withInstallStoreLock,
+  writeInstallManifestAtomic,
+} from "../install-store.js";
 import { resolveCliVersion } from "../version.js";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -119,5 +128,30 @@ describe("managed install commands", () => {
 
     await expect(uninstallCommand()).rejects.toThrow("unverified install store");
     expect(fs.readFileSync(unrelatedFile, "utf8")).toBe("keep");
+  });
+
+  it("refuses to uninstall while another store mutation holds the lock", async () => {
+    const paths = resolveInstallStorePaths();
+    const payloadPath = payloadPathFor(paths, "npm", "2026.720.0");
+    initializeInstallStore(paths);
+    fs.mkdirSync(payloadPath, { recursive: true });
+    flipCurrentAtomic(payloadPath, paths);
+    writeInstallManifestAtomic({
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      source: "npm",
+      version: "2026.720.0",
+      channel: "latest",
+      payloadPath,
+      installedAt: "2026-07-22T18:00:00.000Z",
+      previous: [],
+    }, paths);
+
+    await withInstallStoreLock(
+      async () => {
+        await expect(uninstallCommand()).rejects.toThrow("already running");
+      },
+      paths,
+    );
+    expect(fs.existsSync(paths.lockPath)).toBe(false);
   });
 });

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installCommand, installGitPayload, resolveGitHubRef, resolveGitInstallRequest, resolveNpmInstallRequest } from "../commands/install.js";
 import { uninstallCommand } from "../commands/uninstall.js";
+import { resolvePaperclipInstanceId } from "../config/home.js";
 import {
   INSTALL_MANIFEST_VERSION,
   flipCurrentAtomic,
@@ -15,6 +16,7 @@ import {
   writeInstallManifestAtomic,
 } from "../install-store.js";
 import { resolveCliVersion } from "../version.js";
+import { systemdServiceName } from "../services/service-manager.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -171,7 +173,7 @@ describe("managed install commands", () => {
       ".config",
       "systemd",
       "user",
-      "paperclipai.service",
+      systemdServiceName(resolvePaperclipInstanceId()),
     );
     fs.mkdirSync(path.dirname(unitPath), { recursive: true });
     fs.writeFileSync(unitPath, "unit");

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -164,6 +164,25 @@ describe("managed install commands", () => {
     expect(fs.readFileSync(userData, "utf8")).toBe("keep");
   });
 
+  it("refuses to remove the shared CLI while another instance service is installed", async () => {
+    const paths = resolveInstallStorePaths();
+    const otherUnitPath = path.join(process.env.HOME!, ".config", "systemd", "user", systemdServiceName("team-a"));
+    fs.mkdirSync(path.dirname(otherUnitPath), { recursive: true });
+    fs.writeFileSync(otherUnitPath, "unit");
+
+    await expect(uninstallCommand({
+      detectServiceManager: vi.fn(async () => ({
+        supported: true as const,
+        manager: { status: vi.fn(async () => ({ installed: false, active: false })) } as never,
+      })),
+      platform: "linux",
+      userHomeDir: process.env.HOME!,
+    })).rejects.toThrow("other instance services are installed");
+
+    expect(fs.existsSync(paths.cliRoot)).toBe(false);
+    expect(fs.existsSync(otherUnitPath)).toBe(true);
+  });
+
   it("preserves the managed install when an existing systemd unit cannot be checked", async () => {
     const paths = resolveInstallStorePaths();
     fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });

--- a/cli/src/__tests__/install-command.test.ts
+++ b/cli/src/__tests__/install-command.test.ts
@@ -107,6 +107,33 @@ describe("managed install commands", () => {
     expect(fs.readFileSync(userData, "utf8")).toBe("keep");
   });
 
+  it("preserves the managed install when an existing systemd unit cannot be checked", async () => {
+    const paths = resolveInstallStorePaths();
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, "managed shim");
+    const unitPath = path.join(
+      process.env.HOME!,
+      ".config",
+      "systemd",
+      "user",
+      "paperclipai.service",
+    );
+    fs.mkdirSync(path.dirname(unitPath), { recursive: true });
+    fs.writeFileSync(unitPath, "unit");
+
+    await expect(uninstallCommand({
+      detectServiceManager: vi.fn(async () => ({
+        supported: false as const,
+        reason: "No usable systemd user manager was detected",
+      })),
+      platform: "linux",
+      userHomeDir: process.env.HOME!,
+    })).rejects.toThrow("Cannot verify or remove the background service");
+
+    expect(fs.existsSync(paths.shimPath)).toBe(true);
+    expect(fs.existsSync(unitPath)).toBe(true);
+  });
+
   it("rejects a symlinked installs root before npm writes outside the store", async () => {
     const paths = resolveInstallStorePaths();
     const outside = path.join(root, "outside");

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   INSTALL_MANIFEST_VERSION,
+  MANAGED_SHIM_MARKER,
   addManagedPathBlock,
   buildNextManifest,
   flipCurrentAtomic,
@@ -125,5 +126,29 @@ describe("managed install store", () => {
     fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
     fs.writeFileSync(paths.shimPath, "#!/bin/sh\necho other-command\n");
     expect(() => writeManagedShim(paths)).toThrow("non-managed command");
+  });
+
+  it("refuses symlinked rc files, unsafe shim parents, and multiply linked shims", () => {
+    const outsideRc = path.join(root, "outside-rc");
+    fs.writeFileSync(outsideRc, "keep\n");
+    const rcPath = path.join(root, "home", ".bashrc");
+    fs.mkdirSync(path.dirname(rcPath), { recursive: true });
+    fs.symlinkSync(outsideRc, rcPath);
+    expect(() => addManagedPathBlock(rcPath)).toThrow("non-regular shell rc file");
+    expect(() => removeManagedPathBlock(rcPath)).toThrow("non-regular shell rc file");
+    expect(fs.readFileSync(outsideRc, "utf8")).toBe("keep\n");
+
+    fs.rmSync(rcPath);
+    const localDir = path.join(root, "home", ".local");
+    const outsideBin = path.join(root, "outside-bin");
+    fs.mkdirSync(outsideBin);
+    fs.symlinkSync(outsideBin, localDir, "dir");
+    expect(() => writeManagedShim(paths)).toThrow("unsafe shim directory");
+
+    fs.rmSync(localDir);
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, `# ${MANAGED_SHIM_MARKER}\n`);
+    fs.linkSync(paths.shimPath, path.join(root, "linked-shim"));
+    expect(() => writeManagedShim(paths)).toThrow("multiply linked shim");
   });
 });

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  INSTALL_MANIFEST_VERSION,
+  addManagedPathBlock,
+  buildNextManifest,
+  flipCurrentAtomic,
+  payloadPathFor,
+  pruneInstallPayloads,
+  readInstallManifest,
+  removeManagedPathBlock,
+  resolveInstallStorePaths,
+  writeInstallManifestAtomic,
+  writeManagedShim,
+  type InstallManifest,
+  type InstallRecord,
+} from "../install-store.js";
+
+function record(payloadPath: string, version: string): InstallRecord {
+  return {
+    source: "npm",
+    version,
+    channel: "latest",
+    payloadPath,
+    installedAt: `2026-07-${version.padStart(2, "0")}T00:00:00.000Z`,
+  };
+}
+
+describe("managed install store", () => {
+  let root: string;
+  let paths: ReturnType<typeof resolveInstallStorePaths>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-store-"));
+    paths = resolveInstallStorePaths({
+      homeDir: path.join(root, "home"),
+      paperclipHome: path.join(root, "home", ".paperclip"),
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves the documented npm and git payload layout", () => {
+    expect(payloadPathFor(paths, "npm", "2026.720.0")).toBe(
+      path.join(paths.cliRoot, "installs", "npm", "2026.720.0"),
+    );
+    expect(payloadPathFor(paths, "git", "ab12cd34ef56")).toBe(
+      path.join(paths.cliRoot, "installs", "git", "ab12cd34ef56"),
+    );
+  });
+
+  it("writes and reads the manifest atomically with private permissions", () => {
+    const payloadPath = payloadPathFor(paths, "npm", "1.2.3");
+    const manifest: InstallManifest = {
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      ...record(payloadPath, "1.2.3"),
+      previous: [],
+    };
+    writeInstallManifestAtomic(manifest, paths);
+    expect(readInstallManifest(paths)).toEqual(manifest);
+    expect(fs.statSync(paths.manifestPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("leaves the old current payload working when interrupted before rename", () => {
+    const oldPayload = payloadPathFor(paths, "npm", "1.0.0");
+    const newPayload = payloadPathFor(paths, "npm", "2.0.0");
+    fs.mkdirSync(oldPayload, { recursive: true });
+    fs.mkdirSync(newPayload, { recursive: true });
+    flipCurrentAtomic(oldPayload, paths);
+
+    expect(() =>
+      flipCurrentAtomic(newPayload, paths, {
+        beforeRename: () => {
+          throw new Error("simulated crash");
+        },
+      }),
+    ).toThrow("simulated crash");
+
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(oldPayload));
+    expect(fs.readdirSync(paths.cliRoot).filter((entry) => entry.startsWith(".current-"))).toEqual([]);
+  });
+
+  it("retains current plus two previous payloads and prunes older entries", () => {
+    const payloads = ["1", "2", "3", "4"].map((version) => payloadPathFor(paths, "npm", version));
+    for (const payload of payloads) fs.mkdirSync(payload, { recursive: true });
+    const previousManifest: InstallManifest = {
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      ...record(payloads[2], "3"),
+      previous: [record(payloads[1], "2"), record(payloads[0], "1")],
+    };
+    const next = buildNextManifest(record(payloads[3], "4"), previousManifest);
+
+    expect(next.previous.map((entry) => entry.version)).toEqual(["3", "2"]);
+    expect(pruneInstallPayloads(next, paths)).toEqual([payloads[0]]);
+    expect(fs.existsSync(payloads[0])).toBe(false);
+    expect(payloads.slice(1).every((payload) => fs.existsSync(payload))).toBe(true);
+  });
+
+  it("writes a stable shim and manages an idempotent shell PATH block", () => {
+    writeManagedShim(paths);
+    const shim = fs.readFileSync(paths.shimPath, "utf8");
+    expect(shim).toContain("$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js");
+    expect(fs.statSync(paths.shimPath).mode & 0o777).toBe(0o755);
+
+    const rcPath = path.join(root, "home", ".bashrc");
+    expect(addManagedPathBlock(rcPath)).toBe(true);
+    expect(addManagedPathBlock(rcPath)).toBe(false);
+    expect(removeManagedPathBlock(rcPath)).toBe(true);
+    expect(fs.readFileSync(rcPath, "utf8")).not.toContain("paperclipai managed PATH");
+  });
+
+  it("refuses symlinked payload roots and pre-existing non-managed shims", () => {
+    const outside = path.join(root, "outside");
+    fs.mkdirSync(outside, { recursive: true });
+    fs.mkdirSync(paths.installsRoot, { recursive: true });
+    fs.symlinkSync(outside, path.join(paths.installsRoot, "npm"), "dir");
+    const escapedPayload = path.join(paths.installsRoot, "npm", "1.2.3");
+    fs.mkdirSync(path.join(outside, "1.2.3"));
+    expect(() => flipCurrentAtomic(escapedPayload, paths)).toThrow("resolves outside");
+
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, "#!/bin/sh\necho other-command\n");
+    expect(() => writeManagedShim(paths)).toThrow("non-managed command");
+  });
+});

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -138,6 +138,15 @@ describe("managed install store", () => {
     expect(fs.existsSync(paths.lockPath)).toBe(false);
   });
 
+  it("fails closed without replacing a stale-looking lock", async () => {
+    const staleToken = "999999:stale";
+    await withInstallStoreLock(async () => undefined, paths);
+    fs.writeFileSync(paths.lockPath, `${staleToken}\n`, { mode: 0o600 });
+
+    await expect(withInstallStoreLock(async () => undefined, paths)).rejects.toThrow("stale lock");
+    expect(fs.readFileSync(paths.lockPath, "utf8")).toBe(`${staleToken}\n`);
+  });
+
   it("reports managed provenance only for the payload selected by current", () => {
     const manifestPayload = payloadPathFor(paths, "npm", "1.0.0");
     const currentPayload = payloadPathFor(paths, "npm", "2.0.0");

--- a/cli/src/__tests__/install-store.test.ts
+++ b/cli/src/__tests__/install-store.test.ts
@@ -8,11 +8,14 @@ import {
   addManagedPathBlock,
   buildNextManifest,
   flipCurrentAtomic,
+  isManagedExecutable,
   payloadPathFor,
   pruneInstallPayloads,
   readInstallManifest,
   removeManagedPathBlock,
+  removeManagedShim,
   resolveInstallStorePaths,
+  withInstallStoreLock,
   writeInstallManifestAtomic,
   writeManagedShim,
   type InstallManifest,
@@ -101,10 +104,12 @@ describe("managed install store", () => {
     expect(payloads.slice(1).every((payload) => fs.existsSync(payload))).toBe(true);
   });
 
-  it("writes a stable shim and manages an idempotent shell PATH block", () => {
+  it("writes a stable shim with the validated runtime and custom store path", () => {
     writeManagedShim(paths);
     const shim = fs.readFileSync(paths.shimPath, "utf8");
-    expect(shim).toContain("$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js");
+    expect(shim).toContain(process.execPath);
+    expect(shim).toContain(paths.currentPath);
+    expect(shim).not.toContain("PAPERCLIP_HOME");
     expect(fs.statSync(paths.shimPath).mode & 0o777).toBe(0o755);
 
     const rcPath = path.join(root, "home", ".bashrc");
@@ -112,6 +117,42 @@ describe("managed install store", () => {
     expect(addManagedPathBlock(rcPath)).toBe(false);
     expect(removeManagedPathBlock(rcPath)).toBe(true);
     expect(fs.readFileSync(rcPath, "utf8")).not.toContain("paperclipai managed PATH");
+  });
+
+  it("rejects marker substrings that are not the exact managed shim format", () => {
+    fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true });
+    fs.writeFileSync(paths.shimPath, `#!/bin/sh\necho '${MANAGED_SHIM_MARKER}'\n`);
+
+    expect(removeManagedShim(paths)).toBe(false);
+    expect(fs.existsSync(paths.shimPath)).toBe(true);
+    expect(() => writeManagedShim(paths)).toThrow("non-managed command");
+  });
+
+  it("serializes install-store mutations with an exclusive lock", async () => {
+    await expect(
+      withInstallStoreLock(
+        () => withInstallStoreLock(async () => undefined, paths),
+        paths,
+      ),
+    ).rejects.toThrow("already running");
+    expect(fs.existsSync(paths.lockPath)).toBe(false);
+  });
+
+  it("reports managed provenance only for the payload selected by current", () => {
+    const manifestPayload = payloadPathFor(paths, "npm", "1.0.0");
+    const currentPayload = payloadPathFor(paths, "npm", "2.0.0");
+    const executable = path.join(manifestPayload, "node_modules", "paperclipai", "dist", "index.js");
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    fs.writeFileSync(executable, "");
+    fs.mkdirSync(currentPayload, { recursive: true });
+    flipCurrentAtomic(currentPayload, paths);
+    const manifest: InstallManifest = {
+      schemaVersion: INSTALL_MANIFEST_VERSION,
+      ...record(manifestPayload, "1.0.0"),
+      previous: [],
+    };
+
+    expect(isManagedExecutable(executable, manifest, paths)).toBe(false);
   });
 
   it("refuses symlinked payload roots and pre-existing non-managed shims", () => {

--- a/cli/src/__tests__/managed-install-check.test.ts
+++ b/cli/src/__tests__/managed-install-check.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { managedInstallChecks } from "../checks/managed-install-check.js";
 import {
+  MANAGED_STORE_MARKER,
   buildNextManifest,
   flipCurrentAtomic,
   resolveInstallStorePaths,
@@ -51,9 +52,24 @@ describe("managed install doctor checks", () => {
       homeDir: root,
     });
     fs.mkdirSync(paths.cliRoot, { recursive: true });
+    fs.writeFileSync(paths.markerPath, MANAGED_STORE_MARKER);
 
     expect(managedInstallChecks(paths)).toEqual([
       expect.objectContaining({ name: "Managed install manifest", status: "fail" }),
+    ]);
+  });
+
+  it("ignores the shared CLI directory when it only contains update notice state", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
+    const paths = resolveInstallStorePaths({
+      paperclipHome: path.join(root, ".paperclip"),
+      homeDir: root,
+    });
+    fs.mkdirSync(paths.cliRoot, { recursive: true });
+    fs.writeFileSync(path.join(paths.cliRoot, "update-check.json"), "{}\n");
+
+    expect(managedInstallChecks(paths)).toEqual([
+      expect.objectContaining({ name: "Managed install", status: "pass" }),
     ]);
   });
 });

--- a/cli/src/__tests__/managed-install-check.test.ts
+++ b/cli/src/__tests__/managed-install-check.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { managedInstallChecks } from "../checks/managed-install-check.js";
+import {
+  buildNextManifest,
+  flipCurrentAtomic,
+  resolveInstallStorePaths,
+  writeInstallManifestAtomic,
+  writeManagedShim,
+} from "../install-store.js";
+
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+});
+
+describe("managed install doctor checks", () => {
+  it("passes for a consistent store, manifest, current link, shim, and PATH", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
+    const paths = resolveInstallStorePaths({
+      paperclipHome: path.join(root, ".paperclip"),
+      homeDir: root,
+    });
+    const payloadPath = path.join(paths.installsRoot, "npm", "1.2.3");
+    fs.mkdirSync(path.join(payloadPath, "dist"), { recursive: true });
+    const manifest = buildNextManifest(
+      {
+        source: "npm",
+        version: "1.2.3",
+        channel: "latest",
+        payloadPath,
+        installedAt: "2026-07-22T00:00:00.000Z",
+      },
+      null,
+    );
+    flipCurrentAtomic(payloadPath, paths);
+    writeInstallManifestAtomic(manifest, paths);
+    writeManagedShim(paths);
+    process.env.PATH = `${path.dirname(paths.shimPath)}${path.delimiter}${originalPath ?? ""}`;
+
+    expect(managedInstallChecks(paths).every((result) => result.status === "pass")).toBe(true);
+  });
+
+  it("fails when managed artifacts exist without a manifest", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
+    const paths = resolveInstallStorePaths({
+      paperclipHome: path.join(root, ".paperclip"),
+      homeDir: root,
+    });
+    fs.mkdirSync(paths.cliRoot, { recursive: true });
+
+    expect(managedInstallChecks(paths)).toEqual([
+      expect.objectContaining({ name: "Managed install manifest", status: "fail" }),
+    ]);
+  });
+});

--- a/cli/src/__tests__/managed-install-check.test.ts
+++ b/cli/src/__tests__/managed-install-check.test.ts
@@ -72,4 +72,17 @@ describe("managed install doctor checks", () => {
       expect.objectContaining({ name: "Managed install", status: "pass" }),
     ]);
   });
+
+  it("ignores an empty installs directory left by a harmless lock lifecycle", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-install-doctor-"));
+    const paths = resolveInstallStorePaths({
+      paperclipHome: path.join(root, ".paperclip"),
+      homeDir: root,
+    });
+    fs.mkdirSync(paths.installsRoot, { recursive: true });
+
+    expect(managedInstallChecks(paths)).toEqual([
+      expect.objectContaining({ name: "Managed install", status: "pass" }),
+    ]);
+  });
 });

--- a/cli/src/__tests__/onboard-service.test.ts
+++ b/cli/src/__tests__/onboard-service.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleOnboardService } from "../onboard-service.js";
+
+function supportedDetection() {
+  return {
+    supported: true as const,
+    manager: {
+      platform: "systemd" as const,
+      instanceId: "default",
+      serviceName: "paperclipai.service",
+      definitionPath: "/tmp/paperclipai.service",
+      renderDefinition: () => "unit",
+      install: vi.fn(async () => ({ changed: true })),
+      uninstall: vi.fn(async () => undefined),
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      restart: vi.fn(async () => undefined),
+      status: vi.fn(async () => ({
+        platform: "systemd" as const,
+        serviceName: "paperclipai.service",
+        installed: true,
+        active: true,
+        enabled: true,
+        pid: 123,
+      })),
+      logs: vi.fn(async () => undefined),
+    },
+  };
+}
+
+describe("onboard service policy", () => {
+  it("does not install during --yes onboarding without opt-in", async () => {
+    const detection = supportedDetection();
+    const info = vi.fn();
+
+    const installed = await handleOnboardService(
+      { yes: true },
+      { detect: vi.fn(async () => detection), isInteractive: () => false, info },
+    );
+
+    expect(installed).toBe(false);
+    expect(detection.manager.install).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("--install-service"));
+  });
+
+  it("installs when --yes explicitly opts in", async () => {
+    const detection = supportedDetection();
+
+    const installed = await handleOnboardService(
+      { yes: true, installService: true },
+      { detect: vi.fn(async () => detection), isInteractive: () => false },
+    );
+
+    expect(installed).toBe(true);
+    expect(detection.manager.install).toHaveBeenCalledWith({ startNow: true, startOnLogin: true });
+  });
+
+  it("asks during interactive onboarding", async () => {
+    const detection = supportedDetection();
+    const confirm = vi.fn(async () => true);
+
+    const installed = await handleOnboardService(
+      {},
+      { detect: vi.fn(async () => detection), isInteractive: () => true, confirm },
+    );
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(installed).toBe(true);
+  });
+
+  it("silences the hint with --no-install-service", async () => {
+    const info = vi.fn();
+    const detect = vi.fn(async () => supportedDetection());
+
+    const installed = await handleOnboardService(
+      { yes: true, installService: false },
+      { detect, isInteractive: () => false, info },
+    );
+
+    expect(installed).toBe(false);
+    expect(detect).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
+  });
+});

--- a/cli/src/__tests__/service-health-check.test.ts
+++ b/cli/src/__tests__/service-health-check.test.ts
@@ -3,7 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { serviceHealthChecks } from "../checks/service-health-check.js";
+import { resolveRestartExpectedVersion } from "../commands/service.js";
 import type { PaperclipConfig } from "../config/schema.js";
+import { packageVersion } from "../version.js";
 
 const config = {
   server: { host: "127.0.0.1", port: 3100 },
@@ -38,6 +40,11 @@ function managerFixture(active = true) {
 }
 
 describe("service health doctor checks", () => {
+  it("uses the bare package version when restart health has no prior server version", () => {
+    expect(resolveRestartExpectedVersion(null)).toBe(packageVersion);
+    expect(resolveRestartExpectedVersion("1.2.3")).toBe("1.2.3");
+  });
+
   it("passes for a current, active, healthy service", async () => {
     const manager = managerFixture();
     const results = await serviceHealthChecks(config, {

--- a/cli/src/__tests__/service-health-check.test.ts
+++ b/cli/src/__tests__/service-health-check.test.ts
@@ -6,7 +6,6 @@ import { serviceHealthChecks } from "../checks/service-health-check.js";
 import { resolveRestartExpectedVersion } from "../commands/service.js";
 import type { PaperclipConfig } from "../config/schema.js";
 import { buildLocalHealthUrl } from "../utils/health-url.js";
-import { packageVersion } from "../version.js";
 
 const config = {
   server: { host: "127.0.0.1", port: 3100 },
@@ -41,8 +40,9 @@ function managerFixture(active = true) {
 }
 
 describe("service health doctor checks", () => {
-  it("uses the current CLI version unless an expected restart version is explicit", () => {
-    expect(resolveRestartExpectedVersion(null)).toBe(packageVersion);
+  it("skips exact version matching unless a restart version is explicit", () => {
+    expect(resolveRestartExpectedVersion(null)).toBeNull();
+    expect(resolveRestartExpectedVersion(undefined)).toBeNull();
     expect(resolveRestartExpectedVersion("1.2.3")).toBe("1.2.3");
   });
 

--- a/cli/src/__tests__/service-health-check.test.ts
+++ b/cli/src/__tests__/service-health-check.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { serviceHealthChecks } from "../checks/service-health-check.js";
 import { resolveRestartExpectedVersion } from "../commands/service.js";
 import type { PaperclipConfig } from "../config/schema.js";
+import { buildLocalHealthUrl } from "../utils/health-url.js";
 import { packageVersion } from "../version.js";
 
 const config = {
@@ -40,9 +41,14 @@ function managerFixture(active = true) {
 }
 
 describe("service health doctor checks", () => {
-  it("uses the bare package version when restart health has no prior server version", () => {
+  it("uses the current CLI version unless an expected restart version is explicit", () => {
     expect(resolveRestartExpectedVersion(null)).toBe(packageVersion);
     expect(resolveRestartExpectedVersion("1.2.3")).toBe("1.2.3");
+  });
+
+  it("brackets configured IPv6 hosts in health URLs", () => {
+    expect(buildLocalHealthUrl("::1", 3100)).toBe("http://[::1]:3100/api/health");
+    expect(buildLocalHealthUrl("::", 3100)).toBe("http://127.0.0.1:3100/api/health");
   });
 
   it("passes for a current, active, healthy service", async () => {

--- a/cli/src/__tests__/service-health-check.test.ts
+++ b/cli/src/__tests__/service-health-check.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { serviceHealthChecks } from "../checks/service-health-check.js";
+import type { PaperclipConfig } from "../config/schema.js";
+
+const config = {
+  server: { host: "127.0.0.1", port: 3100 },
+} as PaperclipConfig;
+
+function managerFixture(active = true) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-service-doctor-"));
+  const definitionPath = path.join(root, "paperclipai.service");
+  fs.writeFileSync(definitionPath, "unit");
+  return {
+    platform: "systemd" as const,
+    instanceId: "default",
+    serviceName: "paperclipai.service",
+    definitionPath,
+    renderDefinition: () => "unit",
+    install: vi.fn(async () => ({ changed: false })),
+    uninstall: vi.fn(async () => undefined),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    restart: vi.fn(async () => undefined),
+    status: vi.fn(async () => ({
+      platform: "systemd" as const,
+      serviceName: "paperclipai.service",
+      installed: true,
+      active,
+      enabled: true,
+      pid: active ? 123 : null,
+      linger: true,
+    })),
+    logs: vi.fn(async () => undefined),
+  };
+}
+
+describe("service health doctor checks", () => {
+  it("passes for a current, active, healthy service", async () => {
+    const manager = managerFixture();
+    const results = await serviceHealthChecks(config, {
+      detect: vi.fn(async () => ({ supported: true as const, manager })),
+      probe: vi.fn(async () => ({ ok: true, version: "1.2.3" })),
+    });
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  it("detects a foreground process on the configured port while the service is inactive", async () => {
+    const manager = managerFixture(false);
+    const results = await serviceHealthChecks(config, {
+      detect: vi.fn(async () => ({ supported: true as const, manager })),
+      probe: vi.fn(async () => ({ ok: true, version: "1.2.3" })),
+    });
+
+    expect(results).toContainEqual(
+      expect.objectContaining({
+        name: "Service runtime",
+        status: "fail",
+        message: expect.stringContaining("another Paperclip process"),
+      }),
+    );
+  });
+});

--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -75,6 +75,21 @@ describe("systemd drift regeneration", () => {
     expect(await fs.readFile(manager.definitionPath, "utf8")).toBe(manager.renderDefinition());
     expect(calls).toContain("systemctl --user daemon-reload");
   });
+
+  it("keeps the unit installed when stopping an active service fails", async () => {
+    const userHome = await temporaryDirectory();
+    const runner: CommandRunner = async (command, args) => {
+      if (args.includes("--property=LoadState,ActiveState,UnitFileState,MainPID")) return { stdout: "LoadState=loaded\nActiveState=active\nUnitFileState=enabled\nMainPID=42\n", stderr: "" };
+      if (command === "systemctl" && args.includes("stop")) throw new Error("stop failed");
+      return { stdout: "", stderr: "" };
+    };
+    const manager = new SystemdServiceManager("default", runner, path.join(userHome, ".paperclip"), path.join(userHome, ".local/bin/paperclipai"), userHome);
+    await fs.mkdir(path.dirname(manager.definitionPath), { recursive: true });
+    await fs.writeFile(manager.definitionPath, manager.renderDefinition(), "utf8");
+
+    await expect(manager.uninstall()).rejects.toThrow("stop failed");
+    await expect(fs.access(manager.definitionPath)).resolves.toBeUndefined();
+  });
 });
 
 describe("service adapter dispatch", () => {
@@ -99,6 +114,22 @@ describe("service adapter dispatch", () => {
 });
 
 describe("launchd lifecycle", () => {
+  it("starts without changing the saved login preference", async () => {
+    const userHome = await temporaryDirectory();
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, ...args].join(" "));
+      if (args[0] === "print-disabled") return { stdout: `\"ing.paperclip.paperclipai.team-a\" => true`, stderr: "" };
+      return { stdout: "", stderr: "" };
+    };
+    const manager = new LaunchdServiceManager("team-a", runner, path.join(userHome, ".paperclip"), path.join(userHome, ".local/bin/paperclipai"), userHome);
+
+    await manager.start();
+
+    expect(calls).toContain(`launchctl disable gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
+    expect(calls).not.toContain(`launchctl enable gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
+  });
+
   it("disables login startup and unloads the keepalive job when stopped", async () => {
     const userHome = await temporaryDirectory();
     const calls: string[] = [];

--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -37,6 +37,17 @@ describe("service definition generation", () => {
     expect(unit).not.toContain("API_KEY");
   });
 
+  it("escapes systemd variable and specifier expansion in configured values", () => {
+    const unit = renderSystemdUnit({
+      instanceId: "team-$USER-%i",
+      shimPath: "/home/$USER/%i/paperclipai",
+      homeDir: "/home/$USER/%i/.paperclip",
+    });
+
+    expect(unit).toContain('ExecStart="/home/$$USER/%%i/paperclipai" run --instance "team-$$USER-%%i"');
+    expect(unit).toContain('Environment="PAPERCLIP_HOME=/home/$$USER/%%i/.paperclip"');
+  });
+
   it("generates a launchd agent with keepalive and instance logs", () => {
     const plist = renderLaunchdPlist({ instanceId: "team-a", shimPath: "/Users/alice/.local/bin/paperclipai", homeDir: "/Users/alice/.paperclip", stdoutPath: "/Users/alice/.paperclip/instances/team-a/logs/service.log", stderrPath: "/Users/alice/.paperclip/instances/team-a/logs/service.err.log" });
     expect(plist).toContain("ing.paperclip.paperclipai.team-a");

--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -130,6 +130,23 @@ describe("launchd lifecycle", () => {
     expect(calls).not.toContain(`launchctl enable gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
   });
 
+  it("preserves disabled state when the service name contains regex metacharacters", async () => {
+    const userHome = await temporaryDirectory();
+    const calls: string[] = [];
+    const serviceName = "ing.paperclip.paperclipai.team[qa]+";
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, ...args].join(" "));
+      if (args[0] === "print-disabled") return { stdout: `"${serviceName}" => true`, stderr: "" };
+      return { stdout: "", stderr: "" };
+    };
+    const manager = new LaunchdServiceManager("team[qa]+", runner, path.join(userHome, ".paperclip"), path.join(userHome, ".local/bin/paperclipai"), userHome);
+
+    await manager.start();
+
+    expect(calls).toContain(`launchctl disable gui/${process.getuid?.() ?? 0}/${serviceName}`);
+    expect(calls).not.toContain(`launchctl enable gui/${process.getuid?.() ?? 0}/${serviceName}`);
+  });
+
   it("disables login startup and unloads the keepalive job when stopped", async () => {
     const userHome = await temporaryDirectory();
     const calls: string[] = [];

--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -104,6 +104,20 @@ describe("launchd lifecycle", () => {
     expect(calls).toContain(`launchctl bootout gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
     expect(calls.some((call) => call.includes("launchctl kill"))).toBe(false);
   });
+
+  it("disables login startup when uninstalled", async () => {
+    const userHome = await temporaryDirectory();
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, ...args].join(" "));
+      return { stdout: "", stderr: "" };
+    };
+    const manager = new LaunchdServiceManager("team-a", runner, path.join(userHome, ".paperclip"), path.join(userHome, ".local/bin/paperclipai"), userHome);
+
+    await manager.uninstall();
+
+    expect(calls).toContain(`launchctl disable gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
+  });
 });
 
 describe("single-writer guard", () => {

--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertForegroundRunAllowed,
+  detectServiceManager,
+  LaunchdServiceManager,
+  renderLaunchdPlist,
+  renderSystemdUnit,
+  SystemdServiceManager,
+  type CommandRunner,
+  type ServiceManager,
+} from "../services/service-manager.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+  delete process.env.PAPERCLIP_SERVICE_MANAGED;
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-service-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("service definition generation", () => {
+  it("generates a stable systemd notify unit without secrets", () => {
+    const unit = renderSystemdUnit({ instanceId: "team-a", shimPath: "/home/alice/.local/bin/paperclipai", homeDir: "/home/alice/.paperclip" });
+    expect(unit).toContain("Type=notify");
+    expect(unit).toContain("NotifyAccess=all");
+    expect(unit).toContain('ExecStart="/home/alice/.local/bin/paperclipai" run --instance "team-a"');
+    expect(unit).toContain("Restart=always");
+    expect(unit).toContain("TimeoutStopSec=300");
+    expect(unit).not.toContain("API_KEY");
+  });
+
+  it("generates a launchd agent with keepalive and instance logs", () => {
+    const plist = renderLaunchdPlist({ instanceId: "team-a", shimPath: "/Users/alice/.local/bin/paperclipai", homeDir: "/Users/alice/.paperclip", stdoutPath: "/Users/alice/.paperclip/instances/team-a/logs/service.log", stderrPath: "/Users/alice/.paperclip/instances/team-a/logs/service.err.log" });
+    expect(plist).toContain("ing.paperclip.paperclipai.team-a");
+    expect(plist).toContain("<key>RunAtLoad</key><true/>");
+    expect(plist).toContain("<key>KeepAlive</key><true/>");
+    expect(plist).toContain("service.err.log");
+  });
+});
+
+describe("systemd drift regeneration", () => {
+  it("rewrites a drifted unit and reloads the user manager", async () => {
+    const userHome = await temporaryDirectory();
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, ...args].join(" "));
+      return { stdout: "", stderr: "" };
+    };
+    const manager = new SystemdServiceManager("default", runner, path.join(userHome, ".paperclip"), path.join(userHome, ".local/bin/paperclipai"), userHome);
+    await fs.mkdir(path.dirname(manager.definitionPath), { recursive: true });
+    await fs.writeFile(manager.definitionPath, "stale\n", "utf8");
+
+    const result = await manager.install({ startNow: false, startOnLogin: false });
+
+    expect(result.changed).toBe(true);
+    expect(await fs.readFile(manager.definitionPath, "utf8")).toBe(manager.renderDefinition());
+    expect(calls).toContain("systemctl --user daemon-reload");
+  });
+});
+
+describe("service adapter dispatch", () => {
+  it("selects launchd on macOS", async () => {
+    const detection = await detectServiceManager({ platform: "darwin", instanceId: "default" });
+    expect(detection.supported).toBe(true);
+    if (detection.supported) expect(detection.manager).toBeInstanceOf(LaunchdServiceManager);
+  });
+
+  it("selects systemd only when the user manager is reachable", async () => {
+    const runner: CommandRunner = async () => ({ stdout: "", stderr: "" });
+    const detection = await detectServiceManager({ platform: "linux", instanceId: "default", runner });
+    expect(detection.supported).toBe(true);
+    if (detection.supported) expect(detection.manager).toBeInstanceOf(SystemdServiceManager);
+  });
+
+  it("returns a foreground-run skip on unsupported hosts", async () => {
+    const runner: CommandRunner = async () => { throw new Error("no bus"); };
+    const detection = await detectServiceManager({ platform: "linux", instanceId: "default", runner });
+    expect(detection).toEqual({ supported: false, reason: expect.stringContaining("paperclipai run") });
+  });
+});
+
+describe("launchd lifecycle", () => {
+  it("disables login startup and unloads the keepalive job when stopped", async () => {
+    const userHome = await temporaryDirectory();
+    const calls: string[] = [];
+    const runner: CommandRunner = async (command, args) => {
+      calls.push([command, ...args].join(" "));
+      return { stdout: "", stderr: "" };
+    };
+    const manager = new LaunchdServiceManager("team-a", runner, path.join(userHome, ".paperclip"), path.join(userHome, ".local/bin/paperclipai"), userHome);
+
+    await manager.install({ startNow: false, startOnLogin: false });
+    await manager.stop();
+
+    expect(calls).toContain(`launchctl disable gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
+    expect(calls).toContain(`launchctl bootout gui/${process.getuid?.() ?? 0}/ing.paperclip.paperclipai.team-a`);
+    expect(calls.some((call) => call.includes("launchctl kill"))).toBe(false);
+  });
+});
+
+describe("single-writer guard", () => {
+  const activeManager = { status: async () => ({ active: true, serviceName: "paperclipai.service" }) } as unknown as ServiceManager;
+  const detector = async () => ({ supported: true as const, manager: activeManager });
+
+  it("refuses a second foreground writer", async () => {
+    await expect(assertForegroundRunAllowed("default", false, detector)).rejects.toThrow("already running");
+  });
+
+  it("allows an explicit force override", async () => {
+    await expect(assertForegroundRunAllowed("default", true, detector)).resolves.toBeUndefined();
+  });
+
+  it("allows the supervisor-owned process", async () => {
+    process.env.PAPERCLIP_SERVICE_MANAGED = "1";
+    await expect(assertForegroundRunAllowed("default", false, detector)).resolves.toBeUndefined();
+  });
+});

--- a/cli/src/__tests__/update-command.test.ts
+++ b/cli/src/__tests__/update-command.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flipCurrentAtomic, initializeInstallStore, payloadPathFor, readInstallManifest, resolveInstallStorePaths, writeInstallManifestAtomic, type InstallManifest, type InstallRecord } from "../install-store.js";
 import type { CommandRunner } from "../commands/install.js";
-import { detectInstallMode, resolveUpdateRequest, rollbackManagedInstall, updateCommand } from "../commands/update.js";
+import { compareVersions, detectInstallMode, resolveUpdateRequest, rollbackManagedInstall, updateCommand } from "../commands/update.js";
 
 let root: string;
 let previousHome: string | undefined;
@@ -36,6 +36,12 @@ afterEach(() => {
 });
 
 describe("update command", () => {
+  it("orders SemVer prerelease identifiers numerically", () => {
+    expect(compareVersions("1.0.0-canary.10", "1.0.0-canary.2")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0-1", "1.0.0-alpha")).toBeLessThan(0);
+    expect(compareVersions("1.0.0-alpha", "1.0.0-alpha.1")).toBeLessThan(0);
+  });
+
   it("detects managed, global npm, npx, and source modes", () => {
     const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
     const payload = payloadPathFor(paths, "npm", "1.0.0"); const entrypoint = createPayload(payload, "1.0.0");
@@ -67,9 +73,11 @@ describe("update command", () => {
     flipCurrentAtomic(oldPayload, paths);
     writeInstallManifestAtomic({ schemaVersion: 1, source: "git", version: "0.3.1", channel: "pinned", repo: "paperclipai/paperclip", ref: "master", sha: oldSha, payloadPath: oldPayload, installedAt: "2026-07-22T00:00:00.000Z", previous: [] }, paths);
     const backup = vi.fn(async () => undefined);
+    const restartActiveService = vi.fn(async () => true);
     const runCommand = vi.fn(async (file: string) => file === "curl" ? { stdout: JSON.stringify({ sha: newSha }), stderr: "" } : { stdout: "0.3.1\n", stderr: "" });
-    await updateCommand({}, { paths, executablePath: executable, runCommand, backup, now: () => new Date("2026-07-22T12:00:00Z") });
+    await updateCommand({}, { paths, executablePath: executable, runCommand, backup, restartActiveService, now: () => new Date("2026-07-22T12:00:00Z") });
     expect(backup).toHaveBeenCalledOnce();
+    expect(restartActiveService).toHaveBeenCalledWith("0.3.1");
     expect(readInstallManifest(paths)?.sha).toBe(newSha);
     expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(newPayload));
   });
@@ -90,6 +98,14 @@ describe("update command", () => {
     writeInstallManifestAtomic({ schemaVersion: 1, ...record(payload, "2.0.0"), previous: [] }, paths);
     const runCommand = vi.fn(async () => ({ stdout: '"1.0.0"\n', stderr: "" }));
     await expect(updateCommand({ version: "1.0.0", dryRun: true }, { paths, executablePath: entrypoint, runCommand, confirm: async () => false })).rejects.toThrow("Downgrade cancelled");
+  });
+
+  it("requires explicit confirmation before a global npm downgrade", async () => {
+    const paths = resolveInstallStorePaths();
+    const executable = path.join(root, "lib", "node_modules", "paperclipai", "dist", "index.js");
+    const runCommand = vi.fn(async () => ({ stdout: '"0.2.0"\n', stderr: "" }));
+    await expect(updateCommand({ version: "0.2.0" }, { paths, executablePath: executable, runCommand, confirm: async () => false })).rejects.toThrow("Downgrade cancelled");
+    expect(runCommand).toHaveBeenCalledTimes(1);
   });
 
   it("isolates global npm updates from hostile registry configuration", async () => {
@@ -117,13 +133,15 @@ describe("update command", () => {
     const oldPayload = payloadPathFor(paths, "npm", "1.0.0"); const executable = createPayload(oldPayload, "1.0.0"); flipCurrentAtomic(oldPayload, paths);
     writeInstallManifestAtomic({ schemaVersion: 1, ...record(oldPayload, "1.0.0"), previous: [] }, paths);
     const backup = vi.fn(async () => undefined);
+    const restartActiveService = vi.fn(async () => true);
     const runCommand = vi.fn(async (file: string, args: string[]) => {
       if (args[0] === "view") return { stdout: '"2.0.0"\n', stderr: "" };
       if (file === "npm" && args[0] === "install") { const prefix = args[args.indexOf("--prefix") + 1]; createPayload(prefix, "2.0.0"); return { stdout: "", stderr: "" }; }
       return { stdout: "2.0.0\n", stderr: "" };
     });
-    await updateCommand({}, { paths, executablePath: executable, runCommand, backup, now: () => new Date("2026-07-22T12:00:00Z") });
+    await updateCommand({}, { paths, executablePath: executable, runCommand, backup, restartActiveService, now: () => new Date("2026-07-22T12:00:00Z") });
     expect(backup).toHaveBeenCalledOnce();
+    expect(restartActiveService).toHaveBeenCalledWith("2.0.0");
     expect(readInstallManifest(paths)?.version).toBe("2.0.0");
     expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(payloadPathFor(paths, "npm", "2.0.0")));
     const rolledBack = rollbackManagedInstall(paths);

--- a/cli/src/__tests__/update-command.test.ts
+++ b/cli/src/__tests__/update-command.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flipCurrentAtomic, initializeInstallStore, payloadPathFor, readInstallManifest, resolveInstallStorePaths, writeInstallManifestAtomic, type InstallManifest, type InstallRecord } from "../install-store.js";
+import { detectInstallMode, resolveUpdateRequest, rollbackManagedInstall, updateCommand } from "../commands/update.js";
+
+let root: string;
+let previousHome: string | undefined;
+let previousPaperclipHome: string | undefined;
+
+function record(payloadPath: string, version: string, channel: "latest" | "canary" | "pinned" = "latest"): InstallRecord {
+  return { source: "npm", version, channel, payloadPath, installedAt: `2026-07-22T00:00:0${version}.000Z` };
+}
+function createPayload(payloadPath: string, version: string): string {
+  const entrypoint = path.join(payloadPath, "node_modules", "paperclipai", "dist", "index.js");
+  fs.mkdirSync(path.dirname(entrypoint), { recursive: true });
+  fs.writeFileSync(entrypoint, version);
+  return entrypoint;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-update-"));
+  previousHome = process.env.HOME;
+  previousPaperclipHome = process.env.PAPERCLIP_HOME;
+  process.env.HOME = path.join(root, "home");
+  process.env.PAPERCLIP_HOME = path.join(root, "paperclip");
+});
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.HOME; else process.env.HOME = previousHome;
+  if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME; else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+  fs.rmSync(root, { recursive: true, force: true });
+  process.exitCode = undefined;
+});
+
+describe("update command", () => {
+  it("detects managed, global npm, npx, and source modes", () => {
+    const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
+    const payload = payloadPathFor(paths, "npm", "1.0.0"); const entrypoint = createPayload(payload, "1.0.0");
+    flipCurrentAtomic(payload, paths);
+    writeInstallManifestAtomic({ schemaVersion: 1, ...record(payload, "1.0.0"), previous: [] }, paths);
+    expect(detectInstallMode(entrypoint, paths)).toBe("managed");
+    expect(detectInstallMode(path.join(root, "lib", "node_modules", "paperclipai", "dist", "index.js"), paths)).toBe("global-npm");
+    expect(detectInstallMode(path.join(root, ".npm", "_npx", "abc", "node_modules", "paperclipai", "dist", "index.js"), paths)).toBe("npx");
+    const source = path.join(root, "source"); fs.mkdirSync(path.join(source, ".git"), { recursive: true });
+    expect(detectInstallMode(path.join(source, "cli", "src", "index.ts"), paths)).toBe("source");
+  });
+
+  it("resolves channels and keeps pinned installs pinned by default", () => {
+    const manifest = { channel: "pinned", version: "1.2.3" } as InstallManifest;
+    expect(resolveUpdateRequest(manifest, {})).toEqual({ spec: "1.2.3", channel: "pinned", explicit: false });
+    expect(resolveUpdateRequest(manifest, { latest: true })).toEqual({ spec: "latest", channel: "latest", explicit: true });
+    expect(() => resolveUpdateRequest(manifest, { latest: true, canary: true })).toThrow("only one");
+  });
+
+  it("requires explicit confirmation before downgrading", async () => {
+    const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
+    const payload = payloadPathFor(paths, "npm", "2.0.0"); const entrypoint = createPayload(payload, "2.0.0"); flipCurrentAtomic(payload, paths);
+    writeInstallManifestAtomic({ schemaVersion: 1, ...record(payload, "2.0.0"), previous: [] }, paths);
+    const runCommand = vi.fn(async () => ({ stdout: '"1.0.0"\n', stderr: "" }));
+    await expect(updateCommand({ version: "1.0.0", dryRun: true }, { paths, executablePath: entrypoint, runCommand, confirm: async () => false })).rejects.toThrow("Downgrade cancelled");
+  });
+
+  it("backs up, installs side-by-side, flips, and rolls back instantly", async () => {
+    const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
+    const oldPayload = payloadPathFor(paths, "npm", "1.0.0"); const executable = createPayload(oldPayload, "1.0.0"); flipCurrentAtomic(oldPayload, paths);
+    writeInstallManifestAtomic({ schemaVersion: 1, ...record(oldPayload, "1.0.0"), previous: [] }, paths);
+    const backup = vi.fn(async () => undefined);
+    const runCommand = vi.fn(async (file: string, args: string[]) => {
+      if (args[0] === "view") return { stdout: '"2.0.0"\n', stderr: "" };
+      if (file === "npm" && args[0] === "install") { const prefix = args[args.indexOf("--prefix") + 1]; createPayload(prefix, "2.0.0"); return { stdout: "", stderr: "" }; }
+      return { stdout: "2.0.0\n", stderr: "" };
+    });
+    await updateCommand({}, { paths, executablePath: executable, runCommand, backup, now: () => new Date("2026-07-22T12:00:00Z") });
+    expect(backup).toHaveBeenCalledOnce();
+    expect(readInstallManifest(paths)?.version).toBe("2.0.0");
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(payloadPathFor(paths, "npm", "2.0.0")));
+    const rolledBack = rollbackManagedInstall(paths);
+    expect(rolledBack.version).toBe("1.0.0");
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(oldPayload));
+  });
+});

--- a/cli/src/__tests__/update-command.test.ts
+++ b/cli/src/__tests__/update-command.test.ts
@@ -98,7 +98,7 @@ describe("update command", () => {
     vi.stubEnv("NPM_CONFIG_REGISTRY", "http://attacker-registry.invalid");
     fs.mkdirSync(process.env.HOME!, { recursive: true });
     fs.writeFileSync(path.join(process.env.HOME!, ".npmrc"), "registry=http://attacker-registry.invalid\n");
-    const runCommand = vi.fn(async (_file: string, args: string[], commandOptions?: Parameters<CommandRunner>[2]) => {
+    const runCommand = vi.fn<CommandRunner>(async (_file, args, commandOptions) => {
       if (args[0] === "view") return { stdout: '"2.0.0"\n', stderr: "" };
       expect(args).toContain("--registry=https://registry.npmjs.org");
       expect(args).toContain("--@paperclipai:registry=https://registry.npmjs.org");

--- a/cli/src/__tests__/update-command.test.ts
+++ b/cli/src/__tests__/update-command.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flipCurrentAtomic, initializeInstallStore, payloadPathFor, readInstallManifest, resolveInstallStorePaths, writeInstallManifestAtomic, type InstallManifest, type InstallRecord } from "../install-store.js";
+import type { CommandRunner } from "../commands/install.js";
 import { detectInstallMode, resolveUpdateRequest, rollbackManagedInstall, updateCommand } from "../commands/update.js";
 
 let root: string;
@@ -27,6 +28,7 @@ beforeEach(() => {
   process.env.PAPERCLIP_HOME = path.join(root, "paperclip");
 });
 afterEach(() => {
+  vi.unstubAllEnvs();
   if (previousHome === undefined) delete process.env.HOME; else process.env.HOME = previousHome;
   if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME; else process.env.PAPERCLIP_HOME = previousPaperclipHome;
   fs.rmSync(root, { recursive: true, force: true });
@@ -88,6 +90,26 @@ describe("update command", () => {
     writeInstallManifestAtomic({ schemaVersion: 1, ...record(payload, "2.0.0"), previous: [] }, paths);
     const runCommand = vi.fn(async () => ({ stdout: '"1.0.0"\n', stderr: "" }));
     await expect(updateCommand({ version: "1.0.0", dryRun: true }, { paths, executablePath: entrypoint, runCommand, confirm: async () => false })).rejects.toThrow("Downgrade cancelled");
+  });
+
+  it("isolates global npm updates from hostile registry configuration", async () => {
+    const paths = resolveInstallStorePaths();
+    const executable = path.join(root, "lib", "node_modules", "paperclipai", "dist", "index.js");
+    vi.stubEnv("NPM_CONFIG_REGISTRY", "http://attacker-registry.invalid");
+    fs.mkdirSync(process.env.HOME!, { recursive: true });
+    fs.writeFileSync(path.join(process.env.HOME!, ".npmrc"), "registry=http://attacker-registry.invalid\n");
+    const runCommand = vi.fn(async (_file: string, args: string[], commandOptions?: Parameters<CommandRunner>[2]) => {
+      if (args[0] === "view") return { stdout: '"2.0.0"\n', stderr: "" };
+      expect(args).toContain("--registry=https://registry.npmjs.org");
+      expect(args).toContain("--@paperclipai:registry=https://registry.npmjs.org");
+      expect(commandOptions?.env?.NPM_CONFIG_REGISTRY).toBe("https://registry.npmjs.org");
+      expect(commandOptions?.env?.npm_config_registry).toBe("https://registry.npmjs.org");
+      expect(commandOptions?.env?.NPM_CONFIG_USERCONFIG).toBe(commandOptions?.env?.npm_config_userconfig);
+      expect(fs.readFileSync(commandOptions!.env!.NPM_CONFIG_USERCONFIG!, "utf8")).toContain("registry=https://registry.npmjs.org");
+      return { stdout: "", stderr: "" };
+    });
+    await updateCommand({}, { paths, executablePath: executable, runCommand });
+    expect(runCommand).toHaveBeenCalledTimes(2);
   });
 
   it("backs up, installs side-by-side, flips, and rolls back instantly", async () => {

--- a/cli/src/__tests__/update-command.test.ts
+++ b/cli/src/__tests__/update-command.test.ts
@@ -53,6 +53,35 @@ describe("update command", () => {
     expect(() => resolveUpdateRequest(manifest, { latest: true, canary: true })).toThrow("only one");
   });
 
+  it("re-resolves a moving git branch and activates the new SHA payload", async () => {
+    const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
+    const oldSha = "1".repeat(40); const newSha = "2".repeat(40);
+    const oldPayload = payloadPathFor(paths, "git", oldSha.slice(0, 12));
+    const executable = createPayload(oldPayload, "0.3.1");
+    fs.writeFileSync(path.join(oldPayload, "node_modules", "paperclipai", "package.json"), JSON.stringify({ version: "0.3.1" }));
+    const newPayload = payloadPathFor(paths, "git", newSha.slice(0, 12));
+    createPayload(newPayload, "0.3.1");
+    fs.writeFileSync(path.join(newPayload, "node_modules", "paperclipai", "package.json"), JSON.stringify({ version: "0.3.1" }));
+    flipCurrentAtomic(oldPayload, paths);
+    writeInstallManifestAtomic({ schemaVersion: 1, source: "git", version: "0.3.1", channel: "pinned", repo: "paperclipai/paperclip", ref: "master", sha: oldSha, payloadPath: oldPayload, installedAt: "2026-07-22T00:00:00.000Z", previous: [] }, paths);
+    const backup = vi.fn(async () => undefined);
+    const runCommand = vi.fn(async (file: string) => file === "curl" ? { stdout: JSON.stringify({ sha: newSha }), stderr: "" } : { stdout: "0.3.1\n", stderr: "" });
+    await updateCommand({}, { paths, executablePath: executable, runCommand, backup, now: () => new Date("2026-07-22T12:00:00Z") });
+    expect(backup).toHaveBeenCalledOnce();
+    expect(readInstallManifest(paths)?.sha).toBe(newSha);
+    expect(fs.realpathSync(paths.currentPath)).toBe(fs.realpathSync(newPayload));
+  });
+
+  it("reports SHA git installs as pinned without resolving again", async () => {
+    const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
+    const sha = "3".repeat(40); const payload = payloadPathFor(paths, "git", sha.slice(0, 12)); const executable = createPayload(payload, "0.3.1");
+    flipCurrentAtomic(payload, paths);
+    writeInstallManifestAtomic({ schemaVersion: 1, source: "git", version: "0.3.1", channel: "pinned", repo: "paperclipai/paperclip", ref: sha.slice(0, 12), sha, payloadPath: payload, installedAt: "2026-07-22T00:00:00.000Z", previous: [] }, paths);
+    const runCommand = vi.fn(async () => ({ stdout: "", stderr: "" }));
+    await updateCommand({}, { paths, executablePath: executable, runCommand });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
   it("requires explicit confirmation before downgrading", async () => {
     const paths = resolveInstallStorePaths(); initializeInstallStore(paths);
     const payload = payloadPathFor(paths, "npm", "2.0.0"); const entrypoint = createPayload(payload, "2.0.0"); flipCurrentAtomic(payload, paths);

--- a/cli/src/__tests__/update-notice.test.ts
+++ b/cli/src/__tests__/update-notice.test.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkForUpdateNotice, isUpdateNoticeEnabled } from "../update-notice.js";
+let root: string; let previous: string | undefined;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-notice-")); previous = process.env.PAPERCLIP_UPDATE_CHECK; delete process.env.PAPERCLIP_UPDATE_CHECK; });
+afterEach(() => { if (previous === undefined) delete process.env.PAPERCLIP_UPDATE_CHECK; else process.env.PAPERCLIP_UPDATE_CHECK = previous; fs.rmSync(root, { recursive: true, force: true }); });
+describe("update notice", () => {
+  it("honors the environment and config kill switches", () => {
+    process.env.PAPERCLIP_UPDATE_CHECK = "0"; expect(isUpdateNoticeEnabled(path.join(root, "missing.json"))).toBe(false);
+    delete process.env.PAPERCLIP_UPDATE_CHECK; const config = path.join(root, "config.json"); fs.writeFileSync(config, JSON.stringify({ updates: { checkEnabled: false } })); expect(isUpdateNoticeEnabled(config)).toBe(false);
+  });
+  it("throttles registry checks for 24 hours", async () => {
+    const cachePath = path.join(root, "cache.json"); const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ "dist-tags": { latest: "99.0.0" } }), { status: 200 }));
+    expect(await checkForUpdateNotice({ cachePath, now: 1000, fetchImpl })).toBe("99.0.0");
+    expect(await checkForUpdateNotice({ cachePath, now: 2000, fetchImpl })).toBe("99.0.0");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+});

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -16,3 +16,5 @@ export { logCheck } from "./log-check.js";
 export { portCheck } from "./port-check.js";
 export { secretsCheck } from "./secrets-check.js";
 export { storageCheck } from "./storage-check.js";
+export { managedInstallChecks, nodeRuntimeCheck } from "./managed-install-check.js";
+export { serviceHealthChecks } from "./service-health-check.js";

--- a/cli/src/checks/managed-install-check.ts
+++ b/cli/src/checks/managed-install-check.ts
@@ -17,13 +17,19 @@ function pathContains(directory: string): boolean {
 }
 
 function hasManagedArtifacts(paths: InstallStorePaths): boolean {
-  return [
-    paths.installsRoot,
+  const persistentArtifacts = [
     paths.manifestPath,
     paths.markerPath,
     paths.currentPath,
     paths.shimPath,
   ].some((entry) => fs.existsSync(entry));
+  if (persistentArtifacts) return true;
+  try {
+    return fs.readdirSync(paths.installsRoot).length > 0;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    return true;
+  }
 }
 
 export function nodeRuntimeCheck(): CheckResult {

--- a/cli/src/checks/managed-install-check.ts
+++ b/cli/src/checks/managed-install-check.ts
@@ -17,9 +17,13 @@ function pathContains(directory: string): boolean {
 }
 
 function hasManagedArtifacts(paths: InstallStorePaths): boolean {
-  return [paths.cliRoot, paths.manifestPath, paths.currentPath, paths.shimPath].some((entry) =>
-    fs.existsSync(entry),
-  );
+  return [
+    paths.installsRoot,
+    paths.manifestPath,
+    paths.markerPath,
+    paths.currentPath,
+    paths.shimPath,
+  ].some((entry) => fs.existsSync(entry));
 }
 
 export function nodeRuntimeCheck(): CheckResult {

--- a/cli/src/checks/managed-install-check.ts
+++ b/cli/src/checks/managed-install-check.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  MANAGED_SHIM_MARKER,
+  readInstallManifest,
+  resolveInstallStorePaths,
+  type InstallStorePaths,
+} from "../install-store.js";
+import type { CheckResult } from "./index.js";
+
+function pathContains(directory: string): boolean {
+  const normalized = path.resolve(directory);
+  return (process.env.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean)
+    .some((entry) => path.resolve(entry) === normalized);
+}
+
+function hasManagedArtifacts(paths: InstallStorePaths): boolean {
+  return [paths.cliRoot, paths.manifestPath, paths.currentPath, paths.shimPath].some((entry) =>
+    fs.existsSync(entry),
+  );
+}
+
+export function nodeRuntimeCheck(): CheckResult {
+  const major = Number.parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+  return major >= 20
+    ? { name: "Node.js runtime", status: "pass", message: `Node.js ${process.versions.node}` }
+    : {
+        name: "Node.js runtime",
+        status: "fail",
+        message: `Node.js ${process.versions.node} is unsupported`,
+        repairHint: "Install Node.js 20 or newer before installing or running Paperclip",
+      };
+}
+
+export function managedInstallChecks(
+  paths = resolveInstallStorePaths(),
+): CheckResult[] {
+  if (!hasManagedArtifacts(paths)) {
+    return [
+      {
+        name: "Managed install",
+        status: "pass",
+        message: "Not present (optional for npx, global npm, and source-checkout usage)",
+      },
+    ];
+  }
+
+  let manifest;
+  try {
+    manifest = readInstallManifest(paths);
+  } catch (error) {
+    return [
+      {
+        name: "Managed install manifest",
+        status: "fail",
+        message: error instanceof Error ? error.message : String(error),
+        repairHint: "Re-run `paperclipai install` to rebuild the managed install metadata",
+      },
+    ];
+  }
+
+  if (!manifest) {
+    return [
+      {
+        name: "Managed install manifest",
+        status: "fail",
+        message: `Managed install artifacts exist but ${paths.manifestPath} is missing`,
+        repairHint: "Re-run `paperclipai install`",
+      },
+    ];
+  }
+
+  const results: CheckResult[] = [];
+  const payloadPath = path.resolve(manifest.payloadPath);
+  const relativePayload = path.relative(paths.installsRoot, payloadPath);
+  const payloadInStore = Boolean(relativePayload) && !relativePayload.startsWith("..") && !path.isAbsolute(relativePayload);
+  const payloadExists = payloadInStore && fs.existsSync(payloadPath) && fs.statSync(payloadPath).isDirectory();
+  let currentMatches = false;
+  try {
+    currentMatches = fs.lstatSync(paths.currentPath).isSymbolicLink()
+      && fs.realpathSync(paths.currentPath) === fs.realpathSync(payloadPath);
+  } catch {
+    currentMatches = false;
+  }
+
+  results.push(
+    payloadExists && currentMatches
+      ? {
+          name: "Managed install store",
+          status: "pass",
+          message: `${manifest.source} ${manifest.version} is active`,
+        }
+      : {
+          name: "Managed install store",
+          status: "fail",
+          message: !payloadExists
+            ? `Manifest payload is missing or outside the install store: ${manifest.payloadPath}`
+            : `Current link does not point to ${manifest.payloadPath}`,
+          repairHint: "Re-run `paperclipai install` or roll back to a retained payload",
+        },
+  );
+
+  let shimValid = false;
+  try {
+    shimValid = fs.readFileSync(paths.shimPath, "utf8").includes(MANAGED_SHIM_MARKER);
+  } catch {
+    shimValid = false;
+  }
+  results.push(
+    shimValid
+      ? { name: "Managed install shim", status: "pass", message: paths.shimPath }
+      : {
+          name: "Managed install shim",
+          status: "fail",
+          message: `Missing or unrecognized shim at ${paths.shimPath}`,
+          repairHint: "Re-run `paperclipai install`",
+        },
+  );
+
+  const shimDirectory = path.dirname(paths.shimPath);
+  results.push(
+    pathContains(shimDirectory)
+      ? { name: "Managed install PATH", status: "pass", message: `${shimDirectory} is on PATH` }
+      : {
+          name: "Managed install PATH",
+          status: "warn",
+          message: `${shimDirectory} is not on PATH`,
+          repairHint: 'Run `export PATH="$HOME/.local/bin:$PATH"` and add it to your shell startup file',
+        },
+  );
+
+  const retained = new Set(
+    [manifest, ...manifest.previous].map((record) => path.resolve(record.payloadPath)),
+  );
+  const orphaned: string[] = [];
+  for (const source of ["npm", "git"] as const) {
+    const sourceRoot = path.join(paths.installsRoot, source);
+    if (!fs.existsSync(sourceRoot)) continue;
+    for (const entry of fs.readdirSync(sourceRoot)) {
+      const candidate = path.join(sourceRoot, entry);
+      if (!entry.startsWith(".") && !retained.has(path.resolve(candidate))) orphaned.push(candidate);
+    }
+  }
+  results.push(
+    orphaned.length === 0
+      ? { name: "Managed install retention", status: "pass", message: "No orphaned payloads" }
+      : {
+          name: "Managed install retention",
+          status: "warn",
+          message: `${orphaned.length} orphaned payload${orphaned.length === 1 ? "" : "s"} found`,
+          repairHint: "A successful `paperclipai update` prunes unretained payloads",
+        },
+  );
+
+  return results;
+}

--- a/cli/src/checks/service-health-check.ts
+++ b/cli/src/checks/service-health-check.ts
@@ -6,6 +6,7 @@ import {
   detectServiceManager,
   type ServiceManagerDetection,
 } from "../services/service-manager.js";
+import { buildLocalHealthUrl } from "../utils/health-url.js";
 import type { CheckResult } from "./index.js";
 
 type HealthResult = { ok: boolean; version: string | null; error?: string };
@@ -14,17 +15,11 @@ type ServiceCheckDependencies = {
   probe: (config: PaperclipConfig) => Promise<HealthResult>;
 };
 
-function healthUrl(config: PaperclipConfig): string {
-  const configuredHost = config.server.host?.trim();
-  const host = !configuredHost || configuredHost === "0.0.0.0" || configuredHost === "::"
-    ? "127.0.0.1"
-    : configuredHost;
-  return `http://${host}:${config.server.port}/api/health`;
-}
-
 async function probeHealth(config: PaperclipConfig): Promise<HealthResult> {
   try {
-    const response = await fetch(healthUrl(config), { signal: AbortSignal.timeout(2_000) });
+    const response = await fetch(buildLocalHealthUrl(config.server.host, config.server.port), {
+      signal: AbortSignal.timeout(2_000),
+    });
     const body = (await response.json()) as {
       status?: unknown;
       serverVersion?: unknown;

--- a/cli/src/checks/service-health-check.ts
+++ b/cli/src/checks/service-health-check.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs/promises";
+import type { PaperclipConfig } from "../config/schema.js";
+import { resolvePaperclipInstanceId } from "../config/home.js";
+import { readInstallManifest } from "../install-store.js";
+import {
+  detectServiceManager,
+  type ServiceManagerDetection,
+} from "../services/service-manager.js";
+import type { CheckResult } from "./index.js";
+
+type HealthResult = { ok: boolean; version: string | null; error?: string };
+type ServiceCheckDependencies = {
+  detect: (instanceId: string) => Promise<ServiceManagerDetection>;
+  probe: (config: PaperclipConfig) => Promise<HealthResult>;
+};
+
+function healthUrl(config: PaperclipConfig): string {
+  const configuredHost = config.server.host?.trim();
+  const host = !configuredHost || configuredHost === "0.0.0.0" || configuredHost === "::"
+    ? "127.0.0.1"
+    : configuredHost;
+  return `http://${host}:${config.server.port}/api/health`;
+}
+
+async function probeHealth(config: PaperclipConfig): Promise<HealthResult> {
+  try {
+    const response = await fetch(healthUrl(config), { signal: AbortSignal.timeout(2_000) });
+    const body = (await response.json()) as {
+      status?: unknown;
+      serverVersion?: unknown;
+      version?: unknown;
+    };
+    const version = typeof body.serverVersion === "string"
+      ? body.serverVersion
+      : typeof body.version === "string"
+        ? body.version
+        : null;
+    return { ok: response.ok && body.status === "ok", version };
+  } catch (error) {
+    return { ok: false, version: null, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function serviceHealthChecks(
+  config: PaperclipConfig,
+  dependencies: Partial<ServiceCheckDependencies> = {},
+): Promise<CheckResult[]> {
+  const deps: ServiceCheckDependencies = {
+    detect: (instanceId) => detectServiceManager({ instanceId }),
+    probe: probeHealth,
+    ...dependencies,
+  };
+  const instanceId = resolvePaperclipInstanceId();
+  const detection = await deps.detect(instanceId);
+  if (!detection.supported) {
+    return [{ name: "Background service", status: "pass", message: detection.reason }];
+  }
+
+  const manager = detection.manager;
+  const status = await manager.status();
+  if (!status.installed) {
+    return [
+      {
+        name: "Background service",
+        status: "pass",
+        message: `Not installed for instance ${instanceId} (optional)`,
+      },
+    ];
+  }
+
+  const results: CheckResult[] = [];
+  let definitionCurrent = false;
+  try {
+    definitionCurrent = (await fs.readFile(manager.definitionPath, "utf8")) === manager.renderDefinition();
+  } catch {
+    definitionCurrent = false;
+  }
+  results.push(
+    definitionCurrent
+      ? { name: "Service definition", status: "pass", message: manager.definitionPath }
+      : {
+          name: "Service definition",
+          status: "fail",
+          message: `Missing or drifted definition at ${manager.definitionPath}`,
+          repairHint: "Run `paperclipai service install` to regenerate the service definition",
+        },
+  );
+
+  const health = await deps.probe(config);
+  results.push(
+    status.active
+      ? { name: "Service runtime", status: "pass", message: `${status.serviceName} is active` }
+      : {
+          name: "Service runtime",
+          status: "fail",
+          message: health.ok
+            ? `${status.serviceName} is inactive but the configured port is serving another Paperclip process`
+            : `${status.serviceName} is ${status.detail ?? "inactive"}`,
+          repairHint: "Run `paperclipai service start`, or stop the conflicting foreground process first",
+        },
+  );
+
+  const expectedVersion = readInstallManifest()?.version ?? null;
+  results.push(
+    !health.ok
+      ? {
+          name: "Service health",
+          status: "fail",
+          message: health.error ?? "Health endpoint did not report ok",
+          repairHint: "Inspect `paperclipai service status` and `paperclipai service logs`",
+        }
+      : expectedVersion && health.version !== expectedVersion
+        ? {
+            name: "Service version",
+            status: "fail",
+            message: `Running ${health.version ?? "unknown"}; managed install is ${expectedVersion}`,
+            repairHint: "Run `paperclipai service restart --expected-version " + expectedVersion + "`",
+          }
+        : {
+            name: "Service health",
+            status: "pass",
+            message: `Healthy${health.version ? ` at version ${health.version}` : ""}`,
+          },
+  );
+
+  if (status.enabled && status.linger === false) {
+    results.push({
+      name: "Service linger",
+      status: "warn",
+      message: "Start-on-login is enabled but systemd user lingering is off",
+      repairHint: "Re-run `paperclipai service install --enable-linger` if the service must survive logout",
+    });
+  }
+
+  return results;
+}

--- a/cli/src/checks/service-health-check.ts
+++ b/cli/src/checks/service-health-check.ts
@@ -100,7 +100,10 @@ export async function serviceHealthChecks(
         },
   );
 
-  const expectedVersion = readInstallManifest()?.version ?? null;
+  let expectedVersion: string | null = null;
+  try {
+    expectedVersion = readInstallManifest()?.version ?? null;
+  } catch {}
   results.push(
     !health.ok
       ? {

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -19,6 +19,7 @@ import {
 } from "../checks/index.js";
 import { loadPaperclipEnvFile } from "../config/env.js";
 import { printPaperclipCliBanner } from "../utils/banner.js";
+import { printUpdateNotice } from "../update-notice.js";
 
 const STATUS_ICON = {
   pass: pc.green("✓"),
@@ -31,6 +32,7 @@ export async function doctor(opts: {
   repair?: boolean;
   yes?: boolean;
 }): Promise<{ passed: number; warned: number; failed: number }> {
+  await printUpdateNotice(opts.config);
   printPaperclipCliBanner();
   p.intro(pc.bgCyan(pc.black(" paperclip doctor ")));
 

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -9,8 +9,11 @@ import {
   deploymentAuthCheck,
   llmCheck,
   logCheck,
+  managedInstallChecks,
+  nodeRuntimeCheck,
   portCheck,
   secretsCheck,
+  serviceHealthChecks,
   storageCheck,
   type CheckResult,
 } from "../checks/index.js";
@@ -119,6 +122,21 @@ export async function doctor(opts: {
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);
+
+  // 10. Runtime and managed install checks
+  const nodeResult = nodeRuntimeCheck();
+  results.push(nodeResult);
+  printResult(nodeResult);
+  for (const result of managedInstallChecks()) {
+    results.push(result);
+    printResult(result);
+  }
+
+  // 11. Background service checks
+  for (const result of await serviceHealthChecks(config)) {
+    results.push(result);
+    printResult(result);
+  }
 
   // Summary
   return printSummary(results);

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -26,7 +26,7 @@ const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
 export type InstallOptions = { canary?: boolean; version?: string; yes?: boolean };
 
-type CommandRunner = (
+export type CommandRunner = (
   file: string,
   args: string[],
   options?: Parameters<typeof execFileAsync>[2],
@@ -66,7 +66,7 @@ function parseResolvedVersion(stdout: string): string {
   throw new Error(`npm returned an unexpected version response: ${trimmed}`);
 }
 
-async function resolvePublishedVersion(spec: string, runCommand: CommandRunner): Promise<string> {
+export async function resolvePublishedVersion(spec: string, runCommand: CommandRunner): Promise<string> {
   const result = await runCommand(
     "npm",
     ["view", `paperclipai@${spec}`, "version", "--json", `--registry=${PUBLIC_NPM_REGISTRY}`],
@@ -79,7 +79,7 @@ function payloadEntrypoint(payloadPath: string): string {
   return path.join(payloadPath, "node_modules", "paperclipai", "dist", "index.js");
 }
 
-async function smokePayload(payloadPath: string, expectedVersion: string, runCommand: CommandRunner): Promise<void> {
+export async function smokePayload(payloadPath: string, expectedVersion: string, runCommand: CommandRunner): Promise<void> {
   const entrypoint = payloadEntrypoint(payloadPath);
   if (!fs.existsSync(entrypoint)) throw new Error(`Installed package is missing its CLI entrypoint: ${entrypoint}`);
   const result = await runCommand(process.execPath, [entrypoint, "--version"], { maxBuffer: 1024 * 1024 });
@@ -89,7 +89,7 @@ async function smokePayload(payloadPath: string, expectedVersion: string, runCom
   }
 }
 
-async function installNpmPayload(
+export async function installNpmPayload(
   version: string,
   runCommand: CommandRunner,
   paths = resolveInstallStorePaths(),

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -21,7 +21,7 @@ import {
 } from "../install-store.js";
 
 const execFileAsync = promisify(execFile);
-const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org";
+export const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org";
 const DEFAULT_GITHUB_REPO = "paperclipai/paperclip";
 const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -13,6 +13,7 @@ import {
   pruneInstallPayloads,
   readInstallManifest,
   resolveInstallStorePaths,
+  withInstallStoreLock,
   writeInstallManifestAtomic,
   writeManagedShim,
   type InstallChannel,
@@ -88,8 +89,11 @@ async function smokePayload(payloadPath: string, expectedVersion: string, runCom
   }
 }
 
-async function installNpmPayload(version: string, runCommand: CommandRunner): Promise<{ payloadPath: string; reused: boolean }> {
-  const paths = resolveInstallStorePaths();
+async function installNpmPayload(
+  version: string,
+  runCommand: CommandRunner,
+  paths = resolveInstallStorePaths(),
+): Promise<{ payloadPath: string; reused: boolean }> {
   const payloadPath = payloadPathFor(paths, "npm", version);
   if (fs.existsSync(payloadPath)) {
     await smokePayload(payloadPath, version, runCommand);
@@ -185,28 +189,31 @@ export async function installCommand(
   console.log(`Installing paperclipai@${version}...`);
 
   const paths = resolveInstallStorePaths();
-  assertManagedShimWritable(paths);
-  const currentManifest = readInstallManifest(paths);
-  const installed = await installNpmPayload(version, runCommand);
-  const record: InstallRecord = {
-    source: "npm",
-    version,
-    channel: request.channel,
-    payloadPath: installed.payloadPath,
-    installedAt: (dependencies.now?.() ?? new Date()).toISOString(),
-  };
-  const nextManifest = buildNextManifest(record, currentManifest);
-  const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
-  flipCurrentAtomic(installed.payloadPath, paths);
-  try {
-    writeInstallManifestAtomic(nextManifest, paths);
-  } catch (error) {
-    if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths);
-    else fs.rmSync(paths.currentPath, { force: true });
-    throw error;
-  }
-  writeManagedShim(paths);
-  pruneInstallPayloads(nextManifest, paths);
+  const installed = await withInstallStoreLock(async () => {
+    assertManagedShimWritable(paths);
+    const currentManifest = readInstallManifest(paths);
+    const payload = await installNpmPayload(version, runCommand, paths);
+    const record: InstallRecord = {
+      source: "npm",
+      version,
+      channel: request.channel,
+      payloadPath: payload.payloadPath,
+      installedAt: (dependencies.now?.() ?? new Date()).toISOString(),
+    };
+    const nextManifest = buildNextManifest(record, currentManifest);
+    const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
+    flipCurrentAtomic(payload.payloadPath, paths);
+    try {
+      writeInstallManifestAtomic(nextManifest, paths);
+    } catch (error) {
+      if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths);
+      else fs.rmSync(paths.currentPath, { force: true });
+      throw error;
+    }
+    writeManagedShim(paths);
+    pruneInstallPayloads(nextManifest, paths);
+    return payload;
+  }, paths);
   await ensureShimOnPath(options);
 
   console.log(pc.green(`${installed.reused ? "Activated cached" : "Installed"} paperclipai ${version} (${request.channel}).`));

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -22,9 +22,10 @@ import {
 
 const execFileAsync = promisify(execFile);
 const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org";
+const DEFAULT_GITHUB_REPO = "paperclipai/paperclip";
 const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
-export type InstallOptions = { canary?: boolean; version?: string; yes?: boolean };
+export type InstallOptions = { canary?: boolean; version?: string; ref?: string; repo?: string; yes?: boolean };
 
 export type CommandRunner = (
   file: string,
@@ -73,6 +74,25 @@ export async function resolvePublishedVersion(spec: string, runCommand: CommandR
     { maxBuffer: 1024 * 1024 },
   );
   return parseResolvedVersion(result.stdout);
+}
+
+export function resolveGitInstallRequest(options: InstallOptions): { repo: string; ref: string; pinned: boolean } | null {
+  if (!options.ref && !options.repo) return null;
+  if (!options.ref) throw new Error("--repo requires --ref.");
+  if (options.canary || options.version) throw new Error("--ref cannot be combined with --canary or --version.");
+  const repo = (options.repo ?? DEFAULT_GITHUB_REPO).trim();
+  const ref = options.ref.trim();
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) throw new Error(`--repo must be an owner/name GitHub repository, received '${repo}'.`);
+  if (!ref || ref.startsWith("-") || /[\0\r\n]/.test(ref)) throw new Error(`Invalid GitHub ref '${options.ref}'.`);
+  return { repo, ref, pinned: /^[0-9a-f]{7,40}$/i.test(ref) };
+}
+
+export async function resolveGitHubRef(repo: string, ref: string, runCommand: CommandRunner): Promise<string> {
+  const result = await runCommand("curl", ["--fail", "--silent", "--show-error", "--location", "--header", "Accept: application/vnd.github+json", "--header", "User-Agent: paperclipai-install", `https://api.github.com/repos/${repo}/commits/${encodeURIComponent(ref)}`], { maxBuffer: 4 * 1024 * 1024 });
+  let sha: unknown;
+  try { sha = (JSON.parse(result.stdout) as { sha?: unknown }).sha; } catch { throw new Error(`GitHub returned an invalid response while resolving ${repo}@${ref}.`); }
+  if (typeof sha !== "string" || !/^[0-9a-f]{40}$/i.test(sha)) throw new Error(`GitHub did not return a full commit SHA for ${repo}@${ref}.`);
+  return sha.toLowerCase();
 }
 
 function payloadEntrypoint(payloadPath: string): string {
@@ -144,6 +164,38 @@ export async function installNpmPayload(
   }
 }
 
+export async function installGitPayload(repo: string, sha: string, runCommand: CommandRunner, paths = resolveInstallStorePaths()): Promise<{ payloadPath: string; reused: boolean; version: string }> {
+  const identifier = sha.slice(0, 12);
+  const payloadPath = payloadPathFor(paths, "git", identifier);
+  if (fs.existsSync(payloadPath)) {
+    const metadata = JSON.parse(fs.readFileSync(path.join(payloadPath, "node_modules", "paperclipai", "package.json"), "utf8")) as { version: string };
+    await smokePayload(payloadPath, metadata.version, runCommand);
+    return { payloadPath, reused: true, version: metadata.version };
+  }
+  const sourceRoot = path.dirname(payloadPath);
+  fs.mkdirSync(sourceRoot, { recursive: true, mode: 0o700 });
+  const stagingRoot = path.join(sourceRoot, `.${identifier}.tmp-${process.pid}-${Date.now()}`);
+  const checkoutPath = path.join(stagingRoot, "source");
+  const archivePath = path.join(stagingRoot, "source.tar.gz");
+  const stagedPayload = path.join(stagingRoot, "payload");
+  fs.rmSync(stagingRoot, { recursive: true, force: true });
+  fs.mkdirSync(checkoutPath, { recursive: true, mode: 0o700 });
+  try {
+    await runCommand("curl", ["--fail", "--silent", "--show-error", "--location", "--output", archivePath, `https://codeload.github.com/${repo}/tar.gz/${sha}`], { maxBuffer: 4 * 1024 * 1024 });
+    await runCommand("tar", ["-xzf", archivePath, "--strip-components=1", "-C", checkoutPath], { maxBuffer: 4 * 1024 * 1024 });
+    await runCommand("corepack", ["pnpm", "install", "--frozen-lockfile"], { cwd: checkoutPath, maxBuffer: 32 * 1024 * 1024 });
+    await runCommand("bash", ["scripts/build-npm.sh", "--skip-checks"], { cwd: checkoutPath, maxBuffer: 32 * 1024 * 1024 });
+    const metadata = JSON.parse(fs.readFileSync(path.join(checkoutPath, "cli", "package.json"), "utf8")) as { version: string };
+    await runCommand("npm", ["pack", "--pack-destination", stagingRoot], { cwd: path.join(checkoutPath, "cli"), maxBuffer: 16 * 1024 * 1024 });
+    const tarball = fs.readdirSync(stagingRoot).find((entry) => entry.endsWith(".tgz"));
+    if (!tarball) throw new Error("npm pack did not produce a paperclipai tarball.");
+    await runCommand("npm", ["install", "--prefix", stagedPayload, path.join(stagingRoot, tarball), "--no-audit", "--no-fund"], { cwd: stagingRoot, maxBuffer: 32 * 1024 * 1024 });
+    await smokePayload(stagedPayload, metadata.version, runCommand);
+    fs.renameSync(stagedPayload, payloadPath);
+    return { payloadPath, reused: false, version: metadata.version };
+  } finally { fs.rmSync(stagingRoot, { recursive: true, force: true }); }
+}
+
 function pathContains(directory: string): boolean {
   const normalized = path.resolve(directory);
   return (process.env.PATH ?? "").split(path.delimiter).filter(Boolean).some((entry) => path.resolve(entry) === normalized);
@@ -183,6 +235,26 @@ export async function installCommand(
 ): Promise<void> {
   assertSupportedNodeVersion();
   const runCommand = dependencies.runCommand ?? execFileAsync;
+  const gitRequest = resolveGitInstallRequest(options);
+  if (gitRequest) {
+    const sha = await resolveGitHubRef(gitRequest.repo, gitRequest.ref, runCommand);
+    const paths = resolveInstallStorePaths();
+    const installed = await withInstallStoreLock(async () => {
+      assertManagedShimWritable(paths);
+      const currentManifest = readInstallManifest(paths);
+      const payload = await installGitPayload(gitRequest.repo, sha, runCommand, paths);
+      const record: InstallRecord = { source: "git", version: payload.version, channel: "pinned", repo: gitRequest.repo, ref: gitRequest.ref, sha, payloadPath: payload.payloadPath, installedAt: (dependencies.now?.() ?? new Date()).toISOString() };
+      const nextManifest = buildNextManifest(record, currentManifest);
+      const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
+      flipCurrentAtomic(payload.payloadPath, paths);
+      try { writeInstallManifestAtomic(nextManifest, paths); } catch (error) { if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths); else fs.rmSync(paths.currentPath, { force: true }); throw error; }
+      writeManagedShim(paths); pruneInstallPayloads(nextManifest, paths); return payload;
+    }, paths);
+    await ensureShimOnPath(options);
+    console.log(pc.yellow(`Warning: running unreleased code from ${gitRequest.repo}@${gitRequest.ref} (${sha.slice(0, 12)}).`));
+    console.log(pc.green(`${installed.reused ? "Activated cached" : "Installed"} paperclipai git payload ${sha.slice(0, 12)}.`));
+    return;
+  }
   const request = resolveNpmInstallRequest(options);
   console.log(`Resolving paperclipai@${request.spec} from ${PUBLIC_NPM_REGISTRY}...`);
   const version = await resolvePublishedVersion(request.spec, runCommand);

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -1,0 +1,215 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  addManagedPathBlock,
+  assertManagedShimWritable,
+  buildNextManifest,
+  flipCurrentAtomic,
+  payloadPathFor,
+  pruneInstallPayloads,
+  readInstallManifest,
+  resolveInstallStorePaths,
+  writeInstallManifestAtomic,
+  writeManagedShim,
+  type InstallChannel,
+  type InstallRecord,
+} from "../install-store.js";
+
+const execFileAsync = promisify(execFile);
+const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org";
+const EXACT_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export type InstallOptions = { canary?: boolean; version?: string; yes?: boolean };
+
+type CommandRunner = (
+  file: string,
+  args: string[],
+  options?: Parameters<typeof execFileAsync>[2],
+) => Promise<{ stdout: string; stderr: string }>;
+
+function assertSupportedNodeVersion(): void {
+  const major = Number(process.versions.node.split(".")[0]);
+  if (!Number.isFinite(major) || major < 20) {
+    throw new Error(`Managed installs require Node.js 20 or newer (found ${process.version}).`);
+  }
+}
+
+export function resolveNpmInstallRequest(options: InstallOptions): {
+  spec: string;
+  channel: InstallChannel;
+} {
+  if (options.canary && options.version) throw new Error("Choose either --canary or --version, not both.");
+  if (options.version) {
+    const version = options.version.trim();
+    if (!EXACT_VERSION_PATTERN.test(version)) {
+      throw new Error(`--version requires an exact published version, received '${options.version}'.`);
+    }
+    return { spec: version, channel: "pinned" };
+  }
+  return options.canary ? { spec: "canary", channel: "canary" } : { spec: "latest", channel: "latest" };
+}
+
+function parseResolvedVersion(stdout: string): string {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error("npm returned an empty version response.");
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    if (EXACT_VERSION_PATTERN.test(trimmed)) return trimmed;
+  }
+  throw new Error(`npm returned an unexpected version response: ${trimmed}`);
+}
+
+async function resolvePublishedVersion(spec: string, runCommand: CommandRunner): Promise<string> {
+  const result = await runCommand(
+    "npm",
+    ["view", `paperclipai@${spec}`, "version", "--json", `--registry=${PUBLIC_NPM_REGISTRY}`],
+    { maxBuffer: 1024 * 1024 },
+  );
+  return parseResolvedVersion(result.stdout);
+}
+
+function payloadEntrypoint(payloadPath: string): string {
+  return path.join(payloadPath, "node_modules", "paperclipai", "dist", "index.js");
+}
+
+async function smokePayload(payloadPath: string, expectedVersion: string, runCommand: CommandRunner): Promise<void> {
+  const entrypoint = payloadEntrypoint(payloadPath);
+  if (!fs.existsSync(entrypoint)) throw new Error(`Installed package is missing its CLI entrypoint: ${entrypoint}`);
+  const result = await runCommand(process.execPath, [entrypoint, "--version"], { maxBuffer: 1024 * 1024 });
+  const reportedVersion = result.stdout.trim().split(/\s+/)[0];
+  if (reportedVersion !== expectedVersion) {
+    throw new Error(`Installed CLI smoke check reported ${reportedVersion || "no version"}; expected ${expectedVersion}.`);
+  }
+}
+
+async function installNpmPayload(version: string, runCommand: CommandRunner): Promise<{ payloadPath: string; reused: boolean }> {
+  const paths = resolveInstallStorePaths();
+  const payloadPath = payloadPathFor(paths, "npm", version);
+  if (fs.existsSync(payloadPath)) {
+    await smokePayload(payloadPath, version, runCommand);
+    return { payloadPath, reused: true };
+  }
+  const sourceRoot = path.dirname(payloadPath);
+  fs.mkdirSync(sourceRoot, { recursive: true, mode: 0o700 });
+  const sourceStat = fs.lstatSync(sourceRoot);
+  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+    throw new Error(`Refusing to install into unsafe payload root ${sourceRoot}.`);
+  }
+  fs.chmodSync(paths.cliRoot, 0o700);
+  fs.chmodSync(paths.installsRoot, 0o700);
+  fs.chmodSync(sourceRoot, 0o700);
+  const stagingPath = path.join(sourceRoot, `.${version}.tmp-${process.pid}-${Date.now()}`);
+  const npmUserConfigPath = path.join(sourceRoot, `.npmrc-${process.pid}-${Date.now()}`);
+  fs.rmSync(stagingPath, { recursive: true, force: true });
+  try {
+    fs.writeFileSync(
+      npmUserConfigPath,
+      `registry=${PUBLIC_NPM_REGISTRY}\n@paperclipai:registry=${PUBLIC_NPM_REGISTRY}\n`,
+      { mode: 0o600 },
+    );
+    await runCommand(
+      "npm",
+      [
+        "install",
+        "--prefix",
+        stagingPath,
+        `paperclipai@${version}`,
+        `--registry=${PUBLIC_NPM_REGISTRY}`,
+        `--@paperclipai:registry=${PUBLIC_NPM_REGISTRY}`,
+        "--no-audit",
+        "--no-fund",
+      ],
+      {
+        cwd: sourceRoot,
+        env: { ...process.env, npm_config_userconfig: npmUserConfigPath },
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    );
+    await smokePayload(stagingPath, version, runCommand);
+    fs.renameSync(stagingPath, payloadPath);
+    return { payloadPath, reused: false };
+  } finally {
+    fs.rmSync(stagingPath, { recursive: true, force: true });
+    fs.rmSync(npmUserConfigPath, { force: true });
+  }
+}
+
+function pathContains(directory: string): boolean {
+  const normalized = path.resolve(directory);
+  return (process.env.PATH ?? "").split(path.delimiter).filter(Boolean).some((entry) => path.resolve(entry) === normalized);
+}
+
+function shellRcPath(): string | null {
+  const home = process.env.HOME;
+  if (!home) return null;
+  const shell = path.basename(process.env.SHELL ?? "");
+  if (shell === "bash") return path.join(home, ".bashrc");
+  if (shell === "zsh") return path.join(home, ".zshrc");
+  return null;
+}
+
+async function ensureShimOnPath(options: InstallOptions): Promise<void> {
+  const paths = resolveInstallStorePaths();
+  const binDir = path.dirname(paths.shimPath);
+  if (pathContains(binDir)) return;
+  const manualInstruction = `export PATH="$HOME/.local/bin:$PATH"`;
+  const rcPath = shellRcPath();
+  if (!process.stdin.isTTY || !process.stdout.isTTY || !rcPath) {
+    console.log(pc.yellow(`Add Paperclip to PATH for this shell:\n  ${manualInstruction}`));
+    return;
+  }
+  const confirmed = options.yes === true ? true : await p.confirm({ message: `Add ~/.local/bin to PATH in ${rcPath}?`, initialValue: true });
+  if (p.isCancel(confirmed) || !confirmed) {
+    console.log(pc.yellow(`PATH was not changed. Run:\n  ${manualInstruction}`));
+    return;
+  }
+  const changed = addManagedPathBlock(rcPath);
+  console.log(changed ? pc.green(`Updated ${rcPath}.`) : pc.dim(`${rcPath} already contains the PATH block.`));
+}
+
+export async function installCommand(
+  options: InstallOptions,
+  dependencies: { runCommand?: CommandRunner; now?: () => Date } = {},
+): Promise<void> {
+  assertSupportedNodeVersion();
+  const runCommand = dependencies.runCommand ?? execFileAsync;
+  const request = resolveNpmInstallRequest(options);
+  console.log(`Resolving paperclipai@${request.spec} from ${PUBLIC_NPM_REGISTRY}...`);
+  const version = await resolvePublishedVersion(request.spec, runCommand);
+  console.log(`Installing paperclipai@${version}...`);
+
+  const paths = resolveInstallStorePaths();
+  assertManagedShimWritable(paths);
+  const currentManifest = readInstallManifest(paths);
+  const installed = await installNpmPayload(version, runCommand);
+  const record: InstallRecord = {
+    source: "npm",
+    version,
+    channel: request.channel,
+    payloadPath: installed.payloadPath,
+    installedAt: (dependencies.now?.() ?? new Date()).toISOString(),
+  };
+  const nextManifest = buildNextManifest(record, currentManifest);
+  const oldTarget = fs.existsSync(paths.currentPath) ? fs.readlinkSync(paths.currentPath) : null;
+  flipCurrentAtomic(installed.payloadPath, paths);
+  try {
+    writeInstallManifestAtomic(nextManifest, paths);
+  } catch (error) {
+    if (oldTarget) flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths);
+    else fs.rmSync(paths.currentPath, { force: true });
+    throw error;
+  }
+  writeManagedShim(paths);
+  pruneInstallPayloads(nextManifest, paths);
+  await ensureShimOnPath(options);
+
+  console.log(pc.green(`${installed.reused ? "Activated cached" : "Installed"} paperclipai ${version} (${request.channel}).`));
+  console.log(pc.dim(`Payload: ${installed.payloadPath}`));
+  console.log(`Run ${pc.cyan("paperclipai --version")} to verify the managed install.`);
+}

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -43,6 +43,8 @@ import {
   trackInstallStarted,
   trackInstallCompleted,
 } from "../telemetry.js";
+import { handleOnboardService } from "../onboard-service.js";
+import { readInstallManifest, isManagedExecutable } from "../install-store.js";
 
 type SetupMode = "quickstart" | "advanced";
 
@@ -52,6 +54,7 @@ type OnboardOptions = {
   yes?: boolean;
   invokedByRun?: boolean;
   bind?: BindMode;
+  installService?: boolean;
 };
 
 type OnboardDefaults = Pick<PaperclipConfig, "database" | "logging" | "server" | "auth" | "storage" | "secrets">;
@@ -322,6 +325,21 @@ function canCreateBootstrapInviteImmediately(config: Pick<PaperclipConfig, "data
   return config.server.deploymentMode === "authenticated" && config.database.mode !== "embedded-postgres";
 }
 
+export function isEphemeralNpxExecution(entrypoint = process.argv[1]): boolean {
+  if (!entrypoint) return false;
+  const normalized = entrypoint.replaceAll("\\", "/");
+  return normalized.includes("/_npx/") || normalized.includes("/npm/_npx/");
+}
+
+function printManagedInstallHint(): void {
+  const manifest = readInstallManifest();
+  if (manifest && isManagedExecutable(process.argv[1], manifest)) return;
+  if (!isEphemeralNpxExecution()) return;
+  p.log.info(
+    `This npx run is temporary. Use ${pc.cyan("paperclipai install")} for atomic updates, rollback, and service support.`,
+  );
+}
+
 export async function onboard(opts: OnboardOptions): Promise<void> {
   if (opts.bind && !["loopback", "lan", "tailnet"].includes(opts.bind)) {
     throw new Error(`Unsupported bind preset for onboard: ${opts.bind}. Use loopback, lan, or tailnet.`);
@@ -400,7 +418,10 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
       "Next commands",
     );
 
-    let shouldRunNow = opts.run === true || opts.yes === true;
+    printManagedInstallHint();
+    const serviceInstalled = await handleOnboardService(opts);
+
+    let shouldRunNow = !serviceInstalled && (opts.run === true || opts.yes === true);
     if (!shouldRunNow && !opts.invokedByRun && process.stdin.isTTY && process.stdout.isTTY) {
       const answer = await p.confirm({
         message: "Start Paperclip now?",
@@ -655,12 +676,16 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
     "Next commands",
   );
 
+  printManagedInstallHint();
+
   if (canCreateBootstrapInviteImmediately({ database, server })) {
     p.log.step("Generating bootstrap CEO invite");
     await bootstrapCeoInvite({ config: configPath });
   }
 
-  let shouldRunNow = opts.run === true || opts.yes === true;
+  const serviceInstalled = await handleOnboardService(opts);
+
+  let shouldRunNow = !serviceInstalled && (opts.run === true || opts.yes === true);
   if (!shouldRunNow && !opts.invokedByRun && process.stdin.isTTY && process.stdout.isTTY) {
     const answer = await p.confirm({
       message: "Start Paperclip now?",

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -16,6 +16,7 @@ import {
   resolvePaperclipHomeDir,
   resolvePaperclipInstanceId,
 } from "../config/home.js";
+import { assertForegroundRunAllowed } from "../services/service-manager.js";
 
 interface RunOptions {
   config?: string;
@@ -23,6 +24,7 @@ interface RunOptions {
   repair?: boolean;
   yes?: boolean;
   bind?: "loopback" | "lan" | "tailnet";
+  force?: boolean;
 }
 
 interface StartedServer {
@@ -35,6 +37,7 @@ interface StartedServer {
 export async function runCommand(opts: RunOptions): Promise<void> {
   const instanceId = resolvePaperclipInstanceId(opts.instance);
   process.env.PAPERCLIP_INSTANCE_ID = instanceId;
+  await assertForegroundRunAllowed(instanceId, opts.force);
 
   const homeDir = resolvePaperclipHomeDir();
   fs.mkdirSync(homeDir, { recursive: true });

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -17,6 +17,7 @@ import {
   resolvePaperclipInstanceId,
 } from "../config/home.js";
 import { assertForegroundRunAllowed } from "../services/service-manager.js";
+import { printUpdateNotice } from "../update-notice.js";
 
 interface RunOptions {
   config?: string;
@@ -48,6 +49,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const configPath = resolveConfigPath(opts.config);
   process.env.PAPERCLIP_CONFIG = configPath;
   loadPaperclipEnvFile(configPath);
+  await printUpdateNotice(configPath);
 
   p.intro(pc.bgCyan(pc.black(" paperclipai run ")));
   p.log.message(pc.dim(`Home: ${paths.homeDir}`));

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
-import { cliVersion } from "../version.js";
+import { packageVersion } from "../version.js";
 import { readConfig, resolveConfigPath } from "../config/store.js";
 import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
 import { detectServiceManager, type ServiceManager, type ServiceStatus } from "../services/service-manager.js";
@@ -53,6 +53,10 @@ async function waitForHealth(instanceId: string, expectedVersion: string | null,
   throw new Error(`Paperclip service did not become healthy${expectedVersion ? ` at version ${expectedVersion}` : ""}: ${last.error ?? `reported ${last.serverVersion ?? "no version"}`}`);
 }
 
+export function resolveRestartExpectedVersion(serverVersion: string | null): string {
+  return serverVersion ?? packageVersion;
+}
+
 async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, drainRequired: boolean): Promise<{ requestedAt: string; previousVersion: string }> {
   if (!status.pid) throw new Error(`Cannot restart ${status.serviceName}: supervisor did not report a server pid.`);
   const health = await probeHealth(instanceId);
@@ -68,7 +72,7 @@ async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, 
     drainRequired,
     requestedByRunId: process.env.PAPERCLIP_RUN_ID?.trim() || null,
   }, null, 2)}\n`, "utf8");
-  return { requestedAt, previousVersion: health.serverVersion ?? cliVersion };
+  return { requestedAt, previousVersion: resolveRestartExpectedVersion(health.serverVersion) };
 }
 
 async function waitForRestartReport(requestedAt: string, timeoutMs = 10_000): Promise<unknown | null> {

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
 import { readConfig, resolveConfigPath } from "../config/store.js";
-import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
+import { resolvePaperclipInstanceId, resolvePaperclipInstanceRoot } from "../config/home.js";
 import { detectServiceManager, type ServiceManager, type ServiceStatus } from "../services/service-manager.js";
 import { buildLocalHealthUrl } from "../utils/health-url.js";
 
@@ -57,11 +57,11 @@ export function resolveRestartExpectedVersion(expectedVersion: string | null | u
 async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, drainRequired: boolean): Promise<{ requestedAt: string }> {
   if (!status.pid) throw new Error(`Cannot restart ${status.serviceName}: supervisor did not report a server pid.`);
   const health = await probeHealth(instanceId);
-  const homeDir = resolvePaperclipHomeDir();
+  const instanceRoot = resolvePaperclipInstanceRoot(instanceId);
   const requestedAt = new Date().toISOString();
-  await fs.mkdir(homeDir, { recursive: true });
-  await fs.rm(path.join(homeDir, "hot-restart-report.json"), { force: true });
-  await fs.writeFile(path.join(homeDir, "hot-restart-intent.json"), `${JSON.stringify({
+  await fs.mkdir(instanceRoot, { recursive: true });
+  await fs.rm(path.join(instanceRoot, "hot-restart-report.json"), { force: true });
+  await fs.writeFile(path.join(instanceRoot, "hot-restart-intent.json"), `${JSON.stringify({
     version: 1,
     requestedAt,
     previousServerPid: status.pid,
@@ -72,8 +72,8 @@ async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, 
   return { requestedAt };
 }
 
-async function waitForRestartReport(requestedAt: string, timeoutMs = 10_000): Promise<unknown | null> {
-  const reportPath = path.join(resolvePaperclipHomeDir(), "hot-restart-report.json");
+async function waitForRestartReport(instanceId: string, requestedAt: string, timeoutMs = 10_000): Promise<unknown | null> {
+  const reportPath = path.join(resolvePaperclipInstanceRoot(instanceId), "hot-restart-report.json");
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
@@ -95,7 +95,7 @@ export async function restartManagedService(input: { instanceId?: string; expect
   const intent = await writeHotRestartIntent(before, instanceId, input.waitForDrain ?? false);
   await detection.manager.restart();
   const health = await waitForHealth(instanceId, resolveRestartExpectedVersion(input.expectedVersion));
-  return { status: await detection.manager.status(), health, report: await waitForRestartReport(intent.requestedAt) };
+  return { status: await detection.manager.status(), health, report: await waitForRestartReport(instanceId, intent.requestedAt) };
 }
 
 export function registerServiceCommands(program: Command): void {

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -6,6 +6,7 @@ import { packageVersion } from "../version.js";
 import { readConfig, resolveConfigPath } from "../config/store.js";
 import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
 import { detectServiceManager, type ServiceManager, type ServiceStatus } from "../services/service-manager.js";
+import { buildLocalHealthUrl } from "../utils/health-url.js";
 
 type CommonOptions = { instance?: string; json?: boolean };
 type HealthResult = { ok: boolean; serverVersion: string | null; error?: string };
@@ -26,10 +27,7 @@ async function resolveManager(opts: CommonOptions): Promise<ServiceManager | nul
 function healthUrl(instanceId: string): string {
   process.env.PAPERCLIP_INSTANCE_ID = instanceId;
   const config = readConfig(resolveConfigPath());
-  const port = config?.server.port ?? 3100;
-  const configuredHost = config?.server.host?.trim();
-  const host = !configuredHost || configuredHost === "0.0.0.0" || configuredHost === "::" ? "127.0.0.1" : configuredHost;
-  return `http://${host}:${port}/api/health`;
+  return buildLocalHealthUrl(config?.server.host, config?.server.port ?? 3100);
 }
 
 async function probeHealth(instanceId: string): Promise<HealthResult> {
@@ -53,11 +51,11 @@ async function waitForHealth(instanceId: string, expectedVersion: string | null,
   throw new Error(`Paperclip service did not become healthy${expectedVersion ? ` at version ${expectedVersion}` : ""}: ${last.error ?? `reported ${last.serverVersion ?? "no version"}`}`);
 }
 
-export function resolveRestartExpectedVersion(serverVersion: string | null): string {
-  return serverVersion ?? packageVersion;
+export function resolveRestartExpectedVersion(expectedVersion: string | null | undefined): string {
+  return expectedVersion ?? packageVersion;
 }
 
-async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, drainRequired: boolean): Promise<{ requestedAt: string; previousVersion: string }> {
+async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, drainRequired: boolean): Promise<{ requestedAt: string }> {
   if (!status.pid) throw new Error(`Cannot restart ${status.serviceName}: supervisor did not report a server pid.`);
   const health = await probeHealth(instanceId);
   const homeDir = resolvePaperclipHomeDir();
@@ -72,7 +70,7 @@ async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, 
     drainRequired,
     requestedByRunId: process.env.PAPERCLIP_RUN_ID?.trim() || null,
   }, null, 2)}\n`, "utf8");
-  return { requestedAt, previousVersion: resolveRestartExpectedVersion(health.serverVersion) };
+  return { requestedAt };
 }
 
 async function waitForRestartReport(requestedAt: string, timeoutMs = 10_000): Promise<unknown | null> {
@@ -97,7 +95,7 @@ export async function restartManagedService(input: { instanceId?: string; expect
   const before = await detection.manager.status();
   const intent = await writeHotRestartIntent(before, instanceId, input.waitForDrain ?? false);
   await detection.manager.restart();
-  const health = await waitForHealth(instanceId, input.expectedVersion ?? intent.previousVersion);
+  const health = await waitForHealth(instanceId, resolveRestartExpectedVersion(input.expectedVersion));
   return { status: await detection.manager.status(), health, report: await waitForRestartReport(intent.requestedAt) };
 }
 

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as p from "@clack/prompts";
 import type { Command } from "commander";
-import { packageVersion } from "../version.js";
 import { readConfig, resolveConfigPath } from "../config/store.js";
 import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
 import { detectServiceManager, type ServiceManager, type ServiceStatus } from "../services/service-manager.js";
@@ -51,8 +50,8 @@ async function waitForHealth(instanceId: string, expectedVersion: string | null,
   throw new Error(`Paperclip service did not become healthy${expectedVersion ? ` at version ${expectedVersion}` : ""}: ${last.error ?? `reported ${last.serverVersion ?? "no version"}`}`);
 }
 
-export function resolveRestartExpectedVersion(expectedVersion: string | null | undefined): string {
-  return expectedVersion ?? packageVersion;
+export function resolveRestartExpectedVersion(expectedVersion: string | null | undefined): string | null {
+  return expectedVersion ?? null;
 }
 
 async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, drainRequired: boolean): Promise<{ requestedAt: string }> {

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import type { Command } from "commander";
+import { cliVersion } from "../version.js";
+import { readConfig, resolveConfigPath } from "../config/store.js";
+import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
+import { detectServiceManager, type ServiceManager, type ServiceStatus } from "../services/service-manager.js";
+
+type CommonOptions = { instance?: string; json?: boolean };
+type HealthResult = { ok: boolean; serverVersion: string | null; error?: string };
+
+function output(value: unknown, json: boolean | undefined): void {
+  if (json) console.log(JSON.stringify(value, null, 2));
+  else if (typeof value === "string") console.log(value);
+  else console.log(JSON.stringify(value, null, 2));
+}
+
+async function resolveManager(opts: CommonOptions): Promise<ServiceManager | null> {
+  const detection = await detectServiceManager({ instanceId: opts.instance });
+  if (detection.supported) return detection.manager;
+  output({ supported: false, message: detection.reason }, opts.json);
+  return null;
+}
+
+function healthUrl(instanceId: string): string {
+  process.env.PAPERCLIP_INSTANCE_ID = instanceId;
+  const config = readConfig(resolveConfigPath());
+  const port = config?.server.port ?? 3100;
+  const configuredHost = config?.server.host?.trim();
+  const host = !configuredHost || configuredHost === "0.0.0.0" || configuredHost === "::" ? "127.0.0.1" : configuredHost;
+  return `http://${host}:${port}/api/health`;
+}
+
+async function probeHealth(instanceId: string): Promise<HealthResult> {
+  try {
+    const response = await fetch(healthUrl(instanceId), { signal: AbortSignal.timeout(2_000) });
+    const body = await response.json() as { status?: unknown; serverVersion?: unknown; version?: unknown };
+    return { ok: response.ok && body.status === "ok", serverVersion: typeof body.serverVersion === "string" ? body.serverVersion : typeof body.version === "string" ? body.version : null };
+  } catch (error) {
+    return { ok: false, serverVersion: null, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function waitForHealth(instanceId: string, expectedVersion: string | null, timeoutMs = 60_000): Promise<HealthResult> {
+  const deadline = Date.now() + timeoutMs;
+  let last: HealthResult = { ok: false, serverVersion: null };
+  while (Date.now() < deadline) {
+    last = await probeHealth(instanceId);
+    if (last.ok && (!expectedVersion || last.serverVersion === expectedVersion)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Paperclip service did not become healthy${expectedVersion ? ` at version ${expectedVersion}` : ""}: ${last.error ?? `reported ${last.serverVersion ?? "no version"}`}`);
+}
+
+async function writeHotRestartIntent(status: ServiceStatus, instanceId: string, drainRequired: boolean): Promise<{ requestedAt: string; previousVersion: string }> {
+  if (!status.pid) throw new Error(`Cannot restart ${status.serviceName}: supervisor did not report a server pid.`);
+  const health = await probeHealth(instanceId);
+  const homeDir = resolvePaperclipHomeDir();
+  const requestedAt = new Date().toISOString();
+  await fs.mkdir(homeDir, { recursive: true });
+  await fs.rm(path.join(homeDir, "hot-restart-report.json"), { force: true });
+  await fs.writeFile(path.join(homeDir, "hot-restart-intent.json"), `${JSON.stringify({
+    version: 1,
+    requestedAt,
+    previousServerPid: status.pid,
+    previousServerVersion: health.serverVersion,
+    drainRequired,
+    requestedByRunId: process.env.PAPERCLIP_RUN_ID?.trim() || null,
+  }, null, 2)}\n`, "utf8");
+  return { requestedAt, previousVersion: health.serverVersion ?? cliVersion };
+}
+
+async function waitForRestartReport(requestedAt: string, timeoutMs = 10_000): Promise<unknown | null> {
+  const reportPath = path.join(resolvePaperclipHomeDir(), "hot-restart-report.json");
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const report = JSON.parse(await fs.readFile(reportPath, "utf8")) as { requestedAt?: unknown };
+      if (report.requestedAt === requestedAt) return report;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return null;
+}
+
+export async function restartManagedService(input: { instanceId?: string; expectedVersion?: string | null; waitForDrain?: boolean } = {}): Promise<{ status: ServiceStatus; health: HealthResult; report: unknown | null }> {
+  const instanceId = resolvePaperclipInstanceId(input.instanceId);
+  const detection = await detectServiceManager({ instanceId });
+  if (!detection.supported) throw new Error(detection.reason);
+  const before = await detection.manager.status();
+  const intent = await writeHotRestartIntent(before, instanceId, input.waitForDrain ?? false);
+  await detection.manager.restart();
+  const health = await waitForHealth(instanceId, input.expectedVersion ?? intent.previousVersion);
+  return { status: await detection.manager.status(), health, report: await waitForRestartReport(intent.requestedAt) };
+}
+
+export function registerServiceCommands(program: Command): void {
+  const service = program.command("service").description("Manage Paperclip as a background service");
+  const common = (command: Command) => command.option("-i, --instance <id>", "Local instance id (default: default)").option("--json", "Print machine-readable JSON", false);
+
+  common(service.command("install").description("Install and register the background service"))
+    .option("--no-start-now", "Install without starting now")
+    .option("--no-start-on-login", "Install without enabling start on login")
+    .option("--enable-linger", "Allow systemd startup without an active login session", false)
+    .action(async (opts) => {
+      const manager = await resolveManager(opts); if (!manager) return;
+      const result = await manager.install({ startNow: opts.startNow, startOnLogin: opts.startOnLogin });
+      let lingerEnabled = false;
+      if (manager.enableLinger) {
+        let consent = opts.enableLinger === true;
+        if (!consent && process.stdin.isTTY && process.stdout.isTTY) {
+          consent = await p.confirm({ message: "Allow Paperclip to run without an active login session? This runs 'loginctl enable-linger' for your user and may request system authorization.", initialValue: false }) === true;
+        }
+        if (consent) { await manager.enableLinger(); lingerEnabled = true; }
+      }
+      output({ installed: true, changed: result.changed, platform: manager.platform, serviceName: manager.serviceName, definitionPath: manager.definitionPath, lingerEnabled }, opts.json);
+    });
+
+  common(service.command("uninstall").description("Stop, disable, and remove the background service")).action(async (opts) => {
+    const manager = await resolveManager(opts); if (!manager) return;
+    await manager.uninstall();
+    const status = await manager.status();
+    if (status.installed || status.active) throw new Error(`${manager.serviceName} is still loaded after uninstall.`);
+    output({ uninstalled: true, serviceName: manager.serviceName }, opts.json);
+  });
+
+  for (const verb of ["start", "stop"] as const) {
+    common(service.command(verb).description(`${verb === "start" ? "Start" : "Stop"} the background service`)).action(async (opts) => {
+      const manager = await resolveManager(opts); if (!manager) return;
+      await manager[verb]();
+      output(await manager.status(), opts.json);
+    });
+  }
+
+  common(service.command("restart").description("Hot-restart the service while preserving active agent runs"))
+    .option("--wait", "Wait for active runs to drain instead of adopting them", false)
+    .option("--expected-version <version>", "Require the restarted server to report this version")
+    .action(async (opts) => output(await restartManagedService({ instanceId: opts.instance, expectedVersion: opts.expectedVersion, waitForDrain: opts.wait }), opts.json));
+
+  common(service.command("status").description("Show supervisor and health status")).action(async (opts) => {
+    const manager = await resolveManager(opts); if (!manager) return;
+    const instanceId = resolvePaperclipInstanceId(opts.instance);
+    output({ ...await manager.status(), health: await probeHealth(instanceId) }, opts.json);
+  });
+
+  common(service.command("logs").description("Show service logs"))
+    .option("-f, --follow", "Follow new log output", false)
+    .option("-n, --lines <count>", "Number of recent lines", "100")
+    .action(async (opts) => {
+      const manager = await resolveManager(opts); if (!manager) return;
+      const lines = Number.parseInt(opts.lines, 10);
+      if (!Number.isInteger(lines) || lines < 1) throw new Error("--lines must be a positive integer.");
+      await manager.logs(opts.follow, lines);
+    });
+}

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -10,13 +10,31 @@ import {
   withInstallStoreLock,
 } from "../install-store.js";
 import { resolvePaperclipInstanceId } from "../config/home.js";
-import { detectServiceManager, systemdServiceName } from "../services/service-manager.js";
+import { detectServiceManager, launchdServiceName, systemdServiceName } from "../services/service-manager.js";
 
 type UninstallDependencies = {
   detectServiceManager: typeof detectServiceManager;
   platform: NodeJS.Platform;
   userHomeDir: string;
 };
+
+function otherServiceDefinitions(platform: NodeJS.Platform, userHomeDir: string, instanceId: string): string[] {
+  const directory = platform === "linux"
+    ? path.join(userHomeDir, ".config", "systemd", "user")
+    : platform === "darwin"
+      ? path.join(userHomeDir, "Library", "LaunchAgents")
+      : null;
+  if (!directory || !fs.existsSync(directory)) return [];
+  const currentName = platform === "linux"
+    ? systemdServiceName(instanceId)
+    : `${launchdServiceName(instanceId)}.plist`;
+  const pattern = platform === "linux"
+    ? /^paperclipai(?:-.+)?\.service$/
+    : /^ing\.paperclip\.paperclipai(?:\..+)?\.plist$/;
+  return fs.readdirSync(directory)
+    .filter((name) => name !== currentName && pattern.test(name))
+    .map((name) => path.join(directory, name));
+}
 
 export async function uninstallCommand(
   dependencies: Partial<UninstallDependencies> = {},
@@ -26,6 +44,10 @@ export async function uninstallCommand(
   const platform = dependencies.platform ?? process.platform;
   const userHomeDir = dependencies.userHomeDir ?? os.homedir();
   const detection = await detect({ instanceId, platform });
+  const otherDefinitions = otherServiceDefinitions(platform, userHomeDir, instanceId);
+  if (otherDefinitions.length > 0) {
+    throw new Error(`Cannot remove the shared managed CLI while other instance services are installed: ${otherDefinitions.join(", ")}. Uninstall those services first.`);
+  }
   if (!detection.supported && platform === "linux") {
     const definitionPath = path.join(
       userHomeDir,

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import pc from "picocolors";
 import {
@@ -9,17 +10,36 @@ import {
   withInstallStoreLock,
 } from "../install-store.js";
 import { resolvePaperclipInstanceId } from "../config/home.js";
-import { detectServiceManager } from "../services/service-manager.js";
+import { detectServiceManager, systemdServiceName } from "../services/service-manager.js";
 
 type UninstallDependencies = {
   detectServiceManager: typeof detectServiceManager;
+  platform: NodeJS.Platform;
+  userHomeDir: string;
 };
 
 export async function uninstallCommand(
   dependencies: Partial<UninstallDependencies> = {},
 ): Promise<void> {
+  const instanceId = resolvePaperclipInstanceId();
   const detect = dependencies.detectServiceManager ?? detectServiceManager;
-  const detection = await detect({ instanceId: resolvePaperclipInstanceId() });
+  const platform = dependencies.platform ?? process.platform;
+  const userHomeDir = dependencies.userHomeDir ?? os.homedir();
+  const detection = await detect({ instanceId, platform });
+  if (!detection.supported && platform === "linux") {
+    const definitionPath = path.join(
+      userHomeDir,
+      ".config",
+      "systemd",
+      "user",
+      systemdServiceName(instanceId),
+    );
+    if (fs.existsSync(definitionPath)) {
+      throw new Error(
+        `Cannot verify or remove the background service: ${detection.reason}. Retry when the service manager is available.`,
+      );
+    }
+  }
   if (detection.supported) {
     const status = await detection.manager.status();
     if (status.installed || status.active) await detection.manager.uninstall();

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -6,6 +6,7 @@ import {
   removeManagedPathBlock,
   removeManagedShim,
   resolveInstallStorePaths,
+  withInstallStoreLock,
 } from "../install-store.js";
 import { resolvePaperclipInstanceId } from "../config/home.js";
 import { detectServiceManager } from "../services/service-manager.js";
@@ -25,14 +26,19 @@ export async function uninstallCommand(
   }
 
   const paths = resolveInstallStorePaths();
-  if (fs.existsSync(paths.cliRoot)) assertManagedInstallStore(paths);
-  const shimRemoved = removeManagedShim(paths);
-  fs.rmSync(paths.cliRoot, { recursive: true, force: true });
+  const hadStore = fs.existsSync(paths.cliRoot);
+  if (hadStore) assertManagedInstallStore(paths);
+  const shimRemoved = await withInstallStoreLock(async () => {
+    if (hadStore) assertManagedInstallStore(paths);
+    const removed = removeManagedShim(paths);
 
-  const home = process.env.HOME;
-  for (const rcFile of home ? [path.join(home, ".bashrc"), path.join(home, ".zshrc")] : []) {
-    removeManagedPathBlock(rcFile);
-  }
+    const home = process.env.HOME;
+    for (const rcFile of home ? [path.join(home, ".bashrc"), path.join(home, ".zshrc")] : []) {
+      removeManagedPathBlock(rcFile);
+    }
+    fs.rmSync(paths.cliRoot, { recursive: true, force: true });
+    return removed;
+  }, paths, { initialize: !hadStore });
 
   if (!shimRemoved) {
     console.log(pc.yellow(`Left ${paths.shimPath} unchanged because it is not a Paperclip-managed shim.`));

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import pc from "picocolors";
+import {
+  removeManagedPathBlock,
+  removeManagedShim,
+  resolveInstallStorePaths,
+} from "../install-store.js";
+
+export async function uninstallCommand(): Promise<void> {
+  const paths = resolveInstallStorePaths();
+  const shimRemoved = removeManagedShim(paths);
+  fs.rmSync(paths.cliRoot, { recursive: true, force: true });
+
+  const home = process.env.HOME;
+  for (const rcFile of home ? [path.join(home, ".bashrc"), path.join(home, ".zshrc")] : []) {
+    removeManagedPathBlock(rcFile);
+  }
+
+  if (!shimRemoved) {
+    console.log(pc.yellow(`Left ${paths.shimPath} unchanged because it is not a Paperclip-managed shim.`));
+  }
+  console.log(pc.green("Removed the managed Paperclip CLI install."));
+  console.log(pc.dim(`User data was left untouched under ${paths.paperclipHome}.`));
+}

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import pc from "picocolors";
 import {
+  assertManagedInstallStore,
   removeManagedPathBlock,
   removeManagedShim,
   resolveInstallStorePaths,
@@ -24,6 +25,7 @@ export async function uninstallCommand(
   }
 
   const paths = resolveInstallStorePaths();
+  if (fs.existsSync(paths.cliRoot)) assertManagedInstallStore(paths);
   const shimRemoved = removeManagedShim(paths);
   fs.rmSync(paths.cliRoot, { recursive: true, force: true });
 

--- a/cli/src/commands/uninstall.ts
+++ b/cli/src/commands/uninstall.ts
@@ -6,8 +6,23 @@ import {
   removeManagedShim,
   resolveInstallStorePaths,
 } from "../install-store.js";
+import { resolvePaperclipInstanceId } from "../config/home.js";
+import { detectServiceManager } from "../services/service-manager.js";
 
-export async function uninstallCommand(): Promise<void> {
+type UninstallDependencies = {
+  detectServiceManager: typeof detectServiceManager;
+};
+
+export async function uninstallCommand(
+  dependencies: Partial<UninstallDependencies> = {},
+): Promise<void> {
+  const detect = dependencies.detectServiceManager ?? detectServiceManager;
+  const detection = await detect({ instanceId: resolvePaperclipInstanceId() });
+  if (detection.supported) {
+    const status = await detection.manager.status();
+    if (status.installed || status.active) await detection.manager.uninstall();
+  }
+
   const paths = resolveInstallStorePaths();
   const shimRemoved = removeManagedShim(paths);
   fs.rmSync(paths.cliRoot, { recursive: true, force: true });

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -6,7 +6,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { buildNextManifest, flipCurrentAtomic, isManagedExecutable, pruneInstallPayloads, readInstallManifest, resolveInstallStorePaths, withInstallStoreLock, writeInstallManifestAtomic, type InstallChannel, type InstallManifest, type InstallRecord, type InstallStorePaths } from "../install-store.js";
 import { dbBackupCommand } from "./db-backup.js";
-import { installNpmPayload, resolvePublishedVersion, type CommandRunner } from "./install.js";
+import { installGitPayload, installNpmPayload, resolveGitHubRef, resolvePublishedVersion, type CommandRunner } from "./install.js";
 
 const execFileAsync = promisify(execFile);
 export type InstallMode = "managed" | "global-npm" | "npx" | "source" | "unknown";
@@ -86,7 +86,23 @@ export async function updateCommand(options: UpdateOptions, overrides: Partial<D
   const request = resolveUpdateRequest(manifest, options);
   if (mode === "npx") { emit(options, { mode, action: "install" }, "This is an ephemeral npx install. Run `paperclipai install`, then use `paperclipai update` from the managed shim."); return; }
   if (mode === "source" || mode === "unknown") { emit(options, { mode, action: "manual" }, "This appears to be a source checkout. Update it with `git pull` followed by `pnpm install`; Paperclip will not mutate the repository."); return; }
-  if (mode === "managed" && manifest?.source === "git") { emit(options, { mode, source: "git", action: "manual", ref: manifest.ref ?? manifest.sha }, "Managed git payload updates require reinstalling the desired ref; the current payload was left unchanged."); return; }
+  if (mode === "managed" && manifest?.source === "git") {
+    if (!manifest.repo || !manifest.ref || !manifest.sha) throw new Error("Managed git install metadata is incomplete.");
+    if (/^[0-9a-f]{7,40}$/i.test(manifest.ref)) { emit(options, { mode, source: "git", pinned: true, sha: manifest.sha }, `Git install is pinned at ${manifest.sha.slice(0, 12)}.`); return; }
+    const targetSha = await resolveGitHubRef(manifest.repo, manifest.ref, runCommand);
+    if (targetSha === manifest.sha) { emit(options, { mode, source: "git", changed: false, sha: targetSha, ref: manifest.ref }, `${manifest.repo}@${manifest.ref} is already at ${targetSha.slice(0, 12)}.`); return; }
+    if (options.check || options.dryRun) { emit(options, { mode, source: "git", changed: true, currentSha: manifest.sha, targetSha, ref: manifest.ref, dryRun: Boolean(options.dryRun) }, `Git update available: ${manifest.sha.slice(0, 12)} → ${targetSha.slice(0, 12)}.`); if (options.check) process.exitCode = 10; return; }
+    if (options.backup !== false) await (overrides.backup ?? (() => dbBackupCommand({})))();
+    const installed = await withInstallStoreLock(async () => {
+      const payload = await installGitPayload(manifest.repo!, targetSha, runCommand, paths);
+      const record: InstallRecord = { source: "git", version: payload.version, channel: "pinned", repo: manifest.repo, ref: manifest.ref, sha: targetSha, payloadPath: payload.payloadPath, installedAt: (overrides.now?.() ?? new Date()).toISOString() };
+      const next = buildNextManifest(record, manifest); const oldTarget = fs.readlinkSync(paths.currentPath); flipCurrentAtomic(payload.payloadPath, paths);
+      try { writeInstallManifestAtomic(next, paths); } catch (error) { flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths); throw error; }
+      pruneInstallPayloads(next, paths); return payload;
+    }, paths);
+    emit(options, { mode, source: "git", changed: true, currentSha: manifest.sha, targetSha, reused: installed.reused }, pc.yellow(`Updated unreleased git payload ${manifest.sha.slice(0, 12)} → ${targetSha.slice(0, 12)} from ${manifest.repo}@${manifest.ref}.`));
+    return;
+  }
   const targetVersion = await resolvePublishedVersion(request.spec, runCommand);
   const currentVersion = manifest?.version;
   const comparison = currentVersion ? compareVersions(targetVersion, currentVersion) : 1;

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -6,7 +7,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { buildNextManifest, flipCurrentAtomic, isManagedExecutable, pruneInstallPayloads, readInstallManifest, resolveInstallStorePaths, withInstallStoreLock, writeInstallManifestAtomic, type InstallChannel, type InstallManifest, type InstallRecord, type InstallStorePaths } from "../install-store.js";
 import { dbBackupCommand } from "./db-backup.js";
-import { installGitPayload, installNpmPayload, resolveGitHubRef, resolvePublishedVersion, type CommandRunner } from "./install.js";
+import { installGitPayload, installNpmPayload, PUBLIC_NPM_REGISTRY, resolveGitHubRef, resolvePublishedVersion, type CommandRunner } from "./install.js";
 
 const execFileAsync = promisify(execFile);
 export type InstallMode = "managed" | "global-npm" | "npx" | "source" | "unknown";
@@ -108,8 +109,26 @@ export async function updateCommand(options: UpdateOptions, overrides: Partial<D
   const comparison = currentVersion ? compareVersions(targetVersion, currentVersion) : 1;
   if (options.check) { emit(options, { mode, currentVersion: currentVersion ?? null, targetVersion, updateAvailable: comparison > 0, downgrade: comparison < 0, channel: request.channel }, comparison > 0 ? `Update available: ${targetVersion}` : comparison < 0 ? `Target ${targetVersion} is older than ${currentVersion}.` : `paperclipai ${targetVersion} is current.`); if (comparison > 0) process.exitCode = 10; return; }
   if (mode === "global-npm") {
-    const args = ["install", "-g", `paperclipai@${targetVersion}`]; console.log(`Running: npm ${args.join(" ")}`);
-    if (!options.dryRun) await runCommand("npm", args, { maxBuffer: 16 * 1024 * 1024 });
+    const args = ["install", "-g", `paperclipai@${targetVersion}`, `--registry=${PUBLIC_NPM_REGISTRY}`, `--@paperclipai:registry=${PUBLIC_NPM_REGISTRY}`]; console.log(`Running: npm ${args.join(" ")}`);
+    if (!options.dryRun) {
+      const npmConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-npm-"));
+      const npmUserConfigPath = path.join(npmConfigDir, "npmrc");
+      try {
+        fs.writeFileSync(npmUserConfigPath, `registry=${PUBLIC_NPM_REGISTRY}\n@paperclipai:registry=${PUBLIC_NPM_REGISTRY}\n`, { mode: 0o600 });
+        await runCommand("npm", args, {
+          env: {
+            ...process.env,
+            npm_config_registry: PUBLIC_NPM_REGISTRY,
+            NPM_CONFIG_REGISTRY: PUBLIC_NPM_REGISTRY,
+            npm_config_userconfig: npmUserConfigPath,
+            NPM_CONFIG_USERCONFIG: npmUserConfigPath,
+          },
+          maxBuffer: 16 * 1024 * 1024,
+        });
+      } finally {
+        fs.rmSync(npmConfigDir, { recursive: true, force: true });
+      }
+    }
     emit(options, { mode, action: "update", targetVersion, dryRun: Boolean(options.dryRun), command: ["npm", ...args] }, options.dryRun ? "Dry run complete." : pc.green(`Updated global npm install to ${targetVersion}.`)); return;
   }
   if (!manifest) throw new Error("Managed install metadata is missing.");

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -8,11 +8,23 @@ import pc from "picocolors";
 import { buildNextManifest, flipCurrentAtomic, isManagedExecutable, pruneInstallPayloads, readInstallManifest, resolveInstallStorePaths, withInstallStoreLock, writeInstallManifestAtomic, type InstallChannel, type InstallManifest, type InstallRecord, type InstallStorePaths } from "../install-store.js";
 import { dbBackupCommand } from "./db-backup.js";
 import { installGitPayload, installNpmPayload, PUBLIC_NPM_REGISTRY, resolveGitHubRef, resolvePublishedVersion, type CommandRunner } from "./install.js";
+import { resolvePaperclipInstanceId } from "../config/home.js";
+import { detectServiceManager } from "../services/service-manager.js";
+import { restartManagedService } from "./service.js";
+import { packageVersion } from "../version.js";
 
 const execFileAsync = promisify(execFile);
 export type InstallMode = "managed" | "global-npm" | "npx" | "source" | "unknown";
 export type UpdateOptions = { canary?: boolean; latest?: boolean; version?: string; rollback?: boolean; check?: boolean; dryRun?: boolean; json?: boolean; yes?: boolean; backup?: boolean };
-type Dependencies = { executablePath: string; runCommand: CommandRunner; backup: () => Promise<void>; confirm: (message: string) => Promise<boolean>; now: () => Date; paths: InstallStorePaths };
+type Dependencies = { executablePath: string; runCommand: CommandRunner; backup: () => Promise<void>; confirm: (message: string) => Promise<boolean>; now: () => Date; paths: InstallStorePaths; restartActiveService: (expectedVersion: string) => Promise<boolean> };
+
+async function restartActiveManagedService(expectedVersion: string): Promise<boolean> {
+  const instanceId = resolvePaperclipInstanceId();
+  const detection = await detectServiceManager({ instanceId });
+  if (!detection.supported || !(await detection.manager.status()).active) return false;
+  await restartManagedService({ instanceId, expectedVersion });
+  return true;
+}
 
 export function detectInstallMode(executablePath = process.argv[1] ?? "", paths = resolveInstallStorePaths()): InstallMode {
   const resolved = path.resolve(executablePath || ".");
@@ -36,7 +48,21 @@ export function compareVersions(left: string, right: string): number {
   if (a.prerelease === b.prerelease) return 0;
   if (!a.prerelease) return 1;
   if (!b.prerelease) return -1;
-  return a.prerelease.localeCompare(b.prerelease);
+  const aParts = a.prerelease.split(".");
+  const bParts = b.prerelease.split(".");
+  for (let index = 0; index < Math.max(aParts.length, bParts.length); index += 1) {
+    const leftPart = aParts[index];
+    const rightPart = bParts[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+    const leftNumeric = /^\d+$/.test(leftPart);
+    const rightNumeric = /^\d+$/.test(rightPart);
+    if (leftNumeric && rightNumeric) return Math.sign(Number(leftPart) - Number(rightPart));
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftPart < rightPart ? -1 : 1;
+  }
+  return 0;
 }
 
 export function resolveUpdateRequest(manifest: InstallManifest | null, options: Pick<UpdateOptions, "canary" | "latest" | "version">): { spec: string; channel: InstallChannel; explicit: boolean } {
@@ -81,7 +107,8 @@ export async function updateCommand(options: UpdateOptions, overrides: Partial<D
     if (mode !== "managed") throw new Error("--rollback is only available for managed installs.");
     if (options.dryRun) { emit(options, { mode, action: "rollback", dryRun: true, target: manifest?.previous[0]?.version ?? null }, `Would roll back to ${manifest?.previous[0]?.version ?? "the previous payload"}.`); return; }
     const next = await withInstallStoreLock(async () => rollbackManagedInstall(paths), paths);
-    emit(options, { mode, action: "rollback", version: next.version }, pc.green(`Rolled back instantly to paperclipai ${next.version}. Database migrations are not reversed; restore the pre-update backup if needed.`));
+    const restarted = await (overrides.restartActiveService ?? restartActiveManagedService)(next.version);
+    emit(options, { mode, action: "rollback", version: next.version, restarted }, pc.green(`Rolled back to paperclipai ${next.version}${restarted ? " and restarted the active service" : ""}. Database migrations are not reversed; restore the pre-update backup if needed.`));
     return;
   }
   const request = resolveUpdateRequest(manifest, options);
@@ -101,14 +128,16 @@ export async function updateCommand(options: UpdateOptions, overrides: Partial<D
       try { writeInstallManifestAtomic(next, paths); } catch (error) { flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths); throw error; }
       pruneInstallPayloads(next, paths); return payload;
     }, paths);
-    emit(options, { mode, source: "git", changed: true, currentSha: manifest.sha, targetSha, reused: installed.reused }, pc.yellow(`Updated unreleased git payload ${manifest.sha.slice(0, 12)} → ${targetSha.slice(0, 12)} from ${manifest.repo}@${manifest.ref}.`));
+    const restarted = await (overrides.restartActiveService ?? restartActiveManagedService)(installed.version);
+    emit(options, { mode, source: "git", changed: true, currentSha: manifest.sha, targetSha, reused: installed.reused, restarted }, pc.yellow(`Updated unreleased git payload ${manifest.sha.slice(0, 12)} → ${targetSha.slice(0, 12)} from ${manifest.repo}@${manifest.ref}${restarted ? " and restarted the active service" : ""}.`));
     return;
   }
   const targetVersion = await resolvePublishedVersion(request.spec, runCommand);
-  const currentVersion = manifest?.version;
+  const currentVersion = manifest?.version ?? (mode === "global-npm" ? packageVersion : undefined);
   const comparison = currentVersion ? compareVersions(targetVersion, currentVersion) : 1;
   if (options.check) { emit(options, { mode, currentVersion: currentVersion ?? null, targetVersion, updateAvailable: comparison > 0, downgrade: comparison < 0, channel: request.channel }, comparison > 0 ? `Update available: ${targetVersion}` : comparison < 0 ? `Target ${targetVersion} is older than ${currentVersion}.` : `paperclipai ${targetVersion} is current.`); if (comparison > 0) process.exitCode = 10; return; }
   if (mode === "global-npm") {
+    if (comparison < 0 && options.yes !== true) { const confirmed = await (overrides.confirm ?? defaultConfirm)(`Downgrade paperclipai from ${currentVersion} to ${targetVersion}?`); if (!confirmed) throw new Error("Downgrade cancelled. Re-run with --yes to confirm explicitly."); }
     const args = ["install", "-g", `paperclipai@${targetVersion}`, `--registry=${PUBLIC_NPM_REGISTRY}`, `--@paperclipai:registry=${PUBLIC_NPM_REGISTRY}`]; console.log(`Running: npm ${args.join(" ")}`);
     if (!options.dryRun) {
       const npmConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-npm-"));
@@ -143,5 +172,6 @@ export async function updateCommand(options: UpdateOptions, overrides: Partial<D
     try { writeInstallManifestAtomic(next, paths); } catch (error) { flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths); throw error; }
     pruneInstallPayloads(next, paths); return payload;
   }, paths);
-  emit(options, { mode, currentVersion, targetVersion, changed: true, reused: installed.reused }, pc.green(`Updated paperclipai ${currentVersion} → ${targetVersion}. Run \`paperclipai update --rollback\` for an instant payload rollback.`));
+  const restarted = await (overrides.restartActiveService ?? restartActiveManagedService)(targetVersion);
+  emit(options, { mode, currentVersion, targetVersion, changed: true, reused: installed.reused, restarted }, pc.green(`Updated paperclipai ${currentVersion} → ${targetVersion}${restarted ? " and restarted the active service" : ""}. Run \`paperclipai update --rollback\` for an instant payload rollback.`));
 }

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { buildNextManifest, flipCurrentAtomic, isManagedExecutable, pruneInstallPayloads, readInstallManifest, resolveInstallStorePaths, withInstallStoreLock, writeInstallManifestAtomic, type InstallChannel, type InstallManifest, type InstallRecord, type InstallStorePaths } from "../install-store.js";
+import { dbBackupCommand } from "./db-backup.js";
+import { installNpmPayload, resolvePublishedVersion, type CommandRunner } from "./install.js";
+
+const execFileAsync = promisify(execFile);
+export type InstallMode = "managed" | "global-npm" | "npx" | "source" | "unknown";
+export type UpdateOptions = { canary?: boolean; latest?: boolean; version?: string; rollback?: boolean; check?: boolean; dryRun?: boolean; json?: boolean; yes?: boolean; backup?: boolean };
+type Dependencies = { executablePath: string; runCommand: CommandRunner; backup: () => Promise<void>; confirm: (message: string) => Promise<boolean>; now: () => Date; paths: InstallStorePaths };
+
+export function detectInstallMode(executablePath = process.argv[1] ?? "", paths = resolveInstallStorePaths()): InstallMode {
+  const resolved = path.resolve(executablePath || ".");
+  const manifest = readInstallManifest(paths);
+  if (manifest && isManagedExecutable(resolved, manifest, paths)) return "managed";
+  const normalized = resolved.split(path.sep).join("/");
+  if (normalized.includes("/.npm/_npx/") || normalized.includes("/node_modules/.cache/npx/")) return "npx";
+  if (normalized.includes("/node_modules/paperclipai/")) return "global-npm";
+  let cursor = path.dirname(resolved);
+  while (cursor !== path.dirname(cursor)) {
+    if (fs.existsSync(path.join(cursor, ".git"))) return "source";
+    cursor = path.dirname(cursor);
+  }
+  return "unknown";
+}
+
+export function compareVersions(left: string, right: string): number {
+  const parse = (value: string) => { const [core, prerelease = ""] = value.replace(/^v/, "").split("-", 2); return { numbers: core.split(".").map((part) => Number(part) || 0), prerelease }; };
+  const a = parse(left); const b = parse(right);
+  for (let index = 0; index < Math.max(a.numbers.length, b.numbers.length); index += 1) { const delta = (a.numbers[index] ?? 0) - (b.numbers[index] ?? 0); if (delta !== 0) return Math.sign(delta); }
+  if (a.prerelease === b.prerelease) return 0;
+  if (!a.prerelease) return 1;
+  if (!b.prerelease) return -1;
+  return a.prerelease.localeCompare(b.prerelease);
+}
+
+export function resolveUpdateRequest(manifest: InstallManifest | null, options: Pick<UpdateOptions, "canary" | "latest" | "version">): { spec: string; channel: InstallChannel; explicit: boolean } {
+  const selected = Number(Boolean(options.canary)) + Number(Boolean(options.latest)) + Number(Boolean(options.version));
+  if (selected > 1) throw new Error("Choose only one of --latest, --canary, or --version.");
+  if (options.version) return { spec: options.version.trim(), channel: "pinned", explicit: true };
+  if (options.canary) return { spec: "canary", channel: "canary", explicit: true };
+  if (options.latest) return { spec: "latest", channel: "latest", explicit: true };
+  if (manifest?.channel === "pinned") return { spec: manifest.version, channel: "pinned", explicit: false };
+  const channel = manifest?.channel === "canary" ? "canary" : "latest";
+  return { spec: channel, channel, explicit: false };
+}
+
+export function rollbackManagedInstall(paths = resolveInstallStorePaths()): InstallManifest {
+  const manifest = readInstallManifest(paths);
+  if (!manifest) throw new Error("No managed install was found to roll back.");
+  const target = manifest.previous[0];
+  if (!target) throw new Error("No previous managed payload is available for rollback.");
+  if (!fs.existsSync(target.payloadPath)) throw new Error(`Previous payload is missing: ${target.payloadPath}`);
+  const current: InstallRecord = { source: manifest.source, version: manifest.version, channel: manifest.channel, payloadPath: manifest.payloadPath, repo: manifest.repo, ref: manifest.ref, sha: manifest.sha, installedAt: manifest.installedAt };
+  const next: InstallManifest = { schemaVersion: manifest.schemaVersion, ...target, previous: [current, ...manifest.previous.slice(1)].slice(0, 2) };
+  const oldTarget = fs.readlinkSync(paths.currentPath);
+  flipCurrentAtomic(target.payloadPath, paths);
+  try { writeInstallManifestAtomic(next, paths); } catch (error) { flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths); throw error; }
+  return next;
+}
+
+async function defaultConfirm(message: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  const answer = await p.confirm({ message, initialValue: false });
+  return !p.isCancel(answer) && answer === true;
+}
+function emit(options: UpdateOptions, value: Record<string, unknown>, message: string): void { if (options.json) console.log(JSON.stringify(value, null, 2)); else console.log(message); }
+
+export async function updateCommand(options: UpdateOptions, overrides: Partial<Dependencies> = {}): Promise<void> {
+  const paths = overrides.paths ?? resolveInstallStorePaths();
+  const executablePath = overrides.executablePath ?? process.argv[1] ?? "";
+  const runCommand = overrides.runCommand ?? execFileAsync;
+  const mode = detectInstallMode(executablePath, paths);
+  const manifest = readInstallManifest(paths);
+  if (options.rollback) {
+    if (mode !== "managed") throw new Error("--rollback is only available for managed installs.");
+    if (options.dryRun) { emit(options, { mode, action: "rollback", dryRun: true, target: manifest?.previous[0]?.version ?? null }, `Would roll back to ${manifest?.previous[0]?.version ?? "the previous payload"}.`); return; }
+    const next = await withInstallStoreLock(async () => rollbackManagedInstall(paths), paths);
+    emit(options, { mode, action: "rollback", version: next.version }, pc.green(`Rolled back instantly to paperclipai ${next.version}. Database migrations are not reversed; restore the pre-update backup if needed.`));
+    return;
+  }
+  const request = resolveUpdateRequest(manifest, options);
+  if (mode === "npx") { emit(options, { mode, action: "install" }, "This is an ephemeral npx install. Run `paperclipai install`, then use `paperclipai update` from the managed shim."); return; }
+  if (mode === "source" || mode === "unknown") { emit(options, { mode, action: "manual" }, "This appears to be a source checkout. Update it with `git pull` followed by `pnpm install`; Paperclip will not mutate the repository."); return; }
+  if (mode === "managed" && manifest?.source === "git") { emit(options, { mode, source: "git", action: "manual", ref: manifest.ref ?? manifest.sha }, "Managed git payload updates require reinstalling the desired ref; the current payload was left unchanged."); return; }
+  const targetVersion = await resolvePublishedVersion(request.spec, runCommand);
+  const currentVersion = manifest?.version;
+  const comparison = currentVersion ? compareVersions(targetVersion, currentVersion) : 1;
+  if (options.check) { emit(options, { mode, currentVersion: currentVersion ?? null, targetVersion, updateAvailable: comparison > 0, downgrade: comparison < 0, channel: request.channel }, comparison > 0 ? `Update available: ${targetVersion}` : comparison < 0 ? `Target ${targetVersion} is older than ${currentVersion}.` : `paperclipai ${targetVersion} is current.`); if (comparison > 0) process.exitCode = 10; return; }
+  if (mode === "global-npm") {
+    const args = ["install", "-g", `paperclipai@${targetVersion}`]; console.log(`Running: npm ${args.join(" ")}`);
+    if (!options.dryRun) await runCommand("npm", args, { maxBuffer: 16 * 1024 * 1024 });
+    emit(options, { mode, action: "update", targetVersion, dryRun: Boolean(options.dryRun), command: ["npm", ...args] }, options.dryRun ? "Dry run complete." : pc.green(`Updated global npm install to ${targetVersion}.`)); return;
+  }
+  if (!manifest) throw new Error("Managed install metadata is missing.");
+  if (comparison === 0) { emit(options, { mode, currentVersion, targetVersion, changed: false }, `paperclipai ${targetVersion} is already active.`); return; }
+  if (comparison < 0 && options.yes !== true) { const confirmed = await (overrides.confirm ?? defaultConfirm)(`Downgrade paperclipai from ${currentVersion} to ${targetVersion}?`); if (!confirmed) throw new Error("Downgrade cancelled. Re-run with --yes to confirm explicitly."); }
+  if (options.dryRun) { emit(options, { mode, currentVersion, targetVersion, action: comparison < 0 ? "downgrade" : "update", backup: options.backup !== false, dryRun: true }, `Would ${comparison < 0 ? "downgrade" : "update"} paperclipai ${currentVersion} → ${targetVersion}${options.backup === false ? " without a backup" : " after a database backup"}.`); return; }
+  if (options.backup !== false) await (overrides.backup ?? (() => dbBackupCommand({})))();
+  const installed = await withInstallStoreLock(async () => {
+    const payload = await installNpmPayload(targetVersion, runCommand, paths);
+    const record: InstallRecord = { source: "npm", version: targetVersion, channel: request.channel, payloadPath: payload.payloadPath, installedAt: (overrides.now?.() ?? new Date()).toISOString() };
+    const next = buildNextManifest(record, manifest); const oldTarget = fs.readlinkSync(paths.currentPath); flipCurrentAtomic(payload.payloadPath, paths);
+    try { writeInstallManifestAtomic(next, paths); } catch (error) { flipCurrentAtomic(path.resolve(paths.cliRoot, oldTarget), paths); throw error; }
+    pruneInstallPayloads(next, paths); return payload;
+  }, paths);
+  emit(options, { mode, currentVersion, targetVersion, changed: true, reused: installed.reused }, pc.green(`Updated paperclipai ${currentVersion} → ${targetVersion}. Run \`paperclipai update --rollback\` for an instant payload rollback.`));
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,6 +64,8 @@ program
   .description("Install Paperclip into a managed per-user CLI store")
   .option("--canary", "Install the npm canary channel")
   .option("--version <version>", "Install an exact published npm version")
+  .option("--ref <ref>", "Install a GitHub branch, tag, or commit SHA")
+  .option("--repo <owner/name>", "Override the GitHub repository used with --ref")
   .option("-y, --yes", "Consent to the supported shell PATH update without prompting")
   .action(installCommand);
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -43,16 +43,33 @@ import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerAssetCommands } from "./commands/client/asset.js";
 import { registerSkillCommands } from "./commands/client/skill.js";
 import { cliVersion } from "./version.js";
+import { installCommand } from "./commands/install.js";
+import { uninstallCommand } from "./commands/uninstall.js";
 import { registerServiceCommands } from "./commands/service.js";
 
 const program = new Command();
 const DATA_DIR_OPTION_HELP =
   "Paperclip data directory root (isolates state from ~/.paperclip)";
 
+program.enablePositionalOptions();
+
 program
   .name("paperclipai")
   .description("Paperclip CLI — setup, diagnose, and configure your instance")
   .version(cliVersion);
+
+program
+  .command("install")
+  .description("Install Paperclip into a managed per-user CLI store")
+  .option("--canary", "Install the npm canary channel")
+  .option("--version <version>", "Install an exact published npm version")
+  .option("-y, --yes", "Consent to the supported shell PATH update without prompting")
+  .action(installCommand);
+
+program
+  .command("uninstall")
+  .description("Remove the managed CLI install while preserving user data")
+  .action(uninstallCommand);
 
 program.hook("preAction", (_thisCommand, actionCommand) => {
   const options = actionCommand.optsWithGlobals() as DataDirOptionLike;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -45,6 +45,7 @@ import { registerSkillCommands } from "./commands/client/skill.js";
 import { cliVersion } from "./version.js";
 import { installCommand } from "./commands/install.js";
 import { uninstallCommand } from "./commands/uninstall.js";
+import { updateCommand } from "./commands/update.js";
 import { registerServiceCommands } from "./commands/service.js";
 
 const program = new Command();
@@ -70,6 +71,21 @@ program
   .command("uninstall")
   .description("Remove the managed CLI install while preserving user data")
   .action(uninstallCommand);
+
+program
+  .command("update")
+  .alias("upgrade")
+  .description("Check, update, or roll back the Paperclip CLI")
+  .option("--latest", "Switch to the latest stable channel")
+  .option("--canary", "Switch to the canary channel")
+  .option("--version <version>", "Install an exact published version")
+  .option("--rollback", "Flip back to the retained previous managed payload")
+  .option("--check", "Check for an available update without applying it")
+  .option("--dry-run", "Print the action without changing anything")
+  .option("--json", "Print machine-readable output")
+  .option("-y, --yes", "Confirm an explicit downgrade")
+  .option("--no-backup", "Skip the pre-update database backup")
+  .action(updateCommand);
 
 program.hook("preAction", (_thisCommand, actionCommand) => {
   const options = actionCommand.optsWithGlobals() as DataDirOptionLike;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -89,6 +89,8 @@ program
   .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
   .option("--bind <mode>", "Quickstart reachability preset (loopback, lan, tailnet)")
   .option("-y, --yes", "Accept quickstart defaults (trusted local loopback unless --bind is set) and start immediately", false)
+  .option("--install-service", "Install and start the background service after onboarding")
+  .option("--no-install-service", "Do not install or suggest the background service")
   .option("--run", "Start Paperclip immediately after saving config", false)
   .action(onboard);
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -43,6 +43,7 @@ import { registerAdapterCommands } from "./commands/client/adapter.js";
 import { registerAssetCommands } from "./commands/client/asset.js";
 import { registerSkillCommands } from "./commands/client/skill.js";
 import { cliVersion } from "./version.js";
+import { registerServiceCommands } from "./commands/service.js";
 
 const program = new Command();
 const DATA_DIR_OPTION_HELP =
@@ -131,9 +132,11 @@ const run = program
   .option("--bind <mode>", "On first run, use onboarding reachability preset (loopback, lan, tailnet)")
   .option("--repair", "Attempt automatic repairs during doctor", true)
   .option("--no-repair", "Disable automatic repairs during doctor")
+  .option("--force", "Run even when the same instance is active under the service manager")
   .action(runCommand);
 
 registerRunCommands(run);
+registerServiceCommands(program);
 
 const heartbeat = program.command("heartbeat").description("Heartbeat utilities");
 

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -381,8 +381,8 @@ export function writeManagedShim(paths = resolveInstallStorePaths()): void {
   const homeDir = path.dirname(path.dirname(path.dirname(paths.shimPath)));
   const localDir = path.dirname(path.dirname(paths.shimPath));
   fs.mkdirSync(homeDir, { recursive: true, mode: 0o700 });
-  fs.mkdirSync(localDir, { mode: 0o755 });
-  fs.mkdirSync(path.dirname(paths.shimPath), { mode: 0o755 });
+  fs.mkdirSync(localDir, { recursive: true, mode: 0o755 });
+  fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true, mode: 0o755 });
   assertManagedShimWritable(paths);
   const entrypoint = path.join(paths.currentPath, "node_modules", "paperclipai", "dist", "index.js");
   const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nexec ${shellQuote(process.execPath)} ${shellQuote(entrypoint)} "\$@"\n`;

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -144,15 +144,6 @@ export function assertManagedInstallStore(paths = resolveInstallStorePaths()): I
   return manifest;
 }
 
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
-  }
-}
-
 export async function withInstallStoreLock<T>(
   callback: () => Promise<T>,
   paths = resolveInstallStorePaths(),
@@ -172,18 +163,11 @@ export async function withInstallStoreLock<T>(
       }
       const owner = fs.readFileSync(paths.lockPath, "utf8").trim();
       const ownerPid = Number.parseInt(owner.split(":", 1)[0] ?? "", 10);
-      if (Number.isInteger(ownerPid) && ownerPid > 0 && processIsAlive(ownerPid)) {
-        throw new Error(`Another managed install is already running (pid ${ownerPid}).`);
-      }
-      fs.rmSync(paths.lockPath, { force: true });
-      try {
-        fs.linkSync(temporaryPath, paths.lockPath);
-      } catch (retryError) {
-        if ((retryError as NodeJS.ErrnoException).code === "EEXIST") {
-          throw new Error("Another managed install started while recovering a stale lock.");
-        }
-        throw retryError;
-      }
+      const ownerLabel = Number.isInteger(ownerPid) && ownerPid > 0 ? ` (pid ${ownerPid})` : "";
+      throw new Error(
+        `Another managed install is already running${ownerLabel}. ` +
+        `If no install process is active, remove the stale lock at ${paths.lockPath} and retry.`,
+      );
     } finally {
       fs.rmSync(temporaryPath, { force: true });
     }

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 import { resolvePaperclipHomeDir } from "./config/home.js";
 
 export const INSTALL_MANIFEST_VERSION = 1;
-export const MANAGED_SHIM_MARKER = "paperclipai managed install shim";
+export const MANAGED_SHIM_MARKER = "paperclipai managed install shim v1";
+export const MANAGED_STORE_MARKER = "paperclipai managed install store v1\n";
 export const PATH_BLOCK_START = "# >>> paperclipai managed PATH >>>";
 export const PATH_BLOCK_END = "# <<< paperclipai managed PATH <<<";
 
@@ -31,6 +32,8 @@ export type InstallStorePaths = {
   cliRoot: string;
   installsRoot: string;
   manifestPath: string;
+  markerPath: string;
+  lockPath: string;
   currentPath: string;
   shimPath: string;
 };
@@ -76,9 +79,127 @@ export function resolveInstallStorePaths(options: {
     cliRoot,
     installsRoot: path.join(cliRoot, "installs"),
     manifestPath: path.join(cliRoot, "install.json"),
+    markerPath: path.join(cliRoot, ".managed-install"),
+    lockPath: path.join(cliRoot, ".install.lock"),
     currentPath: path.join(cliRoot, "current"),
     shimPath: path.join(homeDir, ".local", "bin", "paperclipai"),
   };
+}
+
+export function initializeInstallStore(paths = resolveInstallStorePaths()): void {
+  ensurePrivateDirectory(paths.cliRoot);
+  ensurePrivateDirectory(paths.installsRoot);
+  try {
+    const markerStat = fs.lstatSync(paths.markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink() || markerStat.nlink > 1) {
+      throw new Error(`Refusing to use unsafe install-store marker ${paths.markerPath}.`);
+    }
+    assertOwnedByCurrentUser(markerStat, paths.markerPath);
+    if (fs.readFileSync(paths.markerPath, "utf8") !== MANAGED_STORE_MARKER) {
+      throw new Error(`Refusing to use unrecognized install store ${paths.cliRoot}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    try {
+      fs.writeFileSync(paths.markerPath, MANAGED_STORE_MARKER, { mode: 0o600, flag: "wx" });
+    } catch (writeError) {
+      if (
+        (writeError as NodeJS.ErrnoException).code !== "EEXIST" ||
+        fs.readFileSync(paths.markerPath, "utf8") !== MANAGED_STORE_MARKER
+      ) {
+        throw writeError;
+      }
+    }
+  }
+}
+
+export function assertManagedInstallStore(paths = resolveInstallStorePaths()): InstallManifest {
+  const cliStat = fs.lstatSync(paths.cliRoot);
+  if (!cliStat.isDirectory() || cliStat.isSymbolicLink()) {
+    throw new Error(`Refusing to remove unsafe install-store path ${paths.cliRoot}.`);
+  }
+  assertOwnedByCurrentUser(cliStat, paths.cliRoot);
+  let markerStat: fs.Stats;
+  try {
+    markerStat = fs.lstatSync(paths.markerPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Refusing to remove unverified install store ${paths.cliRoot}.`);
+    }
+    throw error;
+  }
+  if (!markerStat.isFile() || markerStat.isSymbolicLink() || markerStat.nlink > 1) {
+    throw new Error(`Refusing to remove unverified install store ${paths.cliRoot}.`);
+  }
+  assertOwnedByCurrentUser(markerStat, paths.markerPath);
+  if (fs.readFileSync(paths.markerPath, "utf8") !== MANAGED_STORE_MARKER) {
+    throw new Error(`Refusing to remove unverified install store ${paths.cliRoot}.`);
+  }
+  const manifest = readInstallManifest(paths);
+  if (!manifest) throw new Error(`Refusing to remove install store without a manifest at ${paths.cliRoot}.`);
+  const relativePayload = path.relative(paths.installsRoot, path.resolve(manifest.payloadPath));
+  if (!relativePayload || relativePayload.startsWith("..") || path.isAbsolute(relativePayload)) {
+    throw new Error(`Refusing to remove install store with an invalid manifest at ${paths.cliRoot}.`);
+  }
+  return manifest;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+export async function withInstallStoreLock<T>(
+  callback: () => Promise<T>,
+  paths = resolveInstallStorePaths(),
+): Promise<T> {
+  initializeInstallStore(paths);
+  const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  const acquire = (): void => {
+    const temporaryPath = `${paths.lockPath}.${token}.tmp`;
+    try {
+      fs.writeFileSync(temporaryPath, `${token}\n`, { mode: 0o600, flag: "wx" });
+      try {
+        fs.linkSync(temporaryPath, paths.lockPath);
+        return;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+      const owner = fs.readFileSync(paths.lockPath, "utf8").trim();
+      const ownerPid = Number.parseInt(owner.split(":", 1)[0] ?? "", 10);
+      if (Number.isInteger(ownerPid) && ownerPid > 0 && processIsAlive(ownerPid)) {
+        throw new Error(`Another managed install is already running (pid ${ownerPid}).`);
+      }
+      fs.rmSync(paths.lockPath, { force: true });
+      try {
+        fs.linkSync(temporaryPath, paths.lockPath);
+      } catch (retryError) {
+        if ((retryError as NodeJS.ErrnoException).code === "EEXIST") {
+          throw new Error("Another managed install started while recovering a stale lock.");
+        }
+        throw retryError;
+      }
+    } finally {
+      fs.rmSync(temporaryPath, { force: true });
+    }
+  };
+
+  acquire();
+  try {
+    return await callback();
+  } finally {
+    try {
+      if (fs.readFileSync(paths.lockPath, "utf8").trim() === token) {
+        fs.rmSync(paths.lockPath, { force: true });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
 }
 
 export function payloadPathFor(
@@ -246,12 +367,28 @@ export function assertManagedShimWritable(paths = resolveInstallStorePaths()): v
     assertOwnedByCurrentUser(stat, paths.shimPath);
     if (stat.nlink > 1) throw new Error(`Refusing to replace multiply linked shim ${paths.shimPath}.`);
     const existing = fs.readFileSync(paths.shimPath, "utf8");
-    if (!existing.includes(MANAGED_SHIM_MARKER)) {
+    if (!isManagedShimContents(existing)) {
       throw new Error(`Refusing to replace existing non-managed command ${paths.shimPath}.`);
     }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function isManagedShimContents(contents: string): boolean {
+  const lines = contents.split("\n");
+  return (
+    lines.length === 5 &&
+    lines[0] === "#!/bin/sh" &&
+    lines[1] === `# ${MANAGED_SHIM_MARKER}` &&
+    lines[2] === "set -eu" &&
+    /^exec '(?:[^']|'"'"')+' '(?:[^']|'"'"')+' "\$@"$/.test(lines[3]) &&
+    lines[4] === ""
+  );
 }
 
 export function writeManagedShim(paths = resolveInstallStorePaths()): void {
@@ -262,14 +399,15 @@ export function writeManagedShim(paths = resolveInstallStorePaths()): void {
   fs.mkdirSync(localDir, { mode: 0o755 });
   fs.mkdirSync(path.dirname(paths.shimPath), { mode: 0o755 });
   assertManagedShimWritable(paths);
-  const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nPAPERCLIP_HOME="\${PAPERCLIP_HOME:-\$HOME/.paperclip}"\nexec node "\$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js" "\$@"\n`;
+  const entrypoint = path.join(paths.currentPath, "node_modules", "paperclipai", "dist", "index.js");
+  const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nexec ${shellQuote(process.execPath)} ${shellQuote(entrypoint)} "\$@"\n`;
   writeFileAtomic(paths.shimPath, contents, 0o755);
 }
 
 export function removeManagedShim(paths = resolveInstallStorePaths()): boolean {
   try {
     const contents = fs.readFileSync(paths.shimPath, "utf8");
-    if (!contents.includes(MANAGED_SHIM_MARKER)) return false;
+    if (!isManagedShimContents(contents)) return false;
     fs.rmSync(paths.shimPath, { force: true });
     return true;
   } catch (error) {
@@ -333,7 +471,11 @@ export function isManagedExecutable(
   try {
     const executableRealPath = fs.realpathSync(executablePath);
     const payloadRealPath = fs.realpathSync(manifest.payloadPath);
-    return executableRealPath.startsWith(`${payloadRealPath}${path.sep}`) && fs.existsSync(paths.currentPath);
+    const currentRealPath = fs.realpathSync(paths.currentPath);
+    return (
+      currentRealPath === payloadRealPath &&
+      executableRealPath.startsWith(`${payloadRealPath}${path.sep}`)
+    );
   } catch {
     return false;
   }

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -1,0 +1,293 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePaperclipHomeDir } from "./config/home.js";
+
+export const INSTALL_MANIFEST_VERSION = 1;
+export const MANAGED_SHIM_MARKER = "paperclipai managed install shim";
+export const PATH_BLOCK_START = "# >>> paperclipai managed PATH >>>";
+export const PATH_BLOCK_END = "# <<< paperclipai managed PATH <<<";
+
+export type InstallSource = "npm" | "git";
+export type InstallChannel = "latest" | "canary" | "pinned";
+
+export type InstallRecord = {
+  source: InstallSource;
+  version: string;
+  channel: InstallChannel;
+  payloadPath: string;
+  repo?: string;
+  ref?: string;
+  sha?: string;
+  installedAt: string;
+};
+
+export type InstallManifest = InstallRecord & {
+  schemaVersion: typeof INSTALL_MANIFEST_VERSION;
+  previous: InstallRecord[];
+};
+
+export type InstallStorePaths = {
+  paperclipHome: string;
+  cliRoot: string;
+  installsRoot: string;
+  manifestPath: string;
+  currentPath: string;
+  shimPath: string;
+};
+
+function ensurePrivateDirectory(directoryPath: string): void {
+  fs.mkdirSync(directoryPath, { recursive: true, mode: 0o700 });
+  const stat = fs.lstatSync(directoryPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Refusing to use non-directory install-store path ${directoryPath}.`);
+  }
+  fs.chmodSync(directoryPath, 0o700);
+}
+
+export function resolveInstallStorePaths(options: {
+  paperclipHome?: string;
+  homeDir?: string;
+} = {}): InstallStorePaths {
+  const paperclipHome = path.resolve(options.paperclipHome ?? resolvePaperclipHomeDir());
+  const homeDir = path.resolve(options.homeDir ?? process.env.HOME ?? path.dirname(paperclipHome));
+  const cliRoot = path.join(paperclipHome, "cli");
+  return {
+    paperclipHome,
+    cliRoot,
+    installsRoot: path.join(cliRoot, "installs"),
+    manifestPath: path.join(cliRoot, "install.json"),
+    currentPath: path.join(cliRoot, "current"),
+    shimPath: path.join(homeDir, ".local", "bin", "paperclipai"),
+  };
+}
+
+export function payloadPathFor(
+  paths: InstallStorePaths,
+  source: InstallSource,
+  identifier: string,
+): string {
+  if (!/^[A-Za-z0-9._-]+$/.test(identifier)) {
+    throw new Error(`Invalid install payload identifier '${identifier}'.`);
+  }
+  return path.join(paths.installsRoot, source, identifier);
+}
+
+export function readInstallManifest(paths = resolveInstallStorePaths()): InstallManifest | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(paths.manifestPath, "utf8")) as InstallManifest;
+    if (
+      value.schemaVersion !== INSTALL_MANIFEST_VERSION ||
+      (value.source !== "npm" && value.source !== "git") ||
+      !Array.isArray(value.previous) ||
+      typeof value.payloadPath !== "string"
+    ) {
+      throw new Error("unsupported manifest shape");
+    }
+    return value;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new Error(`Could not read managed install manifest at ${paths.manifestPath}: ${String(error)}`);
+  }
+}
+
+export function writeInstallManifestAtomic(
+  manifest: InstallManifest,
+  paths = resolveInstallStorePaths(),
+): void {
+  ensurePrivateDirectory(paths.cliRoot);
+  const temporaryPath = `${paths.manifestPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporaryPath, paths.manifestPath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function assertPayloadPath(payloadPath: string, paths: InstallStorePaths): void {
+  const relative = path.relative(paths.installsRoot, path.resolve(payloadPath));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to activate payload outside ${paths.installsRoot}.`);
+  }
+  const stat = fs.lstatSync(payloadPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Refusing to activate non-directory payload ${payloadPath}.`);
+  }
+  const installsRealPath = fs.realpathSync(paths.installsRoot);
+  const payloadRealPath = fs.realpathSync(payloadPath);
+  if (!payloadRealPath.startsWith(`${installsRealPath}${path.sep}`)) {
+    throw new Error(`Refusing to activate payload that resolves outside ${paths.installsRoot}.`);
+  }
+}
+
+export function flipCurrentAtomic(
+  payloadPath: string,
+  paths = resolveInstallStorePaths(),
+  hooks: { beforeRename?: () => void } = {},
+): void {
+  assertPayloadPath(payloadPath, paths);
+  ensurePrivateDirectory(paths.cliRoot);
+  try {
+    const currentStat = fs.lstatSync(paths.currentPath);
+    if (!currentStat.isSymbolicLink()) {
+      throw new Error(`Refusing to replace non-symlink ${paths.currentPath}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  const temporaryLink = path.join(
+    paths.cliRoot,
+    `.current-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  const relativeTarget = path.relative(paths.cliRoot, payloadPath);
+  try {
+    fs.symlinkSync(relativeTarget, temporaryLink, "dir");
+    hooks.beforeRename?.();
+    fs.renameSync(temporaryLink, paths.currentPath);
+  } finally {
+    fs.rmSync(temporaryLink, { force: true });
+  }
+}
+
+export function buildNextManifest(
+  record: InstallRecord,
+  current: InstallManifest | null,
+): InstallManifest {
+  const candidates: InstallRecord[] = current
+    ? [
+        {
+          source: current.source,
+          version: current.version,
+          channel: current.channel,
+          payloadPath: current.payloadPath,
+          repo: current.repo,
+          ref: current.ref,
+          sha: current.sha,
+          installedAt: current.installedAt,
+        },
+        ...current.previous,
+      ]
+    : [];
+  const previous = candidates
+    .filter((candidate) => path.resolve(candidate.payloadPath) !== path.resolve(record.payloadPath))
+    .filter(
+      (candidate, index, all) =>
+        all.findIndex((other) => path.resolve(other.payloadPath) === path.resolve(candidate.payloadPath)) ===
+        index,
+    )
+    .slice(0, 2);
+
+  return { schemaVersion: INSTALL_MANIFEST_VERSION, ...record, previous };
+}
+
+export function pruneInstallPayloads(
+  manifest: InstallManifest,
+  paths = resolveInstallStorePaths(),
+): string[] {
+  const retained = new Set(
+    [manifest, ...manifest.previous].map((record) => path.resolve(record.payloadPath)),
+  );
+  const removed: string[] = [];
+  for (const source of ["npm", "git"] as const) {
+    const sourceRoot = path.join(paths.installsRoot, source);
+    if (!fs.existsSync(sourceRoot)) continue;
+    const sourceStat = fs.lstatSync(sourceRoot);
+    if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+      throw new Error(`Refusing to prune unsafe install-store path ${sourceRoot}.`);
+    }
+    for (const entry of fs.readdirSync(sourceRoot)) {
+      if (entry.startsWith(".")) continue;
+      const candidate = path.join(sourceRoot, entry);
+      if (!retained.has(path.resolve(candidate))) {
+        fs.rmSync(candidate, { recursive: true, force: true });
+        removed.push(candidate);
+      }
+    }
+  }
+  return removed;
+}
+
+export function assertManagedShimWritable(paths = resolveInstallStorePaths()): void {
+  try {
+    const stat = fs.lstatSync(paths.shimPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to replace symlinked shim ${paths.shimPath}.`);
+    }
+    const existing = fs.readFileSync(paths.shimPath, "utf8");
+    if (!existing.includes(MANAGED_SHIM_MARKER)) {
+      throw new Error(`Refusing to replace existing non-managed command ${paths.shimPath}.`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+export function writeManagedShim(paths = resolveInstallStorePaths()): void {
+  assertManagedShimWritable(paths);
+  fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true, mode: 0o755 });
+  const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nPAPERCLIP_HOME="\${PAPERCLIP_HOME:-\$HOME/.paperclip}"\nexec node "\$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js" "\$@"\n`;
+  fs.writeFileSync(paths.shimPath, contents, { mode: 0o755 });
+  fs.chmodSync(paths.shimPath, 0o755);
+}
+
+export function removeManagedShim(paths = resolveInstallStorePaths()): boolean {
+  try {
+    const contents = fs.readFileSync(paths.shimPath, "utf8");
+    if (!contents.includes(MANAGED_SHIM_MARKER)) return false;
+    fs.rmSync(paths.shimPath, { force: true });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+export function managedPathBlock(): string {
+  return `${PATH_BLOCK_START}\nexport PATH="$HOME/.local/bin:$PATH"\n${PATH_BLOCK_END}`;
+}
+
+export function addManagedPathBlock(rcPath: string): boolean {
+  let existing = "";
+  try {
+    existing = fs.readFileSync(rcPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (existing.includes(PATH_BLOCK_START)) return false;
+  fs.mkdirSync(path.dirname(rcPath), { recursive: true });
+  const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  fs.appendFileSync(rcPath, `${prefix}${managedPathBlock()}\n`);
+  return true;
+}
+
+export function removeManagedPathBlock(rcPath: string): boolean {
+  let existing: string;
+  try {
+    existing = fs.readFileSync(rcPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+  const escapedStart = PATH_BLOCK_START.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedEnd = PATH_BLOCK_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const next = existing.replace(new RegExp(`(?:^|\\n)${escapedStart}\\n[\\s\\S]*?${escapedEnd}\\n?`), "\n");
+  if (next === existing) return false;
+  fs.writeFileSync(rcPath, next.replace(/^\n/, ""));
+  return true;
+}
+
+export function isManagedExecutable(
+  executablePath: string | undefined,
+  manifest: InstallManifest,
+  paths = resolveInstallStorePaths(),
+): boolean {
+  if (!executablePath) return false;
+  try {
+    const executableRealPath = fs.realpathSync(executablePath);
+    const payloadRealPath = fs.realpathSync(manifest.payloadPath);
+    return executableRealPath.startsWith(`${payloadRealPath}${path.sep}`) && fs.existsSync(paths.currentPath);
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -156,8 +156,9 @@ function processIsAlive(pid: number): boolean {
 export async function withInstallStoreLock<T>(
   callback: () => Promise<T>,
   paths = resolveInstallStorePaths(),
+  options: { initialize?: boolean } = {},
 ): Promise<T> {
-  initializeInstallStore(paths);
+  if (options.initialize !== false) initializeInstallStore(paths);
   const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
   const acquire = (): void => {
     const temporaryPath = `${paths.lockPath}.${token}.tmp`;

--- a/cli/src/install-store.ts
+++ b/cli/src/install-store.ts
@@ -44,6 +44,26 @@ function ensurePrivateDirectory(directoryPath: string): void {
   fs.chmodSync(directoryPath, 0o700);
 }
 
+function assertOwnedByCurrentUser(stat: fs.Stats, targetPath: string): void {
+  const getuid = process.getuid;
+  if (typeof getuid === "function" && stat.uid !== getuid()) {
+    throw new Error(`Refusing to modify path not owned by the current user: ${targetPath}.`);
+  }
+}
+
+function writeFileAtomic(filePath: string, contents: string, mode: number): void {
+  const temporaryPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  try {
+    fs.writeFileSync(temporaryPath, contents, { mode, flag: "wx" });
+    fs.renameSync(temporaryPath, filePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
 export function resolveInstallStorePaths(options: {
   paperclipHome?: string;
   homeDir?: string;
@@ -209,11 +229,22 @@ export function pruneInstallPayloads(
 }
 
 export function assertManagedShimWritable(paths = resolveInstallStorePaths()): void {
+  const homeDir = path.dirname(path.dirname(path.dirname(paths.shimPath)));
+  for (const directoryPath of [homeDir, path.join(homeDir, ".local"), path.dirname(paths.shimPath)]) {
+    if (!fs.existsSync(directoryPath)) continue;
+    const directoryStat = fs.lstatSync(directoryPath);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+      throw new Error(`Refusing to use unsafe shim directory ${directoryPath}.`);
+    }
+    assertOwnedByCurrentUser(directoryStat, directoryPath);
+  }
   try {
     const stat = fs.lstatSync(paths.shimPath);
-    if (stat.isSymbolicLink()) {
-      throw new Error(`Refusing to replace symlinked shim ${paths.shimPath}.`);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Refusing to replace non-regular shim ${paths.shimPath}.`);
     }
+    assertOwnedByCurrentUser(stat, paths.shimPath);
+    if (stat.nlink > 1) throw new Error(`Refusing to replace multiply linked shim ${paths.shimPath}.`);
     const existing = fs.readFileSync(paths.shimPath, "utf8");
     if (!existing.includes(MANAGED_SHIM_MARKER)) {
       throw new Error(`Refusing to replace existing non-managed command ${paths.shimPath}.`);
@@ -225,10 +256,14 @@ export function assertManagedShimWritable(paths = resolveInstallStorePaths()): v
 
 export function writeManagedShim(paths = resolveInstallStorePaths()): void {
   assertManagedShimWritable(paths);
-  fs.mkdirSync(path.dirname(paths.shimPath), { recursive: true, mode: 0o755 });
+  const homeDir = path.dirname(path.dirname(path.dirname(paths.shimPath)));
+  const localDir = path.dirname(path.dirname(paths.shimPath));
+  fs.mkdirSync(homeDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(localDir, { mode: 0o755 });
+  fs.mkdirSync(path.dirname(paths.shimPath), { mode: 0o755 });
+  assertManagedShimWritable(paths);
   const contents = `#!/bin/sh\n# ${MANAGED_SHIM_MARKER}\nset -eu\nPAPERCLIP_HOME="\${PAPERCLIP_HOME:-\$HOME/.paperclip}"\nexec node "\$PAPERCLIP_HOME/cli/current/node_modules/paperclipai/dist/index.js" "\$@"\n`;
-  fs.writeFileSync(paths.shimPath, contents, { mode: 0o755 });
-  fs.chmodSync(paths.shimPath, 0o755);
+  writeFileAtomic(paths.shimPath, contents, 0o755);
 }
 
 export function removeManagedShim(paths = resolveInstallStorePaths()): boolean {
@@ -249,7 +284,14 @@ export function managedPathBlock(): string {
 
 export function addManagedPathBlock(rcPath: string): boolean {
   let existing = "";
+  let mode = 0o600;
   try {
+    const stat = fs.lstatSync(rcPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Refusing to modify non-regular shell rc file ${rcPath}.`);
+    }
+    assertOwnedByCurrentUser(stat, rcPath);
+    mode = stat.mode & 0o777;
     existing = fs.readFileSync(rcPath, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
@@ -257,13 +299,18 @@ export function addManagedPathBlock(rcPath: string): boolean {
   if (existing.includes(PATH_BLOCK_START)) return false;
   fs.mkdirSync(path.dirname(rcPath), { recursive: true });
   const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-  fs.appendFileSync(rcPath, `${prefix}${managedPathBlock()}\n`);
+  writeFileAtomic(rcPath, `${existing}${prefix}${managedPathBlock()}\n`, mode);
   return true;
 }
 
 export function removeManagedPathBlock(rcPath: string): boolean {
   let existing: string;
   try {
+    const stat = fs.lstatSync(rcPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Refusing to modify non-regular shell rc file ${rcPath}.`);
+    }
+    assertOwnedByCurrentUser(stat, rcPath);
     existing = fs.readFileSync(rcPath, "utf8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
@@ -273,7 +320,7 @@ export function removeManagedPathBlock(rcPath: string): boolean {
   const escapedEnd = PATH_BLOCK_END.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const next = existing.replace(new RegExp(`(?:^|\\n)${escapedStart}\\n[\\s\\S]*?${escapedEnd}\\n?`), "\n");
   if (next === existing) return false;
-  fs.writeFileSync(rcPath, next.replace(/^\n/, ""));
+  writeFileAtomic(rcPath, next.replace(/^\n/, ""), fs.statSync(rcPath).mode & 0o777);
   return true;
 }
 

--- a/cli/src/onboard-service.ts
+++ b/cli/src/onboard-service.ts
@@ -14,6 +14,7 @@ export type OnboardServiceOptions = {
 type OnboardServiceDependencies = {
   detect: (instanceId: string) => Promise<ServiceManagerDetection>;
   confirm: () => Promise<boolean>;
+  confirmLinger: () => Promise<boolean>;
   isInteractive: () => boolean;
   info: (message: string) => void;
   success: (message: string) => void;
@@ -26,6 +27,13 @@ const defaultDependencies: OnboardServiceDependencies = {
     const answer = await p.confirm({
       message: "Install Paperclip as a background service?",
       initialValue: true,
+    });
+    return !p.isCancel(answer) && answer === true;
+  },
+  confirmLinger: async () => {
+    const answer = await p.confirm({
+      message: "Allow Paperclip to keep running after logout? This may request system authorization.",
+      initialValue: false,
     });
     return !p.isCancel(answer) && answer === true;
   },
@@ -61,6 +69,9 @@ export async function handleOnboardService(
   if (!explicitlyRequested && !(await deps.confirm())) return false;
 
   await detection.manager.install({ startNow: true, startOnLogin: true });
+  if (!explicitlyRequested && detection.manager.enableLinger && await deps.confirmLinger()) {
+    await detection.manager.enableLinger();
+  }
   deps.success(`Installed and started ${detection.manager.serviceName}.`);
   return true;
 }

--- a/cli/src/onboard-service.ts
+++ b/cli/src/onboard-service.ts
@@ -1,0 +1,66 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { resolvePaperclipInstanceId } from "./config/home.js";
+import {
+  detectServiceManager,
+  type ServiceManagerDetection,
+} from "./services/service-manager.js";
+
+export type OnboardServiceOptions = {
+  yes?: boolean;
+  installService?: boolean;
+};
+
+type OnboardServiceDependencies = {
+  detect: (instanceId: string) => Promise<ServiceManagerDetection>;
+  confirm: () => Promise<boolean>;
+  isInteractive: () => boolean;
+  info: (message: string) => void;
+  success: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+const defaultDependencies: OnboardServiceDependencies = {
+  detect: (instanceId) => detectServiceManager({ instanceId }),
+  confirm: async () => {
+    const answer = await p.confirm({
+      message: "Install Paperclip as a background service?",
+      initialValue: true,
+    });
+    return !p.isCancel(answer) && answer === true;
+  },
+  isInteractive: () => process.stdin.isTTY === true && process.stdout.isTTY === true,
+  info: (message) => p.log.message(pc.dim(message)),
+  success: (message) => p.log.success(message),
+  warn: (message) => p.log.warn(message),
+};
+
+export async function handleOnboardService(
+  options: OnboardServiceOptions,
+  dependencies: Partial<OnboardServiceDependencies> = {},
+): Promise<boolean> {
+  const deps = { ...defaultDependencies, ...dependencies };
+  if (options.installService === false) return false;
+
+  const explicitlyRequested = options.installService === true;
+  const canPrompt = options.yes !== true && deps.isInteractive();
+  if (!explicitlyRequested && !canPrompt) {
+    deps.info(
+      "Background service not installed. Use `paperclipai onboard --install-service` or `paperclipai service install` to opt in.",
+    );
+    return false;
+  }
+
+  const instanceId = resolvePaperclipInstanceId();
+  const detection = await deps.detect(instanceId);
+  if (!detection.supported) {
+    if (explicitlyRequested) deps.warn(detection.reason);
+    return false;
+  }
+
+  if (!explicitlyRequested && !(await deps.confirm())) return false;
+
+  await detection.manager.install({ startNow: true, startOnLogin: true });
+  deps.success(`Installed and started ${detection.manager.serviceName}.`);
+  return true;
+}

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -1,0 +1,285 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { resolvePaperclipHomeDir, resolvePaperclipInstanceId } from "../config/home.js";
+
+const execFileAsync = promisify(execFile);
+
+export type ServicePlatform = "systemd" | "launchd";
+export type ServiceStatus = {
+  platform: ServicePlatform;
+  serviceName: string;
+  installed: boolean;
+  active: boolean;
+  enabled: boolean;
+  pid: number | null;
+  detail?: string;
+  linger?: boolean | null;
+};
+export type ServiceInstallOptions = { startNow: boolean; startOnLogin: boolean };
+
+export interface ServiceManager {
+  readonly platform: ServicePlatform;
+  readonly instanceId: string;
+  readonly serviceName: string;
+  readonly definitionPath: string;
+  renderDefinition(): string;
+  install(options: ServiceInstallOptions): Promise<{ changed: boolean }>;
+  uninstall(): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  restart(): Promise<void>;
+  status(): Promise<ServiceStatus>;
+  logs(follow: boolean, lines: number): Promise<void>;
+  enableLinger?(): Promise<void>;
+}
+
+export type CommandResult = { stdout: string; stderr: string };
+export type CommandRunner = (command: string, args: string[], options?: { inherit?: boolean }) => Promise<CommandResult>;
+
+export const defaultCommandRunner: CommandRunner = async (command, args, options) => {
+  if (options?.inherit) {
+    await new Promise<void>((resolve, reject) => {
+      const child = execFile(command, args, { windowsHide: true }, (error) => error ? reject(error) : resolve());
+      child.stdout?.pipe(process.stdout);
+      child.stderr?.pipe(process.stderr);
+    });
+    return { stdout: "", stderr: "" };
+  }
+  const result = await execFileAsync(command, args, { encoding: "utf8", windowsHide: true });
+  return { stdout: result.stdout, stderr: result.stderr };
+};
+
+function escapeSystemd(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+function escapeXml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;");
+}
+
+export function resolveServiceShimPath(homeDir = os.homedir()): string {
+  return process.env.PAPERCLIP_SHIM_PATH?.trim() || path.join(homeDir, ".local", "bin", "paperclipai");
+}
+
+export function systemdServiceName(instanceId: string): string {
+  return instanceId === "default" ? "paperclipai.service" : `paperclipai-${instanceId}.service`;
+}
+
+export function launchdServiceName(instanceId: string): string {
+  return instanceId === "default" ? "ing.paperclip.paperclipai" : `ing.paperclip.paperclipai.${instanceId}`;
+}
+
+export function renderSystemdUnit(input: { instanceId: string; shimPath: string; homeDir: string }): string {
+  return `[Unit]
+Description=Paperclip AI (${input.instanceId})
+After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=notify
+NotifyAccess=all
+ExecStart="${escapeSystemd(input.shimPath)}" run --instance "${escapeSystemd(input.instanceId)}"
+Environment="PAPERCLIP_SERVICE_MANAGED=1"
+Environment="PAPERCLIP_INSTANCE_ID=${escapeSystemd(input.instanceId)}"
+Environment="PAPERCLIP_HOME=${escapeSystemd(input.homeDir)}"
+WorkingDirectory=%h
+Restart=always
+RestartSec=5
+TimeoutStopSec=300
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function renderLaunchdPlist(input: { instanceId: string; shimPath: string; homeDir: string; stdoutPath: string; stderrPath: string }): string {
+  const label = launchdServiceName(input.instanceId);
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${escapeXml(label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escapeXml(input.shimPath)}</string><string>run</string><string>--instance</string><string>${escapeXml(input.instanceId)}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PAPERCLIP_SERVICE_MANAGED</key><string>1</string>
+    <key>PAPERCLIP_INSTANCE_ID</key><string>${escapeXml(input.instanceId)}</string>
+    <key>PAPERCLIP_HOME</key><string>${escapeXml(input.homeDir)}</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>5</integer>
+  <key>ExitTimeOut</key><integer>300</integer>
+  <key>StandardOutPath</key><string>${escapeXml(input.stdoutPath)}</string>
+  <key>StandardErrorPath</key><string>${escapeXml(input.stderrPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+async function writeIfChanged(filePath: string, contents: string): Promise<boolean> {
+  try {
+    if (await fs.readFile(filePath, "utf8") === contents) return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, contents, { encoding: "utf8", mode: 0o644 });
+  return true;
+}
+
+export class SystemdServiceManager implements ServiceManager {
+  readonly platform = "systemd" as const;
+  readonly serviceName: string;
+  readonly definitionPath: string;
+
+  constructor(readonly instanceId: string, private readonly runner: CommandRunner = defaultCommandRunner, private readonly homeDir = resolvePaperclipHomeDir(), private readonly shimPath = resolveServiceShimPath(), userHomeDir = os.homedir()) {
+    this.serviceName = systemdServiceName(instanceId);
+    this.definitionPath = path.join(userHomeDir, ".config", "systemd", "user", this.serviceName);
+  }
+
+  renderDefinition(): string {
+    return renderSystemdUnit({ instanceId: this.instanceId, shimPath: this.shimPath, homeDir: this.homeDir });
+  }
+
+  private async ensureCurrent(): Promise<boolean> {
+    const changed = await writeIfChanged(this.definitionPath, this.renderDefinition());
+    if (changed) await this.runner("systemctl", ["--user", "daemon-reload"]);
+    return changed;
+  }
+
+  async install(options: ServiceInstallOptions): Promise<{ changed: boolean }> {
+    const changed = await this.ensureCurrent();
+    if (options.startOnLogin) await this.runner("systemctl", ["--user", "enable", this.serviceName]);
+    else await this.runner("systemctl", ["--user", "disable", this.serviceName]).catch(() => undefined);
+    if (options.startNow) await this.start();
+    return { changed };
+  }
+
+  async uninstall(): Promise<void> {
+    await this.stop().catch(() => undefined);
+    await this.runner("systemctl", ["--user", "disable", this.serviceName]).catch(() => undefined);
+    await fs.rm(this.definitionPath, { force: true });
+    await this.runner("systemctl", ["--user", "daemon-reload"]);
+    await this.runner("systemctl", ["--user", "reset-failed", this.serviceName]).catch(() => undefined);
+  }
+
+  async start(): Promise<void> { await this.ensureCurrent(); await this.runner("systemctl", ["--user", "start", this.serviceName]); }
+  async stop(): Promise<void> { await this.runner("systemctl", ["--user", "stop", this.serviceName]); }
+  async restart(): Promise<void> { await this.ensureCurrent(); await this.runner("systemctl", ["--user", "restart", this.serviceName]); }
+
+  async status(): Promise<ServiceStatus> {
+    let output: string;
+    try {
+      output = (await this.runner("systemctl", ["--user", "show", this.serviceName, "--property=LoadState,ActiveState,UnitFileState,MainPID"])).stdout;
+    } catch {
+      return { platform: this.platform, serviceName: this.serviceName, installed: false, active: false, enabled: false, pid: null, linger: await this.lingerStatus() };
+    }
+    const values = Object.fromEntries(output.trim().split(/\r?\n/).map((line) => line.split(/=(.*)/s).slice(0, 2)));
+    const pid = Number(values.MainPID);
+    return { platform: this.platform, serviceName: this.serviceName, installed: values.LoadState === "loaded", active: values.ActiveState === "active", enabled: values.UnitFileState === "enabled", pid: Number.isInteger(pid) && pid > 0 ? pid : null, detail: values.ActiveState, linger: await this.lingerStatus() };
+  }
+
+  private async lingerStatus(): Promise<boolean | null> {
+    try {
+      const result = await this.runner("loginctl", ["show-user", String(process.getuid?.() ?? os.userInfo().username), "--property=Linger", "--value"]);
+      return result.stdout.trim() === "yes";
+    } catch { return null; }
+  }
+
+  async enableLinger(): Promise<void> { await this.runner("loginctl", ["enable-linger", os.userInfo().username]); }
+  async logs(follow: boolean, lines: number): Promise<void> { await this.runner("journalctl", ["--user", "--unit", this.serviceName, "--lines", String(lines), ...(follow ? ["--follow"] : [])], { inherit: true }); }
+}
+
+export class LaunchdServiceManager implements ServiceManager {
+  readonly platform = "launchd" as const;
+  readonly serviceName: string;
+  readonly definitionPath: string;
+  private readonly domain = `gui/${process.getuid?.() ?? 0}`;
+  private readonly stdoutPath: string;
+  private readonly stderrPath: string;
+
+  constructor(readonly instanceId: string, private readonly runner: CommandRunner = defaultCommandRunner, private readonly homeDir = resolvePaperclipHomeDir(), private readonly shimPath = resolveServiceShimPath(), userHomeDir = os.homedir()) {
+    this.serviceName = launchdServiceName(instanceId);
+    this.definitionPath = path.join(userHomeDir, "Library", "LaunchAgents", `${this.serviceName}.plist`);
+    const logDir = path.join(homeDir, "instances", instanceId, "logs");
+    this.stdoutPath = path.join(logDir, "service.log");
+    this.stderrPath = path.join(logDir, "service.err.log");
+  }
+
+  renderDefinition(): string { return renderLaunchdPlist({ instanceId: this.instanceId, shimPath: this.shimPath, homeDir: this.homeDir, stdoutPath: this.stdoutPath, stderrPath: this.stderrPath }); }
+
+  async install(options: ServiceInstallOptions): Promise<{ changed: boolean }> {
+    await fs.mkdir(path.dirname(this.stdoutPath), { recursive: true });
+    const changed = await writeIfChanged(this.definitionPath, this.renderDefinition());
+    if (changed) await this.runner("launchctl", ["bootout", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
+    await this.runner("launchctl", [options.startOnLogin ? "enable" : "disable", `${this.domain}/${this.serviceName}`]);
+    if (options.startOnLogin || options.startNow) {
+      await this.runner("launchctl", ["bootstrap", this.domain, this.definitionPath]).catch(async () => this.runner("launchctl", ["kickstart", "-k", `${this.domain}/${this.serviceName}`]));
+    }
+    if (!options.startNow) await this.stop().catch(() => undefined);
+    return { changed };
+  }
+
+  async uninstall(): Promise<void> {
+    await this.runner("launchctl", ["bootout", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
+    await this.runner("launchctl", ["enable", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
+    await fs.rm(this.definitionPath, { force: true });
+  }
+  async start(): Promise<void> { await this.install({ startNow: true, startOnLogin: true }); }
+  async stop(): Promise<void> { await this.runner("launchctl", ["bootout", `${this.domain}/${this.serviceName}`]); }
+  async restart(): Promise<void> { await writeIfChanged(this.definitionPath, this.renderDefinition()); await this.runner("launchctl", ["kickstart", "-k", `${this.domain}/${this.serviceName}`]); }
+
+  async status(): Promise<ServiceStatus> {
+    try {
+      const result = await this.runner("launchctl", ["print", `${this.domain}/${this.serviceName}`]);
+      const pidMatch = result.stdout.match(/\bpid\s*=\s*(\d+)/);
+      const pid = pidMatch ? Number(pidMatch[1]) : null;
+      return { platform: this.platform, serviceName: this.serviceName, installed: true, active: Boolean(pid), enabled: await this.isEnabled(), pid, detail: pid ? "running" : "loaded" };
+    } catch {
+      let installed = true;
+      try { await fs.access(this.definitionPath); } catch { installed = false; }
+      return { platform: this.platform, serviceName: this.serviceName, installed, active: false, enabled: installed && await this.isEnabled(), pid: null };
+    }
+  }
+
+  private async isEnabled(): Promise<boolean> {
+    try {
+      const result = await this.runner("launchctl", ["print-disabled", this.domain]);
+      return !new RegExp(`"${this.serviceName.replaceAll(".", "\\.")}"\\s*=>\\s*true`).test(result.stdout);
+    } catch { return true; }
+  }
+
+  async logs(follow: boolean, lines: number): Promise<void> { await this.runner("tail", ["-n", String(lines), ...(follow ? ["-F"] : []), this.stdoutPath, this.stderrPath], { inherit: true }); }
+}
+
+export type ServiceManagerDetection = { supported: true; manager: ServiceManager } | { supported: false; reason: string };
+
+export async function detectServiceManager(input: { instanceId?: string; platform?: NodeJS.Platform; runner?: CommandRunner } = {}): Promise<ServiceManagerDetection> {
+  const instanceId = resolvePaperclipInstanceId(input.instanceId);
+  const platform = input.platform ?? process.platform;
+  const runner = input.runner ?? defaultCommandRunner;
+  if (platform === "darwin") return { supported: true, manager: new LaunchdServiceManager(instanceId, runner) };
+  if (platform !== "linux") return { supported: false, reason: `Service management is not supported on ${platform}. Use paperclipai run instead.` };
+  try {
+    await runner("systemctl", ["--user", "show-environment"]);
+    return { supported: true, manager: new SystemdServiceManager(instanceId, runner) };
+  } catch {
+    return { supported: false, reason: "No usable systemd user manager was detected (common in containers and WSL1). Use paperclipai run instead." };
+  }
+}
+
+export async function assertForegroundRunAllowed(instanceId: string, force = false, detector: typeof detectServiceManager = detectServiceManager): Promise<void> {
+  if (force || process.env.PAPERCLIP_SERVICE_MANAGED === "1") return;
+  const detection = await detector({ instanceId });
+  if (!detection.supported) return;
+  const status = await detection.manager.status();
+  if (status.active) throw new Error(`Paperclip instance '${instanceId}' is already running as ${status.serviceName}. Use 'paperclipai service status --instance ${instanceId}' or pass --force to bypass this safety check.`);
+}

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -64,6 +64,10 @@ function escapeXml(value: string): string {
   return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;");
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function resolveServiceShimPath(homeDir = os.homedir()): string {
   return process.env.PAPERCLIP_SHIM_PATH?.trim() || path.join(homeDir, ".local", "bin", "paperclipai");
 }
@@ -258,7 +262,7 @@ export class LaunchdServiceManager implements ServiceManager {
   private async isEnabled(): Promise<boolean> {
     try {
       const result = await this.runner("launchctl", ["print-disabled", this.domain]);
-      return !new RegExp(`"${this.serviceName.replaceAll(".", "\\.")}"\\s*=>\\s*true`).test(result.stdout);
+      return !new RegExp(`"${escapeRegExp(this.serviceName)}"\\s*=>\\s*true`).test(result.stdout);
     } catch { return true; }
   }
 

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -168,7 +168,8 @@ export class SystemdServiceManager implements ServiceManager {
   }
 
   async uninstall(): Promise<void> {
-    await this.stop().catch(() => undefined);
+    const status = await this.status();
+    if (status.active) await this.stop();
     await this.runner("systemctl", ["--user", "disable", this.serviceName]).catch(() => undefined);
     await fs.rm(this.definitionPath, { force: true });
     await this.runner("systemctl", ["--user", "daemon-reload"]);
@@ -237,7 +238,7 @@ export class LaunchdServiceManager implements ServiceManager {
     await this.runner("launchctl", ["disable", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
     await fs.rm(this.definitionPath, { force: true });
   }
-  async start(): Promise<void> { await this.install({ startNow: true, startOnLogin: true }); }
+  async start(): Promise<void> { await this.install({ startNow: true, startOnLogin: await this.isEnabled() }); }
   async stop(): Promise<void> { await this.runner("launchctl", ["bootout", `${this.domain}/${this.serviceName}`]); }
   async restart(): Promise<void> { await writeIfChanged(this.definitionPath, this.renderDefinition()); await this.runner("launchctl", ["kickstart", "-k", `${this.domain}/${this.serviceName}`]); }
 

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -53,7 +53,11 @@ export const defaultCommandRunner: CommandRunner = async (command, args, options
 };
 
 function escapeSystemd(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("$", () => "$$")
+    .replaceAll("%", "%%");
 }
 
 function escapeXml(value: string): string {

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -230,7 +230,7 @@ export class LaunchdServiceManager implements ServiceManager {
 
   async uninstall(): Promise<void> {
     await this.runner("launchctl", ["bootout", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
-    await this.runner("launchctl", ["enable", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
+    await this.runner("launchctl", ["disable", `${this.domain}/${this.serviceName}`]).catch(() => undefined);
     await fs.rm(this.definitionPath, { force: true });
   }
   async start(): Promise<void> { await this.install({ startNow: true, startOnLogin: true }); }

--- a/cli/src/update-notice.ts
+++ b/cli/src/update-notice.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import path from "node:path";
+import { packageVersion } from "./version.js";
+import { compareVersions } from "./commands/update.js";
+import { readInstallManifest, resolveInstallStorePaths } from "./install-store.js";
+import { resolveConfigPath } from "./config/store.js";
+const NOTICE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+export function isUpdateNoticeEnabled(configPath?: string): boolean {
+  if (process.env.PAPERCLIP_UPDATE_CHECK === "0") return false;
+  try { const raw = JSON.parse(fs.readFileSync(resolveConfigPath(configPath), "utf8")) as { updates?: { checkEnabled?: boolean } }; return raw.updates?.checkEnabled !== false; } catch { return true; }
+}
+export async function checkForUpdateNotice(options: { configPath?: string; now?: number; fetchImpl?: typeof fetch; cachePath?: string } = {}): Promise<string | null> {
+  if (!isUpdateNoticeEnabled(options.configPath)) return null;
+  const paths = resolveInstallStorePaths(); const cachePath = options.cachePath ?? path.join(paths.cliRoot, "update-check.json"); const now = options.now ?? Date.now();
+  try { const cache = JSON.parse(fs.readFileSync(cachePath, "utf8")) as { checkedAt?: number; latest?: string }; if (cache.checkedAt && now - cache.checkedAt < NOTICE_INTERVAL_MS) return cache.latest && compareVersions(cache.latest, packageVersion) > 0 ? cache.latest : null; } catch {}
+  const tag = readInstallManifest(paths)?.channel === "canary" ? "canary" : "latest";
+  try { const response = await (options.fetchImpl ?? fetch)("https://registry.npmjs.org/paperclipai", { signal: AbortSignal.timeout(2500) }); if (!response.ok) return null; const body = await response.json() as { ["dist-tags"]?: Record<string, string> }; const latest = body["dist-tags"]?.[tag]; fs.mkdirSync(path.dirname(cachePath), { recursive: true, mode: 0o700 }); fs.writeFileSync(cachePath, JSON.stringify({ checkedAt: now, latest: latest ?? null }) + "\n", { mode: 0o600 }); return latest && compareVersions(latest, packageVersion) > 0 ? latest : null; } catch { return null; }
+}
+export async function printUpdateNotice(configPath?: string): Promise<void> { const latest = await checkForUpdateNotice({ configPath }); if (latest) console.log(`Update available: ${latest} — run \`paperclipai update\``); }

--- a/cli/src/utils/health-url.ts
+++ b/cli/src/utils/health-url.ts
@@ -1,0 +1,10 @@
+export function buildLocalHealthUrl(host: string | undefined, port: number): string {
+  const configuredHost = host?.trim();
+  const reachableHost = !configuredHost || configuredHost === "0.0.0.0" || configuredHost === "::"
+    ? "127.0.0.1"
+    : configuredHost;
+  const urlHost = reachableHost.includes(":") && !reachableHost.startsWith("[")
+    ? `[${reachableHost}]`
+    : reachableHost;
+  return `http://${urlHost}:${port}/api/health`;
+}

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -12,7 +12,7 @@ type PackageJson = {
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as PackageJson;
 
-const packageVersion = pkg.version ?? "0.0.0";
+export const packageVersion = pkg.version ?? "0.0.0";
 
 export function resolveCliVersion(executablePath = process.argv[1]): string {
   try {

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,4 +1,9 @@
 import { createRequire } from "node:module";
+import {
+  isManagedExecutable,
+  readInstallManifest,
+  resolveInstallStorePaths,
+} from "./install-store.js";
 
 type PackageJson = {
   version?: string;
@@ -7,4 +12,21 @@ type PackageJson = {
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as PackageJson;
 
-export const cliVersion = pkg.version ?? "0.0.0";
+const packageVersion = pkg.version ?? "0.0.0";
+
+export function resolveCliVersion(executablePath = process.argv[1]): string {
+  try {
+    const paths = resolveInstallStorePaths();
+    const manifest = readInstallManifest(paths);
+    if (!manifest || !isManagedExecutable(executablePath, manifest, paths)) return packageVersion;
+    const provenance =
+      manifest.source === "git"
+        ? `managed git ${manifest.ref ?? manifest.sha ?? "unknown"}`
+        : `managed npm ${manifest.channel}`;
+    return `${packageVersion} (${provenance}; payload ${manifest.payloadPath})`;
+  } catch {
+    return packageVersion;
+  }
+}
+
+export const cliVersion = resolveCliVersion();

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -17,7 +17,14 @@ pnpm paperclipai --help
 Recommended installation and interactive onboarding:
 
 ```sh
-curl -fsSL https://paperclip.ing/install.sh | bash
+curl -fsSLO https://paperclip.ing/install.sh
+curl -fsSLO https://paperclip.ing/install.sh.sha256
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c install.sh.sha256
+else
+  shasum -a 256 -c install.sh.sha256
+fi
+bash install.sh
 ```
 
 First-time local bootstrap from a source checkout:

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -2,6 +2,7 @@
 
 Paperclip CLI now supports both:
 
+- installation and lifecycle management (`install`, `uninstall`, `update`, `upgrade`, `service`)
 - instance setup/diagnostics (`onboard`, `doctor`, `configure`, `env`, `allowed-hostname`, `env-lab`)
 - control-plane client operations (issues, approvals, agents, activity, dashboard)
 
@@ -13,7 +14,13 @@ Use repo script in development:
 pnpm paperclipai --help
 ```
 
-First-time local bootstrap + run:
+Recommended installation and interactive onboarding:
+
+```sh
+curl -fsSL https://paperclip.ing/install.sh | bash
+```
+
+First-time local bootstrap from a source checkout:
 
 ```sh
 pnpm paperclipai run
@@ -24,6 +31,60 @@ Choose local instance:
 ```sh
 pnpm paperclipai run --instance dev
 ```
+
+## Install, Update, And Uninstall
+
+Managed installs keep CLI payloads under `~/.paperclip/cli`, expose a stable
+`~/.local/bin/paperclipai` shim, switch versions atomically, and retain two
+previous payloads for rollback.
+
+```sh
+paperclipai install
+paperclipai install --canary
+paperclipai install --version <version>
+paperclipai install --ref <branch|tag|sha> [--repo owner/repo]
+paperclipai update
+paperclipai update --latest|--canary|--version <version>|--ref <ref>
+paperclipai update --rollback
+paperclipai upgrade
+paperclipai uninstall
+```
+
+`upgrade` aliases `update`. `uninstall` removes managed code and the shim but
+preserves instance data under `~/.paperclip/instances/`. See
+`doc/INSTALLING.md` for installation methods, security notes, PATH setup, and
+the complete update and rollback behavior.
+
+## Onboarding And Service Management
+
+Interactive onboarding offers to install a background service on supported
+platforms. `--yes` never installs it implicitly; automation must opt in.
+
+```sh
+paperclipai onboard
+paperclipai onboard --yes
+paperclipai onboard --yes --install-service
+paperclipai onboard --yes --no-install-service
+```
+
+Service lifecycle commands remain under the `service` namespace:
+
+```sh
+paperclipai service install [--no-start-now] [--no-start-on-login]
+paperclipai service uninstall
+paperclipai service start
+paperclipai service stop
+paperclipai service restart [--wait]
+paperclipai service status [--json]
+paperclipai service logs [-f]
+```
+
+Every service verb supports `--instance <id>` and `--json`. Linux and WSL2 use
+a systemd user unit when available; macOS uses a LaunchAgent. Unsupported
+environments receive foreground `paperclipai run` guidance.
+
+`paperclipai doctor` includes managed-install and service-health diagnostics in
+addition to configuration, storage, database, logging, and port checks.
 
 ## Deployment Modes
 

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -44,7 +44,7 @@ paperclipai install --canary
 paperclipai install --version <version>
 paperclipai install --ref <branch|tag|sha> [--repo owner/repo]
 paperclipai update
-paperclipai update --latest|--canary|--version <version>|--ref <ref>
+paperclipai update --latest|--canary|--version <version>
 paperclipai update --rollback
 paperclipai upgrade
 paperclipai uninstall

--- a/doc/INSTALLING.md
+++ b/doc/INSTALLING.md
@@ -1,0 +1,233 @@
+# Installing Paperclip
+
+Paperclip supports a managed installation, an ephemeral `npx` tryout, a
+traditional global npm installation, and development from a source checkout.
+The managed installation is recommended because it provides atomic updates,
+rollback, git-ref installs, and a stable entrypoint for the background service.
+
+## Recommended Install
+
+On macOS, Linux, or WSL2:
+
+```sh
+curl -fsSL https://paperclip.ing/install.sh | bash
+```
+
+The bootstrap script:
+
+1. verifies that the platform is supported;
+2. ensures Node.js 20 or newer is available;
+3. delegates installation to `paperclipai install`;
+4. starts interactive onboarding when stdin and stdout are terminals.
+
+The script prints and confirms any command that requires elevated privileges.
+Use `--no-prompt` for automation and `--no-onboard` to stop after installing:
+
+```sh
+curl -fsSL https://paperclip.ing/install.sh | bash -s -- --no-prompt --no-onboard
+paperclipai onboard --yes
+```
+
+If the vanity installer endpoint is unavailable, fetch the same
+release-controlled source from GitHub raw content:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/paperclipai/paperclip/master/scripts/install.sh | bash
+```
+
+For audits or incident response, pin the raw URL to a release tag or commit
+SHA instead of `master`, download it first, and compare it with the published
+checksum at `https://paperclip.ing/install.sh.sha256`.
+
+Each installer flag also has a `PAPERCLIP_INSTALL_*` environment-variable
+equivalent for environments where passing arguments through a pipe is awkward.
+
+## Managed Install Layout
+
+Managed code is separate from instance data:
+
+```text
+~/.paperclip/cli/
+├── install.json
+├── current -> installs/npm/2026.720.0
+└── installs/
+    ├── npm/<version>/
+    └── git/<sha12>/
+
+~/.local/bin/paperclipai
+```
+
+The `paperclipai` shim remains stable while `current` switches atomically
+between complete payloads. Paperclip keeps the two previous managed payloads
+for rollback. Configuration, databases, uploads, logs, secrets, and workspaces
+remain under `~/.paperclip/instances/` and are not stored inside CLI payloads.
+
+If `~/.local/bin` is not on `PATH`, the installer offers to update the relevant
+shell startup file when running interactively. Non-interactive installs print
+the exact `export PATH` command instead of editing shell files silently.
+
+## Install Sources
+
+Install the current stable release:
+
+```sh
+npx --registry https://registry.npmjs.org paperclipai install
+```
+
+Install canary or pin an exact published version:
+
+```sh
+npx --registry https://registry.npmjs.org paperclipai install --canary
+npx --registry https://registry.npmjs.org paperclipai install --version 2026.720.0
+```
+
+Install a branch, tag, or commit from GitHub:
+
+```sh
+npx --registry https://registry.npmjs.org paperclipai install --ref master
+npx --registry https://registry.npmjs.org paperclipai install --ref v2026.720.0
+npx --registry https://registry.npmjs.org paperclipai install --ref <commit-sha>
+```
+
+Use a fork by adding `--repo owner/repository`:
+
+```sh
+npx --registry https://registry.npmjs.org paperclipai install \
+  --repo your-org/paperclip \
+  --ref your-branch
+```
+
+Git-ref installs resolve the requested ref to an exact commit before building.
+Review and trust the repository and ref: installing a git ref executes that
+revision's package installation and release build scripts on your machine.
+
+## Onboarding And The Service
+
+Run onboarding after a non-interactive installation:
+
+```sh
+paperclipai onboard
+```
+
+Interactive onboarding asks whether Paperclip should run as a background
+service when the platform supports one. Automated onboarding deliberately does
+not install a service unless explicitly requested:
+
+```sh
+paperclipai onboard --yes                    # configure only; no service install
+paperclipai onboard --yes --install-service  # explicit automation opt-in
+paperclipai onboard --yes --no-install-service
+```
+
+Service commands are namespaced:
+
+```sh
+paperclipai service install
+paperclipai service status
+paperclipai service start
+paperclipai service stop
+paperclipai service restart
+paperclipai service logs -f
+paperclipai service uninstall
+```
+
+Paperclip uses a systemd user service on Linux and WSL2 systems with user
+systemd, and a LaunchAgent on macOS. Containers, WSL1, and systems without a
+supported user service manager receive foreground `paperclipai run` guidance
+instead of a hard failure.
+
+The service uses the stable managed-install shim, restarts after crashes, and
+can start on login. On Linux, service installation may offer to enable user
+lingering so it can continue without an active login session. The command
+explains and confirms that system-level action before running it.
+
+Use one server process per instance. `paperclipai run` refuses to start when
+the same instance is already supervised; stop the service first or use
+`--force` only when you intentionally accept the single-writer risk.
+
+## Update And Rollback
+
+Update according to the source and channel recorded in the install manifest:
+
+```sh
+paperclipai update
+```
+
+Select a different release source explicitly:
+
+```sh
+paperclipai update --latest
+paperclipai update --canary
+paperclipai update --version 2026.720.0
+paperclipai update --ref master
+paperclipai update --repo your-org/paperclip --ref your-branch
+```
+
+Managed updates create a database backup before switching payloads, verify the
+new CLI, atomically flip `current`, and restart an installed service. A failed
+install or verification leaves the previous payload active.
+
+Roll back to the previous retained payload:
+
+```sh
+paperclipai update --rollback
+```
+
+The `upgrade` command is an alias for `update`. Exact versions and commit SHAs
+are pinned; provide a new target when you want them to move.
+
+## Other Installation Methods
+
+Ephemeral tryout with no managed install:
+
+```sh
+npx --registry https://registry.npmjs.org paperclipai onboard --yes
+```
+
+Traditional global npm install:
+
+```sh
+npm install --global --registry https://registry.npmjs.org paperclipai
+paperclipai onboard
+```
+
+Source checkout for development:
+
+```sh
+git clone https://github.com/paperclipai/paperclip.git
+cd paperclip
+pnpm install
+pnpm dev
+```
+
+The managed `paperclipai update` command can update managed and global npm
+installs. For source checkouts it reports the appropriate git workflow instead
+of modifying the checkout automatically.
+
+## Diagnose An Installation
+
+Run:
+
+```sh
+paperclipai doctor
+paperclipai service status
+```
+
+`doctor` checks the managed install store, manifest, `current` link, shim,
+`PATH`, Node.js version, and service state. Service diagnostics cover unit-file
+presence and drift, running state, configured port ownership, and the running
+server version.
+
+## Uninstall
+
+Remove the background service and managed CLI payloads:
+
+```sh
+paperclipai service uninstall
+paperclipai uninstall
+```
+
+`paperclipai uninstall` removes the managed shim, manifest, and CLI payloads.
+It deliberately preserves `~/.paperclip/instances/`, including configuration,
+databases, uploads, logs, secrets, backups, and workspaces. Back up and remove
+that data separately only when you intend to delete the Paperclip instance.

--- a/doc/INSTALLING.md
+++ b/doc/INSTALLING.md
@@ -21,6 +21,8 @@ The bootstrap script:
 4. starts interactive onboarding when stdin and stdout are terminals.
 
 The script prints and confirms any command that requires elevated privileges.
+Third-party Node.js bootstrap scripts are pinned and SHA-256 verified before
+execution; the installer stops if a published script changes unexpectedly.
 Use `--no-prompt` for automation and `--no-onboard` to stop after installing:
 
 ```sh

--- a/doc/INSTALLING.md
+++ b/doc/INSTALLING.md
@@ -10,7 +10,14 @@ rollback, git-ref installs, and a stable entrypoint for the background service.
 On macOS, Linux, or WSL2:
 
 ```sh
-curl -fsSL https://paperclip.ing/install.sh | bash
+curl -fsSLO https://paperclip.ing/install.sh
+curl -fsSLO https://paperclip.ing/install.sh.sha256
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c install.sh.sha256
+else
+  shasum -a 256 -c install.sh.sha256
+fi
+bash install.sh
 ```
 
 The bootstrap script:

--- a/doc/INSTALLING.md
+++ b/doc/INSTALLING.md
@@ -162,8 +162,6 @@ Select a different release source explicitly:
 paperclipai update --latest
 paperclipai update --canary
 paperclipai update --version 2026.720.0
-paperclipai update --ref master
-paperclipai update --repo your-org/paperclip --ref your-branch
 ```
 
 Managed updates create a database backup before switching payloads, verify the

--- a/doc/INSTALLING.md
+++ b/doc/INSTALLING.md
@@ -32,7 +32,8 @@ If the vanity installer endpoint is unavailable, fetch the same
 release-controlled source from GitHub raw content:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/paperclipai/paperclip/master/scripts/install.sh | bash
+raw_base=https://raw.githubusercontent.com/paperclipai/paperclip
+curl -fsSL "$raw_base/master/scripts/install.sh" | bash
 ```
 
 For audits or incident response, pin the raw URL to a release tag or commit
@@ -40,7 +41,7 @@ SHA instead of `master`, download it first, and compare it with the published
 checksum at `https://paperclip.ing/install.sh.sha256`.
 
 Each installer flag also has a `PAPERCLIP_INSTALL_*` environment-variable
-equivalent for environments where passing arguments through a pipe is awkward.
+equivalent. This helps where passing arguments through a pipe is awkward.
 
 ## Managed Install Layout
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "check:token-gates": "node scripts/check-token-gates.mjs",
     "check:no-git-push": "node scripts/check-no-git-push.mjs",
     "test:check-no-git-push": "node --test scripts/check-no-git-push.test.mjs",
+    "test:install-sh-docker": "./scripts/test-install-sh-docker.sh",
     "test:hermes-gateway-smoke": "node --test scripts/smoke/hermes-gateway-smoke.test.mjs",
     "docs:dev": "cd docs && npx mintlify dev",
     "smoke:hermes-gateway-join": "./scripts/smoke/hermes-gateway-join.sh",

--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -103,6 +103,10 @@ export const telemetryConfigSchema = z.object({
   enabled: z.boolean().default(true),
 }).default({});
 
+export const updatesConfigSchema = z.object({
+  checkEnabled: z.boolean().default(true),
+}).default({});
+
 export const paperclipConfigSchema = z
   .object({
     $meta: configMetaSchema,
@@ -111,6 +115,7 @@ export const paperclipConfigSchema = z
     logging: loggingConfigSchema,
     server: serverConfigSchema,
     telemetry: telemetryConfigSchema,
+    updates: updatesConfigSchema.optional(),
     auth: authConfigSchema.default({
       baseUrlMode: "auto",
       disableSignUp: false,
@@ -195,5 +200,6 @@ export type SecretsConfig = z.infer<typeof secretsConfigSchema>;
 export type SecretsLocalEncryptedConfig = z.infer<typeof secretsLocalEncryptedConfigSchema>;
 export type AuthConfig = z.infer<typeof authConfigSchema>;
 export type TelemetryConfig = z.infer<typeof telemetryConfigSchema>;
+export type UpdatesConfig = z.infer<typeof updatesConfigSchema>;
 export type ConfigMeta = z.infer<typeof configMetaSchema>;
 export type DatabaseBackupConfig = z.infer<typeof databaseBackupConfigSchema>;

--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -36,7 +36,8 @@ test("bundled package staging materializes publishConfig entrypoints", () => {
 test("bundled package dry runs preview without querying published versions", () => {
   assert.match(releaseScript, /run_bundled_npm_pack pack --pack-destination "\$publish_dir"/);
   assert.match(releaseLib, /BUNDLED_NPM_PACK_VERSION="10\.9\.7"/);
-  assert.match(releaseLib, /BUNDLED_NPM_PUBLISH_VERSION="11\.16\.0"/);
+  assert.match(releaseLib, /BUNDLED_NPM_PUBLISH_VERSION="11\.18\.0"/);
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PACK_VERSION"/);
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PUBLISH_VERSION"/);
+  assert.match(releaseLib, /"\$@" --loglevel verbose/);
 });

--- a/scripts/clean-install-git.sh
+++ b/scripts/clean-install-git.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PC_TEST_ROOT="${PC_TEST_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install-git.XXXXXX")}" 
+PC_TEST_ROOT="${PC_TEST_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install-git.XXXXXX")}"
 PC_HOME="${PC_HOME:-$PC_TEST_ROOT/home}"
 PC_CACHE="${PC_CACHE:-$PC_TEST_ROOT/npm-cache}"
 KEEP_TEMP="${KEEP_TEMP:-0}"

--- a/scripts/clean-install-git.sh
+++ b/scripts/clean-install-git.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PC_TEST_ROOT="${PC_TEST_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install-git.XXXXXX")}" 
+PC_HOME="${PC_HOME:-$PC_TEST_ROOT/home}"
+PC_CACHE="${PC_CACHE:-$PC_TEST_ROOT/npm-cache}"
+KEEP_TEMP="${KEEP_TEMP:-0}"
+
+cleanup() {
+  if [ "$KEEP_TEMP" != "1" ]; then
+    rm -rf "$PC_TEST_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$PC_HOME" "$PC_CACHE"
+
+echo "REPO_ROOT: $REPO_ROOT"
+echo "PC_TEST_ROOT: $PC_TEST_ROOT"
+echo "PC_HOME: $PC_HOME"
+
+env \
+  HOME="$PC_HOME" \
+  PAPERCLIP_HOME="$PC_HOME/.paperclip" \
+  npm_config_cache="$PC_CACHE" \
+  npm_config_userconfig="$PC_HOME/.npmrc" \
+  PATH="$PC_HOME/.local/bin:$PATH" \
+  pnpm --dir "$REPO_ROOT" paperclipai install --yes
+
+test -x "$PC_HOME/.local/bin/paperclipai"
+test -L "$PC_HOME/.paperclip/cli/current"
+test -f "$PC_HOME/.paperclip/cli/install.json"
+
+env HOME="$PC_HOME" PAPERCLIP_HOME="$PC_HOME/.paperclip" PATH="$PC_HOME/.local/bin:$PATH" paperclipai --version
+env HOME="$PC_HOME" PAPERCLIP_HOME="$PC_HOME/.paperclip" PATH="$PC_HOME/.local/bin:$PATH" paperclipai doctor \
+  --config "$PC_TEST_ROOT/missing-config.json" >/dev/null || true
+
+env \
+  HOME="$PC_HOME" \
+  PAPERCLIP_HOME="$PC_HOME/.paperclip" \
+  PATH="$PC_HOME/.local/bin:$PATH" \
+  pnpm --dir "$REPO_ROOT" paperclipai uninstall
+
+test ! -e "$PC_HOME/.paperclip/cli"
+test ! -e "$PC_HOME/.local/bin/paperclipai"

--- a/scripts/clean-install-npm.sh
+++ b/scripts/clean-install-npm.sh
@@ -8,6 +8,7 @@ mkdir -p "$PC_HOME" "$PC_CACHE"
 trap 'rm -rf "$PC_TEST_ROOT"' EXIT
 
 export HOME="$PC_HOME"
+export PAPERCLIP_HOME="$PC_HOME/.paperclip"
 export npm_config_cache="$PC_CACHE"
 export npm_config_userconfig="$PC_HOME/.npmrc"
 export PATH="$PC_HOME/.local/bin:$PATH"
@@ -16,14 +17,14 @@ cd "$PC_TEST_ROOT"
 npx --yes --registry https://registry.npmjs.org paperclipai install
 
 test -x "$PC_HOME/.local/bin/paperclipai"
-test -L "$PC_HOME/.paperclip/cli/current"
-test -f "$PC_HOME/.paperclip/cli/install.json"
+test -L "$PAPERCLIP_HOME/cli/current"
+test -f "$PAPERCLIP_HOME/cli/install.json"
 paperclipai --version
 
-mkdir -p "$PC_HOME/.paperclip/instances/default"
-touch "$PC_HOME/.paperclip/instances/default/user-data-marker"
+mkdir -p "$PAPERCLIP_HOME/instances/default"
+touch "$PAPERCLIP_HOME/instances/default/user-data-marker"
 paperclipai uninstall
 
-test ! -e "$PC_HOME/.paperclip/cli"
+test ! -e "$PAPERCLIP_HOME/cli"
 test ! -e "$PC_HOME/.local/bin/paperclipai"
-test -f "$PC_HOME/.paperclip/instances/default/user-data-marker"
+test -f "$PAPERCLIP_HOME/instances/default/user-data-marker"

--- a/scripts/clean-install-npm.sh
+++ b/scripts/clean-install-npm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+PC_TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install.XXXXXX")"
+PC_HOME="$PC_TEST_ROOT/home"
+PC_CACHE="$PC_TEST_ROOT/npm-cache"
+mkdir -p "$PC_HOME" "$PC_CACHE"
+trap 'rm -rf "$PC_TEST_ROOT"' EXIT
+
+export HOME="$PC_HOME"
+export npm_config_cache="$PC_CACHE"
+export npm_config_userconfig="$PC_HOME/.npmrc"
+export PATH="$PC_HOME/.local/bin:$PATH"
+
+cd "$PC_TEST_ROOT"
+npx --yes --registry https://registry.npmjs.org paperclipai install
+
+test -x "$PC_HOME/.local/bin/paperclipai"
+test -L "$PC_HOME/.paperclip/cli/current"
+test -f "$PC_HOME/.paperclip/cli/install.json"
+paperclipai --version
+
+mkdir -p "$PC_HOME/.paperclip/instances/default"
+touch "$PC_HOME/.paperclip/instances/default/user-data-marker"
+paperclipai uninstall
+
+test ! -e "$PC_HOME/.paperclip/cli"
+test ! -e "$PC_HOME/.local/bin/paperclipai"
+test -f "$PC_HOME/.paperclip/instances/default/user-data-marker"

--- a/scripts/clean-install-npm.sh
+++ b/scripts/clean-install-npm.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PC_INSTALL_DRIVER="${PC_INSTALL_DRIVER:-source}"
+
 PC_TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-clean-install.XXXXXX")"
 PC_HOME="$PC_TEST_ROOT/home"
 PC_CACHE="$PC_TEST_ROOT/npm-cache"
@@ -13,8 +16,11 @@ export npm_config_cache="$PC_CACHE"
 export npm_config_userconfig="$PC_HOME/.npmrc"
 export PATH="$PC_HOME/.local/bin:$PATH"
 
-cd "$PC_TEST_ROOT"
-npx --yes --registry https://registry.npmjs.org paperclipai install
+if [ "$PC_INSTALL_DRIVER" = "published" ]; then
+  (cd "$PC_TEST_ROOT" && npx --yes --registry https://registry.npmjs.org paperclipai install)
+else
+  (cd "$REPO_ROOT" && pnpm paperclipai install --yes)
+fi
 
 test -x "$PC_HOME/.local/bin/paperclipai"
 test -L "$PAPERCLIP_HOME/cli/current"
@@ -23,7 +29,7 @@ paperclipai --version
 
 mkdir -p "$PAPERCLIP_HOME/instances/default"
 touch "$PAPERCLIP_HOME/instances/default/user-data-marker"
-paperclipai uninstall
+(cd "$REPO_ROOT" && pnpm paperclipai uninstall)
 
 test ! -e "$PAPERCLIP_HOME/cli"
 test ! -e "$PC_HOME/.local/bin/paperclipai"

--- a/scripts/install-sh-fixtures/npx
+++ b/scripts/install-sh-fixtures/npx
@@ -3,11 +3,13 @@ set -euo pipefail
 
 : "${PAPERCLIP_INSTALL_TEST_LOG:?PAPERCLIP_INSTALL_TEST_LOG is required}"
 node --version >"${PAPERCLIP_INSTALL_TEST_LOG}.node"
-printf 'NPM_CONFIG_REGISTRY=%s\n' "${NPM_CONFIG_REGISTRY:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
-printf 'npm_config_registry=%s\n' "${npm_config_registry:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
-printf 'NPM_CONFIG_USERCONFIG=%s\n' "${NPM_CONFIG_USERCONFIG:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
-printf 'npm_config_userconfig=%s\n' "${npm_config_userconfig:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
-if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
-  sed 's/^/npmrc:/' "$NPM_CONFIG_USERCONFIG" >>"$PAPERCLIP_INSTALL_TEST_LOG"
-fi
-printf '%s\n' "$@" >>"$PAPERCLIP_INSTALL_TEST_LOG"
+{
+  printf 'NPM_CONFIG_REGISTRY=%s\n' "${NPM_CONFIG_REGISTRY:-}"
+  printf 'npm_config_registry=%s\n' "${npm_config_registry:-}"
+  printf 'NPM_CONFIG_USERCONFIG=%s\n' "${NPM_CONFIG_USERCONFIG:-}"
+  printf 'npm_config_userconfig=%s\n' "${npm_config_userconfig:-}"
+  if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+    sed 's/^/npmrc:/' "$NPM_CONFIG_USERCONFIG"
+  fi
+  printf '%s\n' "$@"
+} >>"$PAPERCLIP_INSTALL_TEST_LOG"

--- a/scripts/install-sh-fixtures/npx
+++ b/scripts/install-sh-fixtures/npx
@@ -3,4 +3,11 @@ set -euo pipefail
 
 : "${PAPERCLIP_INSTALL_TEST_LOG:?PAPERCLIP_INSTALL_TEST_LOG is required}"
 node --version >"${PAPERCLIP_INSTALL_TEST_LOG}.node"
+printf 'NPM_CONFIG_REGISTRY=%s\n' "${NPM_CONFIG_REGISTRY:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
+printf 'npm_config_registry=%s\n' "${npm_config_registry:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
+printf 'NPM_CONFIG_USERCONFIG=%s\n' "${NPM_CONFIG_USERCONFIG:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
+printf 'npm_config_userconfig=%s\n' "${npm_config_userconfig:-}" >>"$PAPERCLIP_INSTALL_TEST_LOG"
+if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+  sed 's/^/npmrc:/' "$NPM_CONFIG_USERCONFIG" >>"$PAPERCLIP_INSTALL_TEST_LOG"
+fi
 printf '%s\n' "$@" >>"$PAPERCLIP_INSTALL_TEST_LOG"

--- a/scripts/install-sh-fixtures/npx
+++ b/scripts/install-sh-fixtures/npx
@@ -3,4 +3,4 @@ set -euo pipefail
 
 : "${PAPERCLIP_INSTALL_TEST_LOG:?PAPERCLIP_INSTALL_TEST_LOG is required}"
 node --version >"${PAPERCLIP_INSTALL_TEST_LOG}.node"
-printf '%s\n' "$@" >"$PAPERCLIP_INSTALL_TEST_LOG"
+printf '%s\n' "$@" >>"$PAPERCLIP_INSTALL_TEST_LOG"

--- a/scripts/install-sh-fixtures/npx
+++ b/scripts/install-sh-fixtures/npx
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PAPERCLIP_INSTALL_TEST_LOG:?PAPERCLIP_INSTALL_TEST_LOG is required}"
+node --version >"${PAPERCLIP_INSTALL_TEST_LOG}.node"
+printf '%s\n' "$@" >"$PAPERCLIP_INSTALL_TEST_LOG"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 MIN_NODE_MAJOR=20
 DEFAULT_NODE_MAJOR=22
 PAPERCLIP_PACKAGE="paperclipai"
+PUBLIC_NPM_REGISTRY="https://registry.npmjs.org"
 HOMEBREW_INSTALL_COMMIT="99e13e96cbbdc1ac1ac09c0a40b450bf219ef3aa"
 HOMEBREW_INSTALL_SHA256="99287f194a8b3c9e6b0203a11a5fa54518be57209343e6bb954dec4635796d9d"
 NODESOURCE_DEB_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
@@ -354,7 +355,12 @@ INSTALL_ARGS=(install)
 [ "$CANARY" = "1" ] && INSTALL_ARGS+=(--canary)
 [ -n "$VERSION" ] && INSTALL_ARGS+=(--version "$VERSION")
 [ "$NO_PROMPT" = "1" ] && INSTALL_ARGS+=(--yes)
-INSTALL_COMMAND=(npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}")
+ensure_temp_dir
+NPM_USERCONFIG="$TEMP_DIR/npmrc"
+printf 'registry=%s\n@paperclipai:registry=%s\n' "$PUBLIC_NPM_REGISTRY" "$PUBLIC_NPM_REGISTRY" >"$NPM_USERCONFIG"
+chmod 600 "$NPM_USERCONFIG"
+NPM_ENV=(env "NPM_CONFIG_REGISTRY=$PUBLIC_NPM_REGISTRY" "npm_config_registry=$PUBLIC_NPM_REGISTRY" "NPM_CONFIG_USERCONFIG=$NPM_USERCONFIG" "npm_config_userconfig=$NPM_USERCONFIG")
+INSTALL_COMMAND=("${NPM_ENV[@]}" npx --yes "--registry=$PUBLIC_NPM_REGISTRY" "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}")
 
 log "Delegating to the Paperclip CLI"
 if [ "$DRY_RUN" = "1" ]; then
@@ -367,8 +373,8 @@ print_command "${INSTALL_COMMAND[@]}"
 
 if [ "$INSTALL_SERVICE" = "1" ]; then
   log "Installing the Paperclip service"
-  print_command npx --yes "$PACKAGE_SPEC" service install
-  npx --yes "$PACKAGE_SPEC" service install
+  print_command "${NPM_ENV[@]}" npx --yes "--registry=$PUBLIC_NPM_REGISTRY" "$PACKAGE_SPEC" service install
+  "${NPM_ENV[@]}" npx --yes "--registry=$PUBLIC_NPM_REGISTRY" "$PACKAGE_SPEC" service install
 fi
 
 if [ "$NO_ONBOARD" = "0" ] && [ -t 0 ] && [ -t 1 ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -354,15 +354,16 @@ INSTALL_ARGS=(install)
 [ "$CANARY" = "1" ] && INSTALL_ARGS+=(--canary)
 [ -n "$VERSION" ] && INSTALL_ARGS+=(--version "$VERSION")
 [ "$NO_PROMPT" = "1" ] && INSTALL_ARGS+=(--yes)
+INSTALL_COMMAND=(npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}")
 
 log "Delegating to the Paperclip CLI"
-print_command npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
-
 if [ "$DRY_RUN" = "1" ]; then
+  print_command "${INSTALL_COMMAND[@]}"
   exit 0
 fi
 
-npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
+print_command "${INSTALL_COMMAND[@]}"
+"${INSTALL_COMMAND[@]}"
 
 if [ "$INSTALL_SERVICE" = "1" ]; then
   log "Installing the Paperclip service"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,6 +146,10 @@ if [ "$CANARY" = "1" ] && [ -n "$VERSION" ]; then
   fail "--canary and --version cannot be used together"
 fi
 
+if [ -n "$REF" ] || [ -n "$REPO" ]; then
+  fail "git-ref installs are not available in this installer build; omit --ref and --repo"
+fi
+
 if [ ! -t 0 ] || [ ! -t 1 ]; then
   NO_PROMPT=1
 fi
@@ -339,10 +343,17 @@ INSTALL_ARGS=(install)
 
 log "Delegating to the Paperclip CLI"
 print_command npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
-npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
 
 if [ "$DRY_RUN" = "1" ]; then
   exit 0
+fi
+
+npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
+
+if [ "$INSTALL_SERVICE" = "1" ]; then
+  log "Installing the Paperclip service"
+  print_command npx --yes "$PACKAGE_SPEC" service install
+  npx --yes "$PACKAGE_SPEC" service install
 fi
 
 if [ "$NO_ONBOARD" = "0" ] && [ -t 0 ] && [ -t 1 ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 MIN_NODE_MAJOR=20
 DEFAULT_NODE_MAJOR=22
 PAPERCLIP_PACKAGE="paperclipai"
+HOMEBREW_INSTALL_COMMIT="99e13e96cbbdc1ac1ac09c0a40b450bf219ef3aa"
+HOMEBREW_INSTALL_SHA256="99287f194a8b3c9e6b0203a11a5fa54518be57209343e6bb954dec4635796d9d"
+NODESOURCE_DEB_SHA256="575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1"
+NODESOURCE_RPM_SHA256="b0ed2b9b66002e7ee802e8777cf3a92b25f1ecc0129812dc6f59a43a536810cc"
 
 CANARY=0
 VERSION=""
@@ -237,10 +241,20 @@ ensure_temp_dir() {
 download_checked_script() {
   local url="$1"
   local destination="$2"
+  local expected_sha256="$3"
+  local actual_sha256
 
   command -v curl >/dev/null 2>&1 || fail "curl is required to bootstrap Node.js"
   curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
   [ -s "$destination" ] || fail "downloaded script is empty: $url"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha256="$(sha256sum "$destination" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual_sha256="$(shasum -a 256 "$destination" | awk '{print $1}')"
+  else
+    fail "sha256sum or shasum is required to verify downloaded scripts"
+  fi
+  [ "$actual_sha256" = "$expected_sha256" ] || fail "checksum mismatch for downloaded script: $url"
   [ "$(head -c 2 "$destination")" = '#!' ] || fail "downloaded file is not an executable script: $url"
   bash -n "$destination" || fail "downloaded script failed syntax validation: $url"
 }
@@ -259,7 +273,7 @@ install_node_macos() {
     ensure_temp_dir
     local brew_installer="$TEMP_DIR/homebrew-install.sh"
     log "Homebrew is required to install Node.js"
-    download_checked_script "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh" "$brew_installer"
+    download_checked_script "https://raw.githubusercontent.com/Homebrew/install/$HOMEBREW_INSTALL_COMMIT/install.sh" "$brew_installer" "$HOMEBREW_INSTALL_SHA256"
     if [ "$NO_PROMPT" = "1" ]; then
       run_command env NONINTERACTIVE=1 /bin/bash "$brew_installer"
     else
@@ -282,7 +296,7 @@ install_node_apt() {
   local nodesource_installer="$TEMP_DIR/nodesource-setup.sh"
   run_privileged env DEBIAN_FRONTEND=noninteractive apt-get update
   run_privileged env DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl
-  download_checked_script "https://deb.nodesource.com/setup_${DEFAULT_NODE_MAJOR}.x" "$nodesource_installer"
+  download_checked_script "https://deb.nodesource.com/setup_${DEFAULT_NODE_MAJOR}.x" "$nodesource_installer" "$NODESOURCE_DEB_SHA256"
   run_privileged env DEBIAN_FRONTEND=noninteractive bash "$nodesource_installer"
   run_privileged env DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 }
@@ -291,7 +305,7 @@ install_node_dnf() {
   ensure_temp_dir
   local nodesource_installer="$TEMP_DIR/nodesource-setup.sh"
   run_privileged dnf install -y ca-certificates curl
-  download_checked_script "https://rpm.nodesource.com/setup_${DEFAULT_NODE_MAJOR}.x" "$nodesource_installer"
+  download_checked_script "https://rpm.nodesource.com/setup_${DEFAULT_NODE_MAJOR}.x" "$nodesource_installer" "$NODESOURCE_RPM_SHA256"
   run_privileged bash "$nodesource_installer"
   run_privileged dnf install -y nodejs
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -335,12 +335,7 @@ fi
 INSTALL_ARGS=(install)
 [ "$CANARY" = "1" ] && INSTALL_ARGS+=(--canary)
 [ -n "$VERSION" ] && INSTALL_ARGS+=(--version "$VERSION")
-[ -n "$REF" ] && INSTALL_ARGS+=(--ref "$REF")
-[ -n "$REPO" ] && INSTALL_ARGS+=(--repo "$REPO")
-[ "$NO_PROMPT" = "1" ] && INSTALL_ARGS+=(--no-prompt)
-[ "$INSTALL_SERVICE" = "1" ] && INSTALL_ARGS+=(--install-service)
-[ "$DRY_RUN" = "1" ] && INSTALL_ARGS+=(--dry-run)
-[ "$VERBOSE" = "1" ] && INSTALL_ARGS+=(--verbose)
+[ "$NO_PROMPT" = "1" ] && INSTALL_ARGS+=(--yes)
 
 log "Delegating to the Paperclip CLI"
 print_command npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MIN_NODE_MAJOR=20
+DEFAULT_NODE_MAJOR=22
+PAPERCLIP_PACKAGE="paperclipai"
+
+CANARY=0
+VERSION=""
+REF=""
+REPO=""
+NO_ONBOARD=0
+NO_PROMPT=0
+INSTALL_SERVICE=0
+DRY_RUN=0
+VERBOSE=0
+TEMP_DIR=""
+
+usage() {
+  cat <<'EOF'
+Install Paperclip on macOS, Linux, or WSL2.
+
+Usage:
+  curl -fsSL https://paperclip.ing/install.sh | bash
+  curl -fsSL https://paperclip.ing/install.sh | bash -s -- [options]
+
+Options:
+  --canary                 Install the canary channel
+  --version <version>      Install an exact published version
+  --ref <ref>              Install a GitHub branch, tag, or commit
+  --repo <owner/repo>      Override the GitHub repository
+  --no-onboard             Do not start onboarding after installation
+  --no-prompt              Run non-interactively
+  --install-service        Install the per-user Paperclip service
+  --dry-run                Print the install plan without changing files
+  --verbose                Enable verbose installer output
+  -h, --help               Show this help
+
+Every option also has a PAPERCLIP_INSTALL_* environment equivalent, for example
+PAPERCLIP_INSTALL_REF=master and PAPERCLIP_INSTALL_NO_PROMPT=1.
+EOF
+}
+
+log() {
+  printf '[paperclip] %s\n' "$*"
+}
+
+fail() {
+  printf '[paperclip] error: %s\n' "$*" >&2
+  exit 1
+}
+
+parse_bool() {
+  local name="$1"
+  local value="${2:-}"
+
+  case "${value,,}" in
+    ""|0|false|no|off) printf '0' ;;
+    1|true|yes|on) printf '1' ;;
+    *) fail "$name must be one of: 1, 0, true, false, yes, no, on, off" ;;
+  esac
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  [ -n "$value" ] || fail "$option requires a value"
+}
+
+cleanup() {
+  if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+
+trap cleanup EXIT
+
+CANARY="$(parse_bool PAPERCLIP_INSTALL_CANARY "${PAPERCLIP_INSTALL_CANARY:-}")"
+VERSION="${PAPERCLIP_INSTALL_VERSION:-}"
+REF="${PAPERCLIP_INSTALL_REF:-}"
+REPO="${PAPERCLIP_INSTALL_REPO:-}"
+NO_ONBOARD="$(parse_bool PAPERCLIP_INSTALL_NO_ONBOARD "${PAPERCLIP_INSTALL_NO_ONBOARD:-}")"
+NO_PROMPT="$(parse_bool PAPERCLIP_INSTALL_NO_PROMPT "${PAPERCLIP_INSTALL_NO_PROMPT:-}")"
+INSTALL_SERVICE="$(parse_bool PAPERCLIP_INSTALL_INSTALL_SERVICE "${PAPERCLIP_INSTALL_INSTALL_SERVICE:-}")"
+DRY_RUN="$(parse_bool PAPERCLIP_INSTALL_DRY_RUN "${PAPERCLIP_INSTALL_DRY_RUN:-}")"
+VERBOSE="$(parse_bool PAPERCLIP_INSTALL_VERBOSE "${PAPERCLIP_INSTALL_VERBOSE:-}")"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --canary)
+      CANARY=1
+      shift
+      ;;
+    --version)
+      require_value "$1" "${2:-}"
+      VERSION="$2"
+      shift 2
+      ;;
+    --ref)
+      require_value "$1" "${2:-}"
+      REF="$2"
+      shift 2
+      ;;
+    --repo)
+      require_value "$1" "${2:-}"
+      REPO="$2"
+      shift 2
+      ;;
+    --no-onboard)
+      NO_ONBOARD=1
+      shift
+      ;;
+    --no-prompt)
+      NO_PROMPT=1
+      shift
+      ;;
+    --install-service)
+      INSTALL_SERVICE=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --verbose)
+      VERBOSE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+[ "$#" -eq 0 ] || fail "unexpected argument: $1"
+
+if [ "$CANARY" = "1" ] && [ -n "$VERSION" ]; then
+  fail "--canary and --version cannot be used together"
+fi
+
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  NO_PROMPT=1
+fi
+
+if [ "$VERBOSE" = "1" ]; then
+  set -x
+fi
+
+OS="$(uname -s 2>/dev/null || true)"
+ARCH="$(uname -m 2>/dev/null || true)"
+
+case "$OS" in
+  Darwin) OS_NAME="macos" ;;
+  Linux) OS_NAME="linux" ;;
+  *) fail "unsupported operating system: ${OS:-unknown}. Use macOS, Linux, or WSL2." ;;
+esac
+
+case "$ARCH" in
+  x86_64|amd64) ARCH_NAME="x64" ;;
+  arm64|aarch64) ARCH_NAME="arm64" ;;
+  *) fail "unsupported architecture: ${ARCH:-unknown}. Supported architectures: x64, arm64." ;;
+esac
+
+log "Detected $OS_NAME/$ARCH_NAME"
+
+node_major() {
+  local version
+  version="$(node --version 2>/dev/null || true)"
+  version="${version#v}"
+  printf '%s' "${version%%.*}"
+}
+
+has_supported_node() {
+  local major
+  command -v node >/dev/null 2>&1 || return 1
+  major="$(node_major)"
+  [[ "$major" =~ ^[0-9]+$ ]] || return 1
+  [ "$major" -ge "$MIN_NODE_MAJOR" ] || return 1
+  command -v npm >/dev/null 2>&1 || return 1
+  command -v npx >/dev/null 2>&1 || return 1
+}
+
+print_command() {
+  printf '[paperclip] +'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+confirm_command() {
+  print_command "$@"
+  if [ "$NO_PROMPT" = "1" ]; then
+    return 0
+  fi
+
+  local answer
+  printf '[paperclip] Run this command? [y/N] ' >/dev/tty
+  IFS= read -r answer </dev/tty || answer=""
+  case "$answer" in
+    y|Y|yes|YES|Yes) ;;
+    *) fail "installation cancelled" ;;
+  esac
+}
+
+run_command() {
+  confirm_command "$@"
+  "$@"
+}
+
+run_privileged() {
+  if [ "$(id -u)" -eq 0 ]; then
+    run_command "$@"
+    return
+  fi
+
+  command -v sudo >/dev/null 2>&1 || fail "sudo is required to install Node.js with the system package manager"
+  run_command sudo "$@"
+}
+
+ensure_temp_dir() {
+  if [ -z "$TEMP_DIR" ]; then
+    TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-install.XXXXXX")"
+  fi
+}
+
+download_checked_script() {
+  local url="$1"
+  local destination="$2"
+
+  command -v curl >/dev/null 2>&1 || fail "curl is required to bootstrap Node.js"
+  curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
+  [ -s "$destination" ] || fail "downloaded script is empty: $url"
+  [ "$(head -c 2 "$destination")" = '#!' ] || fail "downloaded file is not an executable script: $url"
+  bash -n "$destination" || fail "downloaded script failed syntax validation: $url"
+}
+
+check_version_manager() {
+  if [ -n "${NVM_DIR:-}" ] || [ -d "${HOME:-}/.nvm" ]; then
+    fail "nvm was detected. Run 'nvm install ${DEFAULT_NODE_MAJOR}' and retry this installer."
+  fi
+  if command -v asdf >/dev/null 2>&1 || [ -d "${HOME:-}/.asdf" ]; then
+    fail "asdf was detected. Run 'asdf install nodejs ${DEFAULT_NODE_MAJOR}' and retry this installer."
+  fi
+}
+
+install_node_macos() {
+  if ! command -v brew >/dev/null 2>&1; then
+    ensure_temp_dir
+    local brew_installer="$TEMP_DIR/homebrew-install.sh"
+    log "Homebrew is required to install Node.js"
+    download_checked_script "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh" "$brew_installer"
+    if [ "$NO_PROMPT" = "1" ]; then
+      run_command env NONINTERACTIVE=1 /bin/bash "$brew_installer"
+    else
+      run_command /bin/bash "$brew_installer"
+    fi
+
+    if [ -x /opt/homebrew/bin/brew ]; then
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -x /usr/local/bin/brew ]; then
+      eval "$(/usr/local/bin/brew shellenv)"
+    fi
+  fi
+
+  command -v brew >/dev/null 2>&1 || fail "Homebrew installation completed but 'brew' is not available on PATH"
+  run_command brew install node
+}
+
+install_node_apt() {
+  ensure_temp_dir
+  local nodesource_installer="$TEMP_DIR/nodesource-setup.sh"
+  run_privileged env DEBIAN_FRONTEND=noninteractive apt-get update
+  run_privileged env DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl
+  download_checked_script "https://deb.nodesource.com/setup_${DEFAULT_NODE_MAJOR}.x" "$nodesource_installer"
+  run_privileged env DEBIAN_FRONTEND=noninteractive bash "$nodesource_installer"
+  run_privileged env DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+}
+
+install_node_dnf() {
+  ensure_temp_dir
+  local nodesource_installer="$TEMP_DIR/nodesource-setup.sh"
+  run_privileged dnf install -y ca-certificates curl
+  download_checked_script "https://rpm.nodesource.com/setup_${DEFAULT_NODE_MAJOR}.x" "$nodesource_installer"
+  run_privileged bash "$nodesource_installer"
+  run_privileged dnf install -y nodejs
+}
+
+install_node_linux() {
+  if command -v apt-get >/dev/null 2>&1; then
+    install_node_apt
+  elif command -v dnf >/dev/null 2>&1; then
+    install_node_dnf
+  elif command -v pacman >/dev/null 2>&1; then
+    run_privileged pacman -Sy --noconfirm --needed nodejs npm
+  elif command -v apk >/dev/null 2>&1; then
+    run_privileged apk add --no-cache nodejs npm
+  else
+    fail "no supported Node.js package manager found. Supported: apt, dnf, pacman, apk."
+  fi
+}
+
+if has_supported_node; then
+  log "Using Node.js $(node --version)"
+else
+  if command -v node >/dev/null 2>&1; then
+    log "Node.js $(node --version 2>/dev/null || printf unknown) is too old; Node.js >= $MIN_NODE_MAJOR is required"
+  else
+    log "Node.js was not found"
+  fi
+  check_version_manager
+  log "Installing Node.js $DEFAULT_NODE_MAJOR"
+  if [ "$OS_NAME" = "macos" ]; then
+    install_node_macos
+  else
+    install_node_linux
+  fi
+  has_supported_node || fail "Node.js installation finished, but Node.js >= $MIN_NODE_MAJOR with npm/npx is not available"
+  log "Installed Node.js $(node --version)"
+fi
+
+PACKAGE_SPEC="$PAPERCLIP_PACKAGE@latest"
+if [ "$CANARY" = "1" ]; then
+  PACKAGE_SPEC="$PAPERCLIP_PACKAGE@canary"
+elif [ -n "$VERSION" ]; then
+  PACKAGE_SPEC="$PAPERCLIP_PACKAGE@$VERSION"
+fi
+
+INSTALL_ARGS=(install)
+[ "$CANARY" = "1" ] && INSTALL_ARGS+=(--canary)
+[ -n "$VERSION" ] && INSTALL_ARGS+=(--version "$VERSION")
+[ -n "$REF" ] && INSTALL_ARGS+=(--ref "$REF")
+[ -n "$REPO" ] && INSTALL_ARGS+=(--repo "$REPO")
+[ "$NO_PROMPT" = "1" ] && INSTALL_ARGS+=(--no-prompt)
+[ "$INSTALL_SERVICE" = "1" ] && INSTALL_ARGS+=(--install-service)
+[ "$DRY_RUN" = "1" ] && INSTALL_ARGS+=(--dry-run)
+[ "$VERBOSE" = "1" ] && INSTALL_ARGS+=(--verbose)
+
+log "Delegating to the Paperclip CLI"
+print_command npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
+npx --yes "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}"
+
+if [ "$DRY_RUN" = "1" ]; then
+  exit 0
+fi
+
+if [ "$NO_ONBOARD" = "0" ] && [ -t 0 ] && [ -t 1 ]; then
+  if command -v paperclipai >/dev/null 2>&1; then
+    exec paperclipai onboard
+  elif [ -x "${HOME:-}/.local/bin/paperclipai" ]; then
+    exec "${HOME}/.local/bin/paperclipai" onboard
+  else
+    fail "Paperclip was installed, but 'paperclipai' is not available on PATH. Open a new shell and run 'paperclipai onboard'."
+  fi
+fi
+
+if [ "$NO_ONBOARD" = "0" ]; then
+  log "Installation complete. Next: paperclipai onboard"
+else
+  log "Installation complete."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,8 +26,9 @@ usage() {
 Install Paperclip on macOS, Linux, or WSL2.
 
 Usage:
-  curl -fsSL https://paperclip.ing/install.sh | bash
-  curl -fsSL https://paperclip.ing/install.sh | bash -s -- [options]
+  curl -fsSLO https://paperclip.ing/install.sh
+  bash install.sh [options]
+  curl -fsSL https://paperclip.ing/install.sh | bash -s -- --no-prompt [options]
 
 Options:
   --canary                 Install the canary channel
@@ -155,8 +156,8 @@ if [ -n "$REF" ] || [ -n "$REPO" ]; then
   fail "git-ref installs are not available in this installer build; omit --ref and --repo"
 fi
 
-if [ ! -t 0 ] || [ ! -t 1 ]; then
-  NO_PROMPT=1
+if { [ ! -t 0 ] || [ ! -t 1 ]; } && [ "$NO_PROMPT" != "1" ]; then
+  fail "non-interactive installation requires explicit --no-prompt; download the script first for interactive review"
 fi
 
 if [ "$VERBOSE" = "1" ]; then

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -311,14 +311,14 @@ package_publish_tool() {
 }
 
 BUNDLED_NPM_PACK_VERSION="10.9.7"
-BUNDLED_NPM_PUBLISH_VERSION="11.16.0"
+BUNDLED_NPM_PUBLISH_VERSION="11.18.0"
 
 run_bundled_npm_pack() {
   npx --yes "npm@$BUNDLED_NPM_PACK_VERSION" "$@"
 }
 
 run_bundled_npm_publish() {
-  npx --yes "npm@$BUNDLED_NPM_PUBLISH_VERSION" "$@"
+  npx --yes "npm@$BUNDLED_NPM_PUBLISH_VERSION" "$@" --loglevel verbose
 }
 
 run_package_publish() {

--- a/scripts/release-lib.test.mjs
+++ b/scripts/release-lib.test.mjs
@@ -91,7 +91,7 @@ exit 1
 set -euo pipefail
 printf 'npx %s\n' "$*" >> "$FAKE_CALL_LOG"
 [ "$1" = "--yes" ] && shift
-[ "$1" = "npm@11.16.0" ] && shift
+[ "$1" = "npm@11.18.0" ] && shift
 exec npm "$@"
 `,
   );
@@ -145,8 +145,11 @@ test("publish_package_to_npm uses trusted-publishing-capable npm for bundled dep
   const result = runPublishHelper({ pnpmMode: "success", publishTool: "npm" });
 
   assert.equal(result.status, 0);
-  assert.match(result.calls, /^npx --yes npm@11\.16\.0 publish --tag canary --access public$/m);
-  assert.match(result.calls, /^npm publish --tag canary --access public$/m);
+  assert.match(
+    result.calls,
+    /^npx --yes npm@11\.18\.0 publish --tag canary --access public --loglevel verbose$/m,
+  );
+  assert.match(result.calls, /^npm publish --tag canary --access public --loglevel verbose$/m);
   assert.doesNotMatch(result.calls, /^pnpm publish/m);
 });
 

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -68,6 +68,28 @@ run_with_node with-node bash /paperclip-scripts/install.sh --no-onboard
 assert_line "$RESULTS_DIR/with-node.args" "paperclipai@latest"
 assert_line "$RESULTS_DIR/with-node.args" "install"
 assert_line "$RESULTS_DIR/with-node.args" "--yes"
+assert_line "$RESULTS_DIR/with-node.args" "--registry=https://registry.npmjs.org"
+assert_line "$RESULTS_DIR/with-node.args" "NPM_CONFIG_REGISTRY=https://registry.npmjs.org"
+assert_line "$RESULTS_DIR/with-node.args" "npm_config_registry=https://registry.npmjs.org"
+assert_line "$RESULTS_DIR/with-node.args" "npmrc:registry=https://registry.npmjs.org"
+
+echo "==> hostile npm config isolation"
+mkdir -p "$RESULTS_DIR/hostile-home"
+printf 'registry=http://attacker-registry.invalid\n' >"$RESULTS_DIR/hostile-home/.npmrc"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/hostile-home \
+  -e NPM_CONFIG_REGISTRY=http://attacker-registry.invalid \
+  -e npm_config_registry=http://attacker-registry.invalid \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/hostile.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-onboard
+assert_line "$RESULTS_DIR/hostile.args" "--registry=https://registry.npmjs.org"
+assert_line "$RESULTS_DIR/hostile.args" "NPM_CONFIG_REGISTRY=https://registry.npmjs.org"
+assert_line "$RESULTS_DIR/hostile.args" "npm_config_registry=https://registry.npmjs.org"
+assert_line "$RESULTS_DIR/hostile.args" "npmrc:registry=https://registry.npmjs.org"
 
 echo "==> --ref master"
 if run_with_node ref-master bash /paperclip-scripts/install.sh --ref master --no-onboard; then

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -50,6 +50,16 @@ assert_line() {
   }
 }
 
+assert_no_line() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fx -- "$unexpected" "$file" >/dev/null; then
+    printf 'Did not expect %q in %s\n' "$unexpected" "$file" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
 echo "==> shellcheck"
 run_shellcheck
 
@@ -57,16 +67,16 @@ echo "==> existing Node"
 run_with_node with-node bash /paperclip-scripts/install.sh --no-onboard
 assert_line "$RESULTS_DIR/with-node.args" "paperclipai@latest"
 assert_line "$RESULTS_DIR/with-node.args" "install"
-assert_line "$RESULTS_DIR/with-node.args" "--no-prompt"
+assert_line "$RESULTS_DIR/with-node.args" "--yes"
 
 echo "==> --ref master"
 run_with_node ref-master bash /paperclip-scripts/install.sh --ref master --no-onboard
-assert_line "$RESULTS_DIR/ref-master.args" "--ref"
-assert_line "$RESULTS_DIR/ref-master.args" "master"
+assert_no_line "$RESULTS_DIR/ref-master.args" "--ref"
+assert_no_line "$RESULTS_DIR/ref-master.args" "master"
 
 echo "==> piped --no-prompt"
 run_with_node piped bash -c 'cat /paperclip-scripts/install.sh | bash -s -- --no-prompt --no-onboard'
-assert_line "$RESULTS_DIR/piped.args" "--no-prompt"
+assert_line "$RESULTS_DIR/piped.args" "--yes"
 
 echo "==> environment twins"
 docker run --rm \
@@ -83,9 +93,9 @@ docker run --rm \
 assert_line "$RESULTS_DIR/env.args" "paperclipai@2026.722.0"
 assert_line "$RESULTS_DIR/env.args" "--version"
 assert_line "$RESULTS_DIR/env.args" "2026.722.0"
-assert_line "$RESULTS_DIR/env.args" "--repo"
-assert_line "$RESULTS_DIR/env.args" "example/paperclip"
-assert_line "$RESULTS_DIR/env.args" "--install-service"
+assert_no_line "$RESULTS_DIR/env.args" "--repo"
+assert_no_line "$RESULTS_DIR/env.args" "example/paperclip"
+assert_no_line "$RESULTS_DIR/env.args" "--install-service"
 
 echo "==> no Node, apt bootstrap"
 docker run --rm \

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-install-sh.XXXXXX")"
+KEEP_RESULTS="${KEEP_RESULTS:-0}"
+
+cleanup() {
+  if [ "$KEEP_RESULTS" = "1" ]; then
+    printf 'Kept installer test results at %s\n' "$RESULTS_DIR"
+    return
+  fi
+  rm -rf "$RESULTS_DIR"
+}
+
+trap cleanup EXIT
+
+command -v docker >/dev/null 2>&1 || {
+  echo "docker is required" >&2
+  exit 1
+}
+
+run_shellcheck() {
+  docker run --rm \
+    -v "$REPO_ROOT:/work:ro" \
+    -w /work \
+    koalaman/shellcheck:stable \
+    scripts/install.sh scripts/test-install-sh-docker.sh scripts/install-sh-fixtures/npx
+}
+
+run_with_node() {
+  local name="$1"
+  shift
+  docker run --rm \
+    -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+    -v "$RESULTS_DIR:/results" \
+    -e "PAPERCLIP_INSTALL_TEST_LOG=/results/$name.args" \
+    -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    node:22-bookworm-slim \
+    "$@"
+}
+
+assert_line() {
+  local file="$1"
+  local expected="$2"
+  grep -Fx -- "$expected" "$file" >/dev/null || {
+    printf 'Expected %q in %s\n' "$expected" "$file" >&2
+    cat "$file" >&2
+    exit 1
+  }
+}
+
+echo "==> shellcheck"
+run_shellcheck
+
+echo "==> existing Node"
+run_with_node with-node bash /paperclip-scripts/install.sh --no-onboard
+assert_line "$RESULTS_DIR/with-node.args" "paperclipai@latest"
+assert_line "$RESULTS_DIR/with-node.args" "install"
+assert_line "$RESULTS_DIR/with-node.args" "--no-prompt"
+
+echo "==> --ref master"
+run_with_node ref-master bash /paperclip-scripts/install.sh --ref master --no-onboard
+assert_line "$RESULTS_DIR/ref-master.args" "--ref"
+assert_line "$RESULTS_DIR/ref-master.args" "master"
+
+echo "==> piped --no-prompt"
+run_with_node piped bash -c 'cat /paperclip-scripts/install.sh | bash -s -- --no-prompt --no-onboard'
+assert_line "$RESULTS_DIR/piped.args" "--no-prompt"
+
+echo "==> environment twins"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/env.args \
+  -e PAPERCLIP_INSTALL_VERSION=2026.722.0 \
+  -e PAPERCLIP_INSTALL_REPO=example/paperclip \
+  -e PAPERCLIP_INSTALL_INSTALL_SERVICE=1 \
+  -e PAPERCLIP_INSTALL_NO_ONBOARD=1 \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh
+assert_line "$RESULTS_DIR/env.args" "paperclipai@2026.722.0"
+assert_line "$RESULTS_DIR/env.args" "--version"
+assert_line "$RESULTS_DIR/env.args" "2026.722.0"
+assert_line "$RESULTS_DIR/env.args" "--repo"
+assert_line "$RESULTS_DIR/env.args" "example/paperclip"
+assert_line "$RESULTS_DIR/env.args" "--install-service"
+
+echo "==> no Node, apt bootstrap"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/no-node.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  ubuntu:24.04 \
+  bash -c 'apt-get update >/dev/null && apt-get install -y ca-certificates curl >/dev/null && bash /paperclip-scripts/install.sh --no-prompt --no-onboard'
+assert_line "$RESULTS_DIR/no-node.args" "paperclipai@latest"
+node_version="$(cat "$RESULTS_DIR/no-node.args.node")"
+node_major="${node_version#v}"
+node_major="${node_major%%.*}"
+[ "$node_major" -ge 20 ] || {
+  printf 'Expected Node >= 20, got %s\n' "$node_version" >&2
+  exit 1
+}
+
+echo "Installer Docker checks passed."

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -101,6 +101,12 @@ fi
   exit 1
 }
 
+echo "==> piped mode requires explicit consent"
+if run_with_node piped-rejected bash -c 'cat /paperclip-scripts/install.sh | bash -s -- --no-onboard'; then
+  echo "Expected piped install without --no-prompt to fail" >&2
+  exit 1
+fi
+
 echo "==> piped --no-prompt"
 run_with_node piped bash -c 'cat /paperclip-scripts/install.sh | bash -s -- --no-prompt --no-onboard'
 assert_line "$RESULTS_DIR/piped.args" "--yes"

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -70,13 +70,25 @@ assert_line "$RESULTS_DIR/with-node.args" "install"
 assert_line "$RESULTS_DIR/with-node.args" "--yes"
 
 echo "==> --ref master"
-run_with_node ref-master bash /paperclip-scripts/install.sh --ref master --no-onboard
-assert_no_line "$RESULTS_DIR/ref-master.args" "--ref"
-assert_no_line "$RESULTS_DIR/ref-master.args" "master"
+if run_with_node ref-master bash /paperclip-scripts/install.sh --ref master --no-onboard; then
+  echo "Expected --ref to fail until git-ref installation support is integrated" >&2
+  exit 1
+fi
+[ ! -e "$RESULTS_DIR/ref-master.args" ] || {
+  echo "Expected --ref failure before invoking npx" >&2
+  exit 1
+}
 
 echo "==> piped --no-prompt"
 run_with_node piped bash -c 'cat /paperclip-scripts/install.sh | bash -s -- --no-prompt --no-onboard'
 assert_line "$RESULTS_DIR/piped.args" "--yes"
+
+echo "==> dry run"
+run_with_node dry-run bash /paperclip-scripts/install.sh --dry-run --no-onboard
+[ ! -e "$RESULTS_DIR/dry-run.args" ] || {
+  echo "Expected --dry-run to avoid invoking npx" >&2
+  exit 1
+}
 
 echo "==> environment twins"
 docker run --rm \
@@ -84,7 +96,6 @@ docker run --rm \
   -v "$RESULTS_DIR:/results" \
   -e PAPERCLIP_INSTALL_TEST_LOG=/results/env.args \
   -e PAPERCLIP_INSTALL_VERSION=2026.722.0 \
-  -e PAPERCLIP_INSTALL_REPO=example/paperclip \
   -e PAPERCLIP_INSTALL_INSTALL_SERVICE=1 \
   -e PAPERCLIP_INSTALL_NO_ONBOARD=1 \
   -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
@@ -94,8 +105,8 @@ assert_line "$RESULTS_DIR/env.args" "paperclipai@2026.722.0"
 assert_line "$RESULTS_DIR/env.args" "--version"
 assert_line "$RESULTS_DIR/env.args" "2026.722.0"
 assert_no_line "$RESULTS_DIR/env.args" "--repo"
-assert_no_line "$RESULTS_DIR/env.args" "example/paperclip"
 assert_no_line "$RESULTS_DIR/env.args" "--install-service"
+assert_line "$RESULTS_DIR/env.args" "service"
 
 echo "==> no Node, apt bootstrap"
 docker run --rm \

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,6 +65,7 @@ import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
 import { conflict } from "./errors.js";
 import { coordinateHeartbeatSchedulerShutdown } from "./shutdown.js";
+import { systemdNotify } from "./services/systemd-notify.js";
 import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
@@ -1146,6 +1147,9 @@ export async function startServer(): Promise<StartedServer> {
     server.listen(listenPort, config.host, () => {
       server.off("error", onError);
       logger.info(`Server listening on ${config.host}:${listenPort}`);
+      void systemdNotify(["--ready", `--status=Listening on ${config.host}:${listenPort}`]).then((notified) => {
+        if (notified) logger.info("Notified systemd that Paperclip is ready");
+      });
       if (process.env.PAPERCLIP_OPEN_ON_LISTEN === "true") {
         const openHost = config.host === "0.0.0.0" || config.host === "::" ? "127.0.0.1" : config.host;
         const url = `http://${openHost}:${listenPort}`;
@@ -1199,6 +1203,7 @@ export async function startServer(): Promise<StartedServer> {
   
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+      await systemdNotify(["--stopping", `--status=Stopping after ${signal}`]);
       heartbeatSchedulerStopped = true;
       if (heartbeatSchedulerInterval) {
         clearInterval(heartbeatSchedulerInterval);

--- a/server/src/services/hot-restart.ts
+++ b/server/src/services/hot-restart.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolvePaperclipHomeDir } from "../home-paths.js";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 
 export const HOT_RESTART_INTENT_FILENAME = "hot-restart-intent.json";
 export const HOT_RESTART_REPORT_FILENAME = "hot-restart-report.json";
@@ -56,7 +56,7 @@ export type HotRestartReport = {
 };
 
 function resolveHotRestartPath(filename: string, homeDir?: string) {
-  return path.join(resolvePaperclipHomeDir(homeDir), filename);
+  return path.join(resolvePaperclipInstanceRoot({ homeDir }), filename);
 }
 
 export function resolveHotRestartIntentPath(homeDir?: string) {

--- a/server/src/services/systemd-notify.ts
+++ b/server/src/services/systemd-notify.ts
@@ -1,0 +1,8 @@
+import { execFile } from "node:child_process";
+
+export async function systemdNotify(args: string[]): Promise<boolean> {
+  if (!process.env.NOTIFY_SOCKET?.trim()) return false;
+  return await new Promise<boolean>((resolve) => {
+    execFile("systemd-notify", args, { windowsHide: true }, (error) => resolve(!error));
+  });
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies
> - Local operators need a predictable way to install and operate the CLI without depending on ephemeral `npx` execution
> - A durable installer needs an owned per-user payload store, safe PATH integration, and service lifecycle support
> - Updating that store must preserve the prior payload, back up the database before switching, and avoid mutating source or npx checkouts
> - Global npm users should get the familiar package-manager update behavior while still seeing the exact command being executed
> - This pull request adds the managed install, bootstrap installer, service lifecycle, update/upgrade, passive update notice, and instant rollback workflows
> - The benefit is a recoverable, inspectable installation model with safer upgrades and clear behavior across install modes

## Linked Issues or Issue Description

### Problem

Paperclip currently documents npm/npx workflows but lacks a first-class durable installation and update lifecycle. Operators cannot install into an owned per-user store, manage a supported user service, update side-by-side with a pre-switch database backup, or instantly return to a retained previous payload. Ephemeral npx, global npm, managed, and source checkouts also need distinct safe behavior.

### Proposed Solution

Add a managed CLI store and stable shim, a verified shell bootstrap installer, user-service lifecycle commands, and an `update`/`upgrade` command that detects install mode. Managed npm updates resolve the selected channel, back up the database, install and smoke a side-by-side payload, atomically flip `current`, and retain the previous payload for `--rollback`. Global npm updates print and execute the exact npm command; npx/source modes print safe migration guidance.

### Alternatives Considered

- Keep recommending `npx`: simple, but ephemeral and unable to support atomic rollback or stable service definitions.
- Require users to run global npm updates manually: avoids executing npm, but conflicts with the accepted one-command operator experience and reference CLIs.
- Reinstall known-good versions for rollback: works, but is slower and network-dependent compared with retaining two previous payloads.

### Additional Context

The updater includes explicit downgrade consent, `--check`, `--dry-run`, `--json`, a default-on 24-hour update notice with environment/config kill switches, and fail-closed filesystem ownership/symlink checks.

## What Changed

- Added a hardened per-user managed install store, atomic `current` flip, stable shim, manifest retention, install locking, uninstall safety, and doctor checks.
- Added `paperclipai install`, `uninstall`, `service`, and onboarding integrations plus a verified shell bootstrap installer and Docker smoke fixtures.
- Added `paperclipai update` with `upgrade` alias, install-mode detection, latest/canary/pinned resolution, downgrade confirmation, database backup, side-by-side npm payload smoke, atomic activation, global npm execution, dry-run/check/JSON modes, and instant rollback.
- Added default-on 24-hour update notices for `run` and `doctor`, disabled by `PAPERCLIP_UPDATE_CHECK=0` or `updates.checkEnabled: false`.
- Added focused unit/integration coverage and updated installation/CLI documentation.

## Verification

- `pnpm --filter paperclipai typecheck`
- `pnpm vitest run cli/src/__tests__/update-command.test.ts cli/src/__tests__/update-notice.test.ts cli/src/__tests__/install-command.test.ts`
- `pnpm vitest run packages/shared/src/config-schema.test.ts cli/src/__tests__/update-command.test.ts cli/src/__tests__/update-notice.test.ts`
- `pnpm --filter paperclipai build`
- `pnpm --filter paperclipai dev update --dry-run`

## Risks

- The installer and updater write executable shims, symlinks, service definitions, and shell rc blocks; ownership, symlink, hard-link, and marker checks fail closed before destructive changes.
- Managed updates execute npm and make a network request for target resolution; registry arguments are fixed and exact versions are validated before installation.
- Database migrations are forward-only, so rollback flips only the CLI payload; the updater takes a database backup before activation unless `--no-backup` is explicitly supplied.
- Passive notices contact the npm registry at most once per 24 hours, never block startup, and have environment/config kill switches.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.5, tool-enabled coding agent with repository/API/shell execution; context-window size is not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge