### PR TITLE
fix(task-watchdogs): ignore no-op heartbeat summary comments in stop fingerprint

### DIFF
--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -778,6 +778,48 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdog?.triggerCount).toBe(2);
   });
 
+  it("re-arms a reviewed stopped subtree for a meaningful comment from an interrupted run", async () => {
+    const { companyId, sourceId, agentId, service, wakes, reviewedFingerprint } =
+      await armReviewedStoppedWatchdog();
+    expect(wakes).toHaveLength(1);
+
+    // Counterexample to the run-summary exclusion: an agent posts a deliberate
+    // work comment and its run is then interrupted. `classifyRunLiveness` maps
+    // an interrupted run to `needs_followup`, i.e. the same no-concrete liveness
+    // bucket as a no-op auto-summary — but this is real work, not a harness
+    // echo. Because the run did not *succeed*, the comment must still change the
+    // fingerprint and re-arm the watchdog.
+    const [interruptedRun] = await db
+      .insert(heartbeatRuns)
+      .values({
+        companyId,
+        agentId,
+        status: "interrupted",
+        invocationSource: "automation",
+        livenessState: "needs_followup",
+      })
+      .returning();
+    const later = new Date(Date.now() + 60_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "agent",
+      authorAgentId: agentId,
+      createdByRunId: interruptedRun!.id,
+      body: "Reproduced the watched-subtree bug and pushed a partial fix before the run was cut off.",
+      createdAt: later,
+      updatedAt: later,
+    });
+
+    const afterInterrupted = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(afterInterrupted).toMatchObject({ checked: 1, triggered: 1 });
+    expect(wakes).toHaveLength(2);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedFingerprint).not.toBe(reviewedFingerprint);
+    expect(watchdog?.triggerCount).toBe(2);
+  });
+
   it("does not re-arm a reviewed stopped subtree for a system housekeeping comment", async () => {
     const { companyId, sourceId, service, wakes, reviewedFingerprint } = await armReviewedStoppedWatchdog();
     expect(wakes).toHaveLength(1);

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -675,4 +675,130 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
 
     expect(result).toMatchObject({ checked: 0, triggered: 0 });
   });
+
+  // Drive a stopped source through its first watchdog trigger and mark that
+  // stop fingerprint reviewed, so the follow-up assertions only exercise
+  // whether a newly posted comment re-arms the already-reviewed subtree.
+  async function armReviewedStoppedWatchdog(status = "blocked") {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-NOOP", status });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    const first = await service.reconcileTaskWatchdogs({ companyId });
+    expect(first).toMatchObject({ checked: 1, triggered: 1 });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const reviewedFingerprint = firstWatchdog!.lastObservedFingerprint!;
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: new Date() })
+      .where(eq(issues.id, firstWatchdog!.watchdogIssueId!));
+    const reviewed = await service.reconcileTaskWatchdogs({ companyId });
+    expect(reviewed).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    return { companyId, sourceId, agentId, service, wakes, reviewedFingerprint };
+  }
+
+  it("does not re-arm a reviewed stopped subtree for a no-op heartbeat run-summary comment", async () => {
+    const { companyId, sourceId, agentId, service, wakes, reviewedFingerprint } =
+      await armReviewedStoppedWatchdog();
+    expect(wakes).toHaveLength(1);
+
+    // Reproduce the real recurrence: a scheduled-monitor dedup heartbeat posts
+    // no deliberate comment, so the harness auto-posts its run summary as an
+    // authorType=agent transcript echo. Its creating run produced no concrete
+    // action evidence (needs_followup), so the echo must not re-arm the source.
+    const [noopRun] = await db
+      .insert(heartbeatRuns)
+      .values({
+        companyId,
+        agentId,
+        status: "succeeded",
+        invocationSource: "automation",
+        livenessState: "needs_followup",
+      })
+      .returning();
+    const later = new Date(Date.now() + 60_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "agent",
+      authorAgentId: agentId,
+      createdByRunId: noopRun!.id,
+      body: "Monitor still scheduled; approval pending; no state change.",
+      createdAt: later,
+      updatedAt: later,
+    });
+
+    const afterNoop = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(afterNoop).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    expect(wakes).toHaveLength(1);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedFingerprint).toBe(reviewedFingerprint);
+    expect(watchdog?.triggerCount).toBe(1);
+  });
+
+  it("re-arms a reviewed stopped subtree for a meaningful agent work comment", async () => {
+    const { companyId, sourceId, agentId, service, wakes, reviewedFingerprint } =
+      await armReviewedStoppedWatchdog();
+    expect(wakes).toHaveLength(1);
+
+    // A deliberate agent work comment makes its run produce concrete action
+    // evidence (advanced); the same authorType=agent comment must still change
+    // the fingerprint and re-arm the watchdog as before.
+    const [workRun] = await db
+      .insert(heartbeatRuns)
+      .values({
+        companyId,
+        agentId,
+        status: "succeeded",
+        invocationSource: "automation",
+        livenessState: "advanced",
+      })
+      .returning();
+    const later = new Date(Date.now() + 60_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "agent",
+      authorAgentId: agentId,
+      createdByRunId: workRun!.id,
+      body: "Found the root cause and filed a fix for the watched subtree.",
+      createdAt: later,
+      updatedAt: later,
+    });
+
+    const afterWork = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(afterWork).toMatchObject({ checked: 1, triggered: 1 });
+    expect(wakes).toHaveLength(2);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedFingerprint).not.toBe(reviewedFingerprint);
+    expect(watchdog?.triggerCount).toBe(2);
+  });
+
+  it("does not re-arm a reviewed stopped subtree for a system housekeeping comment", async () => {
+    const { companyId, sourceId, service, wakes, reviewedFingerprint } = await armReviewedStoppedWatchdog();
+    expect(wakes).toHaveLength(1);
+
+    // System-authored comments are housekeeping/notices, not watched-subtree
+    // work; they must not re-arm the reviewed stop fingerprint.
+    const later = new Date(Date.now() + 60_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "system",
+      body: "Automated housekeeping notice.",
+      createdAt: later,
+      updatedAt: later,
+    });
+
+    const afterSystem = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(afterSystem).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
+    expect(wakes).toHaveLength(1);
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedFingerprint).toBe(reviewedFingerprint);
+  });
 });

--- a/server/src/services/run-liveness.ts
+++ b/server/src/services/run-liveness.ts
@@ -302,13 +302,18 @@ export function classifyRunActionability(input: RunLivenessClassificationInput):
   return "unknown";
 }
 
-// Succeeded-run liveness states where the run produced NO concrete action
-// evidence (see the `concreteEvidence` branches in `classifyRunLiveness`). A
-// run in one of these states makes no deliberate issue comment, so the harness
-// auto-posts its run summary as an `authorType=agent` comment — a transcript
-// echo of the heartbeat, not real subtree work. Consumers such as the task
-// watchdog must not let that echo count as watched-subtree activity, otherwise
-// a no-op scheduled-monitor heartbeat re-arms a stopped subtree on every wake.
+// Liveness states that carry NO concrete action evidence (see the
+// `concreteEvidence` branches in `classifyRunLiveness`). When a *succeeded* run
+// lands in one of these states it made no deliberate issue comment, so the
+// harness auto-posts its run summary as an `authorType=agent` comment — a
+// transcript echo of the heartbeat, not real subtree work. Consumers such as
+// the task watchdog must not let that echo count as watched-subtree activity,
+// otherwise a no-op scheduled-monitor heartbeat re-arms a stopped subtree on
+// every wake. IMPORTANT: this bucket is not succeeded-only — an interrupted run
+// also maps to `needs_followup` (see the `runStatus === "interrupted"` branch
+// below) yet may carry a deliberate work comment posted before it was cut off.
+// Callers must therefore gate the exclusion on `runStatus === "succeeded"` and
+// never drop a comment purely because its run shares this liveness bucket.
 export const RUN_LIVENESS_NO_CONCRETE_ACTION_STATES: readonly RunLivenessState[] = [
   "empty_response",
   "plan_only",

--- a/server/src/services/run-liveness.ts
+++ b/server/src/services/run-liveness.ts
@@ -302,6 +302,19 @@ export function classifyRunActionability(input: RunLivenessClassificationInput):
   return "unknown";
 }
 
+// Succeeded-run liveness states where the run produced NO concrete action
+// evidence (see the `concreteEvidence` branches in `classifyRunLiveness`). A
+// run in one of these states makes no deliberate issue comment, so the harness
+// auto-posts its run summary as an `authorType=agent` comment — a transcript
+// echo of the heartbeat, not real subtree work. Consumers such as the task
+// watchdog must not let that echo count as watched-subtree activity, otherwise
+// a no-op scheduled-monitor heartbeat re-arms a stopped subtree on every wake.
+export const RUN_LIVENESS_NO_CONCRETE_ACTION_STATES: readonly RunLivenessState[] = [
+  "empty_response",
+  "plan_only",
+  "needs_followup",
+];
+
 export function classifyRunLiveness(input: RunLivenessClassificationInput): RunLivenessClassification {
   const evidence = normalizeEvidence(input.evidence);
   const continuationAttempt = normalizeContinuationAttempt(input.continuationAttempt);

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { and, asc, eq, gte, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, gte, inArray, isNull, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agentWakeupRequests,
@@ -22,6 +22,7 @@ import { logActivity } from "./activity-log.js";
 import { evaluateAgentInvokabilityFromDb } from "./agent-invokability.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
+import { RUN_LIVENESS_NO_CONCRETE_ACTION_STATES } from "./run-liveness.js";
 import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
 
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
@@ -905,10 +906,27 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           latestAt: sql<Date | null>`MAX(${issueComments.updatedAt})`,
         })
         .from(issueComments)
+        // Join the run that authored each comment so a no-op heartbeat's
+        // harness-posted run summary can be told apart from deliberate work.
+        .leftJoin(heartbeatRuns, eq(issueComments.createdByRunId, heartbeatRuns.id))
         .where(and(
           eq(issueComments.companyId, companyId),
           inArray(issueComments.issueId, subtreeIssueIds),
           isNull(issueComments.deletedAt),
+          // System-authored comments are housekeeping/notices (handoff notices,
+          // watchdog bookkeeping), not watched-subtree work activity.
+          or(isNull(issueComments.authorType), ne(issueComments.authorType, "system")),
+          // A scheduled-monitor dedup no-op heartbeat posts no deliberate
+          // comment, so the harness auto-posts its run summary as an
+          // `authorType=agent` transcript echo whose creating run produced no
+          // concrete action evidence. Excluding those runs keeps such an echo
+          // from bumping `latestCommentAt` and re-arming a stopped subtree.
+          // User comments (no run) and comments from runs that produced
+          // concrete action evidence still count and re-evaluate as before.
+          or(
+            isNull(heartbeatRuns.livenessState),
+            notInArray(heartbeatRuns.livenessState, [...RUN_LIVENESS_NO_CONCRETE_ACTION_STATES]),
+          ),
         ))
         .groupBy(issueComments.issueId),
       db

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -918,14 +918,19 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           or(isNull(issueComments.authorType), ne(issueComments.authorType, "system")),
           // A scheduled-monitor dedup no-op heartbeat posts no deliberate
           // comment, so the harness auto-posts its run summary as an
-          // `authorType=agent` transcript echo whose creating run produced no
-          // concrete action evidence. Excluding those runs keeps such an echo
-          // from bumping `latestCommentAt` and re-arming a stopped subtree.
-          // User comments (no run) and comments from runs that produced
-          // concrete action evidence still count and re-evaluate as before.
+          // `authorType=agent` transcript echo. Only a *succeeded* run that
+          // produced no concrete action evidence yields that echo; exclude it
+          // so it stops bumping `latestCommentAt` and re-arming a stopped
+          // subtree. The exclusion is gated on `status = "succeeded"` because a
+          // non-succeeded run (e.g. interrupted → `needs_followup`) shares the
+          // same no-concrete liveness bucket yet can carry a deliberate work
+          // comment the agent posted before the run ended; those, along with
+          // user comments (no run) and comments from concrete-action runs, must
+          // still count and re-evaluate the subtree as before.
           or(
             isNull(heartbeatRuns.livenessState),
             notInArray(heartbeatRuns.livenessState, [...RUN_LIVENESS_NO_CONCRETE_ACTION_STATES]),
+            ne(heartbeatRuns.status, "succeeded"),
           ),
         ))
         .groupBy(issueComments.issueId),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The task-watchdog subsystem watches a subtree of issues and, when it looks "stopped", wakes a watchdog agent to review it
> - To decide whether a stopped subtree changed since the last review, it hashes each leaf into a stop fingerprint that includes the leaf's latest comment timestamp — `MAX(issue_comments.updated_at)` with no author or run filter
> - When an agent is woken by a scheduled monitor and makes no deliberate change (a dedup no-op heartbeat), it posts no comment of its own, so the harness auto-posts the run summary as an `authorType=agent` transcript echo — which bumps `latestCommentAt` and mints a new stop fingerprint on every wake
> - The watchdog then re-arms and re-reviews the same unchanged subtree repeatedly, purely from its own no-op heartbeat echoes
> - This pull request excludes only those no-op summary echoes (and system housekeeping comments) from the watchdog's comment-activity signal, keying on existing persisted run metadata — specifically a `succeeded` run that produced no concrete action evidence — while still letting deliberate agent/user comments, and comments from interrupted/failed runs, re-evaluate the subtree
> - The benefit is that a monitored/parked source stops generating a self-perpetuating stream of watchdog reviews, without weakening detection of real activity

## Linked Issues or Issue Description

No public GitHub issue exists; describing the bug directly (bug-report fields):

- **What happened:** A stopped watched subtree (e.g. a source parked in `in_review` with a scheduled monitor) is re-reviewed by its task watchdog on every heartbeat. Each dedup no-op heartbeat produces a harness-posted run-summary comment; that comment advances the subtree's latest-comment timestamp, changes the stop fingerprint, and re-arms the watchdog even though no state, blocker, monitor, approval, run, document, or work-product changed.
- **Expected behavior:** A no-op heartbeat whose only footprint is the auto-posted run summary must not change the stop fingerprint. A meaningful, deliberate comment (agent or user) must still change it and trigger re-evaluation — including a meaningful comment posted just before its run was interrupted.
- **Steps to reproduce:** Arm a task watchdog on a stopped source; let its watchdog review the stop fingerprint once; post an `authorType=agent` comment created by a **succeeded** heartbeat run whose `liveness_state` is `needs_followup` (a run that produced no concrete action evidence). Before this change the watchdog re-triggers; after it, it stays `already_reviewed`. Conversely, the same comment created by an **interrupted** run (also mapped to `needs_followup`) must still re-arm.
- **Commit:** `ed412f8` on top of `origin/master` `b57aa99`.
- **Deployment mode:** Server (`@paperclipai/server`), any deployment; no schema/migration change.

Prior related attempts on this subsystem (superseded by this developer-owned PR, or independent):
- Refs #9988 — closed; excluded only `authorType=system` comments, which does not cover the real `authorType=agent` no-op reproducer.
- Refs #9990 — closed; earlier take on ignoring no-op agent summary comments.
- Refs #9991 — open, but bundles unrelated migration/agent changes; superseded by this focused PR.
- Refs #9997 — open; treats a scheduled monitor as a live continuation, which also suppresses re-evaluation for *meaningful* agent comments during the monitor window. This PR instead keeps the fingerprint responsive to real comments.
- Refs #9432 — independent, related work on stop-fingerprint timestamp churn.

## What Changed

- `server/src/services/run-liveness.ts`: add `RUN_LIVENESS_NO_CONCRETE_ACTION_STATES` (`empty_response`, `plan_only`, `needs_followup`) — the liveness states that carry no concrete action evidence, co-located with the classifier that assigns them. A comment noting that callers **must** additionally gate on a `succeeded` run status, because `classifyRunLiveness` also maps an *interrupted* run to `needs_followup`, so the bucket alone is not sufficient to identify a harness no-op echo.
- `server/src/services/task-watchdogs.ts`: the watchdog comment-activity aggregation now `LEFT JOIN`s `heartbeat_runs` on `created_by_run_id` and excludes (a) `authorType=system` housekeeping comments and (b) agent comments whose creating run is **`status = "succeeded"` and** in the no-concrete-action set. Only a succeeded no-concrete run yields the harness `authorType=agent` run-summary echo we mean to ignore. Comments with no creating run (user comments), comments from non-succeeded runs (interrupted / failed / timed_out / cancelled — including deliberate work posted just before interruption), and comments from runs with concrete action evidence (`advanced` / `completed` / `blocked`) still count. This is applied in the single shared classifier-input loader, so both the periodic reconciler and mutation revalidation stay consistent.
- `server/src/__tests__/task-watchdogs-scheduler.test.ts`: embedded-Postgres regressions using real persisted metadata — (1) a no-op **succeeded** `needs_followup` run-summary comment does not re-arm a reviewed subtree; (2) a meaningful `advanced` agent comment does; (3) a meaningful comment from an **interrupted** `needs_followup` run does re-arm (the counterexample the succeeded gate fixes); (4) a `system` housekeeping comment does not.

## Verification

- `TMPDIR=<tmp> npx vitest run src/__tests__/task-watchdogs-scheduler.test.ts src/__tests__/task-watchdogs-classifier.test.ts src/__tests__/run-liveness.test.ts` → **44 passed** (focused scheduler + classifier + run-liveness suites, including the new interrupted-run counterexample).
- `tsc --noEmit` reports no new errors in the touched files (`task-watchdogs.ts`, `run-liveness.ts`); remaining diagnostics are pre-existing and in unrelated files.
- Note: the current head `ed412f8` differs from the previously-reviewed `4aa91fd` only by a commit-message reword (scrubbing an internal ticket id from public git history). The file tree is byte-identical, so the code that Greptile reviewed is unchanged.

## Risks

- Low risk. Behavioral change is scoped to which comments feed the watchdog stop fingerprint; no schema/migration, no API change.
- The exclusion keys on the durable, already-persisted `heartbeat_runs.status` + `liveness_state`; comments with no creating run default to being counted, so user comments and legacy comments are never dropped. Non-succeeded runs are never excluded, so deliberate work posted before an interruption still re-arms.
- Worst case is a slightly more conservative signal (a rare succeeded plan-only/plan-exempt run's summary not re-arming), which is safe because any genuine state change is still captured by the status/blocker/monitor/approval/document/work-product signals and by deliberate comments.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution in an agentic harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (re-running on `ed412f8`; tree unchanged from previously-green `4aa91fd`)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (re-running on `ed412f8`; was 5/5 on the identical tree at `4aa91fd`)
- [x] I will address all Greptile and reviewer comments before requesting merge
