### PR TITLE
fix(ui): confirm agent termination

### DIFF
--- a/ui/src/components/AgentActionButtons.test.tsx
+++ b/ui/src/components/AgentActionButtons.test.tsx
@@ -108,6 +108,7 @@ describe("AgentActionButtons", () => {
     mockAgentsApi.pause.mockResolvedValue(makeAgent({ status: "paused" }));
     mockAgentsApi.resume.mockResolvedValue(makeAgent({ status: "idle" }));
     mockAgentsApi.invoke.mockResolvedValue({ id: "run-1" });
+    mockAgentsApi.terminate.mockResolvedValue(makeAgent({ status: "terminated" }));
     mockAgentsApi.resetSession.mockResolvedValue(undefined);
   });
 
@@ -174,5 +175,32 @@ describe("AgentActionButtons", () => {
 
     expect(container.textContent).toContain("Pause");
     expect(container.textContent).not.toContain("Clear error");
+  });
+
+  it("requires confirmation before terminating an agent", async () => {
+    render(makeAgent());
+    await flushReact();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[aria-label="Open actions for Alpha Agent"]')?.click();
+    });
+    await flushReact();
+
+    await act(async () => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent?.trim() === "Terminate")
+        ?.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.terminate).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Terminate Alpha Agent?");
+
+    await act(async () => {
+      document.body.querySelector<HTMLButtonElement>('[data-slot="alert-dialog-action"]')?.click();
+    });
+    await flushReact();
+
+    expect(mockAgentsApi.terminate).toHaveBeenCalledWith("agent-1", "company-1");
   });
 });

--- a/ui/src/components/AgentActionButtons.tsx
+++ b/ui/src/components/AgentActionButtons.tsx
@@ -203,6 +203,7 @@ export function AgentActionButtons({
   const { pushToast } = useToastActions();
   const [moreOpen, setMoreOpen] = useState(false);
   const [pauseConfirmOpen, setPauseConfirmOpen] = useState(false);
+  const [terminateConfirmOpen, setTerminateConfirmOpen] = useState(false);
 
   const resolvedCompanyId = companyId ?? agent.companyId;
   const canonicalAgentRef = agentRouteRef(agent);
@@ -365,6 +366,25 @@ export function AgentActionButtons({
           </AlertDialogContent>
         </AlertDialog>
       )}
+      <AlertDialog open={terminateConfirmOpen} onOpenChange={setTerminateConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Terminate {agent.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently terminates the agent and cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => agentAction.mutate("terminate")}
+            >
+              Terminate
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {showStatus && (
         <span className="hidden sm:inline">
           <AgentStatusBadge status={agent.status} />
@@ -414,8 +434,8 @@ export function AgentActionButtons({
             <button
               className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 text-destructive"
               onClick={() => {
-                agentAction.mutate("terminate");
                 setMoreOpen(false);
+                setTerminateConfirmOpen(true);
               }}
             >
               <Trash2 className="h-3 w-3" />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane people use to manage AI agents and their work
> - Board operators can terminate agents from both the agent list and agent detail page
> - Agent termination is irreversible, but the shared action currently invokes it on the first click
> - The shared `AgentActionButtons` component is the single UI path for both surfaces
> - This pull request reuses Paperclip's existing `AlertDialog` pattern at that shared boundary
> - The benefit is protection from accidental agent deletion without changing the API or adding a new abstraction

## Linked Issues or Issue Description

- Fixes: #9607

## What Changed

- Require explicit confirmation before invoking agent termination.
- Add a focused regression test proving the terminate API is not called until confirmation.

## Verification

- `pnpm exec vitest run ui/src/components/AgentActionButtons.test.tsx` — 4 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:tokens` — passed.
- `git diff --check` — passed.
- `pnpm check:token-gates` — reports five pre-existing `#9627` literals in unchanged files on `upstream/master`; neither changed file is reported.

## Risks

- Low risk: this is a UI-only guard around the existing terminate mutation.
- No API, data-model, dependency, or migration changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 (Codex agent; exact internal build ID and context-window size are not exposed), with reasoning, shell, and GitHub tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
