### PR TITLE
fix(test): gate interaction-continuation retry barrier on terminal write

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2211,7 +2211,21 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         .select()
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.agentId, agentId));
-      return rows.length >= 2 ? rows : null;
+      if (rows.length < 2) return null;
+      // Gate on the *terminal* write of the background recovery, not the
+      // intermediate retry-run commit. recordPlanApprovalResumeFailureRetry
+      // writes the system comment first and updates the interaction
+      // result.resumeFailure last (heartbeat.ts:5627 then :5632), so once
+      // resumeFailure.status is observed the comment + issue update are also
+      // committed and every assertion below is race-free.
+      const interactionRow = await db
+        .select({ result: issueThreadInteractions.result })
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, interactionId))
+        .then((interactionRows) => interactionRows[0] ?? null);
+      const result = interactionRow?.result ?? null;
+      const resumeFailure = result && "resumeFailure" in result ? result.resumeFailure : null;
+      return resumeFailure?.status === "retrying" ? rows : null;
     });
     expect(runs).toHaveLength(2);
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat subsystem drives all agent lifecycle work — it executes agent runs, persists the results, and fires recovery logic when a run fails
> - The `heartbeat-process-recovery` test suite stress-tests the recovery paths, including the `interaction-continuation` retry flow where a failed agent interaction wake is retried with bounded back-off
> - The test `schedules bounded retries for failed accepted interaction continuation wakes` was intermittently failing on CI with `expected [] to have a length of 1 but got +0` at the system-comment assertion
> - The race: the old `waitForValue` barrier resolved as soon as `runs.length >= 2` (the retry-run row), then immediately read the system comment and interaction rows — but `recordPlanApprovalResumeFailureRetry` writes the retry-run row first, then (in sequence) the system comment and the interaction `result.resumeFailure` update last, so the poll could land between those writes and see an empty comments list
> - This pull request moves the barrier to the terminal write: it now returns only once both `runs.length >= 2` AND `interaction.result.resumeFailure.status === "retrying"` are observed, so every downstream assertion is race-free
> - The benefit is a deterministically stable test with no production-code change and no modified assertions

## Linked Issues or Issue Description

No public GitHub issue exists for this flaky test; describing inline below (following the bug template).

**What happened**

`heartbeat-process-recovery.test.ts` test `schedules bounded retries for failed accepted interaction continuation wakes` failed intermittently on CI with `expected [] to have a length of 1 but got +0` at the system-comment assertion (test line ~2277).

**Expected behavior**

The system-comment assertion should always find the comment present once the retry run has committed, because the recovery function writes the comment as part of the same recovery sequence.

**Steps to reproduce**

Inject a 150 ms delay in `heartbeat.ts` between the retry-run commit and the recovery-record call. With the old barrier (`runs.length >= 2` only), this causes 20/20 failures. The poll resolves on the retry-run row and then immediately queries the system comment and interaction rows — but `recordPlanApprovalResumeFailureRetry` writes in order: (1) retry-run row, (2) system comment, (3) interaction `result.resumeFailure` update. The poll can land between steps 1 and 2 and observe zero comments.

**Paperclip version or commit**

Reproduced on current `origin/master` (commit `4e8cd757e`). Fix rebased onto `master` at the same point.

**Deployment mode**

Server suite (vitest, no UI dependency).

## What Changed

- `server/src/__tests__/heartbeat-process-recovery.test.ts`: strengthened the `waitForValue` barrier for the interaction-continuation retry test to gate on the terminal write (`interaction.result.resumeFailure.status === "retrying"`) in addition to `runs.length >= 2`. Once the interaction update is visible, the retry-run row, wakeups, system comment, and issue update are all committed and every existing `expect` is race-free. All pre-existing assertions are preserved unchanged.

## Verification

- **Write-ordering claim confirmed:** `heartbeat.ts` inserts the system comment at line ~5627, then updates the interaction `result.resumeFailure` at ~5632, after the retry-run transaction commits — the terminal write is indeed last.
- **Deterministic repro:** OLD barrier + injected 150 ms delay → 20/20 fail; FIXED barrier + same delay → 20/20 pass; delay removed before committing.
- **Full-file loop >= 50x:** `npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` -> 50/50 pass.
- **Re-verified 10/10** after rebasing onto current `origin/master`.
- **Typecheck clean** for the changed file.

## Risks

Low risk. Test-only change. No production code modified. All existing assertions preserved — only the synchronization point is strengthened, so the test can no longer resolve early.

## Model Used

Claude Sonnet 4.6 (`claude-sonnet-4-6`), Anthropic — 200K context window, tool use, extended reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (N/A — test-only fix, no docs affected)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge