### PR TITLE
Fix issue context injection for assignment and review wakes

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -316,6 +316,8 @@ An ownership change selects who owns the issue after the comment is committed:
 
 A wake is the delivery path for a selected agent owner. If an interrupting update also assigns a non-terminal, non-backlog issue to an agent, Paperclip should enqueue one wake for the new assignee and include the interrupting comment and interrupted run id in the wake payload/context when available. Stale scheduled retries for the previous owner must not run after ownership changes away from that owner.
 
+Fresh assignment and execution-stage handoff wakes should include the issue id, identifier, title, description, and a bounded recent issue-comment thread in startup context. Historical thread comments are distinct from the new-comment delta that caused a wake: adapters may render the history for orientation, but must not describe it as pending feedback or require the agent to acknowledge it as new. Deleted comments stay excluded, quarantined low-trust bodies stay sanitized, and any omitted or truncated context should set the payload's fallback-fetch signal.
+
 If the committed update assigns the issue to a user, clears the agent assignee, or leaves the issue without an agent owner, Paperclip must not imply that an agent handoff happened. The issue is then waiting on the human owner or on a future explicit assignment, blocker, approval, interaction, monitor, or recovery action.
 
 Plain text is not assignment. Writing an agent's name, role, or team label in a comment does not change ownership and does not create an agent wake. Agent routing from comment text requires a structured agent mention that resolves inside the company, an explicit `assigneeAgentId` mutation, or an existing current agent assignee receiving normal issue-thread feedback.

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -906,6 +906,94 @@ describe("renderPaperclipWakePrompt", () => {
     expect(fallbackPrompt).toContain("- fallback fetch needed: yes");
   });
 
+  it("preserves and renders historical issue context without treating it as a new comment batch", () => {
+    const payload = {
+      reason: "execution_review_requested",
+      issue: {
+        id: "issue-1",
+        identifier: "TEST-1581",
+        title: "Review the implementation",
+        description: "Acceptance criteria and implementation details.",
+        descriptionTruncated: false,
+        status: "in_review",
+      },
+      issueThread: {
+        comments: [
+          {
+            id: "comment-oldest",
+            issueId: "issue-1",
+            body: "Original implementation notes.",
+            createdAt: "2026-07-21T10:00:00.000Z",
+            author: { type: "agent", id: "engineering-lead" },
+          },
+          {
+            id: "comment-newest",
+            issueId: "issue-1",
+            body: "Board audit checklist.",
+            createdAt: "2026-07-22T10:00:00.000Z",
+            author: { type: "user", id: "board-member" },
+          },
+        ],
+        totalCount: 4,
+        includedCount: 2,
+        omittedCount: 2,
+        truncated: true,
+      },
+      commentIds: [],
+      commentWindow: {
+        requestedCount: 0,
+        includedCount: 0,
+        missingCount: 0,
+      },
+      comments: [],
+      fallbackFetchNeeded: false,
+    };
+
+    const serialized = JSON.parse(stringifyPaperclipWakePayload(payload) ?? "{}");
+    expect(serialized).toMatchObject({
+      issue: {
+        id: "issue-1",
+        identifier: "TEST-1581",
+        title: "Review the implementation",
+        description: "Acceptance criteria and implementation details.",
+        descriptionTruncated: false,
+      },
+      issueThread: {
+        comments: [
+          {
+            id: "comment-oldest",
+            body: "Original implementation notes.",
+            authorType: "agent",
+            authorId: "engineering-lead",
+          },
+          {
+            id: "comment-newest",
+            body: "Board audit checklist.",
+            authorType: "user",
+            authorId: "board-member",
+          },
+        ],
+        totalCount: 4,
+        includedCount: 2,
+        omittedCount: 2,
+        truncated: true,
+      },
+    });
+
+    const prompt = renderPaperclipWakePrompt(payload);
+    expect(prompt).toContain("- existing issue comments: 2/4");
+    expect(prompt).toContain("- fallback fetch needed: yes");
+    expect(prompt).toContain("Existing issue comment thread (historical context, oldest to newest):");
+    expect(prompt.indexOf("Original implementation notes.")).toBeLessThan(
+      prompt.indexOf("Board audit checklist."),
+    );
+    expect(prompt).toContain("[2 issue comments omitted from inline history]");
+    expect(prompt).not.toContain("acknowledge the latest comment");
+    expect(prompt).not.toContain("- pending comments:");
+    expect(prompt).not.toContain("- latest comment id:");
+    expect(prompt).not.toContain("New comments in order:");
+  });
+
   it("renders the execution workspace branch guard only on non-resumed sessions", () => {
     const payload = {
       reason: "issue_assigned",

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -438,6 +438,8 @@ type PaperclipWakeIssue = {
   id: string | null;
   identifier: string | null;
   title: string | null;
+  description: string | null;
+  descriptionTruncated: boolean;
   status: string | null;
   workMode: string | null;
   priority: string | null;
@@ -470,6 +472,14 @@ type PaperclipWakeComment = {
   createdAt: string | null;
   authorType: string | null;
   authorId: string | null;
+};
+
+type PaperclipWakeIssueThread = {
+  comments: PaperclipWakeComment[];
+  totalCount: number;
+  includedCount: number;
+  omittedCount: number;
+  truncated: boolean;
 };
 
 type PaperclipWakePlanReviewAuthor = {
@@ -670,6 +680,7 @@ type PaperclipWakePayload = {
   commentIds: string[];
   latestCommentId: string | null;
   comments: PaperclipWakeComment[];
+  issueThread: PaperclipWakeIssueThread | null;
   requestedCount: number;
   includedCount: number;
   missingCount: number;
@@ -702,6 +713,7 @@ function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null 
   const id = asString(issue.id, "").trim() || null;
   const identifier = asString(issue.identifier, "").trim() || null;
   const title = asString(issue.title, "").trim() || null;
+  const description = asString(issue.description, "") || null;
   const status = asString(issue.status, "").trim() || null;
   const workMode = asString(issue.workMode, "").trim() || null;
   const priority = asString(issue.priority, "").trim() || null;
@@ -710,6 +722,8 @@ function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null 
     id,
     identifier,
     title,
+    description,
+    descriptionTruncated: asBoolean(issue.descriptionTruncated, false),
     status,
     workMode,
     priority,
@@ -729,6 +743,39 @@ function normalizePaperclipWakeComment(value: unknown): PaperclipWakeComment | n
     createdAt: asString(comment.createdAt, "").trim() || null,
     authorType: asString(author.type, "").trim() || null,
     authorId: asString(author.id, "").trim() || null,
+  };
+}
+
+function normalizePaperclipWakeIssueThread(value: unknown): PaperclipWakeIssueThread | null {
+  const thread = parseObject(value);
+  const comments = Array.isArray(thread.comments)
+    ? thread.comments
+        .map((entry) => normalizePaperclipWakeComment(entry))
+        .filter((entry): entry is PaperclipWakeComment => Boolean(entry))
+    : [];
+  const reportedTotalCount = Math.max(0, Math.trunc(asNumber(thread.totalCount, comments.length)));
+  const totalCount = Math.max(reportedTotalCount, comments.length);
+  const includedCount = comments.length;
+  const reportedOmittedCount = Math.max(0, Math.trunc(asNumber(thread.omittedCount, 0)));
+  const omittedCount = Math.max(reportedOmittedCount, totalCount - includedCount);
+  const truncated =
+    asBoolean(thread.truncated, false) ||
+    omittedCount > 0 ||
+    comments.some((comment) => comment.bodyTruncated);
+  if (
+    comments.length === 0 &&
+    totalCount === 0 &&
+    !Array.isArray(thread.comments) &&
+    Object.keys(thread).length === 0
+  ) {
+    return null;
+  }
+  return {
+    comments,
+    totalCount,
+    includedCount,
+    omittedCount,
+    truncated,
   };
 }
 
@@ -1221,11 +1268,13 @@ function markdownInlineCode(value: string): string {
 
 export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayload | null {
   const payload = parseObject(value);
+  const issue = normalizePaperclipWakeIssue(payload.issue);
   const comments = Array.isArray(payload.comments)
     ? payload.comments
         .map((entry) => normalizePaperclipWakeComment(entry))
         .filter((entry): entry is PaperclipWakeComment => Boolean(entry))
     : [];
+  const issueThread = normalizePaperclipWakeIssueThread(payload.issueThread);
   const commentWindow = parseObject(payload.commentWindow);
   const commentIds = Array.isArray(payload.commentIds)
     ? payload.commentIds
@@ -1262,14 +1311,14 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
   const activeTreeHold = normalizePaperclipWakeTreeHoldSummary(payload.activeTreeHold);
   const checkboxSelection = normalizePaperclipWakeCheckboxSelection(payload.checkboxSelection);
   const executionWorkspace = normalizePaperclipWakeExecutionWorkspace(payload.executionWorkspace);
-  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !livenessContinuation && !taskWatchdog && !checkboxSelection && !executionWorkspace && !recovery && !normalizePaperclipWakeIssue(payload.issue)) {
+  if (comments.length === 0 && commentIds.length === 0 && !issueThread && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !livenessContinuation && !taskWatchdog && !checkboxSelection && !executionWorkspace && !recovery && !issue) {
     return null;
   }
 
   return {
     reason: asString(payload.reason, "").trim() || null,
     recovery,
-    issue: normalizePaperclipWakeIssue(payload.issue),
+    issue,
     checkedOutByHarness: asBoolean(payload.checkedOutByHarness, false),
     dependencyBlockedInteraction: asBoolean(payload.dependencyBlockedInteraction, false),
     treeHoldInteraction: asBoolean(payload.treeHoldInteraction, false),
@@ -1291,11 +1340,18 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     commentIds,
     latestCommentId: asString(payload.latestCommentId, "").trim() || null,
     comments,
+    issueThread,
     requestedCount: asNumber(commentWindow.requestedCount, comments.length || commentIds.length),
     includedCount: asNumber(commentWindow.includedCount, comments.length),
     missingCount: asNumber(commentWindow.missingCount, 0),
-    truncated: asBoolean(payload.truncated, false),
-    fallbackFetchNeeded: asBoolean(payload.fallbackFetchNeeded, false),
+    truncated:
+      asBoolean(payload.truncated, false) ||
+      issue?.descriptionTruncated === true ||
+      issueThread?.truncated === true,
+    fallbackFetchNeeded:
+      asBoolean(payload.fallbackFetchNeeded, false) ||
+      issue?.descriptionTruncated === true ||
+      issueThread?.truncated === true,
   };
 }
 
@@ -1396,6 +1452,11 @@ export function renderPaperclipWakePrompt(
   const wakeSummaryLines = [
     `- reason: ${normalized.reason ?? "unknown"}`,
     `- issue: ${normalized.issue?.identifier ?? normalized.issue?.id ?? "unknown"}${normalized.issue?.title ? ` ${normalized.issue.title}` : ""}`,
+    ...(normalized.issueThread
+      ? [
+          `- existing issue comments: ${normalized.issueThread.includedCount}/${normalized.issueThread.totalCount}`,
+        ]
+      : []),
     ...(hasWakeCommentBatch
       ? [
           `- pending comments: ${normalized.includedCount}/${normalized.requestedCount}`,
@@ -1763,6 +1824,29 @@ export function renderPaperclipWakePrompt(
       "Do not call `/api/issues/{id}/checkout` again unless you intentionally switch to a different task.",
       "",
     );
+  }
+
+  if (normalized.issueThread && normalized.issueThread.comments.length > 0) {
+    lines.push("Existing issue comment thread (historical context, oldest to newest):");
+    for (const [index, comment] of normalized.issueThread.comments.entries()) {
+      const authorLabel = comment.authorId
+        ? `${comment.authorType ?? "unknown"} ${comment.authorId}`
+        : comment.authorType ?? "unknown";
+      lines.push(
+        `${index + 1}. historical comment ${comment.id ?? "unknown"} at ${comment.createdAt ?? "unknown"} by ${authorLabel}`,
+        comment.body,
+      );
+      if (comment.bodyTruncated) {
+        lines.push("[historical comment body truncated]");
+      }
+      lines.push("");
+    }
+    if (normalized.issueThread.omittedCount > 0) {
+      lines.push(
+        `[${normalized.issueThread.omittedCount} issue comments omitted from inline history]`,
+        "",
+      );
+    }
   }
 
   if (normalized.comments.length > 0) {

--- a/packages/adapters/claude-local/src/server/acp.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.test.ts
@@ -86,6 +86,7 @@ class FakeRuntime {
     mode: "persistent" | "oneshot";
     cwd?: string;
     resumeSessionId?: string;
+    sessionOptions?: { env?: Record<string, string> };
   }> = [];
   startInputs: Array<{ handle: FakeRuntimeHandle; text: string; requestId: string; timeoutMs?: number }> = [];
   closeInputs: Array<{ handle: FakeRuntimeHandle; reason: string; discardPersistentState?: boolean }> = [];
@@ -106,6 +107,7 @@ class FakeRuntime {
     mode: "persistent" | "oneshot";
     cwd?: string;
     resumeSessionId?: string;
+    sessionOptions?: { env?: Record<string, string> };
   }): Promise<FakeRuntimeHandle> {
     this.ensureInputs.push(input);
     this.ensureCount += 1;
@@ -553,6 +555,130 @@ describe("claude_local ACP lane", () => {
       explicit: false,
       fallbackReason: expect.stringContaining("bidirectional remote process"),
     });
+  });
+
+  it("injects reviewer issue context and historical comments into the ACP startup prompt", async () => {
+    const root = await makeTempRoot("paperclip-claude-acp-wake-context-");
+    const runtimes: FakeRuntime[] = [];
+    const execute = createClaudeAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => {
+        const runtime = new FakeRuntime(options);
+        runtimes.push(runtime);
+        return runtime as never;
+      },
+    });
+    const taskMarkdown = [
+      "# Paperclip Review Issue",
+      "",
+      "- ID: ISSUE-42",
+      "- Title: Deliver reviewer handoff context",
+      "",
+      "## Description",
+      "",
+      "Reviewers must receive the linked issue context in the same heartbeat.",
+    ].join("\n");
+
+    const result = await execute(buildContext(root, {
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: "ISSUE-42",
+      },
+      context: {
+        issueId: "issue-context-42",
+        taskId: "issue-context-42",
+        wakeReason: "execution_review_requested",
+        paperclipTaskMarkdown: taskMarkdown,
+        paperclipWorkspace: {
+          cwd: root,
+          source: "project_workspace",
+          workspaceId: "workspace-1",
+        },
+        paperclipWake: {
+          reason: "execution_review_requested",
+          issue: {
+            id: "issue-context-42",
+            identifier: "ISSUE-42",
+            title: "Deliver reviewer handoff context",
+            description: "Reviewers must receive the linked issue context in the same heartbeat.",
+            descriptionTruncated: false,
+            status: "in_review",
+            workMode: "standard",
+            priority: "high",
+          },
+          executionStage: {
+            stage: "review",
+            wakeRole: "reviewer",
+          },
+          commentIds: [],
+          latestCommentId: null,
+          comments: [],
+          issueThread: {
+            comments: [
+              {
+                id: "comment-review-request",
+                issueId: "issue-context-42",
+                body: "Please verify the automatic handoff end to end.",
+                bodyTruncated: false,
+                createdAt: "2026-07-23T08:10:00.000Z",
+                author: { type: "agent", id: "engineering-lead" },
+              },
+              {
+                id: "comment-review-criteria",
+                issueId: "issue-context-42",
+                body: "Confirm that no manual Paperclip API lookup was required.",
+                bodyTruncated: false,
+                createdAt: "2026-07-23T08:12:00.000Z",
+                author: { type: "user", id: "board-user" },
+              },
+            ],
+            totalCount: 2,
+            includedCount: 2,
+            omittedCount: 0,
+            truncated: false,
+          },
+          commentWindow: {
+            requestedCount: 0,
+            includedCount: 0,
+            missingCount: 0,
+          },
+          truncated: false,
+          fallbackFetchNeeded: false,
+        },
+      },
+    }));
+
+    expect(result.exitCode).toBe(0);
+    const prompt = runtimes[0]?.startInputs[0]?.text;
+    expect(prompt).toContain("- Title: Deliver reviewer handoff context");
+    expect(prompt).toContain(
+      "Reviewers must receive the linked issue context in the same heartbeat.",
+    );
+    expect(prompt).toContain(
+      "Existing issue comment thread (historical context, oldest to newest):",
+    );
+    expect(prompt).toContain("PAPERCLIP_WAKE_PAYLOAD_JSON");
+    expect(prompt).toContain("Please verify the automatic handoff end to end.");
+    expect(prompt).toContain("Confirm that no manual Paperclip API lookup was required.");
+    expect(prompt!.indexOf("Please verify the automatic handoff end to end.")).toBeLessThan(
+      prompt!.indexOf("Confirm that no manual Paperclip API lookup was required."),
+    );
+
+    const runtimeWakePayload =
+      runtimes[0]?.ensureInputs[0]?.sessionOptions?.env?.PAPERCLIP_WAKE_PAYLOAD_JSON;
+    expect(runtimeWakePayload).toBeTruthy();
+    const structuredWake = JSON.parse(runtimeWakePayload!) as {
+      issue: { description: string };
+      issueThread: { comments: Array<{ body: string }> };
+    };
+    expect(structuredWake.issue.description).toBe(
+      "Reviewers must receive the linked issue context in the same heartbeat.",
+    );
+    expect(structuredWake.issueThread.comments.map((comment) => comment.body)).toEqual([
+      "Please verify the automatic handoff end to end.",
+      "Confirm that no manual Paperclip API lookup was required.",
+    ]);
   });
 
   it("resumes compatible ACP sessions on later Claude ACP runs", async () => {

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -11,6 +11,25 @@ import {
   resetClaudeCliCapabilitiesCacheForTests,
 } from "@paperclipai/adapter-claude-local/server";
 
+function fakeClaudeCommandPath(directory: string): string {
+  return path.join(directory, process.platform === "win32" ? "claude.cmd" : "claude");
+}
+
+async function writeNodeCommand(commandPath: string, script: string): Promise<void> {
+  if (process.platform === "win32") {
+    const scriptPath = `${commandPath}.cjs`;
+    await fs.writeFile(scriptPath, script, "utf8");
+    await fs.writeFile(
+      commandPath,
+      `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+      "utf8",
+    );
+    return;
+  }
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 async function writeFailingClaudeCommand(
   commandPath: string,
   options: { resultEvent: Record<string, unknown>; exitCode?: number },
@@ -21,8 +40,7 @@ async function writeFailingClaudeCommand(
 console.log(${JSON.stringify(payload)});
 process.exit(${exit});
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function writeTextFailingClaudeCommand(
@@ -39,8 +57,7 @@ if (${JSON.stringify(options.stderr ?? "")}) {
 }
 process.exit(${exit});
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
@@ -72,6 +89,7 @@ const payload = {
   paperclipApiUrl: process.env.PAPERCLIP_API_URL || null,
   paperclipApiKey: process.env.PAPERCLIP_API_KEY || null,
   paperclipApiBridgeMode: process.env.PAPERCLIP_API_BRIDGE_MODE || null,
+  paperclipWakePayloadJson: process.env.PAPERCLIP_WAKE_PAYLOAD_JSON || null,
 };
 if (capturePath) {
   fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
@@ -80,8 +98,7 @@ console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "11111
 console.log(JSON.stringify({ type: "assistant", session_id: "11111111-1111-4111-8111-111111111111", message: { content: [{ type: "text", text: "hello" }] } }));
 console.log(JSON.stringify({ type: "result", session_id: "11111111-1111-4111-8111-111111111111", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function writeHelpWithoutEffortClaudeCommand(commandPath: string): Promise<void> {
@@ -118,8 +135,7 @@ console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "33333
 console.log(JSON.stringify({ type: "assistant", session_id: "33333333-3333-4333-8333-333333333333", message: { content: [{ type: "text", text: "hello" }] } }));
 console.log(JSON.stringify({ type: "result", session_id: "33333333-3333-4333-8333-333333333333", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function writeHelpWithEffortClaudeCommand(commandPath: string): Promise<void> {
@@ -157,8 +173,7 @@ console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "44444
 console.log(JSON.stringify({ type: "assistant", session_id: "44444444-4444-4444-8444-444444444444", message: { content: [{ type: "text", text: "hello" }] } }));
 console.log(JSON.stringify({ type: "result", session_id: "44444444-4444-4444-8444-444444444444", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 type CapturePayload = {
@@ -173,6 +188,7 @@ type CapturePayload = {
   paperclipApiUrl?: string | null;
   paperclipApiKey?: string | null;
   paperclipApiBridgeMode?: string | null;
+  paperclipWakePayloadJson?: string | null;
   appendedSystemPromptFilePath?: string | null;
   appendedSystemPromptFileContents?: string | null;
 };
@@ -213,8 +229,7 @@ console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "bbbbb
 console.log(JSON.stringify({ type: "assistant", session_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", message: { content: [{ type: "text", text: "hello" }] } }));
 console.log(JSON.stringify({ type: "result", session_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function writeAlwaysPoisonedMessageIdClaudeCommand(commandPath: string): Promise<void> {
@@ -243,8 +258,7 @@ console.log(JSON.stringify({
 }));
 process.exit(1);
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function writeRetryThenSucceedClaudeCommand(commandPath: string): Promise<void> {
@@ -284,8 +298,7 @@ console.log(JSON.stringify({ type: "system", subtype: "init", session_id: "22222
 console.log(JSON.stringify({ type: "assistant", session_id: "22222222-2222-4222-8222-222222222222", message: { content: [{ type: "text", text: "hello" }] } }));
 console.log(JSON.stringify({ type: "result", session_id: "22222222-2222-4222-8222-222222222222", result: "hello", usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 } }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+  await writeNodeCommand(commandPath, script);
 }
 
 async function setupExecuteEnv(
@@ -294,7 +307,7 @@ async function setupExecuteEnv(
 ) {
   const workspace = path.join(root, "workspace");
   const binDir = path.join(root, "bin");
-  const commandPath = path.join(binDir, "claude");
+  const commandPath = fakeClaudeCommandPath(binDir);
   const capturePath = path.join(root, "capture.json");
   const statePath = path.join(root, "state.txt");
   await fs.mkdir(workspace, { recursive: true });
@@ -350,6 +363,132 @@ function createLocalSandboxRunner() {
 }
 
 describe("claude execute", () => {
+  it("injects assigned issue context and historical comments into the CLI startup context", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-wake-context-"));
+    const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
+    const taskMarkdown = [
+      "# Assigned Paperclip Issue",
+      "",
+      "- ID: ISSUE-42",
+      "- Title: Deliver reviewer handoff context",
+      "",
+      "## Description",
+      "",
+      "Reviewers must receive the complete handoff without an API lookup.",
+    ].join("\n");
+    const paperclipWake = {
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-context-42",
+        identifier: "ISSUE-42",
+        title: "Deliver reviewer handoff context",
+        description: "Reviewers must receive the complete handoff without an API lookup.",
+        descriptionTruncated: false,
+        status: "in_progress",
+        workMode: "standard",
+        priority: "high",
+      },
+      commentIds: [],
+      latestCommentId: null,
+      comments: [],
+      issueThread: {
+        comments: [
+          {
+            id: "comment-oldest",
+            issueId: "issue-context-42",
+            body: "Board requested an independent review.",
+            bodyTruncated: false,
+            createdAt: "2026-07-23T07:28:00.000Z",
+            author: { type: "user", id: "board-user" },
+          },
+          {
+            id: "comment-newest",
+            issueId: "issue-context-42",
+            body: "Engineering completed the implementation handoff.",
+            bodyTruncated: false,
+            createdAt: "2026-07-23T08:15:00.000Z",
+            author: { type: "agent", id: "engineering-lead" },
+          },
+        ],
+        totalCount: 2,
+        includedCount: 2,
+        omittedCount: 0,
+        truncated: false,
+      },
+      commentWindow: {
+        requestedCount: 0,
+        includedCount: 0,
+        missingCount: 0,
+      },
+      truncated: false,
+      fallbackFetchNeeded: false,
+    };
+
+    try {
+      const result = await execute({
+        runId: "run-wake-context",
+        agent: {
+          id: "review-agent",
+          companyId: "company-1",
+          name: "Review Agent",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: "ISSUE-42" },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "Review the assigned issue.",
+        },
+        context: {
+          issueId: "issue-context-42",
+          taskId: "issue-context-42",
+          wakeReason: "issue_assigned",
+          paperclipTaskMarkdown: taskMarkdown,
+          paperclipWake,
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.prompt).toContain("- Title: Deliver reviewer handoff context");
+      expect(capture.prompt).toContain(
+        "Reviewers must receive the complete handoff without an API lookup.",
+      );
+      expect(capture.prompt).toContain(
+        "Existing issue comment thread (historical context, oldest to newest):",
+      );
+      expect(capture.prompt).toContain("Board requested an independent review.");
+      expect(capture.prompt).toContain("Engineering completed the implementation handoff.");
+      expect(capture.prompt.indexOf("Board requested an independent review.")).toBeLessThan(
+        capture.prompt.indexOf("Engineering completed the implementation handoff."),
+      );
+
+      expect(capture.paperclipWakePayloadJson).toBeTruthy();
+      const structuredWake = JSON.parse(capture.paperclipWakePayloadJson!) as {
+        issue: { id: string; identifier: string; title: string; description: string };
+        issueThread: { comments: Array<{ id: string; body: string }> };
+      };
+      expect(structuredWake.issue).toMatchObject({
+        id: "issue-context-42",
+        identifier: "ISSUE-42",
+        title: "Deliver reviewer handoff context",
+        description: "Reviewers must receive the complete handoff without an API lookup.",
+      });
+      expect(structuredWake.issueThread.comments.map((comment) => [comment.id, comment.body])).toEqual([
+        ["comment-oldest", "Board requested an independent review."],
+        ["comment-newest", "Engineering completed the implementation handoff."],
+      ]);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("uses a strict per-agent MCP config only when managed servers are present", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-mcp-config-"));
     const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
@@ -725,7 +864,7 @@ describe("claude execute", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-meta-"));
     const workspace = path.join(root, "workspace");
     const binDir = path.join(root, "bin");
-    const commandPath = path.join(binDir, "claude");
+    const commandPath = fakeClaudeCommandPath(binDir);
     const capturePath = path.join(root, "capture.json");
     const claudeConfigDir = path.join(root, "claude-config");
     await fs.mkdir(workspace, { recursive: true });
@@ -801,7 +940,7 @@ describe("claude execute", () => {
     const localWorkspace = path.join(root, "workspace");
     const remoteWorkspace = path.join(root, "sandbox-$HOME");
     const binDir = path.join(root, "bin");
-    const commandPath = path.join(binDir, "claude");
+    const commandPath = fakeClaudeCommandPath(binDir);
     const capturePath1 = path.join(remoteWorkspace, "capture-1.json");
     const claudeRoot = path.join(root, ".claude");
     const previousHome = process.env.HOME;
@@ -1079,7 +1218,7 @@ describe("claude execute", () => {
   it("reuses a stable Paperclip-managed Claude prompt bundle across equivalent runs", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-bundle-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
+    const commandPath = fakeClaudeCommandPath(root);
     const capturePath1 = path.join(root, "capture-1.json");
     const capturePath2 = path.join(root, "capture-2.json");
     const instructionsPath = path.join(root, "AGENTS.md");
@@ -1245,7 +1384,7 @@ describe("claude execute", () => {
   it("starts a fresh Claude session when the stable prompt bundle changes", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-reset-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
+    const commandPath = fakeClaudeCommandPath(root);
     const capturePath1 = path.join(root, "capture-before.json");
     const capturePath2 = path.join(root, "capture-after.json");
     const instructionsPath = path.join(root, "AGENTS.md");
@@ -1352,7 +1491,7 @@ describe("claude execute", () => {
   it("classifies Claude 'out of extra usage' failures as provider quota errors", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-transient-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
+    const commandPath = fakeClaudeCommandPath(root);
     await fs.mkdir(workspace, { recursive: true });
     await writeFailingClaudeCommand(commandPath, {
       resultEvent: {
@@ -1419,7 +1558,7 @@ describe("claude execute", () => {
   it("treats subtype=success results as successful even when the process exits nonzero", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-success-subtype-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
+    const commandPath = fakeClaudeCommandPath(root);
     await fs.mkdir(workspace, { recursive: true });
     await writeFailingClaudeCommand(commandPath, {
       exitCode: 1,
@@ -1477,7 +1616,7 @@ describe("claude execute", () => {
   it("classifies rate-limit / overloaded failures without reset metadata as transient", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-rate-limit-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
+    const commandPath = fakeClaudeCommandPath(root);
     await fs.mkdir(workspace, { recursive: true });
     await writeFailingClaudeCommand(commandPath, {
       resultEvent: {
@@ -1536,7 +1675,7 @@ describe("claude execute", () => {
   it("does not reclassify deterministic Claude failures (auth, max turns) as transient", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-max-turns-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
+    const commandPath = fakeClaudeCommandPath(root);
     await fs.mkdir(workspace, { recursive: true });
     await writeFailingClaudeCommand(commandPath, {
       resultEvent: {

--- a/server/src/__tests__/issue-comment-redaction.test.ts
+++ b/server/src/__tests__/issue-comment-redaction.test.ts
@@ -11,7 +11,10 @@ import {
   issueReferenceMentions,
   issues,
 } from "@paperclipai/db";
-import { companySearchQuerySchema } from "@paperclipai/shared";
+import {
+  LOW_TRUST_REVIEW_PRESET,
+  companySearchQuerySchema,
+} from "@paperclipai/shared";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -22,6 +25,7 @@ import { companySearchService } from "../services/company-search.js";
 import { buildPaperclipWakePayload } from "../services/heartbeat.js";
 import { issueReferenceService } from "../services/issue-references.js";
 import { issueService } from "../services/issues.js";
+import { LOW_TRUST_QUARANTINED_BODY } from "../services/source-trust.js";
 import type { StorageService } from "../storage/types.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -69,6 +73,7 @@ describeEmbeddedPostgres("deleted issue comment redaction", () => {
       companyId,
       identifier: "RED-1",
       title: "Deleted comment redaction",
+      description: "Review the complete issue context without a manual API lookup.",
       status: "todo",
       priority: "medium",
     });
@@ -185,6 +190,211 @@ describeEmbeddedPostgres("deleted issue comment redaction", () => {
     ]);
     expect(JSON.stringify(wakePayload)).not.toContain("secret deleted body");
     expect(JSON.stringify(wakePayload)).not.toContain("secret metadata");
+  });
+
+  it.each([
+    "issue_assigned",
+    "issue_assignment_recovery",
+    "execution_review_requested",
+  ] as const)(
+    "includes bounded, sanitized issue context for %s handoffs",
+    async (wakeReason) => {
+      const { companyId, issueId } = await seedIssue();
+      const threadComments = Array.from({ length: 10 }, (_, index) => ({
+        id: randomUUID(),
+        companyId,
+        issueId,
+        authorUserId: "board-user-1",
+        body: `historical comment ${String(index + 1).padStart(2, "0")}`,
+        metadata:
+          index === 9
+            ? { oversized: `historical-metadata-marker-${"x".repeat(100_000)}` }
+            : null,
+        createdAt: new Date(
+          `2026-07-01T00:${String(index + 1).padStart(2, "0")}:00.000Z`,
+        ),
+      }));
+      const quarantinedCommentId = randomUUID();
+      const deletedCommentId = randomUUID();
+
+      await db.insert(issueComments).values([
+        ...threadComments,
+        {
+          id: quarantinedCommentId,
+          companyId,
+          issueId,
+          authorUserId: "board-user-1",
+          body: "secret quarantined instructions",
+          sourceTrust: {
+            preset: LOW_TRUST_REVIEW_PRESET,
+            disposition: "quarantined",
+            sourceIssueId: issueId,
+          },
+          createdAt: new Date("2026-07-01T00:11:00.000Z"),
+        },
+        {
+          id: deletedCommentId,
+          companyId,
+          issueId,
+          authorUserId: "board-user-1",
+          body: "secret deleted handoff detail",
+          deletedAt: new Date("2026-07-01T00:13:00.000Z"),
+          deletedByType: "user",
+          deletedByUserId: "board-user-1",
+          createdAt: new Date("2026-07-01T00:12:00.000Z"),
+        },
+      ]);
+
+      const wakePayload = await buildPaperclipWakePayload({
+        db,
+        companyId,
+        contextSnapshot: {
+          issueId,
+          wakeReason,
+        },
+      });
+
+      expect(wakePayload?.reason).toBe(wakeReason);
+      expect(wakePayload?.issue).toMatchObject({
+        id: issueId,
+        identifier: "RED-1",
+        title: "Deleted comment redaction",
+        description: "Review the complete issue context without a manual API lookup.",
+        descriptionTruncated: false,
+      });
+      expect(wakePayload?.commentIds).toEqual([]);
+      expect(wakePayload?.comments).toEqual([]);
+      expect(wakePayload?.latestCommentId).toBeNull();
+      expect(wakePayload?.commentWindow).toEqual({
+        requestedCount: 0,
+        includedCount: 0,
+        missingCount: 0,
+      });
+
+      expect(wakePayload?.issueThread).toMatchObject({
+        totalCount: 11,
+        includedCount: 8,
+        omittedCount: 3,
+        truncated: true,
+      });
+      expect(
+        wakePayload?.issueThread?.comments.map((comment) => comment.id),
+      ).toEqual([
+        ...threadComments.slice(3).map((comment) => comment.id),
+        quarantinedCommentId,
+      ]);
+      expect(
+        wakePayload?.issueThread?.comments.map((comment) => comment.body),
+      ).toEqual([
+        ...threadComments.slice(3).map((comment) => comment.body),
+        LOW_TRUST_QUARANTINED_BODY,
+      ]);
+      expect(wakePayload?.truncated).toBe(true);
+      expect(wakePayload?.fallbackFetchNeeded).toBe(true);
+
+      const serializedPayload = JSON.stringify(wakePayload);
+      expect(serializedPayload).not.toContain("secret deleted handoff detail");
+      expect(serializedPayload).not.toContain("secret quarantined instructions");
+      expect(serializedPayload).not.toContain("historical-metadata-marker");
+      expect(serializedPayload).not.toContain(deletedCommentId);
+    },
+  );
+
+  it("provides a complete short assignment thread without requiring a fallback fetch", async () => {
+    const { companyId, issueId } = await seedIssue();
+    await db.insert(issueComments).values([
+      {
+        id: randomUUID(),
+        companyId,
+        issueId,
+        authorUserId: "board-user-1",
+        body: "Initial acceptance criteria.",
+        createdAt: new Date("2026-07-01T00:01:00.000Z"),
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        issueId,
+        authorUserId: "board-user-1",
+        body: "Review handoff details.",
+        createdAt: new Date("2026-07-01T00:02:00.000Z"),
+      },
+    ]);
+
+    const wakePayload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    expect(wakePayload?.issueThread).toMatchObject({
+      totalCount: 2,
+      includedCount: 2,
+      omittedCount: 0,
+      truncated: false,
+    });
+    expect(
+      wakePayload?.issueThread?.comments.map((comment) => comment.body),
+    ).toEqual([
+      "Initial acceptance criteria.",
+      "Review handoff details.",
+    ]);
+    expect(wakePayload?.truncated).toBe(false);
+    expect(wakePayload?.fallbackFetchNeeded).toBe(false);
+  });
+
+  it("keeps the triggering comment delta separate from historical handoff context", async () => {
+    const { companyId, issueId } = await seedIssue();
+    const historicalCommentId = randomUUID();
+    const wakeCommentId = randomUUID();
+    await db.insert(issueComments).values([
+      {
+        id: historicalCommentId,
+        companyId,
+        issueId,
+        authorUserId: "board-user-1",
+        body: "Existing implementation context.",
+        createdAt: new Date("2026-07-01T00:01:00.000Z"),
+      },
+      {
+        id: wakeCommentId,
+        companyId,
+        issueId,
+        authorUserId: "board-user-1",
+        body: "New feedback that caused this wake.",
+        createdAt: new Date("2026-07-01T00:02:00.000Z"),
+      },
+    ]);
+
+    const wakePayload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+        wakeCommentIds: [wakeCommentId],
+      },
+    });
+
+    expect(wakePayload?.commentIds).toEqual([wakeCommentId]);
+    expect(wakePayload?.comments.map((comment) => comment.id)).toEqual([
+      wakeCommentId,
+    ]);
+    expect(wakePayload?.issueThread).toMatchObject({
+      totalCount: 1,
+      includedCount: 1,
+      omittedCount: 0,
+      truncated: false,
+    });
+    expect(wakePayload?.issueThread?.comments).toEqual([
+      expect.objectContaining({
+        id: historicalCommentId,
+        body: "Existing implementation context.",
+      }),
+    ]);
   });
 
   it("excludes deleted comment bodies from company search", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -315,6 +315,7 @@ const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
+const MAX_INLINE_WAKE_ISSUE_DESCRIPTION_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -349,6 +350,14 @@ const CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE = "configuration_incomplete";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_WAKE_REASON = "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_CAUSE = "execution_review_participant_recovery";
+const ISSUE_CONTEXT_HANDOFF_WAKE_REASONS = new Set([
+  "issue_assigned",
+  "issue_assignment_recovery",
+  "execution_review_requested",
+  EXECUTION_REVIEW_PARTICIPANT_RECOVERY_WAKE_REASON,
+  "execution_approval_requested",
+  "execution_changes_requested",
+]);
 const GITHUB_PR_WORKFLOW_SKILL_KEY = "paperclipai/bundled/software-development/github-pr-workflow";
 const GITHUB_PR_WORKFLOW_SKILL_SLUG = "github-pr-workflow";
 const PUSH_CAPABILITY_ENV_KEYS = ["GH_TOKEN", "GITHUB_TOKEN"] as const;
@@ -4376,6 +4385,94 @@ export function mergeCoalescedContextSnapshot(
   return merged;
 }
 
+type InlineWakeCommentRow = Pick<
+  typeof issueComments.$inferSelect,
+  | "id"
+  | "issueId"
+  | "body"
+  | "authorType"
+  | "authorAgentId"
+  | "authorUserId"
+  | "presentation"
+  | "metadata"
+  | "deletedAt"
+  | "deletedByType"
+  | "deletedByAgentId"
+  | "deletedByUserId"
+  | "deletedByRunId"
+  | "sourceTrust"
+  | "createdAt"
+>;
+
+function serializeInlineWakeComment(
+  row: InlineWakeCommentRow,
+  input: {
+    allowedBodyChars: number;
+    exposeLowTrustRaw: boolean;
+    includeExtendedFields: boolean;
+  },
+) {
+  if (input.allowedBodyChars <= 0) return null;
+
+  const deletedAt = row.deletedAt ?? null;
+  const safeRow =
+    deletedAt || input.exposeLowTrustRaw
+      ? row
+      : sanitizeQuarantinedCommentForHigherTrust(row);
+  const fullBody = deletedAt ? "" : safeRow.body;
+  const body =
+    fullBody.length > input.allowedBodyChars
+      ? fullBody.slice(0, input.allowedBodyChars)
+      : fullBody;
+  const bodyTruncated = body.length < fullBody.length;
+
+  return {
+    comment: {
+      id: row.id,
+      issueId: row.issueId,
+      authorType:
+        row.authorType ??
+        (row.authorAgentId ? "agent" : row.authorUserId ? "user" : "system"),
+      body,
+      bodyTruncated,
+      ...(input.includeExtendedFields
+        ? {
+            presentation: deletedAt ? null : safeRow.presentation ?? null,
+            metadata: deletedAt ? null : safeRow.metadata ?? null,
+            deletedAt: deletedAt ? deletedAt.toISOString() : null,
+            deletedByType: deletedAt ? row.deletedByType ?? null : null,
+            deletedByAgentId: deletedAt ? row.deletedByAgentId ?? null : null,
+            deletedByUserId: deletedAt ? row.deletedByUserId ?? null : null,
+            deletedByRunId: deletedAt ? row.deletedByRunId ?? null : null,
+            sourceTrust: row.sourceTrust ?? null,
+          }
+        : {}),
+      createdAt: row.createdAt.toISOString(),
+      author: row.authorAgentId
+        ? { type: "agent", id: row.authorAgentId }
+        : row.authorUserId
+          ? { type: "user", id: row.authorUserId }
+          : { type: "system", id: null },
+    },
+    consumedBodyChars: body.length,
+    bodyTruncated,
+  };
+}
+
+function shouldIncludeIssueThreadContext(
+  contextSnapshot: Record<string, unknown>,
+) {
+  const wakeReason = readNonEmptyString(contextSnapshot.wakeReason);
+  if (wakeReason && ISSUE_CONTEXT_HANDOFF_WAKE_REASONS.has(wakeReason)) {
+    return true;
+  }
+
+  const wakeRole = readNonEmptyString(
+    parseObject(contextSnapshot.executionStage).wakeRole,
+  );
+  return wakeRole === "reviewer" || wakeRole === "approver" || wakeRole === "executor";
+}
+
 export async function buildPaperclipWakePayload(input: {
   db: Db;
   companyId: string;
@@ -4394,6 +4491,7 @@ export async function buildPaperclipWakePayload(input: {
         id: string;
         identifier: string | null;
         title: string;
+        description?: string | null;
         status: string;
         priority: string;
         workMode: string;
@@ -4416,6 +4514,7 @@ export async function buildPaperclipWakePayload(input: {
             id: issues.id,
             identifier: issues.identifier,
             title: issues.title,
+            description: issues.description,
             status: issues.status,
             priority: issues.priority,
             workMode: issues.workMode,
@@ -4426,8 +4525,47 @@ export async function buildPaperclipWakePayload(input: {
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
 
+  const resolvedIssueId = issueSummary?.id ?? issueId;
+  const includeIssueThread =
+    Boolean(resolvedIssueId) &&
+    shouldIncludeIssueThreadContext(input.contextSnapshot);
+  let issueThreadIdsNewestFirst: string[] = [];
+  let issueThreadTotalCount = 0;
+  if (includeIssueThread && resolvedIssueId) {
+    const issueThreadWhere =
+      commentIds.length > 0
+        ? and(
+            eq(issueComments.companyId, input.companyId),
+            eq(issueComments.issueId, resolvedIssueId),
+            isNull(issueComments.deletedAt),
+            notInArray(issueComments.id, commentIds),
+          )
+        : and(
+            eq(issueComments.companyId, input.companyId),
+            eq(issueComments.issueId, resolvedIssueId),
+            isNull(issueComments.deletedAt),
+          );
+    const [issueThreadIdRows, issueThreadCountRows] = await Promise.all([
+      input.db
+        .select({ id: issueComments.id })
+        .from(issueComments)
+        .where(issueThreadWhere)
+        .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+        .limit(MAX_INLINE_WAKE_COMMENTS),
+      input.db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(issueComments)
+        .where(issueThreadWhere),
+    ]);
+    issueThreadIdsNewestFirst = issueThreadIdRows.map((row) => row.id);
+    issueThreadTotalCount = Math.max(
+      issueThreadCountRows[0]?.count ?? 0,
+      issueThreadIdsNewestFirst.length,
+    );
+  }
+  const hydratedCommentIds = [...new Set([...commentIds, ...issueThreadIdsNewestFirst])];
   const commentRows =
-    commentIds.length === 0
+    hydratedCommentIds.length === 0
       ? []
       : await input.db
           .select({
@@ -4451,7 +4589,7 @@ export async function buildPaperclipWakePayload(input: {
           .where(
             and(
               eq(issueComments.companyId, input.companyId),
-              inArray(issueComments.id, commentIds),
+              inArray(issueComments.id, hydratedCommentIds),
             ),
           );
 
@@ -4477,42 +4615,65 @@ export async function buildPaperclipWakePayload(input: {
       break;
     }
 
-    const deletedAt = row.deletedAt ?? null;
-    const safeRow = deletedAt || input.exposeLowTrustRaw ? row : sanitizeQuarantinedCommentForHigherTrust(row);
-    const fullBody = deletedAt ? "" : safeRow.body;
     const allowedBodyChars = Math.min(MAX_INLINE_WAKE_COMMENT_BODY_CHARS, remainingBodyChars);
-    if (allowedBodyChars <= 0) {
+    const serialized = serializeInlineWakeComment(row, {
+      allowedBodyChars,
+      exposeLowTrustRaw: input.exposeLowTrustRaw === true,
+      includeExtendedFields: true,
+    });
+    if (!serialized) {
       truncated = true;
       break;
     }
-
-    const body = fullBody.length > allowedBodyChars ? fullBody.slice(0, allowedBodyChars) : fullBody;
-    const bodyTruncated = body.length < fullBody.length;
-    if (bodyTruncated) truncated = true;
-    remainingBodyChars -= body.length;
-
-    comments.push({
-      id: row.id,
-      issueId: row.issueId,
-      authorType: row.authorType ?? (row.authorAgentId ? "agent" : row.authorUserId ? "user" : "system"),
-      body,
-      bodyTruncated,
-      presentation: deletedAt ? null : safeRow.presentation ?? null,
-      metadata: deletedAt ? null : safeRow.metadata ?? null,
-      deletedAt: deletedAt ? deletedAt.toISOString() : null,
-      deletedByType: deletedAt ? row.deletedByType ?? null : null,
-      deletedByAgentId: deletedAt ? row.deletedByAgentId ?? null : null,
-      deletedByUserId: deletedAt ? row.deletedByUserId ?? null : null,
-      deletedByRunId: deletedAt ? row.deletedByRunId ?? null : null,
-      sourceTrust: row.sourceTrust ?? null,
-      createdAt: row.createdAt.toISOString(),
-      author: row.authorAgentId
-        ? { type: "agent", id: row.authorAgentId }
-        : row.authorUserId
-          ? { type: "user", id: row.authorUserId }
-          : { type: "system", id: null },
-    });
+    if (serialized.bodyTruncated) truncated = true;
+    remainingBodyChars -= serialized.consumedBodyChars;
+    comments.push(serialized.comment);
   }
+
+  const issueThreadCommentsNewestFirst: Array<Record<string, unknown>> = [];
+  let issueThreadRemainingBodyChars = MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS;
+  let issueThreadTruncated = false;
+  for (const commentId of issueThreadIdsNewestFirst) {
+    const row = commentsById.get(commentId);
+    if (!row) {
+      issueThreadTruncated = true;
+      continue;
+    }
+    const serialized = serializeInlineWakeComment(row, {
+      allowedBodyChars: Math.min(
+        MAX_INLINE_WAKE_COMMENT_BODY_CHARS,
+        issueThreadRemainingBodyChars,
+      ),
+      exposeLowTrustRaw: input.exposeLowTrustRaw === true,
+      includeExtendedFields: false,
+    });
+    if (!serialized) {
+      issueThreadTruncated = true;
+      break;
+    }
+    if (serialized.bodyTruncated) issueThreadTruncated = true;
+    issueThreadRemainingBodyChars -= serialized.consumedBodyChars;
+    issueThreadCommentsNewestFirst.push(serialized.comment);
+  }
+  const issueThreadComments = issueThreadCommentsNewestFirst.reverse();
+  const issueThreadOmittedCount = Math.max(
+    0,
+    issueThreadTotalCount - issueThreadComments.length,
+  );
+  if (issueThreadOmittedCount > 0) issueThreadTruncated = true;
+  const issueThread = includeIssueThread
+    ? {
+        comments: issueThreadComments,
+        totalCount: issueThreadTotalCount,
+        includedCount: issueThreadComments.length,
+        omittedCount: issueThreadOmittedCount,
+        truncated: issueThreadTruncated,
+      }
+    : null;
+  const issueDescription = issueSummary?.description ?? null;
+  const issueDescriptionTruncated =
+    typeof issueDescription === "string" &&
+    issueDescription.length > MAX_INLINE_WAKE_ISSUE_DESCRIPTION_CHARS;
 
   const annotationDeltas = annotationCommentId && issueId
     ? await input.db
@@ -4582,7 +4743,11 @@ export async function buildPaperclipWakePayload(input: {
       interactionId,
     })
     : null;
-  const payloadTruncated = truncated || planReviewContext?.truncated === true;
+  const payloadTruncated =
+    truncated ||
+    issueDescriptionTruncated ||
+    issueThread?.truncated === true ||
+    planReviewContext?.truncated === true;
   const recoveryActionId = readNonEmptyString(input.contextSnapshot.recoveryActionId);
   const recoveryCause = readNonEmptyString(input.contextSnapshot.recoveryCause);
   const recoveryAction = recoveryActionId
@@ -4627,6 +4792,11 @@ export async function buildPaperclipWakePayload(input: {
           id: issueSummary.id,
           identifier: issueSummary.identifier,
           title: issueSummary.title,
+          description:
+            typeof issueDescription === "string"
+              ? issueDescription.slice(0, MAX_INLINE_WAKE_ISSUE_DESCRIPTION_CHARS)
+              : null,
+          descriptionTruncated: issueDescriptionTruncated,
           status: issueSummary.status,
           priority: issueSummary.priority,
           workMode: issueSummary.workMode,
@@ -4681,6 +4851,7 @@ export async function buildPaperclipWakePayload(input: {
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,
     comments,
+    issueThread,
     annotationDeltas,
     planReviewContext,
     commentWindow: {
@@ -12075,6 +12246,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             id: issueRef.id,
             identifier: issueRef.identifier,
             title: issueRef.title,
+            description: issueRef.description,
             status: issueRef.status,
             priority: issueRef.priority,
             workMode: issueRef.workMode,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to coordinate AI agents and their work
> - Heartbeat wake payloads provide the scoped context an adapter needs to start or resume an assigned issue
> - Fresh assignment and execution-review wakes already carried issue identity, but only explicit new-comment IDs were hydrated
> - Existing issue discussion was therefore absent from the structured wake context, forcing a reviewer to fetch the thread manually
> - Historical context must remain separate from the new-comment delta so adapters do not mislabel old discussion as pending feedback
> - This pull request adds a bounded, sanitized historical thread to fresh handoff wakes and verifies both Claude CLI and ACP delivery
> - The benefit is a self-contained reviewer handoff without changing existing acknowledgement semantics

## Linked Issues or Issue Description

No matching public GitHub issue or pull request was found.

**What happened?**

Assigning an issue to an agent, or transitioning it into an execution review stage, produced a structured wake payload with the issue ID and execution stage but no existing issue comments. The server only hydrated comments named by explicit wake-comment IDs; assignment and review wakes normally have none.

**Expected behavior**

Fresh assignment, assignment-recovery, review, approval, and change-request handoffs should include the issue ID, identifier, title, description, and a bounded recent issue thread in startup context. Historical comments must remain distinct from new-comment deltas.

**Steps to reproduce**

1. Create an issue with a description and at least one existing comment.
2. Assign it to a `claude_local` agent or transition it to an execution review participant.
3. Inspect `paperclipWake` and the adapter startup prompt.
4. Observe that the issue metadata is present but `comments` is empty and the existing thread is absent.

**Version / deployment**

Reproduced at `v2026.720.0` (`903bd157`) and confirmed unchanged through current `master` during implementation. The behavior is core wake construction and affects both Claude CLI and ACP lanes; no database mode or migration is involved.

## What Changed

- Add capped issue descriptions and a separate `issueThread` window to structured handoff wake payloads.
- Hydrate the latest eight non-deleted comments, render them oldest-to-newest, sanitize quarantined low-trust bodies, and omit extended metadata from persisted historical context.
- Keep explicit new-comment deltas separate and deduplicated from historical context.
- Derive truncation and fallback-fetch signals when descriptions or thread history are incomplete.
- Cover assignment, assignment recovery, execution review, short complete threads, long truncated threads, redaction, metadata bounds, and delta/history separation.
- Verify delivery through the shared renderer and both `claude_local` CLI and ACP transports.
- Document the handoff-context contract in `doc/execution-semantics.md`.

## Verification

- `corepack pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts` — 67 passed, 6 skipped.
- `corepack pnpm exec vitest run packages/adapters/claude-local/src/server/acp.test.ts -t "injects reviewer issue context"` — 1 passed, 16 skipped.
- `corepack pnpm exec vitest run server/src/__tests__/issue-comment-redaction.test.ts` — 8 passed.
- `corepack pnpm exec vitest run server/src/__tests__/claude-local-execute.test.ts -t "injects assigned issue context"` — 1 passed, 24 skipped.
- `corepack pnpm --filter @paperclipai/adapter-utils --filter @paperclipai/adapter-claude-local -r typecheck` — passed.
- `node scripts/ensure-plugin-build-deps.mjs` followed by `node node_modules/typescript/bin/tsc -p server/tsconfig.json --noEmit` — passed.
- `corepack pnpm run check:tokens` and `git diff --check` — passed.

The full ACP file contains one unrelated upstream Windows-only failure because its runner-backed sandbox fixture invokes `sh`; the new ACP transport case passes. The full Claude execute fixture still has six unrelated Windows-only failures from existing POSIX path/sandbox assumptions; the new Windows CLI transport case passes. A frozen dependency refresh installed the current lockfile but its root postinstall hit the known Windows symlink-permission limitation; both touched-package typechecks and the server TypeScript check passed afterward. The full draft-PR CI matrix is green against commit `d6754f9`; the fresh Greptile review is still pending.

## Risks

- Low migration risk: the payload shape is additive and requires no schema migration.
- Fresh handoff wakes add two bounded comment queries; ordinary comment-delta wakes are unchanged.
- Payload size is capped at eight comments, 4,000 characters per body, 12,000 body characters total, and 12,000 description characters. Extended presentation/metadata fields are not copied into historical context.
- Older omitted comments set `fallbackFetchNeeded`, so agents can fetch broader history when genuinely required.
- A live deployed heartbeat confirmation remains necessary after review; this PR does not deploy or change a running instance.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with `gpt-5.6-sol`, xhigh reasoning, tool use, local code execution, and parallel review agents. Context-window size was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge