### PR TITLE
fix(auth): reject JWTs after agent runs finish

### DIFF
--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -334,6 +334,31 @@ describe("agent auth middleware", () => {
     expect(res.body).toMatchObject({ type: "none", source: "none" });
   });
 
+  it("rejects a JWT for a run that has not been claimed from the queue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: {
+        id: runId,
+        companyId,
+        agentId,
+        responsibleUserId: "user-claim",
+        status: "queued",
+      },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "none", source: "none" });
+  });
+
   it("preserves signed skill_test JWT scope on the request actor", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -33,7 +33,13 @@ function createSelectChain(rowsForTable: (table: unknown) => unknown[]) {
 function createDbState(input: {
   agent: { id: string; companyId: string; status?: string };
   agentKey?: { id: string; agentId: string; companyId: string; keyHash: string; responsibleUserId?: string | null };
-  run?: { id: string; companyId: string; agentId: string; responsibleUserId?: string | null };
+  run?: {
+    id: string;
+    companyId: string;
+    agentId: string;
+    responsibleUserId?: string | null;
+    status?: string;
+  };
 }) {
   const activity: Array<Record<string, unknown>> = [];
   const agentRow = {
@@ -58,6 +64,7 @@ function createDbState(input: {
         companyId: input.run.companyId,
         agentId: input.run.agentId,
         responsibleUserId: input.run.responsibleUserId ?? null,
+        status: input.run.status ?? "running",
       }
     : null;
 
@@ -282,6 +289,31 @@ describe("agent auth middleware", () => {
       onBehalfOfUserId: "user-claim",
       source: "agent_jwt",
     });
+  });
+
+  it("rejects an otherwise valid agent JWT after its run finishes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: {
+        id: runId,
+        companyId,
+        agentId,
+        responsibleUserId: "user-claim",
+        status: "succeeded",
+      },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "none", source: "none" });
   });
 
   it("preserves signed skill_test JWT scope on the request actor", async () => {

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -308,12 +308,11 @@ describe("agent auth middleware", () => {
     const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
 
     const res = await request(createApp(db))
-      .get("/actor")
+      .get(`/companies/${companyId}/protected`)
       .set("Authorization", `Bearer ${token}`)
       .set("X-Paperclip-Run-Id", runId);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ type: "none", source: "none" });
+    expect(res.status).toBe(401);
   });
 
   it("rejects an otherwise valid agent JWT when its run no longer exists", async () => {
@@ -326,12 +325,11 @@ describe("agent auth middleware", () => {
     const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
 
     const res = await request(createApp(db))
-      .get("/actor")
+      .get(`/companies/${companyId}/protected`)
       .set("Authorization", `Bearer ${token}`)
       .set("X-Paperclip-Run-Id", runId);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ type: "none", source: "none" });
+    expect(res.status).toBe(401);
   });
 
   it("rejects a JWT for a run that has not been claimed from the queue", async () => {
@@ -351,12 +349,56 @@ describe("agent auth middleware", () => {
     const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
 
     const res = await request(createApp(db))
+      .get(`/companies/${companyId}/protected`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("does not reclassify a finished agent JWT as a local-trusted board administrator", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: { id: runId, companyId, agentId, status: "succeeded" },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+    const res = await request(createApp(db, "local_trusted"))
+      .get(`/companies/${companyId}/protected`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(401);
+  });
+
+  it.each([
+    ["company", { companyId: randomUUID() }],
+    ["agent", { agentId: randomUUID() }],
+  ])("rejects a running JWT when the %s does not match its run", async (_label, override) => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const runOverride = override as { companyId?: string; agentId?: string };
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: {
+        id: runId,
+        companyId: runOverride.companyId ?? companyId,
+        agentId: runOverride.agentId ?? agentId,
+        status: "running",
+      },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+    const res = await request(createApp(db, "local_trusted"))
       .get("/actor")
       .set("Authorization", `Bearer ${token}`)
       .set("X-Paperclip-Run-Id", runId);
 
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ type: "none", source: "none" });
+    expect(res.status).toBe(401);
   });
 
   it("preserves signed skill_test JWT scope on the request actor", async () => {

--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -316,6 +316,24 @@ describe("agent auth middleware", () => {
     expect(res.body).toMatchObject({ type: "none", source: "none" });
   });
 
+  it("rejects an otherwise valid agent JWT when its run no longer exists", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", runId, "user-claim");
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "none", source: "none" });
+  });
+
   it("preserves signed skill_test JWT scope on the request actor", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -374,7 +374,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         runId: claims.run_id,
       });
       if (!activeRun) {
-        next();
+        next(unauthorized("Agent JWT is not authorized for an active run"));
         return;
       }
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -72,13 +72,19 @@ function invalidAgentTokenMessage(token: string) {
   return "Agent token did not verify; obtain fresh credentials and retry";
 }
 
-async function resolveLegacyRunResponsibleUserId(
+async function resolveActiveAgentRun(
   db: Db,
   input: { companyId: string; agentId: string; runId: string },
 ) {
   if (!isUuidLike(input.runId)) return null;
   const run = await db
-    .select({ responsibleUserId: heartbeatRuns.responsibleUserId })
+    .select({
+      id: heartbeatRuns.id,
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+      responsibleUserId: heartbeatRuns.responsibleUserId,
+      status: heartbeatRuns.status,
+    })
     .from(heartbeatRuns)
     .where(
       and(
@@ -88,8 +94,14 @@ async function resolveLegacyRunResponsibleUserId(
       ),
     )
     .then((rows) => rows[0] ?? null);
-  return normalizeOptionalString(run?.responsibleUserId);
+  return run?.id === input.runId &&
+    run.companyId === input.companyId &&
+    run.agentId === input.agentId &&
+    run.status === "running"
+    ? run
+    : null;
 }
+
 
 async function loadResponsibleUserMemberships(
   db: Db,
@@ -356,13 +368,19 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         return;
       }
 
+      const activeRun = await resolveActiveAgentRun(db, {
+        companyId: claims.company_id,
+        agentId: claims.sub,
+        runId: claims.run_id,
+      });
+      if (!activeRun) {
+        next();
+        return;
+      }
+
       const onBehalfOfUserId = claims.responsible_user_id !== undefined
         ? normalizeOptionalString(claims.responsible_user_id)
-        : await resolveLegacyRunResponsibleUserId(db, {
-            companyId: claims.company_id,
-            agentId: claims.sub,
-            runId: claims.run_id,
-          });
+        : normalizeOptionalString(activeRun.responsibleUserId);
       const onBehalfOfMemberships = await loadResponsibleUserMemberships(db, {
         companyId: claims.company_id,
         userId: onBehalfOfUserId,

--- a/tests/e2e/pipelines-tutorial-flow.spec.ts
+++ b/tests/e2e/pipelines-tutorial-flow.spec.ts
@@ -107,7 +107,33 @@ async function createPipelineWriterAgentKey(board: APIRequestContext, companyId:
   await expectOk(approveResponse, "approve pipeline-writer join");
   const approved = await approveResponse.json() as { createdAgentId: string };
 
-  const runId = randomUUID();
+  const configureResponse = await board.patch(`/api/agents/${approved.createdAgentId}`, {
+    data: {
+      adapterConfig: {
+        command: process.execPath,
+        args: ["-e", "setTimeout(() => {}, 220000)"],
+        timeoutSec: 230,
+      },
+    },
+  });
+  await expectOk(configureResponse, "configure pipeline-writer runtime");
+
+  const invokeResponse = await board.post(`/api/agents/${approved.createdAgentId}/heartbeat/invoke`, {
+    data: {},
+  });
+  await expectOk(invokeResponse, "start pipeline-writer run");
+  const invoked = await invokeResponse.json() as { id: string };
+
+  let status = "queued";
+  for (let attempt = 0; attempt < 100 && status !== "running"; attempt += 1) {
+    const runResponse = await board.get(`/api/heartbeat-runs/${invoked.id}`);
+    await expectOk(runResponse, "read pipeline-writer run");
+    status = ((await runResponse.json()) as { status: string }).status;
+    if (status !== "running") await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  expect(status).toBe("running");
+
+  const runId = invoked.id;
   const token = createLocalAgentJwt(approved.createdAgentId, companyId, "process", runId);
   if (!token) throw new Error("PAPERCLIP_AGENT_JWT_SECRET is required for pipeline writer JWT setup");
   return { agentId: approved.createdAgentId, runId, token };
@@ -431,6 +457,10 @@ test.describe("Pipelines tutorial UI flow", () => {
     expect(editedA.version).toBeGreaterThan(childA.version);
     expect(rereviewed.case.version).toBeGreaterThan(changedReview.version);
 
+    await expectOk(
+      await board.post(`/api/heartbeat-runs/${key.runId}/cancel`),
+      "cancel pipeline-writer run",
+    );
     await agentApi.dispose();
     await board.dispose();
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local adapter runs receive short-lived signed JWTs so the agent can call the Paperclip API as the intended run identity
> - Those JWTs include a run ID, but authentication previously validated only the signature, claims, and agent record
> - A token therefore remained usable after its heartbeat run reached a terminal state, until its time-based expiry
> - Run-scoped credentials should stop authorizing requests when their run is no longer active
> - This pull request validates the signed run against the database and accepts it only while that exact company/agent run is `running`
> - The benefit is immediate run-bound revocation without adding a token denylist or migration

## Inline bug report

No public issue was found, so this follows the bug-report template inline.

### Pre-submission checklist

- [x] I searched existing open and closed issues and this is not a duplicate.
- [x] I reproduced this on current `master`.
- [x] I confirmed the behavior originates in Paperclip's local-agent JWT middleware, not an adapter provider or local configuration.

### What happened?

A valid local-agent JWT remains accepted after its associated heartbeat run finishes. The request continues to receive an `agent_jwt` actor until the token's `exp` time even though its signed run ID is no longer active.

### Expected behavior

The middleware should reject the JWT as soon as the exact signed company/agent run is no longer `running`.

### Steps to reproduce

1. Create a local-agent JWT for a heartbeat run.
2. Transition the run from `running` to a terminal status such as `succeeded`.
3. Send another API request with the still-unexpired JWT.

### Paperclip version or commit

`master` at `e55d702916c4` before this change.

### Deployment mode

Self-hosted server.

### Installation method

Built from source with pnpm.

### Agent adapter(s) involved

Hermes; the bug is in core local-agent JWT middleware and can affect any local adapter using this credential path.

### Database mode

External Postgres.

### Access context

Agent bearer JWT.

### Node.js version

`v22.22.3`.

### Operating system

Linux 6.8 x86_64.

### Relevant logs or output

The focused regression received an `agent_jwt` actor after the fixture run changed to `succeeded` before the fix; it receives the anonymous actor afterward. No credential or instance-local output is included.

### Privacy checklist

- [x] I reviewed the text for usernames, paths, API keys, tokens, company names, and other private instance data.

## What Changed

- Resolve the exact signed run by run ID, company ID, and agent ID during local-agent JWT authentication.
- Accept the JWT only while that run has status `running`.
- Reuse the validated run row for legacy `responsible_user_id` fallback rather than issuing a second lookup.
- Add regressions proving that an otherwise valid JWT becomes anonymous before queue claim, after its run succeeds, or after its run row disappears.

## Verification

- `pnpm exec vitest run src/__tests__/agent-auth-middleware.test.ts` — 10 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.
- The new regression failed before the implementation by receiving an `agent_jwt` actor and passed afterward.

## Risks

- Every local-agent JWT request now performs one indexed heartbeat-run lookup. This replaces the existing lookup used by legacy claim-less JWTs and adds one lookup for modern JWTs.
- Queued runs remain unauthorized by design: `claimQueuedRun` atomically persists `status = running` before `executeRun` can mint the JWT and invoke the adapter.
- Authorization ends immediately when a run leaves `running`; this is intentional because the adapter process has already finished before terminal finalization.
- No schema migration or public API shape change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, with repository tool use and red-green TDD.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: internal authentication behavior and regression coverage only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
