### PR TITLE
fix(authz): extend manager-chain authority to issue:mutate and issue:comment

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1553,6 +1553,43 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("another company");
   });
 
+  it("allows a manager to mutate and comment on a report's issue via the reporting chain", async () => {
+    const company = await createCompany(db, "ManagerChainIssue");
+    const managerAgent = await createAgent(db, company.id, { role: "ceo" });
+    const childAgent = await createAgent(db, company.id, { reportsTo: managerAgent.id });
+    const grandchildAgent = await createAgent(db, company.id, { reportsTo: childAgent.id });
+
+    for (const action of ["issue:mutate", "issue:comment"] as const) {
+      const directReport = await authorizationService(db).decide({
+        actor: { type: "agent", agentId: managerAgent.id, companyId: company.id, source: "agent_jwt" },
+        action,
+        resource: { type: "issue", companyId: company.id, assigneeAgentId: childAgent.id },
+      });
+      expect(directReport).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+
+      const indirectReport = await authorizationService(db).decide({
+        actor: { type: "agent", agentId: managerAgent.id, companyId: company.id, source: "agent_jwt" },
+        action,
+        resource: { type: "issue", companyId: company.id, assigneeAgentId: grandchildAgent.id },
+      });
+      expect(indirectReport).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+    }
+  });
+
+  it("denies mutating an issue assigned to an agent outside the actor's reporting subtree", async () => {
+    const company = await createCompany(db, "ManagerChainNonReport");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const unrelatedAgent = await createAgent(db, company.id, { role: "engineer" });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_jwt" },
+      action: "issue:mutate",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: unrelatedAgent.id },
+    });
+
+    expect(decision).toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+  });
+
   it("allows scoped assignment inside a granted project and denies other projects", async () => {
     const company = await createCompany(db, "ProjectScope");
     const project = await createProject(db, company.id, "Allowed");

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2047,7 +2047,9 @@ export function authorizationService(db: Db) {
     }
 
     if (
-      input.action === "tasks:manage_active_checkouts" &&
+      (input.action === "tasks:manage_active_checkouts" ||
+        input.action === "issue:comment" ||
+        input.action === "issue:mutate") &&
       input.resource.type === "issue" &&
       input.resource.assigneeAgentId &&
       await isManagerOf(companyId, actorAgentId, input.resource.assigneeAgentId)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The authorization service (`server/src/services/authorization.ts`) decides whether an agent actor may act on an issue, resolving actions like `issue:mutate`, `issue:comment`, and `tasks:manage_active_checkouts`
> - It already models an org chart: a manager may reach into the subtree of agents that report to them (`isManagerOf` → `isAgentInSubtree`)
> - That reporting-chain authority was wired for `tasks:manage_active_checkouts` only, so a manager (e.g. the top-of-chart CEO) could release a report's checkout but could not PATCH or comment on that report's issue
> - This pull request extends the same manager-chain gate to also cover `issue:mutate` and `issue:comment`
> - The benefit is that a manager can administer status/assignment and communicate on issues owned by their direct or indirect reports, without loosening cross-company or non-report boundaries

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the underlying bug inline, following `bug_report.yml`:

**What happened?**
An agent that manages another agent in the reporting chain (e.g. the top-of-org-chart CEO) receives `deny_missing_grant` when it attempts `issue:mutate` (PATCH `status`, `assigneeAgentId`, etc.) or `issue:comment` on an issue assigned to one of its direct or indirect reports. The manager-chain allow block in `authorization.ts` gated only `tasks:manage_active_checkouts`, so checkout management was permitted but mutation/commenting was not.

**Expected behavior**
The manager is authorized for `issue:mutate` and `issue:comment` on issues assigned anywhere in its reporting subtree, mirroring the existing `tasks:manage_active_checkouts` behavior. The reporting subtree is the authority boundary; cross-company and non-report access stays denied.

**Steps to reproduce**
1. In one company, create a manager agent A and a report agent B where B reports to A (directly or via an intermediate agent).
2. Assign an issue to B.
3. As agent A, call `authorizationService.decide` (or PATCH the issue via the API) with action `issue:mutate` on B's issue.
4. Observe `allowed: false, reason: "deny_missing_grant"`. Expected: `allowed: true, reason: "allow_manager_chain"`.

**Paperclip version or commit**
`master` @ b517b887a (base of this PR).

**Deployment mode**
Self-hosted server.

## What Changed

- Extended the `isManagerOf` allow block in `server/src/services/authorization.ts` so its condition also matches `issue:mutate` and `issue:comment` (previously `tasks:manage_active_checkouts` only), returning `allow_manager_chain`.
- Added `authorization-service.test.ts` coverage: manager allowed on `issue:mutate` and `issue:comment` for both a direct report and an indirect (grandchild) report; a non-report same-company assignee still denied with `deny_missing_grant`.

## Verification

- `cd server && npx vitest run src/__tests__/authorization-service.test.ts` → 51/51 pass (includes the 2 new cases).
- `cd server && pnpm run typecheck` → clean (`tsc --noEmit`).
- Manual reasoning: cross-company access is rejected earlier by the agent company-boundary guard (`input.actor.companyId !== companyId` → `deny_company_boundary`), which precedes this block; non-report assignees fall through to `deny_missing_grant`.

## Risks

- Low risk. Widens the *action set* on an existing, already-trusted authority path (`isManagerOf`); it does not widen the *principal set* or bypass the company-boundary guard. No schema/migration changes. Behavioral shift is intentional and scoped to same-company manager→report relationships.

## Model Used

- Claude Opus 4.8, model ID `claude-opus-4-8`, 1M-context variant, extended thinking, with tool use / code execution (ran the repo test suite and typecheck locally).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
