### PR TITLE
ui: default new issues to Ask mode, remember last-used work mode (SAG-7567)

### DIFF
--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -469,7 +469,7 @@ describe("NewIssueDialog", () => {
         goalId: "goal-1",
         projectId: "project-1",
         executionWorkspaceId: "workspace-1",
-        workMode: "standard",
+        workMode: "ask",
       }),
     );
 
@@ -790,7 +790,7 @@ describe("NewIssueDialog", () => {
       expect.objectContaining({
         title: "Typed issue",
         description: "Typed description",
-        workMode: "standard",
+        workMode: "ask",
       }),
     );
 
@@ -833,7 +833,7 @@ describe("NewIssueDialog", () => {
       expect.objectContaining({
         title,
         description,
-        workMode: "standard",
+        workMode: "ask",
       }),
     );
 
@@ -921,12 +921,22 @@ describe("NewIssueDialog", () => {
     await flush();
 
     const modeChip = () => container.querySelector("[data-issue-work-mode-chip]");
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("ask");
 
     await act(async () => {
       modeChip()?.dispatchEvent(new KeyboardEvent("keydown", {
         bubbles: true,
         code: "",
+        key: ".",
+        metaKey: true,
+      }));
+    });
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
+
+    await act(async () => {
+      modeChip()?.dispatchEvent(new KeyboardEvent("keydown", {
+        bubbles: true,
+        code: "Period",
         key: ".",
         metaKey: true,
       }));
@@ -943,16 +953,6 @@ describe("NewIssueDialog", () => {
     });
     expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("ask");
 
-    await act(async () => {
-      modeChip()?.dispatchEvent(new KeyboardEvent("keydown", {
-        bubbles: true,
-        code: "Period",
-        key: ".",
-        metaKey: true,
-      }));
-    });
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
-
     act(() => root.unmount());
   });
 
@@ -961,7 +961,7 @@ describe("NewIssueDialog", () => {
     await flush();
 
     const modeChip = () => container.querySelector("[data-issue-work-mode-chip]");
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("ask");
     expect(dialogContentState.onEscapeKeyDown).not.toBeNull();
 
     const commandPeriodAsEscape = new KeyboardEvent("keydown", {
@@ -975,7 +975,7 @@ describe("NewIssueDialog", () => {
     });
 
     expect(commandPeriodAsEscape.defaultPrevented).toBe(true);
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("planning");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
     expect(dialogState.closeNewIssue).not.toHaveBeenCalled();
 
     const plainEscape = new KeyboardEvent("keydown", {
@@ -988,7 +988,7 @@ describe("NewIssueDialog", () => {
     });
 
     expect(plainEscape.defaultPrevented).toBe(false);
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("planning");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
 
     const controlEscape = new KeyboardEvent("keydown", {
       bubbles: true,
@@ -1001,7 +1001,7 @@ describe("NewIssueDialog", () => {
     });
 
     expect(controlEscape.defaultPrevented).toBe(false);
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("planning");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
 
     act(() => root.unmount());
   });
@@ -1011,7 +1011,7 @@ describe("NewIssueDialog", () => {
     await flush();
 
     const modeChip = () => container.querySelector("[data-issue-work-mode-chip]");
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("ask");
 
     await act(async () => {
       modeChip()?.dispatchEvent(new KeyboardEvent("keydown", {
@@ -1021,7 +1021,7 @@ describe("NewIssueDialog", () => {
         ctrlKey: true,
       }));
     });
-    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("planning");
+    expect(modeChip()?.getAttribute("data-issue-work-mode-chip")).toBe("standard");
 
     act(() => root.unmount());
   });

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -168,6 +168,26 @@ function clearDraft() {
   localStorage.removeItem(DRAFT_KEY);
 }
 
+const WORK_MODE_PREF_KEY = "paperclip:work-mode-pref";
+
+function loadWorkModePref(): IssueWorkMode {
+  try {
+    const raw = localStorage.getItem(WORK_MODE_PREF_KEY);
+    if (raw && isIssueWorkMode(raw)) return raw;
+  } catch {
+    // ignore storage access errors
+  }
+  return "ask";
+}
+
+function saveWorkModePref(mode: IssueWorkMode) {
+  try {
+    localStorage.setItem(WORK_MODE_PREF_KEY, mode);
+  } catch {
+    // ignore storage access errors
+  }
+}
+
 function isTextDocumentFile(file: File) {
   const name = file.name.toLowerCase();
   return (
@@ -446,7 +466,7 @@ export function NewIssueDialog() {
   const [assigneeChrome, setAssigneeChrome] = useState(false);
   const [executionWorkspaceMode, setExecutionWorkspaceMode] = useState<string>("shared_workspace");
   const [selectedExecutionWorkspaceId, setSelectedExecutionWorkspaceId] = useState("");
-  const [workMode, setWorkMode] = useState<IssueWorkMode>("standard");
+  const [workMode, setWorkMode] = useState<IssueWorkMode>(() => loadWorkModePref());
   const [expanded, setExpanded] = useState(false);
   const [dialogCompanyId, setDialogCompanyId] = useState<string | null>(null);
   const [stagedFiles, setStagedFiles] = useState<StagedIssueFile[]>([]);
@@ -621,6 +641,7 @@ export function NewIssueDialog() {
             : undefined,
         });
       }
+      saveWorkModePref(workMode);
       clearDraft();
       reset();
       closeNewIssue();
@@ -757,7 +778,7 @@ export function NewIssueDialog() {
 
     const draft = loadDraft();
     if (newIssueDefaults.parentId) {
-      const nextWorkMode = isIssueWorkMode(newIssueDefaults.workMode) ? newIssueDefaults.workMode : "standard";
+      const nextWorkMode = isIssueWorkMode(newIssueDefaults.workMode) ? newIssueDefaults.workMode : loadWorkModePref();
       const defaultProjectId = newIssueDefaults.projectId ?? "";
       const defaultProject = orderedProjects.find((project) => project.id === defaultProjectId);
       const hasExplicitProjectWorkspaceId = newIssueDefaults.projectWorkspaceId !== undefined;
@@ -781,7 +802,7 @@ export function NewIssueDialog() {
         ? defaultProjectId || null
         : null;
     } else if (newIssueDefaults.title) {
-      const nextWorkMode = isIssueWorkMode(newIssueDefaults.workMode) ? newIssueDefaults.workMode : "standard";
+      const nextWorkMode = isIssueWorkMode(newIssueDefaults.workMode) ? newIssueDefaults.workMode : loadWorkModePref();
       setIssueText(newIssueDefaults.title, newIssueDefaults.description ?? "");
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
@@ -808,7 +829,7 @@ export function NewIssueDialog() {
         ? defaultProjectId || null
         : null;
     } else if (draft && draft.title.trim()) {
-      const nextWorkMode = isIssueWorkMode(draft.workMode) ? draft.workMode : "standard";
+      const nextWorkMode = isIssueWorkMode(draft.workMode) ? draft.workMode : loadWorkModePref();
       const restoredProjectId = newIssueDefaults.projectId ?? draft.projectId;
       const restoredProject = orderedProjects.find((project) => project.id === restoredProjectId);
       const hasExplicitProjectWorkspaceId = newIssueDefaults.projectWorkspaceId !== undefined;
@@ -857,7 +878,7 @@ export function NewIssueDialog() {
         ? restoredProjectId || null
         : null;
     } else {
-      setWorkMode("standard");
+      setWorkMode(isIssueWorkMode(newIssueDefaults.workMode) ? newIssueDefaults.workMode : loadWorkModePref());
       const defaultProjectId = newIssueDefaults.projectId ?? "";
       const defaultProject = orderedProjects.find((project) => project.id === defaultProjectId);
       const hasExplicitProjectWorkspaceId = newIssueDefaults.projectWorkspaceId !== undefined;
@@ -943,7 +964,7 @@ export function NewIssueDialog() {
     setAssigneeChrome(false);
     setExecutionWorkspaceMode("shared_workspace");
     setSelectedExecutionWorkspaceId("");
-    setWorkMode("standard");
+    setWorkMode(loadWorkModePref());
     setExpanded(false);
     setDialogCompanyId(null);
     setStagedFiles([]);


### PR DESCRIPTION
## Summary
- Default the New Issue dialog's work mode to **Ask**, and remember the user's last-used work mode across sessions via a new `paperclip:work-mode-pref` localStorage key.
- Precedence: explicit `newIssueDefaults.workMode` > restored unsent draft's `workMode` > remembered preference (default `ask` when nothing stored).
- Persist the preference on successful issue creation.
- Also fixed the dialog's "fresh, no defaults, no draft" branch (the path hit by the primary "New Issue" button/command-palette/mobile-nav entry points) to use the same precedence — this branch hardcoded `"standard"` and wasn't in the original spec's list of fallback sites, but leaving it untouched would have silently defeated the Ask-default and remembered-preference behavior for the most common entry point.

## Test plan
- [x] `pnpm --filter @paperclipai/ui typecheck` — clean
- [x] `pnpm exec vitest run src/components/NewIssueDialog.test.tsx` (from `ui/`) — 23/23 passed (6 pre-existing assertions updated to reflect the new Ask default/cycle order)
- [x] Manually traced all 4 work-mode-initialization branches (parentId, title, draft-restore, no-defaults) against the precedence rule

Ref: SAG-7567 / SAG-7562 / SAG-7557

🤖 Generated with [Claude Code](https://claude.com/claude-code)