### PR TITLE
test(plugins): cover the never-a-wildcard invariant for proactive scope resolution

### DIFF
--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -617,6 +617,51 @@ describe("plugin proactive company scope (LOOA-629)", () => {
     }
   });
 
+  it("never injects a scope into a call that references no company (direct-companyId branch)", async () => {
+    // The "never a wildcard" invariant (#10103 review gap), direct-companyId
+    // derivation branch: a proactive call with no company reference must reach
+    // the gate scope-less. The gate classifies it as instance-level
+    // (kind "none") and passes params through verbatim — so the handler seeing
+    // NO companyId proves the manager did not inject one of its authorized
+    // companies into the call.
+    const { handle, companiesGet } = makeHandle();
+    try {
+      await handle.start();
+      handle.setProactiveCompanyScopes(["company-1"]);
+      await handle.call("getData", {
+        params: { mode: "omit", hostMethod: "companies.get" },
+      } as unknown as HostToWorkerMethods["getData"][0]);
+      expect(companiesGet).toHaveBeenCalledTimes(1);
+      const receivedParams = companiesGet.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect(receivedParams?.companyId).toBeUndefined();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("never grants a wildcard: company-scoped state.get with an empty scopeId stays denied scope-less", async () => {
+    // Same invariant via the scopeKind:"company" derivation branch — an empty
+    // scopeId must resolve to null (no proactive grant). The gate then
+    // escalates the empty-scopeId request to kind "all", which is denied. The
+    // message assertion is load-bearing: "company context is required" proves
+    // NO scope was granted, whereas a wrongly-injected grant would fail with
+    // 'the current invocation is scoped to company "company-1"' instead.
+    const { handle, stateGet } = makeHandle();
+    try {
+      await handle.start();
+      handle.setProactiveCompanyScopes(["company-1"]);
+      await expect(handle.call("getData", {
+        params: { mode: "omit", hostMethod: "state.get" },
+      } as unknown as HostToWorkerMethods["getData"][0])).rejects.toMatchObject({
+        code: PLUGIN_RPC_ERROR_CODES.INVOCATION_SCOPE_DENIED,
+        message: expect.stringContaining("company context is required"),
+      });
+      expect(stateGet).not.toHaveBeenCalled();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
   it("revokes proactive access when the authorized set is cleared", async () => {
     const { handle, companiesGet } = makeHandle();
     try {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins run as isolated worker processes; a governed-access gate scopes every worker→host call to a company context so no plugin can read or act beyond its authorization
> - Proactive plugins (e.g. a chat gateway) make worker→host calls from their own timers/loops, outside any host-issued invocation; #10103 taught the host to resolve a bounded company scope for such calls from the plugin's configured companies
> - The safety keystone of that design is the *never-a-wildcard* invariant: a proactive call that references no specific company must receive no scope grant at all — but that null path had no test coverage (flagged in #10103's review)
> - This pull request adds the two missing regression tests, one per company-derivation branch, so the invariant is enforced by CI rather than by code review memory
> - The benefit is that any future refactor that accidentally grants blanket or defaulted company scope to proactive plugin calls fails the suite immediately

## Linked Issues or Issue Description

- Refs #10103 — the proactive-scope mechanism this PR adds coverage for; its review noted the untested null path in `referencedCompanyId`
- No standalone issue exists; the underlying gap: `referencedCompanyId` is designed to return `null` for calls that reference no company (e.g. `companies.list`, instance-scoped `state.get`) so the proactive path never issues a blanket grant, but no test exercised either null branch

## What Changed

- Added `never injects a scope into a call that references no company (direct-companyId branch)`: a proactive `companies.get` with no company reference must reach the handler scope-less — asserted by the handler receiving params with no injected `companyId`
- Added `never grants a wildcard: company-scoped state.get with an empty scopeId stays denied scope-less`: an empty `scopeId` resolves to `null` (not to an authorized company) and is denied with `company context is required` — the message assertion is load-bearing, since a wrongly-injected grant would instead fail with `the current invocation is scoped to company "company-1"`
- Both cases drive the real worker subprocess fixture so resolution flows through the worker manager, matching the existing suite's approach

## Verification

- `cd server && pnpm vitest run src/__tests__/plugin-worker-manager.test.ts` → 20/20 passing (18 existing + 2 new)
- To see the tests catch a violation: hard-code `contextForWorkerMessage` to return an authorized scope for no-invocation calls — both new cases fail with the discriminating assertions

## Risks

- Low risk — test-only change; no production code modified

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), extended thinking, agentic tool use via Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (n/a — test-only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending on this push)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (re-review requested)
- [x] I will address all Greptile and reviewer comments before requesting merge