### PR TITLE
fix(issues): suppress comment wakes on terminal transitions

### DIFF
--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -474,6 +474,44 @@ describe("issue update comment wakeups", () => {
     );
   });
 
+  it.each(["done", "cancelled"] as const)(
+    "does not wake the assignee when a board comment transitions the issue to %s",
+    async (status) => {
+      const existing = makeIssue({
+        assigneeAgentId: ASSIGNEE_AGENT_ID,
+        assigneeUserId: null,
+        status: "todo",
+      });
+      const updated = { ...existing, status };
+      mockIssueService.getById.mockResolvedValue(existing);
+      mockIssueService.update.mockResolvedValue(updated);
+      mockIssueService.addComment.mockResolvedValue({
+        id: `comment-${status}`,
+        issueId: existing.id,
+        companyId: existing.companyId,
+        body: `closing as ${status}`,
+      });
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${existing.id}`)
+        .send({
+          status,
+          comment: `closing as ${status}`,
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        existing.id,
+        expect.objectContaining({ status }),
+      );
+      expect(mockIssueService.addComment).toHaveBeenCalled();
+      await vi.waitFor(() => expect(mockIssueService.findMentionedAgents).toHaveBeenCalled());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    },
+    15_000,
+  );
+
   it("wakes the assignee on top-level board issue comments", async () => {
     const existing = makeIssue({
       assigneeAgentId: ASSIGNEE_AGENT_ID,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8666,7 +8666,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || isClosedIssueStatus(issue.status);
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {


### PR DESCRIPTION
## Thinking Path

- Traced the issue PATCH route's combined comment/status flow.
- The stale-assignee comment-wake predicate used the pre-update `isClosed` value, so `{ status: "done", comment: "..." }` could enqueue work after the issue was already terminal.
- The persisted post-update status is the authoritative gate; explicit reopen/resume branches remain unchanged.

## Linked Issue(s) / Bug Report

This is a current-master, narrowly scoped replacement for the route predicate in #6657, which is now conflicting and also bundles older heartbeat changes. It is related to, but does not claim to resolve, the broader terminal-comment semantics in #8749.

Reproduction: PATCH an assigned nonterminal issue with both a comment and `status: "done"` or `status: "cancelled"`. The request succeeds, then the stale assignee receives an asynchronous wake for terminal work.

## What Changed

- Gate stale-assignee comment wakes on the persisted post-update issue status.
- Add route regressions for both `done` and `cancelled` transitions.
- Give the cold-import route regressions an explicit timeout to avoid Vitest's 5-second default flake.

## Verification

- `issue-update-comment-wakeup-routes.test.ts` — 9 passed.
- Reopen route regression file — 72 passed in independent review.
- New terminal-transition cases passed five repeated runs under the explicit timeout in independent review.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks / Rollout Notes

Low risk. Active-issue comments and explicit reopen/resume behavior are unchanged. This only suppresses the stale-assignee wake when the persisted issue is terminal.

## Model Used

OpenAI Codex `gpt-5.6-sol` with repository inspection, test execution, and independent read-only review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: internal route behavior only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
