### PR TITLE
fix(issues): skip non-invokable mention wake targets

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -502,14 +502,20 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
   });
 
-  it("resolves only structured same-company agent mentions", async () => {
+  it("resolves only structured same-company wakeable agent mentions", async () => {
     const companyId = await seedAssignableAgentCompany();
     const otherCompanyId = await seedAssignableAgentCompany();
     const localAgentId = randomUUID();
     const foreignAgentId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const pausedAgentId = randomUUID();
+    const pendingAgentId = randomUUID();
 
     await db.insert(agents).values([
       agentRow(companyId, { id: localAgentId, name: "LocalAgent" }),
+      agentRow(companyId, { id: terminatedAgentId, name: "TerminatedAgent", status: "terminated" }),
+      agentRow(companyId, { id: pausedAgentId, name: "PausedAgent", status: "paused" }),
+      agentRow(companyId, { id: pendingAgentId, name: "PendingAgent", status: "pending_approval" }),
       agentRow(otherCompanyId, { id: foreignAgentId, name: "ForeignAgent" }),
     ]);
 
@@ -517,6 +523,9 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       companyId,
       [
         `hello [@LocalAgent](${buildAgentMentionHref(localAgentId)})`,
+        `skip [@TerminatedAgent](${buildAgentMentionHref(terminatedAgentId)})`,
+        `skip [@PausedAgent](${buildAgentMentionHref(pausedAgentId)})`,
+        `skip [@PendingAgent](${buildAgentMentionHref(pendingAgentId)})`,
         `and [@ForeignAgent](${buildAgentMentionHref(foreignAgentId)})`,
       ].join(" "),
     );

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -510,12 +510,16 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     const terminatedAgentId = randomUUID();
     const pausedAgentId = randomUUID();
     const pendingAgentId = randomUUID();
+    const invalidChainAgentId = randomUUID();
+    const terminatedManagerId = randomUUID();
 
     await db.insert(agents).values([
       agentRow(companyId, { id: localAgentId, name: "LocalAgent" }),
       agentRow(companyId, { id: terminatedAgentId, name: "TerminatedAgent", status: "terminated" }),
       agentRow(companyId, { id: pausedAgentId, name: "PausedAgent", status: "paused" }),
       agentRow(companyId, { id: pendingAgentId, name: "PendingAgent", status: "pending_approval" }),
+      agentRow(companyId, { id: terminatedManagerId, name: "TerminatedManager", status: "terminated" }),
+      agentRow(companyId, { id: invalidChainAgentId, name: "InvalidChainAgent", reportsTo: terminatedManagerId }),
       agentRow(otherCompanyId, { id: foreignAgentId, name: "ForeignAgent" }),
     ]);
 
@@ -526,6 +530,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         `skip [@TerminatedAgent](${buildAgentMentionHref(terminatedAgentId)})`,
         `skip [@PausedAgent](${buildAgentMentionHref(pausedAgentId)})`,
         `skip [@PendingAgent](${buildAgentMentionHref(pendingAgentId)})`,
+        `skip [@InvalidChainAgent](${buildAgentMentionHref(invalidChainAgentId)})`,
         `and [@ForeignAgent](${buildAgentMentionHref(foreignAgentId)})`,
       ].join(" "),
     );

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -872,12 +872,16 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     const terminatedAgentId = randomUUID();
     const pausedAgentId = randomUUID();
     const pendingAgentId = randomUUID();
+    const invalidChainAgentId = randomUUID();
+    const terminatedManagerId = randomUUID();
 
     await db.insert(agents).values([
       agentRow(companyId, { id: localAgentId, name: "LocalAgent" }),
       agentRow(companyId, { id: terminatedAgentId, name: "TerminatedAgent", status: "terminated" }),
       agentRow(companyId, { id: pausedAgentId, name: "PausedAgent", status: "paused" }),
       agentRow(companyId, { id: pendingAgentId, name: "PendingAgent", status: "pending_approval" }),
+      agentRow(companyId, { id: terminatedManagerId, name: "TerminatedManager", status: "terminated" }),
+      agentRow(companyId, { id: invalidChainAgentId, name: "InvalidChainAgent", reportsTo: terminatedManagerId }),
       agentRow(otherCompanyId, { id: foreignAgentId, name: "ForeignAgent" }),
     ]);
 
@@ -888,6 +892,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
         `skip [@TerminatedAgent](${buildAgentMentionHref(terminatedAgentId)})`,
         `skip [@PausedAgent](${buildAgentMentionHref(pausedAgentId)})`,
         `skip [@PendingAgent](${buildAgentMentionHref(pendingAgentId)})`,
+        `skip [@InvalidChainAgent](${buildAgentMentionHref(invalidChainAgentId)})`,
         `and [@ForeignAgent](${buildAgentMentionHref(foreignAgentId)})`,
       ].join(" "),
     );

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -864,14 +864,20 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
   });
 
-  it("resolves only structured same-company agent mentions", async () => {
+  it("resolves only structured same-company wakeable agent mentions", async () => {
     const companyId = await seedAssignableAgentCompany();
     const otherCompanyId = await seedAssignableAgentCompany();
     const localAgentId = randomUUID();
     const foreignAgentId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const pausedAgentId = randomUUID();
+    const pendingAgentId = randomUUID();
 
     await db.insert(agents).values([
       agentRow(companyId, { id: localAgentId, name: "LocalAgent" }),
+      agentRow(companyId, { id: terminatedAgentId, name: "TerminatedAgent", status: "terminated" }),
+      agentRow(companyId, { id: pausedAgentId, name: "PausedAgent", status: "paused" }),
+      agentRow(companyId, { id: pendingAgentId, name: "PendingAgent", status: "pending_approval" }),
       agentRow(otherCompanyId, { id: foreignAgentId, name: "ForeignAgent" }),
     ]);
 
@@ -879,6 +885,9 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       companyId,
       [
         `hello [@LocalAgent](${buildAgentMentionHref(localAgentId)})`,
+        `skip [@TerminatedAgent](${buildAgentMentionHref(terminatedAgentId)})`,
+        `skip [@PausedAgent](${buildAgentMentionHref(pausedAgentId)})`,
+        `skip [@PendingAgent](${buildAgentMentionHref(pendingAgentId)})`,
         `and [@ForeignAgent](${buildAgentMentionHref(foreignAgentId)})`,
       ].join(" "),
     );

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7654,10 +7654,14 @@ export function issueService(db: Db) {
       const explicitAgentMentionIds = extractAgentMentionIds(body);
       if (explicitAgentMentionIds.length === 0) return [];
 
-      const rows = await db.select({ id: agents.id })
+      const rows = await db.select({ id: agents.id, status: agents.status })
         .from(agents).where(eq(agents.companyId, companyId));
-      const companyAgentIds = new Set(rows.map((agent) => agent.id));
-      return explicitAgentMentionIds.filter((agentId) => companyAgentIds.has(agentId));
+      const wakeableCompanyAgentIds = new Set(
+        rows
+          .filter((agent) => agent.status !== "paused" && agent.status !== "terminated" && agent.status !== "pending_approval")
+          .map((agent) => agent.id),
+      );
+      return explicitAgentMentionIds.filter((agentId) => wakeableCompanyAgentIds.has(agentId));
     },
 
     findMentionedProjectIds: async (

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -60,6 +60,7 @@ import {
   issueCommentAuthorTypeSchema,
   issueCommentMetadataSchema,
   issueCommentPresentationSchema,
+  isAgentInvokable,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
@@ -7654,11 +7655,17 @@ export function issueService(db: Db) {
       const explicitAgentMentionIds = extractAgentMentionIds(body);
       if (explicitAgentMentionIds.length === 0) return [];
 
-      const rows = await db.select({ id: agents.id, status: agents.status })
+      const rows = await db.select({
+        id: agents.id,
+        companyId: agents.companyId,
+        name: agents.name,
+        status: agents.status,
+        reportsTo: agents.reportsTo,
+      })
         .from(agents).where(eq(agents.companyId, companyId));
       const wakeableCompanyAgentIds = new Set(
         rows
-          .filter((agent) => agent.status !== "paused" && agent.status !== "terminated" && agent.status !== "pending_approval")
+          .filter((agent) => isAgentInvokable({ agent, agents: rows }))
           .map((agent) => agent.id),
       );
       return explicitAgentMentionIds.filter((agentId) => wakeableCompanyAgentIds.has(agentId));

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -91,6 +91,7 @@ import {
   issueCommentAuthorTypeSchema,
   issueCommentMetadataSchema,
   issueCommentPresentationSchema,
+  isAgentInvokable,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
@@ -12849,14 +12850,20 @@ export function issueService(db: Db) {
       const explicitAgentMentionIds = extractAgentMentionIds(body);
       if (explicitAgentMentionIds.length === 0) return [];
 
-      const rows = await db
-        .select({ id: agents.id })
-        .from(agents)
-        .where(eq(agents.companyId, companyId));
-      const companyAgentIds = new Set(rows.map((agent) => agent.id));
-      return explicitAgentMentionIds.filter((agentId) =>
-        companyAgentIds.has(agentId),
+      const rows = await db.select({
+        id: agents.id,
+        companyId: agents.companyId,
+        name: agents.name,
+        status: agents.status,
+        reportsTo: agents.reportsTo,
+      })
+        .from(agents).where(eq(agents.companyId, companyId));
+      const wakeableCompanyAgentIds = new Set(
+        rows
+          .filter((agent) => isAgentInvokable({ agent, agents: rows }))
+          .map((agent) => agent.id),
       );
+      return explicitAgentMentionIds.filter((agentId) => wakeableCompanyAgentIds.has(agentId));
     },
 
     findMentionedProjectIds: async (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Comment mentions are part of the issue/task control-plane loop: a board or agent can mention another in-company agent and Paperclip queues a targeted wake.
> - The wake path already rejects non-invokable agents such as `paused`, `terminated`, and `pending_approval`, but mention resolution could still return those agent ids.
> - That means a structured mention of a stale or terminated duplicate can turn into a 409 wake attempt instead of selecting only targets that can actually run.
> - This pull request keeps mention resolution company-scoped and structured-only, but filters out non-invokable target statuses before the wake queue sees them.
> - The benefit is fewer noisy failed wake attempts and a tighter control-plane invariant: mention-triggered wakes only target agents that are eligible to be invoked.

## Linked Issues or Issue Description

Fixes: #9770

## What Changed

- Updated `issueService.findMentionedAgents` to load agent status and return only same-company mention targets that are not `paused`, `terminated`, or `pending_approval`.
- Extended the existing issue-service mention test to cover same-company terminated, paused, and pending-approval agents alongside the existing foreign-company guard.

## Verification

- `corepack pnpm vitest run src/__tests__/issues-service.test.ts --config vitest.config.ts` from `server/` (7 passed, 100 skipped)
- `git diff --check`
- Duplicate search before opening: `gh pr list --repo paperclipai/paperclip --state open --search "mention wake terminated paused pending_approval invokable agent" --json number,title,url,headRefName,author --limit 50`

## Risks

- Low risk: this narrows only automated mention wake targets and preserves the existing structured-mention and company-boundary behavior.
- A mention of a paused, terminated, or pending-approval agent will no longer enqueue a failing wake. The mention text still remains in the comment, but the agent will not be woken until an invokable replacement is mentioned.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent in Codex desktop, tool-assisted repository inspection and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
