### PR TITLE
Render managed experimental settings as locked, with a 'Managed by Paperclip Cloud' badge

### DIFF
--- a/ui/src/api/instanceSettings.ts
+++ b/ui/src/api/instanceSettings.ts
@@ -1,5 +1,5 @@
 import type {
-  InstanceExperimentalSettings,
+  InstanceExperimentalSettingsWithManaged,
   InstanceGeneralSettings,
   InstanceSettings,
   IssueGraphLivenessAutoRecoveryPreview,
@@ -19,9 +19,9 @@ export const instanceSettingsApi = {
   updateGeneral: (patch: PatchInstanceGeneralSettings) =>
     api.patch<InstanceGeneralSettings>("/instance/settings/general", patch),
   getExperimental: () =>
-    api.get<InstanceExperimentalSettings>("/instance/settings/experimental"),
+    api.get<InstanceExperimentalSettingsWithManaged>("/instance/settings/experimental"),
   updateExperimental: (patch: PatchInstanceExperimentalSettings) =>
-    api.patch<InstanceExperimentalSettings>("/instance/settings/experimental", patch),
+    api.patch<InstanceExperimentalSettingsWithManaged>("/instance/settings/experimental", patch),
   previewIssueGraphLivenessAutoRecovery: (input: { lookbackHours?: number }) =>
     api.post<IssueGraphLivenessAutoRecoveryPreview>(
       "/instance/settings/experimental/issue-graph-liveness-auto-recovery/preview",

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InstanceExperimentalSettings } from "./InstanceExperimentalSettings";
+import { queryKeys } from "../lib/queryKeys";
 
 const mockInstanceSettingsApi = vi.hoisted(() => ({
   getExperimental: vi.fn(),
@@ -574,11 +575,12 @@ describe("InstanceExperimentalSettings — cloud-managed keys", () => {
 
   let container: HTMLDivElement;
   let root: Root | null = null;
+  let queryClient: QueryClient;
 
   async function renderPage(settings: InstanceExperimentalSettingsWithManaged) {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({ ...settings });
     root = createRoot(container);
-    const queryClient = new QueryClient({
+    queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
     flushSync(() => {
@@ -655,6 +657,39 @@ describe("InstanceExperimentalSettings — cloud-managed keys", () => {
     expect(mockInstanceSettingsApi.previewIssueGraphLivenessAutoRecovery).not.toHaveBeenCalled();
     expect(mockInstanceSettingsApi.updateExperimental).not.toHaveBeenCalled();
     expect(document.body.textContent).not.toContain("Confirm auto-recovery");
+  });
+
+  it("closes an open recovery preview when a refresh marks auto-recovery as managed", async () => {
+    mockInstanceSettingsApi.previewIssueGraphLivenessAutoRecovery.mockResolvedValue(
+      emptyRecoveryPreview(),
+    );
+    const settings = defaultExperimentalSettings();
+    await renderPage(settings);
+
+    const toggle = container.querySelector<HTMLButtonElement>(AUTO_RECOVERY_TOGGLE_SELECTOR);
+    await act(() => toggle?.click());
+    await flushReact();
+    expect(document.body.textContent).toContain("Confirm auto-recovery");
+
+    const managedSettings: InstanceExperimentalSettingsWithManaged = {
+      ...settings,
+      enableIssueGraphLivenessAutoRecovery: true,
+      managedKeys: {
+        enableIssueGraphLivenessAutoRecovery: { managed: true, managedBy: "paperclip-cloud" },
+      },
+    };
+    await act(() => {
+      queryClient.setQueryData(queryKeys.instance.experimentalSettings, managedSettings);
+    });
+    await flushReact();
+
+    expect(document.body.textContent).not.toContain("Confirm auto-recovery");
+    expect(document.body.querySelector('[data-slot="dialog-overlay"]')).toBeNull();
+    expect(mockInstanceSettingsApi.updateExperimental).not.toHaveBeenCalled();
+    expect(mockInstanceSettingsApi.runIssueGraphLivenessAutoRecovery).not.toHaveBeenCalled();
+
+    const lockedToggle = container.querySelector<HTMLButtonElement>(AUTO_RECOVERY_TOGGLE_SELECTOR);
+    expect(lockedToggle?.disabled).toBe(true);
   });
 
   it("renders no managed badge and keeps toggles editable without managedKeys (self-hosted)", async () => {

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type {
   InstanceExperimentalSettings as InstanceExperimentalSettingsPayload,
+  InstanceExperimentalSettingsWithManaged,
   IssueGraphLivenessAutoRecoveryPreview,
 } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -565,5 +566,107 @@ describe("InstanceExperimentalSettings — Conference Room Chat card (PAP-11233)
     expect(document.body.querySelector('[data-slot="dialog-overlay"]')).toBeNull();
     const enabledToggle = container.querySelector<HTMLButtonElement>(AUTO_RECOVERY_TOGGLE_SELECTOR);
     expect(enabledToggle?.getAttribute("aria-checked")).toBe("true");
+  });
+});
+
+describe("InstanceExperimentalSettings — cloud-managed keys", () => {
+  const MANAGED_BADGE_TEXT = "Managed by Paperclip Cloud";
+
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  async function renderPage(settings: InstanceExperimentalSettingsWithManaged) {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ ...settings });
+    root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    flushSync(() => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <InstanceExperimentalSettings />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockInstanceSettingsApi.updateExperimental.mockImplementation(async (patch) => ({
+      ...defaultExperimentalSettings(),
+      ...patch,
+    }));
+  });
+
+  afterEach(() => {
+    flushSync(() => {
+      root?.unmount();
+    });
+    root = null;
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a managed key locked with the badge while unmanaged keys stay editable", async () => {
+    await renderPage({
+      ...defaultExperimentalSettings(),
+      enableApps: true,
+      managedKeys: {
+        enableApps: { managed: true, managedBy: "paperclip-cloud" },
+      },
+    });
+
+    expect(container.textContent).toContain(MANAGED_BADGE_TEXT);
+
+    const appsToggle = container.querySelector<HTMLButtonElement>(APPS_TOGGLE_SELECTOR);
+    expect(appsToggle?.getAttribute("aria-checked")).toBe("true");
+    expect(appsToggle?.disabled).toBe(true);
+
+    await act(() => appsToggle?.click());
+    await flushReact();
+    expect(mockInstanceSettingsApi.updateExperimental).not.toHaveBeenCalled();
+
+    const summariesToggle = container.querySelector<HTMLButtonElement>(SUMMARIES_TOGGLE_SELECTOR);
+    expect(summariesToggle?.disabled).toBe(false);
+
+    await act(() => summariesToggle?.click());
+    await flushReact();
+    expect(mockInstanceSettingsApi.updateExperimental).toHaveBeenCalledWith({
+      enableSummaries: true,
+    });
+  });
+
+  it("locks the managed auto-recovery toggle without opening the preview dialog", async () => {
+    await renderPage({
+      ...defaultExperimentalSettings(),
+      managedKeys: {
+        enableIssueGraphLivenessAutoRecovery: { managed: true, managedBy: "paperclip-cloud" },
+      },
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>(AUTO_RECOVERY_TOGGLE_SELECTOR);
+    expect(toggle?.disabled).toBe(true);
+
+    await act(() => toggle?.click());
+    await flushReact();
+
+    expect(mockInstanceSettingsApi.previewIssueGraphLivenessAutoRecovery).not.toHaveBeenCalled();
+    expect(mockInstanceSettingsApi.updateExperimental).not.toHaveBeenCalled();
+    expect(document.body.textContent).not.toContain("Confirm auto-recovery");
+  });
+
+  it("renders no managed badge and keeps toggles editable without managedKeys (self-hosted)", async () => {
+    await renderPage(defaultExperimentalSettings());
+
+    expect(container.textContent).not.toContain(MANAGED_BADGE_TEXT);
+
+    const appsToggle = container.querySelector<HTMLButtonElement>(APPS_TOGGLE_SELECTOR);
+    expect(appsToggle?.disabled).toBe(false);
+
+    await act(() => appsToggle?.click());
+    await flushReact();
+    expect(mockInstanceSettingsApi.updateExperimental).toHaveBeenCalledWith({ enableApps: true });
   });
 });

--- a/ui/src/pages/InstanceExperimentalSettings.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.tsx
@@ -321,6 +321,17 @@ export function InstanceExperimentalSettings() {
     }
   }, [experimentalQuery.data?.issueGraphLivenessAutoRecoveryLookbackHours]);
 
+  const autoRecoveryManaged =
+    experimentalQuery.data?.managedKeys?.enableIssueGraphLivenessAutoRecovery?.managed === true;
+
+  // If refreshed settings mark auto-recovery as managed while the preview
+  // dialog is open, close it so its confirmation actions cannot emit a PATCH.
+  useEffect(() => {
+    if (autoRecoveryManaged) {
+      closeRecoveryPreview();
+    }
+  }, [autoRecoveryManaged]);
+
   if (experimentalQuery.isLoading) {
     return <div className="text-sm text-muted-foreground">Loading experimental settings...</div>;
   }
@@ -369,7 +380,6 @@ export function InstanceExperimentalSettings() {
   const autoRestartDevServerWhenIdle = experimentalQuery.data?.autoRestartDevServerWhenIdle === true;
   const enableIssueGraphLivenessAutoRecovery =
     experimentalQuery.data?.enableIssueGraphLivenessAutoRecovery === true;
-  const autoRecoveryManaged = managedKeys.enableIssueGraphLivenessAutoRecovery?.managed === true;
   const lookbackHours =
     experimentalQuery.data?.issueGraphLivenessAutoRecoveryLookbackHours ?? 24;
   const parsedLookbackHours = Number.parseInt(lookbackHoursDraft, 10);
@@ -379,6 +389,7 @@ export function InstanceExperimentalSettings() {
     toggleMutation.isPending || previewMutation.isPending || runRecoveryMutation.isPending;
 
   function previewForEnable() {
+    if (autoRecoveryManaged) return;
     if (!lookbackHoursIsValid) {
       setActionError("Lookback hours must be a whole number from 1 to 720.");
       return;
@@ -388,6 +399,7 @@ export function InstanceExperimentalSettings() {
   }
 
   function enableOnly() {
+    if (autoRecoveryManaged) return;
     if (!lookbackHoursIsValid) return;
     closeRecoveryPreview();
     toggleMutation.mutate({
@@ -397,6 +409,7 @@ export function InstanceExperimentalSettings() {
   }
 
   function enableAndRun() {
+    if (autoRecoveryManaged) return;
     if (!lookbackHoursIsValid) return;
     closeRecoveryPreview();
     toggleMutation.mutate({
@@ -763,7 +776,7 @@ export function InstanceExperimentalSettings() {
         </div>
       </Card>
 
-      {previewDialogOpen ? (
+      {previewDialogOpen && !autoRecoveryManaged ? (
         <RecoveryPreviewDialog
           open
           onOpenChange={(open) => {

--- a/ui/src/pages/InstanceExperimentalSettings.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Clock, FlaskConical, Play, Search } from "lucide-react";
+import { AlertTriangle, Clock, FlaskConical, Lock, Play, Search } from "lucide-react";
 import type {
   InstanceExperimentalSettings,
+  InstanceExperimentalSettingsWithManaged,
   IssueGraphLivenessAutoRecoveryPreview,
+  ManagedSettingMetadata,
   PatchInstanceExperimentalSettings,
 } from "@paperclipai/shared";
 import { instanceSettingsApi } from "@/api/instanceSettings";
@@ -73,6 +75,63 @@ function formatActivationTimestamp(iso: string): string {
 
 // PAP-11233: keep Conference Room code intact, but hide the user-facing opt-in for now.
 const SHOW_CONFERENCE_ROOM_EXPERIMENTAL_SETTING = false;
+
+function ManagedByCloudBadge() {
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      <Lock aria-hidden="true" />
+      Managed by Paperclip Cloud
+    </Badge>
+  );
+}
+
+function ExperimentalToggleCard({
+  title,
+  experimental = false,
+  description,
+  footnote,
+  checked,
+  onCheckedChange,
+  disabled,
+  managed,
+  ariaLabel,
+}: {
+  title: string;
+  experimental?: boolean;
+  description: string;
+  footnote?: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled: boolean;
+  managed?: ManagedSettingMetadata;
+  ariaLabel: string;
+}) {
+  const isManaged = managed?.managed === true;
+  return (
+    <Card className="block p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold">{title}</h2>
+            {experimental ? <Badge variant="secondary">Experimental</Badge> : null}
+            {isManaged ? <ManagedByCloudBadge /> : null}
+          </div>
+          <p className="max-w-2xl text-sm text-muted-foreground">{description}</p>
+          {footnote ? <p className="max-w-2xl text-xs text-muted-foreground">{footnote}</p> : null}
+        </div>
+        <ToggleSwitch
+          checked={checked}
+          onCheckedChange={(next) => {
+            if (isManaged) return;
+            onCheckedChange(next);
+          }}
+          disabled={disabled || isManaged}
+          aria-label={ariaLabel}
+        />
+      </div>
+    </Card>
+  );
+}
 
 function RecoveryPreviewDialog({
   preview,
@@ -189,20 +248,20 @@ export function InstanceExperimentalSettings() {
   });
 
   const toggleMutation = useMutation<
-    InstanceExperimentalSettings,
+    InstanceExperimentalSettingsWithManaged,
     Error,
     PatchInstanceExperimentalSettings,
-    { previousSettings?: InstanceExperimentalSettings }
+    { previousSettings?: InstanceExperimentalSettingsWithManaged }
   >({
     mutationFn: async (patch: PatchInstanceExperimentalSettings) =>
       instanceSettingsApi.updateExperimental(patch),
     onMutate: async (patch) => {
       await queryClient.cancelQueries({ queryKey: queryKeys.instance.experimentalSettings });
-      const previousSettings = queryClient.getQueryData<InstanceExperimentalSettings>(
+      const previousSettings = queryClient.getQueryData<InstanceExperimentalSettingsWithManaged>(
         queryKeys.instance.experimentalSettings,
       );
       if (previousSettings) {
-        queryClient.setQueryData<InstanceExperimentalSettings>(
+        queryClient.setQueryData<InstanceExperimentalSettingsWithManaged>(
           queryKeys.instance.experimentalSettings,
           { ...previousSettings, ...patch },
         );
@@ -277,7 +336,12 @@ export function InstanceExperimentalSettings() {
   }
 
   const inWorktree = isWorktreeRuntime();
+  // Present only on cloud-managed instances: keys the managed overlay controls
+  // render locked with the "Managed by Paperclip Cloud" badge. Self-hosted
+  // responses carry no `managedKeys`, so every card stays editable.
+  const managedKeys = experimentalQuery.data?.managedKeys ?? {};
   const enableWorktreeRunExecution = experimentalQuery.data?.enableWorktreeRunExecution === true;
+  const worktreeRunExecutionManaged = managedKeys.enableWorktreeRunExecution?.managed === true;
   const worktreeRunExecutionState = resolveWorktreeRunExecutionDisplayState(
     experimentalQuery.data,
     getWorktreeInstanceId(),
@@ -305,6 +369,7 @@ export function InstanceExperimentalSettings() {
   const autoRestartDevServerWhenIdle = experimentalQuery.data?.autoRestartDevServerWhenIdle === true;
   const enableIssueGraphLivenessAutoRecovery =
     experimentalQuery.data?.enableIssueGraphLivenessAutoRecovery === true;
+  const autoRecoveryManaged = managedKeys.enableIssueGraphLivenessAutoRecovery?.managed === true;
   const lookbackHours =
     experimentalQuery.data?.issueGraphLivenessAutoRecoveryLookbackHours ?? 24;
   const parsedLookbackHours = Number.parseInt(lookbackHoursDraft, 10);
@@ -381,7 +446,10 @@ export function InstanceExperimentalSettings() {
           <div className="flex flex-col gap-4">
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1.5">
-                <h2 className="text-sm font-semibold">Run tasks in this worktree</h2>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h2 className="text-sm font-semibold">Run tasks in this worktree</h2>
+                  {worktreeRunExecutionManaged ? <ManagedByCloudBadge /> : null}
+                </div>
                 <p className="max-w-2xl text-sm text-muted-foreground">
                   This is an isolated git-worktree preview instance. Turn this on to let the scheduler execute runs
                   here. Only tasks created after enabling will run automatically — copied/pre-existing tasks stay
@@ -390,10 +458,11 @@ export function InstanceExperimentalSettings() {
               </div>
               <ToggleSwitch
                 checked={enableWorktreeRunExecution}
-                onCheckedChange={(checked) =>
-                  toggleMutation.mutate({ enableWorktreeRunExecution: checked })
-                }
-                disabled={toggleMutation.isPending}
+                onCheckedChange={(checked) => {
+                  if (worktreeRunExecutionManaged) return;
+                  toggleMutation.mutate({ enableWorktreeRunExecution: checked });
+                }}
+                disabled={toggleMutation.isPending || worktreeRunExecutionManaged}
                 aria-label="Toggle worktree run execution setting"
               />
             </div>
@@ -429,346 +498,189 @@ export function InstanceExperimentalSettings() {
         </Card>
       ) : null}
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <div className="flex items-center gap-2">
-              <h2 className="text-sm font-semibold">Apps</h2>
-              <Badge variant="secondary">Experimental</Badge>
-            </div>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show the Apps navigation and allow access to app connections, gateways, and advanced app tooling.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableApps}
-            onCheckedChange={() => toggleMutation.mutate({ enableApps: !enableApps })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle apps experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Apps"
+        experimental
+        description="Show the Apps navigation and allow access to app connections, gateways, and advanced app tooling."
+        checked={enableApps}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableApps: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableApps}
+        ariaLabel="Toggle apps experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <div className="flex items-center gap-2">
-              <h2 className="text-sm font-semibold">Cases</h2>
-              <Badge variant="secondary">Experimental</Badge>
-            </div>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Durable work products (blog posts, tweet storms…) that tasks create and iterate on. Adds the
-              Cases tab and the agent case API.
-            </p>
-            <p className="max-w-2xl text-xs text-muted-foreground">
-              Turning Cases off hides the tab and blocks the case API; existing case data is kept.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableCases}
-            onCheckedChange={() => toggleMutation.mutate({ enableCases: !enableCases })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle cases experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Cases"
+        experimental
+        description="Durable work products (blog posts, tweet storms…) that tasks create and iterate on. Adds the Cases tab and the agent case API."
+        footnote="Turning Cases off hides the tab and blocks the case API; existing case data is kept."
+        checked={enableCases}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableCases: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableCases}
+        ariaLabel="Toggle cases experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Enable Environments</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show environment management in company settings and allow project and agent environment assignment
-              controls.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableEnvironments}
-            onCheckedChange={() => toggleMutation.mutate({ enableEnvironments: !enableEnvironments })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle environments experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Enable Environments"
+        description="Show environment management in company settings and allow project and agent environment assignment controls."
+        checked={enableEnvironments}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableEnvironments: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableEnvironments}
+        ariaLabel="Toggle environments experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Built-in Agents</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show Paperclip-managed built-in agent surfaces, including built-in roster badges, the Built-in agents
-              tab, and built-in agent setup controls.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableBuiltInAgents}
-            onCheckedChange={() => toggleMutation.mutate({ enableBuiltInAgents: !enableBuiltInAgents })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle built-in agents experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Built-in Agents"
+        description="Show Paperclip-managed built-in agent surfaces, including built-in roster badges, the Built-in agents tab, and built-in agent setup controls."
+        checked={enableBuiltInAgents}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableBuiltInAgents: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableBuiltInAgents}
+        ariaLabel="Toggle built-in agents experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Summaries</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show Summarizer-generated status slots on project and workspace pages, with on-demand refresh and
-              revision history. Existing summary data is kept when this is disabled.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableSummaries}
-            onCheckedChange={() => toggleMutation.mutate({ enableSummaries: !enableSummaries })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle summaries experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Summaries"
+        description="Show Summarizer-generated status slots on project and workspace pages, with on-demand refresh and revision history. Existing summary data is kept when this is disabled."
+        checked={enableSummaries}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableSummaries: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableSummaries}
+        ariaLabel="Toggle summaries experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Experimental File Viewer</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show task detail controls for browsing and previewing workspace files relative to a task.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableExperimentalFileViewer}
-            onCheckedChange={() =>
-              toggleMutation.mutate({
-                enableExperimentalFileViewer: !enableExperimentalFileViewer,
-              })
-            }
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle experimental file viewer setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Experimental File Viewer"
+        description="Show task detail controls for browsing and previewing workspace files relative to a task."
+        checked={enableExperimentalFileViewer}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableExperimentalFileViewer: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableExperimentalFileViewer}
+        ariaLabel="Toggle experimental file viewer setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Enable External Objects</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Detect external URLs in issues and show resolved status for pull requests, tickets, and other referenced
-              work objects.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableExternalObjects}
-            onCheckedChange={() => toggleMutation.mutate({ enableExternalObjects: !enableExternalObjects })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle external objects experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Enable External Objects"
+        description="Detect external URLs in issues and show resolved status for pull requests, tickets, and other referenced work objects."
+        checked={enableExternalObjects}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableExternalObjects: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableExternalObjects}
+        ariaLabel="Toggle external objects experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Decisions</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show the Decisions item in the main sidebar — the attention home that surfaces the tasks awaiting your
-              input — while the surface is still being evaluated.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableDecisions}
-            onCheckedChange={() => toggleMutation.mutate({ enableDecisions: !enableDecisions })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle decisions experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Decisions"
+        description="Show the Decisions item in the main sidebar — the attention home that surfaces the tasks awaiting your input — while the surface is still being evaluated."
+        checked={enableDecisions}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableDecisions: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableDecisions}
+        ariaLabel="Toggle decisions experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Goals Sidebar Link</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Restore the Goals item in the main sidebar while the goals surface is being evaluated.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableGoalsSidebarLink}
-            onCheckedChange={() => toggleMutation.mutate({ enableGoalsSidebarLink: !enableGoalsSidebarLink })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle goals sidebar link experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Goals Sidebar Link"
+        description="Restore the Goals item in the main sidebar while the goals surface is being evaluated."
+        checked={enableGoalsSidebarLink}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableGoalsSidebarLink: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableGoalsSidebarLink}
+        ariaLabel="Toggle goals sidebar link experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Enable Isolated Workspaces</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show execution workspace controls in project configuration and allow isolated workspace behavior for new
-              and existing task runs.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableIsolatedWorkspaces}
-            onCheckedChange={() => toggleMutation.mutate({ enableIsolatedWorkspaces: !enableIsolatedWorkspaces })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle isolated workspaces experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Enable Isolated Workspaces"
+        description="Show execution workspace controls in project configuration and allow isolated workspace behavior for new and existing task runs."
+        checked={enableIsolatedWorkspaces}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableIsolatedWorkspaces: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableIsolatedWorkspaces}
+        ariaLabel="Toggle isolated workspaces experimental setting"
+      />
 
       {SHOW_CONFERENCE_ROOM_EXPERIMENTAL_SETTING ? (
-        <Card className="block p-5">
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1.5">
-              <h2 className="text-sm font-semibold">Conference Room Chat</h2>
-              <p className="max-w-2xl text-sm text-muted-foreground">
-                Adds a Conference Room — one chat where you and your whole team work together — plus the live activity
-                feed and the redesigned onboarding. Also restyles task threads as chat bubbles. Turn off anytime to
-                restore the classic UI.
-              </p>
-            </div>
-            <ToggleSwitch
-              checked={enableConferenceRoomChat}
-              onCheckedChange={() =>
-                toggleMutation.mutate({
-                  enableConferenceRoomChat: !enableConferenceRoomChat,
-                })
-              }
-              disabled={toggleMutation.isPending}
-              aria-label="Toggle conference room chat experimental setting"
-            />
-          </div>
-        </Card>
+        <ExperimentalToggleCard
+          title="Conference Room Chat"
+          description="Adds a Conference Room — one chat where you and your whole team work together — plus the live activity feed and the redesigned onboarding. Also restyles task threads as chat bubbles. Turn off anytime to restore the classic UI."
+          checked={enableConferenceRoomChat}
+          onCheckedChange={(checked) => toggleMutation.mutate({ enableConferenceRoomChat: checked })}
+          disabled={toggleMutation.isPending}
+          managed={managedKeys.enableConferenceRoomChat}
+          ariaLabel="Toggle conference room chat experimental setting"
+        />
       ) : null}
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Task Plan Decomposition Panel</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show accepted-plan decomposition history on task detail pages. Intended for debugging and validating
-              subtask creation behavior while the presentation is still being refined.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableIssuePlanDecompositions}
-            onCheckedChange={() =>
-              toggleMutation.mutate({
-                enableIssuePlanDecompositions: !enableIssuePlanDecompositions,
-              })
-            }
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle task plan decomposition panel experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Task Plan Decomposition Panel"
+        description="Show accepted-plan decomposition history on task detail pages. Intended for debugging and validating subtask creation behavior while the presentation is still being refined."
+        checked={enableIssuePlanDecompositions}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableIssuePlanDecompositions: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableIssuePlanDecompositions}
+        ariaLabel="Toggle task plan decomposition panel experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Task Watchdogs</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show task detail controls for configuring watchdog agents that verify stopped task subtrees and restore
-              live paths when work should continue.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableTaskWatchdogs}
-            onCheckedChange={(checked) =>
-              toggleMutation.mutate({
-                enableTaskWatchdogs: checked,
-              })
-            }
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle task watchdogs experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Task Watchdogs"
+        description="Show task detail controls for configuring watchdog agents that verify stopped task subtrees and restore live paths when work should continue."
+        checked={enableTaskWatchdogs}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableTaskWatchdogs: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableTaskWatchdogs}
+        ariaLabel="Toggle task watchdogs experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Cloud Sync</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show local Paperclip Cloud upstream connection, preview, push, retry, and activation review surfaces.
-              Saved connections and run history are preserved when this is disabled.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableCloudSync}
-            onCheckedChange={() => toggleMutation.mutate({ enableCloudSync: !enableCloudSync })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle cloud sync experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Cloud Sync"
+        description="Show local Paperclip Cloud upstream connection, preview, push, retry, and activation review surfaces. Saved connections and run history are preserved when this is disabled."
+        checked={enableCloudSync}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableCloudSync: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableCloudSync}
+        ariaLabel="Toggle cloud sync experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Server Info Debug View</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Show a "Server" section in the account drawer with the current server restart time and running commit.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableServerInfoDebugView}
-            onCheckedChange={() =>
-              toggleMutation.mutate({
-                enableServerInfoDebugView: !enableServerInfoDebugView,
-              })
-            }
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle server info debug view experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Server Info Debug View"
+        description='Show a "Server" section in the account drawer with the current server restart time and running commit.'
+        checked={enableServerInfoDebugView}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableServerInfoDebugView: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableServerInfoDebugView}
+        ariaLabel="Toggle server info debug view experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Smoke Lab</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              Add a "Smoke Lab" tab under Apps → Developer and an "Integration smoke" card on the
-              dashboard for exercising every integration path against deterministic local fixtures
-              (fake OAuth provider + loopback MCP servers). Private (non-public) deployments only.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={enableSmokeLab}
-            onCheckedChange={() => toggleMutation.mutate({ enableSmokeLab: !enableSmokeLab })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle smoke lab experimental setting"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Smoke Lab"
+        description='Add a "Smoke Lab" tab under Apps → Developer and an "Integration smoke" card on the dashboard for exercising every integration path against deterministic local fixtures (fake OAuth provider + loopback MCP servers). Private (non-public) deployments only.'
+        checked={enableSmokeLab}
+        onCheckedChange={(checked) => toggleMutation.mutate({ enableSmokeLab: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.enableSmokeLab}
+        ariaLabel="Toggle smoke lab experimental setting"
+      />
 
-      <Card className="block p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1.5">
-            <h2 className="text-sm font-semibold">Auto-Restart Dev Server When Idle</h2>
-            <p className="max-w-2xl text-sm text-muted-foreground">
-              In `pnpm dev:once`, wait for all queued and running local agent runs to finish, then restart the server
-              automatically when backend changes or migrations make the current boot stale.
-            </p>
-          </div>
-          <ToggleSwitch
-            checked={autoRestartDevServerWhenIdle}
-            onCheckedChange={() => toggleMutation.mutate({ autoRestartDevServerWhenIdle: !autoRestartDevServerWhenIdle })}
-            disabled={toggleMutation.isPending}
-            aria-label="Toggle guarded dev-server auto-restart"
-          />
-        </div>
-      </Card>
+      <ExperimentalToggleCard
+        title="Auto-Restart Dev Server When Idle"
+        description="In `pnpm dev:once`, wait for all queued and running local agent runs to finish, then restart the server automatically when backend changes or migrations make the current boot stale."
+        checked={autoRestartDevServerWhenIdle}
+        onCheckedChange={(checked) => toggleMutation.mutate({ autoRestartDevServerWhenIdle: checked })}
+        disabled={toggleMutation.isPending}
+        managed={managedKeys.autoRestartDevServerWhenIdle}
+        ariaLabel="Toggle guarded dev-server auto-restart"
+      />
 
       <Card className="block p-5">
         <div className="flex flex-col gap-5">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1.5">
-              <h2 className="text-sm font-semibold">Auto-Create Recovery Tasks</h2>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-sm font-semibold">Auto-Create Recovery Tasks</h2>
+                {autoRecoveryManaged ? <ManagedByCloudBadge /> : null}
+              </div>
               <p className="max-w-2xl text-sm text-muted-foreground">
                 Let the heartbeat scheduler create recovery tasks for task dependency chains found inside the
                 configured lookback window.
@@ -777,13 +689,14 @@ export function InstanceExperimentalSettings() {
             <ToggleSwitch
               checked={enableIssueGraphLivenessAutoRecovery}
               onCheckedChange={() => {
+                if (autoRecoveryManaged) return;
                 if (enableIssueGraphLivenessAutoRecovery) {
                   toggleMutation.mutate({ enableIssueGraphLivenessAutoRecovery: false });
                   return;
                 }
                 previewForEnable();
               }}
-              disabled={recoveryActionPending}
+              disabled={recoveryActionPending || autoRecoveryManaged}
               aria-label="Toggle task graph liveness auto-recovery"
             />
           </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The experimental settings page renders one interactive toggle per feature from the settings API
> - On managed instances some values are enforced by the hosting control plane, and the API now reports those keys as managed
> - Rendering enforced values as live toggles misleads users: the click appears to work, and the value silently snaps back
> - This pull request renders managed keys as locked toggles with a "Managed by Paperclip Cloud" badge and guards the handlers so no PATCH can be emitted
> - The benefit is UI honesty on managed instances, with self-hosted responses rendering exactly as before

## Linked Issues or Issue Description

Builds on #10058 — renders the per-key `managedKeys` metadata #10058 adds to settings responses (typing shared from #10058 at rebase).

No public issue exists; `feature_request` template fields:

- **Problem or motivation:** on managed instances users see fully interactive toggles for settings the control plane enforces; changes appear to apply and never do, with no explanation.
- **Proposed solution:** disabled toggle + badge + guarded handler driven by the settings response's managed-key metadata; the ~17 uniform setting cards are extracted into one shared component with copy, aria-labels, and patch payloads preserved verbatim.
- **Alternatives considered:** hiding managed settings entirely (users lose sight of the effective value and why it is fixed); tooltip-only hints on still-active toggles (doomed PATCHes are still emitted and stripped server-side).
- **Roadmap alignment:** supports the in-progress "Cloud deployments" milestone in `ROADMAP.md`.

## What Changed

- When the settings API reports a feature key as managed (`managedKeys` from the managed-config overlay), the experimental settings page renders that toggle disabled with a badge and a guarded handler, so a click can never emit a PATCH. Previously, managed-instance users saw fully interactive toggles they could never actually change. Self-hosted responses (no `managedKeys`) render exactly as before.
- The ~17 copy-pasted uniform setting cards are extracted into one `ExperimentalToggleCard` component with titles, descriptions, footnotes, aria-labels, and patch payloads preserved verbatim; the two bespoke cards get inline managed handling (the managed auto-recovery toggle also cannot open its preview dialog).
- `ui/src/api/instanceSettings.ts` response typing now uses the shared `InstanceExperimentalSettingsWithManaged` / `ManagedSettingMetadata` types from #10058; `ui/src/pages/InstanceExperimentalSettings.tsx` locked rendering + card extraction; tests.

## Verification

- 24 page tests (20 existing unmodified + 4 new: locked badge with no PATCH while unmanaged keys stay editable; managed auto-recovery opens no dialog; an open recovery preview closes with no PATCH when a refresh marks auto-recovery managed; self-hosted unaffected): `pnpm --filter @paperclipai/ui exec vitest run src/pages/InstanceExperimentalSettings.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck` clean

## Risks

- Low risk. UI-only change; no server or API behavior changes. Self-hosted responses carry no `managedKeys`, so the page renders exactly as before there. The card extraction preserves copy, aria-labels, and patch payloads verbatim, covered by the 20 pre-existing page tests passing unmodified.

## Model Used

Claude Fable 5 (`claude-fable-5`), extended thinking, agentic tool use; independently peer-reviewed by a second AI agent before push

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

