### PR TITLE
feat(server): include scoped project and milestone intake in wake payload

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -1018,6 +1018,26 @@ Behavior:
 - `thin`: send IDs and pointers only; agent fetches context via API
 - `fat`: include current assignments, goal summary, budget snapshot, and recent comments
 
+Issue-scoped wake payloads include a `goalProjectIntake` snapshot when the
+authoritative issue links a project or goal. The snapshot is restricted to the
+issue company and contains:
+
+- the linked project, including description, lead, target date, status, and
+  timestamps
+- the linked goal (falling back to the project's goal), including description,
+  owner, hierarchy, status, and timestamps
+- active direct child goals as the linked goal's active milestones
+- the previous comparable wake timestamp and full changed records since that
+  timestamp, including milestones that became inactive
+
+The first comparable wake is an initial snapshot; subsequent wakes use the
+previous snapshot's `capturedAt` as `changedSince`. Consumers can therefore
+validate outcome, owner, horizon, dependencies, evidence, approval boundaries,
+and ranking inputs from the scoped descriptions and fields without listing
+unrelated issues. Bounded or truncated intake snapshots set
+`fallbackFetchNeeded` so consumers do not silently treat partial scope as
+complete.
+
 ## 11.5 Recovery Model Profiles
 
 The optional `modelProfiles.cheap` lane is not a retry worker lane. Paperclip may request the cheap profile only for status-only recovery coordination, and those wakes must include guard context that prevents deliverable work and document/plan updates (`allowDeliverableWork: false`, `allowDocumentUpdates: false`, `resumeRequiresNormalModel: true`).

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -906,6 +906,125 @@ describe("renderPaperclipWakePrompt", () => {
     expect(fallbackPrompt).toContain("- fallback fetch needed: yes");
   });
 
+  it("preserves and summarizes scoped goal/project milestone intake data", () => {
+    const payload = {
+      reason: "issue_assigned",
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1581",
+        title: "Validate portfolio intake",
+        status: "in_progress",
+        projectId: "project-1",
+        goalId: "goal-1",
+      },
+      goalProjectIntake: {
+        capturedAt: "2026-07-23T12:00:00.000Z",
+        changedSince: "2026-07-22T12:00:00.000Z",
+        baselineRunId: "run-previous",
+        baselineKind: "incremental",
+        project: {
+          id: "project-1",
+          goalId: "goal-1",
+          name: "Portfolio intelligence",
+          description: "Rank work using evidence and expected outcomes.",
+          status: "in_progress",
+          leadAgentId: "agent-lead",
+          targetDate: "2026-09-30",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          updatedAt: "2026-07-23T10:00:00.000Z",
+        },
+        goal: {
+          id: "goal-1",
+          title: "Build a repeatable growth engine",
+          description: "Outcome, horizon, evidence, and approval boundary.",
+          level: "team",
+          status: "active",
+          ownerAgentId: "agent-owner",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          updatedAt: "2026-07-23T10:00:00.000Z",
+        },
+        activeMilestones: [
+          {
+            id: "milestone-1",
+            title: "Reach $100 MRR",
+            description: "Exit evidence and dependencies.",
+            level: "task",
+            status: "active",
+            parentId: "goal-1",
+            ownerAgentId: "agent-owner",
+            createdAt: "2026-07-02T00:00:00.000Z",
+            updatedAt: "2026-07-23T11:00:00.000Z",
+          },
+        ],
+        deltas: {
+          project: {
+            id: "project-1",
+            goalId: "goal-1",
+            name: "Portfolio intelligence",
+            changeKind: "updated",
+          },
+          goal: null,
+          activeMilestones: [
+            {
+              id: "milestone-1",
+              title: "Reach $100 MRR",
+              changeKind: "updated",
+            },
+          ],
+          noLongerActiveMilestoneIds: ["milestone-old"],
+        },
+        activeMilestoneCount: 1,
+        includedActiveMilestoneCount: 1,
+        truncated: false,
+      },
+      commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+      comments: [],
+      fallbackFetchNeeded: false,
+    };
+
+    const serialized = JSON.parse(
+      stringifyPaperclipWakePayload(payload) ?? "{}",
+    );
+    expect(serialized).toMatchObject({
+      issue: { projectId: "project-1", goalId: "goal-1" },
+      goalProjectIntake: {
+        changedSince: "2026-07-22T12:00:00.000Z",
+        project: {
+          id: "project-1",
+          description: "Rank work using evidence and expected outcomes.",
+        },
+        goal: {
+          id: "goal-1",
+          ownerAgentId: "agent-owner",
+        },
+        activeMilestones: [
+          {
+            id: "milestone-1",
+            description: "Exit evidence and dependencies.",
+          },
+        ],
+        deltas: {
+          project: { changeKind: "updated" },
+          activeMilestones: [
+            { id: "milestone-1", changeKind: "updated" },
+          ],
+          noLongerActiveMilestoneIds: ["milestone-old"],
+        },
+      },
+    });
+
+    const prompt = renderPaperclipWakePrompt(payload);
+    expect(prompt).toContain(
+      "- goal/project intake baseline: incremental (changed since 2026-07-22T12:00:00.000Z)",
+    );
+    expect(prompt).toContain("- linked project: Portfolio intelligence");
+    expect(prompt).toContain("- linked goal: Build a repeatable growth engine");
+    expect(prompt).toContain("- active milestones: 1/1");
+    expect(prompt).toContain(
+      "- intake deltas: project changed, goal unchanged, active milestones 1 changed and 1 no longer active",
+    );
+  });
+
   it("renders the execution workspace branch guard only on non-resumed sessions", () => {
     const payload = {
       reason: "issue_assigned",

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -441,6 +441,55 @@ type PaperclipWakeIssue = {
   status: string | null;
   workMode: string | null;
   priority: string | null;
+  projectId: string | null;
+  goalId: string | null;
+};
+
+type PaperclipWakeGoalRecord = {
+  id: string;
+  title: string | null;
+  description: string | null;
+  descriptionTruncated: boolean;
+  level: string | null;
+  status: string | null;
+  parentId: string | null;
+  ownerAgentId: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  changeKind?: string | null;
+};
+
+type PaperclipWakeProjectRecord = {
+  id: string;
+  goalId: string | null;
+  name: string | null;
+  description: string | null;
+  descriptionTruncated: boolean;
+  status: string | null;
+  leadAgentId: string | null;
+  targetDate: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  changeKind?: string | null;
+};
+
+type PaperclipWakeGoalProjectIntake = {
+  capturedAt: string | null;
+  changedSince: string | null;
+  baselineRunId: string | null;
+  baselineKind: string | null;
+  project: PaperclipWakeProjectRecord | null;
+  goal: PaperclipWakeGoalRecord | null;
+  activeMilestones: PaperclipWakeGoalRecord[];
+  deltas: {
+    project: PaperclipWakeProjectRecord | null;
+    goal: PaperclipWakeGoalRecord | null;
+    activeMilestones: PaperclipWakeGoalRecord[];
+    noLongerActiveMilestoneIds: string[];
+  };
+  activeMilestoneCount: number;
+  includedActiveMilestoneCount: number;
+  truncated: boolean;
 };
 
 type PaperclipWakeExecutionPrincipal = {
@@ -649,6 +698,7 @@ type PaperclipWakePayload = {
   reason: string | null;
   recovery: PaperclipWakeRecovery | null;
   issue: PaperclipWakeIssue | null;
+  goalProjectIntake: PaperclipWakeGoalProjectIntake | null;
   checkedOutByHarness: boolean;
   dependencyBlockedInteraction: boolean;
   treeHoldInteraction: boolean;
@@ -705,6 +755,8 @@ function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null 
   const status = asString(issue.status, "").trim() || null;
   const workMode = asString(issue.workMode, "").trim() || null;
   const priority = asString(issue.priority, "").trim() || null;
+  const projectId = asString(issue.projectId, "").trim() || null;
+  const goalId = asString(issue.goalId, "").trim() || null;
   if (!id && !identifier && !title) return null;
   return {
     id,
@@ -713,6 +765,97 @@ function normalizePaperclipWakeIssue(value: unknown): PaperclipWakeIssue | null 
     status,
     workMode,
     priority,
+    projectId,
+    goalId,
+  };
+}
+
+function normalizePaperclipWakeGoalRecord(value: unknown): PaperclipWakeGoalRecord | null {
+  const goal = parseObject(value);
+  const id = asString(goal.id, "").trim();
+  if (!id) return null;
+  return {
+    id,
+    title: asString(goal.title, "").trim() || null,
+    description: typeof goal.description === "string" ? goal.description : null,
+    descriptionTruncated: asBoolean(goal.descriptionTruncated, false),
+    level: asString(goal.level, "").trim() || null,
+    status: asString(goal.status, "").trim() || null,
+    parentId: asString(goal.parentId, "").trim() || null,
+    ownerAgentId: asString(goal.ownerAgentId, "").trim() || null,
+    createdAt: asString(goal.createdAt, "").trim() || null,
+    updatedAt: asString(goal.updatedAt, "").trim() || null,
+    changeKind: asString(goal.changeKind, "").trim() || null,
+  };
+}
+
+function normalizePaperclipWakeProjectRecord(value: unknown): PaperclipWakeProjectRecord | null {
+  const project = parseObject(value);
+  const id = asString(project.id, "").trim();
+  if (!id) return null;
+  return {
+    id,
+    goalId: asString(project.goalId, "").trim() || null,
+    name: asString(project.name, "").trim() || null,
+    description: typeof project.description === "string" ? project.description : null,
+    descriptionTruncated: asBoolean(project.descriptionTruncated, false),
+    status: asString(project.status, "").trim() || null,
+    leadAgentId: asString(project.leadAgentId, "").trim() || null,
+    targetDate: asString(project.targetDate, "").trim() || null,
+    createdAt: asString(project.createdAt, "").trim() || null,
+    updatedAt: asString(project.updatedAt, "").trim() || null,
+    changeKind: asString(project.changeKind, "").trim() || null,
+  };
+}
+
+function normalizePaperclipWakeGoalProjectIntake(
+  value: unknown,
+): PaperclipWakeGoalProjectIntake | null {
+  const intake = parseObject(value);
+  const project = normalizePaperclipWakeProjectRecord(intake.project);
+  const goal = normalizePaperclipWakeGoalRecord(intake.goal);
+  const activeMilestones = Array.isArray(intake.activeMilestones)
+    ? intake.activeMilestones
+        .map((entry) => normalizePaperclipWakeGoalRecord(entry))
+        .filter((entry): entry is PaperclipWakeGoalRecord => Boolean(entry))
+    : [];
+  if (!project && !goal && activeMilestones.length === 0) return null;
+  const deltas = parseObject(intake.deltas);
+  const activeMilestoneDeltas = Array.isArray(deltas.activeMilestones)
+    ? deltas.activeMilestones
+        .map((entry) => normalizePaperclipWakeGoalRecord(entry))
+        .filter((entry): entry is PaperclipWakeGoalRecord => Boolean(entry))
+    : [];
+  const noLongerActiveMilestoneIds = Array.isArray(
+    deltas.noLongerActiveMilestoneIds,
+  )
+    ? deltas.noLongerActiveMilestoneIds
+        .map((entry) => asString(entry, "").trim())
+        .filter(Boolean)
+    : [];
+  return {
+    capturedAt: asString(intake.capturedAt, "").trim() || null,
+    changedSince: asString(intake.changedSince, "").trim() || null,
+    baselineRunId: asString(intake.baselineRunId, "").trim() || null,
+    baselineKind: asString(intake.baselineKind, "").trim() || null,
+    project,
+    goal,
+    activeMilestones,
+    deltas: {
+      project: normalizePaperclipWakeProjectRecord(deltas.project),
+      goal: normalizePaperclipWakeGoalRecord(deltas.goal),
+      activeMilestones: activeMilestoneDeltas,
+      noLongerActiveMilestoneIds,
+    },
+    activeMilestoneCount: Math.max(
+      0,
+      asNumber(intake.activeMilestoneCount, activeMilestones.length),
+    ),
+    includedActiveMilestoneCount: Math.max(
+      0,
+      asNumber(intake.includedActiveMilestoneCount, activeMilestones.length),
+    ),
+    truncated: asBoolean(intake.truncated, false),
   };
 }
 
@@ -1262,7 +1405,10 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
   const activeTreeHold = normalizePaperclipWakeTreeHoldSummary(payload.activeTreeHold);
   const checkboxSelection = normalizePaperclipWakeCheckboxSelection(payload.checkboxSelection);
   const executionWorkspace = normalizePaperclipWakeExecutionWorkspace(payload.executionWorkspace);
-  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !livenessContinuation && !taskWatchdog && !checkboxSelection && !executionWorkspace && !recovery && !normalizePaperclipWakeIssue(payload.issue)) {
+  const goalProjectIntake = normalizePaperclipWakeGoalProjectIntake(
+    payload.goalProjectIntake,
+  );
+  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !livenessContinuation && !taskWatchdog && !checkboxSelection && !executionWorkspace && !recovery && !goalProjectIntake && !normalizePaperclipWakeIssue(payload.issue)) {
     return null;
   }
 
@@ -1270,6 +1416,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     reason: asString(payload.reason, "").trim() || null,
     recovery,
     issue: normalizePaperclipWakeIssue(payload.issue),
+    goalProjectIntake,
     checkedOutByHarness: asBoolean(payload.checkedOutByHarness, false),
     dependencyBlockedInteraction: asBoolean(payload.dependencyBlockedInteraction, false),
     treeHoldInteraction: asBoolean(payload.treeHoldInteraction, false),
@@ -1453,6 +1600,20 @@ export function renderPaperclipWakePrompt(
   }
   if (normalized.issue?.priority) {
     lines.push(`- issue priority: ${normalized.issue.priority}`);
+  }
+  if (normalized.goalProjectIntake) {
+    const intake = normalized.goalProjectIntake;
+    const changedMilestoneCount = intake.deltas.activeMilestones.length;
+    lines.push(
+      `- goal/project intake baseline: ${intake.baselineKind ?? "unknown"}${intake.changedSince ? ` (changed since ${intake.changedSince})` : ""}`,
+      `- linked project: ${intake.project?.name ?? intake.project?.id ?? "none"}`,
+      `- linked goal: ${intake.goal?.title ?? intake.goal?.id ?? "none"}`,
+      `- active milestones: ${intake.includedActiveMilestoneCount}/${intake.activeMilestoneCount}`,
+      `- intake deltas: project ${intake.deltas.project ? "changed" : "unchanged"}, goal ${intake.deltas.goal ? "changed" : "unchanged"}, active milestones ${changedMilestoneCount} changed and ${intake.deltas.noLongerActiveMilestoneIds.length} no longer active`,
+    );
+    if (intake.truncated) {
+      lines.push("- goal/project intake payload truncated: yes");
+    }
   }
   if (normalized.checkboxSelection) {
     if (normalized.checkboxSelection.prompt) {

--- a/server/src/__tests__/heartbeat-goal-project-intake.test.ts
+++ b/server/src/__tests__/heartbeat-goal-project-intake.test.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  goals,
+  heartbeatRuns,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { buildPaperclipWakePayload } from "../services/heartbeat.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe.sequential
+  : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat goal/project intake tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat goal/project intake", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<
+    ReturnType<typeof startEmbeddedPostgresTestDatabase>
+  > | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase(
+      "paperclip-heartbeat-intake-",
+    );
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("includes company-scoped linked records, active milestones, and changed-since deltas", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const agentId = randomUUID();
+    const goalId = randomUUID();
+    const activeMilestoneId = randomUUID();
+    const inactiveMilestoneId = randomUUID();
+    const crossCompanyMilestoneId = randomUUID();
+    const projectId = randomUUID();
+    const issueId = randomUUID();
+    const previousRunId = randomUUID();
+    const currentRunId = randomUUID();
+    const baselineAt = new Date("2026-07-22T12:00:00.000Z");
+    const changedAt = new Date("2026-07-23T10:00:00.000Z");
+    const currentRunAt = new Date("2026-07-23T12:00:00.000Z");
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Portfolio Company",
+        issuePrefix: "PORT",
+      },
+      {
+        id: otherCompanyId,
+        name: "Other Company",
+        issuePrefix: "OTHR",
+      },
+    ]);
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Portfolio Lead",
+      role: "lead",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+    });
+    await db.insert(goals).values([
+      {
+        id: goalId,
+        companyId,
+        title: "Build a repeatable growth engine",
+        description:
+          "Outcome, owner, horizon, dependencies, evidence, approval boundary, and ranking inputs.",
+        level: "team",
+        status: "active",
+        ownerAgentId: agentId,
+        createdAt: new Date("2026-07-01T00:00:00.000Z"),
+        updatedAt: changedAt,
+      },
+      {
+        id: activeMilestoneId,
+        companyId,
+        title: "Reach $100 MRR",
+        description: "Exit evidence and milestone dependencies.",
+        level: "task",
+        status: "active",
+        parentId: goalId,
+        ownerAgentId: agentId,
+        createdAt: new Date("2026-07-02T00:00:00.000Z"),
+        updatedAt: changedAt,
+      },
+      {
+        id: inactiveMilestoneId,
+        companyId,
+        title: "Reach $1k MRR",
+        level: "task",
+        status: "planned",
+        parentId: goalId,
+        ownerAgentId: agentId,
+      },
+      {
+        id: crossCompanyMilestoneId,
+        companyId: otherCompanyId,
+        title: "Foreign milestone",
+        level: "task",
+        status: "active",
+        parentId: goalId,
+      },
+    ]);
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      goalId,
+      name: "Portfolio intelligence",
+      description:
+        "Planning horizon, evidence source, approval boundary, and ranking inputs.",
+      status: "in_progress",
+      leadAgentId: agentId,
+      targetDate: "2026-09-30",
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: changedAt,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      goalId,
+      identifier: "PORT-1",
+      title: "Validate portfolio intake",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: previousRunId,
+      companyId,
+      agentId,
+      status: "succeeded",
+      createdAt: baselineAt,
+      contextSnapshot: {
+        issueId,
+        paperclipWake: {
+          goalProjectIntake: {
+            capturedAt: baselineAt.toISOString(),
+            project: { id: projectId },
+            goal: { id: goalId },
+            activeMilestones: [
+              { id: activeMilestoneId },
+              { id: "milestone-no-longer-active" },
+            ],
+          },
+        },
+      },
+    });
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      run: {
+        id: currentRunId,
+        agentId,
+        createdAt: currentRunAt,
+      },
+      issueSummary: {
+        id: issueId,
+        identifier: "PORT-1",
+        title: "Validate portfolio intake",
+        status: "in_progress",
+        priority: "high",
+        workMode: "standard",
+        projectId,
+        goalId,
+      },
+    });
+
+    expect(payload?.issue).toMatchObject({ projectId, goalId });
+    expect(payload?.goalProjectIntake).toMatchObject({
+      changedSince: baselineAt.toISOString(),
+      baselineRunId: previousRunId,
+      baselineKind: "incremental",
+      project: {
+        id: projectId,
+        leadAgentId: agentId,
+        targetDate: "2026-09-30",
+      },
+      goal: {
+        id: goalId,
+        ownerAgentId: agentId,
+      },
+      activeMilestoneCount: 1,
+      includedActiveMilestoneCount: 1,
+      truncated: false,
+      deltas: {
+        project: { id: projectId, changeKind: "updated" },
+        goal: { id: goalId, changeKind: "updated" },
+        activeMilestones: [
+          { id: activeMilestoneId, changeKind: "updated" },
+        ],
+        noLongerActiveMilestoneIds: ["milestone-no-longer-active"],
+      },
+    });
+    expect(payload?.goalProjectIntake.activeMilestones).toEqual([
+      expect.objectContaining({
+        id: activeMilestoneId,
+        description: "Exit evidence and milestone dependencies.",
+      }),
+    ]);
+    expect(JSON.stringify(payload)).not.toContain(inactiveMilestoneId);
+    expect(JSON.stringify(payload)).not.toContain(crossCompanyMilestoneId);
+    expect(payload?.fallbackFetchNeeded).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-goal-project-intake.test.ts
+++ b/server/src/__tests__/heartbeat-goal-project-intake.test.ts
@@ -63,8 +63,10 @@ describeEmbeddedPostgres("heartbeat goal/project intake", () => {
     const projectId = randomUUID();
     const issueId = randomUUID();
     const previousRunId = randomUUID();
+    const interleavedRunId = randomUUID();
     const currentRunId = randomUUID();
     const baselineAt = new Date("2026-07-22T12:00:00.000Z");
+    const interleavedAt = new Date("2026-07-23T09:00:00.000Z");
     const changedAt = new Date("2026-07-23T10:00:00.000Z");
     const currentRunAt = new Date("2026-07-23T12:00:00.000Z");
 
@@ -156,27 +158,47 @@ describeEmbeddedPostgres("heartbeat goal/project intake", () => {
       priority: "high",
       assigneeAgentId: agentId,
     });
-    await db.insert(heartbeatRuns).values({
-      id: previousRunId,
-      companyId,
-      agentId,
-      status: "succeeded",
-      createdAt: baselineAt,
-      contextSnapshot: {
-        issueId,
-        paperclipWake: {
-          goalProjectIntake: {
-            capturedAt: baselineAt.toISOString(),
-            project: { id: projectId },
-            goal: { id: goalId },
-            activeMilestones: [
-              { id: activeMilestoneId },
-              { id: "milestone-no-longer-active" },
-            ],
+    await db.insert(heartbeatRuns).values([
+      {
+        id: previousRunId,
+        companyId,
+        agentId,
+        status: "succeeded",
+        createdAt: baselineAt,
+        contextSnapshot: {
+          issueId,
+          paperclipWake: {
+            goalProjectIntake: {
+              capturedAt: baselineAt.toISOString(),
+              project: { id: projectId },
+              goal: { id: goalId },
+              activeMilestones: [
+                { id: activeMilestoneId },
+                { id: "milestone-no-longer-active" },
+              ],
+            },
           },
         },
       },
-    });
+      {
+        id: interleavedRunId,
+        companyId,
+        agentId,
+        status: "succeeded",
+        createdAt: interleavedAt,
+        contextSnapshot: {
+          issueId,
+          paperclipWake: {
+            goalProjectIntake: {
+              capturedAt: interleavedAt.toISOString(),
+              project: { id: randomUUID() },
+              goal: { id: randomUUID() },
+              activeMilestones: [],
+            },
+          },
+        },
+      },
+    ]);
 
     const payload = await buildPaperclipWakePayload({
       db,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4488,6 +4488,10 @@ async function buildGoalProjectIntakeContext(input: {
     0,
     MAX_INLINE_WAKE_ACTIVE_MILESTONES,
   );
+  const previousProjectIdExpression =
+    sql<string | null>`${heartbeatRuns.contextSnapshot} #>> '{paperclipWake,goalProjectIntake,project,id}'`;
+  const previousGoalIdExpression =
+    sql<string | null>`${heartbeatRuns.contextSnapshot} #>> '{paperclipWake,goalProjectIntake,goal,id}'`;
 
   const previousRun = input.run
     ? await input.db
@@ -4507,6 +4511,12 @@ async function buildGoalProjectIntakeContext(input: {
               input.issueSummary.id,
             ),
             sql`${heartbeatRuns.contextSnapshot} -> 'paperclipWake' -> 'goalProjectIntake' is not null`,
+            project?.id
+              ? eq(previousProjectIdExpression, project.id)
+              : isNull(previousProjectIdExpression),
+            goal?.id
+              ? eq(previousGoalIdExpression, goal.id)
+              : isNull(previousGoalIdExpression),
           ),
         )
         .orderBy(desc(heartbeatRuns.createdAt))

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -46,6 +46,7 @@ import {
   documentRevisions,
   issueDocuments,
   executionWorkspaces,
+  goals,
   heartbeatRunEvents,
   heartbeatRuns,
   issueApprovals,
@@ -315,6 +316,9 @@ const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
+const MAX_INLINE_WAKE_ACTIVE_MILESTONES = 20;
+const MAX_INLINE_WAKE_INTAKE_DESCRIPTION_CHARS = 4_000;
+const MAX_INLINE_WAKE_INTAKE_DESCRIPTION_TOTAL_CHARS = 16_000;
 const execFile = promisify(execFileCallback);
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -4376,10 +4380,286 @@ export function mergeCoalescedContextSnapshot(
   return merged;
 }
 
+type PaperclipWakeIssueSummary = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  priority: string;
+  workMode: string;
+  projectId?: string | null;
+  goalId?: string | null;
+  executionPolicy?: unknown;
+};
+
+type PaperclipWakeRunScope = {
+  id: string;
+  agentId: string;
+  createdAt: Date;
+};
+
+function readIntakeRecordId(value: unknown) {
+  return readNonEmptyString(parseObject(value).id);
+}
+
+function readPreviousActiveMilestoneIds(value: unknown) {
+  const intake = parseObject(value);
+  if (!Array.isArray(intake.activeMilestones)) return [];
+  return intake.activeMilestones
+    .map((entry) => readIntakeRecordId(entry))
+    .filter((id): id is string => Boolean(id));
+}
+
+async function buildGoalProjectIntakeContext(input: {
+  db: Db;
+  companyId: string;
+  issueSummary: PaperclipWakeIssueSummary;
+  run?: PaperclipWakeRunScope | null;
+}) {
+  const project = input.issueSummary.projectId
+    ? await input.db
+        .select({
+          id: projects.id,
+          goalId: projects.goalId,
+          name: projects.name,
+          description: projects.description,
+          status: projects.status,
+          leadAgentId: projects.leadAgentId,
+          targetDate: projects.targetDate,
+          createdAt: projects.createdAt,
+          updatedAt: projects.updatedAt,
+        })
+        .from(projects)
+        .where(
+          and(
+            eq(projects.id, input.issueSummary.projectId),
+            eq(projects.companyId, input.companyId),
+          ),
+        )
+        .then((rows) => rows[0] ?? null)
+    : null;
+  const goalId = input.issueSummary.goalId ?? project?.goalId ?? null;
+  const goal = goalId
+    ? await input.db
+        .select({
+          id: goals.id,
+          title: goals.title,
+          description: goals.description,
+          level: goals.level,
+          status: goals.status,
+          parentId: goals.parentId,
+          ownerAgentId: goals.ownerAgentId,
+          createdAt: goals.createdAt,
+          updatedAt: goals.updatedAt,
+        })
+        .from(goals)
+        .where(and(eq(goals.id, goalId), eq(goals.companyId, input.companyId)))
+        .then((rows) => rows[0] ?? null)
+    : null;
+  const activeMilestoneRows = goal
+    ? await input.db
+        .select({
+          id: goals.id,
+          title: goals.title,
+          description: goals.description,
+          level: goals.level,
+          status: goals.status,
+          parentId: goals.parentId,
+          ownerAgentId: goals.ownerAgentId,
+          createdAt: goals.createdAt,
+          updatedAt: goals.updatedAt,
+          totalCount: sql<number>`count(*) over()`,
+        })
+        .from(goals)
+        .where(
+          and(
+            eq(goals.companyId, input.companyId),
+            eq(goals.parentId, goal.id),
+            eq(goals.status, "active"),
+          ),
+        )
+        .orderBy(desc(goals.updatedAt), asc(goals.title))
+        .limit(MAX_INLINE_WAKE_ACTIVE_MILESTONES + 1)
+    : [];
+  const activeMilestoneTruncated =
+    activeMilestoneRows.length > MAX_INLINE_WAKE_ACTIVE_MILESTONES;
+  const activeMilestoneCount = Number(activeMilestoneRows[0]?.totalCount ?? 0);
+  const activeMilestoneSourceRows = activeMilestoneRows.slice(
+    0,
+    MAX_INLINE_WAKE_ACTIVE_MILESTONES,
+  );
+
+  const previousRun = input.run
+    ? await input.db
+        .select({
+          id: heartbeatRuns.id,
+          createdAt: heartbeatRuns.createdAt,
+          contextSnapshot: heartbeatRuns.contextSnapshot,
+        })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, input.companyId),
+            eq(heartbeatRuns.agentId, input.run.agentId),
+            lt(heartbeatRuns.createdAt, input.run.createdAt),
+            eq(
+              sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`,
+              input.issueSummary.id,
+            ),
+            sql`${heartbeatRuns.contextSnapshot} -> 'paperclipWake' -> 'goalProjectIntake' is not null`,
+          ),
+        )
+        .orderBy(desc(heartbeatRuns.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+    : null;
+  const previousWake = parseObject(
+    parseObject(previousRun?.contextSnapshot).paperclipWake,
+  );
+  const previousIntake = parseObject(previousWake.goalProjectIntake);
+  const previousProjectId = readIntakeRecordId(previousIntake.project);
+  const previousGoalId = readIntakeRecordId(previousIntake.goal);
+  const comparablePreviousIntake =
+    previousRun &&
+    (project?.id ?? null) === (previousProjectId ?? null) &&
+    (goal?.id ?? null) === (previousGoalId ?? null) &&
+    readNonEmptyString(previousIntake.capturedAt)
+      ? previousIntake
+      : null;
+  const changedSince = comparablePreviousIntake
+    ? readNonEmptyString(comparablePreviousIntake.capturedAt)
+    : null;
+  const changedSinceDate = changedSince ? new Date(changedSince) : null;
+  const validChangedSinceDate =
+    changedSinceDate && Number.isFinite(changedSinceDate.getTime())
+      ? changedSinceDate
+      : null;
+  const previousActiveMilestoneIds = new Set(
+    comparablePreviousIntake
+      ? readPreviousActiveMilestoneIds(comparablePreviousIntake)
+      : [],
+  );
+
+  let remainingDescriptionChars =
+    MAX_INLINE_WAKE_INTAKE_DESCRIPTION_TOTAL_CHARS;
+  let descriptionTruncated = false;
+  const inlineDescription = (value: string | null) => {
+    if (!value) return { description: null, descriptionTruncated: false };
+    const allowedChars = Math.min(
+      MAX_INLINE_WAKE_INTAKE_DESCRIPTION_CHARS,
+      remainingDescriptionChars,
+    );
+    const description = allowedChars > 0 ? value.slice(0, allowedChars) : "";
+    const truncated = description.length < value.length;
+    remainingDescriptionChars -= description.length;
+    descriptionTruncated ||= truncated;
+    return {
+      description,
+      descriptionTruncated: truncated,
+    };
+  };
+  const serializeGoal = (
+    row: NonNullable<typeof goal>,
+  ) => ({
+    id: row.id,
+    title: row.title,
+    ...inlineDescription(row.description),
+    level: row.level,
+    status: row.status,
+    parentId: row.parentId,
+    ownerAgentId: row.ownerAgentId,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  });
+  const serializedProject = project
+    ? {
+        id: project.id,
+        goalId: project.goalId,
+        name: project.name,
+        ...inlineDescription(project.description),
+        status: project.status,
+        leadAgentId: project.leadAgentId,
+        targetDate: project.targetDate,
+        createdAt: project.createdAt.toISOString(),
+        updatedAt: project.updatedAt.toISOString(),
+      }
+    : null;
+  const serializedGoal = goal ? serializeGoal(goal) : null;
+  const activeMilestones = activeMilestoneSourceRows.map(serializeGoal);
+  const hasChangedSince = (updatedAt: Date) =>
+    !validChangedSinceDate || updatedAt > validChangedSinceDate;
+  const changeKind = (createdAt: Date) =>
+    !validChangedSinceDate
+      ? "snapshot"
+      : createdAt > validChangedSinceDate
+        ? "created"
+        : "updated";
+  const activeMilestoneDeltas = activeMilestones
+    .filter((milestone) => {
+      const source = activeMilestoneSourceRows.find(
+        (row) => row.id === milestone.id,
+      );
+      return source ? hasChangedSince(source.updatedAt) : false;
+    })
+    .map((milestone) => {
+      const source = activeMilestoneSourceRows.find(
+        (row) => row.id === milestone.id,
+      )!;
+      return {
+        id: milestone.id,
+        updatedAt: milestone.updatedAt,
+        changeKind: changeKind(source.createdAt),
+      };
+    });
+  const currentActiveMilestoneIds = new Set(
+    activeMilestones.map((milestone) => milestone.id),
+  );
+  const noLongerActiveMilestoneIds =
+    comparablePreviousIntake && !activeMilestoneTruncated
+      ? [...previousActiveMilestoneIds].filter(
+          (milestoneId) => !currentActiveMilestoneIds.has(milestoneId),
+        )
+      : [];
+
+  return {
+    capturedAt: new Date().toISOString(),
+    changedSince,
+    baselineRunId: comparablePreviousIntake ? previousRun?.id ?? null : null,
+    baselineKind: comparablePreviousIntake ? "incremental" : "initial",
+    project: serializedProject,
+    goal: serializedGoal,
+    activeMilestones,
+    deltas: {
+      project:
+        project && hasChangedSince(project.updatedAt)
+          ? {
+              id: project.id,
+              updatedAt: project.updatedAt.toISOString(),
+              changeKind: changeKind(project.createdAt),
+            }
+          : null,
+      goal:
+        goal && hasChangedSince(goal.updatedAt)
+          ? {
+              id: goal.id,
+              updatedAt: goal.updatedAt.toISOString(),
+              changeKind: changeKind(goal.createdAt),
+            }
+          : null,
+      activeMilestones: activeMilestoneDeltas,
+      noLongerActiveMilestoneIds,
+    },
+    activeMilestoneCount,
+    includedActiveMilestoneCount: activeMilestones.length,
+    truncated: activeMilestoneTruncated || descriptionTruncated,
+  };
+}
+
 export async function buildPaperclipWakePayload(input: {
   db: Db;
   companyId: string;
   contextSnapshot: Record<string, unknown>;
+  run?: PaperclipWakeRunScope | null;
   continuationSummary?:
     | {
         key: string;
@@ -4389,18 +4669,7 @@ export async function buildPaperclipWakePayload(input: {
         updatedAt: Date;
       }
     | null;
-  issueSummary?:
-    | {
-        id: string;
-        identifier: string | null;
-        title: string;
-        status: string;
-        priority: string;
-        workMode: string;
-        projectId?: string | null;
-        executionPolicy?: unknown;
-      }
-    | null;
+  issueSummary?: PaperclipWakeIssueSummary | null;
   exposeLowTrustRaw?: boolean;
 }) {
   const executionStage = parseObject(input.contextSnapshot.executionStage);
@@ -4419,12 +4688,22 @@ export async function buildPaperclipWakePayload(input: {
             status: issues.status,
             priority: issues.priority,
             workMode: issues.workMode,
+            projectId: issues.projectId,
+            goalId: issues.goalId,
           })
           .from(issues)
           .where(and(eq(issues.id, issueId), eq(issues.companyId, input.companyId)))
           .then((rows) => rows[0] ?? null)
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
+  const goalProjectIntake = issueSummary
+    ? await buildGoalProjectIntakeContext({
+        db: input.db,
+        companyId: input.companyId,
+        issueSummary,
+        run: input.run,
+      })
+    : null;
 
   const commentRows =
     commentIds.length === 0
@@ -4582,7 +4861,10 @@ export async function buildPaperclipWakePayload(input: {
       interactionId,
     })
     : null;
-  const payloadTruncated = truncated || planReviewContext?.truncated === true;
+  const payloadTruncated =
+    truncated ||
+    planReviewContext?.truncated === true ||
+    goalProjectIntake?.truncated === true;
   const recoveryActionId = readNonEmptyString(input.contextSnapshot.recoveryActionId);
   const recoveryCause = readNonEmptyString(input.contextSnapshot.recoveryCause);
   const recoveryAction = recoveryActionId
@@ -4630,8 +4912,14 @@ export async function buildPaperclipWakePayload(input: {
           status: issueSummary.status,
           priority: issueSummary.priority,
           workMode: issueSummary.workMode,
+          projectId: issueSummary.projectId ?? null,
+          goalId:
+            issueSummary.goalId ??
+            goalProjectIntake?.goal?.id ??
+            null,
         }
       : null,
+    goalProjectIntake,
     childIssueSummaries: Array.isArray(input.contextSnapshot.childIssueSummaries)
       ? input.contextSnapshot.childIssueSummaries
       : [],
@@ -4689,7 +4977,10 @@ export async function buildPaperclipWakePayload(input: {
       missingCount: missingCommentCount,
     },
     truncated: payloadTruncated,
-    fallbackFetchNeeded: payloadTruncated || missingCommentCount > 0,
+    fallbackFetchNeeded:
+      payloadTruncated ||
+      missingCommentCount > 0 ||
+      goalProjectIntake?.truncated === true,
   };
 }
 
@@ -5914,6 +6205,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         workMode: issues.workMode,
         priority: issues.priority,
         projectId: issues.projectId,
+        goalId: issues.goalId,
         projectWorkspaceId: issues.projectWorkspaceId,
         executionWorkspaceId: issues.executionWorkspaceId,
         executionWorkspacePreference: issues.executionWorkspacePreference,
@@ -12022,6 +12314,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           workMode: issueContext.workMode,
           description: issueContext.description,
           projectId: issueContext.projectId,
+          goalId: issueContext.goalId,
           projectWorkspaceId: issueContext.projectWorkspaceId,
           executionWorkspaceId: issueContext.executionWorkspaceId,
           executionWorkspacePreference: issueContext.executionWorkspacePreference,
@@ -12069,6 +12362,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       db,
       companyId: agent.companyId,
       contextSnapshot: context,
+      run: {
+        id: run.id,
+        agentId: run.agentId,
+        createdAt: run.createdAt,
+      },
       continuationSummary,
       issueSummary: issueRef
         ? {
@@ -12079,6 +12377,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             priority: issueRef.priority,
             workMode: issueRef.workMode,
             projectId: issueRef.projectId,
+            goalId: issueRef.goalId,
             executionPolicy: issueContext?.executionPolicy ?? null,
           }
         : null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to organize and supervise AI-agent work.
> - Issue-scoped heartbeats are the authoritative handoff from the control plane to an agent.
> - Those wakes currently identify linked project and goal records only by ID, so an agent cannot reliably validate portfolio intake fields or determine what changed without broader API access.
> - Goal/project descriptions carry the outcome, horizon, dependencies, evidence, approval boundary, and ranking inputs needed for that validation; active child goals carry milestone state.
> - This pull request adds a bounded, company-scoped project/goal/milestone snapshot and a comparable prior-wake baseline to the wake payload.
> - The benefit is deterministic intake validation from the assigned issue's scope without listing unrelated issues or silently treating truncated data as complete.

## Linked Issues or Issue Description

No matching public issue was found. Related PR: #9059 adds compact goal ancestry and company mission context; this change is complementary and focuses on the full linked project/goal records, active direct-child milestones, and changed-since deltas required for portfolio intake.

### Subsystem affected

Heartbeat orchestration and adapter wake-payload normalization/rendering.

### Problem or motivation

An issue-scoped wake currently exposes `projectId` and `goalId`, but not the linked records or active milestone state. Agents operating with intentionally narrow API access cannot inspect the fields used to validate outcomes, owners, horizons, dependencies, evidence, approval boundaries, and ranking inputs. They also lack a scoped baseline for deciding which project, goal, or milestone records changed since the previous comparable wake.

### Proposed solution

Attach an optional `goalProjectIntake` snapshot to issue-scoped wake payloads. Resolve the linked project and effective goal inside the issue's company boundary, include active direct child goals as milestones, compare against the prior wake for the same company, agent, issue, project, and goal, and emit compact deltas. Bound descriptions and milestone counts; signal truncation through both `truncated` and `fallbackFetchNeeded`.

### Alternatives considered

- Adding new REST endpoints: unnecessary for this handoff and would broaden the public API surface.
- Requiring agents to list goals or projects after every wake: adds round trips and can exceed intentionally scoped access.
- Sending only IDs and timestamps: insufficient for validating the intake fields themselves.

### Roadmap alignment

This is a tightly scoped reliability improvement to the existing goal-aware execution and enforced-outcomes capabilities. It does not duplicate an unshipped roadmap milestone.

## What Changed

- Added company-scoped linked project and effective-goal resolution to issue wake payload assembly.
- Added bounded active direct-child goal snapshots as milestones, with exact counts and truncation signaling.
- Added comparable prior-wake baselines and compact project, goal, active-milestone, and no-longer-active milestone deltas.
- Preserved and summarized the new payload in shared adapter utilities, including `projectId` and `goalId` on the normalized issue.
- Documented the scoped intake contract and added embedded-Postgres plus adapter serialization/rendering tests.

## Verification

- `corepack pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts server/src/__tests__/heartbeat-goal-project-intake.test.ts --silent --reporter=dot` — 74/74 passed.
- `corepack pnpm --filter @paperclipai/server typecheck` — passed.
- `corepack pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `corepack pnpm -r typecheck` — passed across the workspace.
- `corepack pnpm build` — passed across the workspace.
- `server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts` — 23/23 passed with an isolated test Codex home satisfying the suite's existing credential precondition.
- `server/src/__tests__/tool-gateway.test.ts` — 49/49 passed on isolated rerun after the complete-suite runner encountered one timing failure in its local stdio idle-slot case.

## Risks

- Additive payload shape, with no database migration or public endpoint change.
- Each issue wake adds bounded, indexed reads for the linked project, goal, active milestones, and prior comparable run.
- Descriptions are capped at 4,000 characters each and 16,000 characters total; active milestones are capped at 20. Any clipping or count truncation marks the payload incomplete and requires fallback fetching.
- #9059 touches the same heartbeat and adapter utility files, so one PR may need a small conflict resolution if both land.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6 Sol (`openai/gpt-5.6-sol`), 372k context window, high reasoning mode, running in OpenAI Codex with repository inspection, code editing, PostgreSQL-backed tests, shell execution, and GitHub tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
