### PR TITLE
fix(recovery): preserve active issue heartbeat

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5312,7 +5312,106 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
-  it("escalates after repeated adapter_failed continuation retries with the cause in the comment", async () => {
+  it("does not reclaim an issue while its newer task-scoped checkout run is active", async () => {
+    const { companyId, agentId, issueId, runId: olderRunId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    const activeRunId = randomUUID();
+    const activeWakeupRequestId = randomUUID();
+    const activeAt = new Date("2026-03-19T00:10:00.000Z");
+    await db.insert(agentWakeupRequests).values({
+      id: activeWakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { taskId: issueId },
+      status: "claimed",
+      runId: activeRunId,
+      claimedAt: activeAt,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: activeRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: activeWakeupRequestId,
+      contextSnapshot: {
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+      startedAt: activeAt,
+      createdAt: activeAt,
+      updatedAt: activeAt,
+    });
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: activeRunId,
+        executionRunId: activeRunId,
+        updatedAt: activeAt,
+      })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: activeRunId,
+      executionRunId: activeRunId,
+    });
+
+    const activeRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, activeRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(activeRun).toMatchObject({
+      id: activeRunId,
+      status: "running",
+      agentId,
+    });
+    const activeWakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, activeWakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(activeWakeup).toMatchObject({
+      id: activeWakeupRequestId,
+      status: "claimed",
+      runId: activeRunId,
+    });
+
+    const actions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(
+        eq(issueRecoveryActions.companyId, companyId),
+        eq(issueRecoveryActions.sourceIssueId, issueId),
+      ));
+    expect(actions).toHaveLength(0);
+
+    const olderRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, olderRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(olderRun?.status).toBe("succeeded");
+  });
+
+  it("routes stranded recovery exactly once after the retry threshold with no live path", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
@@ -5372,6 +5471,46 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain("3× attempts");
     expect(comments[0]?.body).toContain("Latest cause: `adapter_failed`");
+
+    const firstAction = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(
+        eq(issueRecoveryActions.companyId, companyId),
+        eq(issueRecoveryActions.sourceIssueId, issueId),
+      ))
+      .then((rows) => rows[0] ?? null);
+    expect(firstAction).toBeTruthy();
+    const firstRoutedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    const repeatedResult = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(repeatedResult.escalated).toBe(0);
+    expect(repeatedResult.issueIds).not.toContain(issueId);
+
+    const repeatedActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(
+        eq(issueRecoveryActions.companyId, companyId),
+        eq(issueRecoveryActions.sourceIssueId, issueId),
+      ));
+    expect(repeatedActions).toHaveLength(1);
+    expect(repeatedActions[0]?.id).toBe(firstAction?.id);
+
+    const repeatedRoutedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(repeatedRoutedIssue).toMatchObject({
+      status: firstRoutedIssue?.status,
+      assigneeAgentId: firstRoutedIssue?.assigneeAgentId,
+      parentId: firstRoutedIssue?.parentId,
+    });
   });
 
   it("does not count mixed-cause continuation failures toward the transient cap", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -806,7 +806,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
-    const [run, deferredWake] = await Promise.all([
+    const [run, lockedRun, deferredWake] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -815,6 +815,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             eq(heartbeatRuns.companyId, companyId),
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(issues)
+        .innerJoin(
+          heartbeatRuns,
+          or(
+            eq(heartbeatRuns.id, issues.checkoutRunId),
+            eq(heartbeatRuns.id, issues.executionRunId),
+          ),
+        )
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.id, issueId),
+            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
           ),
         )
@@ -835,7 +855,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return Boolean(run || lockedRun || deferredWake);
   }
 
   async function hasPendingWakeInteraction(companyId: string, issueId: string) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work through issues, heartbeat runs, and lifecycle recovery.
> - Stranded-assignment recovery should act only after an assigned issue has no live execution path.
> - A checked-out heartbeat is represented authoritatively by the issue's `checkoutRunId` or `executionRunId`.
> - Context-only active-run lookup can miss a live run when its snapshot uses `taskId` instead of `issueId`.
> - That miss lets recovery classify an older succeeded run and block an issue while its newer heartbeat is still running.
> - This pull request makes active issue locks part of live-path detection and adds both recurrence and opposite-direction/idempotency coverage.
> - The benefit is preventing live work from being reclaimed without weakening recovery for genuinely stranded work.

## Linked Issues or Issue Description

Refs #6860

### What happened?

`reconcileStrandedAssignedIssues` could create a `stranded_assigned_issue` action for an `in_progress` issue even though a newer heartbeat referenced by the issue's checkout/execution lock was still `running`. The failure is deterministic when an older succeeded run uses `contextSnapshot.issueId` and the newer checked-out run is task-scoped.

### Expected behavior

An issue whose `checkoutRunId` or `executionRunId` references an active heartbeat must remain `in_progress` with its assignee and run locks unchanged. No recovery action should be created. If no live path exists and the retry threshold is exhausted, recovery must still route exactly once.

### Steps to reproduce

1. Create an assigned `in_progress` issue with an older succeeded continuation-recovery run.
2. Create a newer `running` heartbeat for the same issue whose context uses `taskId`.
3. Set the issue's `checkoutRunId` and `executionRunId` to the newer run.
4. Execute `reconcileStrandedAssignedIssues`.
5. Before this change, recovery escalates the issue from the older run despite the live checkout.

### Environment

- Paperclip commit: `e1cc63328a775b6aef508ca4df0dd8017489d87a`
- Deployment mode: built from source / local test environment
- Adapter-specific: no; core recovery lifecycle
- Database: embedded test Postgres
- Access context: system recovery
- Node.js: v22.22.3
- OS: Linux

### Duplicate search

The public PR list was searched for active-heartbeat, execution-lock, and stranded-recovery fixes. PR #6860 is closely related: it checks `executionRunId` and also filters candidates with any non-null execution lock. This PR differs by treating both `checkoutRunId` and `executionRunId` as live only when the referenced heartbeat is actually active, avoiding suppression from a stale terminal lock, and by adding the threshold/idempotency counter-case.

## What Changed

- Added an authoritative lock-to-heartbeat lookup to `hasActiveExecutionPath` for both `checkoutRunId` and `executionRunId`, preserving participant scoping where applicable.
- Added a deterministic regression with an older succeeded run and a newer active task-scoped checkout, asserting no action or issue/run/wakeup mutation.
- Strengthened threshold recovery coverage to prove exactly one action is routed and repeated classifier passes cannot stack actions or change status, assignee, or parent.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "does not reclaim an issue while its newer task-scoped checkout run is active|routes stranded recovery exactly once after the retry threshold with no live path"` — passed, 2 tests.
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — passed, 92 tests.
- `pnpm run typecheck:build-gaps` — passed.
- `pnpm test:run:serialized` — passed, all 119 serialized suites.
- `pnpm build` — passed.
- `pnpm test:run:general` — 297/298 files and 2955/2958 tests passed. Two unrelated local runtime-service port/process tests in `workspace-runtime.test.ts` failed and reproduced in isolation.
- This repository has no `bin/ci`; these commands are its documented PR workflow equivalents.

## Risks

- Low behavioral risk: the change only adds a live-path guard when an issue lock references a heartbeat in an active execution status.
- A stale lock pointing to a terminal or missing run does not suppress recovery.
- The extra indexed-ID join runs once per recovery candidate alongside existing live-path queries; very large candidate sets may incur a small additional database cost.
- No migration, public API, production data, permissions, or ownership changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, agentic tool use with code execution and test-driven debugging.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
