### PR TITLE
fix(codex): retry MCP transport crashes

### DIFF
--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -115,6 +115,20 @@ describe("isCodexUnknownSessionError", () => {
 });
 
 describe("isCodexTransientUpstreamError", () => {
+  it("classifies MCP transport crashes as transient upstream", () => {
+    expect(
+      isCodexTransientUpstreamError({
+        stderr:
+          "rmcp::transport::worker: worker quit with fatal: Transport channel closed, when UnexpectedContentType(Some(\"text/plain\"))",
+      }),
+    ).toBe(true);
+    expect(
+      isCodexTransientUpstreamError({
+        errorMessage: "MCP tool-server connection reset by peer",
+      }),
+    ).toBe(true);
+  });
+
   it("classifies the remote-compaction high-demand failure as transient upstream", () => {
     expect(
       isCodexTransientUpstreamError({

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -8,6 +8,8 @@ import {
 const CODEX_TRANSIENT_UPSTREAM_RE =
   /(?:we(?:'|’)re\s+currently\s+experiencing\s+high\s+demand|temporary\s+errors|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|server\s+overloaded|service\s+unavailable|try\s+again\s+later)/i;
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
+const CODEX_RETRYABLE_TRANSPORT_RE =
+  /(?:rmcp::transport::worker|transport\s+channel\s+closed|unexpectedcontenttype|connection\s+(?:reset|closed|refused)|broken\s+pipe|network\s+is\s+unreachable|timed?\s*out\s+(?:connecting|waiting)|(?:mcp|tool)[-_\s]server.{0,80}(?:disconnect|transport|connection|closed|unavailable)|error\s+sending\s+request\s+for\s+url)/i;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
 const CODEX_PROVIDER_QUOTA_RE =
@@ -285,9 +287,10 @@ export function isCodexTransientUpstreamError(input: {
   const haystack = buildCodexErrorHaystack(input);
 
   if (isCodexProviderQuotaError(input)) return false;
+  if (CODEX_RETRYABLE_TRANSPORT_RE.test(haystack)) return true;
   if (!CODEX_TRANSIENT_UPSTREAM_RE.test(haystack)) return false;
-  // Keep automatic retries scoped to the observed remote-compaction/high-demand
-  // failure shape.
+  // Keep provider-side automatic retries scoped to the observed
+  // remote-compaction/high-demand failure shape.
   return CODEX_REMOTE_COMPACTION_RE.test(haystack) || /high\s+demand|temporary\s+errors/i.test(haystack);
 }
 

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -698,6 +698,59 @@ describe("codex execute", () => {
     }
   });
 
+  it("classifies MCP transport crashes as retryable transient upstream errors", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-transport-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingCodexCommand(
+      commandPath,
+      "rmcp::transport::worker: worker quit with fatal: Transport channel closed, when UnexpectedContentType(Some(\\\"text/plain\\\"))",
+    );
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    await seedSharedCodexAuth(root);
+
+    try {
+      const result = await execute({
+        runId: "run-transport-error",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: "thread-transport-error",
+          sessionParams: null,
+          sessionDisplayId: "thread-transport-error",
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("codex_transient_upstream");
+      expect(result.errorFamily).toBe("transient_upstream");
+      expect(result.errorMessage).toContain("Transport channel closed");
+      expect(result.clearSession).toBe(false);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("persists retry-not-before metadata for codex provider quota failures", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-usage-limit-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -2133,6 +2133,37 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     }
   });
 
+  it("schedules a recovery continuation for codex transport failures", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-07-24T12:00:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "codex_transient_upstream",
+      errorFamily: "transient_upstream",
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    expect(scheduled.run.scheduledRetryAttempt).toBe(1);
+    expect(scheduled.run.scheduledRetryReason).toBe("transient_failure");
+    expect((scheduled.run.contextSnapshot as Record<string, unknown>).codexTransientFallbackMode).toBe("same_session");
+    expect((scheduled.run.contextSnapshot as Record<string, unknown>).retryOfRunId).toBe(runId);
+
+    await cleanupRetryFixture();
+  });
+
   it("honors codex retry-not-before timestamps when they exceed the default bounded backoff", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents and their work
> - Heartbeat execution depends on adapters surfacing failures with enough structure for the control plane to choose recovery behavior
> - The Codex adapter already marks provider overload and quota failures as recoverable, and the heartbeat service already schedules bounded continuation retries for that error family
> - MCP transport crashes were not recognized by the adapter, so transient channel closures fell through as fatal unclassified adapter failures
> - That mismatch could terminalize an otherwise recoverable heartbeat and discard the live issue execution path
> - This pull request classifies recognizable MCP, tool-server, transport, and network disconnect signatures as transient upstream failures
> - The benefit is that Codex reconnects through the existing bounded backoff continuation path instead of losing the run on a one-off transport blip

## Linked Issues or Issue Description

- **What happened:** a Codex MCP transport worker could exit with messages such as `Transport channel closed` / `UnexpectedContentType`, and Paperclip recorded a terminal adapter failure without an automatic continuation.
- **Expected behavior:** transient MCP or network transport failures should use the existing bounded retry policy and preserve the resumable Codex session for the first reconnect attempt.
- **Steps to reproduce:** run a Codex heartbeat through an MCP server that closes the transport or returns an unexpected content type; observe the non-zero Codex exit and transport error on stderr.
- **Affected version:** reproduced on Paperclip commits before this change, including the current adapter behavior on `master`.
- **Deployment mode:** local Codex adapter with MCP/tool-server access.

## What Changed

- Added recognition for MCP worker exits, closed transport channels, unexpected content types, common connection failures, broken pipes, tool-server disconnects, and request transport errors.
- Mapped those failures to the existing `codex_transient_upstream` / `transient_upstream` recovery contract while keeping the current session available for the first reconnect.
- Added parser, adapter execution, and heartbeat scheduling regression tests covering classification and the queued recovery continuation.

## Verification

- `vitest run packages/adapters/codex-local/src/server/parse.test.ts server/src/__tests__/codex-local-execute.test.ts server/src/__tests__/heartbeat-retry-scheduling.test.ts` — 3 files passed, 58 tests passed.
- `git diff --check` — passed.
- Targeted typecheck was attempted, but this runner installs with `NODE_ENV=production` and omitted TypeScript dev links / `@types/node`; the focused Vitest compilation and runtime coverage passed.

## Risks

- Low-to-moderate risk: regex classification can be broader than a typed protocol error. Patterns are limited to explicit transport/network/tool-server failure language and continue to exclude provider quota and deterministic compaction request errors.
- No schema, migration, API contract, or UI changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex coding agent; exact runtime model ID and context-window size were not exposed by the execution environment. Used reasoning, repository search, terminal execution, code editing, and test execution capabilities.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
