### PR TITLE
fix(recovery): hand off blocked deliverable work

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -15,6 +15,8 @@ import {
 import { runningProcesses } from "../adapters/index.js";
 import { heartbeatService } from "../services/heartbeat.ts";
 import { SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY } from "../services/recovery/index.ts";
+import { RECOVERY_REASON_KINDS } from "../services/recovery/origins.ts";
+import { withRecoveryModelProfileHint } from "../services/recovery/model-profile-hint.ts";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -407,6 +409,198 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       recoveryActionId,
       wakeReason: "issue_recovery_action_restored",
       source: "issue.recovery_action_resolution",
+    });
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(runId);
+  });
+
+  it("coalesces concurrent cheap-recovery deliverable handoffs into one deferred normal-model wake", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+    const reason = RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff;
+    const idempotencyKey = [reason, issueId, runId].join(":");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Recovery Agent",
+      role: "engineer",
+      status: "running",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        modelProfile: "cheap",
+        recoveryIntent: "status_only",
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      },
+    });
+    runningProcesses.set(runId, {
+      child: {} as never,
+      graceSec: 0,
+      processGroupId: null,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Publish recovery evidence",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+      executionAgentNameKey: "recovery-agent",
+      executionLockedAt: new Date(),
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const handoffContext = withRecoveryModelProfileHint({
+      issueId,
+      taskId: issueId,
+      sourceRunId: runId,
+      forceFreshSession: true,
+      wakeReason: reason,
+      handoffIntent: "publish_existing_workspace_evidence",
+      livenessContinuationSourceRunId: runId,
+      livenessContinuationState: "pending_deliverable_work",
+      livenessContinuationReason: reason,
+      livenessContinuationInstruction: "Continue with the normal model and publish the pending artifact.",
+    }, "normal_model");
+    const enqueue = () => heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason,
+      idempotencyKey,
+      payload: handoffContext,
+      contextSnapshot: handoffContext,
+      requestedByActorType: "system",
+      requestedByActorId: "issue_routes",
+    });
+
+    const results = await Promise.all([enqueue(), enqueue()]);
+
+    expect(results).toEqual([null, null]);
+    const deferred = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.status, "deferred_issue_execution"),
+        eq(agentWakeupRequests.idempotencyKey, idempotencyKey),
+      ));
+    expect(deferred).toHaveLength(1);
+    expect(deferred[0]?.reason).toBe("issue_execution_deferred");
+
+    await db
+      .update(agentWakeupRequests)
+      .set({
+        idempotencyKey: "existing-cheap-deferred-wake",
+        payload: {
+          ...(deferred[0]?.payload as Record<string, unknown>),
+          modelProfile: "cheap",
+          recoveryIntent: "status_only",
+          allowDeliverableWork: false,
+          allowDocumentUpdates: false,
+          resumeRequiresNormalModel: true,
+          _paperclipWakeContext: {
+            issueId,
+            taskId: issueId,
+            modelProfile: "cheap",
+            recoveryIntent: "status_only",
+            allowDeliverableWork: false,
+            allowDocumentUpdates: false,
+            resumeRequiresNormalModel: true,
+          },
+        },
+      })
+      .where(eq(agentWakeupRequests.id, deferred[0]!.id));
+
+    expect(await enqueue()).toBeNull();
+    const laterComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorUserId: "user-1",
+        body: "Please also publish the pending evidence.",
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    expect(await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: laterComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: laterComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "user-1",
+    })).toBeNull();
+
+    const recoalesced = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.agentId, agentId),
+        eq(agentWakeupRequests.status, "deferred_issue_execution"),
+      ));
+    expect(recoalesced).toHaveLength(1);
+
+    const payload = recoalesced[0]?.payload as Record<string, unknown>;
+    const deferredContext = payload._paperclipWakeContext as Record<string, unknown>;
+    for (const context of [payload, deferredContext]) {
+      expect(context).not.toHaveProperty("modelProfile");
+      expect(context).not.toHaveProperty("paperclipModelProfile");
+      expect(context).not.toHaveProperty("recoveryIntent");
+      expect(context).not.toHaveProperty("allowDeliverableWork");
+      expect(context).not.toHaveProperty("allowDocumentUpdates");
+      expect(context).not.toHaveProperty("resumeRequiresNormalModel");
+    }
+    expect(deferredContext).toMatchObject({
+      issueId,
+      taskId: issueId,
+      sourceRunId: runId,
+      forceFreshSession: true,
+      wakeReason: reason,
+      handoffIntent: "publish_existing_workspace_evidence",
+      livenessContinuationSourceRunId: runId,
+      livenessContinuationState: "pending_deliverable_work",
+      livenessContinuationReason: reason,
+      livenessContinuationInstruction: "Continue with the normal model and publish the pending artifact.",
+      commentId: laterComment.id,
     });
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -46,6 +46,32 @@ describe("heartbeat model profile application", () => {
     expect(merged).toEqual({ model: "primary" });
   });
 
+  it("ignores a persisted cheap issue override for the normal deliverable handoff", () => {
+    const expected = {
+      requested: null,
+      requestedBy: null,
+      applied: null,
+      configSource: null,
+      fallbackReason: null,
+      adapterConfig: null,
+    };
+
+    for (const contextSnapshot of [
+      { wakeReason: "cheap_recovery_deliverable_handoff" },
+      {
+        wakeReason: "issue_commented",
+        livenessContinuationReason: "cheap_recovery_deliverable_handoff",
+      },
+    ]) {
+      expect(resolveModelProfileApplication({
+        adapterModelProfiles: [cheapProfile],
+        agentRuntimeConfig: {},
+        issueModelProfile: "cheap",
+        contextSnapshot,
+      })).toEqual(expected);
+    }
+  });
+
   it("applies cheap profile patches before explicit issue adapter config overrides", () => {
     const modelProfile = resolveModelProfileApplication({
       adapterModelProfiles: [cheapProfile],

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -33,10 +33,13 @@ import {
   heartbeatService,
   resolveModelProfileApplication,
 } from "../services/heartbeat.ts";
+import { withRecoveryModelProfileHint } from "../services/recovery/model-profile-hint.ts";
+import { RECOVERY_REASON_KINDS } from "../services/recovery/origins.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
+let providerQuotaExecutionGate: Promise<void> | null = null;
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -69,20 +72,23 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     heartbeat = heartbeatService(db);
     registerServerAdapter({
       type: PROVIDER_QUOTA_TEST_ADAPTER,
-      execute: async () => ({
-        exitCode: 1,
-        signal: null,
-        timedOut: false,
-        errorMessage: "You've hit your session limit - resets at 4pm (America/Chicago).",
-        errorCode: "provider_quota",
-        errorFamily: "provider_quota",
-        retryNotBefore: "2030-04-22T21:00:00.000Z",
-        resultJson: {
+      execute: async () => {
+        await providerQuotaExecutionGate;
+        return {
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage: "You've hit your session limit - resets at 4pm (America/Chicago).",
+          errorCode: "provider_quota",
           errorFamily: "provider_quota",
           retryNotBefore: "2030-04-22T21:00:00.000Z",
-          providerQuotaRetryNotBefore: "2030-04-22T21:00:00.000Z",
-        },
-      }),
+          resultJson: {
+            errorFamily: "provider_quota",
+            retryNotBefore: "2030-04-22T21:00:00.000Z",
+            providerQuotaRetryNotBefore: "2030-04-22T21:00:00.000Z",
+          },
+        };
+      },
       testEnvironment: async () => ({
         adapterType: PROVIDER_QUOTA_TEST_ADAPTER,
         status: "pass",
@@ -100,6 +106,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     // when teardown starts. The cleanup deletes issues before heartbeat_runs, so
     // a late write races the deletes and can deadlock or break a foreign key.
     await drainHeartbeatRunsToQuiescence(db, heartbeat);
+    providerQuotaExecutionGate = null;
     await cleanupRetryFixture();
   });
 
@@ -331,6 +338,144 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         { timeout: 5_000, interval: 50 },
       )
       .toEqual({ status: "idle", errorReason: null });
+  });
+
+  it("keeps restricted quota retries guarded and defers the normal handoff until the reset-time retry runs", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const reason = RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff;
+    let releaseExecution = () => {};
+    providerQuotaExecutionGate = new Promise<void>((resolve) => {
+      releaseExecution = resolve;
+    });
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Restricted Quota Test",
+        role: "engineer",
+        status: "idle",
+        adapterType: PROVIDER_QUOTA_TEST_ADAPTER,
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+          modelProfiles: { cheap: { enabled: true, adapterConfig: {} } },
+        },
+        permissions: {},
+      });
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Publish recovered evidence after quota reset",
+        status: "todo",
+        priority: "medium",
+        responsibleUserId: "responsible-user",
+        assigneeAgentId: agentId,
+        assigneeAdapterOverrides: { modelProfile: "cheap" },
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const restrictedContext = withRecoveryModelProfileHint({
+        issueId,
+        taskId: issueId,
+        wakeReason: "finish_successful_run_handoff",
+      }, "status_only");
+      const run = await heartbeat.invoke(agentId, "on_demand", restrictedContext, "manual");
+      expect(run).not.toBeNull();
+      await expect.poll(
+        () => heartbeat.getRun(run!.id).then((current) => current?.status),
+        { timeout: 5_000, interval: 50 },
+      ).toBe("running");
+
+      const normalHandoffContext = withRecoveryModelProfileHint({
+        issueId,
+        taskId: issueId,
+        sourceRunId: run!.id,
+        forceFreshSession: true,
+        wakeReason: reason,
+        livenessContinuationReason: reason,
+        livenessContinuationInstruction: "Publish the recovered evidence with the normal model.",
+      }, "normal_model");
+      expect(await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason,
+        idempotencyKey: [reason, issueId, run!.id].join(":"),
+        payload: normalHandoffContext,
+        contextSnapshot: normalHandoffContext,
+        requestedByActorType: "system",
+        requestedByActorId: "test",
+      })).toBeNull();
+
+      releaseExecution();
+      providerQuotaExecutionGate = null;
+      const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+      expect(failedRun?.status).toBe("failed");
+
+      await expect.poll(
+        () => db
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+          .then((rows) => rows.length),
+        { timeout: 5_000, interval: 50 },
+      ).toBe(1);
+      const retryRun = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.retryOfRunId, run!.id))
+        .then((rows) => rows[0]!);
+      expect(retryRun.status).toBe("scheduled_retry");
+      expect(retryRun.scheduledRetryAt?.toISOString()).toBe("2030-04-22T21:00:00.000Z");
+      expect(retryRun.contextSnapshot).toMatchObject({
+        modelProfile: "cheap",
+        recoveryIntent: "status_only",
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      });
+
+      const deferred = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "deferred_issue_execution"),
+        ));
+      expect(deferred).toHaveLength(1);
+      expect((deferred[0]?.payload as Record<string, unknown>)._paperclipWakeContext).toMatchObject({
+        forceFreshSession: true,
+        livenessContinuationReason: reason,
+      });
+      const executionIssue = await db
+        .select({ executionRunId: issues.executionRunId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]);
+      expect(executionIssue?.executionRunId).toBe(retryRun.id);
+      const immediateSuccessors = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(and(
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          inArray(heartbeatRuns.status, ["queued", "running"]),
+        ));
+      expect(immediateSuccessors).toEqual([]);
+    } finally {
+      releaseExecution();
+      providerQuotaExecutionGate = null;
+    }
   });
 
   async function seedMaxTurnFixture(input?: {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -31,6 +31,7 @@ import {
   MAX_TURN_CONTINUATION_RETRY_REASON,
   MAX_TURN_CONTINUATION_WAKE_REASON,
   heartbeatService,
+  resolveModelProfileApplication,
 } from "../services/heartbeat.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -216,11 +217,13 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   it("records provider quota failures, schedules the reset-time retry, and leaves the agent idle", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
 
     await db.insert(companies).values({
       id: companyId,
       name: "Paperclip",
-      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      issuePrefix,
       requireBoardApprovalForNewAgents: false,
       defaultResponsibleUserId: "responsible-user",
     });
@@ -238,11 +241,37 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
           wakeOnDemand: true,
           maxConcurrentRuns: 1,
         },
+        modelProfiles: {
+          cheap: {
+            enabled: true,
+            adapterConfig: {},
+          },
+        },
       },
       permissions: {},
     });
 
-    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Publish recovered evidence after quota reset",
+      status: "todo",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      assigneeAdapterOverrides: { modelProfile: "cheap" },
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {
+      issueId,
+      taskId: issueId,
+      forceFreshSession: true,
+      wakeReason: "cheap_recovery_deliverable_handoff",
+      livenessContinuationReason: "cheap_recovery_deliverable_handoff",
+      livenessContinuationInstruction: "Publish the recovered evidence with the normal model.",
+    }, "manual");
     expect(run).not.toBeNull();
 
     const failedRun = await waitForRunToFinish(heartbeat, run!.id);
@@ -281,6 +310,15 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       "2030-04-22T21:00:00.000Z",
     );
     expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.codexTransientFallbackMode ?? null).toBeNull();
+    expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.livenessContinuationReason).toBe(
+      "cheap_recovery_deliverable_handoff",
+    );
+    expect(resolveModelProfileApplication({
+      adapterModelProfiles: [{ key: "cheap", enabled: true, adapterConfig: { model: "cheap-model" } }],
+      agentRuntimeConfig: {},
+      issueModelProfile: "cheap",
+      contextSnapshot: retryRun?.contextSnapshot as Record<string, unknown> | null,
+    })).toMatchObject({ requested: null, applied: null });
 
     await expect
       .poll(

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -36,6 +36,7 @@ import {
   resolveWorkspaceAfterLowTrustPreflight,
   resolveRuntimeSessionParamsForWorkspace,
   shouldDeferFollowupWakeForSameIssue,
+  shouldQueueFollowupForRunningIssueWake,
   stripHostWorkspaceProvisionForLowTrustSandbox,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForModelChange,
@@ -1917,6 +1918,17 @@ describe("shouldDeferFollowupWakeForSameIssue", () => {
         forceFreshSession: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldQueueFollowupForRunningIssueWake", () => {
+  it("keeps a cheap-recovery deliverable handoff out of the active cheap run", () => {
+    expect(
+      shouldQueueFollowupForRunningIssueWake({
+        contextSnapshot: { wakeReason: "cheap_recovery_deliverable_handoff" },
+        wakeCommentId: null,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -298,11 +298,17 @@ function createRunContextDb(
     if (keys.includes("entityId")) return [];
     if (keys.includes("contextSnapshot")) return runRows;
     if (keys.includes("agentCompanyId")) return runRows;
+    if (keys.length === 2 && keys.includes("id") && keys.includes("status")) {
+      return mockHeartbeatService.wakeup.mock.calls.length > 0
+        ? [{ id: "deliverable-handoff-wake-1", status: "deferred_issue_execution" }]
+        : [];
+    }
     return [{ id: runAgentId, companyId: runAgentCompanyId, permissions: {}, role: "engineer", reportsTo: null }];
   };
   const buildQuery = (selection: Record<string, unknown>) => {
     const rows = rowsForSelection(selection);
     const whereResult = {
+      limit: vi.fn(() => whereResult),
       orderBy: vi.fn(async () => []),
       limit: vi.fn(() => ({
         then: async (resolve: (limitedRows: unknown[]) => unknown) => resolve(rows),
@@ -1190,6 +1196,100 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.removeAttachment).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.link).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.unlink).not.toHaveBeenCalled();
+  });
+
+  it("keeps cheap artifact uploads denied while arranging one deduplicated normal-model handoff", async () => {
+    const app = await createApp(
+      ownerActor(),
+      createRunContextDb({
+        modelProfile: "cheap",
+        recoveryIntent: "status_only",
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      }),
+    );
+    const upload = () => request(app)
+      .post(`/api/companies/${companyId}/issues/${issueId}/attachments`)
+      .attach("file", Buffer.from("report"), { filename: "report.txt", contentType: "text/plain" });
+
+    const first = await upload();
+    const second = await upload();
+
+    expect(first.status, JSON.stringify(first.body)).toBe(403);
+    expect(second.status, JSON.stringify(second.body)).toBe(403);
+    expect(first.body.error).toBe(
+      "Cheap status-only recovery runs cannot update issue documents, plans, or deliverable artifacts",
+    );
+    expect(mockStorageService.putFile).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ownerAgentId,
+      expect.objectContaining({
+        source: "automation",
+        triggerDetail: "system",
+        reason: "cheap_recovery_deliverable_handoff",
+        idempotencyKey: `cheap_recovery_deliverable_handoff:${issueId}:${ownerRunId}`,
+        payload: expect.objectContaining({
+          issueId,
+          sourceRunId: ownerRunId,
+          forceFreshSession: true,
+          handoffIntent: "publish_existing_workspace_evidence",
+          livenessContinuationSourceRunId: ownerRunId,
+          livenessContinuationState: "pending_deliverable_work",
+          livenessContinuationReason: "cheap_recovery_deliverable_handoff",
+          livenessContinuationInstruction: expect.stringContaining("complete the pending deliverable work"),
+        }),
+        contextSnapshot: expect.objectContaining({
+          issueId,
+          taskId: issueId,
+          sourceRunId: ownerRunId,
+          forceFreshSession: true,
+          wakeReason: "cheap_recovery_deliverable_handoff",
+          handoffIntent: "publish_existing_workspace_evidence",
+          livenessContinuationSourceRunId: ownerRunId,
+          livenessContinuationState: "pending_deliverable_work",
+          livenessContinuationReason: "cheap_recovery_deliverable_handoff",
+          livenessContinuationInstruction: expect.stringContaining("complete the pending deliverable work"),
+        }),
+      }),
+    );
+    const wakeupOptions = mockHeartbeatService.wakeup.mock.calls[0]?.[1] as {
+      payload: Record<string, unknown>;
+      contextSnapshot: Record<string, unknown>;
+    };
+    for (const context of [wakeupOptions.payload, wakeupOptions.contextSnapshot]) {
+      expect(context).not.toHaveProperty("modelProfile");
+      expect(context).not.toHaveProperty("paperclipModelProfile");
+      expect(context).not.toHaveProperty("recoveryIntent");
+      expect(context).not.toHaveProperty("allowDeliverableWork");
+      expect(context).not.toHaveProperty("allowDocumentUpdates");
+      expect(context).not.toHaveProperty("resumeRequiresNormalModel");
+      expect(context).not.toHaveProperty("resumeFromRunId");
+      expect(context).not.toHaveProperty("resumeIntent");
+    }
+  }, 20_000);
+
+  it("fails closed without masking a normal-model handoff persistence failure", async () => {
+    mockHeartbeatService.wakeup.mockRejectedValueOnce(new Error("handoff persistence failed"));
+    const app = await createApp(
+      ownerActor(),
+      createRunContextDb({
+        modelProfile: "cheap",
+        recoveryIntent: "status_only",
+        allowDeliverableWork: false,
+        allowDocumentUpdates: false,
+        resumeRequiresNormalModel: true,
+      }),
+    );
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues/${issueId}/attachments`)
+      .attach("file", Buffer.from("report"), { filename: "report.txt", contentType: "text/plain" });
+
+    expect(res.status).toBe(500);
+    expect(mockStorageService.putFile).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/server/src/__tests__/issue-document-restore-routes.test.ts
+++ b/server/src/__tests__/issue-document-restore-routes.test.ts
@@ -155,19 +155,25 @@ function registerModuleMocks() {
 
 function createRunContextDb(contextSnapshot: Record<string, unknown>) {
   return {
-    select: vi.fn(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          then: async (resolve: (rows: unknown[]) => unknown) =>
-            resolve([{
-              id: "run-1",
-              companyId,
-              agentId: "agent-1",
-              contextSnapshot,
-            }]),
+    select: vi.fn((selection?: Record<string, unknown>) => {
+      const rows = Object.keys(selection ?? {}).includes("contextSnapshot")
+        ? [{
+            id: "run-1",
+            companyId,
+            agentId: "agent-1",
+            contextSnapshot,
+          }]
+        : [];
+      const query = {
+        then: async (resolve: (value: unknown[]) => unknown) => resolve(rows),
+        limit: vi.fn(async () => rows),
+      };
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn(() => query),
         })),
-      })),
-    })),
+      };
+    }),
   };
 }
 
@@ -381,6 +387,7 @@ describe("issue document revision routes", () => {
     expect(res.status).toBe(403);
     expect(res.body.error).toContain("Cheap status-only recovery runs cannot update issue documents");
     expect(mockDocumentsService.restoreIssueDocumentRevision).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
   });
 
   it("rejects invalid document keys before attempting restore", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6,6 +6,7 @@ import { and, asc, desc, eq, inArray, isNull, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
+  agentWakeupRequests,
   agents,
   approvals,
   companyMemberships,
@@ -199,6 +200,8 @@ import {
 } from "../services/issues.js";
 import { authorizationDeniedDetails } from "../services/authorization.js";
 import { stalledReviewDecisionService } from "../services/stalled-review-decisions.js";
+import { RECOVERY_REASON_KINDS } from "../services/recovery/origins.js";
+import { withRecoveryModelProfileHint } from "../services/recovery/model-profile-hint.js";
 import { environmentService } from "../services/environments.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -250,6 +253,12 @@ import {
 } from "../services/cross-issue-influence-limit.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const CHEAP_RECOVERY_DELIVERABLE_HANDOFF_IDEMPOTENT_WAKE_STATUSES = [
+  "queued",
+  "deferred_issue_execution",
+  "claimed",
+  "completed",
+];
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
@@ -4900,6 +4909,62 @@ export function issueRoutes(
     };
   }
 
+  async function ensureCheapRecoveryDeliverableHandoff(input: {
+    issue: { id: string; companyId: string };
+    run: {
+      id: string;
+      companyId: string;
+      agentId: string;
+      contextSnapshot: unknown;
+    };
+  }) {
+    const reason = RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff;
+    const idempotencyKey = [reason, input.issue.id, input.run.id].join(":");
+    const existingWake = await db
+      .select({ id: agentWakeupRequests.id, status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, input.issue.companyId),
+        eq(agentWakeupRequests.idempotencyKey, idempotencyKey),
+        inArray(agentWakeupRequests.status, CHEAP_RECOVERY_DELIVERABLE_HANDOFF_IDEMPOTENT_WAKE_STATUSES),
+      ))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (existingWake) return;
+
+    const instruction =
+      "The cheap status-only recovery lane found deliverable work but was correctly denied permission. " +
+      "Continue with the normal model using the existing issue workspace evidence, complete the pending deliverable work, " +
+      "publish any required artifact, and update the issue with the resulting deliverable state.";
+    const handoffContext = {
+      issueId: input.issue.id,
+      taskId: input.issue.id,
+      taskKey: input.issue.id,
+      sourceIssueId: input.issue.id,
+      sourceRunId: input.run.id,
+      forceFreshSession: true,
+      followUpRequested: true,
+      wakeReason: reason,
+      handoffIntent: "publish_existing_workspace_evidence",
+      livenessContinuationSourceRunId: input.run.id,
+      livenessContinuationState: "pending_deliverable_work",
+      livenessContinuationReason: reason,
+      livenessContinuationInstruction: instruction,
+    };
+    const normalHandoffContext = withRecoveryModelProfileHint(handoffContext, "normal_model");
+
+    await heartbeat.wakeup(input.run.agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason,
+      idempotencyKey,
+      payload: normalHandoffContext,
+      contextSnapshot: normalHandoffContext,
+      requestedByActorType: "system",
+      requestedByActorId: "issue_routes",
+    });
+  }
+
   async function assertCheapRecoveryIssueAssigneeProfileAllowed(
     req: Request,
     res: Response,
@@ -4932,6 +4997,7 @@ export function issueRoutes(
     if (!run) return true;
     if (!isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
 
+    await ensureCheapRecoveryDeliverableHandoff({ issue, run });
     res.status(403).json({
       error: "Cheap status-only recovery runs cannot update issue documents, plans, or deliverable artifacts",
       details: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3534,6 +3534,16 @@ function isCheapRecoveryDeliverableHandoffContext(
   );
 }
 
+function isStatusOnlyCheapRecoveryContext(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+) {
+  return readContextModelProfile(contextSnapshot) === "cheap" &&
+    readNonEmptyString(contextSnapshot?.recoveryIntent) === "status_only" &&
+    contextSnapshot?.allowDeliverableWork === false &&
+    contextSnapshot?.allowDocumentUpdates === false &&
+    contextSnapshot?.resumeRequiresNormalModel === true;
+}
+
 export function normalizeModelProfileWakeContext(input: {
   contextSnapshot: Record<string, unknown>;
   payload: Record<string, unknown> | null | undefined;
@@ -11322,7 +11332,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const shouldQuarantineWorkspaceForRetry =
       workspaceValidationRetryPayload !== null &&
       Object.keys(workspaceValidationRetryPayload).length > 0;
-    const retryContextSnapshot: Record<string, unknown> = withRecoveryModelProfileHint({
+    const retryContextSeed: Record<string, unknown> = {
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason,
@@ -11346,7 +11356,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
         : {}),
       ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
-    }, "normal_model");
+    };
+    const retryContextSnapshot: Record<string, unknown> = isStatusOnlyCheapRecoveryContext(contextSnapshot)
+      ? withRecoveryModelProfileHint(retryContextSeed, "status_only")
+      : withRecoveryModelProfileHint(retryContextSeed, "normal_model");
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const continuationRetryIdempotencyKey = retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
       ? `max-turn-continuation:${run.companyId}:${issueId ?? "no-issue"}:${run.id}:${schedule.attempt}`
@@ -16950,6 +16963,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .then((rows) => rows[0] ?? null);
 
         if (!deferred) break;
+
+        // A bounded retry scheduled by the finalizing run already owns this
+        // issue's next execution slot. Keep later deferred work durable until
+        // that retry runs (or exhausts) so provider retryNotBefore/backoff
+        // cannot be bypassed by immediate deferred-wake promotion.
+        const existingExecutionPath = await tx
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(
+            and(
+              eq(heartbeatRuns.companyId, issue.companyId),
+              inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+              sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+              sql`${heartbeatRuns.id} <> ${run.id}`,
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (existingExecutionPath) break;
 
         const deferredAgent = await tx
           .select()

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -210,6 +210,7 @@ import {
 } from "./execution-allowlist.js";
 import {
   RECOVERY_ORIGIN_KINDS,
+  RECOVERY_REASON_KINDS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   RUN_LIVENESS_CONTINUATION_REASON,
@@ -745,6 +746,7 @@ function mergeAdapterRecoveryMetadata(input: {
 }
 const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
   "approval_approved",
+  RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff,
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
   "issue_recovery_action_restored",
 ]);
@@ -3521,6 +3523,17 @@ function readContextModelProfile(
   return readModelProfileKey(contextSnapshot?.modelProfile);
 }
 
+function isCheapRecoveryDeliverableHandoffContext(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+) {
+  return (
+    readNonEmptyString(contextSnapshot?.wakeReason) ===
+      RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff ||
+    readNonEmptyString(contextSnapshot?.livenessContinuationReason) ===
+      RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff
+  );
+}
+
 export function normalizeModelProfileWakeContext(input: {
   contextSnapshot: Record<string, unknown>;
   payload: Record<string, unknown> | null | undefined;
@@ -3556,7 +3569,10 @@ export function resolveModelProfileApplication(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   profileResolutionFallbackReason?: string | null;
 }): ModelProfileApplication {
-  const issueModelProfile = input.issueModelProfile ?? null;
+  const isNormalDeliverableHandoff = isCheapRecoveryDeliverableHandoffContext(input.contextSnapshot);
+  const issueModelProfile = isNormalDeliverableHandoff
+    ? null
+    : input.issueModelProfile ?? null;
   const contextModelProfile = readContextModelProfile(input.contextSnapshot);
   const requested = issueModelProfile ?? contextModelProfile;
   const requestedBy: ModelProfileRequestSource | null = issueModelProfile
@@ -5285,7 +5301,7 @@ export function shouldAutoCheckoutIssueForWake(input: {
   return true;
 }
 
-function shouldQueueFollowupForRunningIssueWake(input: {
+export function shouldQueueFollowupForRunningIssueWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   wakeCommentId: string | null;
 }) {
@@ -18371,12 +18387,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 existingDeferredContext,
                 enrichedContextSnapshot,
               );
-              const mergedDeferredPayload = {
+              const preservesNormalDeliverableHandoff =
+                isCheapRecoveryDeliverableHandoffContext(existingDeferredContext) ||
+                isCheapRecoveryDeliverableHandoffContext(enrichedContextSnapshot);
+              const stickyMergedDeferredContext = preservesNormalDeliverableHandoff
+                ? {
+                    ...mergedDeferredContext,
+                    wakeReason: RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff,
+                  }
+                : mergedDeferredContext;
+              const safeMergedDeferredContext =
+                preservesNormalDeliverableHandoff
+                  ? withRecoveryModelProfileHint(stickyMergedDeferredContext, "normal_model")
+                  : stickyMergedDeferredContext;
+              const mergedDeferredPayloadBase = {
                 ...existingDeferredPayload,
                 ...(payload ?? {}),
                 issueId,
-                [DEFERRED_WAKE_CONTEXT_KEY]: mergedDeferredContext,
+                [DEFERRED_WAKE_CONTEXT_KEY]: safeMergedDeferredContext,
               };
+              const mergedDeferredPayload =
+                preservesNormalDeliverableHandoff
+                  ? withRecoveryModelProfileHint(mergedDeferredPayloadBase, "normal_model")
+                  : mergedDeferredPayloadBase;
 
               await tx
                 .update(agentWakeupRequests)

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -6,6 +6,7 @@ export const RECOVERY_ORIGIN_KINDS = {
 } as const;
 
 export const RECOVERY_REASON_KINDS = {
+  cheapRecoveryDeliverableHandoff: "cheap_recovery_deliverable_handoff",
   runLivenessContinuation: "run_liveness_continuation",
 } as const;
 

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -15,6 +15,7 @@ import {
   isSuccessfulRunHandoffRequiredNoticeBody,
   noticeMetadataReferencesRecoveryAction,
 } from "./successful-run-handoff.js";
+import { RECOVERY_REASON_KINDS } from "./origins.js";
 import { UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON } from "@paperclipai/adapter-utils/server-utils";
 
 const run = {
@@ -382,6 +383,31 @@ describe("successful run handoff decision", () => {
           issueId: "issue-1",
           wakeReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
           handoffRequired: true,
+        },
+      } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "source run is already a corrective handoff run",
+    });
+  });
+
+  it.each([
+    {
+      wakeReason: RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff,
+      livenessContinuationReason: RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff,
+    },
+    {
+      wakeReason: "issue_commented",
+      livenessContinuationReason: RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff,
+    },
+  ])("does not loop from a normal deliverable handoff after $wakeReason", (contextSnapshot) => {
+    expect(decide({
+      run: {
+        ...run,
+        id: "run-deliverable-handoff",
+        contextSnapshot: {
+          issueId: "issue-1",
+          ...contextSnapshot,
         },
       } as any,
     })).toEqual({

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -10,6 +10,7 @@ import {
   runLinkRow,
   systemNoticePresentation,
 } from "./notice-format.js";
+import { RECOVERY_REASON_KINDS } from "./origins.js";
 
 export const FINISH_SUCCESSFUL_RUN_HANDOFF_REASON = "finish_successful_run_handoff";
 export const SUCCESSFUL_RUN_MISSING_STATE_REASON = "successful_run_missing_state";
@@ -318,8 +319,12 @@ function fenceUntrustedText(value: string) {
 
 function isCorrectiveHandoffRun(run: HeartbeatRunRow) {
   const context = readRecord(run.contextSnapshot);
+  const wakeReason = readString(context.wakeReason);
+  const livenessContinuationReason = readString(context.livenessContinuationReason);
   return context.handoffRequired === true ||
-    readString(context.wakeReason) === FINISH_SUCCESSFUL_RUN_HANDOFF_REASON;
+    wakeReason === FINISH_SUCCESSFUL_RUN_HANDOFF_REASON ||
+    wakeReason === RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff ||
+    livenessContinuationReason === RECOVERY_REASON_KINDS.cheapRecoveryDeliverableHandoff;
 }
 
 // A run woken by source_scoped_recovery_action must not become the source of another


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane that assigns AI-agent work, runs heartbeats, and records durable task state.
> - Recovery orchestration has a cheap status-only lane for bounded liveness repair and a normal-model lane for deliverable work.
> - PR #6371 correctly prevents the cheap lane from writing documents, plans, work products, or attachment artifacts.
> - A denied attachment upload proved deliverable work remained, but Paperclip returned 403 without arranging the required normal-model successor.
> - Relaxing the cheap lane would violate least privilege, so the denial and the successor handoff must remain separate invariants.
> - This pull request keeps the 403, records one idempotent deferred normal-model continuation, preserves workspace continuity, forces a fresh unrestricted session, and scrubs every cheap/status-only hint.
> - The benefit is that existing evidence can be published without granting deliverable permissions to the recovery lane or losing work at the authorization boundary.

## Linked Issues or Issue Description

Refs #6371

Related: #9586 covers broader stopped-work repair and recovery authority but does not arrange a normal-model handoff after a denied artifact/deliverable mutation. Current master and open PRs were searched immediately before filing; no open PR implements this handoff.

### Pre-submission checklist

- [x] I searched existing open and closed issues/PRs and found no exact duplicate.
- [x] I reproduced this on current `master`.
- [x] I confirmed the error originates in Paperclip's recovery/heartbeat orchestration, not an adapter, provider, or local configuration.

### What happened?

A cheap successful-run recovery wake carried `allowDeliverableWork: false`, `allowDocumentUpdates: false`, and `resumeRequiresNormalModel: true`. When the authenticated run attempted to upload an existing workspace artifact, Paperclip correctly returned HTTP 403. However, it did not arrange a separate normal-model continuation, so the evidence remained in the workspace with no capable successor path.

### Expected behavior

The upload must remain forbidden and must not mutate storage. The denial must also synchronously arrange one durable normal-model successor for the same issue/agent, defer it until the active cheap run exits, start a fresh normal-model session against the existing issue workspace, surface the pending-deliverable instruction, and remove all cheap/status-only model and permission hints.

### Steps to reproduce

1. Start a successful-run corrective wake using Paperclip's generated cheap/status-only recovery context.
2. Let the run find existing workspace evidence that must be attached to the issue.
3. POST that attachment as the authenticated run.
4. Observe the intended HTTP 403 but, before this change, no separate normal-model wake capable of completing the pending deliverable work.

### Environment

- Paperclip commit: `81f47e70a6296fa9e4dd1855646641b0c42a6c2d`
- Deployment mode: self-hosted server
- Installation method: built from source
- Adapter observed: Hermes; root cause is adapter-independent core orchestration
- Database mode: not database-related
- Access context: agent bearer API key
- Node.js: `v22.22.3`
- Operating system: Linux
- Relevant output: redacted HTTP 403 stating that cheap status-only recovery runs cannot update deliverable artifacts
- Privacy: all instance-local issue IDs, agent IDs, paths, URLs, and task content were omitted or redacted.

## What Changed

- Keep the existing cheap status-only deliverable guard and 403 response unchanged.
- On a denied deliverable mutation, arrange an idempotent `cheap_recovery_deliverable_handoff:{issueId}:{cheapRunId}` continuation for the same issue and agent.
- Classify that wake as requiring a separate follow-up so it becomes `deferred_issue_execution` instead of coalescing into the active cheap run.
- Preserve the source run for traceability and reuse the existing issue workspace, but force a fresh session so a restricted/cheap session cannot leak into deliverable work.
- Ignore the recovery issue's persisted cheap model-profile override for this normal handoff reason.
- Carry the pending-deliverable instruction through Paperclip's rendered liveness-continuation fields.
- Scrub cheap model and guard hints both on initial enqueue and when merging into an existing deferred wake.
- Keep the normal-handoff marker sticky through later comment coalescing and provider-quota retries so the persisted cheap issue override cannot reassert itself.
- Propagate wake-persistence failures as 500 responses while still preventing attachment storage, so callers can retry instead of silently losing the handoff.
- Classify the normal deliverable successor as a corrective handoff, including after comment coalescing, so its successful completion cannot recursively schedule another cheap status-only cleanup cycle.
- Preserve the complete cheap/status-only denial contract on bounded retries of the restricted source run.
- Keep the deferred normal successor behind any scheduled provider-quota retry, so `retryNotBefore` remains authoritative and deferred promotion cannot replace the retry's issue lock.
- Add route, heartbeat-classification, concurrent durable-coalescing, prompt-context, model-hint, and quota-retry regressions.

## Verification

- RED before implementation:
  - the route regression failed because no normal-model wake was arranged after the 403;
  - the heartbeat regression failed because the new reason was not classified as a separate follow-up.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-document-restore-routes.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts server/src/__tests__/heartbeat-model-profile.test.ts server/src/__tests__/heartbeat-retry-scheduling.test.ts server/src/services/recovery/model-profile-hint.test.ts server/src/services/recovery/successful-run-handoff.test.ts` — 8 files, 265 tests passed.
- A focused embedded-Postgres regression proves concurrent attempts yield one durable deferred wake and that coalescing over an existing cheap deferred context cannot resurrect restricted hints.
- `git diff --check` — passed.
- The focused suites emit existing intentional warning-path logs and late background-cleanup diagnostics while passing all assertions.

## Risks

- No permission elevation: the cheap request still returns 403 and cannot write storage, documents, plans, or work products.
- The denied route now has a bounded orchestration side effect. It is restricted to an authenticated active-run owner and uses the existing heartbeat wake service and agent-start serialization.
- Concurrent or repeated requests coalesce into one durable deferred wake. A dedicated merge scrub prevents an older cheap deferred context from contaminating the normal successor.
- If arranging the successor fails, the mutation still fails closed with a 500 so callers can retry rather than receiving a misleading completed denial.
- Restricted-run retries retain every status-only denial flag; normal-handoff retries retain their durable marker; and a deferred normal handoff remains deferred behind the provider reset-time retry instead of bypassing quota timing.
- No schema, migration, API response, or adapter-specific changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex `gpt-5.6-sol` was used with reasoning, repository/file tools, shell command execution, embedded-Postgres tests, and delegated independent architecture/code review. The runtime did not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (existing recovery-lane documentation already defines the intended split)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
