### PR TITLE
fix(recovery): bounded retry for ACP run/turn failures before escalation (REW-30 #4)

### DIFF
--- a/server/src/services/recovery/service.acpx-turn-failed-retry.test.ts
+++ b/server/src/services/recovery/service.acpx-turn-failed-retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { classifyContinuationFailure } from "./service.js";
+
+const run = (errorCode: string | null) =>
+  ({ errorCode } as unknown as Parameters<typeof classifyContinuationFailure>[0]);
+
+// REW-34 / REW-30 spec #4 (auto-retry before escalate). The REW-29 root cause was
+// that ACP engine run/turn deaths (`acpx_turn_failed`) stranded an assigned issue
+// and were escalated to a human after a single attempt with no automatic retry.
+// These codes must classify as a bounded, backed-off retryable failure so the
+// stranded-issue sweep re-enqueues the continuation N times before escalating.
+describe("acpx run-failure continuation retry classification (REW-34)", () => {
+  it("acpx_turn_failed is a bounded-retry run failure, not an immediate escalation", () => {
+    const c = classifyContinuationFailure(run("acpx_turn_failed"));
+    expect(c.kind).toBe("run_failure");
+    // Bounded retry budget > 1 attempt (a single-attempt `default` was the bug).
+    expect(c.maxAttempts).toBeGreaterThan(1);
+    // Exponential backoff needs a positive base delay to space out retries.
+    expect(c.baseBackoffMs).toBeGreaterThan(0);
+    expect(c.errorCode).toBe("acpx_turn_failed");
+  });
+
+  it("acpx_timeout (turn timeout) is treated the same bounded-retry way", () => {
+    const c = classifyContinuationFailure(run("acpx_timeout"));
+    expect(c.kind).toBe("run_failure");
+    expect(c.maxAttempts).toBeGreaterThan(1);
+    expect(c.baseBackoffMs).toBeGreaterThan(0);
+  });
+
+  it("run-failure retry budget/backoff matches the transient-infra budget", () => {
+    const runFailure = classifyContinuationFailure(run("acpx_turn_failed"));
+    const transient = classifyContinuationFailure(run("timeout"));
+    expect(runFailure.maxAttempts).toBe(transient.maxAttempts);
+    expect(runFailure.baseBackoffMs).toBe(transient.baseBackoffMs);
+  });
+
+  it("does not disturb existing classifications", () => {
+    // Regression guards so the new branch stays scoped to the two ACP codes.
+    expect(classifyContinuationFailure(run("agent_not_invokable")).kind).toBe("non_retryable");
+    expect(classifyContinuationFailure(run("timeout")).kind).toBe("transient_infra");
+    expect(classifyContinuationFailure(run("cancelled")).kind).toBe("default");
+    expect(classifyContinuationFailure(run(null)).kind).toBe("default");
+    expect(classifyContinuationFailure(run("some_adapter_error")).kind).toBe("default");
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -288,6 +288,20 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "issue_dependencies_blocked",
 ]);
 
+// Run/turn-level terminations reported by the ACP engine (a failed turn or a
+// turn timeout). These strand an assigned `in_progress` issue by making its live
+// execution path disappear, and were the dominant "stranded with no automatic
+// retry" incident class (see REW-29 root-cause: acpx_turn_failed deaths → the
+// issue is escalated to a human after a single attempt with no retry). They are
+// usually transient (a lost child process, a model hiccup, an environment stall),
+// so give them the same bounded retry budget + exponential backoff as
+// transient-infra failures before escalating to `blocked`. The bounded attempt
+// cap still guarantees a deterministic failure escalates instead of looping.
+const RETRYABLE_RUN_FAILURE_CONTINUATION_ERROR_CODES = new Set<string>([
+  "acpx_turn_failed",
+  "acpx_timeout",
+]);
+
 // A continuation cancelled with this code is a *deliberate wait* (the latest run
 // reported it was parked for review/approval), not a lost execution path. When the
 // issue has a real waiting target we convert it into a normal dependency wait rather
@@ -416,7 +430,7 @@ export function classifyAdapterFailureForRecovery(
 }
 
 type ContinuationRetryClassification = {
-  kind: "transient_infra" | "non_retryable" | "default";
+  kind: "transient_infra" | "run_failure" | "non_retryable" | "default";
   maxAttempts: number;
   baseBackoffMs: number;
   errorCode: string | null;
@@ -430,6 +444,14 @@ export function classifyContinuationFailure(latestRun: LatestIssueRun): Continua
   if (errorCode && TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(errorCode)) {
     return {
       kind: "transient_infra",
+      maxAttempts: CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS,
+      baseBackoffMs: CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS,
+      errorCode,
+    };
+  }
+  if (errorCode && RETRYABLE_RUN_FAILURE_CONTINUATION_ERROR_CODES.has(errorCode)) {
+    return {
+      kind: "run_failure",
       maxAttempts: CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS,
       baseBackoffMs: CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS,
       errorCode,


### PR DESCRIPTION
## REW-30 rule #4 — bounded auto-retry before escalation

Lands the durable reliability fix from REW-29 §B (auto-retry before escalate) onto `master`.

**What this changes:** on `acpx_turn_failed` / `issue_continuation_needed` strandings, the recovery service now attempts N bounded automatic retries (exponential backoff) on the *original* agent before reassigning ownership to the Chief of Staff. Escalation to CoS happens only after retries are exhausted — removing the majority of "prompt the CoS" events.

**Scope note:** rules #5–#8 (idle-agent claim, blocker-hygiene invariant, roster referential integrity, CoS-as-monitor) were audited and found already native in `server/src/services/recovery/`, so this PR is scoped to rule #4 only.

**Verification:** recovery retry suite 4/4 green locally on this commit.

**Why a fork PR:** the deploy identity (`GodOfCrypto69`) is pull-only on this repo, so this is staged as a cross-fork PR for you to review + merge (keeping merge control with you, per the REW-30 decision).

Commit: `8847c5854` — cherry-picked cleanly onto current `origin/master` (1 ahead, 0 behind — fast-forwardable, no divergence).