### PR TITLE
build(codex-local): bump codex-acp 1.1.0→1.1.7 to restore gpt-5.6-sol support

### DIFF
--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -52,7 +52,7 @@
     "probe:quota": "pnpm exec tsx src/cli/quota-probe.ts --json"
   },
   "dependencies": {
-    "@agentclientprotocol/codex-acp": "^1.1.0",
+    "@agentclientprotocol/codex-acp": "^1.1.7",
     "@paperclipai/adapter-utils": "workspace:*",
     "picocolors": "^1.1.1"
   },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `codex_local` adapter runs agents through Codex; its default execution lane is ACP, which spawns the `codex-acp` server and drives the bundled `@openai/codex` core
> - `@agentclientprotocol/codex-acp@1.1.0` pins `@openai/codex@0.142.5`, and that core rejects the `gpt-5.6-sol` model and fails to load its models cache
> - With `gpt-5.6-sol` unusable on the pinned core, every ACP-lane codex_local agent errors out and the local Codex fleet goes offline
> - `codex-acp@1.1.7` depends on `@openai/codex@^0.145.0`, whose core accepts `gpt-5.6-sol`; the adapter already declares `^1.1.0`, so this only moves the resolved version forward
> - This PR raises the dependency floor to `^1.1.7` so the ACP lane resolves a Codex core that supports the model
> - The benefit is the local Codex adapter works again with current models, at zero added cost and no protocol change (codex-acp stays within its 1.1.x line)

## Linked Issues or Issue Description

No public GitHub issue — describing inline (bug report):

- **What happened:** All `codex_local` agents fail to execute; runs error before producing output.
- **Root cause:** The default ACP execution lane resolves its Codex core through `@agentclientprotocol/codex-acp@1.1.0` → `@openai/codex@0.142.5`. That core returns `400 invalid_request_error: "The 'gpt-5.6-sol' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."` and logs `failed to load models cache: missing field 'supports_reasoning_summaries'` / `Model metadata for 'gpt-5.6-sol' not found`.
- **Expected:** codex_local agents run against `gpt-5.6-sol`.
- **Environment:** ChatGPT-account Codex auth; `@openai/codex` 0.142.5 on the ACP lane. `codex exec --model gpt-5.6-sol` succeeds on `@openai/codex` 0.144.1 / 0.145.0 and fails on 0.142.5, isolating the cause to the pinned core version.
- Related (not duplicates): #9780 (resolve gpt-5.6 metadata at source), #9382 (refresh models from Codex cache), #9355 (codex-acp session-config rejections).

## What Changed

- `packages/adapters/codex-local/package.json`: raise `@agentclientprotocol/codex-acp` floor `^1.1.0` → `^1.1.7` (transitively `@openai/codex` 0.142.5 → 0.145.0). Lockfile regeneration is owned by CI per repo policy, so no `pnpm-lock.yaml` change is committed here.

## Verification

- `codex exec --model gpt-5.6-sol` returns normally on `@openai/codex` 0.144.1, 0.145.0, and app-bundled 0.145.0-alpha.30; fails on 0.142.5 with the exact production error.
- After the bump, `@agentclientprotocol/codex-acp` resolves to 1.1.7 and its `@openai/codex` resolves to 0.145.0; that core accepts `gpt-5.6-sol`.
- `pnpm install --frozen-lockfile` succeeds against the CI-regenerated lockfile; 0 remaining references to 0.142.5.
- `codex-acp` is spawned per run, so the running control plane picks up the new core on the next agent run without a restart.

## Risks

- Low. codex-acp stays within its `1.1.x` line (already permitted by the existing `^1.1.0` range), so no ACP protocol/behavior break is expected. The transitive Codex core moves 0.142.5 → 0.145.0 (same series shipped in the current Codex app). No new or paid dependency.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / code execution.

## Checklist

- [x] I searched the GitHub PR list (open + recently closed) for similar PRs and confirmed this is not a duplicate.
