### PR TITLE
fix(workspace): clean terminal issue worktrees

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -486,6 +486,8 @@ Side effects:
 - entering `in_progress` sets `started_at` if null
 - entering `done` sets `completed_at`
 - entering `cancelled` sets `cancelled_at`
+- entering a terminal state makes the linked execution workspace eligible for automatic cleanup once every linked issue is terminal
+- cleanup waits for the active heartbeat to finish; workspaces with uncommitted files remain available with a recorded cleanup reason instead of being deleted automatically
 
 V1 non-terminal liveness rule:
 

--- a/server/src/__tests__/execution-workspace-lifecycle.test.ts
+++ b/server/src/__tests__/execution-workspace-lifecycle.test.ts
@@ -199,6 +199,33 @@ describeEmbeddedPostgres("execution workspace terminal issue cleanup", () => {
     expect(await pathExists(fixture.worktreePath)).toBe(false);
   }, 20_000);
 
+  it("claims a terminal workspace once when linked issues finish concurrently", async () => {
+    const fixture = await createFixture(["done", "done"]);
+
+    const results = await Promise.all(
+      fixture.issueIds.map((issueId) => lifecycle.finishDeferredCleanup({ issueId, actor })),
+    );
+
+    expect(results.map((result) => result.outcome).sort()).toEqual([
+      "archived",
+      "not_applicable",
+    ]);
+    expect(await pathExists(fixture.worktreePath)).toBe(false);
+
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, fixture.executionWorkspaceId))
+      .then((rows) => rows[0]);
+    expect(workspace.status).toBe("archived");
+
+    const cleanupActivities = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "execution_workspace.terminal_issue_cleanup"));
+    expect(cleanupActivities).toHaveLength(1);
+  }, 20_000);
+
   it("keeps a dirty terminal workspace and records why automatic cleanup was skipped", async () => {
     const fixture = await createFixture(["done"]);
     await fs.writeFile(path.join(fixture.worktreePath, "untracked.txt"), "keep me\n", "utf8");

--- a/server/src/__tests__/execution-workspace-lifecycle.test.ts
+++ b/server/src/__tests__/execution-workspace-lifecycle.test.ts
@@ -1,0 +1,221 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  activityLog,
+  companies,
+  createDb,
+  executionWorkspaces,
+  issues,
+  projectWorkspaces,
+  projects,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { executionWorkspaceLifecycleService } from "../services/execution-workspace-lifecycle.js";
+
+const execFileAsync = promisify(execFile);
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres execution workspace lifecycle tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function runGit(cwd: string, args: string[]) {
+  await execFileAsync("git", ["-C", cwd, ...args], { cwd });
+}
+
+async function pathExists(target: string) {
+  return fs.stat(target).then(() => true).catch(() => false);
+}
+
+describeEmbeddedPostgres("execution workspace terminal issue cleanup", () => {
+  let db!: ReturnType<typeof createDb>;
+  let lifecycle!: ReturnType<typeof executionWorkspaceLifecycleService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const tempDirs = new Set<string>();
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-execution-workspace-lifecycle-");
+    db = createDb(tempDb.connectionString);
+    lifecycle = executionWorkspaceLifecycleService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(workspaceOperations);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(companies);
+    for (const dir of tempDirs) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+    tempDirs.clear();
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createFixture(statuses: Array<"done" | "in_review">) {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-terminal-workspace-"));
+    tempDirs.add(repoRoot);
+    await runGit(repoRoot, ["init"]);
+    await runGit(repoRoot, ["config", "user.name", "Paperclip Test"]);
+    await runGit(repoRoot, ["config", "user.email", "test@paperclip.local"]);
+    await fs.writeFile(path.join(repoRoot, "README.md"), "# Test repo\n", "utf8");
+    await runGit(repoRoot, ["add", "README.md"]);
+    await runGit(repoRoot, ["commit", "-m", "Initial commit"]);
+    await runGit(repoRoot, ["branch", "-M", "main"]);
+
+    const worktreePath = path.join(path.dirname(repoRoot), `paperclip-terminal-worktree-${randomUUID()}`);
+    tempDirs.add(worktreePath);
+    const branchName = `terminal-cleanup-${randomUUID()}`;
+    await runGit(repoRoot, ["branch", branchName]);
+    await runGit(repoRoot, ["worktree", "add", worktreePath, branchName]);
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace cleanup",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+        workspaceStrategy: { type: "git_worktree" },
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Terminal workspace",
+      status: "active",
+      cwd: worktreePath,
+      providerType: "git_worktree",
+      providerRef: worktreePath,
+      branchName,
+      baseRef: "main",
+      metadata: { createdByRuntime: true },
+    });
+    const issueIds = statuses.map(() => randomUUID());
+    await db.insert(issues).values(statuses.map((status, index) => ({
+      id: issueIds[index],
+      companyId,
+      projectId,
+      title: `Issue ${index + 1}`,
+      status,
+      priority: "medium" as const,
+      executionWorkspaceId,
+    })));
+
+    return { executionWorkspaceId, issueIds, worktreePath };
+  }
+
+  const actor = {
+    actorType: "system" as const,
+    actorId: "terminal-workspace-cleanup-test",
+    agentId: null,
+    runId: null,
+  };
+
+  it("defers cleanup until the terminal heartbeat finishes, then removes the worktree", async () => {
+    const fixture = await createFixture(["done"]);
+
+    const scheduled = await lifecycle.reconcileTerminalIssueWorkspace({
+      issueId: fixture.issueIds[0],
+      defer: true,
+      actor,
+    });
+    expect(scheduled.outcome).toBe("deferred");
+    expect(await pathExists(fixture.worktreePath)).toBe(true);
+
+    const cleaned = await lifecycle.finishDeferredCleanup({
+      issueId: fixture.issueIds[0],
+      actor,
+    });
+    expect(cleaned.outcome).toBe("archived");
+    expect(await pathExists(fixture.worktreePath)).toBe(false);
+
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, fixture.executionWorkspaceId))
+      .then((rows) => rows[0]);
+    expect(workspace.status).toBe("archived");
+    expect(workspace.cleanupEligibleAt).toBeNull();
+  }, 20_000);
+
+  it("waits until every issue linked to an inherited workspace is terminal", async () => {
+    const fixture = await createFixture(["done", "in_review"]);
+
+    const blocked = await lifecycle.finishDeferredCleanup({
+      issueId: fixture.issueIds[0],
+      actor,
+    });
+    expect(blocked.outcome).toBe("blocked");
+    expect(await pathExists(fixture.worktreePath)).toBe(true);
+
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, fixture.issueIds[1]));
+    const cleaned = await lifecycle.finishDeferredCleanup({
+      issueId: fixture.issueIds[1],
+      actor,
+    });
+    expect(cleaned.outcome).toBe("archived");
+    expect(await pathExists(fixture.worktreePath)).toBe(false);
+  }, 20_000);
+
+  it("keeps a dirty terminal workspace and records why automatic cleanup was skipped", async () => {
+    const fixture = await createFixture(["done"]);
+    await fs.writeFile(path.join(fixture.worktreePath, "untracked.txt"), "keep me\n", "utf8");
+
+    const blocked = await lifecycle.finishDeferredCleanup({
+      issueId: fixture.issueIds[0],
+      actor,
+    });
+    expect(blocked.outcome).toBe("blocked");
+    expect(await pathExists(fixture.worktreePath)).toBe(true);
+
+    const workspace = await db
+      .select()
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, fixture.executionWorkspaceId))
+      .then((rows) => rows[0]);
+    expect(workspace.status).toBe("active");
+    expect(workspace.cleanupReason).toContain("uncommitted files");
+  }, 20_000);
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -100,6 +100,7 @@ import {
   companySkillService,
   companyService,
   companySearchService,
+  executionWorkspaceLifecycleService,
   executionWorkspaceService,
   goalService,
   heartbeatService,
@@ -8450,6 +8451,31 @@ export function issueRoutes(
           (item) => item.issue.identifier ?? item.issue.id,
         ),
       };
+    }
+
+    const becameTerminal =
+      !isClosedIssueStatus(existing.status) && isClosedIssueStatus(issue.status);
+    if (becameTerminal && issue.executionWorkspaceId) {
+      const deferWorkspaceCleanup = Boolean(
+        actor.runId || existing.executionRunId || runToCancelForCancelledStatus,
+      );
+      await executionWorkspaceLifecycleService(db)
+        .reconcileTerminalIssueWorkspace({
+          issueId: issue.id,
+          defer: deferWorkspaceCleanup,
+          actor: {
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId ?? null,
+            runId: actor.runId ?? null,
+          },
+        })
+        .catch((err) => {
+          logger.warn(
+            { err, issueId: issue.id, executionWorkspaceId: issue.executionWorkspaceId },
+            "failed to reconcile terminal issue execution workspace",
+          );
+        });
     }
 
     const assigneeChanged =

--- a/server/src/services/execution-workspace-lifecycle.ts
+++ b/server/src/services/execution-workspace-lifecycle.ts
@@ -1,0 +1,254 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues, projects, projectWorkspaces } from "@paperclipai/db";
+import type { ExecutionWorkspace, ExecutionWorkspaceCloseReadiness } from "@paperclipai/shared";
+import { logger } from "../middleware/logger.js";
+import { logActivity, type LogActivityInput } from "./activity-log.js";
+import {
+  executionWorkspaceService,
+  readExecutionWorkspaceConfig,
+} from "./execution-workspaces.js";
+import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
+import { workspaceOperationService } from "./workspace-operations.js";
+import {
+  cleanupExecutionWorkspaceArtifacts,
+  stopRuntimeServicesForExecutionWorkspace,
+} from "./workspace-runtime.js";
+
+const TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
+
+type CleanupActor = Pick<LogActivityInput, "actorType" | "actorId" | "agentId" | "runId">;
+
+export type TerminalWorkspaceCleanupResult =
+  | { outcome: "not_applicable" | "deferred"; workspace: ExecutionWorkspace | null }
+  | { outcome: "blocked"; workspace: ExecutionWorkspace; reason: string }
+  | { outcome: "archived" | "cleanup_failed"; workspace: ExecutionWorkspace; warnings: string[] };
+
+function automaticCleanupBlockReason(readiness: ExecutionWorkspaceCloseReadiness) {
+  const openIssueCount = readiness.linkedIssues.filter((issue) => !issue.isTerminal).length;
+  if (openIssueCount > 0) {
+    return openIssueCount === 1
+      ? "Automatic cleanup is waiting for 1 linked issue to reach a terminal status."
+      : `Automatic cleanup is waiting for ${openIssueCount} linked issues to reach a terminal status.`;
+  }
+  if (readiness.blockingReasons.length > 0) {
+    return readiness.blockingReasons.join(" | ");
+  }
+  if (
+    !readiness.isSharedWorkspace
+    && (readiness.git?.hasDirtyTrackedFiles || readiness.git?.hasUntrackedFiles)
+  ) {
+    return "Automatic cleanup skipped because the workspace contains uncommitted files.";
+  }
+  return null;
+}
+
+async function writeLifecycleActivity(
+  db: Db,
+  workspace: ExecutionWorkspace,
+  actor: CleanupActor,
+  action: string,
+  details: Record<string, unknown>,
+) {
+  await logActivity(db, {
+    companyId: workspace.companyId,
+    actorType: actor.actorType,
+    actorId: actor.actorId,
+    agentId: actor.agentId ?? null,
+    runId: actor.runId ?? null,
+    action,
+    entityType: "execution_workspace",
+    entityId: workspace.id,
+    details,
+  });
+}
+
+async function archiveExecutionWorkspace(
+  db: Db,
+  workspace: ExecutionWorkspace,
+  actor: CleanupActor,
+): Promise<TerminalWorkspaceCleanupResult> {
+  const svc = executionWorkspaceService(db);
+  const workspaceOperationsSvc = workspaceOperationService(db);
+  const closedAt = new Date();
+  let archivedWorkspace = await svc.update(workspace.id, {
+    status: "archived",
+    closedAt,
+    cleanupEligibleAt: null,
+    cleanupReason: null,
+  });
+  if (!archivedWorkspace) {
+    return { outcome: "not_applicable", workspace: null };
+  }
+
+  if (workspace.mode === "shared_workspace") {
+    await db
+      .update(issues)
+      .set({
+        executionWorkspaceId: null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(issues.companyId, workspace.companyId),
+          eq(issues.executionWorkspaceId, workspace.id),
+        ),
+      );
+  }
+
+  let cleanupWarnings: string[] = [];
+  try {
+    await stopRuntimeServicesForExecutionWorkspace({
+      db,
+      executionWorkspaceId: workspace.id,
+      workspaceCwd: workspace.cwd,
+    });
+    const projectWorkspace = workspace.projectWorkspaceId
+      ? await db
+          .select({
+            cwd: projectWorkspaces.cwd,
+            cleanupCommand: projectWorkspaces.cleanupCommand,
+          })
+          .from(projectWorkspaces)
+          .where(
+            and(
+              eq(projectWorkspaces.id, workspace.projectWorkspaceId),
+              eq(projectWorkspaces.companyId, workspace.companyId),
+            ),
+          )
+          .then((rows) => rows[0] ?? null)
+      : null;
+    const projectPolicy = workspace.projectId
+      ? await db
+          .select({
+            executionWorkspacePolicy: projects.executionWorkspacePolicy,
+          })
+          .from(projects)
+          .where(and(eq(projects.id, workspace.projectId), eq(projects.companyId, workspace.companyId)))
+          .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy))
+      : null;
+    const config = readExecutionWorkspaceConfig(workspace.metadata);
+    const cleanupResult = await cleanupExecutionWorkspaceArtifacts({
+      workspace,
+      projectWorkspace,
+      teardownCommand: config?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
+      cleanupCommand: config?.cleanupCommand ?? null,
+      recorder: workspaceOperationsSvc.createRecorder({
+        companyId: workspace.companyId,
+        executionWorkspaceId: workspace.id,
+      }),
+    });
+    cleanupWarnings = cleanupResult.warnings;
+    const cleanupPatch: Record<string, unknown> = {
+      closedAt,
+      cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
+    };
+    if (!cleanupResult.cleaned) cleanupPatch.status = "cleanup_failed";
+    if (cleanupWarnings.length > 0 || !cleanupResult.cleaned) {
+      archivedWorkspace = (await svc.update(workspace.id, cleanupPatch)) ?? archivedWorkspace;
+    }
+  } catch (error) {
+    const failureReason = error instanceof Error ? error.message : String(error);
+    archivedWorkspace =
+      (await svc.update(workspace.id, {
+        status: "cleanup_failed",
+        closedAt,
+        cleanupReason: failureReason,
+      })) ?? archivedWorkspace;
+    cleanupWarnings = [failureReason];
+  }
+
+  const outcome = archivedWorkspace.status === "cleanup_failed" ? "cleanup_failed" : "archived";
+  await writeLifecycleActivity(db, archivedWorkspace, actor, "execution_workspace.terminal_issue_cleanup", {
+    outcome,
+    cleanupWarnings,
+    source: "terminal_issue",
+  });
+  return { outcome, workspace: archivedWorkspace, warnings: cleanupWarnings };
+}
+
+export function executionWorkspaceLifecycleService(db: Db) {
+  const svc = executionWorkspaceService(db);
+
+  async function reconcileTerminalIssueWorkspace(input: {
+    issueId: string;
+    defer: boolean;
+    actor: CleanupActor;
+  }): Promise<TerminalWorkspaceCleanupResult> {
+    const issue = await db
+      .select({
+        companyId: issues.companyId,
+        executionWorkspaceId: issues.executionWorkspaceId,
+        status: issues.status,
+      })
+      .from(issues)
+      .where(eq(issues.id, input.issueId))
+      .then((rows) => rows[0] ?? null);
+    if (!issue?.executionWorkspaceId || !TERMINAL_ISSUE_STATUSES.has(issue.status)) {
+      return { outcome: "not_applicable", workspace: null };
+    }
+
+    const workspace = await svc.getById(issue.executionWorkspaceId);
+    if (!workspace || workspace.status === "archived" || workspace.status === "cleanup_failed") {
+      return { outcome: "not_applicable", workspace };
+    }
+
+    const readiness = await svc.getCloseReadiness(workspace.id);
+    if (!readiness) return { outcome: "not_applicable", workspace };
+    const blockReason = automaticCleanupBlockReason(readiness);
+    if (blockReason) {
+      const shouldPersistReason = workspace.cleanupEligibleAt !== null || workspace.cleanupReason !== blockReason;
+      const updated = shouldPersistReason
+        ? (await svc.update(workspace.id, {
+            cleanupEligibleAt: null,
+            cleanupReason: blockReason,
+          })) ?? workspace
+        : workspace;
+      if (shouldPersistReason) {
+        await writeLifecycleActivity(db, updated, input.actor, "execution_workspace.cleanup_blocked", {
+          issueId: input.issueId,
+          reason: blockReason,
+          source: "terminal_issue",
+        });
+      }
+      return { outcome: "blocked", workspace: updated, reason: blockReason };
+    }
+
+    if (input.defer) {
+      const updated = (await svc.update(workspace.id, {
+        cleanupEligibleAt: new Date(),
+        cleanupReason: "Automatic cleanup is waiting for the terminal heartbeat run to finish.",
+      })) ?? workspace;
+      await writeLifecycleActivity(db, updated, input.actor, "execution_workspace.cleanup_scheduled", {
+        issueId: input.issueId,
+        source: "terminal_issue",
+      });
+      return { outcome: "deferred", workspace: updated };
+    }
+
+    return archiveExecutionWorkspace(db, workspace, input.actor);
+  }
+
+  async function finishDeferredCleanup(input: {
+    issueId: string;
+    actor: CleanupActor;
+  }): Promise<TerminalWorkspaceCleanupResult> {
+    try {
+      return await reconcileTerminalIssueWorkspace({
+        ...input,
+        defer: false,
+      });
+    } catch (error) {
+      logger.warn(
+        { err: error, issueId: input.issueId },
+        "failed to automatically clean terminal issue execution workspace",
+      );
+      throw error;
+    }
+  }
+
+  return {
+    reconcileTerminalIssueWorkspace,
+    finishDeferredCleanup,
+  };
+}

--- a/server/src/services/execution-workspace-lifecycle.ts
+++ b/server/src/services/execution-workspace-lifecycle.ts
@@ -1,6 +1,6 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { issues, projects, projectWorkspaces } from "@paperclipai/db";
+import { executionWorkspaces, issues, projects, projectWorkspaces } from "@paperclipai/db";
 import type { ExecutionWorkspace, ExecutionWorkspaceCloseReadiness } from "@paperclipai/shared";
 import { logger } from "../middleware/logger.js";
 import { logActivity, type LogActivityInput } from "./activity-log.js";
@@ -71,12 +71,29 @@ async function archiveExecutionWorkspace(
   const svc = executionWorkspaceService(db);
   const workspaceOperationsSvc = workspaceOperationService(db);
   const closedAt = new Date();
-  let archivedWorkspace = await svc.update(workspace.id, {
-    status: "archived",
-    closedAt,
-    cleanupEligibleAt: null,
-    cleanupReason: null,
-  });
+  const claimedWorkspaceId = await db
+    .update(executionWorkspaces)
+    .set({
+      status: "archived",
+      closedAt,
+      cleanupEligibleAt: null,
+      cleanupReason: null,
+      updatedAt: closedAt,
+    })
+    .where(
+      and(
+        eq(executionWorkspaces.id, workspace.id),
+        eq(executionWorkspaces.companyId, workspace.companyId),
+        inArray(executionWorkspaces.status, ["active", "idle", "in_review"]),
+      ),
+    )
+    .returning({ id: executionWorkspaces.id })
+    .then((rows) => rows[0]?.id ?? null);
+  if (!claimedWorkspaceId) {
+    return { outcome: "not_applicable", workspace: await svc.getById(workspace.id) };
+  }
+
+  let archivedWorkspace = await svc.getById(claimedWorkspaceId);
   if (!archivedWorkspace) {
     return { outcome: "not_applicable", workspace: null };
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -155,6 +155,7 @@ import {
 } from "./issue-continuation-summary.js";
 import { buildPlanReviewContext } from "./plan-review-context.js";
 import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
+import { executionWorkspaceLifecycleService } from "./execution-workspace-lifecycle.js";
 import { workspaceOperationService, type WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
 import {
@@ -5460,6 +5461,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   const issuesSvc = issueService(db);
   const treeControlSvc = issueTreeControlService(db);
   const executionWorkspacesSvc = executionWorkspaceService(db);
+  const executionWorkspaceLifecycle = executionWorkspaceLifecycleService(db);
   const environmentsSvc = environmentService(db);
   const environmentRuntime = options.environmentRuntime ?? environmentRuntimeService(db, {
     pluginWorkerManager: options.pluginWorkerManager,
@@ -14309,6 +14311,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             }
           }
           activeRunExecutions.delete(run.id);
+          const terminalIssueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+          if (terminalIssueId) {
+            await executionWorkspaceLifecycle.finishDeferredCleanup({
+              issueId: terminalIssueId,
+              actor: {
+                actorType: "agent",
+                actorId: run.agentId,
+                agentId: run.agentId,
+                runId: run.id,
+              },
+            }).catch((err) => {
+              logger.warn(
+                { err, issueId: terminalIssueId, runId: run.id },
+                "failed to finish terminal issue execution workspace cleanup",
+              );
+            });
+          }
           await startNextQueuedRunForAgent(run.agentId);
         }
   }

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -133,6 +133,10 @@ export {
   type ParsedCustomImageSetupSshCommand,
 } from "./environment-custom-image-terminal-sessions.js";
 export { executionWorkspaceService } from "./execution-workspaces.js";
+export {
+  executionWorkspaceLifecycleService,
+  type TerminalWorkspaceCleanupResult,
+} from "./execution-workspace-lifecycle.js";
 export { workspaceOperationService } from "./workspace-operations.js";
 export { workspaceFileResourceService } from "./workspace-file-resources.js";
 export { workProductService } from "./work-products.js";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and gives task runs isolated execution workspaces.
> - Execution workspaces already have a guarded close path that stops services, records operations, and removes runtime-created artifacts.
> - Terminal issue transitions did not invoke that lifecycle, so completed tasks accumulated active workspace records and worktree directories.
> - Cleanup cannot race the heartbeat that is still running inside the workspace or another linked issue reaching a terminal status at the same time.
> - Inherited workspaces must remain available until every linked issue is terminal, and uncommitted files must survive automatic cleanup.
> - This pull request connects terminal issue transitions to the existing cleanup engine and atomically claims each destructive cleanup once.
> - The benefit is bounded workspace storage without sacrificing active, shared, dirty, or concurrently closing work.

## Linked Issues or Issue Description

No public GitHub issue exists for this core lifecycle bug.

Bug report:

- Preflight: searched open and closed issues/PRs; reproduced against `master`; confirmed the leak originates in Paperclip core rather than an adapter.
- What happened: moving an issue with a runtime-created execution workspace to `done` or `cancelled` left the workspace record active and its Git worktree on disk indefinitely.
- Expected behavior: a terminal transition should schedule the existing guarded close/archive lifecycle, wait for the active heartbeat to release runtime services, and remove only an eligible clean workspace.
- Steps to reproduce: configure a project with `git_worktree`, run an issue to create an execution workspace, move the issue to a terminal status, then observe that the workspace remains active and the worktree still exists.
- Version/deployment: reproduced from `master` in a source-built local/self-hosted deployment using PostgreSQL; regression coverage uses the embedded PostgreSQL test harness.
- Scope: core behavior, not adapter-specific; both agent and board terminal transitions are covered.

Related public work:

- Refs #5620 — earlier overlapping terminal closeout hook; this change additionally defers the running heartbeat, guards linked/dirty workspaces, and handles concurrent transitions.
- Refs #6402 — destructive cleanup guardrails for unreviewed Git state.
- Refs #6965 — operator-driven stale workspace reaper.
- Refs #9181 — shared workspace reuse and record-only archive behavior.
- Refs #9579 — closed workspace metadata cleanup.
- Supersedes #10026, which GitHub automatically closed when its fork branch was renamed to remove an internal ticket identifier.

## What Changed

- Added a terminal-workspace lifecycle service that schedules or performs cleanup through the existing workspace cleanup engine.
- Deferred agent-triggered cleanup until heartbeat finalization releases runtime services.
- Guarded inherited workspaces until every linked issue is terminal and preserved dirty/untracked isolated worktrees with an auditable reason.
- Atomically transitioned eligible workspace records before destructive cleanup so concurrent terminal transitions cannot remove the same worktree twice or overwrite a successful archive with `cleanup_failed`.
- Added embedded-PostgreSQL regression coverage for deferred cleanup, linked issues, dirty worktree preservation, and concurrent cleanup claims.
- Documented terminal issue workspace side effects in the implementation specification.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passed on the current head.
- `pnpm exec vitest run server/src/__tests__/execution-workspace-lifecycle.test.ts` — 4/4 passed on the current head, including the concurrent linked-issue regression.
- Earlier scoped integration matrix for the same lifecycle patch: 49/49 passed; isolated worktree suite: 34/34 passed.
- No Docker resources were created for verification.

## Risks

- Terminal transitions now automatically archive eligible execution workspaces.
- Cleanup is gated on all linked issues being terminal, waits for active heartbeat finalization, refuses automatic deletion with tracked or untracked changes, and uses a single atomic claimant for destructive work.
- Existing cleanup failures remain visible as `cleanup_failed` with warnings and workspace operation history.
- No database migration or UI change is included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, with reasoning, repository tool use, code execution, and test execution. The runtime does not expose a more specific backend model ID or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
