### PR TITLE
fix(interactions): stop wedging confirmation accept on a terminal workspace_finalize

### DIFF
--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -2069,6 +2069,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     async function seedAcceptGateFixture(options?: {
       kind?: AcceptGateInteractionKind;
       sourceRunId?: string | null;
+      sourceRunStatus?: string;
     }) {
       const companyId = randomUUID();
       const projectId = randomUUID();
@@ -2115,6 +2116,8 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
         runtimeConfig: {},
         permissions: {},
       });
+      const sourceRunStatus = options?.sourceRunStatus ?? "succeeded";
+      const sourceRunTerminal = sourceRunStatus !== "running";
       await db.insert(heartbeatRuns).values([
         ...(sourceRunId
           ? [
@@ -2123,9 +2126,9 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
                 companyId,
                 agentId,
                 invocationSource: "manual",
-                status: "succeeded",
+                status: sourceRunStatus,
                 startedAt: new Date("2026-05-23T21:55:00.000Z"),
-                finishedAt: new Date("2026-05-23T22:05:00.000Z"),
+                finishedAt: sourceRunTerminal ? new Date("2026-05-23T22:05:00.000Z") : null,
               },
             ]
           : []),
@@ -2297,6 +2300,105 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
         id: interactionId,
         kind: "request_confirmation",
         status: "accepted",
+      });
+    });
+
+    it("allows request_confirmation accept when the source run's workspace_finalize failed", async () => {
+      // A sync-back that ran and FAILED is terminal. The run will not retry it, so
+      // the confirmation must not stay wedged behind a misleading "still syncing"
+      // error — the user can merge/act manually.
+      const { companyId, executionWorkspaceId, issueId, goalId, interactionId, sourceRunId } =
+        await seedAcceptGateFixture({ sourceRunStatus: "failed" });
+
+      await db.insert(workspaceOperations).values({
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: sourceRunId,
+        phase: "workspace_config_freshness",
+        status: "succeeded",
+        startedAt: new Date("2026-05-23T22:00:00.000Z"),
+      });
+      await db.insert(workspaceOperations).values({
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: sourceRunId,
+        phase: "workspace_finalize",
+        status: "failed",
+        startedAt: new Date("2026-05-23T22:05:00.000Z"),
+      });
+
+      const accepted = await interactionsSvc.acceptInteraction(
+        { id: issueId, companyId, goalId, projectId: null },
+        interactionId,
+        {},
+        { userId: "local-board" },
+      );
+
+      expect(accepted.interaction).toMatchObject({
+        id: interactionId,
+        kind: "request_confirmation",
+        status: "accepted",
+      });
+    });
+
+    it("allows request_confirmation accept when a running workspace_finalize is stale (source run ended)", async () => {
+      // The source run died mid-finalize, leaving a `running` op that will never
+      // advance. A terminal/missing owner run means the record is stale, so the
+      // gate must not wait on it forever.
+      const { companyId, executionWorkspaceId, issueId, goalId, interactionId, sourceRunId } =
+        await seedAcceptGateFixture({ sourceRunStatus: "failed" });
+
+      await db.insert(workspaceOperations).values({
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: sourceRunId,
+        phase: "workspace_finalize",
+        status: "running",
+        startedAt: new Date("2026-05-23T22:05:00.000Z"),
+      });
+
+      const accepted = await interactionsSvc.acceptInteraction(
+        { id: issueId, companyId, goalId, projectId: null },
+        interactionId,
+        {},
+        { userId: "local-board" },
+      );
+
+      expect(accepted.interaction).toMatchObject({
+        id: interactionId,
+        kind: "request_confirmation",
+        status: "accepted",
+      });
+    });
+
+    it("refuses request_confirmation accept while a workspace_finalize is running on a live source run", async () => {
+      // A genuinely in-flight sync-back on a still-active run must still block, so
+      // the confirmation cannot race commits that are actively being synced back.
+      const { companyId, executionWorkspaceId, issueId, goalId, interactionId, sourceRunId } =
+        await seedAcceptGateFixture({ sourceRunStatus: "running" });
+
+      await db.insert(workspaceOperations).values({
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: sourceRunId,
+        phase: "workspace_finalize",
+        status: "running",
+        startedAt: new Date("2026-05-23T22:05:00.000Z"),
+      });
+
+      await expect(
+        interactionsSvc.acceptInteraction(
+          { id: issueId, companyId, goalId, projectId: null },
+          interactionId,
+          {},
+          { userId: "local-board" },
+        ),
+      ).rejects.toMatchObject({
+        status: 409,
+        message: expect.stringContaining(
+          "the run that created this interaction has not finished syncing its workspace",
+        ),
+        details: { executionWorkspaceId, sourceRunId },
       });
     });
 

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -888,6 +888,11 @@ export function issueThreadInteractionService(db: Db) {
 
     if (!executionWorkspaceId) return;
 
+    // Block only while the source run's worktree sync-back is genuinely still
+    // pending or in flight. A finalize that reached a terminal outcome — including
+    // a `failed` sync-back or a stale `running` record left by an ended run — is
+    // treated as settled by `runWorkspaceIsFinalized`, so a dead run can no longer
+    // wedge this confirmation forever.
     const isFinalized = await runWorkspaceIsFinalized(
       args.db,
       args.issue.companyId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1059,11 +1059,42 @@ async function listPendingFinalizeBlockerIssueIds(
 }
 
 /**
- * Returns whether a specific run's operations on a specific execution workspace
- * reached the workspace_finalize barrier.
+ * Whether a heartbeat run has reached a terminal state or no longer exists.
+ * A terminal/missing run can make no further progress on its execution
+ * workspace, so callers must not wait on it to advance an in-flight operation.
+ */
+export async function heartbeatRunIsTerminalOrMissing(
+  dbOrTx: Pick<Db, "select">,
+  runId: string,
+): Promise<boolean> {
+  const run = await dbOrTx
+    .select({ status: heartbeatRuns.status })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows: Array<{ status: string }>) => rows[0] ?? null);
+  if (!run) return true;
+  return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+}
+
+/**
+ * Returns whether a specific run's sync-back on a specific execution workspace
+ * has settled — i.e. the accept/review gates that guard against a still-in-flight
+ * worktree sync no longer need to block on this run.
  *
- * Runs with no operations on the workspace are considered finalized because
- * they never touched the workspace state that accept/review gates protect.
+ * Semantics:
+ * - No operations recorded → settled. The run never touched the workspace state
+ *   the gates protect.
+ * - Earlier phases recorded but no `workspace_finalize` yet → NOT settled. The
+ *   sync-back hasn't been attempted; the gate should wait for it.
+ * - Latest `workspace_finalize` reached a terminal status (`succeeded`, `failed`,
+ *   or `skipped`) → settled. A finalize that ran and finished is done even if it
+ *   failed: it will not retry within this run, so continuing to block would wedge
+ *   the gate forever — a failed sync-back must not permanently block a
+ *   confirmation accept behind a misleading "still syncing" error.
+ * - Latest `workspace_finalize` is still `running` → in flight, so NOT settled —
+ *   unless the owning run has itself ended, in which case the `running` record is
+ *   stale (the process died mid-finalize) and we treat it as settled rather than
+ *   wait on a run that can never make progress.
  */
 export async function runWorkspaceIsFinalized(
   dbOrTx: Pick<Db, "select">,
@@ -1086,13 +1117,24 @@ export async function runWorkspaceIsFinalized(
       ),
     );
 
-  let latest: { phase: string; status: string; startedAt: Date } | null = null;
+  if (rows.length === 0) return true;
+
+  let latestFinalize: { status: string; startedAt: Date } | null = null;
   for (const row of rows) {
-    if (!latest || row.startedAt > latest.startedAt) latest = row;
+    if (row.phase !== "workspace_finalize") continue;
+    if (!latestFinalize || row.startedAt > latestFinalize.startedAt) latestFinalize = row;
   }
 
-  if (!latest) return true;
-  return latest.phase === "workspace_finalize" && latest.status === "succeeded";
+  // The run touched the workspace but hasn't reached the sync-back phase yet.
+  if (!latestFinalize) return false;
+
+  // A finalize that reached any terminal status is settled — including `failed`
+  // and `skipped`. It will not retry within this run, so gates must stop waiting.
+  if (latestFinalize.status !== "running") return true;
+
+  // Finalize is still marked `running`. It is only genuinely in flight while the
+  // owning run is alive; a `running` record left behind by an ended run is stale.
+  return heartbeatRunIsTerminalOrMissing(dbOrTx, runId);
 }
 
 async function listIssueDependencyReadinessMap(
@@ -4456,13 +4498,7 @@ export function issueService(db: Db) {
   }
 
   async function isTerminalOrMissingHeartbeatRun(runId: string, dbOrTx: DbReader = db) {
-    const run = await dbOrTx
-      .select({ status: heartbeatRuns.status })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId))
-      .then((rows) => rows[0] ?? null);
-    if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    return heartbeatRunIsTerminalOrMissing(dbOrTx, runId);
   }
 
   async function adoptStaleCheckoutRun(input: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Agents do their work in isolated execution workspaces (worktrees); when a run finishes it syncs its worktree back to the branch in a `workspace_finalize` phase.
> - Human-facing thread interactions — like the "Merged" / mark-done confirmation button — are gated so a person can't accept while the creating run is still syncing commits back, which would race the sync-back.
> - That gate treated **only** a `succeeded` finalize as "done": if a run's sync-back reached a terminal `failed` state, or the run died mid-finalize leaving a stale `running` record, the confirmation stayed permanently blocked with a misleading "…has not finished syncing its workspace" error — even though nothing was syncing and the run had long since ended.
> - So an operator who hit a failed/abandoned sync-back could never accept the confirmation through the UI; the only workaround was to merge and mark the task done by hand.
> - This pull request fixes the settle semantics so the gate blocks only while a sync-back is genuinely pending or in flight, and treats any terminal finalize (`succeeded`/`failed`/`skipped`) — or a `running` record owned by an already-ended run — as settled.
> - The benefit is that a failed or abandoned sync-back no longer wedges a human confirmation behind a false "still syncing" error, while a genuinely in-flight sync-back on a live run still correctly blocks.

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the bug in-PR following the bug-report fields:

- **What happened:** Clicking the "Merged" confirmation at the bottom of a thread returns a 409 error saying the workspace hasn't finished syncing, but no sync is in progress and the originating run has already ended. The confirmation can never be accepted through the UI.
- **Expected behavior:** Once the originating run's sync-back has reached a terminal state (`succeeded`, `failed`, or `skipped`) — or the run that owned an in-progress sync-back has itself ended — the confirmation should be acceptable. Only a sync-back genuinely still in flight on a live run should block.
- **Steps to reproduce:**
  1. Start an agent run in an execution workspace that records workspace operations.
  2. Have the run's `workspace_finalize` (sync-back) reach a terminal `failed` state (or have the run die mid-finalize, leaving a `running` finalize record).
  3. Open the associated `request_confirmation` / `request_checkbox_confirmation` interaction and click accept / "Merged".
  4. Observe the 409 "…has not finished syncing its workspace" error, with no way to proceed.
- **Deployment mode:** local (embedded postgres). Affects the interaction accept path in `server`.

**Related PRs** (same underlying bug, surfaced during the pre-flight duplicate search — different approaches):
- #9520 — decouples confirmation-card accepts from workspace sync by recording the decision immediately and rerouting execution onto a fresh worktree. That is a broader behavioral change; this PR is a narrower fix to the finalize-settled predicate that keeps the gate closed for genuinely in-flight syncs.
- #9416 / #9687 / #9639 — recover/release finalize barriers held by dead or failed runs. This PR overlaps in spirit (a dead run must not hold a gate open forever) but is scoped to the human confirmation-accept path only and deliberately leaves the automated dependency barrier strict.

## What Changed

- `runWorkspaceIsFinalized` now settles on **any** terminal `workspace_finalize` status (`succeeded`, `failed`, or `skipped`) instead of only `succeeded`, so a failed sync-back no longer blocks a confirmation accept forever.
- A `running` finalize still blocks — **unless** its owning heartbeat run has itself reached a terminal state or no longer exists, in which case the `running` record is treated as stale and settled.
- Preserved existing behavior for the "no workspace operations at all" case (settled) and the "earlier phases recorded but no finalize yet" case (still blocks — sync-back hasn't been attempted).
- Extracted a shared `heartbeatRunIsTerminalOrMissing` helper and reused it from the existing `isTerminalOrMissingHeartbeatRun` closure (no behavior change there).
- Left the blocker/dependency-readiness barrier (`listPendingFinalizeBlockerIssueIds`) **unchanged**: an automated dependent must not build on a base that never received a blocker's synced-back commits, so a failed finalize still keeps that gate closed. Only the human-driven confirmation accept is relaxed.
- Added regression tests: failed-finalize accept, stale-running-on-dead-run accept, and running-on-live-run still-refuses (409).

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-thread-interactions-service.test.ts` — the new and existing accept-gate tests pass, including the strict 409 case confirming a live in-flight sync-back still blocks.
- Server typecheck: `pnpm --filter @paperclipai/server typecheck` passes.
- Manual reasoning: with a run whose `workspace_finalize` is `failed`, accepting the confirmation now succeeds; with a `running` finalize on a still-live run, accept still returns 409.

## Risks

Low risk, scoped to the human confirmation-accept path:
- Relaxing the gate to accept on a `failed` finalize means a human could accept a confirmation for a run whose sync-back didn't complete. This is intentional and matches reality — the run has ended and will not retry, so either the commits landed or the human handles them manually. The automated dependency barrier that protects downstream automated work is deliberately left strict.
- The stale-`running` path depends on the owning run being terminal/missing; a genuinely live run with a `running` finalize still blocks, so no in-flight sync-back is raced.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8`, 1M-context variant. Extended reasoning with tool use (code exploration, local vitest execution, and typecheck).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (JSDoc on the settle predicate rewritten to document the new semantics)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
