### PR TITLE
fix(server): gate heartbeat-fallback comment to never publish raw transcript

### DIFF
--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -63,6 +63,49 @@ describe("buildHeartbeatRunIssueComment", () => {
   it("returns null when there is no usable final text", () => {
     expect(buildHeartbeatRunIssueComment({ costUsd: 1.2 })).toBeNull();
   });
+
+  it("suppresses raw transcript when the summary reads like inter-tool narration", () => {
+    const narration =
+      "Let me check the issue thread first. I'll fetch the latest comments and then decide what to do next.";
+    const comment = buildHeartbeatRunIssueComment({ summary: narration });
+
+    expect(comment).not.toContain("Let me check");
+    expect(comment).toContain("did not post a summary comment");
+  });
+
+  it("suppresses each narration opener variant", () => {
+    for (const opener of [
+      "Let me look into this.",
+      "I'll start by reading the file.",
+      "I need to inspect the config.",
+      "I can see the problem now.",
+      "Looking at the logs, the error is clear.",
+      "Fetching the run details from the API.",
+      "Checking the current branch state.",
+      "First, I will reproduce the bug.",
+    ]) {
+      expect(buildHeartbeatRunIssueComment({ summary: opener })).toContain(
+        "did not post a summary comment",
+      );
+    }
+  });
+
+  it("suppresses over-long fallback summaries even without a narration opener", () => {
+    const comment = buildHeartbeatRunIssueComment({ summary: "x".repeat(1201) });
+    expect(comment).toContain("did not post a summary comment");
+    expect(comment).not.toContain("xxxx");
+  });
+
+  it("posts a clean, in-length summary with no narration opener normally", () => {
+    const summary = "## Summary\n\n- fixed the fallback gate\n- added regression tests";
+    expect(buildHeartbeatRunIssueComment({ summary })).toBe(summary);
+  });
+
+  it("posts a summary exactly at the length cap", () => {
+    const summary = "S" + "x".repeat(1199);
+    expect(summary.length).toBe(1200);
+    expect(buildHeartbeatRunIssueComment({ summary })).toBe(summary);
+  });
 });
 
 describe("mergeHeartbeatRunResultJson", () => {

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -92,6 +92,15 @@ export function summarizeHeartbeatRunResultJson(
   return Object.keys(summary).length > 0 ? summary : null;
 }
 
+// The fallback comment is only posted when a run ends without the agent posting
+// its own comment via the API. In that case `resultJson.summary` can be raw
+// inter-tool narration (assistantTexts concatenated by the adapter), which must
+// never be published verbatim to the board — see BRO-1507 / BRO-1516.
+export const MAX_FALLBACK_COMMENT_CHARS = 1200;
+const NARRATION_OPENERS = /^(let me|i.ll|i need to|i can see|looking at|fetching|checking|first,)/i;
+const FALLBACK_WITHHELD_COMMENT =
+  "Run completed. Agent did not post a summary comment this run (transcript withheld — see run log).";
+
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
 ): string | null {
@@ -99,10 +108,17 @@ export function buildHeartbeatRunIssueComment(
     return null;
   }
 
-  return (
+  const text =
     readCommentText(resultJson.summary)
     ?? readCommentText(resultJson.result)
-    ?? readCommentText(resultJson.message)
-    ?? null
-  );
+    ?? readCommentText(resultJson.message);
+  if (!text) {
+    return null;
+  }
+
+  if (text.length > MAX_FALLBACK_COMMENT_CHARS || NARRATION_OPENERS.test(text)) {
+    return FALLBACK_WITHHELD_COMMENT;
+  }
+
+  return text;
 }


### PR DESCRIPTION
## Problem

When an issue-scoped run ends **without the agent posting its own comment** via `POST /comments`, the server auto-publishes `resultJson.summary` verbatim as the board comment (`heartbeat.ts` fallback at the `findRunIssueComment` → `buildHeartbeatRunIssueComment` path). For runs that produce no final `result`, that `summary` is concatenated **inter-tool narration** (`assistantTexts` joined in the claude-local adapter's `parse.ts`), so raw transcript leaks onto the board.

This is the CEO-spiral root cause diagnosed by Fable in BRO-1507.

## Fix

`buildHeartbeatRunIssueComment` (`server/src/services/heartbeat-run-summary.ts`) now gates the fallback. After resolving the text (`summary` → `result` → `message`), if it:
- opens with a narration phrase (`let me`, `i'll`, `i need to`, `i can see`, `looking at`, `fetching`, `checking`, `first,`), **or**
- exceeds `MAX_FALLBACK_COMMENT_CHARS` (1200)

it returns a fixed stub instead of the transcript:

> Run completed. Agent did not post a summary comment this run (transcript withheld — see run log).

Runs that post via the API are unaffected — the fallback only fires when `findRunIssueComment` finds no agent comment for the run.

## AC coverage

1. ✅ Run ending w/o comment, narration-opener summary → stub, not transcript.
2. ✅ Run ending w/o comment, clean summary (≤1200 chars, no opener) → posts normally.
3. ✅ API-posted runs unaffected (fallback never fires; unchanged call site).
4. ✅ Upstream PR to paperclipai/paperclip (this PR).

## Tests

`server/src/__tests__/heartbeat-run-summary.test.ts` — 13/13 pass. New cases: each narration-opener variant, the length cap, the exact 1200-char boundary (posts), and the clean-summary passthrough.

Refs BRO-1516, parent BRO-1507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)