### PR TITLE
test(ci): cover PR lockfile patch trigger

### DIFF
--- a/scripts/__tests__/release-verify-workflow.test.mjs
+++ b/scripts/__tests__/release-verify-workflow.test.mjs
@@ -10,6 +10,14 @@ function readWorkflow(name) {
   return readFileSync(path.join(repoRoot, ".github/workflows", name), "utf8");
 }
 
+function readPrManifestPattern() {
+  const prWorkflow = readWorkflow("pr.yml");
+  const manifestPattern = prWorkflow.match(/^\s*manifest_pattern='([^']+)'$/m)?.[1];
+
+  assert.ok(manifestPattern, "expected a manifest_pattern definition in pr.yml");
+  return new RegExp(manifestPattern);
+}
+
 test("release workflow delegates stable and canary verification to the reusable workflow", () => {
   const releaseWorkflow = readWorkflow("release.yml");
 
@@ -49,4 +57,49 @@ test("release verify workflow covers the same split test surface as stable PR ve
 
   assert.match(verifyWorkflow, /pnpm test:run:general -- --group/);
   assert.match(verifyWorkflow, /pnpm test:run:serialized -- --shard-index/);
+});
+
+test("pr workflow regenerates the lockfile for dependency graph inputs", () => {
+  const manifestPattern = readPrManifestPattern();
+
+  const triggeringPaths = [
+    "package.json",
+    "packages/shared/package.json",
+    "pnpm-workspace.yaml",
+    ".npmrc",
+    "pnpmfile.cjs",
+    "pnpmfile.js",
+    "pnpmfile.mjs",
+    "patches/acpx@0.12.0.patch",
+    "patches/nested/fix.patch",
+  ];
+
+  for (const filePath of triggeringPaths) {
+    assert.equal(
+      manifestPattern.test(filePath),
+      true,
+      `${filePath} should trigger lockfile regeneration`,
+    );
+  }
+});
+
+test("pr workflow lockfile trigger stays scoped to root-level config and patches", () => {
+  const manifestPattern = readPrManifestPattern();
+
+  const ignoredPaths = [
+    "README.md",
+    "packages/shared/src/index.ts",
+    "packages/shared/.npmrc",
+    "packages/shared/pnpmfile.cjs",
+    "packages/shared/patches/acpx.patch",
+    "docs/patches/acpx.patch",
+  ];
+
+  for (const filePath of ignoredPaths) {
+    assert.equal(
+      manifestPattern.test(filePath),
+      false,
+      `${filePath} should not trigger lockfile regeneration`,
+    );
+  }
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses workflow automation and checks to keep repository changes reproducible and safe
> - The lockfile regeneration path for patch-based changes was recently fixed in PR #10132
> - That fix needed regression coverage so future workflow edits do not silently break the trigger logic
> - This change exercises the workflow-wiring Node test that parses `.github/workflows/pr.yml`
> - It verifies the positive path for root `patches/` inputs and keeps the negative cases for non-triggering lookalikes
> - This pull request adds that coverage without changing runtime behavior
> - The benefit is lower risk of a future workflow regression slipping past review

## Linked Issues or Issue Description

- Refs #10132
- This follow-up adds regression coverage for the workflow trigger behavior introduced there; no separate public issue was filed.

## What Changed

- Added test coverage to the existing workflow-wiring Node test that parses `.github/workflows/pr.yml`.
- Confirmed root `patches/` paths trigger lockfile regeneration alongside the existing manifest/config inputs.
- Confirmed nested package/doc `patches/` paths and root-only config lookalikes do not trigger the lockfile path.

## Verification

- `node --test ./scripts/__tests__/release-verify-workflow.test.mjs`
- `git diff --check origin/master...HEAD`

## Risks

- Low risk: this is a test-only change with no runtime code path changes.
- The main residual risk is future workflow shape drift, which the new coverage is meant to catch.

## Model Used

- OpenAI Codex (GPT-5, tool-use enabled)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
