### PR TITLE
feat(plugin-sdk): human-attributed issue comments for chat gateway plugins

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -706,6 +706,7 @@ Governance helpers:
 - `ctx.issues.assertCheckoutOwner({ issueId, companyId, actorAgentId, actorRunId })` lets plugin actions preserve agent-run checkout ownership.
 - `ctx.issues.requestWakeup(issueId, companyId, options)` requests assignment wakeups through host heartbeat semantics, including terminal-status, blocker, assignee, and budget hard-stop checks.
 - `ctx.issues.requestWakeups(issueIds, companyId, options)` applies the same host-owned wakeup semantics to a batch and may use an idempotency key prefix for stable coordinator retries.
+- `ctx.issues.createComment(issueId, body, companyId, options)` posts a comment attributed to the plugin's own agent by default (`options.authorAgentId`). Passing `options.actorUserId` instead attributes the comment to that human company member — this requires `issue.comments.create_human_attributed` in addition to `issue.comments.create`, and the host independently verifies `actorUserId` is an active human member of the company before applying it, so a plugin can never forge attribution to an arbitrary or inactive user. A human-attributed comment on a non-terminal-status issue with an assignee also triggers the same assignee wakeup a board user's comment gets.
 
 Plugin-originated issue, relation, document, comment, and wakeup mutations must write activity entries with `actorType: "plugin"` and details fields for `sourcePluginId`, `sourcePluginKey`, `initiatingActorType`, `initiatingActorId`, and `initiatingRunId` when a user or agent run initiated the plugin work.
 
@@ -810,6 +811,7 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `issues.create`
 - `issues.update`
 - `issue.comments.create`
+- `issue.comments.create_human_attributed`
 - `issue.interactions.create`
 - `issue.documents.write`
 - `issue.relations.write`

--- a/packages/plugins/sdk/README.md
+++ b/packages/plugins/sdk/README.md
@@ -334,6 +334,7 @@ Declare in `manifest.capabilities`. Grouped by scope:
 | | `issues.checkout` |
 | | `issues.wakeup` |
 | | `issue.comments.create` |
+| | `issue.comments.create_human_attributed` |
 | | `issue.documents.write` |
 | | `issue.relations.write` |
 | | `activity.log.write` |
@@ -569,6 +570,26 @@ const summary = await ctx.issues.summaries.getOrchestration({
 });
 ```
 
+By default, `ctx.issues.createComment` attributes the comment to the calling
+plugin's own agent (`authorAgentId`). A plugin that relays a message a human
+actually sent — a chat gateway bridging Slack/Telegram replies back onto an
+issue, for example — can instead attribute the comment to that person by
+passing `actorUserId`:
+
+```ts
+await ctx.issues.createComment(issueId, replyText, companyId, {
+  actorUserId: verifiedSlackUser.paperclipUserId,
+});
+```
+
+This requires the `issue.comments.create_human_attributed` capability in
+addition to `issue.comments.create`. The host independently verifies that
+`actorUserId` is an active human member of the issue's company before
+applying the comment — a plugin cannot forge attribution to an arbitrary or
+inactive user id. When the issue has a non-terminal status and an assigned
+agent, a human-attributed comment also wakes that assignee, the same way a
+board user's comment does in the web app.
+
 Required capabilities:
 
 | API | Capability |
@@ -577,6 +598,8 @@ Required capabilities:
 | `ctx.issues.relations.setBlockedBy` / `addBlockers` / `removeBlockers` | `issue.relations.write` |
 | `ctx.issues.getSubtree` | `issue.subtree.read` |
 | `ctx.issues.assertCheckoutOwner` | `issues.checkout` |
+| `ctx.issues.createComment` | `issue.comments.create` |
+| `ctx.issues.createComment` with `actorUserId` | `issue.comments.create` + `issue.comments.create_human_attributed` |
 | `ctx.issues.requestWakeup` / `requestWakeups` | `issues.wakeup` |
 | `ctx.issues.summaries.getOrchestration` | `issues.orchestration.read` |
 

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -882,6 +882,13 @@ export function createHostClientHandlers(
       return services.issues.listComments(params);
     }),
     "issues.createComment": gated("issues.createComment", async (params) => {
+      if (params.actorUserId && !capabilitySet.has("issue.comments.create_human_attributed")) {
+        throw new CapabilityDeniedError(
+          pluginId,
+          "issues.createComment",
+          "issue.comments.create_human_attributed",
+        );
+      }
       return services.issues.createComment(params);
     }),
     "issues.createInteraction": gated("issues.createInteraction", async (params) => {

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -1449,7 +1449,14 @@ export interface WorkerToHostMethods {
     result: IssueComment[],
   ];
   "issues.createComment": [
-    params: { issueId: string; body: string; companyId: string; authorAgentId?: string },
+    params: {
+      issueId: string;
+      body: string;
+      companyId: string;
+      authorAgentId?: string;
+      /** Active human company member the comment is attributed to. Requires `issue.comments.create_human_attributed`. */
+      actorUserId?: string;
+    },
     result: IssueComment,
   ];
   "issues.createInteraction": [

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1673,6 +1673,9 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async createComment(issueId, body, companyId, options) {
         requireCapability(manifest, capabilitySet, "issue.comments.create");
+        if (options?.actorUserId) {
+          requireCapability(manifest, capabilitySet, "issue.comments.create_human_attributed");
+        }
         const parentIssue = issues.get(issueId);
         if (!isInCompany(parentIssue, companyId)) {
           throw new Error(`Issue not found: ${issueId}`);
@@ -1682,9 +1685,9 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           id: randomUUID(),
           companyId: parentIssue.companyId,
           issueId,
-          authorType: options?.authorAgentId ? "agent" : "system",
-          authorAgentId: options?.authorAgentId ?? null,
-          authorUserId: null,
+          authorType: options?.actorUserId ? "user" : options?.authorAgentId ? "agent" : "system",
+          authorAgentId: options?.actorUserId ? null : options?.authorAgentId ?? null,
+          authorUserId: options?.actorUserId ?? null,
           body,
           presentation: null,
           metadata: null,

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -1680,6 +1680,25 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         if (!isInCompany(parentIssue, companyId)) {
           throw new Error(`Issue not found: ${issueId}`);
         }
+        if (options?.actorUserId) {
+          // Mirror the host's `requireActiveHumanMember` check so the harness
+          // rejects the same forged attributions production does: the actor
+          // must be an active `user` member of the issue's company. Seed
+          // members via `createTestPluginHost({ accessMembers: [...] })`.
+          const actorUserId = options.actorUserId;
+          const isActiveHumanMember = [...accessMembers.values()].some(
+            (member) =>
+              member.companyId === companyId
+              && member.principalType === "user"
+              && member.principalId === actorUserId
+              && member.status === "active",
+          );
+          if (!isActiveHumanMember) {
+            throw new Error(
+              `actorUserId "${actorUserId}" is not an active human member of this company`,
+            );
+          }
+        }
         const now = new Date();
         const comment: IssueComment = {
           id: randomUUID(),

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -1331,6 +1331,7 @@ export interface PluginIssueSummariesClient {
  * - `issues.orchestration.read` for orchestration summaries
  * - `issue.comments.read` for `listComments`
  * - `issue.comments.create` for `createComment`
+ * - `issue.comments.create_human_attributed` for `createComment` calls that pass `actorUserId`
  * - `issue.interactions.create` for `createInteraction`, `suggestTasks`, `askUserQuestions`, `requestConfirmation`, and `requestCheckboxConfirmation`
  * - `issue.documents.read` for `documents.list` and `documents.get`
  * - `issue.documents.write` for `documents.upsert` and `documents.delete`
@@ -1434,11 +1435,29 @@ export interface PluginIssuesClient {
     } & PluginIssueMutationActor,
   ): Promise<PluginIssueWakeupBatchResult[]>;
   listComments(issueId: string, companyId: string): Promise<IssueComment[]>;
+  /**
+   * Post a comment on an issue.
+   *
+   * Pass `authorAgentId` to attribute the comment to the plugin's own agent
+   * identity (requires `issue.comments.create`, the default).
+   *
+   * Pass `actorUserId` to attribute the comment to a real human instead —
+   * for example, relaying a paired chat user's reply back into the issue
+   * thread. Requires the additional `issue.comments.create_human_attributed`
+   * capability. The host independently verifies that `actorUserId` is an
+   * active human member of the issue's company before applying the
+   * attribution — a plugin can only ever attribute comments to identities
+   * that could have posted them in the web app. A human-attributed comment
+   * also participates in the normal wake-the-assignee behavior a board
+   * user's comment gets in the web app (subject to the same closed-issue /
+   * no-assignee exclusions) — unlike a plugin's own agent-attributed
+   * comments, which never wake anyone.
+   */
   createComment(
     issueId: string,
     body: string,
     companyId: string,
-    options?: { authorAgentId?: string },
+    options?: { authorAgentId?: string; actorUserId?: string },
   ): Promise<IssueComment>;
   createInteraction(
     issueId: string,

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -864,8 +864,19 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
           return callHost("issues.listComments", { issueId, companyId });
         },
 
-        async createComment(issueId: string, body: string, companyId: string, options?: { authorAgentId?: string }) {
-          return callHost("issues.createComment", { issueId, body, companyId, authorAgentId: options?.authorAgentId });
+        async createComment(
+          issueId: string,
+          body: string,
+          companyId: string,
+          options?: { authorAgentId?: string; actorUserId?: string },
+        ) {
+          return callHost("issues.createComment", {
+            issueId,
+            body,
+            companyId,
+            authorAgentId: options?.authorAgentId,
+            actorUserId: options?.actorUserId,
+          });
         },
 
         async createInteraction(issueId: string, interaction, companyId: string, options?: { authorAgentId?: string }) {

--- a/packages/plugins/sdk/tests/host-client-factory.test.ts
+++ b/packages/plugins/sdk/tests/host-client-factory.test.ts
@@ -231,4 +231,78 @@ describe("createHostClientHandlers invocation company scope", () => {
     ).rejects.toBeInstanceOf(InvocationScopeDeniedError);
     expect(searchAudit).not.toHaveBeenCalled();
   });
+
+  it("rejects a human-attributed createComment call when only issue.comments.create is granted", async () => {
+    const createComment = vi.fn(async () => ({ id: "comment-1" }));
+    const services = {
+      issues: { createComment },
+    } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["issue.comments.create"],
+      services,
+    });
+    const context = { invocationScope: { companyId: "company-a" } };
+
+    await expect(
+      handlers["issues.createComment"]({
+        issueId: "issue-a",
+        body: "hello",
+        companyId: "company-a",
+        actorUserId: "user-a",
+      }, context),
+    ).rejects.toBeInstanceOf(CapabilityDeniedError);
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it("allows a human-attributed createComment call once issue.comments.create_human_attributed is also granted", async () => {
+    const createComment = vi.fn(async () => ({ id: "comment-1" }));
+    const services = {
+      issues: { createComment },
+    } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["issue.comments.create", "issue.comments.create_human_attributed"],
+      services,
+    });
+    const context = { invocationScope: { companyId: "company-a" } };
+
+    await expect(
+      handlers["issues.createComment"]({
+        issueId: "issue-a",
+        body: "hello",
+        companyId: "company-a",
+        actorUserId: "user-a",
+      }, context),
+    ).resolves.toEqual({ id: "comment-1" });
+    expect(createComment).toHaveBeenCalledWith({
+      issueId: "issue-a",
+      body: "hello",
+      companyId: "company-a",
+      actorUserId: "user-a",
+    });
+  });
+
+  it("still allows a plain agent-attributed createComment call without the human-attribution capability", async () => {
+    const createComment = vi.fn(async () => ({ id: "comment-2" }));
+    const services = {
+      issues: { createComment },
+    } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["issue.comments.create"],
+      services,
+    });
+    const context = { invocationScope: { companyId: "company-a" } };
+
+    await expect(
+      handlers["issues.createComment"]({
+        issueId: "issue-a",
+        body: "hello",
+        companyId: "company-a",
+        authorAgentId: "agent-a",
+      }, context),
+    ).resolves.toEqual({ id: "comment-2" });
+    expect(createComment).toHaveBeenCalled();
+  });
 });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1256,6 +1256,7 @@ export const PLUGIN_CAPABILITIES = [
   "issues.checkout",
   "issues.wakeup",
   "issue.comments.create",
+  "issue.comments.create_human_attributed",
   "issue.interactions.create",
   "issue.documents.write",
   "projects.managed",

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -9,10 +9,13 @@ import {
   agentWakeupRequests,
   agents,
   companies,
+  companyMemberships,
   costEvents,
   createDb,
   executionWorkspaces,
+  heartbeatRunEvents,
   heartbeatRuns,
+  issueComments,
   issueRelations,
   issues,
   pluginManagedResources,
@@ -59,19 +62,45 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     db = createDb(tempDb.connectionString);
   }, 20_000);
 
+  function isHeartbeatRunDependentFkError(error: unknown) {
+    const message = error instanceof Error ? `${error.message} ${String(error.cause ?? "")}` : String(error);
+    return (
+      message.includes("heartbeat_run_events_run_id_heartbeat_runs_id_fk")
+      || message.includes("activity_log_run_id_heartbeat_runs_id_fk")
+    );
+  }
+
+  // A real (fire-and-forget) heartbeat run may still be executing in the
+  // background when a test's own createComment-triggered wakeup completes —
+  // retry deletion so that race doesn't fail cleanup with an FK violation.
+  async function deleteHeartbeatRunsWithDependents() {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await db.delete(heartbeatRunEvents);
+      await db.delete(activityLog);
+      try {
+        await db.delete(heartbeatRuns);
+        return;
+      } catch (error) {
+        if (!isHeartbeatRunDependentFkError(error) || attempt === 4) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+  }
+
   afterEach(async () => {
     await Promise.all(tempRoots.map((root) => fs.rm(root, { recursive: true, force: true })));
     tempRoots.length = 0;
-    await db.delete(activityLog);
     await db.delete(costEvents);
-    await db.delete(heartbeatRuns);
+    await deleteHeartbeatRunsWithDependents();
     await db.delete(agentWakeupRequests);
     await db.delete(issueRelations);
+    await db.delete(issueComments);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
     await db.delete(pluginManagedResources);
     await db.delete(projects);
     await db.delete(plugins);
+    await db.delete(companyMemberships);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -730,5 +759,97 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
       cachedInputTokens: 3,
       outputTokens: 6,
     });
+  });
+
+  it("rejects a human-attributed plugin comment when actorUserId is not an active company member", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs human input",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.gateway", createEventBusStub());
+    await expect(
+      services.issues.createComment({
+        issueId,
+        companyId,
+        body: "Here's my answer",
+        actorUserId: randomUUID(),
+      }),
+    ).rejects.toThrow("is not an active human member of this company");
+
+    await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
+  });
+
+  it("creates a human-attributed plugin comment and wakes the issue's assignee", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const humanUserId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: humanUserId,
+      status: "active",
+      membershipRole: "owner",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs human input",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    // Cap concurrency at 1 and pre-seed a running run so enqueueWakeup's
+    // queued-run bookkeeping is exercised without startNextQueuedRunForAgent
+    // going on to actually claim/execute the new run — that path spins up
+    // real environment/adapter orchestration this test has no business
+    // depending on (and which races the test's own db teardown).
+    await db.update(agents).set({ runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } } }).where(eq(agents.id, agentId));
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      contextSnapshot: {},
+    });
+
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.gateway", createEventBusStub());
+    const comment = await services.issues.createComment({
+      issueId,
+      companyId,
+      body: "Here's my answer",
+      actorUserId: humanUserId,
+    });
+
+    expect(comment).toMatchObject({
+      authorType: "user",
+      authorUserId: humanUserId,
+      authorAgentId: null,
+      body: "Here's my answer",
+    });
+
+    const [wakeupRequest] = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)));
+    expect(wakeupRequest).toMatchObject({
+      reason: "issue_commented",
+      requestedByActorType: "user",
+      requestedByActorId: humanUserId,
+    });
+    expect(wakeupRequest?.status).toBe("queued");
+    expect(wakeupRequest?.runId).toEqual(expect.any(String));
+
+    const [run] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, wakeupRequest!.runId!));
+    expect(run).toMatchObject({ agentId, companyId, status: "queued" });
   });
 });

--- a/server/src/__tests__/plugin-sdk-testing.test.ts
+++ b/server/src/__tests__/plugin-sdk-testing.test.ts
@@ -160,4 +160,96 @@ describe("plugin SDK test harness", () => {
     expect(JSON.stringify(comments)).not.toContain("secret plugin-visible body");
     expect(JSON.stringify(comments)).not.toContain("secret plugin metadata");
   });
+
+  it("rejects a human-attributed comment when the actorUserId is not an active member", async () => {
+    const manifest: PaperclipPluginManifestV1 = {
+      id: "paperclip.test-human-attributed-comment-unverified",
+      apiVersion: 1,
+      version: "0.1.0",
+      displayName: "Human-Attributed Comment (unverified)",
+      description: "Test plugin",
+      author: "Paperclip",
+      categories: ["automation"],
+      capabilities: ["issue.comments.create", "issue.comments.create_human_attributed"],
+      entrypoints: { worker: "./dist/worker.js" },
+    };
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      issues: [{
+        id: "issue-1",
+        companyId: "company-1",
+        title: "Human attribution",
+        status: "todo",
+        priority: "medium",
+      }],
+      // A suspended member must not satisfy the active-human-member check —
+      // the harness mirrors the host's `requireActiveHumanMember` guard so a
+      // plugin test cannot pass an attribution production would reject.
+      accessMembers: [{
+        id: "member-suspended",
+        companyId: "company-1",
+        principalType: "user",
+        principalId: "user-1",
+        status: "suspended",
+        membershipRole: "member",
+        grants: [],
+        createdAt: new Date("2026-06-03T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-03T11:00:00.000Z"),
+      }],
+    });
+
+    await expect(
+      harness.ctx.issues.createComment("issue-1", "relayed reply", "company-1", { actorUserId: "user-1" }),
+    ).rejects.toThrow('actorUserId "user-1" is not an active human member of this company');
+  });
+
+  it("attributes a comment to an active human member for a verified actorUserId", async () => {
+    const manifest: PaperclipPluginManifestV1 = {
+      id: "paperclip.test-human-attributed-comment-verified",
+      apiVersion: 1,
+      version: "0.1.0",
+      displayName: "Human-Attributed Comment (verified)",
+      description: "Test plugin",
+      author: "Paperclip",
+      categories: ["automation"],
+      capabilities: ["issue.comments.create", "issue.comments.create_human_attributed"],
+      entrypoints: { worker: "./dist/worker.js" },
+    };
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      issues: [{
+        id: "issue-1",
+        companyId: "company-1",
+        title: "Human attribution",
+        status: "todo",
+        priority: "medium",
+      }],
+      accessMembers: [{
+        id: "member-active",
+        companyId: "company-1",
+        principalType: "user",
+        principalId: "user-1",
+        status: "active",
+        membershipRole: "member",
+        grants: [],
+        createdAt: new Date("2026-06-03T11:00:00.000Z"),
+        updatedAt: new Date("2026-06-03T11:00:00.000Z"),
+      }],
+    });
+
+    const comment = await harness.ctx.issues.createComment(
+      "issue-1",
+      "relayed reply",
+      "company-1",
+      { actorUserId: "user-1" },
+    );
+
+    expect(comment).toMatchObject({
+      issueId: "issue-1",
+      authorType: "user",
+      authorUserId: "user-1",
+      authorAgentId: null,
+      body: "relayed reply",
+    });
+  });
 });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -4,6 +4,7 @@ import {
   agentTaskSessions as agentTaskSessionsTable,
   agents as agentsTable,
   budgetIncidents,
+  companyMemberships,
   costEvents,
   heartbeatRuns,
   invites,
@@ -652,6 +653,30 @@ export function buildHostServices(
       throw new Error(`${entityName} not found`);
     }
     return record;
+  };
+
+  /**
+   * Verify `userId` is an active human member of `companyId` before letting a
+   * plugin attribute a mutation to them. Mirrors the authorization bar the
+   * web app's own board routes apply — a plugin can only ever attribute an
+   * action to an identity that could have taken it in the web app itself.
+   * Used by any plugin capability that accepts an `actorUserId` (currently
+   * `createComment`'s human-attributed path).
+   */
+  const requireActiveHumanMember = async (companyId: string, userId: string): Promise<void> => {
+    const [membership] = await db
+      .select({ id: companyMemberships.id })
+      .from(companyMemberships)
+      .where(and(
+        eq(companyMemberships.companyId, companyId),
+        eq(companyMemberships.principalType, "user"),
+        eq(companyMemberships.principalId, userId),
+        eq(companyMemberships.status, "active"),
+      ))
+      .limit(1);
+    if (!membership) {
+      throw new Error(`actorUserId "${userId}" is not an active human member of this company`);
+    }
   };
 
   const pluginActivityDetails = (
@@ -2012,23 +2037,67 @@ export function buildHostServices(
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
         const issue = requireInCompany("Issue", await issues.getById(params.issueId), companyId);
+        if (params.actorUserId) {
+          await requireActiveHumanMember(companyId, params.actorUserId);
+        }
         const comment = (await issues.addComment(
           params.issueId,
           params.body,
-          { agentId: params.authorAgentId },
+          { agentId: params.actorUserId ? undefined : params.authorAgentId, userId: params.actorUserId },
         )) as IssueComment;
         await logPluginActivity({
           companyId,
           action: "issue.comment.created",
           entityType: "issue",
           entityId: issue.id,
-          actor: { actorAgentId: params.authorAgentId ?? null },
+          actor: { actorAgentId: params.actorUserId ? null : params.authorAgentId ?? null, actorUserId: params.actorUserId ?? null },
           details: {
             identifier: issue.identifier,
             commentId: comment.id,
             bodySnippet: comment.body.slice(0, 120),
           },
         });
+
+        // Human-attributed comments participate in the same "wake the
+        // assignee" behavior a board user's comment gets in the web app
+        // (routes/issues.ts's addComment route) — a plugin's own
+        // agent-attributed comments never do this. Deliberately narrower
+        // than the HTTP route: no reopen/resume/interrupt/scheduled-retry
+        // handling here, just the core wake. An assignee-less or
+        // closed-status issue is a silent no-op, matching the route's own
+        // guard.
+        if (
+          params.actorUserId
+          && issue.assigneeAgentId
+          && issue.status !== "done"
+          && issue.status !== "cancelled"
+        ) {
+          await heartbeat.wakeup(issue.assigneeAgentId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_commented",
+            payload: {
+              issueId: issue.id,
+              commentId: comment.id,
+              mutation: "comment",
+            },
+            requestedByActorType: "user",
+            requestedByActorId: params.actorUserId,
+            contextSnapshot: {
+              issueId: issue.id,
+              taskId: issue.id,
+              sourceCommentId: comment.id,
+              wakeReason: "issue_commented",
+              source: `plugin:${pluginKey}`,
+            },
+          }).catch((err) => logger.warn({
+            err,
+            issueId: issue.id,
+            commentId: comment.id,
+            agentId: issue.assigneeAgentId,
+          }, "failed to wake assignee on plugin-relayed human comment"));
+        }
+
         return comment;
       },
       async createInteraction(params) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work; agents and humans collaborate on issues through comments.
> - Plugins run in a sandboxed worker and reach the host only through capability-gated `ctx.*` calls — a plugin cannot mutate company data except through those checked surfaces.
> - Chat gateway plugins (Slack/Telegram bridges) relay messages that a real human typed; when they post those back onto an issue they should be attributed to that human, not to the plugin's own agent.
> - The gap: `ctx.issues.createComment` could only attribute a comment to the plugin's agent, so a Slack reply to an issue-comment notification lost the human identity.
> - This pull request adds a separately-gated capability and an `actorUserId` option, and — critically — has the host independently verify the attribution against active company membership so a plugin can never forge a comment as an arbitrary or inactive user.
> - The benefit is that gateway plugins can round-trip human replies with correct attribution and the same assignee-wakeup behavior a board user's comment gets, without weakening the trust boundary.

## Linked Issues or Issue Description

No public GitHub issue exists for this change. The underlying need is described inline below, following the feature request template.

**Problem or motivation**

Chat gateway plugins relay messages a human actually sent. Comments they post on behalf of that person were attributed to the plugin's own agent, so the human identity was lost and the issue assignee was not woken the way a board user's comment wakes them.

**Proposed solution**

Add a separately-gated `issue.comments.create_human_attributed` capability and an `actorUserId` option on `ctx.issues.createComment`. The host verifies `actorUserId` is an active `user` member of the issue's company before applying the comment, then attributes the comment to that human and triggers the standard assignee wakeup for non-terminal, assigned issues.

**Alternatives considered**

Keep attributing to the plugin's agent (rejected — loses the human identity that gateways exist to carry). Trust the plugin's claimed `actorUserId` without host verification (rejected — a plugin could forge attribution to any user). Reuse the existing `issue.comments.create` capability (rejected — human attribution is more sensitive and deserves its own gate).

**Roadmap alignment**

Supports the plugin/gateway integration surface; no change to planned core roadmap items.

## What Changed

- Adds `issue.comments.create_human_attributed` capability, gated separately from `issue.comments.create`.
- `ctx.issues.createComment(...)` accepts an `actorUserId` option; the host independently verifies via `requireActiveHumanMember` that `actorUserId` is an active human company member before applying the comment, so a plugin can never forge attribution.
- A human-attributed comment on a non-terminal issue with an assignee wakes that assignee, mirroring the web app's `routes/issues.ts` add-comment behavior.
- Updates SDK types/protocol/host-client-factory/testing/worker-rpc-host, `PLUGIN_SPEC.md`, and the SDK README.
- Test harness (`testing.ts`) now mirrors the host's active-human-member check, so a plugin author cannot write a passing test for an attribution production would reject (addresses Greptile P2).

## Verification

- `pnpm --filter @paperclipai/plugin-sdk build` (typechecks shared + sdk) — clean.
- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-sdk-testing.test.ts` — 7/7 (2 new: reject-when-suspended, succeed-when-active).
- `pnpm --filter @paperclipai/plugin-sdk exec vitest run tests/host-client-factory.test.ts` — 14/14.
- `server/src/__tests__/plugin-orchestration-apis.test.ts` covers rejection when `actorUserId` isn't an active member and successful attribution + assignee wakeup.

## Risks

Low risk. The new behavior is opt-in behind a dedicated capability and does not change existing agent-attributed comment flows. The host-side membership check is the trust boundary and is covered by tests. The assignee wakeup is best-effort (failures are logged, not thrown) and deliberately mirrors the existing HTTP add-comment route; it uses the pre-insert issue snapshot exactly as that route does, so it introduces no new race class relative to current behavior.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, tool use enabled, via Claude Code running as the Paperclip CTO agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list (open and recently closed) for similar PRs; found duplicate #10048 (being closed in favor of this one), otherwise not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
