### PR TITLE
docs(claude-local): document agent-scoped Z.ai GLM setup

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -24,6 +24,64 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
 
+## Anthropic-compatible providers
+
+Claude Code can be configured to call Anthropic-compatible providers. For
+example, Z.ai's [Claude Code setup](https://docs.z.ai/devpack/tool/claude)
+routes Claude Code requests to its GLM endpoint by setting `ANTHROPIC_BASE_URL`,
+`ANTHROPIC_AUTH_TOKEN`, and default Claude Code model environment variables.
+
+For Paperclip, prefer scoping those variables to a single agent through
+`adapterConfig.env` instead of putting them in a global shell profile or global
+`~/.claude/settings.json`. Agent-scoped configuration lets selected Paperclip
+agents use GLM while normal Claude Code sessions on the same machine keep their
+usual Anthropic configuration.
+
+### Case 1: selected Paperclip agents use Z.ai GLM
+
+Use this when only some Paperclip agents should run through Z.ai:
+
+Use string values in `adapterConfig.env`, including for flag-like values.
+
+```json
+{
+  "adapterType": "claude_local",
+  "adapterConfig": {
+    "cwd": "/absolute/path/to/workspace",
+    "env": {
+      "ANTHROPIC_AUTH_TOKEN": "<zai-api-key>",
+      "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7",
+      "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2[1m]",
+      "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2[1m]",
+      "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "1000000",
+      "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+      "API_TIMEOUT_MS": "3000000"
+    }
+  }
+}
+```
+
+Model names are provider-owned and may change. Check the current Z.ai Claude
+Code documentation before copying GLM model IDs into long-lived agent config.
+
+### Case 2: all Claude Code usage should use Z.ai
+
+If the whole machine is dedicated to Z.ai-backed Claude Code, follow Z.ai's
+Claude Code instructions directly. That path is simpler, but it changes normal
+Claude Code behavior for every session launched from that environment.
+
+### Current limitation and longer-term path
+
+This is not native Z.ai adapter support. Paperclip still runs the
+`claude_local` adapter and Claude Code still owns the provider compatibility
+layer. As a result, UI labels, run metadata, and diagnostics may still look like
+Claude/Anthropic even when the underlying Claude Code request is routed to GLM.
+
+The current workaround is agent-scoped `adapterConfig.env`. Possible follow-ups
+are clearer environment-test diagnostics, a UI preset for
+`claude_local` plus Z.ai GLM, or a separate native Z.ai adapter discussion.
+
 ## Prompt Templates
 
 Templates support `{{variable}}` substitution:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - `claude_local` is the adapter that runs Claude Code for Paperclip agents.
> - Z.ai documents a Claude Code setup for routing Anthropic-compatible requests to GLM.
> - Users who configure that globally can accidentally change normal Claude Code behavior outside Paperclip.
> - Paperclip already supports per-agent adapter environment variables through `adapterConfig.env`.
> - This pull request documents the safer agent-scoped setup for using Z.ai GLM through `claude_local`.
> - The benefit is a supported path users can try today without implying native Z.ai adapter support.

## Linked Issues or Issue Description

- Refs #25
- Refs #1130
- Related prior attempts/discussion: #1043, #1179, #4718

## What Changed

- Added an `Anthropic-compatible providers` section to `docs/adapters/claude-local.md`.
- Documented the recommended agent-scoped `adapterConfig.env` setup for Z.ai GLM.
- Added a GLM-5.2 example using current Z.ai Claude Code environment variable names.
- Clarified the difference between this compatibility path and native Z.ai adapter support.
- Called out the longer-term follow-up path: diagnostics, UI preset, or a separate native adapter discussion.

## Verification

- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8')); console.log('docs/docs.json ok')"`

I did not run the full test suite because this is a docs-only change and this fresh checkout does not have `node_modules` installed.

## Risks

- Low risk: this only updates documentation.
- Z.ai owns the GLM model names, so the doc tells readers to confirm current model IDs before copying them into long-lived agent config.
- This does not change Paperclip behavior; users still need to configure the relevant agent environment variables themselves.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5, Codex desktop coding agent. Used for repository inspection, documentation drafting, shell/git operations, and PR preparation. Context window details are not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
