### PR TITLE
fix(heartbeat): preserve resumable sessions on timeout

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -2710,6 +2710,60 @@ describe("resolveNextSessionState", () => {
     });
   });
 
+  it("adopts a canonical Hermes session emitted by a timeout but not by a generic failure", () => {
+    const timedOutResult = resolveNextSessionState({
+      adapterType: "hermes_local",
+      codec: truncatingHermesSessionCodec,
+      adapterResult: {
+        exitCode: null,
+        signal: "SIGTERM",
+        timedOut: true,
+        sessionParams: {
+          sessionId: "20260723_171700_timeout",
+        },
+        sessionDisplayId: "20260723_171700_",
+        errorMessage: "Timed out after 300s",
+      },
+      outcome: "timed_out",
+      previousParams: null,
+      previousDisplayId: null,
+      previousLegacySessionId: null,
+    });
+
+    expect(timedOutResult).toEqual({
+      params: {
+        sessionId: "20260723_171700_timeout",
+      },
+      displayId: "20260723_171700_timeout",
+      legacySessionId: "20260723_171700_timeout",
+    });
+
+    const failedResult = resolveNextSessionState({
+      adapterType: "hermes_local",
+      codec: truncatingHermesSessionCodec,
+      adapterResult: {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        sessionParams: {
+          sessionId: "20260723_171700_timeout",
+        },
+        sessionDisplayId: "20260723_171700_",
+        errorMessage: "Adapter failed",
+      },
+      outcome: "failed",
+      previousParams: null,
+      previousDisplayId: null,
+      previousLegacySessionId: null,
+    });
+
+    expect(failedResult).toEqual({
+      params: null,
+      displayId: null,
+      legacySessionId: null,
+    });
+  });
+
   it("drops poisoned previous Hermes session state instead of passing it to the next run", () => {
     const result = resolveNextSessionState({
       adapterType: "hermes_local",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6553,7 +6553,7 @@ export function resolveNextSessionState(input: {
     };
   };
 
-  if (input.outcome !== "succeeded") {
+  if (input.outcome !== "succeeded" && input.outcome !== "timed_out") {
     return previousState();
   }
 


### PR DESCRIPTION
## Thinking Path

- Traced Hermes task-session selection from adapter output through `resolveNextSessionState`.
- Confirmed the conservative canonical-session gate accepted fresh state only on `succeeded`, even though a timed-out Hermes process can emit a valid resumable session before termination.
- Kept generic failure, interruption, and cancellation behavior unchanged.

## Linked Issue(s) / Bug Report

Related to #9977, but narrower: #9977 hardens task-session persistence; this fixes selection of a newly emitted canonical Hermes session on a `timed_out` outcome.

Reproduction: return a valid Hermes session ID and params from an adapter result with `timedOut: true`. The run persists `timed_out`, but the next invocation receives the previous session (or no session) instead of the valid newly emitted one.

## What Changed

- Permit `timed_out` outcomes through the canonical-session validation path.
- Continue rejecting fresh session state from generic failures, cancellations, and interruptions.
- Add focused positive and negative resolver regressions.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts -t 'resolveNextSessionState'` — 6 passed.
- Full `heartbeat-workspace-session.test.ts` — 120 passed in independent review.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks / Rollout Notes

Low risk. The change is limited to canonical-session adapters and still requires the emitted Hermes session state to pass existing canonicalization and validation.

## Model Used

OpenAI Codex `gpt-5.6-sol` with repository inspection, test execution, and independent read-only review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: internal behavior only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
