### PR TITLE
fix(hermes): isolate child process environment

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -392,6 +392,35 @@ describe("adapter skill snapshots", () => {
 });
 
 describe("runChildProcess", () => {
+  it("can disable inherited process environment variables", async () => {
+    const previous = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "must-not-reach-child";
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          "process.stdout.write(JSON.stringify({inherited: process.env.DATABASE_URL ?? null, explicit: process.env.EXPLICIT_CHILD_VALUE ?? null}));",
+        ],
+        {
+          cwd: process.cwd(),
+          env: { EXPLICIT_CHILD_VALUE: "kept" },
+          inheritProcessEnv: false,
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ inherited: null, explicit: "kept" });
+    } finally {
+      if (previous === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = previous;
+    }
+  });
+
   it("does not arm a timeout when timeoutSec is 0", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -12,6 +12,7 @@ import {
   buildInvocationEnvForLogs,
   buildPaperclipEnv,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  ensurePathInEnv,
   materializePaperclipSkillCopy,
   refreshPaperclipWorkspaceEnvForExecution,
   renderPaperclipWakePrompt,
@@ -27,6 +28,22 @@ import {
   UNMANAGED_BACKGROUND_TASK_STOP_REASON,
   WATCHDOG_DEFAULT_MANDATE,
 } from "./server-utils.js";
+
+describe("ensurePathInEnv", () => {
+  it("recognizes lowercase PATH casing on Windows without adding a competing key", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const env = { path: "C:\\agent-bin" };
+
+      expect(ensurePathInEnv(env)).toBe(env);
+      expect(env).toEqual({ path: "C:\\agent-bin" });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+});
 
 function isPidAlive(pid: number) {
   try {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3297,6 +3297,7 @@ export async function runChildProcess(
     onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
+    inheritProcessEnv?: boolean;
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
@@ -3306,7 +3307,7 @@ export async function runChildProcess(
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
   return new Promise<RunProcessResult>((resolve, reject) => {
     const rawMerged: NodeJS.ProcessEnv = {
-      ...sanitizeInheritedPaperclipEnv(process.env),
+      ...(opts.inheritProcessEnv === false ? {} : sanitizeInheritedPaperclipEnv(process.env)),
       ...opts.env,
     };
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2504,8 +2504,12 @@ async function resolveSpawnTarget(
 }
 
 export function ensurePathInEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  if (typeof env.PATH === "string" && env.PATH.length > 0) return env;
-  if (typeof env.Path === "string" && env.Path.length > 0) return env;
+  const pathKey = process.platform === "win32"
+    ? Object.keys(env).find((key) => key.toLowerCase() === "path")
+    : "PATH";
+  if (pathKey !== undefined && typeof env[pathKey] === "string" && env[pathKey].length > 0) {
+    return env;
+  }
   return { ...env, PATH: defaultPathForPlatform() };
 }
 

--- a/packages/adapters/hermes/src/server/command-resolution.test.ts
+++ b/packages/adapters/hermes/src/server/command-resolution.test.ts
@@ -100,3 +100,27 @@ test("testEnvironment isolates command probes from server-only environment varia
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("testEnvironment rejects unsupported remote targets without running a local command", async () => {
+  const result = await testEnvironment({
+    companyId: "company-test",
+    adapterType: "hermes_local",
+    executionTarget: {
+      kind: "remote",
+      transport: "sandbox",
+      remoteCwd: "/remote/workspace",
+    },
+    environmentName: "remote-test",
+    config: {
+      command: "/definitely-not-a-local-command",
+    },
+  });
+
+  expect(result.status).toBe("fail");
+  expect(result.checks).toEqual([
+    expect.objectContaining({
+      level: "error",
+      code: "hermes_remote_execution_unsupported",
+    }),
+  ]);
+});

--- a/packages/adapters/hermes/src/server/command-resolution.test.ts
+++ b/packages/adapters/hermes/src/server/command-resolution.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { expect, test } from "vitest";
 
 import { HERMES_CLI } from "../shared/constants.js";
@@ -43,6 +43,60 @@ test("testEnvironment accepts config.command when hermesCommand is absent", asyn
       (check) => check.code === "hermes_version" && check.message.includes("fake-hermes 1.2.3"),
     )).toBe(true);
   } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("testEnvironment isolates command probes from server-only environment variables", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "hermes-command-env-"));
+  const cliPath = path.join(tempDir, "fake-hermes");
+  const capturePath = path.join(tempDir, "captured-env.txt");
+  const previous = {
+    capturePath: process.env.TEST_CAPTURE_PATH,
+    databaseUrl: process.env.DATABASE_URL,
+    jwtSecret: process.env.PAPERCLIP_AGENT_JWT_SECRET,
+    explicit: process.env.EXPLICIT_TEST_SETTING,
+  };
+  process.env.TEST_CAPTURE_PATH = capturePath;
+  process.env.DATABASE_URL = "postgres://server-only";
+  process.env.PAPERCLIP_AGENT_JWT_SECRET = "server-signing-secret";
+  process.env.EXPLICIT_TEST_SETTING = "server-setting";
+
+  try {
+    await writeFile(
+      cliPath,
+      [
+        "#!/bin/sh",
+        'printf "%s|%s|%s\\n" "${DATABASE_URL-unset}" "${PAPERCLIP_AGENT_JWT_SECRET-unset}" "${EXPLICIT_TEST_SETTING-unset}" > "$TEST_CAPTURE_PATH"',
+        "echo fake-hermes 1.2.3",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+
+    await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        command: cliPath,
+        env: {
+          TEST_CAPTURE_PATH: capturePath,
+          EXPLICIT_TEST_SETTING: "agent-setting",
+        },
+      },
+    });
+
+    expect(await readFile(capturePath, "utf8")).toBe("unset|unset|agent-setting\n");
+  } finally {
+    if (previous.capturePath === undefined) delete process.env.TEST_CAPTURE_PATH;
+    else process.env.TEST_CAPTURE_PATH = previous.capturePath;
+    if (previous.databaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previous.databaseUrl;
+    if (previous.jwtSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    else process.env.PAPERCLIP_AGENT_JWT_SECRET = previous.jwtSecret;
+    if (previous.explicit === undefined) delete process.env.EXPLICIT_TEST_SETTING;
+    else process.env.EXPLICIT_TEST_SETTING = previous.explicit;
     await rm(tempDir, { recursive: true, force: true });
   }
 });

--- a/packages/adapters/hermes/src/server/detect-model.test.ts
+++ b/packages/adapters/hermes/src/server/detect-model.test.ts
@@ -138,6 +138,25 @@ test("testEnvironment does not warn about missing API keys when Hermes config pr
   });
 });
 
+test("testEnvironment does not report provider keys that exist only in the server process", async () => {
+  await withHermesHomeConfig([], async () => {
+    process.env.OPENAI_API_KEY = "host-only-placeholder";
+
+    const result = await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        hermesCommand: "python3",
+        model: "openai/gpt-4.1-mini",
+      },
+    });
+
+    const codes = result.checks.map((check) => check.code);
+    expect(codes.includes("hermes_api_keys_found")).toBe(false);
+    expect(codes.includes("hermes_no_api_keys")).toBe(true);
+  });
+});
+
 test("testEnvironment describes provider-omitted runtime config without inventing provider auto", async () => {
   await withHermesHomeConfig([
     "model:",

--- a/packages/adapters/hermes/src/server/detect-model.test.ts
+++ b/packages/adapters/hermes/src/server/detect-model.test.ts
@@ -92,7 +92,7 @@ test("resolveProvider still infers from the requested model when Hermes config i
 
 async function withHermesHomeConfig(
   configLines: string[],
-  fn: () => Promise<void>,
+  fn: (tempHome: string) => Promise<void>,
 ) {
   const tempHome = await mkdtemp(join(tmpdir(), "hermes-paperclip-adapter-"));
   const hermesDir = join(tempHome, ".hermes");
@@ -109,7 +109,7 @@ async function withHermesHomeConfig(
   }
 
   try {
-    await fn();
+    await fn(tempHome);
   } finally {
     await rm(tempHome, { recursive: true, force: true });
   }
@@ -155,6 +155,72 @@ test("testEnvironment does not report provider keys that exist only in the serve
     expect(codes.includes("hermes_api_keys_found")).toBe(false);
     expect(codes.includes("hermes_no_api_keys")).toBe(true);
   });
+});
+
+test("testEnvironment finds configured provider keys case-insensitively on Windows", async () => {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", { value: "win32" });
+
+  try {
+    await withHermesHomeConfig([
+      "model:",
+      "  default: openai/gpt-4.1-mini",
+      "  provider: openai",
+    ], async () => {
+      const result = await testEnvironment({
+        companyId: "company-test",
+        adapterType: "hermes_local",
+        config: {
+          hermesCommand: "python3",
+          model: "openai/gpt-4.1-mini",
+          env: {
+            OpenAI_Api_Key: "agent-config-placeholder",
+          },
+        },
+      });
+
+      const codes = result.checks.map((check) => check.code);
+      expect(codes.includes("hermes_api_keys_found")).toBe(true);
+      expect(codes.includes("hermes_no_api_keys")).toBe(false);
+    });
+  } finally {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  }
+});
+
+test("testEnvironment resolves the configured Windows home case-insensitively", async () => {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", { value: "win32" });
+
+  try {
+    await withHermesHomeConfig([], async (tempHome) => {
+      await writeFile(
+        join(tempHome, ".hermes", ".env"),
+        "OPENAI_API_KEY=agent-config-placeholder\n",
+        "utf8",
+      );
+      delete process.env.HOME;
+      delete process.env.USERPROFILE;
+
+      const result = await testEnvironment({
+        companyId: "company-test",
+        adapterType: "hermes_local",
+        config: {
+          hermesCommand: "python3",
+          model: "openai/gpt-4.1-mini",
+          env: {
+            UserProfile: tempHome,
+          },
+        },
+      });
+
+      const codes = result.checks.map((check) => check.code);
+      expect(codes.includes("hermes_api_keys_found")).toBe(true);
+      expect(codes.includes("hermes_no_api_keys")).toBe(false);
+    });
+  } finally {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  }
 });
 
 test("testEnvironment describes provider-omitted runtime config without inventing provider auto", async () => {

--- a/packages/adapters/hermes/src/server/detect-model.test.ts
+++ b/packages/adapters/hermes/src/server/detect-model.test.ts
@@ -223,6 +223,66 @@ test("testEnvironment resolves the configured Windows home case-insensitively", 
   }
 });
 
+test("testEnvironment detects model config from the configured child HOME", async () => {
+  await withHermesHomeConfig([], async () => {
+    const childHome = await mkdtemp(join(tmpdir(), "hermes-paperclip-child-home-"));
+    const childHermesDir = join(childHome, ".hermes");
+    await mkdir(childHermesDir, { recursive: true });
+    await writeFile(
+      join(childHermesDir, "config.yaml"),
+      [
+        "model:",
+        "  default: openrouter/gpt-4.1-mini",
+        "  provider: openrouter",
+        "  api_key: child-home-secret",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    try {
+      const result = await testEnvironment({
+        companyId: "company-test",
+        adapterType: "hermes_local",
+        config: {
+          hermesCommand: "python3",
+          model: "openrouter/gpt-4.1-mini",
+          env: { HOME: childHome },
+        },
+      });
+
+      const codes = result.checks.map((check) => check.code);
+      expect(codes.includes("hermes_api_key_in_config")).toBe(true);
+      expect(codes.includes("hermes_no_api_keys")).toBe(false);
+    } finally {
+      await rm(childHome, { recursive: true, force: true });
+    }
+  });
+});
+
+test("testEnvironment does not fall back to the server home when child HOME is explicitly empty", async () => {
+  await withHermesHomeConfig([
+    "model:",
+    "  default: openrouter/gpt-4.1-mini",
+    "  provider: openrouter",
+    "  api_key: server-home-secret",
+  ], async () => {
+    const result = await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        hermesCommand: "python3",
+        model: "openrouter/gpt-4.1-mini",
+        env: { HOME: "" },
+      },
+    });
+
+    const codes = result.checks.map((check) => check.code);
+    expect(codes.includes("hermes_api_key_in_config")).toBe(false);
+    expect(codes.includes("hermes_no_api_keys")).toBe(true);
+  });
+});
+
 test("testEnvironment describes provider-omitted runtime config without inventing provider auto", async () => {
   await withHermesHomeConfig([
     "model:",

--- a/packages/adapters/hermes/src/server/detect-model.test.ts
+++ b/packages/adapters/hermes/src/server/detect-model.test.ts
@@ -322,6 +322,59 @@ test("testEnvironment resolves config.yaml and .env from explicit child HERMES_H
   }
 });
 
+test("testEnvironment prioritizes mixed-case child HERMES_HOME over Windows LOCALAPPDATA for config.yaml and .env", async () => {
+  const originalPlatform = process.platform;
+  const hermesHome = await mkdtemp(join(tmpdir(), "hermes-paperclip-windows-explicit-home-"));
+  const localAppData = await mkdtemp(join(tmpdir(), "hermes-paperclip-windows-conflicting-localappdata-"));
+  Object.defineProperty(process, "platform", { value: "win32" });
+
+  try {
+    await writeFile(
+      join(hermesHome, "config.yaml"),
+      [
+        "model:",
+        "  default: explicit-priority-model",
+        "  provider: explicit-home-provider",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(
+      join(hermesHome, ".env"),
+      "OPENAI_API_KEY=from-explicit-hermes-home-only\n",
+      "utf8",
+    );
+
+    const result = await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        hermesCommand: "python3",
+        model: "explicit-priority-model",
+        env: {
+          hErMeS_hOmE: hermesHome,
+          LOCALAPPDATA: localAppData,
+          HOME: "",
+          USERPROFILE: "",
+        },
+      },
+    });
+
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      code: "hermes_api_keys_found",
+      message: "API keys found: OpenAI",
+    }));
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      code: "hermes_provider_unsupported",
+      message: expect.stringContaining('"explicit-home-provider"'),
+    }));
+  } finally {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    await rm(hermesHome, { recursive: true, force: true });
+    await rm(localAppData, { recursive: true, force: true });
+  }
+});
+
 test("testEnvironment resolves native Windows LOCALAPPDATA/hermes config.yaml and .env", async () => {
   const originalPlatform = process.platform;
   const localAppData = await mkdtemp(join(tmpdir(), "hermes-paperclip-localappdata-"));

--- a/packages/adapters/hermes/src/server/detect-model.test.ts
+++ b/packages/adapters/hermes/src/server/detect-model.test.ts
@@ -283,6 +283,89 @@ test("testEnvironment does not fall back to the server home when child HOME is e
   });
 });
 
+test("testEnvironment resolves config.yaml and .env from explicit child HERMES_HOME", async () => {
+  const hermesHome = await mkdtemp(join(tmpdir(), "hermes-paperclip-explicit-home-"));
+
+  try {
+    await writeFile(
+      join(hermesHome, "config.yaml"),
+      [
+        "model:",
+        "  default: explicit-hermes-home-model",
+        "  provider: openai",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(join(hermesHome, ".env"), "OPENAI_API_KEY=explicit-home-key\n", "utf8");
+
+    const result = await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        hermesCommand: "python3",
+        model: "explicit-hermes-home-model",
+        env: {
+          HERMES_HOME: hermesHome,
+          HOME: "",
+          USERPROFILE: "",
+        },
+      },
+    });
+
+    expect(result.checks.some((check) => check.code === "hermes_api_keys_found")).toBe(true);
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      code: "hermes_provider_unsupported",
+    }));
+  } finally {
+    await rm(hermesHome, { recursive: true, force: true });
+  }
+});
+
+test("testEnvironment resolves native Windows LOCALAPPDATA/hermes config.yaml and .env", async () => {
+  const originalPlatform = process.platform;
+  const localAppData = await mkdtemp(join(tmpdir(), "hermes-paperclip-localappdata-"));
+  const hermesHome = join(localAppData, "hermes");
+  Object.defineProperty(process, "platform", { value: "win32" });
+
+  try {
+    await mkdir(hermesHome, { recursive: true });
+    await writeFile(
+      join(hermesHome, "config.yaml"),
+      [
+        "model:",
+        "  default: windows-localappdata-model",
+        "  provider: openai",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(join(hermesHome, ".env"), "OpenAI_Api_Key=windows-localappdata-key\n", "utf8");
+
+    const result = await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        hermesCommand: "python3",
+        model: "windows-localappdata-model",
+        env: {
+          LOCALAPPDATA: localAppData,
+          HOME: "",
+          USERPROFILE: "",
+        },
+      },
+    });
+
+    expect(result.checks.some((check) => check.code === "hermes_api_keys_found")).toBe(true);
+    expect(result.checks).toContainEqual(expect.objectContaining({
+      code: "hermes_provider_unsupported",
+    }));
+  } finally {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    await rm(localAppData, { recursive: true, force: true });
+  }
+});
+
 test("testEnvironment describes provider-omitted runtime config without inventing provider auto", async () => {
   await withHermesHomeConfig([
     "model:",

--- a/packages/adapters/hermes/src/server/detect-model.ts
+++ b/packages/adapters/hermes/src/server/detect-model.ts
@@ -32,8 +32,9 @@ export interface DetectedModel {
  * Read the Hermes config file and extract the default model config.
  */
 export async function detectModel(
-  configPath?: string,
+  configPath?: string | null,
 ): Promise<DetectedModel | null> {
+  if (configPath === null) return null;
   const filePath = configPath ?? join(homedir(), ".hermes", "config.yaml");
 
   let content: string;

--- a/packages/adapters/hermes/src/server/environment.ts
+++ b/packages/adapters/hermes/src/server/environment.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+export type EnvironmentPlatform = NodeJS.Platform;
+
+function environmentNamesMatch(left: string, right: string, platform: EnvironmentPlatform): boolean {
+  return platform === "win32" ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+export function readEnvironmentValue(
+  env: Record<string, string>,
+  key: string,
+  platform: EnvironmentPlatform = process.platform,
+): string | undefined {
+  const matchingKey = Object.keys(env).find((candidate) => environmentNamesMatch(candidate, key, platform));
+  return matchingKey === undefined ? undefined : env[matchingKey];
+}
+
+export function deleteEnvironmentValue(
+  env: Record<string, string>,
+  key: string,
+  platform: EnvironmentPlatform = process.platform,
+): void {
+  for (const candidate of Object.keys(env)) {
+    if (environmentNamesMatch(candidate, key, platform)) delete env[candidate];
+  }
+}
+
+export function resolveHermesConfigPath(
+  env: Record<string, string>,
+  platform: EnvironmentPlatform = process.platform,
+): string | null | undefined {
+  const home = readEnvironmentValue(env, "HOME", platform);
+  if (home !== undefined) return home === "" ? null : path.join(home, ".hermes", "config.yaml");
+
+  const userProfile = readEnvironmentValue(env, "USERPROFILE", platform);
+  if (userProfile !== undefined) {
+    return userProfile === "" ? null : path.join(userProfile, ".hermes", "config.yaml");
+  }
+
+  return undefined;
+}

--- a/packages/adapters/hermes/src/server/environment.ts
+++ b/packages/adapters/hermes/src/server/environment.ts
@@ -25,17 +25,47 @@ export function deleteEnvironmentValue(
   }
 }
 
+export function resolveEffectiveHermesHome(
+  env: Record<string, string>,
+  platform: EnvironmentPlatform = process.platform,
+): string | null | undefined {
+  const hermesHome = readEnvironmentValue(env, "HERMES_HOME", platform);
+  if (hermesHome !== undefined) return hermesHome === "" ? null : hermesHome;
+
+  if (platform === "win32") {
+    const localAppData = readEnvironmentValue(env, "LOCALAPPDATA", platform);
+    if (localAppData !== undefined) {
+      return localAppData === "" ? null : path.join(localAppData, "hermes");
+    }
+  }
+
+  const home = readEnvironmentValue(env, "HOME", platform);
+  if (home !== undefined) return home === "" ? null : path.join(home, ".hermes");
+
+  const userProfile = readEnvironmentValue(env, "USERPROFILE", platform);
+  if (userProfile !== undefined) {
+    return userProfile === "" ? null : path.join(userProfile, ".hermes");
+  }
+
+  return undefined;
+}
+
 export function resolveHermesConfigPath(
   env: Record<string, string>,
   platform: EnvironmentPlatform = process.platform,
 ): string | null | undefined {
-  const home = readEnvironmentValue(env, "HOME", platform);
-  if (home !== undefined) return home === "" ? null : path.join(home, ".hermes", "config.yaml");
+  const hermesHome = resolveEffectiveHermesHome(env, platform);
+  return hermesHome === null || hermesHome === undefined
+    ? hermesHome
+    : path.join(hermesHome, "config.yaml");
+}
 
-  const userProfile = readEnvironmentValue(env, "USERPROFILE", platform);
-  if (userProfile !== undefined) {
-    return userProfile === "" ? null : path.join(userProfile, ".hermes", "config.yaml");
-  }
-
-  return undefined;
+export function resolveHermesEnvPath(
+  env: Record<string, string>,
+  platform: EnvironmentPlatform = process.platform,
+): string | null | undefined {
+  const hermesHome = resolveEffectiveHermesHome(env, platform);
+  return hermesHome === null || hermesHome === undefined
+    ? hermesHome
+    : path.join(hermesHome, ".env");
 }

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -263,6 +263,23 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     );
     expect(vi.mocked(serverUtils.runChildProcess)).not.toHaveBeenCalled();
   });
+
+  it("rejects legacy remote transports before spawning a local process", async () => {
+    const { ctx } = makeCtx();
+    (ctx as any).executionTransport = {
+      remoteExecution: {
+        host: "127.0.0.1",
+        port: 2222,
+        username: "fixture",
+        remoteCwd: "/remote/workspace",
+      },
+    };
+
+    await expect(execute(ctx as any)).rejects.toThrow(
+      "Hermes local adapter does not support remote execution targets",
+    );
+    expect(vi.mocked(serverUtils.runChildProcess)).not.toHaveBeenCalled();
+  });
 });
 
 describe("buildHermesChildEnv", () => {

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -210,10 +210,14 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       databaseUrl: process.env.DATABASE_URL,
       jwtSecret: process.env.PAPERCLIP_AGENT_JWT_SECRET,
       hermesHome: process.env.HERMES_HOME,
+      bashEnv: process.env.BASH_ENV,
+      envHook: process.env.ENV,
     };
     process.env.DATABASE_URL = "postgres://server-only";
     process.env.PAPERCLIP_AGENT_JWT_SECRET = "server-signing-secret";
     process.env.HERMES_HOME = "/server/control-plane-profile";
+    process.env.BASH_ENV = "/server/hostile-bash-env";
+    process.env.ENV = "/server/hostile-shell-env";
 
     try {
       const { ctx } = makeCtx();
@@ -229,6 +233,8 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       expect(opts.env.DATABASE_URL).toBeUndefined();
       expect(opts.env.PAPERCLIP_AGENT_JWT_SECRET).toBeUndefined();
       expect(opts.env.HERMES_HOME).toBeUndefined();
+      expect(opts.env.BASH_ENV).toBeUndefined();
+      expect(opts.env.ENV).toBeUndefined();
       expect(opts.env.PATH).toBe(process.env.PATH);
     } finally {
       if (previous.databaseUrl === undefined) delete process.env.DATABASE_URL;
@@ -237,6 +243,10 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       else process.env.PAPERCLIP_AGENT_JWT_SECRET = previous.jwtSecret;
       if (previous.hermesHome === undefined) delete process.env.HERMES_HOME;
       else process.env.HERMES_HOME = previous.hermesHome;
+      if (previous.bashEnv === undefined) delete process.env.BASH_ENV;
+      else process.env.BASH_ENV = previous.bashEnv;
+      if (previous.envHook === undefined) delete process.env.ENV;
+      else process.env.ENV = previous.envHook;
     }
   });
 });

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -249,9 +249,50 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       else process.env.ENV = previous.envHook;
     }
   });
+
+  it("rejects unsupported remote targets before spawning a local process", async () => {
+    const { ctx } = makeCtx();
+    (ctx as any).executionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      remoteCwd: "/remote/workspace",
+    };
+
+    await expect(execute(ctx as any)).rejects.toThrow(
+      "Hermes local adapter does not support remote execution targets",
+    );
+    expect(vi.mocked(serverUtils.runChildProcess)).not.toHaveBeenCalled();
+  });
 });
 
 describe("buildHermesChildEnv", () => {
+  it("drops credentialed inherited proxy URLs", () => {
+    const env = buildHermesChildEnv(
+      {},
+      {
+        HTTP_PROXY: "http://proxy-user:proxy-pass@proxy.example:8080",
+        HTTPS_PROXY: "https://proxy.example:8443",
+        ALL_PROXY: "socks5://proxy-user@proxy.example:1080",
+        NO_PROXY: "localhost,127.0.0.1",
+      },
+    );
+
+    expect(env.HTTP_PROXY).toBeUndefined();
+    expect(env.ALL_PROXY).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBe("https://proxy.example:8443");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+  });
+
+  it("preserves a credentialed proxy explicitly configured for the agent", () => {
+    const configuredProxy = "http://agent-user:agent-pass@proxy.example:8080";
+    const env = buildHermesChildEnv(
+      { env: { HTTP_PROXY: configuredProxy } },
+      { HTTP_PROXY: "http://server-user:server-pass@proxy.example:8080" },
+    );
+
+    expect(env.HTTP_PROXY).toBe(configuredProxy);
+  });
+
   it("lets configured Windows environment keys override inherited casing", () => {
     const env = buildHermesChildEnv(
       { env: { Path: "C:\\agent-bin" } },

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -250,6 +250,49 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     }
   });
 
+  it("removes mixed-case configured collisions with managed Paperclip identity on Windows", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+
+    try {
+      const { ctx } = makeCtx({
+        env: {
+          paperclip_api_key: "configured-key",
+          paperclip_agent_id: "configured-agent",
+          paperclip_company_id: "configured-company",
+          paperclip_run_id: "configured-run",
+          paperclip_task_id: "configured-task",
+          paperclip_wake_reason: "configured-reason",
+        },
+      });
+      (ctx as any).authToken = "run-scoped-token";
+
+      await execute(ctx as any);
+
+      const mocked = vi.mocked(serverUtils.runChildProcess);
+      const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+      const env = (lastCall[3] as { env: Record<string, string> }).env;
+      for (const key of [
+        "PAPERCLIP_API_KEY",
+        "PAPERCLIP_AGENT_ID",
+        "PAPERCLIP_COMPANY_ID",
+        "PAPERCLIP_RUN_ID",
+        "PAPERCLIP_TASK_ID",
+        "PAPERCLIP_WAKE_REASON",
+      ]) {
+        expect(Object.keys(env).filter((candidate) => candidate.toLowerCase() === key.toLowerCase())).toEqual([key]);
+      }
+      expect(env.PAPERCLIP_API_KEY).toBe("run-scoped-token");
+      expect(env.PAPERCLIP_AGENT_ID).toBe("agent-1");
+      expect(env.PAPERCLIP_COMPANY_ID).toBe("company-1");
+      expect(env.PAPERCLIP_RUN_ID).toBe("test-run-1");
+      expect(env.PAPERCLIP_TASK_ID).toBe("issue-1");
+      expect(env.PAPERCLIP_WAKE_REASON).toBe("manual");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
   it("rejects unsupported remote targets before spawning a local process", async () => {
     const { ctx } = makeCtx();
     (ctx as any).executionTarget = {

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -38,7 +38,7 @@ vi.mock("node:fs/promises", () => ({
   stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
 }));
 
-import { execute } from "./execute.js";
+import { buildHermesChildEnv, execute } from "./execute.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
 
 function makeCtx(overrides: Record<string, unknown> = {}) {
@@ -238,5 +238,17 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       if (previous.hermesHome === undefined) delete process.env.HERMES_HOME;
       else process.env.HERMES_HOME = previous.hermesHome;
     }
+  });
+});
+
+describe("buildHermesChildEnv", () => {
+  it("lets configured Windows environment keys override inherited casing", () => {
+    const env = buildHermesChildEnv(
+      { env: { Path: "C:\\agent-bin" } },
+      { PATH: "C:\\server-bin" },
+      "win32",
+    );
+
+    expect(env).toEqual({ Path: "C:\\agent-bin" });
   });
 });

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -204,4 +204,39 @@ describe("hermes-local adapter onSpawn forwarding", () => {
       else process.env.PAPERCLIP_API_KEY = previousApiKey;
     }
   });
+
+  it("does not forward server-only environment variables to Hermes", async () => {
+    const previous = {
+      databaseUrl: process.env.DATABASE_URL,
+      jwtSecret: process.env.PAPERCLIP_AGENT_JWT_SECRET,
+      hermesHome: process.env.HERMES_HOME,
+    };
+    process.env.DATABASE_URL = "postgres://server-only";
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "server-signing-secret";
+    process.env.HERMES_HOME = "/server/control-plane-profile";
+
+    try {
+      const { ctx } = makeCtx();
+      await execute(ctx as any);
+
+      const mocked = vi.mocked(serverUtils.runChildProcess);
+      const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+      const opts = lastCall[3] as {
+        env: Record<string, string>;
+        inheritProcessEnv?: boolean;
+      };
+      expect(opts.inheritProcessEnv).toBe(false);
+      expect(opts.env.DATABASE_URL).toBeUndefined();
+      expect(opts.env.PAPERCLIP_AGENT_JWT_SECRET).toBeUndefined();
+      expect(opts.env.HERMES_HOME).toBeUndefined();
+      expect(opts.env.PATH).toBe(process.env.PATH);
+    } finally {
+      if (previous.databaseUrl === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = previous.databaseUrl;
+      if (previous.jwtSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+      else process.env.PAPERCLIP_AGENT_JWT_SECRET = previous.jwtSecret;
+      if (previous.hermesHome === undefined) delete process.env.HERMES_HOME;
+      else process.env.HERMES_HOME = previous.hermesHome;
+    }
+  });
 });

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -126,6 +126,18 @@ function buildHermesInheritedEnv(source: NodeJS.ProcessEnv): Record<string, stri
   return env;
 }
 
+export function buildHermesChildEnv(
+  config: Record<string, unknown>,
+  source: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const env = buildHermesInheritedEnv(source);
+  const userEnv = (config.env ?? {}) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(userEnv)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  return env;
+}
+
 export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
@@ -516,10 +528,8 @@ export async function execute(
   }
 
   // ── Build environment ──────────────────────────────────────────────────
-  const userEnv = config.env as Record<string, string> | undefined;
   const env: Record<string, string> = {
-    ...buildHermesInheritedEnv(process.env),
-    ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
+    ...buildHermesChildEnv(config),
     ...buildPaperclipEnv(ctx.agent),
   };
 

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -26,6 +26,7 @@ import type {
   AdapterExecutionResult,
   UsageSummary,
 } from "@paperclipai/adapter-utils";
+import { readAdapterExecutionTarget } from "@paperclipai/adapter-utils/execution-target";
 
 import {
   runChildProcess,
@@ -431,7 +432,11 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
 export async function execute(
   ctx: AdapterExecutionContext,
 ): Promise<AdapterExecutionResult> {
-  if (ctx.executionTarget?.kind === "remote") {
+  const executionTarget = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+  if (executionTarget?.kind === "remote") {
     throw new Error("Hermes local adapter does not support remote execution targets");
   }
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -72,6 +72,60 @@ function cfgStringArray(v: unknown): string[] | undefined {
     : undefined;
 }
 
+const HERMES_INHERITED_ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "USERNAME",
+  "SHELL",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "TERM",
+  "COLORTERM",
+  "NO_COLOR",
+  "FORCE_COLOR",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NODE_EXTRA_CA_CERTS",
+  "XDG_CONFIG_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "SystemRoot",
+  "WINDIR",
+  "COMSPEC",
+  "PATHEXT",
+] as const;
+
+function buildHermesInheritedEnv(source: NodeJS.ProcessEnv): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of HERMES_INHERITED_ENV_ALLOWLIST) {
+    const value = source[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
 export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
@@ -464,7 +518,7 @@ export async function execute(
   // ── Build environment ──────────────────────────────────────────────────
   const userEnv = config.env as Record<string, string> | undefined;
   const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
+    ...buildHermesInheritedEnv(process.env),
     ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
     ...buildPaperclipEnv(ctx.agent),
   };
@@ -535,6 +589,7 @@ export async function execute(
   const result = await runChildProcess(ctx.runId, hermesCmd, args, {
     cwd,
     env,
+    inheritProcessEnv: false,
     timeoutSec,
     graceSec,
     onLog: wrappedOnLog,

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -129,11 +129,19 @@ function buildHermesInheritedEnv(source: NodeJS.ProcessEnv): Record<string, stri
 export function buildHermesChildEnv(
   config: Record<string, unknown>,
   source: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string> {
   const env = buildHermesInheritedEnv(source);
   const userEnv = (config.env ?? {}) as Record<string, unknown>;
   for (const [key, value] of Object.entries(userEnv)) {
-    if (typeof value === "string") env[key] = value;
+    if (typeof value !== "string") continue;
+    if (platform === "win32") {
+      const inheritedKey = Object.keys(env).find(
+        (envKey) => envKey.toLowerCase() === key.toLowerCase(),
+      );
+      if (inheritedKey !== undefined) delete env[inheritedKey];
+    }
+    env[key] = value;
   }
   return env;
 }

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -53,6 +53,7 @@ import {
   detectModel,
   resolveProvider,
 } from "./detect-model.js";
+import { deleteEnvironmentValue, resolveHermesConfigPath } from "./environment.js";
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -126,6 +127,18 @@ const HERMES_PROXY_ENV_KEYS = new Set([
   "https_proxy",
   "all_proxy",
 ]);
+
+const MANAGED_PAPERCLIP_ENV_KEYS = [
+  "PAPERCLIP_AGENT_ID",
+  "PAPERCLIP_COMPANY_ID",
+  "PAPERCLIP_API_URL",
+  "PAPERCLIP_RUN_ID",
+  "PAPERCLIP_API_KEY",
+  "PAPERCLIP_TASK_ID",
+  "PAPERCLIP_WAKE_REASON",
+  "PAPERCLIP_WAKE_COMMENT_ID",
+  "PAPERCLIP_WAKE_PAYLOAD_JSON",
+] as const;
 
 function inheritedProxyContainsCredentials(value: string): boolean {
   if (value.includes("@")) return true;
@@ -440,6 +453,7 @@ export async function execute(
     throw new Error("Hermes local adapter does not support remote execution targets");
   }
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;
+  const childEnv = buildHermesChildEnv(config);
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = resolveHermesCommand(config);
@@ -471,7 +485,7 @@ export async function execute(
 
   if (!explicitProvider) {
     try {
-      detectedConfig = await detectModel();
+      detectedConfig = await detectModel(resolveHermesConfigPath(childEnv));
     } catch {
       // Non-fatal — detection failure shouldn't block execution
     }
@@ -568,16 +582,16 @@ export async function execute(
   }
 
   // ── Build environment ──────────────────────────────────────────────────
-  const env: Record<string, string> = {
-    ...buildHermesChildEnv(config),
-    ...buildPaperclipEnv(ctx.agent),
-  };
+  const env: Record<string, string> = childEnv;
+  for (const key of MANAGED_PAPERCLIP_ENV_KEYS) {
+    deleteEnvironmentValue(env, key);
+  }
+  Object.assign(env, buildPaperclipEnv(ctx.agent));
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
 
   // PAPERCLIP_API_KEY is never accepted from config — the harness-minted run
   // token is the only source of Paperclip API identity.
-  delete env.PAPERCLIP_API_KEY;
   if ((ctx as any).authToken) env.PAPERCLIP_API_KEY = (ctx as any).authToken;
 
   // BUG FIX: Read task context from ctx.context (wake context), not ctx.config (adapter config)

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -117,11 +117,35 @@ const HERMES_INHERITED_ENV_ALLOWLIST = [
   "PATHEXT",
 ] as const;
 
+const HERMES_PROXY_ENV_KEYS = new Set([
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+]);
+
+function inheritedProxyContainsCredentials(value: string): boolean {
+  if (value.includes("@")) return true;
+  try {
+    const url = new URL(value);
+    return url.username.length > 0 || url.password.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function buildHermesInheritedEnv(source: NodeJS.ProcessEnv): Record<string, string> {
   const env: Record<string, string> = {};
   for (const key of HERMES_INHERITED_ENV_ALLOWLIST) {
     const value = source[key];
-    if (value !== undefined) env[key] = value;
+    if (
+      value !== undefined &&
+      !(HERMES_PROXY_ENV_KEYS.has(key) && inheritedProxyContainsCredentials(value))
+    ) {
+      env[key] = value;
+    }
   }
   return env;
 }
@@ -407,6 +431,9 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
 export async function execute(
   ctx: AdapterExecutionContext,
 ): Promise<AdapterExecutionResult> {
+  if (ctx.executionTarget?.kind === "remote") {
+    throw new Error("Hermes local adapter does not support remote execution targets");
+  }
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;
 
   // ── Resolve configuration ──────────────────────────────────────────────

--- a/packages/adapters/hermes/src/server/test.ts
+++ b/packages/adapters/hermes/src/server/test.ts
@@ -334,6 +334,19 @@ export async function testEnvironment(
   ctx: AdapterEnvironmentTestContext,
 ): Promise<AdapterEnvironmentTestResult> {
   const config = (ctx.config ?? {}) as Record<string, unknown>;
+  if (ctx.executionTarget?.kind === "remote") {
+    return {
+      adapterType: ADAPTER_TYPE,
+      status: "fail",
+      checks: [{
+        level: "error",
+        message: "Hermes local adapter does not support remote execution targets",
+        hint: "Use a local execution environment for this adapter.",
+        code: "hermes_remote_execution_unsupported",
+      }],
+      testedAt: new Date().toISOString(),
+    };
+  }
   const command = resolveHermesCommand(config);
   const childEnv = buildHermesChildEnv(config);
   const checks: AdapterEnvironmentCheck[] = [];

--- a/packages/adapters/hermes/src/server/test.ts
+++ b/packages/adapters/hermes/src/server/test.ts
@@ -25,6 +25,15 @@ function asString(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined;
 }
 
+function readEnvironmentValue(env: Record<string, string>, key: string): string | undefined {
+  if (env[key] !== undefined) return env[key];
+  if (process.platform !== "win32") return undefined;
+
+  const normalizedKey = key.toLowerCase();
+  const matchingKey = Object.keys(env).find((candidate) => candidate.toLowerCase() === normalizedKey);
+  return matchingKey === undefined ? undefined : env[matchingKey];
+}
+
 // ---------------------------------------------------------------------------
 // Checks
 // ---------------------------------------------------------------------------
@@ -157,7 +166,10 @@ async function checkApiKeys(
   // accurate results for keys that Hermes already knows about.
   const hermesEnvKeys: Record<string, string> = {};
   try {
-    const homeDir = childEnv.HOME || childEnv.USERPROFILE || "/root";
+    const homeDir =
+      readEnvironmentValue(childEnv, "HOME") ||
+      readEnvironmentValue(childEnv, "USERPROFILE") ||
+      "/root";
     const hermesEnvPath = `${homeDir}/.hermes/.env`;
     const content = readFileSync(hermesEnvPath, "utf-8");
     for (const line of content.split("\n")) {
@@ -174,7 +186,12 @@ async function checkApiKeys(
     // ~/.hermes/.env may not exist — that's fine
   }
 
-  const has = (key: string): boolean => !!(resolvedEnv[key] ?? childEnv[key] ?? hermesEnvKeys[key]);
+  const has = (key: string): boolean =>
+    !!(
+      readEnvironmentValue(resolvedEnv, key) ??
+      readEnvironmentValue(childEnv, key) ??
+      readEnvironmentValue(hermesEnvKeys, key)
+    );
 
   const hasAnthropic = has("ANTHROPIC_API_KEY");
   const hasOpenRouter = has("OPENROUTER_API_KEY");

--- a/packages/adapters/hermes/src/server/test.ts
+++ b/packages/adapters/hermes/src/server/test.ts
@@ -18,20 +18,12 @@ import { promisify } from "node:util";
 import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
 import { detectModel, resolveProvider, inferProviderFromModel } from "./detect-model.js";
 import { buildHermesChildEnv, resolveHermesCommand } from "./execute.js";
+import { readEnvironmentValue, resolveHermesConfigPath } from "./environment.js";
 
 const execFileAsync = promisify(execFile);
 
 function asString(v: unknown): string | undefined {
   return typeof v === "string" ? v : undefined;
-}
-
-function readEnvironmentValue(env: Record<string, string>, key: string): string | undefined {
-  if (env[key] !== undefined) return env[key];
-  if (process.platform !== "win32") return undefined;
-
-  const normalizedKey = key.toLowerCase();
-  const matchingKey = Object.keys(env).find((candidate) => candidate.toLowerCase() === normalizedKey);
-  return matchingKey === undefined ? undefined : env[matchingKey];
 }
 
 // ---------------------------------------------------------------------------
@@ -397,7 +389,7 @@ export async function testEnvironment(
   // 5. Detect Hermes config once for the remaining checks.
   let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
   try {
-    detectedConfig = await detectModel();
+    detectedConfig = await detectModel(resolveHermesConfigPath(childEnv));
   } catch {
     // Non-fatal
   }

--- a/packages/adapters/hermes/src/server/test.ts
+++ b/packages/adapters/hermes/src/server/test.ts
@@ -17,7 +17,7 @@ import { promisify } from "node:util";
 
 import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
 import { detectModel, resolveProvider, inferProviderFromModel } from "./detect-model.js";
-import { resolveHermesCommand } from "./execute.js";
+import { buildHermesChildEnv, resolveHermesCommand } from "./execute.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -31,10 +31,11 @@ function asString(v: unknown): string | undefined {
 
 async function checkCliInstalled(
   command: string,
+  env: Record<string, string>,
 ): Promise<AdapterEnvironmentCheck | null> {
   try {
     // Try to run the command to see if it exists
-    await execFileAsync(command, ["--version"], { timeout: 10_000 });
+    await execFileAsync(command, ["--version"], { timeout: 10_000, env });
     return null; // OK — it ran successfully
   } catch (err: unknown) {
     const e = err as NodeJS.ErrnoException;
@@ -54,10 +55,12 @@ async function checkCliInstalled(
 
 async function checkCliVersion(
   command: string,
+  env: Record<string, string>,
 ): Promise<AdapterEnvironmentCheck | null> {
   try {
     const { stdout } = await execFileAsync(command, ["--version"], {
       timeout: 10_000,
+      env,
     });
     const version = stdout.trim();
     if (version) {
@@ -83,10 +86,11 @@ async function checkCliVersion(
   }
 }
 
-async function checkPython(): Promise<AdapterEnvironmentCheck | null> {
+async function checkPython(env: Record<string, string>): Promise<AdapterEnvironmentCheck | null> {
   try {
     const { stdout } = await execFileAsync("python3", ["--version"], {
       timeout: 5_000,
+      env,
     });
     const version = stdout.trim();
     const match = version.match(/(\d+)\.(\d+)/);
@@ -135,10 +139,12 @@ function checkModel(
 async function checkApiKeys(
   config: Record<string, unknown>,
   detectedConfig: Awaited<ReturnType<typeof detectModel>> | null,
+  childEnv: Record<string, string>,
 ): Promise<AdapterEnvironmentCheck | null> {
   // The server resolves secret refs into config.env before calling testEnvironment,
-  // so we check config.env first (adapter-configured secrets), then fall back to
-  // process.env (server/host environment), then ~/.hermes/.env (Hermes local config).
+  // so we check the isolated child environment first, then ~/.hermes/.env.
+  // Server-only provider keys are intentionally excluded because execution
+  // cannot inherit them unless the agent config explicitly opts them in.
   const envConfig = (config.env ?? {}) as Record<string, unknown>;
   const resolvedEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(envConfig)) {
@@ -151,7 +157,7 @@ async function checkApiKeys(
   // accurate results for keys that Hermes already knows about.
   const hermesEnvKeys: Record<string, string> = {};
   try {
-    const homeDir = process.env.HOME || process.env.USERPROFILE || "/root";
+    const homeDir = childEnv.HOME || childEnv.USERPROFILE || "/root";
     const hermesEnvPath = `${homeDir}/.hermes/.env`;
     const content = readFileSync(hermesEnvPath, "utf-8");
     for (const line of content.split("\n")) {
@@ -168,8 +174,7 @@ async function checkApiKeys(
     // ~/.hermes/.env may not exist — that's fine
   }
 
-  const has = (key: string): boolean =>
-    !!(resolvedEnv[key] ?? process.env[key] ?? hermesEnvKeys[key]);
+  const has = (key: string): boolean => !!(resolvedEnv[key] ?? childEnv[key] ?? hermesEnvKeys[key]);
 
   const hasAnthropic = has("ANTHROPIC_API_KEY");
   const hasOpenRouter = has("OPENROUTER_API_KEY");
@@ -330,10 +335,11 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const config = (ctx.config ?? {}) as Record<string, unknown>;
   const command = resolveHermesCommand(config);
+  const childEnv = buildHermesChildEnv(config);
   const checks: AdapterEnvironmentCheck[] = [];
 
   // 1. CLI installed?
-  const cliCheck = await checkCliInstalled(command);
+  const cliCheck = await checkCliInstalled(command, childEnv);
   if (cliCheck) {
     checks.push(cliCheck);
     if (cliCheck.level === "error") {
@@ -347,11 +353,11 @@ export async function testEnvironment(
   }
 
   // 2. CLI version
-  const versionCheck = await checkCliVersion(command);
+  const versionCheck = await checkCliVersion(command, childEnv);
   if (versionCheck) checks.push(versionCheck);
 
   // 3. Python available?
-  const pythonCheck = await checkPython();
+  const pythonCheck = await checkPython(childEnv);
   if (pythonCheck) checks.push(pythonCheck);
 
   // 4. Model config
@@ -367,7 +373,7 @@ export async function testEnvironment(
   }
 
   // 6. API keys (check config.env — server resolves secrets before calling us)
-  const apiKeyCheck = await checkApiKeys(config, detectedConfig);
+  const apiKeyCheck = await checkApiKeys(config, detectedConfig, childEnv);
   if (apiKeyCheck) checks.push(apiKeyCheck);
 
   // 7. Provider/model consistency

--- a/packages/adapters/hermes/src/server/test.ts
+++ b/packages/adapters/hermes/src/server/test.ts
@@ -18,7 +18,7 @@ import { promisify } from "node:util";
 import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
 import { detectModel, resolveProvider, inferProviderFromModel } from "./detect-model.js";
 import { buildHermesChildEnv, resolveHermesCommand } from "./execute.js";
-import { readEnvironmentValue, resolveHermesConfigPath } from "./environment.js";
+import { readEnvironmentValue, resolveHermesConfigPath, resolveHermesEnvPath } from "./environment.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -143,7 +143,8 @@ async function checkApiKeys(
   childEnv: Record<string, string>,
 ): Promise<AdapterEnvironmentCheck | null> {
   // The server resolves secret refs into config.env before calling testEnvironment,
-  // so we check the isolated child environment first, then ~/.hermes/.env.
+  // so we check the isolated child environment first, then the .env file from
+  // the child's effective Hermes home.
   // Server-only provider keys are intentionally excluded because execution
   // cannot inherit them unless the agent config explicitly opts them in.
   const envConfig = (config.env ?? {}) as Record<string, unknown>;
@@ -152,26 +153,24 @@ async function checkApiKeys(
     if (typeof value === "string" && value.length > 0) resolvedEnv[key] = value;
   }
 
-  // Also read ~/.hermes/.env — Hermes stores API keys there by default and does
+  // Also read the .env file from the effective Hermes home — Hermes stores API keys there by default and does
   // not export them to the parent process, so Paperclip's process.env won't
   // contain them.  Parsing this file ensures the environment test reports
   // accurate results for keys that Hermes already knows about.
   const hermesEnvKeys: Record<string, string> = {};
   try {
-    const homeDir =
-      readEnvironmentValue(childEnv, "HOME") ||
-      readEnvironmentValue(childEnv, "USERPROFILE") ||
-      "/root";
-    const hermesEnvPath = `${homeDir}/.hermes/.env`;
-    const content = readFileSync(hermesEnvPath, "utf-8");
-    for (const line of content.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith("#")) continue;
-      const eqIdx = trimmed.indexOf("=");
-      if (eqIdx > 0) {
-        const key = trimmed.substring(0, eqIdx).trim();
-        const value = trimmed.substring(eqIdx + 1).trim();
-        if (value.length > 0) hermesEnvKeys[key] = value;
+    const hermesEnvPath = resolveHermesEnvPath(childEnv);
+    if (hermesEnvPath !== null && hermesEnvPath !== undefined) {
+      const content = readFileSync(hermesEnvPath, "utf-8");
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eqIdx = trimmed.indexOf("=");
+        if (eqIdx > 0) {
+          const key = trimmed.substring(0, eqIdx).trim();
+          const value = trimmed.substring(eqIdx + 1).trim();
+          if (value.length > 0) hermesEnvKeys[key] = value;
+        }
       }
     }
   } catch {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters launch agent processes from the long-running Paperclip server.
> - The shared process runner normally inherits the server environment, and the Hermes adapter also copied the entire server environment into its explicit child environment.
> - That makes server-only database settings, signing material, control-plane profile paths, and future secrets available to every Hermes run unless each variable is individually denied.
> - Denying only currently known secret names is not durable because new server configuration can be added later.
> - This pull request adds an opt-out for process-environment inheritance and makes Hermes execution and environment-test probes opt out, passing only an explicit OS/runtime allowlist, agent-configured environment, and Paperclip's run-scoped identity.
> - The benefit is that Hermes receives the runtime context it needs without inheriting the Paperclip server's authority.

## Linked Issues or Issue Description

Related to #4734, which strips specific known signing secrets in the shared runner. This PR is complementary: it prevents the Hermes adapter from inheriting arbitrary current and future server-only variables in the first place.

**Problem:** Start Paperclip with a sentinel such as `DATABASE_URL` or `HERMES_HOME`, execute a `hermes_local` run, and inspect the child environment. The variables are present because `execute.ts` spreads `process.env`, and `runChildProcess` also inherits the parent environment.

**Expected:** Hermes should receive only a documented set of non-secret OS/runtime variables, explicitly configured per-agent variables, and run-scoped `PAPERCLIP_*` values. Other server variables should be absent.

**Deployment mode:** Local/private Paperclip using the `hermes_local` adapter.

## What Changed

- Add an optional `inheritProcessEnv` process-runner flag; its default remains `true` so existing adapters are unchanged.
- Set `inheritProcessEnv: false` for Hermes launches.
- Replace the Hermes adapter's `process.env` spread with an explicit cross-platform allowlist for paths, locale, terminal, proxy, CA, XDG, and OS home/runtime variables.
- Continue to merge `config.env` after the allowlist so operators can explicitly grant agent-specific provider credentials or runtime settings.
- Run Hermes `--version` and Python environment-test probes through the same isolated child environment instead of raw `execFile` inheritance.
- Add process-level and adapter-level regressions proving an unrelated server secret, database URL, signing secret, and server `HERMES_HOME` are absent while explicit child values and `PATH` remain available.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts` — 73 passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter test` — 61 passed across all 8 adapter test files.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Medium, intentional compatibility change for Hermes only: provider keys or `HERMES_HOME` supplied solely through the Paperclip server's global environment are no longer inherited implicitly. Put them in the Hermes profile or the agent's explicit adapter `config.env` instead.
- Proxy and custom-CA variables remain allowlisted because isolated deployments may require them for network access; operators who do not want a proxy exposed should configure a credential-free proxy URL or override the agent environment.
- Other adapters retain the existing inheritance default.
- No schema, API, or migration change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using `gpt-5.6-sol`, with repository inspection, code execution, red/green regression testing, and an independent security review agent. The runtime did not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (N/A — no new config key or public API)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
