### PR TITLE
fix(server/approvals): wake requester on reject and request-revision

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -322,6 +322,124 @@ describe("approval routes idempotent retries", () => {
     );
   });
 
+  it("wakes the requesting agent when an approval is rejected", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-9",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-7",
+    });
+    mockApprovalService.reject.mockResolvedValue({
+      approval: {
+        id: "approval-9",
+        companyId: "company-1",
+        type: "request_board_approval",
+        status: "rejected",
+        payload: {},
+        requestedByAgentId: "agent-7",
+      },
+      applied: true,
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-9/reject")
+      .send({ decisionNote: "not now" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-7",
+      expect.objectContaining({
+        reason: "approval_rejected",
+        payload: expect.objectContaining({
+          approvalId: "approval-9",
+          approvalStatus: "rejected",
+          issueId: "issue-1",
+          issueIds: ["issue-1"],
+        }),
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "approval.requester_wakeup_queued" }),
+    );
+  });
+
+  it("wakes the requesting agent when a revision is requested", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-10",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: "agent-8",
+    });
+    mockApprovalService.requestRevision.mockResolvedValue({
+      id: "approval-10",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "revision_requested",
+      payload: {},
+      requestedByAgentId: "agent-8",
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-10/request-revision")
+      .send({ decisionNote: "Need changes" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "agent-8",
+      expect.objectContaining({
+        reason: "approval_revision_requested",
+        payload: expect.objectContaining({
+          approvalId: "approval-10",
+          approvalStatus: "revision_requested",
+          issueId: "issue-1",
+          issueIds: ["issue-1"],
+        }),
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "approval.requester_wakeup_queued" }),
+    );
+  });
+
+  it("does not wake any agent when a rejected approval has no requesting agent", async () => {
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-11",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "pending",
+      payload: {},
+      requestedByAgentId: null,
+    });
+    mockApprovalService.reject.mockResolvedValue({
+      approval: {
+        id: "approval-11",
+        companyId: "company-1",
+        type: "request_board_approval",
+        status: "rejected",
+        payload: {},
+        requestedByAgentId: null,
+      },
+      applied: true,
+    });
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-11/reject")
+      .send({ decisionNote: "no" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "approval.requester_wakeup_queued" }),
+    );
+  });
+
   it("lets agents create generic issue-linked board approval requests", async () => {
     mockApprovalService.create.mockResolvedValue({
       id: "approval-1",

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -407,6 +407,32 @@ describe("approval routes idempotent retries", () => {
     );
   });
 
+  it("does not re-wake the requesting agent on a request-revision retry", async () => {
+    const { unprocessable } = await import("../errors.js");
+    mockApprovalService.getById.mockResolvedValue({
+      id: "approval-10",
+      companyId: "company-1",
+      type: "request_board_approval",
+      status: "revision_requested",
+      payload: {},
+      requestedByAgentId: "agent-8",
+    });
+    mockApprovalService.requestRevision.mockRejectedValue(
+      unprocessable("Only pending approvals can request revision"),
+    );
+
+    const res = await request(await createApp())
+      .post("/api/approvals/approval-10/request-revision")
+      .send({ decisionNote: "Need changes" });
+
+    expect(res.status).toBe(422);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "approval.requester_wakeup_queued" }),
+    );
+  });
+
   it("does not wake any agent when a rejected approval has no requesting agent", async () => {
     mockApprovalService.getById.mockResolvedValue({
       id: "approval-11",

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -104,6 +104,84 @@ export function approvalRoutes(
     return false;
   }
 
+  async function queueRequesterWakeup(opts: {
+    approval: {
+      id: string;
+      companyId: string;
+      status: string;
+      requestedByAgentId: string | null;
+    };
+    reason: string;
+    activitySource: string;
+    decidedByUserId: string;
+    linkedIssueIds: string[];
+  }) {
+    const { approval, reason, activitySource, decidedByUserId, linkedIssueIds } = opts;
+    if (!approval.requestedByAgentId) return;
+    const primaryIssueId = linkedIssueIds[0] ?? null;
+
+    try {
+      const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason,
+        payload: {
+          approvalId: approval.id,
+          approvalStatus: approval.status,
+          issueId: primaryIssueId,
+          issueIds: linkedIssueIds,
+        },
+        requestedByActorType: "user",
+        requestedByActorId: decidedByUserId,
+        contextSnapshot: {
+          source: activitySource,
+          approvalId: approval.id,
+          approvalStatus: approval.status,
+          issueId: primaryIssueId,
+          issueIds: linkedIssueIds,
+          taskId: primaryIssueId,
+          wakeReason: reason,
+        },
+      });
+
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: "user",
+        actorId: decidedByUserId,
+        action: "approval.requester_wakeup_queued",
+        entityType: "approval",
+        entityId: approval.id,
+        details: {
+          requesterAgentId: approval.requestedByAgentId,
+          wakeRunId: wakeRun?.id ?? null,
+          linkedIssueIds,
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          approvalId: approval.id,
+          requestedByAgentId: approval.requestedByAgentId,
+        },
+        "failed to queue requester wakeup after approval decision",
+      );
+      await logActivity(db, {
+        companyId: approval.companyId,
+        actorType: "user",
+        actorId: decidedByUserId,
+        action: "approval.requester_wakeup_failed",
+        entityType: "approval",
+        entityId: approval.id,
+        details: {
+          requesterAgentId: approval.requestedByAgentId,
+          linkedIssueIds,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+
   router.get("/companies/:companyId/approvals", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
@@ -198,12 +276,11 @@ export function approvalRoutes(
     if (applied) {
       const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
       const linkedIssueIds = linkedIssues.map((issue) => issue.id);
-      const primaryIssueId = linkedIssueIds[0] ?? null;
 
       await logActivity(db, {
         companyId: approval.companyId,
         actorType: "user",
-        actorId: req.actor.userId ?? "board",
+        actorId: decidedByUserId,
         action: "approval.approved",
         entityType: "approval",
         entityId: approval.id,
@@ -214,68 +291,13 @@ export function approvalRoutes(
         },
       });
 
-      if (approval.requestedByAgentId) {
-        try {
-          const wakeRun = await heartbeat.wakeup(approval.requestedByAgentId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "approval_approved",
-            payload: {
-              approvalId: approval.id,
-              approvalStatus: approval.status,
-              issueId: primaryIssueId,
-              issueIds: linkedIssueIds,
-            },
-            requestedByActorType: "user",
-            requestedByActorId: req.actor.userId ?? "board",
-            contextSnapshot: {
-              source: "approval.approved",
-              approvalId: approval.id,
-              approvalStatus: approval.status,
-              issueId: primaryIssueId,
-              issueIds: linkedIssueIds,
-              taskId: primaryIssueId,
-              wakeReason: "approval_approved",
-            },
-          });
-
-          await logActivity(db, {
-            companyId: approval.companyId,
-            actorType: "user",
-            actorId: req.actor.userId ?? "board",
-            action: "approval.requester_wakeup_queued",
-            entityType: "approval",
-            entityId: approval.id,
-            details: {
-              requesterAgentId: approval.requestedByAgentId,
-              wakeRunId: wakeRun?.id ?? null,
-              linkedIssueIds,
-            },
-          });
-        } catch (err) {
-          logger.warn(
-            {
-              err,
-              approvalId: approval.id,
-              requestedByAgentId: approval.requestedByAgentId,
-            },
-            "failed to queue requester wakeup after approval",
-          );
-          await logActivity(db, {
-            companyId: approval.companyId,
-            actorType: "user",
-            actorId: req.actor.userId ?? "board",
-            action: "approval.requester_wakeup_failed",
-            entityType: "approval",
-            entityId: approval.id,
-            details: {
-              requesterAgentId: approval.requestedByAgentId,
-              linkedIssueIds,
-              error: err instanceof Error ? err.message : String(err),
-            },
-          });
-        }
-      }
+      await queueRequesterWakeup({
+        approval,
+        reason: "approval_approved",
+        activitySource: "approval.approved",
+        decidedByUserId,
+        linkedIssueIds,
+      });
     }
 
     res.json(redactApprovalPayload(approval));
@@ -292,14 +314,25 @@ export function approvalRoutes(
     const { approval, applied } = await svc.reject(id, decidedByUserId, req.body.decisionNote);
 
     if (applied) {
+      const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
+      const linkedIssueIds = linkedIssues.map((issue) => issue.id);
+
       await logActivity(db, {
         companyId: approval.companyId,
         actorType: "user",
-        actorId: req.actor.userId ?? "board",
+        actorId: decidedByUserId,
         action: "approval.rejected",
         entityType: "approval",
         entityId: approval.id,
-        details: { type: approval.type },
+        details: { type: approval.type, linkedIssueIds },
+      });
+
+      await queueRequesterWakeup({
+        approval,
+        reason: "approval_rejected",
+        activitySource: "approval.rejected",
+        decidedByUserId,
+        linkedIssueIds,
       });
     }
 
@@ -319,14 +352,25 @@ export function approvalRoutes(
       const decidedByUserId = req.actor.userId ?? "board";
       const approval = await svc.requestRevision(id, decidedByUserId, req.body.decisionNote);
 
+      const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
+      const linkedIssueIds = linkedIssues.map((issue) => issue.id);
+
       await logActivity(db, {
         companyId: approval.companyId,
         actorType: "user",
-        actorId: req.actor.userId ?? "board",
+        actorId: decidedByUserId,
         action: "approval.revision_requested",
         entityType: "approval",
         entityId: approval.id,
-        details: { type: approval.type },
+        details: { type: approval.type, linkedIssueIds },
+      });
+
+      await queueRequesterWakeup({
+        approval,
+        reason: "approval_revision_requested",
+        activitySource: "approval.revision_requested",
+        decidedByUserId,
+        linkedIssueIds,
       });
 
       res.json(redactApprovalPayload(approval));

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -217,7 +217,7 @@ export function approvalService(db: Db) {
       }
 
       const now = new Date();
-      return db
+      const rows = await db
         .update(approvals)
         .set({
           status: "revision_requested",
@@ -226,9 +226,13 @@ export function approvalService(db: Db) {
           decidedAt: now,
           updatedAt: now,
         })
-        .where(eq(approvals.id, id))
-        .returning()
-        .then((rows) => rows[0]);
+        .where(and(eq(approvals.id, id), eq(approvals.status, "pending")))
+        .returning();
+      const updated = rows[0];
+      if (!updated) {
+        throw unprocessable("Only pending approvals can request revision");
+      }
+      return updated;
     },
 
     resubmit: async (id: string, payload?: Record<string, unknown>) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents request human approval for gated actions; humans decide via approve, reject, or request-revision, and agents resume work via heartbeat wakeups
> - Approval decisions only queued a requester wakeup on approve — reject and request-revision updated state but never called `heartbeat.wakeup()`
> - The requesting agent therefore sat idle after a reject/revision request until its next heartbeat poll, which is exactly when it most needs to react (rework or abandon the plan); on our production board this showed up as cards parked on human gates with idle agents
> - This pull request extracts a shared `queueRequesterWakeup()` helper and calls it on all three decision paths, and makes the request-revision status transition atomic so retried/concurrent decisions cannot double-wake
> - The benefit is that agents react to *any* approval decision immediately instead of only to approvals

## Linked Issues or Issue Description

No existing issue. Refs #4592 (related but distinct: comment-added wakeups; this PR covers decision wakeups).

**Bug description** (per bug_report template):
- **What happened:** After a human rejects or requests revision on an agent's approval, the requesting agent is not woken. It stays idle until its next heartbeat poll picks up the state change.
- **Expected:** The requesting agent is woken on any approval decision (approve / reject / request-revision), as it already is on approve (`wakeReason: "approval_approved"`).
- **Where:** `server/src/routes/approvals.ts` — reject and request-revision handlers update state and write activity log entries but never call `heartbeat.wakeup()`.
- **Impact:** Agent work stalls behind human gates; recovery is heartbeat-latency-bound.

## What Changed

- Extracted a shared `queueRequesterWakeup()` helper in `server/src/routes/approvals.ts` and call it from approve, reject, and request-revision, with per-path `wakeReason` values (`approval_approved` / `approval_rejected` / `approval_revision_requested`).
- Wakeup failures are logged (`approval.requester_wakeup_failed`) without failing the decision request, matching existing approve-path behavior.
- Made `requestRevision` in `server/src/services/approvals.ts` atomic: the `UPDATE` is now guarded by `status = 'pending'` and 422s when no row transitions, so concurrent/retried revision requests cannot double-apply or double-wake (approve/reject already had this via `resolveApproval`'s `applied` flag).
- Extended `server/src/__tests__/approval-routes-idempotency.test.ts`: wake-on-reject, wake-on-request-revision, no-wake when `requestedByAgentId` is null, and no re-wake on a request-revision retry.

## Verification

```sh
cd server
pnpm vitest run src/__tests__/approval-routes-idempotency.test.ts   # 15/15 pass
pnpm vitest run src/__tests__/approvals-service.test.ts             # 6/6 pass
pnpm exec tsc --noEmit -p tsconfig.json                             # clean
```

Behaviorally: reject or request revision on an agent-requested approval and observe an `approval.requester_wakeup_queued` activity entry and the requesting agent waking immediately instead of at its next heartbeat.

## Risks

- Low. No schema changes, no API contract changes (request-revision still 422s on non-pending approvals — the guard only closes the concurrent-request race).
- Behavioral shift: agents now wake immediately on reject/request-revision. This is the intended fix; wakeup failures are non-fatal and logged.
- The route-level wakeup predates this PR for approve; reject/request-revision reuse the identical mechanism.
- Field-tested: this fix has run in our production deployment since 2026-06-30, carried as a local patch across upgrades to v2026.720.0.

## Model Used

Claude Fable 5 (Anthropic, model ID `claude-fable-5`), via Claude Code — extended thinking, agentic tool use (tests executed against current `master` in a clean worktree). Human-reviewed and submitted by @nydamon.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none applicable — server-internal behavior fix)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
