### PR TITLE
fix(plugins): race-free config delivery + tenant-binding state transitions (follow-up to #10092/#10096)

### DIFF
--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -320,9 +320,12 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
   let initialized = false;
   let manifest: PaperclipPluginManifestV1 | null = null;
   let currentConfig: Record<string, unknown> = {};
-  // The company whose config was last applied via configChanged. Used to fail
-  // closed when a single-tenant plugin would be collapsed onto a second,
-  // distinct company's config. `null` until the first company-scoped delivery.
+  // The company whose config was first *successfully applied* via
+  // configChanged. Used to fail closed when a single-tenant plugin would be
+  // collapsed onto a second, distinct company's config. `null` until a
+  // company-scoped delivery is accepted by the plugin; never transferred to
+  // another company afterwards (deliveries that merely replay the applied
+  // config under a different scope row are acknowledged as no-ops).
   let configCompanyId: string | null = null;
   let databaseNamespace: string | null = null;
   const invocationContextStorage = new AsyncLocalStorage<PluginInvocationContext>();
@@ -1627,17 +1630,23 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
     // secret confusion bug (one company's bot token applied to another's work).
     //
     // Reject the second, distinct company unless the plugin explicitly declares
-    // it handles multiple companies in one worker (multiCompanyConfig). An
-    // idempotent replay of the *same* config for a different company id is
-    // harmless (single-tenant plugins commonly have duplicate scope rows that
-    // all embed the same config), so it is allowed.
+    // it handles multiple companies in one worker (multiCompanyConfig).
     if (
       !plugin.definition.multiCompanyConfig &&
       incomingCompanyId !== null &&
       configCompanyId !== null &&
-      configCompanyId !== incomingCompanyId &&
-      !configsEqual(params.config, currentConfig)
+      configCompanyId !== incomingCompanyId
     ) {
+      // An idempotent replay of the *same* config under a different company id
+      // is harmless — single-tenant plugins commonly have duplicate scope rows
+      // that all embed the same config. Acknowledge it as a no-op: the config
+      // is already applied, and neither the tenant binding nor the plugin
+      // callback may see the second company id, otherwise duplicate startup
+      // rows would transfer the binding away from the company delivered first
+      // and lock it out of future updates.
+      if (configsEqual(params.config, currentConfig)) {
+        return;
+      }
       throw Object.assign(
         new Error(
           `configChanged: refusing to overwrite configuration for company ` +
@@ -1651,15 +1660,20 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
       );
     }
 
-    currentConfig = params.config;
-    if (incomingCompanyId !== null) {
-      configCompanyId = incomingCompanyId;
-    }
-
     if (plugin.definition.onConfigChanged) {
       await plugin.definition.onConfigChanged(params.config, {
         companyId: incomingCompanyId,
       });
+    }
+
+    // Commit only after the plugin accepted the config. Committing before the
+    // callback would let a config the plugin rejected (onConfigChanged threw)
+    // establish the tenant binding, leaving the worker bound to a company
+    // whose config was never applied — and rejecting every other company's
+    // delivery as cross-tenant afterwards.
+    currentConfig = params.config;
+    if (incomingCompanyId !== null && configCompanyId === null) {
+      configCompanyId = incomingCompanyId;
     }
   }
 

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -1616,7 +1616,26 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
     return plugin.definition.onValidateConfig(params.config);
   }
 
-  async function handleConfigChanged(params: ConfigChangedParams): Promise<void> {
+  // configChanged deliveries are applied strictly one at a time. The
+  // guard/dispatch/commit sequence in applyConfigChanged awaits the plugin
+  // callback between reading and writing the tenant-binding state, so two
+  // concurrent deliveries for different companies could otherwise both
+  // observe an unbound worker (configCompanyId === null), both dispatch, and
+  // commit a torn binding (bound to one company, currentConfig from the
+  // other). The host serializes its sends too, but the worker must not rely
+  // on host discipline for tenant isolation.
+  let configChangedChain: Promise<void> = Promise.resolve();
+
+  function handleConfigChanged(params: ConfigChangedParams): Promise<void> {
+    const run = configChangedChain.then(() => applyConfigChanged(params));
+    configChangedChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  async function applyConfigChanged(params: ConfigChangedParams): Promise<void> {
     const incomingCompanyId = params.companyId ?? null;
 
     // Fail-closed cross-tenant guard.

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -514,6 +514,55 @@ describe("worker configChanged cross-tenant guard", () => {
     }
   });
 
+  it("serializes concurrent deliveries so the tenant transition is atomic", async () => {
+    // The commit-after-callback ordering means the binding is read before the
+    // plugin callback resolves and written after. Without worker-side
+    // serialization, two concurrent initial deliveries for different
+    // companies both observe an unbound worker, both dispatch, and commit a
+    // torn binding (bound to one company, currentConfig from the other). The
+    // second delivery must instead queue behind the first and then fail
+    // closed as cross-tenant.
+    const applied: Array<string | null> = [];
+    let releaseFirst!: () => void;
+    const firstInFlight = new Promise<void>((r) => (releaseFirst = r));
+    let deliveries = 0;
+    const plugin = definePlugin({
+      async setup() {},
+      async onConfigChanged(_newConfig, context) {
+        deliveries += 1;
+        if (deliveries === 1) await firstInFlight;
+        applied.push(context?.companyId ?? null);
+      },
+    });
+    const { callWorker, initialize, stop } = makeWorker(plugin);
+
+    try {
+      await initialize();
+
+      const first = callWorker("configChanged", {
+        config: { slackBotToken: "xoxb-A" },
+        companyId: "company-a",
+      });
+      const second = callWorker("configChanged", {
+        config: { slackBotToken: "xoxb-B" },
+        companyId: "company-b",
+      });
+
+      // Let the first delivery enter the plugin callback, then release it.
+      await new Promise((r) => setImmediate(r));
+      releaseFirst();
+
+      await expect(first).resolves.toBeNull();
+      await expect(second).rejects.toMatchObject({
+        code: PLUGIN_RPC_ERROR_CODES.CROSS_TENANT_CONFIG,
+      });
+      // Only company A's config ever reached the plugin.
+      expect(applied).toEqual(["company-a"]);
+    } finally {
+      stop();
+    }
+  });
+
   it("keeps the applied config when a later delivery for the bound company fails", async () => {
     // Pre-fix, a failed update still overwrote currentConfig, so the guard's
     // idempotency comparison ran against a config that was never applied: an

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -412,15 +412,22 @@ describe("worker configChanged cross-tenant guard", () => {
     }
   });
 
-  it("allows an idempotent replay of the same config under a different scope row", async () => {
+  it("acknowledges an idempotent replay under a different scope row without transferring the tenant binding", async () => {
     // Mirrors the live single-tenant gateway: several plugin_config rows keyed
     // by distinct row companyIds but all embedding the same config. Replaying
-    // them must be a no-op, not a fail-closed rejection.
-    const appliedScopes: Array<string | null> = [];
+    // them must be acknowledged as a no-op — not rejected, but also not
+    // re-dispatched under the second scope and, critically, not allowed to
+    // move the tenant binding. Pre-fix, the replay for row-scope-2 rebound the
+    // worker to row-scope-2, so the deterministically-first company
+    // (row-scope-1) was rejected as cross-tenant on its next real update.
+    const applied: Array<{ companyId: string | null; token: unknown }> = [];
     const plugin = definePlugin({
       async setup() {},
-      async onConfigChanged(_newConfig, context) {
-        appliedScopes.push(context?.companyId ?? null);
+      async onConfigChanged(newConfig, context) {
+        applied.push({
+          companyId: context?.companyId ?? null,
+          token: newConfig.slackBotToken,
+        });
       },
     });
     const { callWorker, initialize, stop } = makeWorker(plugin);
@@ -440,7 +447,109 @@ describe("worker configChanged cross-tenant guard", () => {
         }),
       ).resolves.toBeNull();
 
-      expect(appliedScopes).toEqual(["row-scope-1", "row-scope-2"]);
+      // The replay was acknowledged but the plugin only ever saw the binding
+      // scope — a single-tenant plugin must not observe a second company id.
+      expect(applied).toEqual([{ companyId: "row-scope-1", token: "xoxb-A" }]);
+
+      // The binding stayed on the first company: a real config update for it
+      // still lands…
+      await expect(
+        callWorker("configChanged", {
+          config: { ...embedded, slackBotToken: "xoxb-A2" },
+          companyId: "row-scope-1",
+        }),
+      ).resolves.toBeNull();
+      expect(applied[1]).toEqual({ companyId: "row-scope-1", token: "xoxb-A2" });
+
+      // …while a distinct config for the replayed scope still fails closed.
+      await expect(
+        callWorker("configChanged", {
+          config: { ...embedded, slackBotToken: "xoxb-B" },
+          companyId: "row-scope-2",
+        }),
+      ).rejects.toMatchObject({
+        code: PLUGIN_RPC_ERROR_CODES.CROSS_TENANT_CONFIG,
+      });
+    } finally {
+      stop();
+    }
+  });
+
+  it("does not commit the tenant binding when the plugin rejects the config", async () => {
+    // Pre-fix, currentConfig/configCompanyId were committed before
+    // onConfigChanged ran, so a config the plugin threw on still bound the
+    // worker to that company — and every other company's delivery was then
+    // rejected as cross-tenant even though nothing was ever applied.
+    const applied: Array<string | null> = [];
+    const plugin = definePlugin({
+      async setup() {},
+      async onConfigChanged(newConfig, context) {
+        if (newConfig.bad === true) throw new Error("config rejected by plugin");
+        applied.push(context?.companyId ?? null);
+      },
+    });
+    const { callWorker, initialize, stop } = makeWorker(plugin);
+
+    try {
+      await initialize();
+
+      await expect(
+        callWorker("configChanged", {
+          config: { bad: true },
+          companyId: "company-a",
+        }),
+      ).rejects.toMatchObject({ message: expect.stringContaining("config rejected") });
+
+      // The failed delivery must not have bound the worker to company A:
+      // company B's (distinct) config is applied, not rejected as cross-tenant.
+      await expect(
+        callWorker("configChanged", {
+          config: { slackBotToken: "xoxb-B" },
+          companyId: "company-b",
+        }),
+      ).resolves.toBeNull();
+      expect(applied).toEqual(["company-b"]);
+    } finally {
+      stop();
+    }
+  });
+
+  it("keeps the applied config when a later delivery for the bound company fails", async () => {
+    // Pre-fix, a failed update still overwrote currentConfig, so the guard's
+    // idempotency comparison ran against a config that was never applied: an
+    // equal-config replay of the *applied* value under another scope row was
+    // then misclassified as a distinct cross-tenant config and rejected.
+    const plugin = definePlugin({
+      async setup() {},
+      async onConfigChanged(newConfig) {
+        if (newConfig.bad === true) throw new Error("config rejected by plugin");
+      },
+    });
+    const { callWorker, initialize, stop } = makeWorker(plugin);
+
+    try {
+      await initialize();
+      const embedded = { companyId: "company-a", slackBotToken: "xoxb-A" };
+
+      await callWorker("configChanged", {
+        config: { ...embedded },
+        companyId: "row-scope-1",
+      });
+      await expect(
+        callWorker("configChanged", {
+          config: { ...embedded, bad: true },
+          companyId: "row-scope-1",
+        }),
+      ).rejects.toMatchObject({ message: expect.stringContaining("config rejected") });
+
+      // currentConfig still holds the applied value, so replaying it under a
+      // duplicate scope row is recognized as idempotent.
+      await expect(
+        callWorker("configChanged", {
+          config: { ...embedded },
+          companyId: "row-scope-2",
+        }),
+      ).resolves.toBeNull();
     } finally {
       stop();
     }

--- a/server/src/__tests__/plugin-config-delivery.test.ts
+++ b/server/src/__tests__/plugin-config-delivery.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+  deliverStoredCompanyConfig,
+  type ConfigDeliveryRegistry,
+  type ConfigDeliveryWorkerManager,
+} from "../services/plugin-config-delivery.js";
+
+/**
+ * The host delivers stored company config to a plugin worker from two places:
+ * the loader's startup replay and the operator config-save route. Delivering a
+ * value captured before the send loses updates — an operator save landing
+ * between the loader's `listConfigs` snapshot and the replay loop was
+ * delivered first and then overwritten by the stale snapshot row.
+ *
+ * `deliverStoredCompanyConfig` closes that race by serializing deliveries per
+ * plugin and re-reading the row inside the critical section. These tests
+ * exercise exactly those two properties plus the failure-isolation of the
+ * chain. No database or worker process needed: the registry and worker
+ * manager are the function's only collaborators.
+ */
+describe("deliverStoredCompanyConfig", () => {
+  interface SentConfig {
+    pluginId: string;
+    method: string;
+    config: Record<string, unknown>;
+    companyId: unknown;
+  }
+
+  function makeFakes(initialRows: Record<string, Record<string, unknown>>) {
+    // rows are keyed by `${pluginId}:${companyId}` and mutable mid-test to
+    // model an operator save committing while deliveries are in flight.
+    const rows = new Map<string, Record<string, unknown>>(
+      Object.entries(initialRows),
+    );
+    const sent: SentConfig[] = [];
+    let callGate: Promise<void> | null = null;
+    let failNextCall: Error | null = null;
+
+    const registry: ConfigDeliveryRegistry = {
+      async getConfig(pluginId, companyId) {
+        const configJson = rows.get(`${pluginId}:${companyId}`);
+        return configJson === undefined ? null : { configJson };
+      },
+    };
+
+    const workerManager: ConfigDeliveryWorkerManager = {
+      async call(pluginId, method, params) {
+        if (callGate) await callGate;
+        if (failNextCall) {
+          const err = failNextCall;
+          failNextCall = null;
+          throw err;
+        }
+        sent.push({
+          pluginId,
+          method,
+          config: (params?.config ?? {}) as Record<string, unknown>,
+          companyId: params?.companyId,
+        });
+      },
+    };
+
+    return {
+      registry,
+      workerManager,
+      rows,
+      sent,
+      gateCalls(gate: Promise<void>) {
+        callGate = gate;
+      },
+      ungateCalls() {
+        callGate = null;
+      },
+      failNext(err: Error) {
+        failNextCall = err;
+      },
+    };
+  }
+
+  it("sends the stored row through configChanged with the company scope", async () => {
+    const fakes = makeFakes({ "plugin-1:company-a": { token: "xoxb-A" } });
+
+    const result = await deliverStoredCompanyConfig({
+      registry: fakes.registry,
+      workerManager: fakes.workerManager,
+      pluginId: "plugin-1",
+      companyId: "company-a",
+    });
+
+    expect(result).toEqual({ delivered: true });
+    expect(fakes.sent).toEqual([
+      {
+        pluginId: "plugin-1",
+        method: "configChanged",
+        config: { token: "xoxb-A" },
+        companyId: "company-a",
+      },
+    ]);
+  });
+
+  it("skips delivery when no config row exists (anymore)", async () => {
+    const fakes = makeFakes({});
+
+    const result = await deliverStoredCompanyConfig({
+      registry: fakes.registry,
+      workerManager: fakes.workerManager,
+      pluginId: "plugin-1",
+      companyId: "company-a",
+    });
+
+    expect(result).toEqual({ delivered: false, reason: "no-config" });
+    expect(fakes.sent).toEqual([]);
+  });
+
+  it("delivers the latest committed value when a save lands during the startup replay", async () => {
+    // The Greptile-flagged race on the original startup-replay change: the
+    // loader snapshots configs, an operator save for company A commits and
+    // notifies, and the replay loop then reaches company A with its stale
+    // snapshot. With value-capturing delivery the worker ended on the OLD
+    // config; re-reading inside the serialized critical section must leave it
+    // on the NEW one no matter how the two paths interleave.
+    const fakes = makeFakes({ "plugin-1:company-a": { token: "old" } });
+
+    // Hold the replay's delivery RPC in flight after it has read the old row…
+    let releaseReplay!: () => void;
+    fakes.gateCalls(new Promise<void>((r) => (releaseReplay = r)));
+    const replayDelivery = deliverStoredCompanyConfig({
+      registry: fakes.registry,
+      workerManager: fakes.workerManager,
+      pluginId: "plugin-1",
+      companyId: "company-a",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    // …while the operator save commits the new value and enqueues its own
+    // delivery (what the config-save route does after upsertConfig).
+    fakes.rows.set("plugin-1:company-a", { token: "new" });
+    const saveDelivery = deliverStoredCompanyConfig({
+      registry: fakes.registry,
+      workerManager: fakes.workerManager,
+      pluginId: "plugin-1",
+      companyId: "company-a",
+    });
+
+    fakes.ungateCalls();
+    releaseReplay();
+    await Promise.all([replayDelivery, saveDelivery]);
+
+    // The replay sent its (stale) read first, then the queued save delivery
+    // re-read and sent the committed value — the worker ends on the new
+    // config. Pre-fix the order was save-then-replay, ending on the old one.
+    expect(fakes.sent.map((s) => s.config)).toEqual([
+      { token: "old" },
+      { token: "new" },
+    ]);
+  });
+
+  it("serializes deliveries per plugin so sends cannot interleave", async () => {
+    const fakes = makeFakes({
+      "plugin-1:company-a": { token: "a" },
+      "plugin-1:company-b": { token: "b" },
+    });
+
+    let releaseFirst!: () => void;
+    fakes.gateCalls(new Promise<void>((r) => (releaseFirst = r)));
+
+    const first = deliverStoredCompanyConfig({
+      registry: fakes.registry,
+      workerManager: fakes.workerManager,
+      pluginId: "plugin-1",
+      companyId: "company-a",
+    });
+    const second = deliverStoredCompanyConfig({
+      registry: fakes.registry,
+      workerManager: fakes.workerManager,
+      pluginId: "plugin-1",
+      companyId: "company-b",
+    });
+
+    // The second delivery is queued behind the gated first one.
+    await new Promise((r) => setImmediate(r));
+    expect(fakes.sent).toEqual([]);
+
+    fakes.ungateCalls();
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(fakes.sent.map((s) => s.companyId)).toEqual(["company-a", "company-b"]);
+  });
+
+  it("propagates RPC errors to the caller without breaking the chain", async () => {
+    const fakes = makeFakes({
+      "plugin-1:company-a": { token: "a" },
+      "plugin-1:company-b": { token: "b" },
+    });
+    fakes.failNext(Object.assign(new Error("cross-tenant"), { code: -32099 }));
+
+    await expect(
+      deliverStoredCompanyConfig({
+        registry: fakes.registry,
+        workerManager: fakes.workerManager,
+        pluginId: "plugin-1",
+        companyId: "company-a",
+      }),
+    ).rejects.toMatchObject({ message: "cross-tenant", code: -32099 });
+
+    // A failed delivery must not wedge later ones (the loader's replay loop
+    // continues to the next company after logging).
+    await expect(
+      deliverStoredCompanyConfig({
+        registry: fakes.registry,
+        workerManager: fakes.workerManager,
+        pluginId: "plugin-1",
+        companyId: "company-b",
+      }),
+    ).resolves.toEqual({ delivered: true });
+    expect(fakes.sent.map((s) => s.companyId)).toEqual(["company-b"]);
+  });
+});

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -46,6 +46,7 @@ import {
   PLUGIN_STATUSES,
 } from "@paperclipai/shared";
 import { pluginRegistryService } from "../services/plugin-registry.js";
+import { deliverStoredCompanyConfig } from "../services/plugin-config-delivery.js";
 import { pluginLifecycleManager } from "../services/plugin-lifecycle.js";
 import {
   getPluginUiContributionMetadata,
@@ -2350,13 +2351,20 @@ export function pluginRoutes(
       // If the worker implements onConfigChanged, send the new config via RPC.
       // If it doesn't (METHOD_NOT_IMPLEMENTED), restart the worker so it picks
       // up the new config on re-initialize. If no worker is running, skip.
+      //
+      // Delivery goes through deliverStoredCompanyConfig rather than sending
+      // body.configJson directly: it re-reads the just-persisted row inside a
+      // per-plugin critical section shared with the loader's startup replay,
+      // so a save landing while a freshly-started worker is still replaying
+      // stored configs can't be overwritten by the replay's older snapshot.
       if (bridgeDeps?.workerManager.isRunning(plugin.id)) {
         try {
-          await bridgeDeps.workerManager.call(
-            plugin.id,
-            "configChanged",
-            { config: body.configJson, companyId },
-          );
+          await deliverStoredCompanyConfig({
+            registry,
+            workerManager: bridgeDeps.workerManager,
+            pluginId: plugin.id,
+            companyId,
+          });
         } catch (rpcErr) {
           if (
             rpcErr instanceof JsonRpcCallError &&

--- a/server/src/services/plugin-config-delivery.ts
+++ b/server/src/services/plugin-config-delivery.ts
@@ -1,0 +1,102 @@
+/**
+ * Plugin config delivery — race-free host→worker `configChanged` sends.
+ *
+ * Two paths deliver a company's stored config to a running plugin worker:
+ *
+ *  1. The operator config-save route (`routes/plugins.ts`), right after
+ *     persisting the new config.
+ *  2. The plugin loader's startup replay (`plugin-loader.ts` step 5b), which
+ *     fans out every stored company's config to a freshly-started worker.
+ *
+ * Delivering a value captured *before* the send creates a lost-update race:
+ * an operator save landing between the loader's `listConfigs` snapshot and
+ * the replay loop would be delivered first and then overwritten by the stale
+ * snapshot row, leaving the worker on old config even though the database
+ * holds the new value. The same shape exists between two concurrent saves.
+ *
+ * `deliverStoredCompanyConfig` closes the race by construction:
+ *
+ *  - All deliveries for a plugin are serialized through a per-plugin promise
+ *    chain, so two sends can never interleave.
+ *  - The config row is re-read from the database *inside* the critical
+ *    section, immediately before the send.
+ *
+ * A save always enqueues its delivery after its row is committed, and every
+ * delivery reads the latest committed row at execution time — so whichever
+ * delivery runs last carries the newest value, regardless of how saves and
+ * the startup replay interleave.
+ */
+
+import type { ConfigChangedParams } from "@paperclipai/plugin-sdk";
+
+export interface ConfigDeliveryRegistry {
+  /** Latest stored config row for a plugin/company pair, or null if none. */
+  getConfig(
+    pluginId: string,
+    companyId: string,
+  ): Promise<{ configJson: unknown } | null>;
+}
+
+export interface ConfigDeliveryWorkerManager {
+  /** Send a configChanged RPC to the plugin's worker (rejects on RPC error/timeout). */
+  call(
+    pluginId: string,
+    method: "configChanged",
+    params: ConfigChangedParams,
+  ): Promise<unknown>;
+}
+
+export interface DeliverStoredConfigResult {
+  /** True when a `configChanged` RPC was sent (and acknowledged). */
+  delivered: boolean;
+  /** Set when delivery was skipped because no config row exists (anymore). */
+  reason?: "no-config";
+}
+
+// Per-plugin delivery chain. Module-level on purpose: the loader and the
+// config-save route are separate modules but must serialize against each
+// other, and both run in the one server process that owns the worker.
+const deliveryChains = new Map<string, Promise<unknown>>();
+
+/**
+ * Deliver the *current* stored config for `(pluginId, companyId)` to the
+ * plugin's worker via `configChanged`, serialized per plugin.
+ *
+ * RPC errors (cross-tenant rejection, method-not-implemented, timeout)
+ * propagate to the caller; the delivery chain itself always continues.
+ */
+export async function deliverStoredCompanyConfig(input: {
+  registry: ConfigDeliveryRegistry;
+  workerManager: ConfigDeliveryWorkerManager;
+  pluginId: string;
+  companyId: string;
+}): Promise<DeliverStoredConfigResult> {
+  const { registry, workerManager, pluginId, companyId } = input;
+
+  const tail = deliveryChains.get(pluginId) ?? Promise.resolve();
+  const run = tail.then(async (): Promise<DeliverStoredConfigResult> => {
+    // Critical section: read-latest-then-send, with no other delivery for
+    // this plugin in flight.
+    const row = await registry.getConfig(pluginId, companyId);
+    if (!row) return { delivered: false, reason: "no-config" };
+
+    await workerManager.call(pluginId, "configChanged", {
+      config: (row.configJson ?? {}) as Record<string, unknown>,
+      companyId,
+    });
+    return { delivered: true };
+  });
+
+  // The chain must survive a failed delivery, so park a settled continuation
+  // as the new tail and drop it once the chain drains.
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  deliveryChains.set(pluginId, settled);
+  void settled.then(() => {
+    if (deliveryChains.get(pluginId) === settled) deliveryChains.delete(pluginId);
+  });
+
+  return run;
+}

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -43,6 +43,7 @@ import { logger } from "../middleware/logger.js";
 import { pluginManifestValidator } from "./plugin-manifest-validator.js";
 import { pluginCapabilityValidator } from "./plugin-capability-validator.js";
 import { pluginRegistryService } from "./plugin-registry.js";
+import { deliverStoredCompanyConfig } from "./plugin-config-delivery.js";
 import type { PluginWorkerManager, WorkerStartOptions, WorkerToHostHandlers } from "./plugin-worker-manager.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
 import type { PluginJobScheduler } from "./plugin-job-scheduler.js";
@@ -2187,12 +2188,20 @@ export function pluginLoader(
       // (METHOD_NOT_IMPLEMENTED) or is momentarily unavailable simply keeps the
       // runtime ctx.config.get(companyId) model. onConfigChanged is idempotent
       // for well-behaved plugins, so replaying an unchanged config is safe.
+      //
+      // listConfigs only enumerates the configured companies (in deterministic
+      // order); the value actually sent is re-read at delivery time by
+      // deliverStoredCompanyConfig, serialized against the operator
+      // config-save path. An operator save landing mid-replay therefore can't
+      // be overwritten by this loop's earlier snapshot.
       try {
         const configRows = await registry.listConfigs(pluginId);
         for (const row of configRows) {
           try {
-            await workerManager.call(pluginId, "configChanged", {
-              config: (row.configJson ?? {}) as Record<string, unknown>,
+            await deliverStoredCompanyConfig({
+              registry,
+              workerManager,
+              pluginId,
               companyId: row.companyId,
             });
           } catch (configErr) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - First-party **plugins** run as isolated workers spawned by the host `plugin-loader`; company-scoped config reaches a running worker over the host→worker `configChanged` RPC — from the operator config-save route and, since #10092, from a startup replay of every stored company row.
> - #10092's review flagged that the replay delivers a point-in-time snapshot: a save landing between the `listConfigs` snapshot and the replay loop is delivered first and then **overwritten by the stale snapshot row** (lost update).
> - #10096 added a fail-closed cross-tenant guard in the worker RPC host, but its review flagged two state-transition defects: the tenant binding **commits before the plugin accepts the config**, and an idempotent equal-config replay under a different scope row **transfers the binding** away from the first company, locking it out of future updates.
> - Both PRs merged at review confidence 4/5 with these three findings triaged as follow-up work; this pull request is that follow-up.
> - It makes config delivery race-free by construction (serialize per plugin + re-read the row inside the critical section) and makes the guard's state transitions commit-after-success with a stable tenant binding.
> - The benefit is that a worker always ends on the latest committed config, and the tenant binding can neither be established by a rejected config nor migrated by duplicate scope rows.

## Linked Issues or Issue Description

No public GitHub issue — describing in-PR (bug / hardening follow-up to #10092 and #10096, closing the review findings both merged with):

1. **Stale startup replay (host).** `activatePlugin` step 5b captured config values in a `listConfigs` snapshot and sent them later. An operator save landing mid-replay was delivered immediately via the save route and then overwritten by the snapshot's older row — the worker ended startup on old config while the database held the new value. The same lost-update shape existed between two concurrent saves.
2. **Rejected config commits binding (SDK).** `handleConfigChanged` committed `currentConfig`/`configCompanyId` before awaiting `onConfigChanged`. A config the plugin threw on still bound the worker to that company, and every other company's delivery was then rejected as cross-tenant even though nothing was ever applied.
3. **Idempotent replay transfers binding (SDK).** An equal-config replay under a different scope row (the common duplicate-row single-tenant case) rebound `configCompanyId` to the second company, so the deterministically-first company's next real update was rejected as cross-tenant.

## What Changed

- **New `server/src/services/plugin-config-delivery.ts`** — `deliverStoredCompanyConfig(registry, workerManager, pluginId, companyId)`: serializes all `configChanged` sends per plugin through a promise chain and re-reads the config row from the database *inside* the critical section. A save always enqueues its delivery after its row is committed, and every delivery reads the latest committed row at execution time — so whichever delivery runs last carries the newest value, regardless of how saves and the startup replay interleave. RPC errors propagate to the caller; the chain survives failures.
- **`server/src/services/plugin-loader.ts`** — the startup replay now uses `listConfigs` only to enumerate configured companies (deterministic order preserved) and delivers each through the helper. Existing per-error handling (warn on `CROSS_TENANT_CONFIG`, debug otherwise) unchanged.
- **`server/src/routes/plugins.ts`** — the config-save route delivers through the same helper instead of sending `body.configJson` directly: it re-reads the just-persisted row (identical JSON by construction, or newer) under the shared per-plugin critical section. `METHOD_NOT_IMPLEMENTED` → worker-restart handling unchanged.
- **`packages/plugins/sdk/src/worker-rpc-host.ts`** — `handleConfigChanged` now (a) commits `currentConfig`/`configCompanyId` only after `onConfigChanged` resolves; (b) establishes the tenant binding once (first successfully applied company-scoped delivery) and never transfers it; (c) acknowledges an equal-config delivery for a *different* company on a single-tenant plugin as a no-op — no rebinding and no dispatch, so a single-tenant plugin never observes a second company id; and (d) applies deliveries strictly one at a time through a worker-side promise chain, so the guard/dispatch/commit transition is atomic under concurrent deliveries (round-1 review finding on this PR).
- **Tests** — new `server/src/__tests__/plugin-config-delivery.test.ts` (5 cases: payload shape, missing-row skip, the mid-replay save race, per-plugin serialization, failure isolation of the chain); `packages/plugins/sdk/tests/worker-rpc-host.test.ts` gains three regression tests (rejected config must not bind; failed update must not clobber the applied config used for idempotency comparison; concurrent initial deliveries must not commit a torn binding) and the idempotent-replay test now asserts the binding stays on the first company and its real updates still land.

## Verification

- `tsc --noEmit` on `@paperclipai/server` and `@paperclipai/plugin-sdk` — clean.
- New `plugin-config-delivery.test.ts` — 5/5 pass. The race case pins the exact reviewer scenario: replay reads old row → save commits + enqueues → last `configChanged` carries the new value.
- SDK `worker-rpc-host.test.ts` — 10/10 pass. Verified against pre-PR code (`a7186dce4`): the three inherited-finding regression tests fail there; the concurrency test fails against this PR's intermediate commit-after-callback state (the window it guards was introduced and closed within this PR).
- Existing #10092 embedded-postgres `plugin-config-startup-delivery.test.ts` — 3/3 pass (unaffected).
- `plugin-routes-authz.test.ts` + `plugin-lifecycle-restart.test.ts` — 38/38 pass.

## Risks

- **Low functional risk.** Payload shape and RPC path are unchanged. The save route now sends the row it just persisted rather than the in-memory body — byte-identical by construction, or a newer committed value (which is the point).
- **Ordering shift (intended).** Deliveries per plugin are serialized; a save issued while a freshly-started worker is replaying stored configs queues behind the in-flight send and lands after it — previously it could land first and be overwritten.
- **SDK behavior shift on degenerate inputs (intended, per review).** A config the plugin rejects no longer establishes the tenant binding; an equal-config cross-company replay is acknowledged without dispatching `onConfigChanged` under the second scope. Today's single-tenant consumer (the chat gateway) sees identical behavior in all non-degenerate flows.
- **Chain memory.** The per-plugin delivery chain map holds at most one settled tail per plugin and self-cleans when it drains.

## Model Used

Claude — Anthropic `claude-fable-5` (Fable 5), extended thinking, with tool use / code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes:` / `Closes` / `Refs` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no doc surface; internal SDK/host behavior only
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
