### PR TITLE
fix(hermes): defer to configured model default

### DIFF
--- a/packages/adapters/hermes/src/server/command-resolution.test.ts
+++ b/packages/adapters/hermes/src/server/command-resolution.test.ts
@@ -1,10 +1,10 @@
 import os from "node:os";
 import path from "node:path";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { expect, test } from "vitest";
 
 import { HERMES_CLI } from "../shared/constants.js";
-import { resolveHermesCommand } from "./execute.js";
+import { execute, resolveHermesCommand } from "./execute.js";
 import { testEnvironment } from "./test.js";
 
 test("resolveHermesCommand prefers hermesCommand over command", () => {
@@ -45,4 +45,89 @@ test("testEnvironment accepts config.command when hermesCommand is absent", asyn
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+async function runExecuteWithFakeHermes(
+  config: Record<string, unknown>,
+): Promise<{ args: string[]; resultModel: string | null | undefined }> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "hermes-execute-args-"));
+  const cliPath = path.join(tempDir, "fake-hermes");
+  const argsPath = path.join(tempDir, "args.bin");
+  const previousHome = process.env.HOME;
+  const previousUserProfile = process.env.USERPROFILE;
+  const previousHomeDrive = process.env.HOMEDRIVE;
+  const previousHomePath = process.env.HOMEPATH;
+
+  try {
+    await writeFile(
+      cliPath,
+      [
+        "#!/bin/sh",
+        "printf '%s\\0' \"$@\" > \"$HERMES_ARGS_FILE\"",
+        "printf 'ok\\n\\nsession_id: session-test\\n'",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+
+    process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
+    delete process.env.HOMEDRIVE;
+    delete process.env.HOMEPATH;
+
+    const result = await execute({
+      runId: "run-test",
+      agent: {
+        id: "agent-test",
+        name: "Hermes Test Agent",
+        companyId: "company-test",
+        adapterConfig: {},
+      },
+      config: {
+        ...config,
+        hermesCommand: cliPath,
+        cwd: tempDir,
+        env: { HERMES_ARGS_FILE: argsPath },
+      },
+      runtime: {},
+      onLog: async () => {},
+    } as any);
+
+    const args = (await readFile(argsPath))
+      .toString("utf8")
+      .split("\0")
+      .filter((arg) => arg.length > 0);
+    return { args, resultModel: result.model };
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
+    if (previousHomeDrive === undefined) delete process.env.HOMEDRIVE;
+    else process.env.HOMEDRIVE = previousHomeDrive;
+    if (previousHomePath === undefined) delete process.env.HOMEPATH;
+    else process.env.HOMEPATH = previousHomePath;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("execute omits --model when Hermes model config is blank or missing", async () => {
+  for (const config of [{}, { model: "" }, { model: "   " }]) {
+    const { args, resultModel } = await runExecuteWithFakeHermes(config);
+
+    expect(args).not.toContain("-m");
+    expect(args).not.toContain("auto");
+    expect(resultModel).toBeNull();
+  }
+});
+
+test("execute passes an explicit Hermes model override", async () => {
+  const { args, resultModel } = await runExecuteWithFakeHermes({
+    model: "claude-sonnet-4",
+  });
+
+  const modelFlagIndex = args.indexOf("-m");
+  expect(modelFlagIndex).toBeGreaterThanOrEqual(0);
+  expect(args[modelFlagIndex + 1]).toBe("claude-sonnet-4");
+  expect(resultModel).toBe("claude-sonnet-4");
 });

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -43,7 +43,6 @@ import {
   HERMES_CLI,
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
-  DEFAULT_MODEL,
   VALID_PROVIDERS,
 } from "../shared/constants.js";
 
@@ -58,6 +57,11 @@ import {
 
 function cfgString(v: unknown): string | undefined {
   return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+function cfgNonBlankString(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 function cfgNumber(v: unknown): number | undefined {
   return typeof v === "number" ? v : undefined;
@@ -331,7 +335,7 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = resolveHermesCommand(config);
-  const model = cfgString(config.model) || DEFAULT_MODEL;
+  const model = cfgNonBlankString(config.model);
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
@@ -493,7 +497,7 @@ export async function execute(
   // ── Log start ──────────────────────────────────────────────────────────
   await ctx.onLog(
     "stdout",
-    `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
+    `[hermes] Starting Hermes Agent (model=${model ?? "Hermes configured default"}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
   );
   if (prevSessionId) {
     await ctx.onLog(
@@ -552,7 +556,7 @@ export async function execute(
     signal: result.signal,
     timedOut: result.timedOut,
     provider: resolvedProvider,
-    model,
+    model: model ?? null,
   };
 
   if (parsed.errorMessage) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane that configures and launches AI-agent adapters.
> - The Hermes adapter translates Paperclip agent settings into `hermes chat` command-line arguments.
> - A Paperclip model value is optional; when it is omitted, Hermes must select the model from its own active configuration or profile.
> - Current master converts a missing model to `auto` and emits `-m auto`, but any explicit `-m` takes precedence over Hermes configuration.
> - The adapter therefore needs to distinguish an absent/blank Paperclip override from an explicitly configured model.
> - This pull request omits `-m` for missing or whitespace-only values while preserving explicit model overrides.
> - The benefit is that Paperclip respects the operator's Hermes configuration instead of silently replacing it.

## Linked Issues or Issue Description

Related exact earlier implementation: #9072. Its head no longer shares a merge base with current `master`, so it cannot be applied or locally merge-tested against the current repository history. This PR recreates the narrow fix on current master and addresses its open test-harness P2 by capturing argv with NUL delimiters.

Related broader PR: #9422. It also no longer shares a merge base with current `master` and has an open P1 concerning profile-model precedence; this PR does not include its unrelated argument-placement changes.

### Pre-submission checklist

- [x] I searched existing open and closed issues/PRs and linked the exact stale implementation and broader related work above.
- [x] I reproduced this on current `master`.
- [x] I confirmed the behavior originates in Paperclip's Hermes command construction, not Hermes configuration or provider behavior.

### What happened?

When `config.model` was missing, empty, or whitespace-only, the Hermes adapter selected Paperclip's `DEFAULT_MODEL` (`auto`) and passed `-m auto` to `hermes chat`. Because `-m` is an explicit CLI override, Hermes could not use the model configured in the active Hermes configuration/profile.

### Expected behavior

Paperclip should omit `-m` when no non-blank model override is configured. Hermes should then use its own configured default. A non-blank Paperclip model must still be passed explicitly.

### Steps to reproduce

1. Configure a Hermes model/profile outside Paperclip.
2. Leave the Paperclip Hermes adapter model blank.
3. Launch the agent through Paperclip.
4. Observe `hermes chat ... -m auto` instead of an argv with no model flag.

### Environment

- Paperclip commit: `176a9e8230b1222639fb3e1b4d9d80a83adbaf88`
- Deployment mode: self-hosted server
- Installation method: built from source
- Adapter: `hermes_local`
- Database mode: not database-related
- Access context: agent execution
- Node.js: `v22.22.3`
- Operating system: Linux
- Relevant config: model omitted or whitespace-only
- Privacy: no instance-local identifiers, paths, credentials, or output are included.

## What Changed

- Normalize the optional Paperclip model as a trimmed non-blank string.
- Omit `-m` and return `model: null` when no override is configured.
- Preserve explicit non-blank model overrides.
- Log that Hermes' configured default is being used without guessing the selected model.
- Add a real fake-CLI regression with NUL-delimited argv capture so multiline prompts cannot create false model-flag matches.

## Verification

- RED before implementation: `execute omits --model when Hermes model config is blank or missing` failed because `-m` was present.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter test:command-resolution` — 5 tests passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter test` — 8 files and 60 tests passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` — passed.
- `git diff --check` — passed.

## Risks

- Low risk: the behavior changes only when Paperclip has no non-blank model override.
- Operators who intentionally relied on Paperclip translating a blank value to `-m auto` will now receive Hermes' configured default, which is the intended optional-model contract.
- Explicit model values are trimmed and continue to be passed with `-m`.
- No schema, migration, API response, provider-selection, or profile-argument changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex `gpt-5.6-sol` was used with reasoning, repository/file tools, shell execution, RED/GREEN testing, and current-master merge/duplicate inspection. The runtime did not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change needed; this corrects existing optional-model behavior)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
