### PR TITLE
fix(release): publish bundled packages with trusted npm staging

### DIFF
--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -38,24 +38,33 @@ test("bundled package staging materializes publishConfig entrypoints", () => {
 
 test("bundled package staging replaces pnpm symlinks with a physical bundled tree", () => {
   const stagingDir = mkdtempSync(join(tmpdir(), "paperclip-bundled-staging-"));
-  const storePackageDir = join(
+  const storeModulesDir = join(
     stagingDir,
     "node_modules",
     ".pnpm",
     "acpx@0.12.0_patch_hash=abc",
     "node_modules",
+  );
+  const storePackageDir = join(
+    storeModulesDir,
     "acpx",
   );
   mkdirSync(storePackageDir, { recursive: true });
-  writeFileSync(join(storePackageDir, "package.json"), '{"name":"acpx","version":"0.12.0"}\n');
+  writeFileSync(
+    join(storePackageDir, "package.json"),
+    '{"name":"acpx","version":"0.12.0","dependencies":{"commander":"15.0.0"},"optionalDependencies":{"tsx":"4.23.0"}}\n',
+  );
   symlinkSync(storePackageDir, join(stagingDir, "node_modules", "acpx"), "dir");
 
-  materializeBundledNodeModules(stagingDir, ["acpx"]);
+  const runtimeDependencies = materializeBundledNodeModules(stagingDir, ["acpx"]);
 
   const stagedAcpx = join(stagingDir, "node_modules", "acpx");
   assert.equal(lstatSync(stagedAcpx).isSymbolicLink(), false);
   assert.equal(lstatSync(stagedAcpx).isDirectory(), true);
   assert.equal(existsSync(join(stagedAcpx, "package.json")), true);
+  assert.equal(existsSync(join(stagedAcpx, "node_modules")), false);
+  assert.deepEqual(runtimeDependencies.dependencies, { commander: "15.0.0" });
+  assert.deepEqual(runtimeDependencies.optionalDependencies, { tsx: "4.23.0" });
   assert.equal(existsSync(join(stagingDir, "node_modules", ".pnpm")), false);
 });
 

--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,7 +16,7 @@ import test from "node:test";
 
 import cliEsbuildConfig from "../cli/esbuild.config.mjs";
 import { bundledCliNpmDependencies } from "./cli-bundled-npm-dependencies.mjs";
-import { materializeBundledNodeModules, materializePublishManifest } from "./prepare-bundled-package.mjs";
+import { materializePublishManifest } from "./prepare-bundled-package.mjs";
 
 const rootPackage = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 const adapterUtilsPackage = JSON.parse(
@@ -36,41 +45,85 @@ test("bundled package staging materializes publishConfig entrypoints", () => {
   assert.deepEqual(staged.exports, adapterUtilsPackage.publishConfig.exports);
 });
 
-test("bundled package staging replaces pnpm symlinks with a physical bundled tree", () => {
-  const stagingDir = mkdtempSync(join(tmpdir(), "paperclip-bundled-staging-"));
-  const storeModulesDir = join(
-    stagingDir,
-    "node_modules",
-    ".pnpm",
-    "acpx@0.12.0_patch_hash=abc",
-    "node_modules",
-  );
-  const storePackageDir = join(
-    storeModulesDir,
-    "acpx",
-  );
-  mkdirSync(storePackageDir, { recursive: true });
-  writeFileSync(
-    join(storePackageDir, "package.json"),
-    '{"name":"acpx","version":"0.12.0","dependencies":{"commander":"15.0.0"},"optionalDependencies":{"tsx":"4.23.0"}}\n',
-  );
-  symlinkSync(storePackageDir, join(stagingDir, "node_modules", "acpx"), "dir");
+test("bundled package staging rebuilds npm dependencies and applies the acpx patch", (t) => {
+  const fixtureDir = mkdtempSync(join(tmpdir(), "paperclip-bundled-stage-"));
+  const sourceDir = join(fixtureDir, "source");
+  const destinationDir = join(fixtureDir, "destination");
+  const binDir = join(fixtureDir, "bin");
+  const callLog = join(fixtureDir, "calls.log");
+  mkdirSync(sourceDir);
+  mkdirSync(destinationDir);
+  mkdirSync(binDir);
+  writeFileSync(join(sourceDir, "package.json"), JSON.stringify(adapterUtilsPackage));
+  writeFileSync(callLog, "");
+  t.after(() => rmSync(fixtureDir, { recursive: true, force: true }));
 
-  const runtimeDependencies = materializeBundledNodeModules(stagingDir, ["acpx"]);
+  const writeExecutable = (name, body) => {
+    writeFileSync(join(binDir, name), body, { mode: 0o755 });
+  };
+  writeExecutable(
+    "pnpm",
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'pnpm %s\\n' "$*" >> "$FAKE_CALL_LOG"
+destination="\${!#}"
+cp "$FAKE_SOURCE_PACKAGE" "$destination/package.json"
+mkdir -p "$destination/node_modules/.pnpm"
+`,
+  );
+  writeExecutable(
+    "npm",
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'npm %s\\n' "$*" >> "$FAKE_CALL_LOG"
+[ "$*" = "install --omit=dev --ignore-scripts --no-audit --no-fund" ]
+mkdir -p node_modules/acpx/dist
+printf 'unpatched runtime\\n' > node_modules/acpx/dist/runtime.js
+`,
+  );
+  writeExecutable(
+    "patch",
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'patch %s\\n' "$*" >> "$FAKE_CALL_LOG"
+target=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-d" ]; then
+    target="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+patch_input="$(cat)"
+grep -q onAgentStderr <<< "$patch_input"
+printf 'patched onAgentStderr runtime\\n' > "$target/dist/runtime.js"
+`,
+  );
 
-  const stagedAcpx = join(stagingDir, "node_modules", "acpx");
-  assert.equal(lstatSync(stagedAcpx).isSymbolicLink(), false);
-  assert.equal(lstatSync(stagedAcpx).isDirectory(), true);
-  assert.equal(existsSync(join(stagedAcpx, "package.json")), true);
-  assert.equal(existsSync(join(stagedAcpx, "node_modules")), false);
-  assert.deepEqual(runtimeDependencies.dependencies, { commander: "15.0.0" });
-  assert.deepEqual(runtimeDependencies.optionalDependencies, { tsx: "4.23.0" });
-  assert.equal(existsSync(join(stagingDir, "node_modules", ".pnpm")), false);
-});
+  execFileSync(
+    process.execPath,
+    [new URL("./prepare-bundled-package.mjs", import.meta.url).pathname, sourceDir, destinationDir],
+    {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        FAKE_CALL_LOG: callLog,
+        FAKE_SOURCE_PACKAGE: join(sourceDir, "package.json"),
+      },
+      stdio: "pipe",
+    },
+  );
 
-test("bundled package publishes the packed tarball instead of the staged directory", () => {
-  assert.match(releaseLib, /run_bundled_npm_pack pack --pack-destination "\$PWD"/);
-  assert.match(releaseLib, /run_bundled_npm_publish publish "\.\/\$tarball"/);
+  const stagedAcpxDir = join(destinationDir, "node_modules/acpx");
+  assert.equal(lstatSync(stagedAcpxDir).isDirectory(), true);
+  assert.equal(lstatSync(stagedAcpxDir).isSymbolicLink(), false);
+  assert.equal(existsSync(join(destinationDir, "node_modules/.pnpm")), false);
+  assert.match(readFileSync(join(stagedAcpxDir, "dist/runtime.js"), "utf8"), /onAgentStderr/);
+  assert.match(
+    readFileSync(callLog, "utf8"),
+    /patch -p1 --forward -d .*node_modules\/acpx/,
+  );
 });
 
 test("bundled package dry runs preview without querying published versions", () => {
@@ -80,4 +133,5 @@ test("bundled package dry runs preview without querying published versions", () 
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PACK_VERSION"/);
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PUBLISH_VERSION"/);
   assert.match(releaseLib, /"\$@" --loglevel verbose/);
+  assert.match(releaseLib, /publish "\.\/\$tarball" --tag "\$dist_tag"/);
 });

--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import cliEsbuildConfig from "../cli/esbuild.config.mjs";
 import { bundledCliNpmDependencies } from "./cli-bundled-npm-dependencies.mjs";
-import { materializePublishManifest } from "./prepare-bundled-package.mjs";
+import { materializeBundledNodeModules, materializePublishManifest } from "./prepare-bundled-package.mjs";
 
 const rootPackage = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
 const adapterUtilsPackage = JSON.parse(
@@ -31,6 +34,34 @@ test("bundled package staging materializes publishConfig entrypoints", () => {
   assert.equal(staged.main, "./dist/index.js");
   assert.equal(staged.types, "./dist/index.d.ts");
   assert.deepEqual(staged.exports, adapterUtilsPackage.publishConfig.exports);
+});
+
+test("bundled package staging replaces pnpm symlinks with a physical bundled tree", () => {
+  const stagingDir = mkdtempSync(join(tmpdir(), "paperclip-bundled-staging-"));
+  const storePackageDir = join(
+    stagingDir,
+    "node_modules",
+    ".pnpm",
+    "acpx@0.12.0_patch_hash=abc",
+    "node_modules",
+    "acpx",
+  );
+  mkdirSync(storePackageDir, { recursive: true });
+  writeFileSync(join(storePackageDir, "package.json"), '{"name":"acpx","version":"0.12.0"}\n');
+  symlinkSync(storePackageDir, join(stagingDir, "node_modules", "acpx"), "dir");
+
+  materializeBundledNodeModules(stagingDir, ["acpx"]);
+
+  const stagedAcpx = join(stagingDir, "node_modules", "acpx");
+  assert.equal(lstatSync(stagedAcpx).isSymbolicLink(), false);
+  assert.equal(lstatSync(stagedAcpx).isDirectory(), true);
+  assert.equal(existsSync(join(stagedAcpx, "package.json")), true);
+  assert.equal(existsSync(join(stagingDir, "node_modules", ".pnpm")), false);
+});
+
+test("bundled package publishes the packed tarball instead of the staged directory", () => {
+  assert.match(releaseLib, /run_bundled_npm_pack pack --pack-destination "\$PWD"/);
+  assert.match(releaseLib, /run_bundled_npm_publish publish "\.\/\$tarball"/);
 });
 
 test("bundled package dry runs preview without querying published versions", () => {

--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -133,5 +133,6 @@ test("bundled package dry runs preview without querying published versions", () 
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PACK_VERSION"/);
   assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PUBLISH_VERSION"/);
   assert.match(releaseLib, /"\$@" --loglevel verbose/);
-  assert.match(releaseLib, /publish "\.\/\$tarball" --tag "\$dist_tag"/);
+  assert.match(releaseLib, /run_bundled_npm_publish publish --tag "\$dist_tag"/);
+  assert.doesNotMatch(releaseLib, /run_bundled_npm_publish publish "\.\/\$tarball"/);
 });

--- a/scripts/prepare-bundled-package.mjs
+++ b/scripts/prepare-bundled-package.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { cpSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -17,6 +17,31 @@ export function materializePublishManifest(pkg) {
 
   delete publishManifest.publishConfig;
   return publishManifest;
+}
+
+function patchedDependencyPackageName(specifier) {
+  const versionSeparator = specifier.lastIndexOf("@");
+  return versionSeparator > 0 ? specifier.slice(0, versionSeparator) : specifier;
+}
+
+export function applyBundledDependencyPatches(destinationDir, bundledDependencies) {
+  const rootPackage = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8"));
+  const patchedDependencies = rootPackage.pnpm?.patchedDependencies ?? {};
+  const bundledDependencyNames = new Set(bundledDependencies);
+
+  for (const [specifier, patchPath] of Object.entries(patchedDependencies)) {
+    const packageName = patchedDependencyPackageName(specifier);
+    if (!bundledDependencyNames.has(packageName)) continue;
+
+    execFileSync(
+      "patch",
+      ["-p1", "--forward", "-d", resolve(destinationDir, "node_modules", packageName)],
+      {
+        input: readFileSync(resolve(repoRoot, patchPath)),
+        stdio: ["pipe", "inherit", "inherit"],
+      },
+    );
+  }
 }
 
 export function prepareBundledPackage(sourceDir, destinationDir) {
@@ -34,58 +59,29 @@ export function prepareBundledPackage(sourceDir, destinationDir) {
     { cwd: repoRoot, stdio: "inherit" },
   );
 
-  const bundledRuntimeDependencies = materializeBundledNodeModules(
-    resolve(destinationDir),
-    bundledDependencies,
-  );
-
   const deployedPackagePath = resolve(destinationDir, "package.json");
   const deployedPackage = JSON.parse(readFileSync(deployedPackagePath, "utf8"));
-  deployedPackage.dependencies = {
-    ...bundledRuntimeDependencies.dependencies,
-    ...deployedPackage.dependencies,
-  };
-  deployedPackage.optionalDependencies = {
-    ...bundledRuntimeDependencies.optionalDependencies,
-    ...deployedPackage.optionalDependencies,
-  };
   writeFileSync(
     deployedPackagePath,
     `${JSON.stringify(materializePublishManifest(deployedPackage), null, 2)}\n`,
   );
-}
 
-/**
- * pnpm deploy links dependencies through the `.pnpm` virtual store, but npm
- * only bundles physical directories, so a symlinked layout publishes a
- * tarball with zero bundled files and silently drops the patched runtime.
- * Rebuild node_modules as a minimal physical tree holding only the bundled
- * dependencies. Their runtime dependencies are promoted into the staged root
- * manifest so npm installs the normal transitive closure for consumers.
- */
-export function materializeBundledNodeModules(destinationDir, bundledDependencies) {
-  const stagedModules = resolve(destinationDir, "node_modules");
-  const bundledSources = new Map(
-    bundledDependencies.map((name) => [name, realpathSync(resolve(stagedModules, name))]),
+  rmSync(resolve(destinationDir, "node_modules"), { recursive: true, force: true });
+  execFileSync(
+    "npm",
+    ["install", "--omit=dev", "--ignore-scripts", "--no-audit", "--no-fund"],
+    { cwd: destinationDir, stdio: "inherit" },
   );
+  applyBundledDependencyPatches(destinationDir, bundledDependencies);
 
-  const physicalModules = resolve(destinationDir, "node_modules.bundled-tmp");
-  const runtimeDependencies = { dependencies: {}, optionalDependencies: {} };
-  rmSync(physicalModules, { recursive: true, force: true });
-  for (const [name, sourcePath] of bundledSources) {
-    const bundledPackage = JSON.parse(readFileSync(resolve(sourcePath, "package.json"), "utf8"));
-    Object.assign(runtimeDependencies.dependencies, bundledPackage.dependencies);
-    Object.assign(runtimeDependencies.optionalDependencies, bundledPackage.optionalDependencies);
-
-    const target = resolve(physicalModules, name);
-    mkdirSync(dirname(target), { recursive: true });
-    cpSync(sourcePath, target, { recursive: true, dereference: true });
-    rmSync(resolve(target, "node_modules"), { recursive: true, force: true });
+  if (
+    bundledDependencies.includes("acpx") &&
+    !readFileSync(resolve(destinationDir, "node_modules/acpx/dist/runtime.js"), "utf8").includes(
+      "onAgentStderr",
+    )
+  ) {
+    throw new Error("staged acpx runtime is missing the repository patch");
   }
-
-  rmSync(stagedModules, { recursive: true, force: true });
-  renameSync(physicalModules, stagedModules);
-  return runtimeDependencies;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/prepare-bundled-package.mjs
+++ b/scripts/prepare-bundled-package.mjs
@@ -34,10 +34,21 @@ export function prepareBundledPackage(sourceDir, destinationDir) {
     { cwd: repoRoot, stdio: "inherit" },
   );
 
-  materializeBundledNodeModules(resolve(destinationDir), bundledDependencies);
+  const bundledRuntimeDependencies = materializeBundledNodeModules(
+    resolve(destinationDir),
+    bundledDependencies,
+  );
 
   const deployedPackagePath = resolve(destinationDir, "package.json");
   const deployedPackage = JSON.parse(readFileSync(deployedPackagePath, "utf8"));
+  deployedPackage.dependencies = {
+    ...bundledRuntimeDependencies.dependencies,
+    ...deployedPackage.dependencies,
+  };
+  deployedPackage.optionalDependencies = {
+    ...bundledRuntimeDependencies.optionalDependencies,
+    ...deployedPackage.optionalDependencies,
+  };
   writeFileSync(
     deployedPackagePath,
     `${JSON.stringify(materializePublishManifest(deployedPackage), null, 2)}\n`,
@@ -48,8 +59,9 @@ export function prepareBundledPackage(sourceDir, destinationDir) {
  * pnpm deploy links dependencies through the `.pnpm` virtual store, but npm
  * only bundles physical directories, so a symlinked layout publishes a
  * tarball with zero bundled files and silently drops the patched runtime.
- * Rebuild node_modules as a minimal physical tree holding exactly the
- * bundled dependencies.
+ * Rebuild node_modules as a minimal physical tree holding only the bundled
+ * dependencies. Their runtime dependencies are promoted into the staged root
+ * manifest so npm installs the normal transitive closure for consumers.
  */
 export function materializeBundledNodeModules(destinationDir, bundledDependencies) {
   const stagedModules = resolve(destinationDir, "node_modules");
@@ -58,15 +70,22 @@ export function materializeBundledNodeModules(destinationDir, bundledDependencie
   );
 
   const physicalModules = resolve(destinationDir, "node_modules.bundled-tmp");
+  const runtimeDependencies = { dependencies: {}, optionalDependencies: {} };
   rmSync(physicalModules, { recursive: true, force: true });
   for (const [name, sourcePath] of bundledSources) {
+    const bundledPackage = JSON.parse(readFileSync(resolve(sourcePath, "package.json"), "utf8"));
+    Object.assign(runtimeDependencies.dependencies, bundledPackage.dependencies);
+    Object.assign(runtimeDependencies.optionalDependencies, bundledPackage.optionalDependencies);
+
     const target = resolve(physicalModules, name);
     mkdirSync(dirname(target), { recursive: true });
     cpSync(sourcePath, target, { recursive: true, dereference: true });
+    rmSync(resolve(target, "node_modules"), { recursive: true, force: true });
   }
 
   rmSync(stagedModules, { recursive: true, force: true });
   renameSync(physicalModules, stagedModules);
+  return runtimeDependencies;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/prepare-bundled-package.mjs
+++ b/scripts/prepare-bundled-package.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { cpSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -34,12 +34,39 @@ export function prepareBundledPackage(sourceDir, destinationDir) {
     { cwd: repoRoot, stdio: "inherit" },
   );
 
+  materializeBundledNodeModules(resolve(destinationDir), bundledDependencies);
+
   const deployedPackagePath = resolve(destinationDir, "package.json");
   const deployedPackage = JSON.parse(readFileSync(deployedPackagePath, "utf8"));
   writeFileSync(
     deployedPackagePath,
     `${JSON.stringify(materializePublishManifest(deployedPackage), null, 2)}\n`,
   );
+}
+
+/**
+ * pnpm deploy links dependencies through the `.pnpm` virtual store, but npm
+ * only bundles physical directories, so a symlinked layout publishes a
+ * tarball with zero bundled files and silently drops the patched runtime.
+ * Rebuild node_modules as a minimal physical tree holding exactly the
+ * bundled dependencies.
+ */
+export function materializeBundledNodeModules(destinationDir, bundledDependencies) {
+  const stagedModules = resolve(destinationDir, "node_modules");
+  const bundledSources = new Map(
+    bundledDependencies.map((name) => [name, realpathSync(resolve(stagedModules, name))]),
+  );
+
+  const physicalModules = resolve(destinationDir, "node_modules.bundled-tmp");
+  rmSync(physicalModules, { recursive: true, force: true });
+  for (const [name, sourcePath] of bundledSources) {
+    const target = resolve(physicalModules, name);
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(sourcePath, target, { recursive: true, dereference: true });
+  }
+
+  rmSync(stagedModules, { recursive: true, force: true });
+  renameSync(physicalModules, stagedModules);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -327,16 +327,10 @@ run_package_publish() {
   local disable_provenance="${3:-false}"
 
   if [ "$publish_tool" = "npm" ]; then
-    local tarball
-    if ! tarball="$(set -o pipefail; run_bundled_npm_pack pack --pack-destination . 2>/dev/null | tail -1)"; then
-      return 1
-    fi
-    [ -n "$tarball" ] || return 1
-
     if [ "$disable_provenance" = "true" ]; then
-      run_bundled_npm_publish publish "./$tarball" --tag "$dist_tag" --access public --provenance=false
+      run_bundled_npm_publish publish --tag "$dist_tag" --access public --provenance=false
     else
-      run_bundled_npm_publish publish "./$tarball" --tag "$dist_tag" --access public
+      run_bundled_npm_publish publish --tag "$dist_tag" --access public
     fi
     return
   fi

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -327,10 +327,20 @@ run_package_publish() {
   local disable_provenance="${3:-false}"
 
   if [ "$publish_tool" = "npm" ]; then
+    # Publish a pre-packed tarball instead of the staged directory: npm 11's
+    # directory publish re-packs through libnpmpack, which dies with
+    # "Exit handler never called!" on CI runners before reaching the registry.
+    # A file spec skips that phase entirely while keeping trusted publishing.
+    local tarball
+    tarball="$(run_bundled_npm_pack pack --pack-destination "$PWD" | tail -n 1)"
+    if [ -z "$tarball" ] || [ ! -f "$PWD/$tarball" ]; then
+      release_warn "npm pack did not produce a tarball for the bundled package."
+      return 1
+    fi
     if [ "$disable_provenance" = "true" ]; then
-      run_bundled_npm_publish publish --tag "$dist_tag" --access public --provenance=false
+      run_bundled_npm_publish publish "./$tarball" --tag "$dist_tag" --access public --provenance=false
     else
-      run_bundled_npm_publish publish --tag "$dist_tag" --access public
+      run_bundled_npm_publish publish "./$tarball" --tag "$dist_tag" --access public
     fi
     return
   fi

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -327,16 +327,12 @@ run_package_publish() {
   local disable_provenance="${3:-false}"
 
   if [ "$publish_tool" = "npm" ]; then
-    # Publish a pre-packed tarball instead of the staged directory: npm 11's
-    # directory publish re-packs through libnpmpack, which dies with
-    # "Exit handler never called!" on CI runners before reaching the registry.
-    # A file spec skips that phase entirely while keeping trusted publishing.
     local tarball
-    tarball="$(run_bundled_npm_pack pack --pack-destination "$PWD" | tail -n 1)"
-    if [ -z "$tarball" ] || [ ! -f "$PWD/$tarball" ]; then
-      release_warn "npm pack did not produce a tarball for the bundled package."
+    if ! tarball="$(set -o pipefail; run_bundled_npm_pack pack --pack-destination . 2>/dev/null | tail -1)"; then
       return 1
     fi
+    [ -n "$tarball" ] || return 1
+
     if [ "$disable_provenance" = "true" ]; then
       run_bundled_npm_publish publish "./$tarball" --tag "$dist_tag" --access public --provenance=false
     else

--- a/scripts/release-lib.test.mjs
+++ b/scripts/release-lib.test.mjs
@@ -77,24 +77,44 @@ if [ "$1" = "view" ] && [ "$NPM_VERSION_EXISTS" = "true" ]; then
   echo "1.2.3"
   exit 0
 fi
-if [ "$1" = "publish" ]; then
-  echo "published"
-  exit 0
-fi
 if [ "$1" = "pack" ]; then
-  shift
-  destination="."
-  while [ "$#" -gt 0 ]; do
-    if [ "$1" = "--pack-destination" ]; then
-      destination="$2"
-      shift 2
-      continue
-    fi
-    shift
-  done
-  touch "$destination/paperclipai-example-1.2.3.tgz"
+  if [ "$PNPM_MODE" = "pack-failure" ]; then
+    echo "npm error pack failed" >&2
+    exit 1
+  fi
   echo "paperclipai-example-1.2.3.tgz"
   exit 0
+fi
+if [ "$1" = "publish" ]; then
+  case "$PNPM_MODE" in
+    success)
+      echo "published"
+      exit 0
+      ;;
+    tlog-then-success)
+      if [ ! -f "$FAKE_STATE_DIR/npm-called" ]; then
+        touch "$FAKE_STATE_DIR/npm-called"
+        echo "npm error code TLOG_CREATE_ENTRY_ERROR"
+        echo "npm error error creating tlog entry - (409) an equivalent entry already exists in the transparency log with UUID abc"
+        exit 1
+      fi
+      case " $* " in
+        *" --provenance=false "*)
+          echo "published without provenance"
+          exit 0
+          ;;
+      esac
+      ;;
+    tlog-always-fails)
+      echo "npm error code TLOG_CREATE_ENTRY_ERROR"
+      echo "npm error error creating tlog entry - (409) an equivalent entry already exists in the transparency log with UUID abc"
+      exit 1
+      ;;
+    non-tlog-failure)
+      echo "npm error code E500"
+      exit 1
+      ;;
+  esac
 fi
 exit 1
 `,
@@ -106,7 +126,9 @@ exit 1
 set -euo pipefail
 printf 'npx %s\n' "$*" >> "$FAKE_CALL_LOG"
 [ "$1" = "--yes" ] && shift
-case "$1" in npm@*) shift ;; esac
+case "$1" in
+  npm@10.9.7|npm@11.18.0) shift ;;
+esac
 exec npm "$@"
 `,
   );
@@ -156,11 +178,12 @@ test("publish_package_to_npm returns after a successful pnpm publish", () => {
   assert.doesNotMatch(result.calls, /--provenance=false/);
 });
 
-test("publish_package_to_npm uses trusted-publishing-capable npm for bundled dependencies", () => {
+test("publish_package_to_npm packs bundled dependencies before trusted publishing", () => {
   const result = runPublishHelper({ pnpmMode: "success", publishTool: "npm" });
 
   assert.equal(result.status, 0);
-  assert.match(result.calls, /^npx --yes npm@10\.9\.7 pack --pack-destination \S+$/m);
+  assert.match(result.calls, /^npx --yes npm@10\.9\.7 pack --pack-destination \.$/m);
+  assert.match(result.calls, /^npm pack --pack-destination \.$/m);
   assert.match(
     result.calls,
     /^npx --yes npm@11\.18\.0 publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --loglevel verbose$/m,
@@ -170,6 +193,28 @@ test("publish_package_to_npm uses trusted-publishing-capable npm for bundled dep
     /^npm publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --loglevel verbose$/m,
   );
   assert.doesNotMatch(result.calls, /^pnpm publish/m);
+});
+
+test("publish_package_to_npm retries bundled tarball tlog failures without provenance", () => {
+  const result = runPublishHelper({ pnpmMode: "tlog-then-success", publishTool: "npm" });
+
+  assert.equal(result.status, 0);
+  assert.match(result.calls, /^npm view @paperclipai\/example@1\.2\.3 version$/m);
+  assert.match(
+    result.calls,
+    /^npm publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --provenance=false --loglevel verbose$/m,
+  );
+});
+
+test("publish_package_to_npm does not mask bundled pack failures without caller pipefail", () => {
+  const result = runPublishHelper({
+    pnpmMode: "pack-failure",
+    publishTool: "npm",
+    callerPipefail: false,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.calls, / publish /);
 });
 
 test("publish_package_to_npm retries duplicate tlog failures without provenance", () => {

--- a/scripts/release-lib.test.mjs
+++ b/scripts/release-lib.test.mjs
@@ -77,14 +77,6 @@ if [ "$1" = "view" ] && [ "$NPM_VERSION_EXISTS" = "true" ]; then
   echo "1.2.3"
   exit 0
 fi
-if [ "$1" = "pack" ]; then
-  if [ "$PNPM_MODE" = "pack-failure" ]; then
-    echo "npm error pack failed" >&2
-    exit 1
-  fi
-  echo "paperclipai-example-1.2.3.tgz"
-  exit 0
-fi
 if [ "$1" = "publish" ]; then
   case "$PNPM_MODE" in
     success)
@@ -178,43 +170,31 @@ test("publish_package_to_npm returns after a successful pnpm publish", () => {
   assert.doesNotMatch(result.calls, /--provenance=false/);
 });
 
-test("publish_package_to_npm packs bundled dependencies before trusted publishing", () => {
+test("publish_package_to_npm uses trusted publishing from the bundled staging directory", () => {
   const result = runPublishHelper({ pnpmMode: "success", publishTool: "npm" });
 
   assert.equal(result.status, 0);
-  assert.match(result.calls, /^npx --yes npm@10\.9\.7 pack --pack-destination \.$/m);
-  assert.match(result.calls, /^npm pack --pack-destination \.$/m);
   assert.match(
     result.calls,
-    /^npx --yes npm@11\.18\.0 publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --loglevel verbose$/m,
+    /^npx --yes npm@11\.18\.0 publish --tag canary --access public --loglevel verbose$/m,
   );
   assert.match(
     result.calls,
-    /^npm publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --loglevel verbose$/m,
+    /^npm publish --tag canary --access public --loglevel verbose$/m,
   );
+  assert.doesNotMatch(result.calls, / pack /);
   assert.doesNotMatch(result.calls, /^pnpm publish/m);
 });
 
-test("publish_package_to_npm retries bundled tarball tlog failures without provenance", () => {
+test("publish_package_to_npm retries bundled directory tlog failures without provenance", () => {
   const result = runPublishHelper({ pnpmMode: "tlog-then-success", publishTool: "npm" });
 
   assert.equal(result.status, 0);
   assert.match(result.calls, /^npm view @paperclipai\/example@1\.2\.3 version$/m);
   assert.match(
     result.calls,
-    /^npm publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --provenance=false --loglevel verbose$/m,
+    /^npm publish --tag canary --access public --provenance=false --loglevel verbose$/m,
   );
-});
-
-test("publish_package_to_npm does not mask bundled pack failures without caller pipefail", () => {
-  const result = runPublishHelper({
-    pnpmMode: "pack-failure",
-    publishTool: "npm",
-    callerPipefail: false,
-  });
-
-  assert.notEqual(result.status, 0);
-  assert.doesNotMatch(result.calls, / publish /);
 });
 
 test("publish_package_to_npm retries duplicate tlog failures without provenance", () => {

--- a/scripts/release-lib.test.mjs
+++ b/scripts/release-lib.test.mjs
@@ -81,6 +81,21 @@ if [ "$1" = "publish" ]; then
   echo "published"
   exit 0
 fi
+if [ "$1" = "pack" ]; then
+  shift
+  destination="."
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--pack-destination" ]; then
+      destination="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  touch "$destination/paperclipai-example-1.2.3.tgz"
+  echo "paperclipai-example-1.2.3.tgz"
+  exit 0
+fi
 exit 1
 `,
   );
@@ -91,7 +106,7 @@ exit 1
 set -euo pipefail
 printf 'npx %s\n' "$*" >> "$FAKE_CALL_LOG"
 [ "$1" = "--yes" ] && shift
-[ "$1" = "npm@11.18.0" ] && shift
+case "$1" in npm@*) shift ;; esac
 exec npm "$@"
 `,
   );
@@ -145,11 +160,15 @@ test("publish_package_to_npm uses trusted-publishing-capable npm for bundled dep
   const result = runPublishHelper({ pnpmMode: "success", publishTool: "npm" });
 
   assert.equal(result.status, 0);
+  assert.match(result.calls, /^npx --yes npm@10\.9\.7 pack --pack-destination \S+$/m);
   assert.match(
     result.calls,
-    /^npx --yes npm@11\.18\.0 publish --tag canary --access public --loglevel verbose$/m,
+    /^npx --yes npm@11\.18\.0 publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --loglevel verbose$/m,
   );
-  assert.match(result.calls, /^npm publish --tag canary --access public --loglevel verbose$/m);
+  assert.match(
+    result.calls,
+    /^npm publish \.\/paperclipai-example-1\.2\.3\.tgz --tag canary --access public --loglevel verbose$/m,
+  );
   assert.doesNotMatch(result.calls, /^pnpm publish/m);
 });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip publishes its CLI, server, adapters, and shared packages through automated canary and stable release workflows.
> - `@paperclipai/adapter-utils` bundles the patched `acpx` runtime, so it must use npm 11 for OIDC trusted publishing.
> - The prior staging directory contained pnpm's `.pnpm` symlink forest, which crashes npm 11's directory-pack step on GitHub runners and produces a consumer-broken bundled dependency tree.
> - This pull request rebuilds staged production dependencies as a physical npm tree, reapplies repository patches, and publishes that clean directory directly with npm 11 trusted publishing.
> - The benefit is a release path that retains GitHub Actions OIDC trusted publishing while shipping a working patched acpx runtime to consumers.

## Linked Issues or Issue Description

Refs: #9980, #10030, #10041

No public GitHub issue exists for this release failure.

### What happened?

Canary and stable publishing began routing `@paperclipai/adapter-utils` through npm after it declared `bundleDependencies: ["acpx"]`. Publishing the pnpm-deployed directory with npm 11 crashes during npm's directory-pack phase on GitHub runners with `Exit handler never called!`. The same staged shape also produces a broken consumer artifact because acpx cannot resolve transitive runtime dependencies after installation.

### Expected behavior

Bundled packages publish directly from a self-contained staging directory through npm 11 OIDC trusted publishing, and consumers receive a working patched acpx runtime with its transitive dependencies.

### Steps to reproduce

1. Stage `packages/adapter-utils` using the old `pnpm deploy`-only shape.
2. Publish that directory with npm 11 on a GitHub runner.
3. npm crashes before registry/OIDC activity while walking the `.pnpm` symlink forest.
4. Install an artifact packed from that old shape into a fresh npm project and run acpx; its runtime dependency resolution fails.

### Deployment mode

GitHub Actions canary/stable release workflow.

### Relevant logs or output

```text
npm error Exit handler never called!
```

## What Changed

- After `pnpm deploy`, remove the staged pnpm `node_modules` tree and run `npm install --omit=dev --ignore-scripts --no-audit --no-fund` to create a physical hoisted production tree.
- Apply every root `pnpm.patchedDependencies` patch whose package is declared in the staged package's bundled dependencies, failing staging if any patch cannot apply.
- Assert the staged acpx runtime contains the required `onAgentStderr` patch marker.
- Publish the clean staging directory directly with pinned npm 11.18.0, retaining GitHub Actions OIDC trusted publishing, verbose diagnostics, and the duplicate-transparency-log retry without provenance.
- Keep pinned npm 10.9.7 packing only for local/dry-run payload verification; registry publishing does not use a tarball argument.
- Add focused coverage for npm-tree staging, patch application, direct directory publish arguments, and bundled tlog retries.

## Verification

- `bash -n scripts/release-lib.sh scripts/release.sh`
- `node --test scripts/release-lib.test.mjs scripts/acpx-patch-packaging.test.mjs` — 12/12 passed.
- `pnpm test:release-registry` — 68/68 passed.
- Real staging smoke: `node scripts/prepare-bundled-package.mjs packages/adapter-utils <stage>` produced a real `node_modules/acpx` directory, no `.pnpm` directory, and the `onAgentStderr` patch marker.
- Real npm 11 directory-publish smoke: `npx --yes npm@11.18.0 publish --dry-run --tag canary --access public --loglevel verbose` packed 26 bundled dependencies and reached the expected existing-version registry rejection without `Exit handler never called!`.
- The merge-triggered `publish_canary` workflow remains the live OIDC trusted-publishing verification.

## Risks

- The live GitHub Actions trusted-publishing path can only be fully proven by the merge-triggered canary run; npm debug-log upload remains available if it fails.
- Bundling acpx continues to freeze platform-specific transitive artifacts such as esbuild binaries from the Linux release runner. This is a pre-existing consequence of the bundling decision in #9980 and is not expanded here.
- Rebuilding dependencies with npm depends on the exact bundled dependency versions in the staged manifest; staging fails hard if repository patches no longer apply.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, exact model ID `gpt-5.6-sol`, high reasoning mode, with repository tool use and code execution. The harness did not expose a model context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
