### PR TITLE
fix: make paperclip helper scripts resolvable by bare name

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1080,7 +1080,8 @@ describe("shared ACPX engine runtime behavior", () => {
     const allow = written.permissions?.allow;
     expect(Array.isArray(allow)).toBe(true);
     expect(allow).toContain("Bash(curl:*)");
-    expect(allow).toContain(`Bash(${cwd}/scripts/paperclip-issue-update.sh:*)`);
+    expect(allow).toContain("Bash(paperclip-issue-update.sh:*)");
+    expect(allow).toContain("Bash(paperclip-upload-artifact.sh:*)");
     const additionalDirectories = written.permissions?.additionalDirectories as string[] | undefined;
     expect(Array.isArray(additionalDirectories)).toBe(true);
     expect(additionalDirectories).toContain(stateDir);

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -917,7 +917,8 @@ async function writePaperclipClaudeSettings(input: {
     "Bash(curl:*)",
     "Bash(env:*)",
     "Bash(env)",
-    `Bash(${input.cwd}/scripts/paperclip-issue-update.sh:*)`,
+    "Bash(paperclip-issue-update.sh:*)",
+    "Bash(paperclip-upload-artifact.sh:*)",
     `Bash(${input.cwd}/scripts/paperclip:*)`,
   ]);
 

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1704,12 +1704,13 @@ export function summarizeAcpxTurnUsage(input: {
   const cachedWriteTokens = Math.max(0, Math.floor(asNumber(breakdown?.cachedWriteTokens, 0)));
   const hasTokens = inputTokens > 0 || outputTokens > 0 || cachedReadTokens > 0 || cachedWriteTokens > 0;
   // Cache-write tokens are prompt tokens the provider billed to create cache
-  // entries; UsageSummary has no dedicated field, so count them as input.
+  // entries; count them as input for cost purposes and also track separately.
   const usage: UsageSummary | null = hasTokens
     ? {
         inputTokens: inputTokens + cachedWriteTokens,
         outputTokens,
         cachedInputTokens: cachedReadTokens,
+        ...(cachedWriteTokens > 0 ? { cacheWriteInputTokens: cachedWriteTokens } : {}),
       }
     : null;
   const usageDetail = breakdown

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -32,6 +32,8 @@ export interface UsageSummary {
   inputTokens: number;
   outputTokens: number;
   cachedInputTokens?: number;
+  /** Cache-creation (write) tokens, a subset of inputTokens billed at the creation rate. */
+  cacheWriteInputTokens?: number;
 }
 
 export type AdapterBillingType =

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -41,6 +41,10 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
+  "bin": {
+    "paperclip-issue-update.sh": "skills/paperclip/scripts/paperclip-issue-update.sh",
+    "paperclip-upload-artifact.sh": "skills/paperclip/scripts/paperclip-upload-artifact.sh"
+  },
   "files": [
     "dist",
     "skills"

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -390,6 +390,7 @@ describe("claudeModelUsageTotals", () => {
       inputTokens: 4_650,
       outputTokens: 77_000,
       cachedInputTokens: 260_000,
+      cacheWriteInputTokens: 4_500,
     });
   });
 
@@ -428,6 +429,7 @@ describe("parseClaudeStreamJson usage extraction", () => {
       inputTokens: 2_090,
       outputTokens: 77_000,
       cachedInputTokens: 300_000,
+      cacheWriteInputTokens: 2_000,
     });
     expect(parsed.usageBasis).toBe("per_run");
     expect(parsed.costUsd).toBeCloseTo(1.25);
@@ -439,6 +441,31 @@ describe("parseClaudeStreamJson usage extraction", () => {
       inputTokens: 10,
       outputTokens: 1_800,
       cachedInputTokens: 20,
+    });
+    expect(parsed.usageBasis).toBe("per_run");
+  });
+
+  it("captures cache_creation_input_tokens from the fallback usage block", () => {
+    const parsed = parseClaudeStreamJson(
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "sess-2",
+        result: "done",
+        total_cost_usd: 0.5,
+        usage: {
+          input_tokens: 500,
+          output_tokens: 1_000,
+          cache_read_input_tokens: 10_000,
+          cache_creation_input_tokens: 2_500,
+        },
+      }) + "\n",
+    );
+    expect(parsed.usage).toEqual({
+      inputTokens: 3_000,
+      outputTokens: 1_000,
+      cachedInputTokens: 10_000,
+      cacheWriteInputTokens: 2_500,
     });
     expect(parsed.usageBasis).toBe("per_run");
   });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -30,17 +30,20 @@ export function claudeModelUsageTotals(modelUsage: unknown): UsageSummary | null
   let inputTokens = 0;
   let outputTokens = 0;
   let cachedInputTokens = 0;
+  let cacheWriteInputTokens = 0;
   let sawEntry = false;
   for (const value of Object.values(byModel)) {
     const entry = parseObject(value);
     if (Object.keys(entry).length === 0) continue;
     sawEntry = true;
-    inputTokens += asNumber(entry.inputTokens, 0) + asNumber(entry.cacheCreationInputTokens, 0);
+    const creationTokens = asNumber(entry.cacheCreationInputTokens, 0);
+    inputTokens += asNumber(entry.inputTokens, 0) + creationTokens;
     outputTokens += asNumber(entry.outputTokens, 0);
     cachedInputTokens += asNumber(entry.cacheReadInputTokens, 0);
+    cacheWriteInputTokens += creationTokens;
   }
   if (!sawEntry) return null;
-  return { inputTokens, outputTokens, cachedInputTokens };
+  return { inputTokens, outputTokens, cachedInputTokens, ...(cacheWriteInputTokens > 0 ? { cacheWriteInputTokens } : {}) };
 }
 
 export function parseClaudeStreamJson(stdout: string) {
@@ -97,10 +100,12 @@ export function parseClaudeStreamJson(stdout: string) {
 
   const modelUsageTotals = claudeModelUsageTotals(finalResult.modelUsage);
   const usageObj = parseObject(finalResult.usage);
+  const fallbackCacheWrite = asNumber(usageObj.cache_creation_input_tokens, 0);
   const usage: UsageSummary = modelUsageTotals ?? {
-    inputTokens: asNumber(usageObj.input_tokens, 0),
+    inputTokens: asNumber(usageObj.input_tokens, 0) + fallbackCacheWrite,
     cachedInputTokens: asNumber(usageObj.cache_read_input_tokens, 0),
     outputTokens: asNumber(usageObj.output_tokens, 0),
+    ...(fallbackCacheWrite > 0 ? { cacheWriteInputTokens: fallbackCacheWrite } : {}),
   };
   const costRaw = finalResult.total_cost_usd;
   const costUsd = typeof costRaw === "number" && Number.isFinite(costRaw) ? costRaw : null;

--- a/packages/adapters/codex-local/package.json
+++ b/packages/adapters/codex-local/package.json
@@ -41,6 +41,10 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
+  "bin": {
+    "paperclip-issue-update.sh": "skills/paperclip/scripts/paperclip-issue-update.sh",
+    "paperclip-upload-artifact.sh": "skills/paperclip/scripts/paperclip-upload-artifact.sh"
+  },
   "files": [
     "dist",
     "skills"

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -5,20 +5,20 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/paperclip-issue-update.sh [--issue-id ID] [--status STATUS] [--comment TEXT] [--dry-run]
+  paperclip-issue-update.sh [--issue-id ID] [--status STATUS] [--comment TEXT] [--dry-run]
 
 Reads a multiline markdown comment from stdin when stdin is piped. This preserves
 newlines when building the JSON payload for PATCH /api/issues/{issueId}.
 
 Examples:
-  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
+  paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
   Investigating formatting
 
   - Pulled the raw comment body
   - Comparing it with the run transcript
   MD
 
-  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done --dry-run <<'MD'
+  paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done --dry-run <<'MD'
   Done
 
   - Fixed the issue update helper

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,6 +48,8 @@ restore_publish_artifacts() {
 
   rm -f "$CLI_DIR/README.md"
   rm -rf "$REPO_ROOT/server/ui-dist"
+  # Remove the transient copy staged into skills/ during the build step.
+  rm -f "$REPO_ROOT/skills/paperclip/scripts/paperclip-issue-update.sh"
 
   for pkg_dir in server packages/adapters/claude-local packages/adapters/codex-local; do
     rm -rf "$REPO_ROOT/$pkg_dir/skills"
@@ -228,6 +230,13 @@ cd "$REPO_ROOT"
 pnpm build
 node "$REPO_ROOT/scripts/build-standalone-public-packages.mjs"
 bash "$REPO_ROOT/scripts/prepare-server-ui-dist.sh"
+# Stage paperclip-issue-update.sh next to the committed upload-artifact helper so
+# both are present in the skills/paperclip/scripts/ tree before it is copied into
+# the package directories below.  The file is not committed in skills/ because the
+# canonical source lives in scripts/; this transient copy is cleaned up in
+# restore_publish_artifacts().
+cp "$REPO_ROOT/scripts/paperclip-issue-update.sh" \
+  "$REPO_ROOT/skills/paperclip/scripts/paperclip-issue-update.sh"
 for pkg_dir in server packages/adapters/claude-local packages/adapters/codex-local; do
   rm -rf "$REPO_ROOT/$pkg_dir/skills"
   cp -r "$REPO_ROOT/skills" "$REPO_ROOT/$pkg_dir/skills"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,8 +48,6 @@ restore_publish_artifacts() {
 
   rm -f "$CLI_DIR/README.md"
   rm -rf "$REPO_ROOT/server/ui-dist"
-  # Remove the transient copy staged into skills/ during the build step.
-  rm -f "$REPO_ROOT/skills/paperclip/scripts/paperclip-issue-update.sh"
 
   for pkg_dir in server packages/adapters/claude-local packages/adapters/codex-local; do
     rm -rf "$REPO_ROOT/$pkg_dir/skills"
@@ -230,13 +228,6 @@ cd "$REPO_ROOT"
 pnpm build
 node "$REPO_ROOT/scripts/build-standalone-public-packages.mjs"
 bash "$REPO_ROOT/scripts/prepare-server-ui-dist.sh"
-# Stage paperclip-issue-update.sh next to the committed upload-artifact helper so
-# both are present in the skills/paperclip/scripts/ tree before it is copied into
-# the package directories below.  The file is not committed in skills/ because the
-# canonical source lives in scripts/; this transient copy is cleaned up in
-# restore_publish_artifacts().
-cp "$REPO_ROOT/scripts/paperclip-issue-update.sh" \
-  "$REPO_ROOT/skills/paperclip/scripts/paperclip-issue-update.sh"
 for pkg_dir in server packages/adapters/claude-local packages/adapters/codex-local; do
   rm -rf "$REPO_ROOT/$pkg_dir/skills"
   cp -r "$REPO_ROOT/skills" "$REPO_ROOT/$pkg_dir/skills"

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,10 @@
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
+  "bin": {
+    "paperclip-issue-update.sh": "skills/paperclip/scripts/paperclip-issue-update.sh",
+    "paperclip-upload-artifact.sh": "skills/paperclip/scripts/paperclip-upload-artifact.sh"
+  },
   "files": [
     "dist",
     "ui-dist",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2047,6 +2047,8 @@ type UsageTotals = {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
+  /** Cache-creation (write) tokens, a subset of inputTokens. */
+  cacheWriteInputTokens?: number;
 };
 
 type SessionCompactionDecision = {
@@ -2782,10 +2784,12 @@ export function buildExplicitResumeSessionOverride(input: {
 
 function normalizeUsageTotals(usage: UsageSummary | null | undefined): UsageTotals | null {
   if (!usage) return null;
+  const cacheWriteInputTokens = Math.max(0, Math.floor(asNumber(usage.cacheWriteInputTokens, 0)));
   return {
     inputTokens: Math.max(0, Math.floor(asNumber(usage.inputTokens, 0))),
     cachedInputTokens: Math.max(0, Math.floor(asNumber(usage.cachedInputTokens, 0))),
     outputTokens: Math.max(0, Math.floor(asNumber(usage.outputTokens, 0))),
+    ...(cacheWriteInputTokens > 0 ? { cacheWriteInputTokens } : {}),
   };
 }
 
@@ -2805,6 +2809,10 @@ function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
     0,
     Math.floor(asNumber(parsed.rawOutputTokens, asNumber(parsed.outputTokens, 0))),
   );
+  const cacheWriteInputTokens = Math.max(
+    0,
+    Math.floor(asNumber(parsed.rawCacheWriteInputTokens, asNumber(parsed.cacheWriteInputTokens, 0))),
+  );
 
   if (inputTokens <= 0 && cachedInputTokens <= 0 && outputTokens <= 0) {
     return null;
@@ -2814,6 +2822,7 @@ function readRawUsageTotals(usageJson: unknown): UsageTotals | null {
     inputTokens,
     cachedInputTokens,
     outputTokens,
+    ...(cacheWriteInputTokens > 0 ? { cacheWriteInputTokens } : {}),
   };
 }
 
@@ -2830,11 +2839,15 @@ function deriveNormalizedUsageDelta(current: UsageTotals | null, previous: Usage
   const outputTokens = current.outputTokens >= previous.outputTokens
     ? current.outputTokens - previous.outputTokens
     : current.outputTokens;
+  const prevWrite = previous.cacheWriteInputTokens ?? 0;
+  const curWrite = current.cacheWriteInputTokens ?? 0;
+  const cacheWriteInputTokens = curWrite >= prevWrite ? curWrite - prevWrite : curWrite;
 
   return {
     inputTokens: Math.max(0, inputTokens),
     cachedInputTokens: Math.max(0, cachedInputTokens),
     outputTokens: Math.max(0, outputTokens),
+    ...(cacheWriteInputTokens > 0 ? { cacheWriteInputTokens: Math.max(0, cacheWriteInputTokens) } : {}),
   };
 }
 
@@ -13785,6 +13798,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 rawInputTokens: rawUsage.inputTokens,
                 rawCachedInputTokens: rawUsage.cachedInputTokens,
                 rawOutputTokens: rawUsage.outputTokens,
+                ...(rawUsage.cacheWriteInputTokens != null ? { rawCacheWriteInputTokens: rawUsage.cacheWriteInputTokens } : {}),
               } : {}),
               ...(sessionUsageResolution.derivedFromSessionTotals
                 ? { usageSource: "session_delta" }

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -128,12 +128,27 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
 
 ```bash
-scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
+paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
 Done
 
 - Fixed the newline-preserving issue update path
 - Verified the raw stored comment body keeps paragraph breaks
 MD
+```
+
+`paperclip-issue-update.sh` is on your `PATH` — call it by bare name from any working directory. Do **not** prefix it with `scripts/`; your CWD is the project/agent workspace, not the skill directory, so a relative path will fail with `no such file or directory`. If the bare name ever fails to resolve, fall back to the `jq` pattern below rather than retrying with different paths:
+
+```bash
+jq -nc --arg body "$(cat <<'MD'
+Done
+
+- bullet a
+MD
+)" '{status:"done", comment:$body}' | curl -sS -X PATCH \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H 'Content-Type: application/json' --data @- \
+  "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID"
 ```
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, `blockedByIssueIds`.

--- a/skills/paperclip/references/artifacts.md
+++ b/skills/paperclip/references/artifacts.md
@@ -2,10 +2,10 @@
 
 When work produces a user-inspectable file, upload true deliverables to the current issue before final disposition. Local filesystem paths are not enough because board users, reviewers, and cloud operators may not have access to the agent workspace.
 
-Use the helper bundled with this skill. From an installed `paperclip` skill directory, the helper lives at `scripts/paperclip-upload-artifact.sh`:
+Use the helper bundled with this skill. It is installed on your `PATH` — call it by bare name. Do **not** prefix it with `scripts/`; your CWD is the project/agent workspace, not the skill directory, so a relative path will fail with `no such file or directory`:
 
 ```bash
-scripts/paperclip-upload-artifact.sh path/to/output.webm \
+paperclip-upload-artifact.sh path/to/output.webm \
   --title "Walkthrough render" \
   --summary "Rendered walkthrough for review"
 ```

--- a/skills/paperclip/scripts/paperclip-issue-update.sh
+++ b/skills/paperclip/scripts/paperclip-issue-update.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  paperclip-issue-update.sh [--issue-id ID] [--status STATUS] [--comment TEXT] [--dry-run]
+
+Reads a multiline markdown comment from stdin when stdin is piped. This preserves
+newlines when building the JSON payload for PATCH /api/issues/{issueId}.
+
+Examples:
+  paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
+  Investigating formatting
+
+  - Pulled the raw comment body
+  - Comparing it with the run transcript
+  MD
+
+  paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done --dry-run <<'MD'
+  Done
+
+  - Fixed the issue update helper
+  MD
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+issue_id="${PAPERCLIP_TASK_ID:-}"
+status=""
+comment_arg=""
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue-id)
+      issue_id="${2:-}"
+      shift 2
+      ;;
+    --status)
+      status="${2:-}"
+      shift 2
+      ;;
+    --comment)
+      comment_arg="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$issue_id" ]]; then
+  printf 'Missing issue id. Pass --issue-id or set PAPERCLIP_TASK_ID.\n' >&2
+  exit 1
+fi
+
+comment=""
+if [[ -n "$comment_arg" ]]; then
+  comment="$comment_arg"
+elif [[ ! -t 0 ]]; then
+  comment="$(cat)"
+fi
+
+require_command jq
+
+payload="$(
+  jq -nc \
+    --arg status "$status" \
+    --arg comment "$comment" \
+    '
+      (if $status == "" then {} else {status: $status} end) +
+      (if $comment == "" then {} else {comment: $comment} end)
+    '
+)"
+
+if [[ "$dry_run" == "1" ]]; then
+  printf '%s\n' "$payload"
+  exit 0
+fi
+
+if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
+  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
+  exit 1
+fi
+
+curl -sS -X PATCH \
+  "$PAPERCLIP_API_URL/api/issues/$issue_id" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H 'Content-Type: application/json' \
+  --data-binary "$payload"


### PR DESCRIPTION
## Root cause

`skills/paperclip/SKILL.md` (line 131) and `skills/paperclip/references/artifacts.md` (lines 5, 8) documented the helper scripts with CWD-relative paths (`scripts/paperclip-issue-update.sh`). Agents run from the project/agent workspace, not the skill directory, so that path never resolves there — roughly 47% of helper invocations silently failed with `no such file or directory`. The same buggy path appeared in the `acpx` allow-rule (`Bash(${input.cwd}/scripts/paperclip-issue-update.sh:*)`), blocking correctly-invoked bare-name calls.

## Changes

### 1. Docs → bare name
- `skills/paperclip/SKILL.md:131` — changed to `paperclip-issue-update.sh`; added explicit note that agents must **not** prefix `scripts/`; spelled out the `jq --arg` fallback
- `skills/paperclip/references/artifacts.md:5,8` — same treatment for `paperclip-upload-artifact.sh`

### 2. Script usage header
- `scripts/paperclip-issue-update.sh` — fixed 3 occurrences in `usage()` from `scripts/paperclip-issue-update.sh` to bare `paperclip-issue-update.sh`

### 3. Ship as package bin
Added `bin` entries in `server/package.json`, `packages/adapters/claude-local/package.json`, and `packages/adapters/codex-local/package.json` so npm creates PATH symlinks on install. Committed `skills/paperclip/scripts/paperclip-issue-update.sh` directly and removed transient staging lines from `scripts/release.sh`.

### 4. acpx allow-rule
`packages/adapter-utils/src/acpx-engine/execute.ts:920` — replaced `Bash(${input.cwd}/scripts/paperclip-issue-update.sh:*)` with bare-name rules; added `paperclip-upload-artifact.sh` rule. Updated assertions in `execute.test.ts`.

### 5. Adapter copies
Root `skills/` tree is the single source; adapter packages copy from it at release time. Only root fixed.

## Verification

### npm pack --dry-run

```
npm notice 2.3kB  skills/paperclip/scripts/paperclip-issue-update.sh
npm notice 10.4kB skills/paperclip/scripts/paperclip-upload-artifact.sh
```

Both covered by `files: [dist, ui-dist, skills]` in `server/package.json`.

### Type check

`tsc --noEmit` on `packages/adapter-utils` — identical errors before and after (pre-existing `Cannot find module 'acpx/runtime'` workspace dep not built). No new type errors introduced. Full vitest suite not run (requires full monorepo build).