### PR TITLE
feat(qa): add reusable site log audit

### DIFF
--- a/.agents/skills/site-log-audit/SKILL.md
+++ b/.agents/skills/site-log-audit/SKILL.md
@@ -68,7 +68,7 @@ Completion: every grouped signature has one disposition, every new defect has on
 ## Verification
 
 ```bash
-python3 scripts/test_audit_logs.py
+python3 scripts/tests/test_audit_logs.py
 ```
 
 Pass requires multi-site discovery, signature grouping, HTTP status grouping, URL-userinfo redaction, encoded/semicolon query-secret redaction in access/error logs, and fail-closed handling of malformed request targets.

--- a/.agents/skills/site-log-audit/SKILL.md
+++ b/.agents/skills/site-log-audit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: site-log-audit
+description: Use when auditing WordPress wpdev logs for one or every local site. Group redacted error signatures, match them to Paperclip issues, and file only untreated actionable findings.
+version: 1.0.2
+author: ClawTeam Engineering
+license: MIT
+metadata:
+  hermes:
+    tags: [wordpress, wpdev, logs, qa, paperclip]
+    related_skills: [systematic-debugging]
+---
+
+# Site Log Audit
+
+Use for one-site incidents, recurring QA log sweeps, or pre-release checks across every wpdev site.
+
+## Rules
+
+- Read-only. Never truncate, rotate, delete, or mutate logs during audit.
+- Treat `wp-content/debug.log`, OpenLiteSpeed `<site>-error.log`, and `<site>-access.log` as separate evidence streams. Counts can overlap.
+- Redact nonces, tokens, keys, cookies, credentials, and request bodies before storing evidence.
+- A historical line is not proof of current failure. Record timestamp, release path, recurrence, and a fresh read-only probe.
+- Search Paperclip before filing. Link exact issue identifiers for known signatures.
+- File only actionable unmatched findings. Group one root cause per issue; do not create one issue per repeated line.
+- QA must review code/site changes. DevOps must approve integration, default-branch push, release, or deployment.
+
+## Run
+
+From this skill directory:
+
+```bash
+python3 scripts/audit_logs.py --root /home/agents/workspaces/wordpress --site best-matcha > audit.json
+python3 scripts/audit_logs.py --root /home/agents/workspaces/wordpress > all-sites-audit.json
+```
+
+Optional lower bound:
+
+```bash
+python3 scripts/audit_logs.py --root /home/agents/workspaces/wordpress --since 2026-07-21T00:00:00Z
+```
+
+`--site` may repeat. With no `--site`, script discovers every directory under `sites/` and every `<site>-error.log`/`<site>-access.log` pair.
+
+## Procedure
+
+1. Capture immutable context: audit UTC time, site, log paths, byte/line counts, first/last timestamps, active release target, and current health probe.
+2. Run `audit_logs.py`. Review grouped signatures by severity, count, first/last timestamp, source files, and redacted samples.
+3. Separate:
+   - current actionable defect;
+   - known issue (open or fixed but stale in retained logs);
+   - expected/benign request outcome;
+   - historical one-off with no recurrence;
+   - secondary symptom caused by another fatal or test load.
+4. For each plausible defect, search Paperclip using stable tokens: exception/function, file basename, route, DB constraint/table, or error text. Broad title-only searches are insufficient; inspect issue descriptions/comments.
+5. Run smallest read-only reproduction. Never clear logs to manufacture a clean baseline. Compare line count before/after probe instead.
+6. Create one implementation issue for each unmatched root cause. Bind active project and owner, then configure QA Engineer review followed by DevOps Engineer approval. Include reproduction, timestamps/counts, source path, acceptance checks, and exactly one named next action.
+7. Report known issue mappings, new issue identifiers, deferred historical noise, and unresolved access gaps.
+
+Completion: every grouped signature has one disposition, every new defect has one issue, and no stored sample contains a secret.
+
+## Access-log interpretation
+
+- Treat authenticated `400`, `403`, and expected `404` responses as defects only when request contract says success.
+- Group route shape, not secrets or request-specific IDs.
+- Old immutable-release URLs can remain in retained access logs after a fixed deployment. Check active symlink and fresh HTML before filing.
+- Source-map `404`s are usually non-blocking unless release policy requires maps.
+
+## Verification
+
+```bash
+python3 scripts/test_audit_logs.py
+```
+
+Pass requires multi-site discovery, signature grouping, HTTP status grouping, URL-userinfo redaction, encoded/semicolon query-secret redaction in access/error logs, and fail-closed handling of malformed request targets.
+
+## Common pitfalls
+
+1. Clearing logs before audit destroys history. Compare line counts around a fresh probe instead.
+2. Treating retained failures as current defects duplicates fixed work. Prove current release and recurrence.
+3. Searching only issue titles misses mapped defects. Search descriptions/comments with stable signature tokens.
+4. Syncing one skill onto an agent with a replacement API can drop existing desired skills. Read current desired set, append this skill, then sync full set.
+
+## Output contract
+
+JSON object:
+
+- `generated_at`, `root`, `sites`
+- `files`: path, size, lines, first/last timestamp
+- `events`: site, kind, severity/status, normalized signature, count, first/last timestamp, source files, redacted samples
+
+Script classifies evidence, not ownership. Human/agent audit still decides known versus untreated through Paperclip search and current reproduction.

--- a/.agents/skills/site-log-audit/scripts/audit_logs.py
+++ b/.agents/skills/site-log-audit/scripts/audit_logs.py
@@ -54,10 +54,16 @@ SENSITIVE_KEY_PARTS = frozenset({
 def parse_timestamp(line: str) -> datetime | None:
     access = ACCESS.match(line)
     if access:
-        return datetime.strptime(access.group(1), "%d/%b/%Y:%H:%M:%S %z")
+        try:
+            return datetime.strptime(access.group(1), "%d/%b/%Y:%H:%M:%S %z")
+        except ValueError:
+            return None
     match = OLS_TS.match(line)
     if match:
-        return datetime.fromisoformat(match.group(1)).replace(tzinfo=timezone.utc)
+        try:
+            return datetime.fromisoformat(match.group(1)).replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
     match = WP_TS.match(line)
     if match:
         for fmt in ("%d-%b-%Y %H:%M:%S %Z", "%d/%b/%Y:%H:%M:%S %z"):
@@ -119,21 +125,14 @@ def redact_url(raw: str) -> str:
 
 
 def redact_json_bodies(value: str) -> str:
-    def redact(item: object) -> object:
-        if isinstance(item, dict):
-            return {key: "<redacted>" if is_sensitive_key(key) else redact(child) for key, child in item.items()}
-        if isinstance(item, list):
-            return [redact(child) for child in item]
-        return item
-
     start = value.find("{")
     if start < 0:
         return value
     try:
-        body, end = json.JSONDecoder().raw_decode(value[start:])
+        _, end = json.JSONDecoder().raw_decode(value[start:])
     except json.JSONDecodeError:
         return value[:start] + "<redacted>"
-    return value[:start] + json.dumps(redact(body), separators=(",", ":")) + redact_json_bodies(value[start + end:])
+    return value[:start] + "<redacted>" + redact_json_bodies(value[start + end:])
 
 
 def redact_secrets(value: str) -> str:
@@ -223,7 +222,9 @@ def audit(root: Path, sites: list[str], since: datetime | None) -> dict:
                     match = ACCESS.match(line)
                     if not match or int(match.group(4)) < 400:
                         continue
-                    stamp = datetime.strptime(match.group(1), "%d/%b/%Y:%H:%M:%S %z")
+                    stamp = timestamp
+                    if stamp is None:
+                        continue
                     if since and stamp < since:
                         continue
                     method, target, status = match.group(2), redact_url(match.group(3)), int(match.group(4))

--- a/.agents/skills/site-log-audit/scripts/audit_logs.py
+++ b/.agents/skills/site-log-audit/scripts/audit_logs.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Group redacted WordPress/wpdev log signatures without mutating source logs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import parse_qsl, unquote_plus, urlencode, urlsplit, urlunsplit
+
+ERROR_MARKERS = (
+    "PHP Fatal error:",
+    "PHP Parse error:",
+    "PHP Warning:",
+    "PHP Notice:",
+    "PHP Deprecated:",
+    "WordPress database error",
+    "[Elementor:ERROR]",
+    "[Elementor:WARNING]",
+    "[EF save-validation]",
+    "possible dead lock",
+    "Failed to load translations",
+)
+ACCESS = re.compile(
+    r'^\S+\s+\S+\s+\S+\s+\[([^]]+)]\s+"([A-Z]+)\s+([^ ]+)\s+HTTP/[^"]+"\s+(\d{3})\s+'
+)
+OLS_TS = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?)")
+WP_TS = re.compile(r"^\[([^]]+)]")
+LOG_SECRET = re.compile(
+    r"(?<![\w-])([A-Za-z_][\w.-]*)"
+    r"(\s*(?:=(?!//)|:(?!//))\s*)(\"[^\"]*\"|'[^']*'|[^\s,&;]+)",
+    re.I,
+)
+AUTHORIZATION = re.compile(
+    r"\b(authorization\b\s*[:=]\s*)(?:Bearer\s+)?(\"[^\"]*\"|'[^']*'|[^\s,&;]+)",
+    re.I,
+)
+BEARER = re.compile(r"\bBearer\s+[^\s,;]+", re.I)
+URL = re.compile(r"https?://[^\s\"'<>]+", re.I)
+SENSITIVE_KEY_PARTS = frozenset({
+    "authorization",
+    "cookie",
+    "nonce",
+    "passwd",
+    "password",
+    "secret",
+    "token",
+})
+
+
+def parse_timestamp(line: str) -> datetime | None:
+    access = ACCESS.match(line)
+    if access:
+        return datetime.strptime(access.group(1), "%d/%b/%Y:%H:%M:%S %z")
+    match = OLS_TS.match(line)
+    if match:
+        return datetime.fromisoformat(match.group(1)).replace(tzinfo=timezone.utc)
+    match = WP_TS.match(line)
+    if match:
+        for fmt in ("%d-%b-%Y %H:%M:%S %Z", "%d/%b/%Y:%H:%M:%S %z"):
+            try:
+                value = datetime.strptime(match.group(1), fmt)
+                return value.replace(tzinfo=value.tzinfo or timezone.utc)
+            except ValueError:
+                pass
+    return None
+
+
+def iso(value: datetime | None) -> str | None:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z") if value else None
+
+
+def is_sensitive_key(raw: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "_", unquote_plus(raw).casefold()).strip("_")
+    parts = normalized.split("_")
+    return (
+        normalized in {"apikey", "wpnonce"}
+        or bool(SENSITIVE_KEY_PARTS.intersection(parts))
+        or normalized.endswith(("nonce", "passwd", "password", "secret", "token"))
+        or (bool(parts) and parts[-1] == "key")
+    )
+
+
+def redact_params(raw: str) -> str:
+    params = []
+    for key, value in parse_qsl(raw.replace(";", "&"), keep_blank_values=True):
+        if is_sensitive_key(key):
+            value = "<redacted>"
+        elif value.isdigit():
+            value = "<id>"
+        params.append((key, value))
+    return urlencode(params)
+
+
+def redact_url(raw: str) -> str:
+    try:
+        parsed = urlsplit(raw)
+        segments = parsed.path.split("/")
+        for index, segment in enumerate(segments):
+            if segment.isdigit():
+                segments[index] = "<id>"
+            elif index and is_sensitive_key(segments[index - 1]):
+                segments[index] = "<redacted>"
+        path = "/".join(segments)
+        netloc = parsed.netloc
+        if parsed.username is not None or parsed.password is not None:
+            host = parsed.hostname or ""
+            if ":" in host:
+                host = f"[{host}]"
+            netloc = f"<redacted>@{host}"
+            if parsed.port is not None:
+                netloc += f":{parsed.port}"
+        return urlunsplit((parsed.scheme, netloc, path, redact_params(parsed.query), redact_params(parsed.fragment)))
+    except ValueError:
+        return "<malformed-target>"
+
+
+def redact_json_bodies(value: str) -> str:
+    def redact(item: object) -> object:
+        if isinstance(item, dict):
+            return {key: "<redacted>" if is_sensitive_key(key) else redact(child) for key, child in item.items()}
+        if isinstance(item, list):
+            return [redact(child) for child in item]
+        return item
+
+    start = value.find("{")
+    if start < 0:
+        return value
+    try:
+        body, end = json.JSONDecoder().raw_decode(value[start:])
+    except json.JSONDecodeError:
+        return value[:start] + "<redacted>"
+    return value[:start] + json.dumps(redact(body), separators=(",", ":")) + redact_json_bodies(value[start + end:])
+
+
+def redact_secrets(value: str) -> str:
+    value = redact_json_bodies(value)
+    value = AUTHORIZATION.sub(lambda match: f"{match.group(1)}<redacted>", value)
+    value = BEARER.sub("Bearer <redacted>", value)
+    return LOG_SECRET.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}<redacted>" if is_sensitive_key(match.group(1)) else match.group(0),
+        value,
+    )
+
+
+def normalize_message(line: str, root: Path) -> str | None:
+    if not any(marker in line for marker in ERROR_MARKERS):
+        return None
+    message = line.split("[STDERR] ", 1)[-1]
+    message = re.sub(r"^\[[^]]+]\s*", "", message)
+    message = message.replace(str(root) + "/", "<workspace>/")
+    message = re.sub(r"<workspace>/releases/[^/]+/", "<workspace>/releases/<release>/", message)
+    message = re.sub(r"\?ver=[\w.-]+", "?ver=<version>", message)
+    message = re.sub(r"\bline \d+\b", "line <n>", message)
+    message = re.sub(r"\b(post|post_id|meta_id)=\d+\b", r"\1=<id>", message)
+    message = re.sub(r"Duplicate entry '[^']+'", "Duplicate entry '<value>'", message)
+    message = URL.sub(lambda match: redact_url(match.group(0)), message)
+    message = redact_secrets(message)
+    message = re.sub(r"\s+", " ", message).strip()
+    if "No request delivery notification" in message:
+        return "OpenLiteSpeed: No request delivery notification received from LSAPI application; possible dead lock"
+    return message
+
+
+def discover_sites(root: Path, requested: list[str]) -> list[str]:
+    if requested:
+        return sorted(set(requested))
+    sites = {path.name for path in (root / "sites").iterdir() if path.is_dir()} if (root / "sites").is_dir() else set()
+    log_root = root / ".wpdev" / "ols-docker" / "logs"
+    if log_root.is_dir():
+        for path in log_root.glob("*-error.log"):
+            sites.add(path.name.removesuffix("-error.log"))
+        for path in log_root.glob("*-access.log"):
+            sites.add(path.name.removesuffix("-access.log"))
+    return sorted(sites)
+
+
+def candidate_files(root: Path, site: str) -> list[tuple[str, Path]]:
+    log_root = root / ".wpdev" / "ols-docker" / "logs"
+    return [
+        ("error", log_root / f"{site}-error.log"),
+        ("access", log_root / f"{site}-access.log"),
+        ("debug", root / "sites" / site / "wp-content" / "debug.log"),
+    ]
+
+
+def add_event(groups: dict, key: tuple, timestamp: datetime | None, path: Path, sample: str) -> None:
+    event = groups[key]
+    event["count"] += 1
+    event["files"].add(str(path))
+    if timestamp and (event["first"] is None or timestamp < event["first"]):
+        event["first"] = timestamp
+    if timestamp and (event["last"] is None or timestamp > event["last"]):
+        event["last"] = timestamp
+    if sample not in event["samples"] and len(event["samples"]) < 2:
+        event["samples"].append(sample[:1000])
+
+
+def audit(root: Path, sites: list[str], since: datetime | None) -> dict:
+    groups = defaultdict(lambda: {"count": 0, "files": set(), "first": None, "last": None, "samples": []})
+    files = []
+    for site in sites:
+        for kind, path in candidate_files(root, site):
+            if not path.is_file():
+                continue
+            lines = path.read_text(errors="replace").splitlines()
+            timestamps = [value for line in lines if (value := parse_timestamp(line))]
+            files.append({
+                "site": site,
+                "kind": kind,
+                "path": str(path),
+                "bytes": path.stat().st_size,
+                "lines": len(lines),
+                "first_timestamp": iso(min(timestamps)) if timestamps else None,
+                "last_timestamp": iso(max(timestamps)) if timestamps else None,
+            })
+            for line in lines:
+                timestamp = parse_timestamp(line)
+                if kind == "access":
+                    match = ACCESS.match(line)
+                    if not match or int(match.group(4)) < 400:
+                        continue
+                    stamp = datetime.strptime(match.group(1), "%d/%b/%Y:%H:%M:%S %z")
+                    if since and stamp < since:
+                        continue
+                    method, target, status = match.group(2), redact_url(match.group(3)), int(match.group(4))
+                    signature = f"{method} {target} -> HTTP {status}"
+                    add_event(groups, (site, "http", str(status), signature), stamp, path, signature)
+                    continue
+                if since and (timestamp is None or timestamp < since):
+                    continue
+                signature = normalize_message(line, root)
+                if signature:
+                    severity = "fatal" if "Fatal error" in signature or "Parse error" in signature else "warning"
+                    add_event(groups, (site, "log", severity, signature), timestamp, path, signature)
+    events = []
+    for (site, kind, severity, signature), event in groups.items():
+        events.append({
+            "site": site,
+            "kind": kind,
+            "severity": severity,
+            "signature": signature,
+            "count": event["count"],
+            "first_timestamp": iso(event["first"]),
+            "last_timestamp": iso(event["last"]),
+            "files": sorted(event["files"]),
+            "samples": event["samples"],
+        })
+    events.sort(key=lambda item: (item["site"], item["kind"], -item["count"], item["signature"]))
+    return {
+        "generated_at": iso(datetime.now(timezone.utc)),
+        "root": str(root),
+        "sites": sites,
+        "files": sorted(files, key=lambda item: (item["site"], item["kind"])),
+        "events": events,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True, help="wpdev workspace root")
+    parser.add_argument("--site", action="append", default=[], help="site name; repeatable; default discovers all")
+    parser.add_argument("--since", help="inclusive ISO-8601 timestamp")
+    args = parser.parse_args()
+    root = args.root.expanduser().resolve()
+    since = datetime.fromisoformat(args.since.replace("Z", "+00:00")) if args.since else None
+    if since and not since.tzinfo:
+        since = since.replace(tzinfo=timezone.utc)
+    print(json.dumps(audit(root, discover_sites(root, args.site), since), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/site-log-audit/scripts/test_audit_logs.py
+++ b/.agents/skills/site-log-audit/scripts/test_audit_logs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Runnable stdlib self-check for audit_logs.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+with tempfile.TemporaryDirectory() as temp:
+    root = Path(temp)
+    (root / "sites" / "alpha").mkdir(parents=True)
+    (root / "sites" / "beta").mkdir(parents=True)
+    logs = root / ".wpdev" / "ols-docker" / "logs"
+    write(
+        logs / "alpha-error.log",
+        "2026-07-21 01:00:00.000000 [NOTICE] [1] [STDERR] PHP Warning:  Broken value in "
+        + str(root)
+        + "/plugins/example.php on line 42\n"
+        "2026-07-21 01:01:00.000000 [NOTICE] [1] [STDERR] PHP Warning:  Broken value in "
+        + str(root)
+        + "/plugins/example.php on line 99\n"
+        "2026-07-21 01:01:30.000000 [NOTICE] [1] [STDERR] PHP Warning: request token=log-secret Authorization: Bearer abc123 in "
+        + str(root)
+        + "/plugins/secret.php on line 5\n"
+        "2026-07-21 01:01:40.000000 [NOTICE] [1] [STDERR] PHP Warning: request failed at "
+        "https://example.test/check?_wpnonce=nonce-value&access_token=token-value&api_key=key-value"
+        "&password=password-value&cookie=cookie-value&authorization=authorization-value in "
+        + str(root)
+        + "/plugins/query-secret.php on line 6\n"
+        "2026-07-21 01:01:50.000000 [NOTICE] [1] [STDERR] PHP Warning: request failed at "
+        "https://user:embedded-password@example.test/check?access%5Ftoken=encoded-secret&ok=1;_wpnonce=semicolon-secret in "
+        + str(root)
+        + "/plugins/encoded-query-secret.php on line 7\n"
+        "2026-07-21 01:01:55.000000 [NOTICE] [1] [STDERR] PHP Warning: request failed at "
+        "https://example.test/check#access_token=fragment-secret&ok=1 in "
+        + str(root)
+        + "/plugins/fragment.php on line 8\n"
+        "2026-07-21 01:01:57.000000 [NOTICE] [1] [STDERR] PHP Warning: request body {\"token\":\"json-secret\",\"nested\":{\"password\":\"nested-secret\"}} in "
+        + str(root)
+        + "/plugins/json.php on line 9\n"
+        "2026-07-21 01:01:58.000000 [NOTICE] [1] [STDERR] PHP Warning: request body {\"token\":broken-secret in "
+        + str(root)
+        + "/plugins/malformed-json.php on line 10\n"
+        "PHP Warning: undated historical error token=undated-secret\n",
+    )
+    write(
+        logs / "alpha-access.log",
+        '127.0.0.1 - - [21/Jul/2026:01:02:00 +0000] "GET /wp-json/jobs/123?_wpnonce=secret&post_id=456 HTTP/2" 500 10 "-" "test"\n'
+        '127.0.0.1 - - [21/Jul/2026:01:02:10 +0000] "GET http://[broken HTTP/2" 502 10 "-" "test"\n'
+        '127.0.0.1 - - [21/Jul/2026:01:02:20 +0000] "GET /after-malformed?access_token=still-secret HTTP/2" 503 10 "-" "test"\n'
+        '127.0.0.1 - - [21/Jul/2026:01:02:30 +0000] "GET /reset/token/path-secret HTTP/2" 504 10 "-" "test"\n'
+        '127.0.0.1 - - [21/Jul/2026:01:02:40 +0000] "GET /webhook/secret/secret-value/123 HTTP/2" 505 10 "-" "test"\n',
+    )
+    write(
+        root / "sites" / "beta" / "wp-content" / "debug.log",
+        "[21-Jul-2026 01:03:00 UTC] PHP Fatal error:  Boom in " + str(root) + "/plugins/beta.php on line 7\n",
+    )
+    output = subprocess.check_output(
+        ["python3", str(HERE / "audit_logs.py"), "--root", str(root)],
+        text=True,
+    )
+    report = json.loads(output)
+    assert report["sites"] == ["alpha", "beta"], report["sites"]
+    warning = next(event for event in report["events"] if "Broken value" in event["signature"])
+    assert warning["count"] == 2, warning
+    assert "<workspace>/plugins/example.php" in warning["signature"], warning
+    request = next(event for event in report["events"] if event["severity"] == "500")
+    assert request["severity"] == "500", request
+    assert "secret" not in request["signature"], request
+    assert "%3Credacted%3E" in request["signature"], request
+    assert "/<id>" in request["signature"] and "post_id=%3Cid%3E" in request["signature"], request
+    access_file = next(item for item in report["files"] if item["kind"] == "access")
+    assert access_file["first_timestamp"] == "2026-07-21T01:02:00Z", access_file
+    secret_warning = next(event for event in report["events"] if "plugins/secret.php" in event["signature"])
+    assert "log-secret" not in secret_warning["signature"] and "abc123" not in secret_warning["signature"], secret_warning
+    assert secret_warning["signature"].count("<redacted>") == 2, secret_warning
+    query_warning = next(event for event in report["events"] if "plugins/query-secret.php" in event["signature"])
+    for leaked in ("nonce-value", "token-value", "key-value", "password-value", "cookie-value", "authorization-value"):
+        assert leaked not in query_warning["signature"], query_warning
+    assert query_warning["signature"].count("<redacted>") == 6, query_warning
+    encoded_query_warning = next(event for event in report["events"] if "plugins/encoded-query-secret.php" in event["signature"])
+    for leaked in ("user", "embedded-password", "encoded-secret", "semicolon-secret"):
+        assert leaked not in encoded_query_warning["signature"], encoded_query_warning
+    assert encoded_query_warning["signature"].count("<redacted>") == 3, encoded_query_warning
+    fragment_warning = next(event for event in report["events"] if "plugins/fragment.php" in event["signature"])
+    assert "fragment-secret" not in fragment_warning["signature"] and "access_token=<redacted>" in fragment_warning["signature"], fragment_warning
+    json_warning = next(event for event in report["events"] if "plugins/json.php" in event["signature"])
+    assert "json-secret" not in json_warning["signature"] and "nested-secret" not in json_warning["signature"], json_warning
+    assert json_warning["signature"].count("<redacted>") == 2, json_warning
+    malformed_json = next(event for event in report["events"] if "request body <redacted>" in event["signature"])
+    assert "broken-secret" not in malformed_json["signature"] and "<redacted>" in malformed_json["signature"], malformed_json
+    malformed = next(event for event in report["events"] if event["severity"] == "502")
+    assert malformed["signature"] == "GET <malformed-target> -> HTTP 502", malformed
+    after_malformed = next(event for event in report["events"] if event["severity"] == "503")
+    assert "still-secret" not in after_malformed["signature"] and "%3Credacted%3E" in after_malformed["signature"], after_malformed
+    path_secret = next(event for event in report["events"] if event["severity"] == "504")
+    assert "path-secret" not in path_secret["signature"] and "/token/<redacted>" in path_secret["signature"], path_secret
+    nested_path_secret = next(event for event in report["events"] if event["severity"] == "505")
+    assert "secret-value" not in nested_path_secret["signature"], nested_path_secret
+    assert "/secret/<redacted>/<id>" in nested_path_secret["signature"], nested_path_secret
+    fatal = next(event for event in report["events"] if event["severity"] == "fatal")
+    assert fatal["site"] == "beta", fatal
+    filtered = json.loads(
+        subprocess.check_output(
+            [
+                "python3",
+                str(HERE / "audit_logs.py"),
+                "--root",
+                str(root),
+                "--since",
+                "2026-07-21T01:02:50Z",
+            ],
+            text=True,
+        )
+    )
+    assert not any(event["kind"] == "http" for event in filtered["events"]), filtered["events"]
+    assert len(filtered["events"]) == 1 and filtered["events"][0]["severity"] == "fatal", filtered["events"]
+
+print("site-log-audit self-check: PASS")

--- a/.agents/skills/site-log-audit/scripts/tests/test_audit_logs.py
+++ b/.agents/skills/site-log-audit/scripts/tests/test_audit_logs.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent
 
 
 def write(path: Path, text: str) -> None:

--- a/.agents/skills/site-log-audit/scripts/tests/test_audit_logs.py
+++ b/.agents/skills/site-log-audit/scripts/tests/test_audit_logs.py
@@ -45,7 +45,8 @@ with tempfile.TemporaryDirectory() as temp:
         "https://example.test/check#access_token=fragment-secret&ok=1 in "
         + str(root)
         + "/plugins/fragment.php on line 8\n"
-        "2026-07-21 01:01:57.000000 [NOTICE] [1] [STDERR] PHP Warning: request body {\"token\":\"json-secret\",\"nested\":{\"password\":\"nested-secret\"}} in "
+        "2026-07-21 25:01:56.000000 [NOTICE] [1] [STDERR] PHP Warning: malformed timestamp does not abort audit\n"
+        "2026-07-21 01:01:57.000000 [NOTICE] [1] [STDERR] PHP Warning: request body {\"token\":\"json-secret\",\"account\":\"private-account\",\"nested\":{\"password\":\"nested-secret\"}} in "
         + str(root)
         + "/plugins/json.php on line 9\n"
         "2026-07-21 01:01:58.000000 [NOTICE] [1] [STDERR] PHP Warning: request body {\"token\":broken-secret in "
@@ -95,8 +96,9 @@ with tempfile.TemporaryDirectory() as temp:
     fragment_warning = next(event for event in report["events"] if "plugins/fragment.php" in event["signature"])
     assert "fragment-secret" not in fragment_warning["signature"] and "access_token=<redacted>" in fragment_warning["signature"], fragment_warning
     json_warning = next(event for event in report["events"] if "plugins/json.php" in event["signature"])
-    assert "json-secret" not in json_warning["signature"] and "nested-secret" not in json_warning["signature"], json_warning
-    assert json_warning["signature"].count("<redacted>") == 2, json_warning
+    for leaked in ("json-secret", "private-account", "nested-secret", "token", "account", "password"):
+        assert leaked not in json_warning["signature"], json_warning
+    assert "request body <redacted> in <workspace>/plugins/json.php" in json_warning["signature"], json_warning
     malformed_json = next(event for event in report["events"] if "request body <redacted>" in event["signature"])
     assert "broken-secret" not in malformed_json["signature"] and "<redacted>" in malformed_json["signature"], malformed_json
     malformed = next(event for event in report["events"] if event["severity"] == "502")

--- a/artifacts/20260721_Audit logs Best Matcha.md
+++ b/artifacts/20260721_Audit logs Best Matcha.md
@@ -57,7 +57,7 @@ Managed company skill:
 
 - ID: `aedea575-1dce-4a7c-b064-727dfcb0c955`
 - Key: `company/3000c724-cd0c-4ff0-b21c-d721a74c113f/site-log-audit`
-- Files: `SKILL.md`, `scripts/audit_logs.py`, `scripts/test_audit_logs.py`
+- Files: `SKILL.md`, `scripts/audit_logs.py`, `scripts/tests/test_audit_logs.py`
 - Compatibility: `compatible`
 - Trust: `scripts_executables`
 - Audit: warning-only (`script_trust`, `secret_reference`); no hard-stop finding. Secret references are redaction patterns and guidance, not embedded credentials.
@@ -71,7 +71,7 @@ python3 scripts/audit_logs.py \
 python3 scripts/audit_logs.py \
   --root /home/agents/workspaces/wordpress \
   > all-sites-audit.json
-python3 scripts/test_audit_logs.py
+python3 scripts/tests/test_audit_logs.py
 ```
 
 Verification:

--- a/artifacts/20260721_Audit logs Best Matcha.md
+++ b/artifacts/20260721_Audit logs Best Matcha.md
@@ -14,34 +14,34 @@ Current health proof:
 
 - `https://best-matcha.test:8443/` follows one redirect and returns HTTP 200.
 - `https://best-matcha.test:8443/wp-json/` returns HTTP 200.
-- Active Elementor Framework release resolves to `/home/agents/workspaces/wordpress/releases/cla-943-aed7c113/elementor-framework`.
+- Active Elementor Framework release resolves to its local deployed release directory.
 - Fresh homepage HTML contains zero malformed `/wp-content/plugins/home/agents/.../releases/...` asset URLs.
 
 ## Findings untreated before this audit
 
 | Finding | Evidence | Disposition |
 |---|---|---|
-| Voxel Addon `IconField` requires absent `templates/icon-field.php` | 13 fatals plus 13 paired warnings in OLS log; latest 2026-07-21 13:20:49 UTC; `IconField.php:163`; edit-form requests returned HTTP 500 | [CLA-1098](/CLA/issues/CLA-1098) fixed and [CLA-1104](/CLA/issues/CLA-1104) QA-approved; [CLA-1105](/CLA/issues/CLA-1105) integrated commit `9515d12` into Voxel Addon default branch. Best Matcha still needs applicable release deployment before fresh-log closure. |
-| Elementor Framework scalar coercion warnings | 190 OLS history lines and 212 overlapping debug-history lines across `settings_resolver.php` and `includes/media/icons.php`; active release emitted seven fresh `settings_resolver.php:84` warnings from 13:27:22 through 13:29:06 UTC | [CLA-1100](/CLA/issues/CLA-1100) fixed and QA/DevOps-approved at `6469bba5`; dedicated integration and local release deployment remain its named delivery action. |
-| Voxel search terms SSR assumes `props.per_page` | 8 OLS warnings plus 2 debug warnings at `terms-ssr.php:61/85` | [CLA-1101](/CLA/issues/CLA-1101), blocked by live-source contract inspection [CLA-1106](/CLA/issues/CLA-1106). |
-| Voxel price reindex uses `TRUNCATE` across foreign-key reference | 1 WordPress DB error at 2026-07-20 19:12:24 UTC: `wp_voxel_price_index_products` references `wp_voxel_index_products` | [CLA-1102](/CLA/issues/CLA-1102); QA requested changes after data-integrity review, Backend owns remediation. |
-| Code Snippets Pro logs absent optional `code-snippets-pro-en_US.mo` as failure | 8 OLS entries, last 2026-07-19 12:32:27 UTC | [CLA-1103](/CLA/issues/CLA-1103) fixed and QA/DevOps-approved at `3f22f08`; dedicated default-branch integration/deployment remains its named delivery action. |
+| Voxel Addon `IconField` requires absent `templates/icon-field.php` | 13 fatals plus 13 paired warnings in OLS log; latest 2026-07-21 13:20:49 UTC; `IconField.php:163`; edit-form requests returned HTTP 500 | Fix reviewed and integrated. Best Matcha needs applicable release deployment before fresh-log closure. |
+| Elementor Framework scalar coercion warnings | 190 OLS history lines and 212 overlapping debug-history lines across `settings_resolver.php` and `includes/media/icons.php`; active release emitted seven fresh `settings_resolver.php:84` warnings from 13:27:22 through 13:29:06 UTC | Fix reviewed; integration and local release deployment remain delivery work. |
+| Voxel search terms SSR assumes `props.per_page` | 8 OLS warnings plus 2 debug warnings at `terms-ssr.php:61/85` | Blocked by live-source contract inspection. |
+| Voxel price reindex uses `TRUNCATE` across foreign-key reference | 1 WordPress DB error at 2026-07-20 19:12:24 UTC: `wp_voxel_price_index_products` references `wp_voxel_index_products` | Data-integrity review requested changes; backend remediation pending. |
+| Code Snippets Pro logs absent optional `code-snippets-pro-en_US.mo` as failure | 8 OLS entries, last 2026-07-19 12:32:27 UTC | Fix reviewed; default-branch integration and deployment remain delivery work. |
 
 No unmatched actionable signature remains after these tasks were created and routed. All implementation issues use active component projects. Code/site delivery routes through QA Engineer review and DevOps Engineer approval/integration.
 
-## Mapped existing tasks
+## Mapped existing work
 
-| Signature | Evidence | Existing task |
+| Signature | Evidence | Status |
 |---|---|---|
-| Hierarchy `wp_voxel_relations` FK failure for parent 12755 / child 14661 | 3 DB errors and 3 `RelationWriter` fatals | [CLA-891](/CLA/issues/CLA-891) |
-| `ef_voxel_resolve_loop()` undefined | 21 OLS fatals plus debug fatal | [CLA-986](/CLA/issues/CLA-986), done; active release is newer than retained failure |
-| Early `voxel-addon` textdomain loading | 3 debug notices | [CLA-1073](/CLA/issues/CLA-1073), done |
-| Malformed Elementor image envelopes / post 16083 save validation | 6 OLS warnings plus retained debug events | [CLA-310](/CLA/issues/CLA-310), [CLA-361](/CLA/issues/CLA-361), [CLA-541](/CLA/issues/CLA-541) |
-| Elementor editor `localized`, `this.ui.input.val`, `NestedElementBase`, duplicate registration, ReactDOM/global-class errors | Retained editor errors and HTTP 400 global-class requests | [CLA-896](/CLA/issues/CLA-896), [CLA-905](/CLA/issues/CLA-905), [CLA-907](/CLA/issues/CLA-907), [CLA-908](/CLA/issues/CLA-908) |
-| WordPress.org secure connection update warnings | 18 OLS occurrences plus retained debug warnings | [CLA-489](/CLA/issues/CLA-489), done |
-| `FS_METHOD` duplicate definition | 43 early OLS warnings | [CLA-3](/CLA/issues/CLA-3), done |
-| Preview/render-batch 400/403 | Retained access requests | [CLA-929](/CLA/issues/CLA-929), [CLA-943](/CLA/issues/CLA-943) |
-| Old CLA-909 absolute release asset URLs return 404 | Retained access requests | Deployment lineage handled by [CLA-909](/CLA/issues/CLA-909) and [CLA-943](/CLA/issues/CLA-943); current homepage emits none |
+| Hierarchy `wp_voxel_relations` foreign-key failure | 3 DB errors and 3 `RelationWriter` fatals | Existing remediation work tracked. |
+| `ef_voxel_resolve_loop()` undefined | 21 OLS fatals plus debug fatal | Done; active release is newer than retained failure. |
+| Early `voxel-addon` textdomain loading | 3 debug notices | Done. |
+| Malformed Elementor image envelopes / save validation | 6 OLS warnings plus retained debug events | Existing remediation work tracked. |
+| Elementor editor `localized`, `this.ui.input.val`, `NestedElementBase`, duplicate registration, ReactDOM/global-class errors | Retained editor errors and HTTP 400 global-class requests | Existing remediation work tracked. |
+| WordPress.org secure connection update warnings | 18 OLS occurrences plus retained debug warnings | Done. |
+| `FS_METHOD` duplicate definition | 43 early OLS warnings | Done. |
+| Preview/render-batch 400/403 | Retained access requests | Existing remediation work tracked. |
+| Old absolute release asset URLs return 404 | Retained access requests | Deployment lineage handled; current homepage emits none. |
 
 ## Historical or secondary events not filed
 

--- a/artifacts/20260721_Audit logs Best Matcha.md
+++ b/artifacts/20260721_Audit logs Best Matcha.md
@@ -1,0 +1,90 @@
+# Best Matcha log audit — 2026-07-21
+
+## Scope
+
+Read-only audit of local `best-matcha.test`:
+
+- OpenLiteSpeed error log: `.wpdev/ols-docker/logs/best-matcha-error.log` — 298,190 bytes, 1,799 lines, retained from 2026-07-19 through 2026-07-21 13:29 UTC.
+- OpenLiteSpeed access log: `.wpdev/ols-docker/logs/best-matcha-access.log` — 4,235,606 bytes, 13,145 lines, retained from 2026-07-21 08:11 through 13:29 UTC.
+- WordPress debug log: `sites/best-matcha/wp-content/debug.log` — 70,507 bytes, 347 lines, retained through 2026-07-20 21:32 UTC.
+
+Counts between error/debug streams overlap. No log was truncated or mutated.
+
+Current health proof:
+
+- `https://best-matcha.test:8443/` follows one redirect and returns HTTP 200.
+- `https://best-matcha.test:8443/wp-json/` returns HTTP 200.
+- Active Elementor Framework release resolves to `/home/agents/workspaces/wordpress/releases/cla-943-aed7c113/elementor-framework`.
+- Fresh homepage HTML contains zero malformed `/wp-content/plugins/home/agents/.../releases/...` asset URLs.
+
+## Findings untreated before this audit
+
+| Finding | Evidence | Disposition |
+|---|---|---|
+| Voxel Addon `IconField` requires absent `templates/icon-field.php` | 13 fatals plus 13 paired warnings in OLS log; latest 2026-07-21 13:20:49 UTC; `IconField.php:163`; edit-form requests returned HTTP 500 | [CLA-1098](/CLA/issues/CLA-1098) fixed and [CLA-1104](/CLA/issues/CLA-1104) QA-approved; [CLA-1105](/CLA/issues/CLA-1105) integrated commit `9515d12` into Voxel Addon default branch. Best Matcha still needs applicable release deployment before fresh-log closure. |
+| Elementor Framework scalar coercion warnings | 190 OLS history lines and 212 overlapping debug-history lines across `settings_resolver.php` and `includes/media/icons.php`; active release emitted seven fresh `settings_resolver.php:84` warnings from 13:27:22 through 13:29:06 UTC | [CLA-1100](/CLA/issues/CLA-1100) fixed and QA/DevOps-approved at `6469bba5`; dedicated integration and local release deployment remain its named delivery action. |
+| Voxel search terms SSR assumes `props.per_page` | 8 OLS warnings plus 2 debug warnings at `terms-ssr.php:61/85` | [CLA-1101](/CLA/issues/CLA-1101), blocked by live-source contract inspection [CLA-1106](/CLA/issues/CLA-1106). |
+| Voxel price reindex uses `TRUNCATE` across foreign-key reference | 1 WordPress DB error at 2026-07-20 19:12:24 UTC: `wp_voxel_price_index_products` references `wp_voxel_index_products` | [CLA-1102](/CLA/issues/CLA-1102); QA requested changes after data-integrity review, Backend owns remediation. |
+| Code Snippets Pro logs absent optional `code-snippets-pro-en_US.mo` as failure | 8 OLS entries, last 2026-07-19 12:32:27 UTC | [CLA-1103](/CLA/issues/CLA-1103) fixed and QA/DevOps-approved at `3f22f08`; dedicated default-branch integration/deployment remains its named delivery action. |
+
+No unmatched actionable signature remains after these tasks were created and routed. All implementation issues use active component projects. Code/site delivery routes through QA Engineer review and DevOps Engineer approval/integration.
+
+## Mapped existing tasks
+
+| Signature | Evidence | Existing task |
+|---|---|---|
+| Hierarchy `wp_voxel_relations` FK failure for parent 12755 / child 14661 | 3 DB errors and 3 `RelationWriter` fatals | [CLA-891](/CLA/issues/CLA-891) |
+| `ef_voxel_resolve_loop()` undefined | 21 OLS fatals plus debug fatal | [CLA-986](/CLA/issues/CLA-986), done; active release is newer than retained failure |
+| Early `voxel-addon` textdomain loading | 3 debug notices | [CLA-1073](/CLA/issues/CLA-1073), done |
+| Malformed Elementor image envelopes / post 16083 save validation | 6 OLS warnings plus retained debug events | [CLA-310](/CLA/issues/CLA-310), [CLA-361](/CLA/issues/CLA-361), [CLA-541](/CLA/issues/CLA-541) |
+| Elementor editor `localized`, `this.ui.input.val`, `NestedElementBase`, duplicate registration, ReactDOM/global-class errors | Retained editor errors and HTTP 400 global-class requests | [CLA-896](/CLA/issues/CLA-896), [CLA-905](/CLA/issues/CLA-905), [CLA-907](/CLA/issues/CLA-907), [CLA-908](/CLA/issues/CLA-908) |
+| WordPress.org secure connection update warnings | 18 OLS occurrences plus retained debug warnings | [CLA-489](/CLA/issues/CLA-489), done |
+| `FS_METHOD` duplicate definition | 43 early OLS warnings | [CLA-3](/CLA/issues/CLA-3), done |
+| Preview/render-batch 400/403 | Retained access requests | [CLA-929](/CLA/issues/CLA-929), [CLA-943](/CLA/issues/CLA-943) |
+| Old CLA-909 absolute release asset URLs return 404 | Retained access requests | Deployment lineage handled by [CLA-909](/CLA/issues/CLA-909) and [CLA-943](/CLA/issues/CLA-943); current homepage emits none |
+
+## Historical or secondary events not filed
+
+- 285 OpenLiteSpeed LSAPI dead-lock notices cluster around old failing requests and stop at 2026-07-21 02:43 UTC. Current front page and REST root respond with HTTP 200. Monitor; no standalone root cause proven.
+- One LiteSpeed debug-log rename fatal from 2026-07-19 did not recur after debug directory creation.
+- Two early `wp-config.php` parse lines and old `FS_METHOD` setup warnings are retained provisioning history, not current runtime.
+- Source-map 404s are non-runtime artifacts.
+- Expected or contract-dependent authenticated HTTP 400/403 responses were not treated as defects without failed-behavior evidence.
+
+## Reusable all-sites audit skill
+
+Managed company skill:
+
+- ID: `aedea575-1dce-4a7c-b064-727dfcb0c955`
+- Key: `company/3000c724-cd0c-4ff0-b21c-d721a74c113f/site-log-audit`
+- Files: `SKILL.md`, `scripts/audit_logs.py`, `scripts/test_audit_logs.py`
+- Compatibility: `compatible`
+- Trust: `scripts_executables`
+- Audit: warning-only (`script_trust`, `secret_reference`); no hard-stop finding. Secret references are redaction patterns and guidance, not embedded credentials.
+
+Run one site or all discovered sites:
+
+```bash
+python3 scripts/audit_logs.py \
+  --root /home/agents/workspaces/wordpress \
+  --site best-matcha > best-matcha-audit.json
+python3 scripts/audit_logs.py \
+  --root /home/agents/workspaces/wordpress \
+  > all-sites-audit.json
+python3 scripts/test_audit_logs.py
+```
+
+Verification:
+
+- Assert-based self-check: PASS, including sensitive query parameters in error/access lines and malformed request-target continuation.
+- Python compilation: PASS.
+- Managed skill files match verified local source byte-for-byte.
+- Fresh Best Matcha parse since 2026-07-21 12:00 UTC: 3 files and 21 grouped events across all evidence streams.
+- Redaction covers authorization values, bearer tokens, cookies, nonces, API keys, passwords, secrets, and other sensitive query values.
+- Malformed access-log request targets fail closed as `<malformed-target>` without aborting later events.
+
+## QA Engineer wiring
+
+Company skill metadata identifies QA Engineer in `usedByAgents` with `desired: true` and `attachedAgentCount: 1`. Paperclip will materialize the desired skill in QA's runtime on its next applicable run.
+
+Exactly one next action: QA Engineer reviews the security fix commit and fresh verification above. Paperclip then advances approved work to DevOps Engineer for final approval and integration.


### PR DESCRIPTION
## Thinking Path

> - Paperclip supports agent skills alongside core application code.
> - Site operations need repeatable, safe inspection of local WordPress and OpenLiteSpeed logs.
> - Manual review makes recurring failures hard to group and can expose sensitive request data.
> - This change adds local log discovery, grouped redacted signatures, and runnable coverage.

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work

### Feature summary

Add reusable operator skill for auditing WordPress and OpenLiteSpeed logs across local sites.

### Subsystem affected

Cross-cutting operator skills and local site diagnostics.

### Current behavior

Operators manually inspect separate debug, error, and access logs. Repeated failures lack stable grouping, and copied request data can leak credentials or private body content into reports.

### Proposed behavior

Provide stdlib Python audit CLI that discovers supported logs, groups normalized signatures, records severity/count/timestamps, and redacts request secrets and bodies before output. Include one-site and all-site operation plus runnable self-check.

### Reason and benefit

Repeatable grouping makes untreated defects discoverable. Fail-closed redaction prevents report artifacts from retaining arbitrary request-body values.

### Breaking changes

None. Standalone skill and report artifact only; no runtime API or schema changes.

## What Changed

- Added `site-log-audit` skill and stdlib Python audit script.
- Added public-safe Best Matcha audit artifact with grouped findings and remediation guidance.
- Added self-check under `scripts/tests/`.
- Hardened arbitrary request-body redaction and malformed timestamp handling from review.

## Verification

- `python3 .agents/skills/site-log-audit/scripts/tests/test_audit_logs.py`
- `git diff --check origin/master...HEAD`

## Risks

Low. New standalone skill and artifact. Source logs remain sensitive and audit stays read-only.

## Model Used

- Provider: 9router
- Model: `9router/high`
- Context window: not disclosed by provider
- Capabilities: code editing, shell execution, repository and GitHub CLI tooling

## Checklist

- [x] Included thinking path
- [x] Specified model used
- [x] Checked roadmap and duplicates
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] Removed internal/instance-local issue references from public artifact
- [x] Ran focused tests locally
- [x] Added regression coverage
- [ ] All current-head CI gates green
- [ ] Current-head Greptile clean