### PR TITLE
fix(skills): avoid issue helper filesystem search

### DIFF
--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -74,6 +74,14 @@ describe("paperclip skill utils", () => {
     expect(skillBody).toContain("`assigneeUserId` is null");
   });
 
+  it("forbids searching for an unavailable issue update helper", async () => {
+    const skillBody = await fs.readFile(path.resolve("skills/paperclip/SKILL.md"), "utf8");
+
+    expect(skillBody).toContain(
+      "If the helper is unavailable from your current working directory, do not search the filesystem for it. Use the raw `PATCH /api/issues/{issueId}` request above instead.",
+    );
+  });
+
   it("keeps the create-issue-interaction-ui guide as a maintainer-only skill", async () => {
     const skillPath = path.resolve(".agents/skills/create-issue-interaction-ui/SKILL.md");
     const skillBody = await fs.readFile(skillPath, "utf8");

--- a/server/src/__tests__/paperclip-skill-utils.test.ts
+++ b/server/src/__tests__/paperclip-skill-utils.test.ts
@@ -80,6 +80,9 @@ describe("paperclip skill utils", () => {
     expect(skillBody).toContain(
       "If the helper is unavailable from your current working directory, do not search the filesystem for it. Use the raw `PATCH /api/issues/{issueId}` request above instead.",
     );
+    expect(skillBody).toContain(
+      "PATCH $PAPERCLIP_API_URL/api/issues/{issueId}\nHeaders: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID",
+    );
   });
 
   it("keeps the create-issue-interaction-ui guide as a maintainer-only skill", async () => {

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -139,6 +139,8 @@ Done
 MD
 ```
 
+If the helper is unavailable from your current working directory, do not search the filesystem for it. Use the raw `PATCH /api/issues/{issueId}` request above instead.
+
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, `blockedByIssueIds`.
 
 ### Status Quick Guide

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -123,8 +123,8 @@ Before ending any heartbeat, apply this final-disposition checklist:
 When writing issue descriptions or comments, follow the ticket-linking rule in **Comment Style** below.
 
 ```json
-PATCH /api/issues/{issueId}
-Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+PATCH $PAPERCLIP_API_URL/api/issues/{issueId}
+Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "status": "done", "comment": "What was done and why." }
 ```
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for managing AI agents at work
> - Agents use the bundled Paperclip skill to update issue state through the API
> - Step 8 presents both a raw API request and a convenience helper invoked through a working-directory-relative path
> - When that helper is unavailable from an agent's current workspace, the instruction does not define a safe fallback and agents may search the entire filesystem
> - The existing raw `PATCH /api/issues/{issueId}` request already provides the smallest reliable fallback
> - This pull request explicitly directs agents to that request instead of filesystem search and locks the instruction in with a focused regression test
> - The benefit is predictable issue updates without unnecessary or potentially expensive whole-disk discovery

## Linked Issues or Issue Description

- Fixes: #9527
- Related: #4486 — stale, broad skill-trimming PR that incidentally removes the helper example; this PR keeps the fix focused on the unsafe fallback

## What Changed

- Tell agents not to search the filesystem when the issue-update helper is unavailable and to use the documented raw API request instead
- Add a targeted skill-content regression test for that fallback

## Verification

- `mise exec -- pnpm exec vitest run server/src/__tests__/paperclip-skill-utils.test.ts` — 5 tests passed
- `mise exec -- pnpm --filter @paperclipai/server typecheck` — passed
- `mise exec -- pnpm check:tokens` — passed
- `git diff --check` — passed

## Risks

- Low risk: this changes one skill instruction and its content test; it does not change the API or application runtime
- #4486 remains open but is stale, merge-conflicted, broad in scope, and has failed checks; it is linked above for reviewer context

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 (Codex agent; exact internal model ID and context-window size are not exposed), with reasoning, shell, GitHub tool use, and code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
