### PR TITLE
Add read-only Nylas mailbox plugin

### DIFF
--- a/packages/plugins/plugin-nylas-mailbox/.gitignore
+++ b/packages/plugins/plugin-nylas-mailbox/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.paperclip-sdk

--- a/packages/plugins/plugin-nylas-mailbox/README.md
+++ b/packages/plugins/plugin-nylas-mailbox/README.md
@@ -1,0 +1,43 @@
+# Nylas Finance Mailbox
+
+First-party Paperclip connector that gives company agents read-only access to one Nylas mailbox. The default mailbox boundary is the `finance@` grant supplied for this deployment.
+
+Every request uses the grant stored in company plugin configuration. Tool schemas do not accept a grant ID, so an agent cannot redirect a request to another mailbox. The Nylas API key comes from the server-side `PAPERCLIP_NYLAS` environment variable by default. A company-specific Paperclip secret reference can override that environment value and is resolved only while a tool call is running.
+
+## Tools
+
+- `nylas_search_messages` — search finance-mailbox messages with bounded filters and pagination
+- `nylas_get_message` — read one message, including body and attachment metadata
+- `nylas_read_thread` — read thread metadata plus its messages
+- `nylas_list_attachments` — list attachments on a message
+- `nylas_download_attachment` — return a size-capped attachment as base64
+
+The plugin intentionally exposes no send, reply, update, move, or delete operation.
+
+## Configure
+
+Install the built plugin from the Paperclip Plugins page or from the repository root:
+
+```bash
+pnpm --filter @paperclipai/plugin-nylas-mailbox build
+pnpm paperclipai plugin install ./packages/plugins/plugin-nylas-mailbox
+```
+
+Then open the plugin settings for the active company and set:
+
+- **Nylas API key** — optional when `PAPERCLIP_NYLAS` is present in the Paperclip server environment; select a Paperclip company secret here to override the environment value for this company.
+- **Finance mailbox grant ID** — defaults to `29eb5cbe-1129-42b9-93c9-53061483bb8c`.
+- **Nylas API region** — `us` by default; choose `eu` only when the Nylas application is hosted in the EU region.
+- **Maximum attachment download size** — defaults to 1 MB and is capped at 5 MB. Downloaded bytes are returned to the invoking agent as base64.
+
+The Nylas grant needs provider read scopes. Current Nylas documentation specifies at least `gmail.readonly` for Google or `Mail.Read` for Microsoft for message and attachment reads.
+
+## Development
+
+```bash
+pnpm --filter @paperclipai/plugin-nylas-mailbox typecheck
+pnpm --filter @paperclipai/plugin-nylas-mailbox test
+pnpm --filter @paperclipai/plugin-nylas-mailbox build
+```
+
+This is a trusted first-party plugin. It requests only outbound HTTP, optional company secret-reference resolution, and agent-tool registration capabilities. Environment and secret values are never returned in tool results or logs.

--- a/packages/plugins/plugin-nylas-mailbox/esbuild.config.mjs
+++ b/packages/plugins/plugin-nylas-mailbox/esbuild.config.mjs
@@ -1,0 +1,16 @@
+import esbuild from "esbuild";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets();
+const watch = process.argv.includes("--watch");
+
+const workerCtx = await esbuild.context(presets.esbuild.worker);
+const manifestCtx = await esbuild.context(presets.esbuild.manifest);
+
+if (watch) {
+  await Promise.all([workerCtx.watch(), manifestCtx.watch()]);
+  console.log("esbuild watch mode enabled for worker and manifest");
+} else {
+  await Promise.all([workerCtx.rebuild(), manifestCtx.rebuild()]);
+  await Promise.all([workerCtx.dispose(), manifestCtx.dispose()]);
+}

--- a/packages/plugins/plugin-nylas-mailbox/package.json
+++ b/packages/plugins/plugin-nylas-mailbox/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@paperclipai/plugin-nylas-mailbox",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Read-only access to one configured Nylas mailbox for finance workflows.",
+  "scripts": {
+    "prebuild": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "node ./esbuild.config.mjs",
+    "dev": "node ./esbuild.config.mjs --watch",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "connector"
+  ],
+  "author": "Paperclip",
+  "license": "MIT",
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21",
+    "esbuild": "^0.28.1",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/plugins/plugin-nylas-mailbox/src/manifest.ts
+++ b/packages/plugins/plugin-nylas-mailbox/src/manifest.ts
@@ -1,0 +1,135 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+export const PLUGIN_ID = "paperclip.nylas-mailbox";
+export const FINANCE_GRANT_ID = "29eb5cbe-1129-42b9-93c9-53061483bb8c";
+export const DEFAULT_MAX_ATTACHMENT_BYTES = 1_000_000;
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Nylas Finance Mailbox",
+  description: "Read-only search, message, thread, and attachment access to one configured Nylas mailbox for finance workflows.",
+  author: "Paperclip",
+  categories: ["connector"],
+  capabilities: [
+    "agent.tools.register",
+    "http.outbound",
+    "secrets.read-ref",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      apiKey: {
+        type: "object",
+        format: "secret-ref",
+        title: "Nylas API key",
+        description: "Optional company-specific secret reference. When omitted, the plugin uses the server-side PAPERCLIP_NYLAS environment variable.",
+      },
+      grantId: {
+        type: "string",
+        title: "Finance mailbox grant ID",
+        description: "The only Nylas grant this plugin may access. Agents cannot override it.",
+        pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        default: FINANCE_GRANT_ID,
+      },
+      apiRegion: {
+        type: "string",
+        title: "Nylas API region",
+        enum: ["us", "eu"],
+        default: "us",
+      },
+      maxAttachmentBytes: {
+        type: "integer",
+        title: "Maximum attachment download size",
+        description: "Maximum raw bytes returned by the attachment download tool. Downloaded content is returned as base64.",
+        minimum: 1,
+        maximum: 5_000_000,
+        default: DEFAULT_MAX_ATTACHMENT_BYTES,
+      },
+    },
+    additionalProperties: false,
+  },
+  tools: [
+    {
+      name: "nylas_search_messages",
+      displayName: "Search Finance Mailbox",
+      description: "Search messages in the configured finance mailbox. This tool cannot access another Nylas grant.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          limit: { type: "integer", minimum: 1, maximum: 20, description: "Messages to return. Defaults to 20." },
+          pageToken: { type: "string", maxLength: 2_000, description: "Pagination token from a previous result." },
+          subject: { type: "string", maxLength: 500 },
+          anyEmail: { type: "string", maxLength: 2_000, description: "Comma-separated email addresses matched across sender and recipients." },
+          fromEmail: { type: "string", maxLength: 320 },
+          toEmail: { type: "string", maxLength: 320 },
+          unread: { type: "boolean" },
+          hasAttachment: { type: "boolean" },
+          receivedAfter: { type: "integer", minimum: 0, description: "Unix timestamp in seconds." },
+          receivedBefore: { type: "integer", minimum: 0, description: "Unix timestamp in seconds." },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "nylas_get_message",
+      displayName: "Read Finance Message",
+      description: "Read one message, including its body and attachment metadata, from the configured finance mailbox.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          messageId: { type: "string", minLength: 1, maxLength: 2_000 },
+        },
+        required: ["messageId"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "nylas_read_thread",
+      displayName: "Read Finance Thread",
+      description: "Read a thread and its messages from the configured finance mailbox.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          threadId: { type: "string", minLength: 1, maxLength: 2_000 },
+          limit: { type: "integer", minimum: 1, maximum: 50, description: "Messages to return. Defaults to 50." },
+        },
+        required: ["threadId"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "nylas_list_attachments",
+      displayName: "List Finance Message Attachments",
+      description: "List attachment metadata for one message in the configured finance mailbox.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          messageId: { type: "string", minLength: 1, maxLength: 2_000 },
+        },
+        required: ["messageId"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "nylas_download_attachment",
+      displayName: "Download Finance Attachment",
+      description: "Download a size-capped attachment from one message in the configured finance mailbox and return it as base64.",
+      parametersSchema: {
+        type: "object",
+        properties: {
+          messageId: { type: "string", minLength: 1, maxLength: 2_000 },
+          attachmentId: { type: "string", minLength: 1, maxLength: 2_000 },
+        },
+        required: ["messageId", "attachmentId"],
+        additionalProperties: false,
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/plugin-nylas-mailbox/src/worker.ts
+++ b/packages/plugins/plugin-nylas-mailbox/src/worker.ts
@@ -1,0 +1,499 @@
+import { Buffer } from "node:buffer";
+import {
+  definePlugin,
+  runWorker,
+  type EnvSecretRefBinding,
+  type PluginContext,
+  type ToolResult,
+  type ToolRunContext,
+} from "@paperclipai/plugin-sdk";
+import { DEFAULT_MAX_ATTACHMENT_BYTES, FINANCE_GRANT_ID } from "./manifest.js";
+
+const GRANT_ID_PATTERN = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const API_BASES = {
+  us: "https://api.us.nylas.com",
+  eu: "https://api.eu.nylas.com",
+} as const;
+const MAX_CONFIGURED_ATTACHMENT_BYTES = 5_000_000;
+const MAX_BODY_CHARS = 200_000;
+
+type NylasRecord = Record<string, unknown>;
+type NylasRegion = keyof typeof API_BASES;
+
+type NylasConfig = {
+  apiKey: EnvSecretRefBinding | null;
+  grantId: string;
+  apiRegion: NylasRegion;
+  maxAttachmentBytes: number;
+};
+
+function isRecord(value: unknown): value is NylasRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isSecretRef(value: unknown): value is EnvSecretRefBinding {
+  return isRecord(value)
+    && value.type === "secret_ref"
+    && typeof value.secretId === "string"
+    && value.secretId.length > 0;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function environmentApiKey(): string {
+  return readString(process.env.PAPERCLIP_NYLAS) || readString(process.env.paperclip_nylas);
+}
+
+function readRegion(value: unknown): NylasRegion {
+  const region = readString(value) || "us";
+  if (region !== "us" && region !== "eu") {
+    throw new Error("Nylas API region must be either us or eu.");
+  }
+  return region;
+}
+
+function readAttachmentLimit(value: unknown): number {
+  if (value === undefined || value === null || value === "") return DEFAULT_MAX_ATTACHMENT_BYTES;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_CONFIGURED_ATTACHMENT_BYTES) {
+    throw new Error(`Maximum attachment size must be a whole number between 1 and ${MAX_CONFIGURED_ATTACHMENT_BYTES}.`);
+  }
+  return parsed;
+}
+
+function validateConfig(config: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  if (config.apiKey !== undefined && config.apiKey !== null && !isSecretRef(config.apiKey)) {
+    errors.push("Configure the Nylas API key as a Paperclip company secret, never as a raw config value.");
+  } else if (!isSecretRef(config.apiKey) && !environmentApiKey()) {
+    errors.push("Configure a Nylas API-key company secret or set PAPERCLIP_NYLAS in the Paperclip server environment.");
+  }
+
+  const grantId = readString(config.grantId) || FINANCE_GRANT_ID;
+  if (!GRANT_ID_PATTERN.test(grantId)) {
+    errors.push("Configure a valid UUID Nylas grant ID for the finance mailbox.");
+  }
+
+  try {
+    readRegion(config.apiRegion);
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+  }
+
+  try {
+    readAttachmentLimit(config.maxAttachmentBytes);
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error));
+  }
+  return errors;
+}
+
+function requireCompanyId(runCtx: ToolRunContext): string {
+  const companyId = runCtx.companyId?.trim();
+  if (!companyId) throw new Error("Nylas tools require a company-scoped agent run.");
+  return companyId;
+}
+
+async function readConfig(ctx: PluginContext, companyId: string): Promise<NylasConfig> {
+  const raw = await ctx.config.get(companyId);
+  const errors = validateConfig(raw);
+  if (errors.length > 0) throw new Error(errors.join(" "));
+
+  return {
+    apiKey: isSecretRef(raw.apiKey) ? raw.apiKey : null,
+    grantId: readString(raw.grantId) || FINANCE_GRANT_ID,
+    apiRegion: readRegion(raw.apiRegion),
+    maxAttachmentBytes: readAttachmentLimit(raw.maxAttachmentBytes),
+  };
+}
+
+function requiredId(value: unknown, name: string): string {
+  const id = readString(value);
+  if (!id || id.length > 2_000) throw new Error(`${name} must be a non-empty string of 2,000 characters or fewer.`);
+  return id;
+}
+
+function optionalString(value: unknown, name: string, maxLength: number): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "string") throw new Error(`${name} must be a string.`);
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  if (normalized.length > maxLength) throw new Error(`${name} must be ${maxLength} characters or fewer.`);
+  return normalized;
+}
+
+function optionalBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value !== "boolean") throw new Error(`${name} must be true or false.`);
+  return value;
+}
+
+function integerInRange(value: unknown, fallback: number, min: number, max: number, name: string): number {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be a whole number between ${min} and ${max}.`);
+  }
+  return parsed;
+}
+
+function optionalUnixTimestamp(value: unknown, name: string): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${name} must be a non-negative Unix timestamp in seconds.`);
+  return parsed;
+}
+
+function appendQuery(url: URL, key: string, value: string | number | boolean | undefined): void {
+  if (value !== undefined) url.searchParams.set(key, String(value));
+}
+
+function errorText(payload: unknown, status: number): string {
+  if (!isRecord(payload)) return `HTTP ${status}`;
+  const nested = isRecord(payload.error) ? payload.error : null;
+  const type = readString(nested?.type) || readString(nested?.code) || readString(payload.type);
+  const message = readString(nested?.message) || readString(payload.message);
+  const combined = [type, message].filter(Boolean).join(": ");
+  return combined ? combined.slice(0, 500) : `HTTP ${status}`;
+}
+
+async function parseErrorResponse(response: Response): Promise<string> {
+  const payload = await response.json().catch(() => null);
+  return errorText(payload, response.status);
+}
+
+async function readResponseBytesWithLimit(response: Response, maxBytes: number): Promise<Buffer> {
+  if (!response.body) return Buffer.alloc(0);
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(`Attachment exceeds the configured ${maxBytes}-byte limit.`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, totalBytes);
+}
+
+async function authorizedFetch(
+  ctx: PluginContext,
+  companyId: string,
+  path: string,
+  query: Record<string, string | number | boolean | undefined> = {},
+): Promise<{ response: Response; config: NylasConfig }> {
+  const config = await readConfig(ctx, companyId);
+  const apiKey = config.apiKey
+    ? await ctx.secrets.resolve(config.apiKey, { companyId, configPath: "apiKey" })
+    : environmentApiKey();
+  if (!apiKey) {
+    throw new Error("PAPERCLIP_NYLAS is not available to the Paperclip server process and no company secret is configured.");
+  }
+  const url = new URL(`${API_BASES[config.apiRegion]}/v3/grants/${encodeURIComponent(config.grantId)}${path}`);
+  for (const [key, value] of Object.entries(query)) appendQuery(url, key, value);
+
+  const response = await ctx.http.fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+  return { response, config };
+}
+
+async function nylasJson(
+  ctx: PluginContext,
+  companyId: string,
+  path: string,
+  query: Record<string, string | number | boolean | undefined> = {},
+): Promise<NylasRecord> {
+  const { response } = await authorizedFetch(ctx, companyId, path, query);
+  if (!response.ok) throw new Error(`Nylas request failed: ${await parseErrorResponse(response)}`);
+  const payload: unknown = await response.json().catch(() => null);
+  if (!isRecord(payload)) throw new Error("Nylas returned an unreadable JSON response.");
+  return payload;
+}
+
+function normalizedAddresses(value: unknown): Array<{ name: string | null; email: string }> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item) || typeof item.email !== "string") return [];
+    return [{
+      name: typeof item.name === "string" && item.name.trim() ? item.name.trim() : null,
+      email: item.email,
+    }];
+  });
+}
+
+function normalizedStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function normalizedAttachments(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item) || typeof item.id !== "string") return [];
+    return [{
+      id: item.id,
+      filename: typeof item.filename === "string" ? item.filename : null,
+      contentType: typeof item.content_type === "string" ? item.content_type : null,
+      size: typeof item.size === "number" ? item.size : null,
+      isInline: item.is_inline === true,
+      contentId: typeof item.content_id === "string" ? item.content_id : null,
+    }];
+  });
+}
+
+function normalizedBody(value: unknown): { body: string | null; bodyTruncated: boolean } {
+  if (typeof value !== "string") return { body: null, bodyTruncated: false };
+  return {
+    body: value.slice(0, MAX_BODY_CHARS),
+    bodyTruncated: value.length > MAX_BODY_CHARS,
+  };
+}
+
+function normalizedMessage(value: unknown, includeBody: boolean): Record<string, unknown> | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  const body = includeBody ? normalizedBody(value.body) : {};
+  return {
+    id: value.id,
+    threadId: typeof value.thread_id === "string" ? value.thread_id : null,
+    subject: typeof value.subject === "string" ? value.subject : "",
+    from: normalizedAddresses(value.from),
+    to: normalizedAddresses(value.to),
+    cc: normalizedAddresses(value.cc),
+    bcc: normalizedAddresses(value.bcc),
+    replyTo: normalizedAddresses(value.reply_to),
+    date: typeof value.date === "number" ? value.date : null,
+    snippet: typeof value.snippet === "string" ? value.snippet : null,
+    unread: value.unread === true,
+    starred: value.starred === true,
+    folders: normalizedStringArray(value.folders),
+    labels: normalizedStringArray(value.labels),
+    attachments: normalizedAttachments(value.attachments),
+    ...body,
+  };
+}
+
+function normalizedThread(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  return {
+    id: value.id,
+    subject: typeof value.subject === "string" ? value.subject : "",
+    snippet: typeof value.snippet === "string" ? value.snippet : null,
+    participants: normalizedAddresses(value.participants),
+    messageIds: normalizedStringArray(value.message_ids),
+    earliestMessageDate: typeof value.earliest_message_date === "number" ? value.earliest_message_date : null,
+    latestMessageReceivedDate: typeof value.latest_message_received_date === "number" ? value.latest_message_received_date : null,
+    unread: value.unread === true,
+    starred: value.starred === true,
+    hasAttachments: value.has_attachments === true,
+    folders: normalizedStringArray(value.folders),
+    labels: normalizedStringArray(value.labels),
+  };
+}
+
+function responseDataRecord(payload: NylasRecord): NylasRecord {
+  if (!isRecord(payload.data)) throw new Error("Nylas response did not contain an object in data.");
+  return payload.data;
+}
+
+function responseDataArray(payload: NylasRecord): unknown[] {
+  if (!Array.isArray(payload.data)) throw new Error("Nylas response did not contain an array in data.");
+  return payload.data;
+}
+
+function toolResult(content: string, data: unknown): ToolResult {
+  return { content, data };
+}
+
+function filenameFromHeaders(headers: Headers, fallback: string): string {
+  const disposition = headers.get("content-disposition") ?? "";
+  const encoded = disposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded.replace(/^"|"$/g, ""));
+    } catch {
+      return encoded.replace(/^"|"$/g, "");
+    }
+  }
+  return disposition.match(/filename="([^"]+)"/i)?.[1]
+    ?? disposition.match(/filename=([^;]+)/i)?.[1]?.trim()
+    ?? fallback;
+}
+
+function registerTools(ctx: PluginContext): void {
+  ctx.tools.register(
+    "nylas_search_messages",
+    {
+      displayName: "Search Finance Mailbox",
+      description: "Search messages in the configured finance mailbox.",
+      parametersSchema: {},
+    },
+    async (params, runCtx) => {
+      const input = isRecord(params) ? params : {};
+      const companyId = requireCompanyId(runCtx);
+      const payload = await nylasJson(ctx, companyId, "/messages", {
+        limit: integerInRange(input.limit, 20, 1, 20, "limit"),
+        page_token: optionalString(input.pageToken, "pageToken", 2_000),
+        subject: optionalString(input.subject, "subject", 500),
+        any_email: optionalString(input.anyEmail, "anyEmail", 2_000),
+        from: optionalString(input.fromEmail, "fromEmail", 320),
+        to: optionalString(input.toEmail, "toEmail", 320),
+        unread: optionalBoolean(input.unread, "unread"),
+        has_attachment: optionalBoolean(input.hasAttachment, "hasAttachment"),
+        received_after: optionalUnixTimestamp(input.receivedAfter, "receivedAfter"),
+        received_before: optionalUnixTimestamp(input.receivedBefore, "receivedBefore"),
+      });
+      const messages = responseDataArray(payload)
+        .map((message) => normalizedMessage(message, false))
+        .filter((message): message is Record<string, unknown> => message !== null);
+      const nextCursor = typeof payload.next_cursor === "string" ? payload.next_cursor : null;
+      return toolResult(`Found ${messages.length} messages in the configured finance mailbox.`, { messages, nextCursor });
+    },
+  );
+
+  ctx.tools.register(
+    "nylas_get_message",
+    {
+      displayName: "Read Finance Message",
+      description: "Read one message from the configured finance mailbox.",
+      parametersSchema: {},
+    },
+    async (params, runCtx) => {
+      const input = isRecord(params) ? params : {};
+      const companyId = requireCompanyId(runCtx);
+      const messageId = requiredId(input.messageId, "messageId");
+      const payload = await nylasJson(ctx, companyId, `/messages/${encodeURIComponent(messageId)}`);
+      const message = normalizedMessage(responseDataRecord(payload), true);
+      if (!message) throw new Error("Nylas returned an invalid message object.");
+      return toolResult(`Read finance message ${messageId}.`, { message });
+    },
+  );
+
+  ctx.tools.register(
+    "nylas_read_thread",
+    {
+      displayName: "Read Finance Thread",
+      description: "Read a thread and its messages from the configured finance mailbox.",
+      parametersSchema: {},
+    },
+    async (params, runCtx) => {
+      const input = isRecord(params) ? params : {};
+      const companyId = requireCompanyId(runCtx);
+      const threadId = requiredId(input.threadId, "threadId");
+      const limit = integerInRange(input.limit, 50, 1, 50, "limit");
+      const [threadPayload, messagesPayload] = await Promise.all([
+        nylasJson(ctx, companyId, `/threads/${encodeURIComponent(threadId)}`),
+        nylasJson(ctx, companyId, "/messages", { thread_id: threadId, limit }),
+      ]);
+      const thread = normalizedThread(responseDataRecord(threadPayload));
+      if (!thread) throw new Error("Nylas returned an invalid thread object.");
+      const messages = responseDataArray(messagesPayload)
+        .map((message) => normalizedMessage(message, true))
+        .filter((message): message is Record<string, unknown> => message !== null)
+        .sort((left, right) => Number(left.date ?? 0) - Number(right.date ?? 0));
+      const nextCursor = typeof messagesPayload.next_cursor === "string" ? messagesPayload.next_cursor : null;
+      return toolResult(`Read ${messages.length} messages from finance thread ${threadId}.`, {
+        thread,
+        messages,
+        nextCursor,
+      });
+    },
+  );
+
+  ctx.tools.register(
+    "nylas_list_attachments",
+    {
+      displayName: "List Finance Message Attachments",
+      description: "List attachment metadata for one finance message.",
+      parametersSchema: {},
+    },
+    async (params, runCtx) => {
+      const input = isRecord(params) ? params : {};
+      const companyId = requireCompanyId(runCtx);
+      const messageId = requiredId(input.messageId, "messageId");
+      const payload = await nylasJson(ctx, companyId, `/messages/${encodeURIComponent(messageId)}`, {
+        select: "attachments",
+      });
+      const attachments = normalizedAttachments(responseDataRecord(payload).attachments);
+      return toolResult(`Found ${attachments.length} attachments on finance message ${messageId}.`, {
+        messageId,
+        attachments,
+      });
+    },
+  );
+
+  ctx.tools.register(
+    "nylas_download_attachment",
+    {
+      displayName: "Download Finance Attachment",
+      description: "Download one size-capped finance attachment as base64.",
+      parametersSchema: {},
+    },
+    async (params, runCtx) => {
+      const input = isRecord(params) ? params : {};
+      const companyId = requireCompanyId(runCtx);
+      const messageId = requiredId(input.messageId, "messageId");
+      const attachmentId = requiredId(input.attachmentId, "attachmentId");
+      const { response, config } = await authorizedFetch(
+        ctx,
+        companyId,
+        `/attachments/${encodeURIComponent(attachmentId)}/download`,
+        { message_id: messageId },
+      );
+      if (!response.ok) throw new Error(`Nylas attachment download failed: ${await parseErrorResponse(response)}`);
+
+      const declaredSize = Number(response.headers.get("content-length"));
+      if (Number.isFinite(declaredSize) && declaredSize > config.maxAttachmentBytes) {
+        throw new Error(`Attachment is ${declaredSize} bytes, above the configured ${config.maxAttachmentBytes}-byte limit.`);
+      }
+      const bytes = await readResponseBytesWithLimit(response, config.maxAttachmentBytes);
+
+      const filename = filenameFromHeaders(response.headers, attachmentId);
+      const contentType = response.headers.get("content-type") || "application/octet-stream";
+      return toolResult(`Downloaded ${filename} (${bytes.byteLength} bytes) from the configured finance mailbox.`, {
+        messageId,
+        attachmentId,
+        filename,
+        contentType,
+        byteSize: bytes.byteLength,
+        encoding: "base64",
+        content: bytes.toString("base64"),
+      });
+    },
+  );
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    registerTools(ctx);
+  },
+
+  async onValidateConfig(config) {
+    const errors = validateConfig(config);
+    return errors.length > 0 ? { ok: false, errors } : { ok: true };
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Nylas finance mailbox tools are registered" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/plugin-nylas-mailbox/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-nylas-mailbox/tests/plugin.spec.ts
@@ -1,0 +1,289 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ToolResult } from "@paperclipai/plugin-sdk";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest, { FINANCE_GRANT_ID } from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+const COMPANY_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_GRANT_ID = "00000000-0000-4000-8000-000000000099";
+const API_KEY_REF = {
+  type: "secret_ref" as const,
+  secretId: "00000000-0000-4000-8000-000000000002",
+  version: "latest" as const,
+};
+const ORIGINAL_UPPER_ENV = process.env.PAPERCLIP_NYLAS;
+const ORIGINAL_LOWER_ENV = process.env.paperclip_nylas;
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_UPPER_ENV === undefined) delete process.env.PAPERCLIP_NYLAS;
+  else process.env.PAPERCLIP_NYLAS = ORIGINAL_UPPER_ENV;
+  if (ORIGINAL_LOWER_ENV === undefined) delete process.env.paperclip_nylas;
+  else process.env.paperclip_nylas = ORIGINAL_LOWER_ENV;
+});
+
+describe("Nylas finance mailbox plugin", () => {
+  it("declares only read-connector capabilities and tools", () => {
+    expect(manifest.capabilities).toEqual([
+      "agent.tools.register",
+      "http.outbound",
+      "secrets.read-ref",
+    ]);
+    expect(manifest.instanceConfigSchema).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        apiKey: { type: "object", format: "secret-ref" },
+        grantId: { default: FINANCE_GRANT_ID },
+      },
+    });
+    expect(manifest.tools?.map((tool) => tool.name)).toEqual([
+      "nylas_search_messages",
+      "nylas_get_message",
+      "nylas_read_thread",
+      "nylas_list_attachments",
+      "nylas_download_attachment",
+    ]);
+    expect(manifest.tools?.every((tool) => !Object.hasOwn(tool.parametersSchema.properties ?? {}, "grantId"))).toBe(true);
+  });
+
+  it("requires a secret reference and validates the mailbox boundary", async () => {
+    await expect(plugin.definition.onValidateConfig?.({ apiKey: API_KEY_REF })).resolves.toEqual({ ok: true });
+
+    await expect(plugin.definition.onValidateConfig?.({
+      apiKey: "must-not-be-stored-inline",
+      grantId: FINANCE_GRANT_ID,
+    })).resolves.toMatchObject({
+      ok: false,
+      errors: [expect.stringContaining("company secret")],
+    });
+
+    await expect(plugin.definition.onValidateConfig?.({
+      apiKey: API_KEY_REF,
+      grantId: "finance@example.com",
+    })).resolves.toMatchObject({
+      ok: false,
+      errors: [expect.stringContaining("valid UUID")],
+    });
+  });
+
+  it("uses PAPERCLIP_NYLAS when no company secret reference is configured", async () => {
+    process.env.PAPERCLIP_NYLAS = "environment-api-key";
+    delete process.env.paperclip_nylas;
+    const calls: Array<{ url: URL; init?: RequestInit }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      calls.push({ url: new URL(String(input)), init });
+      return jsonResponse({ data: [] });
+    });
+    const harness = createTestHarness({ manifest, config: {} });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(plugin.definition.onValidateConfig?.({})).resolves.toEqual({ ok: true });
+    await harness.executeTool("nylas_search_messages", {}, { companyId: COMPANY_ID });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init?.headers).toMatchObject({ Authorization: "Bearer environment-api-key" });
+    expect(calls[0].url.pathname).toContain(`/grants/${FINANCE_GRANT_ID}/`);
+  });
+
+  it("hard-binds message search to the configured grant and forwards bounded filters", async () => {
+    const calls: Array<{ url: URL; init?: RequestInit }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      calls.push({ url: new URL(String(input)), init });
+      return jsonResponse({
+        request_id: "request-1",
+        data: [{
+          id: "message-1",
+          thread_id: "thread-1",
+          subject: "Invoice 42",
+          from: [{ name: "Vendor", email: "billing@example.com" }],
+          to: [{ email: "finance@example.com" }],
+          date: 1_721_000_000,
+          unread: true,
+          attachments: [{ id: "attachment-1", filename: "invoice.pdf", size: 12_345 }],
+        }],
+        next_cursor: "next-page",
+      });
+    });
+
+    const harness = createTestHarness({
+      manifest,
+      config: { apiKey: API_KEY_REF, grantId: FINANCE_GRANT_ID, apiRegion: "us" },
+    });
+    await plugin.definition.setup(harness.ctx);
+    const result = await harness.executeTool<ToolResult>(
+      "nylas_search_messages",
+      {
+        limit: 5,
+        subject: "Invoice",
+        unread: true,
+        grantId: OTHER_GRANT_ID,
+      },
+      { companyId: COMPANY_ID },
+    );
+
+    expect(result.data).toMatchObject({
+      messages: [{ id: "message-1", subject: "Invoice 42", unread: true }],
+      nextCursor: "next-page",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url.pathname).toBe(`/v3/grants/${FINANCE_GRANT_ID}/messages`);
+    expect(calls[0].url.pathname).not.toContain(OTHER_GRANT_ID);
+    expect(Object.fromEntries(calls[0].url.searchParams)).toMatchObject({
+      limit: "5",
+      subject: "Invoice",
+      unread: "true",
+    });
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Bearer resolved:[object Object]",
+    });
+  });
+
+  it("reads a message and a complete thread from only the configured grant", async () => {
+    const calls: URL[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      calls.push(url);
+      if (url.pathname.endsWith("/messages/message-1")) {
+        return jsonResponse({ data: { id: "message-1", thread_id: "thread-1", subject: "Invoice", body: "<p>Attached.</p>" } });
+      }
+      if (url.pathname.endsWith("/threads/thread-1")) {
+        return jsonResponse({ data: { id: "thread-1", subject: "Invoice", message_ids: ["message-1", "message-2"] } });
+      }
+      if (url.pathname.endsWith("/messages") && url.searchParams.get("thread_id") === "thread-1") {
+        return jsonResponse({
+          data: [
+            { id: "message-2", thread_id: "thread-1", date: 20, body: "Second" },
+            { id: "message-1", thread_id: "thread-1", date: 10, body: "First" },
+          ],
+          next_cursor: null,
+        });
+      }
+      throw new Error(`Unexpected Nylas request: ${url}`);
+    });
+
+    const harness = createTestHarness({ manifest, config: { apiKey: API_KEY_REF } });
+    await plugin.definition.setup(harness.ctx);
+
+    const message = await harness.executeTool<ToolResult>("nylas_get_message", { messageId: "message-1" }, { companyId: COMPANY_ID });
+    expect(message.data).toMatchObject({ message: { body: "<p>Attached.</p>", bodyTruncated: false } });
+
+    const thread = await harness.executeTool<ToolResult>("nylas_read_thread", { threadId: "thread-1" }, { companyId: COMPANY_ID });
+    expect(thread.data).toMatchObject({
+      thread: { id: "thread-1", messageIds: ["message-1", "message-2"] },
+      messages: [{ id: "message-1", body: "First" }, { id: "message-2", body: "Second" }],
+    });
+    expect(calls.every((url) => url.pathname.includes(`/grants/${FINANCE_GRANT_ID}/`))).toBe(true);
+  });
+
+  it("lists and downloads size-capped attachments", async () => {
+    const bytes = Buffer.from("invoice-content", "utf8");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/messages/message-1")) {
+        expect(url.searchParams.get("select")).toBe("attachments");
+        return jsonResponse({
+          data: {
+            id: "message-1",
+            attachments: [{
+              id: "attachment-1",
+              filename: "invoice.pdf",
+              content_type: "application/pdf",
+              size: bytes.byteLength,
+              is_inline: false,
+            }],
+          },
+        });
+      }
+      if (url.pathname.endsWith("/attachments/attachment-1/download")) {
+        expect(url.searchParams.get("message_id")).toBe("message-1");
+        return new Response(bytes, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/pdf",
+            "Content-Length": String(bytes.byteLength),
+            "Content-Disposition": "attachment; filename=invoice.pdf",
+          },
+        });
+      }
+      throw new Error(`Unexpected Nylas request: ${url}`);
+    });
+
+    const harness = createTestHarness({
+      manifest,
+      config: { apiKey: API_KEY_REF, maxAttachmentBytes: 1_000 },
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    const listed = await harness.executeTool<ToolResult>("nylas_list_attachments", { messageId: "message-1" }, { companyId: COMPANY_ID });
+    expect(listed.data).toMatchObject({
+      attachments: [{ id: "attachment-1", filename: "invoice.pdf", contentType: "application/pdf" }],
+    });
+
+    const downloaded = await harness.executeTool<ToolResult>(
+      "nylas_download_attachment",
+      { messageId: "message-1", attachmentId: "attachment-1" },
+      { companyId: COMPANY_ID },
+    );
+    expect(downloaded.data).toMatchObject({
+      filename: "invoice.pdf",
+      contentType: "application/pdf",
+      byteSize: bytes.byteLength,
+      encoding: "base64",
+      content: bytes.toString("base64"),
+    });
+  });
+
+  it("rejects oversized downloads before reading the response body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("too large", {
+      status: 200,
+      headers: { "Content-Length": "5000" },
+    }));
+    const harness = createTestHarness({
+      manifest,
+      config: { apiKey: API_KEY_REF, maxAttachmentBytes: 100 },
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(harness.executeTool(
+      "nylas_download_attachment",
+      { messageId: "message-1", attachmentId: "attachment-1" },
+      { companyId: COMPANY_ID },
+    )).rejects.toThrow("above the configured 100-byte limit");
+  });
+
+  it("stops oversized downloads when the response omits content-length", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(Buffer.alloc(200), { status: 200 }));
+    const harness = createTestHarness({
+      manifest,
+      config: { apiKey: API_KEY_REF, maxAttachmentBytes: 100 },
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(harness.executeTool(
+      "nylas_download_attachment",
+      { messageId: "message-1", attachmentId: "attachment-1" },
+      { companyId: COMPANY_ID },
+    )).rejects.toThrow("exceeds the configured 100-byte limit");
+  });
+
+  it("surfaces Nylas failures without exposing the resolved API key", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({
+      error: { type: "invalid_request_error", message: "Grant not found" },
+    }, 404));
+    const harness = createTestHarness({ manifest, config: { apiKey: API_KEY_REF } });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(harness.executeTool(
+      "nylas_get_message",
+      { messageId: "missing" },
+      { companyId: COMPANY_ID },
+    )).rejects.toThrow("Nylas request failed: invalid_request_error: Grant not found");
+  });
+});

--- a/packages/plugins/plugin-nylas-mailbox/tsconfig.json
+++ b/packages/plugins/plugin-nylas-mailbox/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/plugins/plugin-nylas-mailbox/vitest.config.ts
+++ b/packages/plugins/plugin-nylas-mailbox/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,25 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
 
+  packages/plugins/plugin-nylas-mailbox:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.21
+        version: 22.19.21
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.10(@types/node@22.19.21)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
+
   packages/plugins/plugin-workspace-diff:
     dependencies:
       '@paperclipai/plugin-sdk':


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies and their work.
> - Plugins are the extension boundary for adding company-scoped tools without expanding Paperclip's core API surface.
> - Finance agents need to inspect a specific shared mailbox for invoices, receipts, and supporting evidence.
> - A generic mail integration would expose unnecessary account scope and could let an agent choose a different mailbox grant.
> - The connector therefore needs to bind the mailbox grant server-side, keep credentials out of agent inputs, and expose only read operations.
> - This pull request adds a first-party Nylas mailbox plugin package with a fixed finance grant, secret-reference support, bounded responses, and focused tests.
> - The benefit is a narrow, inspectable finance-mailbox capability that follows Paperclip's existing plugin permission and company-scoping model.

## Linked Issues or Issue Description

- **Problem:** Finance agents need read-only access to a single Nylas mailbox, but Paperclip does not currently include a scoped Nylas connector. Passing a grant or API key through tool inputs would make the mailbox boundary agent-controlled and increase credential exposure.
- **Proposed solution:** Add a plugin that injects the configured finance grant internally, resolves the API key from a company secret reference or the Paperclip server environment, and registers five read-only tools for messages, threads, and attachments.
- **Alternatives considered:** A generic HTTP tool or an external sidecar could call Nylas, but neither gives Paperclip an explicit tool contract, configuration validation, or a fixed mailbox boundary. A broad mail connector was rejected because this use case only needs one finance inbox.
- **Roadmap and duplicates:** `ROADMAP.md` identifies plugins as the preferred extension mechanism. Searches for open Nylas mailbox issues and pull requests found no duplicate or related public work.

## What Changed

- Added the private workspace package `@paperclipai/plugin-nylas-mailbox` with plugin manifest, build configuration, documentation, and lockfile registration.
- Added five read-only tools: message search, message read, thread read, attachment listing, and size-capped attachment download.
- Bound all requests to the configured finance grant inside the worker; tool schemas do not accept a grant ID.
- Added Nylas US/EU region selection, company secret-reference support, `PAPERCLIP_NYLAS` / `paperclip_nylas` server-environment fallback, bounded query inputs, and normalized tool responses.
- Added attachment protections: a 1 MB default cap, a 5 MB maximum configuration, `Content-Length` rejection, and streamed enforcement when that header is missing.
- Added nine focused tests covering capabilities, secret handling, fixed-grant isolation, filters, messages, threads, attachments, stream limits, and safe error reporting.

## Verification

- `pnpm install --frozen-lockfile` — passed.
- `pnpm --filter @paperclipai/plugin-nylas-mailbox typecheck` — passed.
- `pnpm --filter @paperclipai/plugin-nylas-mailbox test` — passed, 9/9 tests.
- `pnpm --filter @paperclipai/plugin-nylas-mailbox build` — passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed with the repository's existing UI build warnings.
- `pnpm test:run` — 2,867 passed, 1 skipped, and 3 unrelated local macOS failures: one workspace-runtime adoption assertion and two `/tmp` versus `/private/tmp` branch-containment assertions. The changed plugin suite passed independently.
- The plugin was installed locally and reported healthy. A live Nylas request was not made because the local Paperclip database has no company against which to execute a company-scoped tool.

## Risks

- The default finance grant ID is deployment-specific. Operators can override it in plugin configuration, but agents cannot supply or change it through tool inputs.
- The API key must remain server-only. Configuration rejects raw inline values and supports a Paperclip secret reference or environment fallback.
- Attachment content is returned as base64 and can increase tool-result size. Downloads are capped and enforced while streaming even when Nylas omits `Content-Length`.
- Nylas response shapes can evolve. The worker normalizes only the fields used by these tools and reports malformed responses explicitly.
- No database migration or existing core API behavior changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, model ID `gpt-5.6`, agentic coding mode with repository tools and code execution. The model's internal reasoning trace and context-window allocation are not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
