### PR TITLE
Exclude archived projects from the default project list route

### DIFF
--- a/server/src/__tests__/projects-list-archived-routes.test.ts
+++ b/server/src/__tests__/projects-list-archived-routes.test.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, projects } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { projectRoutes } from "../routes/projects.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres project list archived tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+function boardActor(companyId: string): Express.Request["actor"] {
+  return {
+    type: "board",
+    userId: "user-1",
+    source: "session",
+    isInstanceAdmin: true,
+    companyIds: [companyId],
+    memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+  };
+}
+
+function createApp(db: ReturnType<typeof createDb>, actor: Express.Request["actor"]) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use("/api", projectRoutes(db));
+  app.use(errorHandler);
+  return app;
+}
+
+describeEmbeddedPostgres("project list archived route defaults", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-projects-list-archived-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(projects);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    const activeProjectId = randomUUID();
+    const archivedProjectId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values([
+      { id: activeProjectId, companyId, name: "Active Project", status: "in_progress" },
+      {
+        id: archivedProjectId,
+        companyId,
+        name: "Archived Project",
+        status: "completed",
+        archivedAt: new Date(),
+      },
+    ]);
+
+    return { activeProjectId, archivedProjectId, companyId };
+  }
+
+  it("omits archived projects by default", async () => {
+    const { activeProjectId, archivedProjectId, companyId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const res = await request(app).get(`/api/companies/${companyId}/projects`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((project: { id: string }) => project.id)).toEqual([activeProjectId]);
+    expect(res.body.map((project: { id: string }) => project.id)).not.toContain(archivedProjectId);
+  });
+
+  it("includes archived projects when includeArchived is true", async () => {
+    const { activeProjectId, archivedProjectId, companyId } = await seed();
+    const app = createApp(db, boardActor(companyId));
+
+    const res = await request(app).get(`/api/companies/${companyId}/projects?includeArchived=true`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((project: { id: string }) => project.id)).toEqual([activeProjectId, archivedProjectId]);
+  });
+});

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -129,7 +129,8 @@ export function projectRoutes(db: Db) {
   router.get("/companies/:companyId/projects", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
-    const result = await svc.list(companyId);
+    const includeArchived = req.query.includeArchived === "true";
+    const result = await svc.list(companyId, { includeArchived });
     res.json(await filterProjectsForActor(req, result));
   });
 

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -590,6 +590,11 @@ export function projectService(db: Db) {
 
   return {
     list: async (companyId: string, opts: { includeArchived?: boolean } = {}): Promise<ProjectWithGoals[]> => {
+      // NOTE: this service default is intentionally the inverse of the HTTP route default.
+      // The route (`GET /companies/:companyId/projects`) defaults `includeArchived` to `false`
+      // (active-only) for its callers, but the service defaults to `true` so that existing
+      // server-internal callers that pass no opts keep their pre-existing "return everything,
+      // including archived" behaviour. Pass `{ includeArchived: false }` explicitly for active-only.
       const includeArchived = opts.includeArchived ?? true;
       const where = includeArchived
         ? eq(projects.companyId, companyId)

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   projects,
@@ -589,8 +589,12 @@ export function projectService(db: Db) {
   };
 
   return {
-    list: async (companyId: string): Promise<ProjectWithGoals[]> => {
-      const rows = await db.select().from(projects).where(eq(projects.companyId, companyId));
+    list: async (companyId: string, opts: { includeArchived?: boolean } = {}): Promise<ProjectWithGoals[]> => {
+      const includeArchived = opts.includeArchived ?? true;
+      const where = includeArchived
+        ? eq(projects.companyId, companyId)
+        : and(eq(projects.companyId, companyId), isNull(projects.archivedAt));
+      const rows = await db.select().from(projects).where(where);
       const withGoals = await attachGoals(db, rows);
       const withWorkspaces = await attachWorkspaces(db, withGoals);
       return attachListMetrics(db, companyId, withWorkspaces);

--- a/ui/src/api/projects.ts
+++ b/ui/src/api/projects.ts
@@ -18,7 +18,12 @@ function projectPath(id: string, companyId?: string, suffix = "") {
 }
 
 export const projectsApi = {
-  list: (companyId: string) => api.get<Project[]>(`/companies/${companyId}/projects`),
+  list: (companyId: string, opts: { includeArchived?: boolean } = {}) => {
+    const params = new URLSearchParams();
+    if (opts.includeArchived) params.set("includeArchived", "true");
+    const query = params.toString();
+    return api.get<Project[]>("/companies/" + encodeURIComponent(companyId) + "/projects" + (query ? "?" + query : ""));
+  },
   get: (id: string, companyId?: string) => api.get<Project>(projectPath(id, companyId)),
   create: (companyId: string, data: Record<string, unknown>) =>
     api.post<Project>(`/companies/${companyId}/projects`, data),

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -1230,6 +1230,31 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
+  it("keeps the current archived project visible in the project property", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      createProject({
+        id: "archived-project",
+        name: "Archived Project",
+        archivedAt: new Date("2026-04-08T00:00:00.000Z"),
+      }),
+    ]);
+
+    const root = renderProperties(container, {
+      issue: createIssue({ projectId: "archived-project" }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
+    });
+    await flush();
+
+    expect(mockProjectsApi.list).toHaveBeenCalledWith("company-1", { includeArchived: true });
+    await waitForAssertion(() => {
+      expect(findRowTrigger(container, "Project")?.textContent).toContain("Archived Project");
+    });
+
+    act(() => root.unmount());
+  });
+
   it("shows a green service link above the workspace row for a live non-main workspace", async () => {
     mockProjectsApi.list.mockResolvedValue([createProject()]);
     const serviceUrl = "http://127.0.0.1:62475";

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -180,7 +180,7 @@ export function NewProjectDialog() {
         await projectsApi.createWorkspace(created.id, workspacePayload);
       }
 
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(selectedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(selectedCompanyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(created.id) });
       reset();
       closeNewProject();

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -325,7 +325,7 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(project.urlKey) });
     }
     if (selectedCompanyId) {
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(selectedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(selectedCompanyId) });
     }
   };
 

--- a/ui/src/components/ProjectWorkspacesContent.tsx
+++ b/ui/src/components/ProjectWorkspacesContent.tsx
@@ -45,7 +45,7 @@ export function ProjectWorkspacesContent({
       queryClient.invalidateQueries({ queryKey: queryKeys.executionWorkspaces.list(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.executionWorkspaces.list(companyId, { projectId }) });
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(companyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listByProject(companyId, projectId) });
     },
@@ -109,7 +109,7 @@ export function ProjectWorkspacesContent({
             queryClient.invalidateQueries({ queryKey: queryKeys.executionWorkspaces.list(companyId) });
             queryClient.invalidateQueries({ queryKey: queryKeys.executionWorkspaces.list(companyId, { projectId }) });
             queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(companyId) });
+            queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(companyId) });
             queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
             queryClient.invalidateQueries({ queryKey: queryKeys.issues.listByProject(companyId, projectId) });
             setClosingWorkspace(null);

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -231,8 +231,8 @@ export function IssueProperties({
     enabled: !!companyId,
   });
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(companyId!),
-    queryFn: () => projectsApi.list(companyId!),
+    queryKey: queryKeys.projects.list(companyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(companyId!, { includeArchived: true }),
     enabled: !!companyId,
   });
   const activeProjects = useMemo(

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -1030,7 +1030,7 @@ function invalidateActivityQueries(
   }
 
   if (entityType === "project") {
-    queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(companyId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(companyId) });
     if (entityId) queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(entityId) });
     return;
   }

--- a/ui/src/lib/queryKeys.test.ts
+++ b/ui/src/lib/queryKeys.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
+
+describe("project query keys", () => {
+  it("separates default and includeArchived project list caches", () => {
+    expect(queryKeys.projects.list("company-1")).toEqual([
+      "projects",
+      "company-1",
+      { includeArchived: false },
+    ]);
+    expect(queryKeys.projects.list("company-1", { includeArchived: true })).toEqual([
+      "projects",
+      "company-1",
+      { includeArchived: true },
+    ]);
+    expect(queryKeys.projects.list("company-1")).not.toEqual(
+      queryKeys.projects.list("company-1", { includeArchived: true }),
+    );
+    expect(queryKeys.projects.all("company-1")).toEqual(["projects", "company-1"]);
+  });
+});

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -243,7 +243,9 @@ export const queryKeys = {
       ["environment-custom-image-setup-sessions", sessionId] as const,
   },
   projects: {
-    list: (companyId: string) => ["projects", companyId] as const,
+    all: (companyId: string) => ["projects", companyId] as const,
+    list: (companyId: string, opts: { includeArchived?: boolean } = {}) =>
+      ["projects", companyId, { includeArchived: opts.includeArchived === true }] as const,
     detail: (id: string) => ["projects", "detail", id] as const,
   },
   cases: {

--- a/ui/src/pages/Cases.tsx
+++ b/ui/src/pages/Cases.tsx
@@ -807,8 +807,8 @@ export function Cases() {
     enabled: !!selectedCompanyId,
   });
   const projectsQuery = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId ?? ""),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId ?? "", { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
   const labelsQuery = useQuery({
@@ -1272,7 +1272,7 @@ export function Cases() {
                           checked={viewState.projectFilters.includes(ALL)}
                           onCheckedChange={(checked) => toggleStringFilter("projectFilters", ALL, checked)}
                         />
-                        {(projectsQuery.data ?? []).map((project) => (
+                        {(projectsQuery.data ?? []).filter((project) => !project.archivedAt).map((project) => (
                           <FilterCheckboxRow
                             key={project.id}
                             label={project.name}

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -204,7 +204,7 @@ export function Costs() {
     queryClient.invalidateQueries({ queryKey: queryKeys.budgets.overview(selectedCompanyId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(selectedCompanyId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId) });
-    queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(selectedCompanyId) });
+    queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(selectedCompanyId) });
   };
 
   const policyMutation = useMutation({

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -91,8 +91,8 @@ export function Dashboard() {
   });
 
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId!),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
 

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -72,8 +72,8 @@ export function GoalDetail() {
   });
 
   const { data: allProjects } = useQuery({
-    queryKey: queryKeys.projects.list(resolvedCompanyId!),
-    queryFn: () => projectsApi.list(resolvedCompanyId!),
+    queryKey: queryKeys.projects.list(resolvedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(resolvedCompanyId!, { includeArchived: true }),
     enabled: !!resolvedCompanyId
   });
 

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -760,8 +760,8 @@ export function Inbox() {
   });
 
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId!),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
   const { data: labels } = useQuery({

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -92,8 +92,8 @@ export function Issues() {
   });
 
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId!),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
 

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -475,7 +475,7 @@ export function ProjectDetail() {
     queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(routeProjectRef) });
     queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectLookupRef) });
     if (resolvedCompanyId) {
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(resolvedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(resolvedCompanyId) });
     }
   };
 
@@ -670,7 +670,7 @@ export function ProjectDetail() {
       queryClient.invalidateQueries({ queryKey: queryKeys.budgets.overview(resolvedCompanyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(routeProjectRef) });
       queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectLookupRef) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(resolvedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(resolvedCompanyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(resolvedCompanyId) });
     },
   });

--- a/ui/src/pages/ProjectWorkspaceDetail.tsx
+++ b/ui/src/pages/ProjectWorkspaceDetail.tsx
@@ -340,7 +340,7 @@ export function ProjectWorkspaceDetail() {
     queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(project.id) });
     queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(project.urlKey) });
     if (lookupCompanyId) {
-      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(lookupCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(lookupCompanyId) });
     }
   };
 

--- a/ui/src/pages/RoutineDetail.test.tsx
+++ b/ui/src/pages/RoutineDetail.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildRoutineProjectOptions } from "./RoutineDetail";
+
+describe("RoutineDetail project selector options", () => {
+  it("excludes archived projects from the editor selector", () => {
+    expect(buildRoutineProjectOptions([
+      { id: "active-project", name: "Active Project", description: "Visible", archivedAt: null },
+      {
+        id: "archived-project",
+        name: "Archived Project",
+        description: "Hidden",
+        archivedAt: new Date("2026-04-02T00:00:00.000Z"),
+      },
+    ])).toEqual([
+      { id: "active-project", label: "Active Project", searchText: "Visible" },
+    ]);
+  });
+});

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -69,6 +69,18 @@ import type {
 
 const LAST_SECTION_STORAGE_KEY = "paperclip.routineLastSection";
 
+export function buildRoutineProjectOptions(
+  projects: ReadonlyArray<{ id: string; name: string; description?: string | null; archivedAt?: Date | string | null }>,
+): InlineEntityOption[] {
+  return projects
+    .filter((project) => !project.archivedAt)
+    .map((project) => ({
+      id: project.id,
+      label: project.name,
+      searchText: project.description ?? "",
+    }));
+}
+
 const SECTION_TITLES: Record<RoutineSectionKey, string> = {
   overview: "Overview",
   triggers: "Triggers",
@@ -220,8 +232,8 @@ export function RoutineDetail() {
     enabled: !!selectedCompanyId,
   });
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId!),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
   const { data: companyMembers } = useQuery({
@@ -567,16 +579,15 @@ export function RoutineDetail() {
     [agents, recentAssigneeIds],
   );
   const projectOptions = useMemo<InlineEntityOption[]>(
-    () =>
-      (projects ?? []).map((project) => ({
-        id: project.id,
-        label: project.name,
-        searchText: project.description ?? "",
-      })),
+    () => buildRoutineProjectOptions(projects ?? []),
     [projects],
   );
   const mentionOptions = useMemo<MentionOption[]>(
-    () => buildMarkdownMentionOptions({ agents, projects, members: companyMembers?.users }),
+    () => buildMarkdownMentionOptions({
+      agents,
+      projects: (projects ?? []).filter((project) => !project.archivedAt),
+      members: companyMembers?.users,
+    }),
     [agents, companyMembers?.users, projects],
   );
 

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -26,6 +26,7 @@ const markdownEditorRenderMock = vi.fn((props: { mentions?: Array<{ id: string; 
 const issuesListRenderMock = vi.fn(({ issues }: { issues: Issue[] }) => (
   <div data-testid="issues-list">{issues.map((issue) => issue.title).join(", ")}</div>
 ));
+const inlineEntitySelectorRenderMock = vi.fn((props: { options?: Array<{ id: string }> }) => props);
 
 vi.mock("@/lib/router", () => ({
   Link: ({ to, children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { to: string; children: ReactNode }) => (
@@ -180,6 +181,29 @@ vi.mock("../api/projects", () => ({
         createdAt: new Date("2026-04-01T00:00:00.000Z"),
         updatedAt: new Date("2026-04-01T00:00:00.000Z"),
       },
+      {
+        id: "project-archived",
+        companyId: "company-1",
+        urlKey: "project-archived",
+        goalId: null,
+        goalIds: [],
+        goals: [],
+        name: "Archived Project",
+        description: null,
+        status: "completed",
+        leadAgentId: null,
+        targetDate: null,
+        color: "#94a3b8",
+        pauseReason: null,
+        pausedAt: null,
+        archivedAt: new Date("2026-04-02T00:00:00.000Z"),
+        executionWorkspacePolicy: null,
+        codebase: null,
+        workspaces: [],
+        primaryWorkspace: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
     ]),
   },
 }));
@@ -237,7 +261,10 @@ vi.mock("../components/MarkdownEditor", () => ({
 }));
 
 vi.mock("../components/InlineEntitySelector", () => ({
-  InlineEntitySelector: () => <button type="button">selector</button>,
+  InlineEntitySelector: (props: { options?: Array<{ id: string }> }) => {
+    inlineEntitySelectorRenderMock(props);
+    return <button type="button">selector</button>;
+  },
 }));
 
 vi.mock("../components/RoutineRunVariablesDialog", () => ({
@@ -365,6 +392,7 @@ describe("Routines page", () => {
     issuesListMock.mockReset();
     markdownEditorRenderMock.mockClear();
     issuesListRenderMock.mockClear();
+    inlineEntitySelectorRenderMock.mockClear();
     localStorage.clear();
   });
 
@@ -786,6 +814,56 @@ describe("Routines page", () => {
 
     expect(runNowButton).toBeTruthy();
     expect(runNowButton?.getAttribute("data-variant")).toBe("outline");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("excludes archived projects from the create composer project selector", async () => {
+    routinesListMock.mockResolvedValue([]);
+    issuesListMock.mockResolvedValue([]);
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Routines />
+        </QueryClientProvider>,
+      );
+      await flush();
+    });
+
+    let createButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Create routine"),
+    );
+    for (let attempts = 0; attempts < 5 && !createButton; attempts += 1) {
+      await act(async () => {
+        await flush();
+      });
+      createButton = Array.from(container.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Create routine"),
+      );
+    }
+
+    await act(async () => {
+      createButton?.click();
+      await flush();
+    });
+
+    const projectSelectorCall = inlineEntitySelectorRenderMock.mock.calls.find(([props]) => {
+      const ids = (props.options ?? []).map((option) => option.id);
+      return ids.includes("project-1") && ids.includes("project-2");
+    });
+
+    expect(projectSelectorCall).toBeTruthy();
+    expect(projectSelectorCall?.[0].options?.map((option) => option.id)).toEqual(["project-1", "project-2"]);
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -357,8 +357,8 @@ export function Routines() {
     enabled: !!selectedCompanyId,
   });
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId!),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
   const { data: companyMembers } = useQuery({
@@ -396,7 +396,7 @@ export function Routines() {
   const mentionOptions = useMemo<MentionOption[]>(() => {
     return buildMarkdownMentionOptions({
       agents,
-      projects,
+      projects: (projects ?? []).filter((project) => !project.archivedAt),
       members: companyMembers?.users,
     });
   }, [agents, companyMembers?.users, projects]);
@@ -602,7 +602,7 @@ export function Routines() {
   );
   const projectOptions = useMemo<InlineEntityOption[]>(
     () =>
-      (projects ?? []).map((project) => ({
+      (projects ?? []).filter((project) => !project.archivedAt).map((project) => ({
         id: project.id,
         label: project.name,
         searchText: project.description ?? "",

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -225,8 +225,8 @@ export function Search() {
   });
 
   const { data: projects = [] } = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId!),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId!, { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
 

--- a/ui/src/pages/Training.tsx
+++ b/ui/src/pages/Training.tsx
@@ -99,8 +99,8 @@ export function TrainingLibrary() {
     enabled: Boolean(selectedCompanyId),
   });
   const projectsQuery = useQuery({
-    queryKey: ["projects", selectedCompanyId],
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId ?? "", { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: Boolean(selectedCompanyId),
   });
   const records = recordsQuery.data ?? [];

--- a/ui/src/pages/apps/gateways/GatewayDetail.tsx
+++ b/ui/src/pages/apps/gateways/GatewayDetail.tsx
@@ -62,8 +62,8 @@ export function GatewayDetail() {
     enabled: !!selectedCompanyId,
   });
   const projectsQuery = useQuery({
-    queryKey: queryKeys.projects.list(selectedCompanyId ?? "__none__"),
-    queryFn: () => projectsApi.list(selectedCompanyId!),
+    queryKey: queryKeys.projects.list(selectedCompanyId ?? "__none__", { includeArchived: true }),
+    queryFn: () => projectsApi.list(selectedCompanyId!, { includeArchived: true }),
     enabled: !!selectedCompanyId,
   });
 

--- a/ui/src/pages/tools/GatewaysTab.tsx
+++ b/ui/src/pages/tools/GatewaysTab.tsx
@@ -138,8 +138,8 @@ export function GatewaysTab({ companyId }: { companyId: string }) {
     queryFn: () => agentsApi.list(companyId),
   });
   const projectsQuery = useQuery({
-    queryKey: queryKeys.projects.list(companyId),
-    queryFn: () => projectsApi.list(companyId),
+    queryKey: queryKeys.projects.list(companyId, { includeArchived: true }),
+    queryFn: () => projectsApi.list(companyId, { includeArchived: true }),
   });
 
   const origin = useMemo(() => {

--- a/ui/src/pages/tools/PoliciesTab.tsx
+++ b/ui/src/pages/tools/PoliciesTab.tsx
@@ -812,8 +812,8 @@ export function PoliciesTab({ companyId }: { companyId: string }) {
     queryFn: () => agentsApi.list(companyId),
   });
   const projects = useQuery({
-    queryKey: queryKeys.projects.list(companyId),
-    queryFn: () => projectsApi.list(companyId),
+    queryKey: queryKeys.projects.list(companyId, { includeArchived: true }),
+    queryFn: () => projectsApi.list(companyId, { includeArchived: true }),
   });
   const applications = useQuery({
     queryKey: queryKeys.tools.applications(companyId),
@@ -958,7 +958,7 @@ export function PoliciesTab({ companyId }: { companyId: string }) {
 
   const saving = createPolicy.isPending || updatePolicy.isPending;
   const agentsList = agents.data ?? [];
-  const projectsList = projects.data ?? [];
+  const projectsList = (projects.data ?? []).filter((project) => !project.archivedAt);
   const applicationList = applications.data?.applications ?? [];
 
   if (form) {

--- a/ui/src/pages/tools/ProfilesTab.tsx
+++ b/ui/src/pages/tools/ProfilesTab.tsx
@@ -312,8 +312,8 @@ function useLookupData(companyId: string) {
     queryFn: () => agentsApi.list(companyId),
   });
   const projects = useQuery({
-    queryKey: queryKeys.projects.list(companyId),
-    queryFn: () => projectsApi.list(companyId),
+    queryKey: queryKeys.projects.list(companyId, { includeArchived: true }),
+    queryFn: () => projectsApi.list(companyId, { includeArchived: true }),
   });
   const routines = useQuery({
     queryKey: queryKeys.routines.list(companyId),
@@ -702,7 +702,7 @@ export function ProfilesTab({ companyId }: { companyId: string }) {
   const applicationOptions = lookups.applications.data?.applications ?? [];
   const connectionOptions = lookups.connections.data?.connections ?? [];
   const agentOptions = lookups.agents.data ?? [];
-  const projectOptions = lookups.projects.data ?? [];
+  const projectOptions = (lookups.projects.data ?? []).filter((project) => !project.archivedAt);
   const routineOptions = lookups.routines.data ?? [];
 
   const invalidateProfiles = () => {

--- a/ui/src/plugins/bridge-init.ts
+++ b/ui/src/plugins/bridge-init.ts
@@ -267,8 +267,8 @@ function PluginSdkIssuesList({
     enabled: !!companyId,
   });
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(companyId ?? "__no-company__"),
-    queryFn: () => projectsApi.list(companyId!),
+    queryKey: queryKeys.projects.list(companyId ?? "__no-company__", { includeArchived: true }),
+    queryFn: () => projectsApi.list(companyId!, { includeArchived: true }),
     enabled: !!companyId,
   });
   const liveRunsQueryKey = queryKeys.liveRuns(companyId ?? "__no-company__");
@@ -464,8 +464,8 @@ function PluginSdkProjectPicker({
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
   const { data: projects } = useQuery({
-    queryKey: queryKeys.projects.list(resolvedCompanyId ?? "__no-company__"),
-    queryFn: () => projectsApi.list(resolvedCompanyId!),
+    queryKey: queryKeys.projects.list(resolvedCompanyId ?? "__no-company__", { includeArchived }),
+    queryFn: () => projectsApi.list(resolvedCompanyId!, { includeArchived }),
     enabled: !!resolvedCompanyId,
   });
   const visibleProjects = useMemo(


### PR DESCRIPTION
## What happened
Archived projects are returned by default from `GET /companies/:companyId/projects`, which causes archived projects to appear in active-selection surfaces.

## Expected behavior
`GET /companies/:companyId/projects` should return active projects only unless `includeArchived=true` is explicitly requested.

## Steps to reproduce
1. Call `GET /companies/:companyId/projects` without `includeArchived=true`.
2. Observe archived projects returned in the list.

## Paperclip version or commit
`bd3cfa556fbd655ca8fb0d66a199cb7ed41159d6`

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The project list route is a core entry point for picking and navigating projects
> - Archived projects should usually stay out of the default list so active work surfaces first
> - At the same time, some flows still need an explicit archived opt-in
> - This pull request changes the default project list route to exclude archived projects unless `includeArchived=true` is requested
> - The benefit is less accidental selection of archived projects while preserving the explicit archived path for administrative or lookup flows

## Linked Issues or Issue Description

No public GitHub issue was used for this change. Bug report:

- **What happened?** Archived projects are returned from `GET /companies/:companyId/projects` by default, so archived rows show up in active-selection surfaces.
- **Expected behavior** `GET /companies/:companyId/projects` should return active projects only unless `includeArchived=true` is set.
- **Steps to reproduce**
  1. Call `GET /companies/:companyId/projects` without `includeArchived=true`.
  2. Observe archived project rows in the response and downstream selectors.
  3. Compare with `includeArchived=true`, which should include archived projects explicitly.
- **Paperclip version or commit** `bd3cfa556fbd655ca8fb0d66a199cb7ed41159d6`
- **Deployment mode** Built from source (`pnpm dev` / `pnpm build`)
- **Installation method** Built from source (`pnpm dev` / `pnpm build`)
- **Database mode** Embedded PGlite (default — `DATABASE_URL` unset)
- **Agent adapter(s) involved** Not adapter-specific (core bug)
- **Access context** Board and agent surfaces both consume this route
- **Node.js version** `v22.22.3`
- **Operating system** `Linux 6.17.0-1017-aws`
- **Relevant logs or output** Default project list requests include archived rows until `includeArchived=true` is set.
- **Additional context** Server-internal callers can still opt into archived projects when they need them.

## What Changed

- Default `GET /companies/:companyId/projects` to active projects only.
- Preserve archived opt-in behavior with `includeArchived=true`.
- Keep direct service-level project listing behavior inclusive so server-internal callers can still request archived projects explicitly.
- Split project list React Query cache keys by `includeArchived`.
- Keep name maps and keep-current UI surfaces aligned with archived rows.
- Keep routine, tool, and case picker options active-only.
- Add regression coverage for the route, cache keys, and project selectors.

## Verification

- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/projects-list-archived-routes.test.ts --pool=forks --isolate`
- `pnpm exec vitest run --project @paperclipai/ui ui/src/lib/queryKeys.test.ts ui/src/pages/Routines.test.tsx ui/src/pages/RoutineDetail.test.tsx ui/src/components/IssueProperties.test.tsx`
- `pnpm typecheck`

## Risks

- Low risk: the change is narrowly scoped to default archived-project visibility.
- UI consumers that relied on archived projects appearing by default will now need to opt in explicitly.
- Cache-key separation is required for correctness; if a caller omits `includeArchived`, it will see active-only data as intended.

## Model Used

OpenAI Codex, GPT-5, code-execution enabled, reasoning-focused, tool-using agent workflow.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

