### PR TITLE
fix(heartbeat): cancel same-run self-comment wakes

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -13,7 +13,10 @@ import {
   issues,
 } from "@paperclipai/db";
 import { runningProcesses } from "../adapters/index.js";
-import { heartbeatService } from "../services/heartbeat.ts";
+import {
+  allReferencedCommentsAreSelfAuthored,
+  heartbeatService,
+} from "../services/heartbeat.ts";
 import { SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY } from "../services/recovery/index.ts";
 import {
   getEmbeddedPostgresTestSupport,
@@ -29,6 +32,20 @@ if (!embeddedPostgresSupport.supported) {
     `Skipping embedded Postgres heartbeat comment wake batching tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
   );
 }
+
+describe("self-authored deferred comment classification", () => {
+  it("does not suppress a batch when any referenced comment is missing", () => {
+    expect(
+      allReferencedCommentsAreSelfAuthored({
+        referencedCommentIds: ["self-comment", "missing-comment"],
+        resolvedComments: [
+          { id: "self-comment", createdByRunId: "closing-run" },
+        ],
+        runId: "closing-run",
+      }),
+    ).toBe(false);
+  });
+});
 
 async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000, intervalMs = 50) {
   const startedAt = Date.now();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1366,6 +1366,214 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
+  it("promotes an approval follow-up coalesced with a self-authored deferred comment wake", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Local CLI Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Approval follow-up must survive self-comment suppression",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const selfComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "local-cli-user",
+          createdByRunId: firstRun?.id ?? null,
+          body: "Closing comment from the same run",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredCommentRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: selfComment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: selfComment.id,
+          wakeCommentId: selfComment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "local-cli-user",
+      });
+
+      expect(deferredCommentRun).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select({ id: agentWakeupRequests.id })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      const approvalRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "approval_approved",
+        payload: {
+          issueId,
+          approvalId: "approval-1",
+          approvalStatus: "approved",
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          approvalId: "approval-1",
+          approvalStatus: "approved",
+          wakeReason: "approval_approved",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "local-board",
+      });
+
+      expect(approvalRun).toBeNull();
+
+      const deferredWake = await db
+        .select({
+          id: agentWakeupRequests.id,
+          coalescedCount: agentWakeupRequests.coalescedCount,
+          payload: agentWakeupRequests.payload,
+        })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, agentId),
+            eq(agentWakeupRequests.status, "deferred_issue_execution"),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      expect(deferredWake).not.toBeNull();
+      expect(deferredWake?.coalescedCount).toBe(1);
+      expect((deferredWake?.payload as Record<string, unknown>)._paperclipWakeContext).toMatchObject({
+        wakeCommentIds: [selfComment.id],
+        wakeReason: "approval_approved",
+        approvalId: "approval-1",
+        approvalStatus: "approved",
+      });
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        return (
+          runs.length === 2 &&
+          runs[0]?.id === firstRun?.id &&
+          runs.every((run) => run.status === "succeeded")
+        );
+      }, 90_000);
+
+      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      expect(secondPayload.paperclip).toBeUndefined();
+      const secondWake = parseWakePayloadFromMessage(secondPayload.message);
+      expect(secondWake).toMatchObject({
+        reason: "approval_approved",
+        commentIds: [selfComment.id],
+        latestCommentId: selfComment.id,
+      });
+
+      const completedDeferredWake = await db
+        .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, deferredWake!.id))
+        .then((rows) => rows[0] ?? null);
+      expect(completedDeferredWake).toMatchObject({ status: "completed", error: null });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
   it("still reopens a finished issue when a deferred batch mixes self-authored and human comments", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1176,8 +1176,9 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("does not promote a same-agent deferred comment wake that is self-authored by the closing run", async () => {
-    const gateway = await createControlledGatewayServer();
+  for (const wakeReason of ["issue_commented", "issue_comment_mentioned"] as const) {
+    it(`does not promote a same-agent deferred ${wakeReason} wake that is self-authored by the closing run`, async () => {
+      const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
     const issueId = randomUUID();
@@ -1269,14 +1270,14 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       const deferredRun = await heartbeat.wakeup(agentId, {
         source: "automation",
         triggerDetail: "system",
-        reason: "issue_commented",
+        reason: wakeReason,
         payload: { issueId, commentId: selfComment.id },
         contextSnapshot: {
           issueId,
           taskId: issueId,
           commentId: selfComment.id,
           wakeCommentId: selfComment.id,
-          wakeReason: "issue_commented",
+          wakeReason,
         },
         requestedByActorType: "user",
         requestedByActorId: "local-cli-user",
@@ -1364,7 +1365,8 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       gateway.releaseFirstWait();
       await gateway.close();
     }
-  }, 120_000);
+    }, 120_000);
+  }
 
   it("promotes an approval follow-up coalesced with a self-authored deferred comment wake", async () => {
     const gateway = await createControlledGatewayServer();
@@ -1561,6 +1563,14 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         commentIds: [selfComment.id],
         latestCommentId: selfComment.id,
       });
+
+      const issueAfterFollowUp = await db
+        .select({ status: issues.status, completedAt: issues.completedAt })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issueAfterFollowUp).toMatchObject({ status: "done" });
+      expect(issueAfterFollowUp?.completedAt).not.toBeNull();
 
       const completedDeferredWake = await db
         .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
-import { and, asc, desc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { WebSocketServer } from "ws";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -1267,9 +1267,10 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       expect(deferredRun).toBeNull();
 
+      let deferredWakeId: string | null = null;
       await waitFor(async () => {
         const deferred = await db
-          .select()
+          .select({ id: agentWakeupRequests.id })
           .from(agentWakeupRequests)
           .where(
             and(
@@ -1279,8 +1280,10 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
             ),
           )
           .then((rows) => rows[0] ?? null);
-        return Boolean(deferred);
+        deferredWakeId = deferred?.id ?? null;
+        return Boolean(deferredWakeId);
       });
+      const targetWakeId = deferredWakeId!;
 
       await db
         .update(issues)
@@ -1300,14 +1303,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         const wake = await db
           .select({ status: agentWakeupRequests.status })
           .from(agentWakeupRequests)
-          .where(
-            and(
-              eq(agentWakeupRequests.companyId, companyId),
-              eq(agentWakeupRequests.agentId, agentId),
-            ),
-          )
-          .orderBy(desc(agentWakeupRequests.requestedAt))
-          .limit(1)
+          .where(eq(agentWakeupRequests.id, targetWakeId))
           .then((rows) => rows[0] ?? null);
         return wake?.status !== "deferred_issue_execution";
       }, 90_000);
@@ -1318,14 +1314,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           error: agentWakeupRequests.error,
         })
         .from(agentWakeupRequests)
-        .where(
-          and(
-            eq(agentWakeupRequests.companyId, companyId),
-            eq(agentWakeupRequests.agentId, agentId),
-          ),
-        )
-        .orderBy(desc(agentWakeupRequests.requestedAt))
-        .limit(1)
+        .where(eq(agentWakeupRequests.id, targetWakeId))
         .then((rows) => rows[0] ?? null);
       expect(deferredWake).toMatchObject({
         status: "cancelled",

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, desc, eq } from "drizzle-orm";
 import { WebSocketServer } from "ws";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -1159,7 +1159,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("does not reopen a finished issue when the deferred comment wake is self-authored by the closing run", async () => {
+  it("does not promote a same-agent deferred comment wake that is self-authored by the closing run", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -1296,17 +1296,50 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
 
       gateway.releaseFirstWait();
 
-      // The deferred wake still promotes (so the agent gets the message), but
-      // the issue must remain `done` because the only referenced comment is
-      // self-authored by the run that is now ending.
-      await waitFor(() => gateway.getAgentPayloads().length === 2, 90_000);
       await waitFor(async () => {
-        const runs = await db
-          .select()
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.agentId, agentId));
-        return runs.length === 2 && runs.every((run) => run.status === "succeeded");
+        const wake = await db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+            ),
+          )
+          .orderBy(desc(agentWakeupRequests.requestedAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        return wake?.status !== "deferred_issue_execution";
       }, 90_000);
+
+      const deferredWake = await db
+        .select({
+          status: agentWakeupRequests.status,
+          error: agentWakeupRequests.error,
+        })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, agentId),
+          ),
+        )
+        .orderBy(desc(agentWakeupRequests.requestedAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      expect(deferredWake).toMatchObject({
+        status: "cancelled",
+        error: "Deferred comment wake suppressed because every referenced comment was authored by the closing run",
+      });
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.status).toBe("succeeded");
+      expect(gateway.getAgentPayloads()).toHaveLength(1);
+      await heartbeat.waitForRunExecutionDrain(firstRun!.id, { timeoutMs: 10_000 });
 
       const issueAfterPromotion = await db
         .select({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16673,7 +16673,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         let deferredCommentWakeIsSelfAuthored = false;
         const deferredWakeIsCommentFollowUp =
           deferredWakeReason === "issue_commented" ||
-          deferredWakeReason === "issue_reopened_via_comment";
+          deferredWakeReason === "issue_reopened_via_comment" ||
+          deferredWakeReason === "issue_comment_mentioned";
         if (deferredWakeIsCommentFollowUp && deferredCommentIds.length > 0) {
           const deferredComments = await tx
             .select({
@@ -16712,6 +16713,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
         const shouldReopenDeferredCommentWake =
+          deferredWakeIsCommentFollowUp &&
           deferredCommentIds.length > 0 &&
           !deferredCommentWakeIsSelfAuthored &&
           (issue.status === "done" || issue.status === "cancelled") &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16669,8 +16669,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             )
             .then((rows) => rows);
           deferredCommentWakeIsSelfAuthored =
+            deferred.agentId === run.agentId &&
             deferredComments.length > 0 &&
             deferredComments.every((comment) => comment.createdByRunId === run.id);
+        }
+        if (deferredCommentWakeIsSelfAuthored) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: new Date(),
+              error: "Deferred comment wake suppressed because every referenced comment was authored by the closing run",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
         }
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16671,7 +16671,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // Suppress reopen only when every referenced comment came from this run;
         // mixed batches must still reopen because they contain a real follow-up.
         let deferredCommentWakeIsSelfAuthored = false;
-        if (deferredCommentIds.length > 0) {
+        const deferredWakeIsCommentFollowUp =
+          deferredWakeReason === "issue_commented" ||
+          deferredWakeReason === "issue_reopened_via_comment";
+        if (deferredWakeIsCommentFollowUp && deferredCommentIds.length > 0) {
           const deferredComments = await tx
             .select({
               id: issueComments.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5262,6 +5262,21 @@ export function extractWakeCommentIds(
   return out;
 }
 
+export function allReferencedCommentsAreSelfAuthored(input: {
+  referencedCommentIds: string[];
+  resolvedComments: Array<{ id: string; createdByRunId: string | null }>;
+  runId: string;
+}): boolean {
+  const referencedIds = Array.from(new Set(input.referencedCommentIds));
+  if (referencedIds.length === 0 || input.resolvedComments.length !== referencedIds.length) {
+    return false;
+  }
+  const resolvedById = new Map(input.resolvedComments.map((comment) => [comment.id, comment]));
+  return referencedIds.every(
+    (commentId) => resolvedById.get(commentId)?.createdByRunId === input.runId,
+  );
+}
+
 function mergeWakeCommentIds(...values: Array<unknown>): string[] {
   const merged: string[] = [];
   const append = (value: unknown) => {
@@ -16658,7 +16673,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         let deferredCommentWakeIsSelfAuthored = false;
         if (deferredCommentIds.length > 0) {
           const deferredComments = await tx
-            .select({ createdByRunId: issueComments.createdByRunId })
+            .select({
+              id: issueComments.id,
+              createdByRunId: issueComments.createdByRunId,
+            })
             .from(issueComments)
             .where(
               and(
@@ -16670,8 +16688,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .then((rows) => rows);
           deferredCommentWakeIsSelfAuthored =
             deferred.agentId === run.agentId &&
-            deferredComments.length > 0 &&
-            deferredComments.every((comment) => comment.createdByRunId === run.id);
+            allReferencedCommentsAreSelfAuthored({
+              referencedCommentIds: deferredCommentIds,
+              resolvedComments: deferredComments,
+              runId: run.id,
+            });
         }
         if (deferredCommentWakeIsSelfAuthored) {
           await tx


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service defers comment wakes while an issue execution is still running, then decides what to do with them when that run ends.
> - Existing protection from #4973 prevents an exclusively run-authored comment batch from reopening a completed issue, but it still promotes the deferred wake and launches another run for the same agent.
> - That follow-up run can post another completion comment, creating another deferred wake even though there is no new human or cross-agent input.
> - A wake whose target is the closing run's own agent and whose referenced comments were all created by that run carries no new work for that agent.
> - This pull request cancels that exact wake while preserving mixed human batches and cross-agent mention wakes.
> - The benefit is that completed executions cannot self-trigger redundant or repeating agent runs.

## Linked Issues or Issue Description

Refs #3980. Refs #3935. Follow-up to the merged fix in #4973; related prior investigation in #6576.

**Problem:** When a run-authored comment is deferred during that run, the deferred request is promoted after finalization even if it targets the same agent and contains no external input. #4973 keeps the issue closed, but the promoted request still starts another run.

**Expected:** Cancel an exclusively same-run-authored deferred comment wake when it targets the closing run's own agent. Continue promoting mixed human/run-authored batches and comments that intentionally wake a different agent.

**Reproduction:** The regression test starts an issue-bound run, records a run-linked comment under user attribution, defers its comment wake, closes the issue, and finalizes the run. Before this change the gateway receives a second payload; after this change the wake is `cancelled` and only the original run exists.

## What Changed

- Cancel a deferred comment wake when its target agent is the closing run's agent and every referenced comment has that run's `createdByRunId`.
- Record a terminal cancellation reason on the wake request instead of promoting it.
- Strengthen the heartbeat batching regression to assert one run, one gateway payload, and a cancelled wake.
- Preserve the existing cross-agent mention and mixed human-comment behavior; the full 11-test batching suite covers both paths.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts` — 11 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Low risk: the behavior change is limited to deferred comment wakes with three simultaneous signals: same target agent, all comments linked to the closing run, and no mixed external comment.
- A run-authored comment that mentions another agent is still delivered to that other agent.
- A mixed batch containing a human comment is still promoted and can reopen a completed issue.
- No schema, API, or migration change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using `gpt-5.6-sol`, with repository inspection, code execution, regression testing, and independent review agents. The runtime did not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (N/A — no public configuration or API contract changed)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
