### PR TITLE
feat(ui): Enter-to-send preference for issue/comment composer

### DIFF
--- a/ui/src/components/CommentThread.test.tsx
+++ b/ui/src/components/CommentThread.test.tsx
@@ -29,15 +29,17 @@ vi.mock("./MarkdownBody", () => ({
 }));
 
 vi.mock("./MarkdownEditor", () => ({
-  MarkdownEditor: ({ value, onChange, placeholder }: {
+  MarkdownEditor: ({ value, onChange, placeholder, submitOnEnter }: {
     value: string;
     onChange: (value: string) => void;
     placeholder?: string;
+    submitOnEnter?: boolean;
   }) => (
     <textarea
       aria-label="Comment editor"
       value={value}
       placeholder={placeholder}
+      data-submit-on-enter={submitOnEnter ? "true" : "false"}
       onChange={(event) => onChange(event.target.value)}
     />
   ),
@@ -162,6 +164,46 @@ describe("CommentThread", () => {
     expect(runLink?.textContent).toContain("run-1234");
     expect(runLink?.className).toContain("rounded-md");
     expect(runLink?.className).toContain("px-2");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("forwards the enter-to-send preference from localStorage to the composer", () => {
+    window.localStorage.setItem("paperclip.composer.enterToSend", "1");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <CommentThread comments={[]} onAdd={async () => {}} />
+        </MemoryRouter>,
+      );
+    });
+
+    const editor = container.querySelector('[aria-label="Comment editor"]');
+    expect(editor?.getAttribute("data-submit-on-enter")).toBe("true");
+
+    act(() => {
+      root.unmount();
+    });
+    window.localStorage.removeItem("paperclip.composer.enterToSend");
+  });
+
+  it("defaults the composer's enter-to-send preference to off", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <CommentThread comments={[]} onAdd={async () => {}} />
+        </MemoryRouter>,
+      );
+    });
+
+    const editor = container.querySelector('[aria-label="Comment editor"]');
+    expect(editor?.getAttribute("data-submit-on-enter")).toBe("false");
 
     act(() => {
       root.unmount();

--- a/ui/src/components/CommentThread.tsx
+++ b/ui/src/components/CommentThread.tsx
@@ -25,6 +25,7 @@ import { timeAgo } from "../lib/timeAgo";
 import { cn, formatDateTime } from "../lib/utils";
 import { restoreSubmittedCommentDraft } from "../lib/comment-submit-draft";
 import { PluginSlotOutlet } from "@/plugins/slots";
+import { useEnterToSendPreference } from "../hooks/useEnterToSendPreference";
 
 interface CommentWithRunMeta extends IssueComment {
   runId?: string | null;
@@ -776,6 +777,7 @@ export function CommentThread({
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const location = useLocation();
   const hasScrolledRef = useRef(false);
+  const [enterToSend] = useEnterToSendPreference();
 
   const timeline = useMemo<TimelineItem[]>(() => {
     const followUpCommentIds = new Set(
@@ -1034,6 +1036,7 @@ export function CommentThread({
             placeholder="Leave a comment..."
             mentions={mentions}
             onSubmit={handleSubmit}
+            submitOnEnter={enterToSend}
             imageUploadHandler={imageUploadHandler}
             contentClassName="min-h-(--sz-60px) text-sm"
           />

--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -104,6 +104,7 @@ vi.mock("./MarkdownEditor", () => ({
     className,
     contentClassName,
     fileDropTarget,
+    submitOnEnter,
   }: {
     value?: string;
     onChange?: (value: string) => void;
@@ -111,6 +112,7 @@ vi.mock("./MarkdownEditor", () => ({
     className?: string;
     contentClassName?: string;
     fileDropTarget?: "editor" | "parent";
+    submitOnEnter?: boolean;
   }, ref) => {
     useImperativeHandle(ref, () => ({
       focus: markdownEditorFocusMock,
@@ -122,6 +124,7 @@ vi.mock("./MarkdownEditor", () => ({
         data-class-name={className}
         data-content-class-name={contentClassName}
         data-file-drop-target={fileDropTarget}
+        data-submit-on-enter={submitOnEnter ? "true" : "false"}
         placeholder={placeholder}
         value={value}
         onChange={(event) => onChange?.(event.target.value)}
@@ -658,6 +661,62 @@ describe("IssueChatThread", () => {
     expect(composer?.getAttribute("data-pending-work-mode")).toBe("planning");
     expect(composer?.className).toContain("amber");
     expect(chip?.textContent).toContain("Plan mode");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("forwards the enter-to-send preference from localStorage to the composer", () => {
+    window.localStorage.setItem("paperclip.composer.enterToSend", "1");
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <IssueChatThread
+            comments={[]}
+            linkedRuns={[]}
+            timelineEvents={[]}
+            liveRuns={[]}
+            issueWorkMode="standard"
+            onAdd={async () => {}}
+            enableLiveTranscriptPolling={false}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    const editor = container.querySelector('[aria-label="Issue chat editor"]');
+    expect(editor?.getAttribute("data-submit-on-enter")).toBe("true");
+
+    act(() => {
+      root.unmount();
+    });
+    window.localStorage.removeItem("paperclip.composer.enterToSend");
+  });
+
+  it("defaults the composer's enter-to-send preference to off", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <MemoryRouter>
+          <IssueChatThread
+            comments={[]}
+            linkedRuns={[]}
+            timelineEvents={[]}
+            liveRuns={[]}
+            issueWorkMode="standard"
+            onAdd={async () => {}}
+            enableLiveTranscriptPolling={false}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    const editor = container.querySelector('[aria-label="Issue chat editor"]');
+    expect(editor?.getAttribute("data-submit-on-enter")).toBe("false");
 
     act(() => {
       root.unmount();

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -47,6 +47,7 @@ import type { ActiveRunForIssue, LiveRunForIssue } from "../api/heartbeats";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 import { useSecondTick } from "../hooks/useSecondTick";
 import { usePaperclipIssueRuntime, type PaperclipIssueRuntimeReassignment } from "../hooks/usePaperclipIssueRuntime";
+import { useEnterToSendPreference } from "../hooks/useEnterToSendPreference";
 import { useOptionalToastActions } from "../context/ToastContext";
 import { copyTextToClipboard } from "../lib/clipboard";
 import {
@@ -3564,6 +3565,7 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
   const composerContainerRef = useRef<HTMLDivElement | null>(null);
   const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const canAcceptFiles = Boolean(onImageUpload || onAttachImage);
+  const [enterToSend] = useEnterToSendPreference();
 
   function queueViewportRestore(snapshot: ReturnType<typeof captureComposerViewportSnapshot>) {
     if (!snapshot) return;
@@ -3931,6 +3933,7 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
         placeholder="Reply"
         mentions={mentions}
         onSubmit={handleSubmit}
+        submitOnEnter={enterToSend}
         imageUploadHandler={onImageUpload}
         fileDropTarget="parent"
         bordered={false}

--- a/ui/src/components/MarkdownEditor.test.tsx
+++ b/ui/src/components/MarkdownEditor.test.tsx
@@ -852,6 +852,7 @@ describe("MarkdownEditor", () => {
       },
     ],
     matchText = "Paperclip App",
+    extraProps: { onSubmit?: () => void; submitOnEnter?: boolean } = {},
   ): Promise<{ option: HTMLButtonElement; root: ReturnType<typeof createRoot>; menu: HTMLElement }> {
     const root = createRoot(container);
 
@@ -861,6 +862,7 @@ describe("MarkdownEditor", () => {
           value="@Pap"
           onChange={handleChange}
           mentions={mentions}
+          {...extraProps}
         />,
       );
     });
@@ -1114,6 +1116,226 @@ describe("MarkdownEditor", () => {
 
     await act(async () => {
       root.unmount();
+    });
+  });
+
+  describe("submitOnEnter", () => {
+    function dispatchEnter(
+      target: Element,
+      init: Partial<KeyboardEventInit> = {},
+    ): KeyboardEvent {
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      });
+      act(() => {
+        target.dispatchEvent(event);
+      });
+      return event;
+    }
+
+    async function renderRichEditor(props: {
+      onSubmit: () => void;
+      submitOnEnter?: boolean;
+      value?: string;
+    }) {
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          <MarkdownEditor
+            value={props.value ?? "Some reply text"}
+            onChange={() => {}}
+            onSubmit={props.onSubmit}
+            submitOnEnter={props.submitOnEnter}
+          />,
+        );
+      });
+      await flush();
+      const editorScope = container.querySelector('[data-testid="mdx-editor"]')?.parentElement;
+      expect(editorScope).toBeTruthy();
+      return { root, editorScope: editorScope! };
+    }
+
+    it("submits on plain Enter when submitOnEnter is enabled", async () => {
+      const onSubmit = vi.fn();
+      const { root, editorScope } = await renderRichEditor({ onSubmit, submitOnEnter: true });
+
+      const event = dispatchEnter(editorScope);
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(event.defaultPrevented).toBe(true);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("inserts a newline via Shift+Enter instead of submitting when submitOnEnter is enabled", async () => {
+      const onSubmit = vi.fn();
+      const { root, editorScope } = await renderRichEditor({ onSubmit, submitOnEnter: true });
+
+      const event = dispatchEnter(editorScope, { shiftKey: true });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("leaves plain Enter as a newline when submitOnEnter is disabled (default)", async () => {
+      const onSubmit = vi.fn();
+      const { root, editorScope } = await renderRichEditor({ onSubmit });
+
+      const event = dispatchEnter(editorScope);
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("always submits on Cmd/Ctrl+Enter regardless of submitOnEnter", async () => {
+      const onSubmitOff = vi.fn();
+      const { root: rootOff, editorScope: scopeOff } = await renderRichEditor({
+        onSubmit: onSubmitOff,
+        submitOnEnter: false,
+      });
+      dispatchEnter(scopeOff, { ctrlKey: true });
+      expect(onSubmitOff).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        rootOff.unmount();
+      });
+
+      const onSubmitOn = vi.fn();
+      const { root: rootOn, editorScope: scopeOn } = await renderRichEditor({
+        onSubmit: onSubmitOn,
+        submitOnEnter: true,
+      });
+      dispatchEnter(scopeOn, { metaKey: true });
+      expect(onSubmitOn).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        rootOn.unmount();
+      });
+    });
+
+    it("does not submit during IME composition even when submitOnEnter is enabled", async () => {
+      const onSubmit = vi.fn();
+      const { root, editorScope } = await renderRichEditor({ onSubmit, submitOnEnter: true });
+
+      const event = dispatchEnter(editorScope, { isComposing: true });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("keeps mention-menu Enter selection precedence and does not send", async () => {
+      const handleChange = vi.fn();
+      const onSubmit = vi.fn();
+      const { root } = await openMentionMenuFor(
+        handleChange,
+        undefined,
+        undefined,
+        { onSubmit, submitOnEnter: true },
+      );
+
+      const scope = container.querySelector('[data-testid="mdx-editor"]')?.parentElement;
+      expect(scope).toBeTruthy();
+
+      dispatchEnter(scope!);
+
+      expect(handleChange).toHaveBeenCalledWith(
+        `[@Paperclip App](${buildProjectMentionHref("project-123", "#336699")}) `,
+      );
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("submits on plain Enter in the raw-fallback textarea when submitOnEnter is enabled", async () => {
+      mdxEditorMockState.throwOnRender = true;
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const onSubmit = vi.fn();
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          <MarkdownEditor
+            value="Some reply text"
+            onChange={() => {}}
+            onSubmit={onSubmit}
+            submitOnEnter
+          />,
+        );
+      });
+      await vi.waitFor(() => {
+        expect(container.querySelector("textarea")).not.toBeNull();
+      });
+      const textarea = container.querySelector("textarea")!;
+
+      const submitEvent = dispatchEnter(textarea);
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(submitEvent.defaultPrevented).toBe(true);
+
+      onSubmit.mockClear();
+      const shiftEvent = dispatchEnter(textarea, { shiftKey: true });
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(shiftEvent.defaultPrevented).toBe(false);
+
+      onSubmit.mockClear();
+      const imeEvent = dispatchEnter(textarea, { isComposing: true });
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(imeEvent.defaultPrevented).toBe(false);
+
+      consoleError.mockRestore();
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("leaves plain Enter as a newline in the raw-fallback textarea when submitOnEnter is disabled", async () => {
+      mdxEditorMockState.throwOnRender = true;
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const onSubmit = vi.fn();
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          <MarkdownEditor
+            value="Some reply text"
+            onChange={() => {}}
+            onSubmit={onSubmit}
+          />,
+        );
+      });
+      await vi.waitFor(() => {
+        expect(container.querySelector("textarea")).not.toBeNull();
+      });
+      const textarea = container.querySelector("textarea")!;
+
+      const plainEvent = dispatchEnter(textarea);
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(plainEvent.defaultPrevented).toBe(false);
+
+      const modEvent = dispatchEnter(textarea, { ctrlKey: true });
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(modEvent.defaultPrevented).toBe(true);
+
+      consoleError.mockRestore();
+      await act(async () => {
+        root.unmount();
+      });
     });
   });
 });

--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -85,8 +85,15 @@ interface MarkdownEditorProps {
   bordered?: boolean;
   /** List of mentionable entities. Enables @-mention autocomplete. */
   mentions?: MentionOption[];
-  /** Called on Cmd/Ctrl+Enter */
+  /** Called on Cmd/Ctrl+Enter, and also on plain Enter when `submitOnEnter` is set. */
   onSubmit?: () => void;
+  /**
+   * When true, plain Enter submits (Shift+Enter inserts a newline) in addition
+   * to the always-on Cmd/Ctrl+Enter. Mention/skill autocomplete selection and
+   * IME composition still take precedence over submit. Defaults to false so
+   * existing Cmd/Ctrl+Enter-only behavior is unchanged.
+   */
+  submitOnEnter?: boolean;
   /** Render the rich editor without allowing edits. */
   readOnly?: boolean;
 }
@@ -146,6 +153,16 @@ function prepareMarkdownForEditor(value: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True while an IME composition is in progress (e.g. Japanese/Chinese/Korean
+ * input). The commit keystroke that closes the IME candidate window is often
+ * `Enter`, which must never submit — `isComposing` covers most browsers, and
+ * `keyCode === 229` is the historical fallback for the ones that don't set it.
+ */
+function isComposingKeyEvent(event: { nativeEvent?: { isComposing?: boolean }; keyCode?: number }): boolean {
+  return Boolean(event.nativeEvent?.isComposing) || event.keyCode === 229;
 }
 
 function hasMeaningfulEditorContent(node: Node | null): boolean {
@@ -631,6 +648,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
   bordered = true,
   mentions,
   onSubmit,
+  submitOnEnter = false,
   readOnly = false,
 }: MarkdownEditorProps, forwardedRef) {
   const editorValue = useMemo(() => prepareMarkdownForEditor(value), [value]);
@@ -1193,7 +1211,17 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           }}
           onBlur={() => onBlur?.()}
           onKeyDown={(event) => {
-            if (onSubmit && event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            if (!onSubmit || event.key !== "Enter") return;
+            if (event.metaKey || event.ctrlKey) {
+              event.preventDefault();
+              onSubmit();
+              return;
+            }
+            if (
+              submitOnEnter
+              && !event.shiftKey
+              && !isComposingKeyEvent(event)
+            ) {
               event.preventDefault();
               onSubmit();
             }
@@ -1272,6 +1300,24 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
               return;
             }
           }
+        }
+
+        // Plain Enter to submit — opt-in via `submitOnEnter`, and only when
+        // unmodified, not composing via IME, and the mention/skill menu isn't
+        // showing (mention selection above always keeps precedence).
+        if (
+          onSubmit
+          && submitOnEnter
+          && e.key === "Enter"
+          && !e.shiftKey
+          && !e.metaKey
+          && !e.ctrlKey
+          && !(mentionActive && filteredMentions.length > 0)
+          && !isComposingKeyEvent(e)
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          onSubmit();
         }
       }}
       onDragEnter={(evt) => {

--- a/ui/src/hooks/useEnterToSendPreference.ts
+++ b/ui/src/hooks/useEnterToSendPreference.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from "react";
+
+export const ENTER_TO_SEND_STORAGE_KEY = "paperclip.composer.enterToSend";
+
+function readStoredEnterToSend(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(ENTER_TO_SEND_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredEnterToSend(value: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ENTER_TO_SEND_STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    // Storage can be unavailable in private contexts; the in-memory value
+    // still works for the current session.
+  }
+}
+
+/**
+ * Per-user "Send message on Enter" preference for the issue-thread and
+ * comment composers (MarkdownEditor). Persisted to localStorage rather than
+ * an instance setting since it's a personal preference, not shared across a
+ * company. Default is off so existing Cmd/Ctrl+Enter behavior is unchanged
+ * until a user opts in. Synced across tabs via the `storage` event.
+ */
+export function useEnterToSendPreference(): [boolean, (next: boolean) => void] {
+  const [enterToSend, setEnterToSendState] = useState<boolean>(() => readStoredEnterToSend());
+
+  useEffect(() => {
+    function onStorage(event: StorageEvent) {
+      if (event.key !== ENTER_TO_SEND_STORAGE_KEY) return;
+      setEnterToSendState(event.newValue === "1");
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const setEnterToSend = useCallback((next: boolean) => {
+    setEnterToSendState(next);
+    writeStoredEnterToSend(next);
+  }, []);
+
+  return [enterToSend, setEnterToSend];
+}

--- a/ui/src/pages/InstanceGeneralSettings.tsx
+++ b/ui/src/pages/InstanceGeneralSettings.tsx
@@ -17,6 +17,7 @@ import { Card } from "@/components/ui/card";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { queryKeys } from "../lib/queryKeys";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { useEnterToSendPreference } from "@/hooks/useEnterToSendPreference";
 import { cn } from "../lib/utils";
 
 const FEEDBACK_TERMS_URL = import.meta.env.VITE_FEEDBACK_TERMS_URL?.trim() || "https://paperclip.ing/tos";
@@ -25,6 +26,7 @@ export function InstanceGeneralSettings() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
+  const [enterToSend, setEnterToSend] = useEnterToSendPreference();
 
   const signOutMutation = useMutation({
     mutationFn: () => authApi.signOut(),
@@ -170,6 +172,24 @@ export function InstanceGeneralSettings() {
             onCheckedChange={() => updateGeneralMutation.mutate({ keyboardShortcuts: !keyboardShortcuts })}
             disabled={updateGeneralMutation.isPending}
             aria-label="Toggle keyboard shortcuts"
+          />
+        </div>
+      </Card>
+
+      <Card className="block p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1.5">
+            <h2 className="text-sm font-semibold">Send message on Enter</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              In task and comment composers, Enter sends the message and Shift+Enter starts a new
+              line. Off by default, when Enter starts a new line and Cmd/Ctrl+Enter sends. This is
+              a personal preference saved on this device only.
+            </p>
+          </div>
+          <ToggleSwitch
+            checked={enterToSend}
+            onCheckedChange={() => setEnterToSend(!enterToSend)}
+            aria-label="Toggle send message on Enter"
           />
         </div>
       </Card>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-thread and comment composers (`MarkdownEditor`) are how users converse with agents and each other
> - Today, plain Enter always inserts a newline and only Cmd/Ctrl+Enter submits — some users expect chat-style Enter-to-send instead, and the conference-room `ChatComposer` already ships that behavior via a `submitKey` prop
> - Without this change, users who prefer Enter-to-send have no way to get that behavior in the issue/comment composers, and the two composer surfaces are inconsistent with each other
> - This pull request adds an opt-in, per-user "Send message on Enter" preference to `MarkdownEditor`, mirrors the existing `ChatComposer` `submitKey` decision logic, wires it into both composer surfaces, and adds a settings toggle
> - The benefit is a consistent, opt-in Enter-to-send experience across all composers, with zero behavior change for anyone who doesn't turn it on

## Linked Issues or Issue Description

No public GitHub issue exists for this yet, so per the feature-request template:

**Subsystem affected**

`ui/` — React + Vite board UI

**Problem or motivation**

The issue-thread and comment composers (`MarkdownEditor`) always require Cmd/Ctrl+Enter to submit; plain Enter only inserts a newline. The conference-room composer (`ChatComposer`) already supports a chat-style "Enter submits" mode via its `submitKey` prop, so the two composer surfaces behave inconsistently, and users who prefer Enter-to-send have no way to opt into it outside the conference room.

**Proposed solution**

Add an opt-in, per-user, `localStorage`-backed preference ("Send message on Enter") that mirrors `ChatComposer`'s existing `submitKey` logic. When enabled, plain Enter submits and Shift+Enter inserts a newline; Cmd/Ctrl+Enter always submits regardless of the setting; mention/skill autocomplete selection and IME composition keep precedence over submit. Default is off, so existing behavior is unchanged until a user opts in. A toggle is added to Instance Settings → General.

**Alternatives considered**

Making it a server-side/instance-wide setting (like `keyboardShortcutsEnabled`) was ruled out because Enter-to-send is a personal typing preference, not something an instance admin should force on all users.

**Roadmap alignment**

N/A — small, self-contained UX preference, not core roadmap work.

## What Changed

- Added `ui/src/hooks/useEnterToSendPreference.ts` — a new `localStorage`-backed hook (key `paperclip.composer.enterToSend`, default `false`) with cross-tab sync via the `storage` event, following the existing pattern in `ThemeContext.tsx`/`SidebarContext.tsx`.
- `ui/src/components/MarkdownEditor.tsx` — added a `submitOnEnter?: boolean` prop (default `false`). In both keydown paths (rich-editor `onKeyDownCapture` and the raw-fallback-textarea `onKeyDown`): Cmd/Ctrl+Enter always submits; plain Enter submits only when `submitOnEnter` is set, unmodified, not mid-IME-composition, and the mention/skill menu isn't open; Shift+Enter always inserts a newline.
- `ui/src/components/IssueChatThread.tsx`, `ui/src/components/CommentThread.tsx` — wired `submitOnEnter={enterToSend}` from the new hook into the composer.
- `ui/src/pages/InstanceGeneralSettings.tsx` — added a "Send message on Enter" toggle card next to the existing "Keyboard shortcuts" control.
- `ui/src/components/MarkdownEditor.test.tsx` (new cases), `ui/src/components/IssueChatThread.test.tsx`, `ui/src/components/CommentThread.test.tsx` — coverage for all behaviors below.

## Verification

`pnpm --filter @paperclipai/ui exec vitest run src/components/MarkdownEditor.test.tsx src/components/IssueChatThread.test.tsx src/components/CommentThread.test.tsx` — 128 passed:

```
 Test Files  1 passed (1)
      Tests  45 passed (45)
(MarkdownEditor.test.tsx)

 Test Files  2 passed (2)
      Tests  83 passed (83)
(IssueChatThread.test.tsx + CommentThread.test.tsx)
```

New `MarkdownEditor.test.tsx` cases (both the rich-editor and raw-fallback-textarea paths) cover:
- (a) Enter sends when `submitOnEnter` is enabled
- (b) Shift+Enter inserts a newline (no submit) when enabled
- (c) Enter is a no-op/newline when `submitOnEnter` is disabled (default)
- (d) Cmd/Ctrl+Enter always submits regardless of the setting
- (e) mention-menu Enter still selects and does not submit
- (f) IME-composition Enter does not submit

`IssueChatThread.test.tsx` / `CommentThread.test.tsx` add plumbing tests confirming the `localStorage` preference is forwarded to the composer as `submitOnEnter`, defaulting to off.

`pnpm --filter @paperclipai/ui typecheck` — clean (no output, `tsc -b` exit 0).

Note: this repo currently has no `lint` script for `@paperclipai/ui` (no ESLint config present), so that item doesn't apply.

**Not done:** screenshots/GIF of the toggle + both behaviors. The only reachable dev environment in this run was the live production instance backing the agent session (already-built, different checkout) — starting a second dev server against that shared DB to capture UI screenshots was judged too risky to attempt here. Happy to add these separately if a reviewer needs them before merge.

## Risks

- Low risk. The new behavior is entirely opt-in and defaults to off, so no existing user sees any behavior change unless they explicitly enable the preference.
- Mention/skill autocomplete and IME composition were explicitly guarded and covered by tests so Enter-to-send can't hijack those interactions.
- Purely client-side (`localStorage`), no server/API/schema changes, no migration risk.

## Model Used

Claude Code Executor (Sonnet), interacting with the `ui/` workspace via the Claude Code CLI/agent harness with standard tool use (file read/edit, shell/test execution). No extended-thinking/other-provider models were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
