### PR TITLE
fix: prevent blocked handoffs from completing issues

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -1198,6 +1198,7 @@ A release candidate is blocked unless these pass:
 3. hard budget stop test
 4. agent pause/resume test
 5. dashboard summary consistency test
+6. successful-heartbeat completion gate test: blocked, unverified, or no-control-plane-evidence output cannot transition an issue to `done`
 
 ## 18. Delivery Plan
 
@@ -1221,6 +1222,7 @@ Current implementation note: the milestones below describe the original V1 seque
 - ship `process` adapter with cancel semantics
 - ship `http` adapter with timeout/error handling
 - persist heartbeat runs and statuses
+- treat successful process exit and issue completion as separate facts: `done` requires an explicit agent disposition, and corrective handoff runs must reject `done` when the source run reported blocked/unverified work or produced no durable control-plane evidence
 
 ## Milestone 4: Cost and Budget Controls
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -126,6 +126,7 @@ import {
 } from "../services/index.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
 import { hydrateSuccessfulRunHandoffLiveness } from "../services/successful-run-handoff-state.js";
+import { successfulRunHandoffDoneGateReason } from "../services/recovery/successful-run-handoff.js";
 import {
   TASK_WATCHDOG_ORIGIN_KIND,
   resolveTaskWatchdogMutationScope,
@@ -7685,6 +7686,22 @@ export function issueRoutes(
       hiddenAt: hiddenAtRaw,
       ...updateFields
     } = req.body;
+    if (req.actor.type === "agent" && actor.agentId && updateFields.status === "done" && actor.runId) {
+      const actorRun = await db
+        .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.id, actor.runId),
+          eq(heartbeatRuns.companyId, existing.companyId),
+          eq(heartbeatRuns.agentId, actor.agentId),
+        ))
+        .then((rows) => rows[0] ?? null);
+      const doneGateReason = successfulRunHandoffDoneGateReason(actorRun?.contextSnapshot, existing.id);
+      if (doneGateReason) {
+        res.status(422).json({ error: doneGateReason });
+        return;
+      }
+    }
     const shouldCancelActiveRunForCancelledStatus =
       existing.status !== "cancelled" && updateFields.status === "cancelled";
     if (resumeRequested === true && !commentBody) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7971,7 +7971,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       })
       : null;
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
-    const detectedProgressSummary = await buildDetectedSuccessfulRunProgressSummary(run);
+    const [detectedProgressSummary, livenessInput] = await Promise.all([
+      buildDetectedSuccessfulRunProgressSummary(run),
+      buildRunLivenessInput(run, parseObject(run.resultJson)),
+    ]);
 
     const [
       activeExecutionPath,
@@ -8131,6 +8134,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agent,
       livenessState: run.livenessState as RunLivenessState | null,
       detectedProgressSummary,
+      evidence: livenessInput.evidence ?? null,
       taskKey,
       hasActiveExecutionPath: Boolean(activeExecutionPath),
       hasQueuedWake: Boolean(queuedWake),

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -123,7 +123,8 @@ describe("successful run handoff decision", () => {
       doneDispositionAllowed: false,
       verificationEvidenceStatus: "not_recorded",
     });
-    expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
+    expect(decision.payload.validDispositionOptions).toContain("mark_cancelled");
     expect(decision.instruction).toContain("must not mark this issue `done`");
     expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot)).toContain("reported blocked work");
     expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot, "another-issue")).toBeNull();
@@ -144,7 +145,8 @@ describe("successful run handoff decision", () => {
       doneDispositionAllowed: false,
       verificationEvidenceStatus: "reported_missing",
     });
-    expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
+    expect(decision.payload.validDispositionOptions).toContain("mark_cancelled");
     expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot)).toContain("reported unverified work");
   });
 
@@ -161,7 +163,8 @@ describe("successful run handoff decision", () => {
       doneDispositionAllowed: false,
       verificationEvidenceStatus: "control_plane_evidence_missing",
     });
-    expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
+    expect(decision.payload.validDispositionOptions).toContain("mark_cancelled");
     expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot, issue.id)).toContain(
       "reported no control plane evidence work",
     );

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -134,7 +134,7 @@ describe("successful run handoff decision", () => {
     const decision = decide({ detectedProgressSummary });
 
     expect(classifySuccessfulRunReportedDisposition({
-      livenessState: "needs_followup",
+      livenessState: "advanced",
       detectedProgressSummary,
     })).toBe("unverified");
     expect(decision.kind).toBe("enqueue");
@@ -163,8 +163,15 @@ describe("successful run handoff decision", () => {
     });
     expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
     expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot, issue.id)).toContain(
-      "reported no_control_plane_evidence work",
+      "reported no control plane evidence work",
     );
+  });
+
+  it("does not gate done for an intentional non-verification statement with durable evidence", () => {
+    expect(classifySuccessfulRunReportedDisposition({
+      livenessState: "advanced",
+      detectedProgressSummary: "The migration was not run by design because this change only updates documentation.",
+    })).toBeNull();
   });
 
   it("does not queue when the issue already has a valid disposition", () => {

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -7,11 +7,13 @@ import {
   buildFinishSuccessfulRunHandoffIdempotencyKey,
   buildSuccessfulRunHandoffExhaustedNotice,
   buildSuccessfulRunHandoffRequiredNotice,
+  classifySuccessfulRunReportedDisposition,
   decideSuccessfulRunHandoff,
   isIdempotentFinishSuccessfulRunHandoffWakeStatus,
   isSuccessfulRunHandoffValidPathSkip,
   isSuccessfulRunHandoffRequiredNoticeBody,
   noticeMetadataReferencesRecoveryAction,
+  successfulRunHandoffDoneGateReason,
 } from "./successful-run-handoff.js";
 import { UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON } from "@paperclipai/adapter-utils/server-utils";
 
@@ -84,6 +86,9 @@ describe("successful run handoff decision", () => {
       allowDeliverableWork: false,
       allowDocumentUpdates: false,
       resumeRequiresNormalModel: true,
+      sourceReportedDisposition: null,
+      doneDispositionAllowed: true,
+      verificationEvidenceStatus: "not_recorded",
     });
     expect(decision.contextSnapshot).toMatchObject({
       wakeReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
@@ -99,6 +104,67 @@ describe("successful run handoff decision", () => {
     expect(decision.instruction).toContain("Resolve the missing disposition before creating or revising any new artifacts");
     expect(decision.instruction).toContain("Choose **exactly one** outcome");
     expect(decision.instruction).toContain("record an explicit continuation path");
+  });
+
+  it("gates done when the source final message reports blocked work", () => {
+    const decision = decide({
+      livenessState: "blocked",
+      detectedProgressSummary: "**Blocked** — The benchmark target is not mounted in this environment.",
+    });
+
+    expect(classifySuccessfulRunReportedDisposition({
+      livenessState: "blocked",
+      detectedProgressSummary: "**Blocked** — The benchmark target is not mounted in this environment.",
+    })).toBe("blocked");
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      sourceReportedDisposition: "blocked",
+      doneDispositionAllowed: false,
+      verificationEvidenceStatus: "not_recorded",
+    });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
+    expect(decision.instruction).toContain("must not mark this issue `done`");
+    expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot)).toContain("reported blocked work");
+    expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot, "another-issue")).toBeNull();
+  });
+
+  it("gates done when the source final message says verification could not run", () => {
+    const detectedProgressSummary = "coqc is not installed, so local compilation could not run.";
+    const decision = decide({ detectedProgressSummary });
+
+    expect(classifySuccessfulRunReportedDisposition({
+      livenessState: "needs_followup",
+      detectedProgressSummary,
+    })).toBe("unverified");
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      sourceReportedDisposition: "unverified",
+      doneDispositionAllowed: false,
+      verificationEvidenceStatus: "reported_missing",
+    });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
+    expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot)).toContain("reported unverified work");
+  });
+
+  it("gates done when a successful run produced no durable control-plane evidence", () => {
+    const decision = decide({
+      livenessState: "needs_followup",
+      detectedProgressSummary: "Implemented the change locally.",
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      sourceReportedDisposition: "no_control_plane_evidence",
+      doneDispositionAllowed: false,
+      verificationEvidenceStatus: "control_plane_evidence_missing",
+    });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done_or_cancelled");
+    expect(successfulRunHandoffDoneGateReason(decision.contextSnapshot, issue.id)).toContain(
+      "reported no_control_plane_evidence work",
+    );
   });
 
   it("does not queue when the issue already has a valid disposition", () => {

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -9,6 +9,7 @@ import {
   buildSuccessfulRunHandoffRequiredNotice,
   classifySuccessfulRunReportedDisposition,
   decideSuccessfulRunHandoff,
+  hasAffirmativeSuccessfulRunCompletionEvidence,
   isIdempotentFinishSuccessfulRunHandoffWakeStatus,
   isSuccessfulRunHandoffValidPathSkip,
   isSuccessfulRunHandoffRequiredNoticeBody,
@@ -49,6 +50,7 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     agent,
     livenessState: "advanced",
     detectedProgressSummary: "Run produced concrete action evidence: 1 issue comment(s)",
+    evidence: { workProductsCreated: 1 },
     taskKey: "issue-1",
     hasActiveExecutionPath: false,
     hasQueuedWake: false,
@@ -88,7 +90,7 @@ describe("successful run handoff decision", () => {
       resumeRequiresNormalModel: true,
       sourceReportedDisposition: null,
       doneDispositionAllowed: true,
-      verificationEvidenceStatus: "not_recorded",
+      verificationEvidenceStatus: "affirmative",
     });
     expect(decision.contextSnapshot).toMatchObject({
       wakeReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
@@ -132,7 +134,7 @@ describe("successful run handoff decision", () => {
 
   it("gates done when the source final message says verification could not run", () => {
     const detectedProgressSummary = "coqc is not installed, so local compilation could not run.";
-    const decision = decide({ detectedProgressSummary });
+    const decision = decide({ detectedProgressSummary, evidence: null });
 
     expect(classifySuccessfulRunReportedDisposition({
       livenessState: "advanced",
@@ -154,6 +156,7 @@ describe("successful run handoff decision", () => {
     const decision = decide({
       livenessState: "needs_followup",
       detectedProgressSummary: "Implemented the change locally.",
+      evidence: null,
     });
 
     expect(decision.kind).toBe("enqueue");
@@ -170,6 +173,78 @@ describe("successful run handoff decision", () => {
     );
   });
 
+  it("gates done for confident completion prose without structured evidence", () => {
+    const decision = decide({
+      livenessState: "needs_followup",
+      detectedProgressSummary: "Completed. The certificate files are correct and ready to ship.",
+      evidence: null,
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      doneDispositionAllowed: false,
+      verificationEvidenceStatus: "control_plane_evidence_missing",
+    });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
+  });
+
+  it("gates done when verification failed and left no durable evidence", () => {
+    const decision = decide({
+      livenessState: "needs_followup",
+      detectedProgressSummary: "Verifier finished with 0/3 checks passing.",
+      evidence: null,
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({ doneDispositionAllowed: false });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
+  });
+
+  it("allows done only with affirmative structured evidence and completion-capable liveness", () => {
+    expect(hasAffirmativeSuccessfulRunCompletionEvidence({
+      livenessState: "advanced",
+      evidence: { workProductsCreated: 1 },
+    })).toBe(true);
+    expect(hasAffirmativeSuccessfulRunCompletionEvidence({
+      livenessState: "blocked",
+      evidence: { workProductsCreated: 1 },
+    })).toBe(false);
+
+    const decision = decide({
+      livenessState: "advanced",
+      detectedProgressSummary: "Created the verified release artifact.",
+      evidence: { workProductsCreated: 1, toolOrActionEventsCreated: 2 },
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      doneDispositionAllowed: true,
+      verificationEvidenceStatus: "affirmative",
+    });
+    expect(decision.payload.validDispositionOptions).toContain("mark_done");
+  });
+
+  it("gates done when all control-plane writes failed", () => {
+    const decision = decide({
+      livenessState: "needs_followup",
+      detectedProgressSummary: "Completed, but every control-plane write failed.",
+      evidence: {
+        issueCommentsCreated: 0,
+        documentRevisionsCreated: 0,
+        workProductsCreated: 0,
+        activityEventsCreated: 0,
+        toolOrActionEventsCreated: 0,
+      },
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({ doneDispositionAllowed: false });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
+  });
   it("does not gate done for an intentional non-verification statement with durable evidence", () => {
     expect(classifySuccessfulRunReportedDisposition({
       livenessState: "advanced",
@@ -262,11 +337,16 @@ describe("successful run handoff decision", () => {
     });
   });
 
-  it("does not queue when a successful run has no progress signal", () => {
-    expect(decide({ livenessState: null, detectedProgressSummary: null })).toEqual({
-      kind: "skip",
-      reason: "successful run did not produce handoff-relevant progress",
+  it("queues a non-done handoff when a clean run has no disposition or evidence", () => {
+    const decision = decide({ livenessState: null, detectedProgressSummary: null, evidence: null });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      doneDispositionAllowed: false,
+      verificationEvidenceStatus: "not_recorded",
     });
+    expect(decision.payload.validDispositionOptions).not.toContain("mark_done");
   });
 
   it("does not treat adapter or runtime failures as missing-disposition handoffs", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -23,6 +23,16 @@ export const SUCCESSFUL_RUN_HANDOFF_OPTIONS = [
   "delegate_or_continue_from_checkpoint",
 ] as const;
 
+export type SuccessfulRunReportedDisposition = "blocked" | "unverified" | "no_control_plane_evidence" | null;
+
+const EXPLICIT_BLOCKED_DISPOSITION_RE = /(?:^|\n)\s*(?:#{1,6}\s*)?(?:\*{1,2})?blocked(?:\*{1,2})?\s*(?:[-—:：]|$)/im;
+const UNVERIFIED_WORK_RE = new RegExp([
+  String.raw`\bunverified\b`,
+  String.raw`\b(?:could not|couldn't|cannot|can't|unable to|was not|wasn't|were not|weren't|not)\s+(?:be\s+)?(?:run|execute|compile|build|test(?:ed)?|verify|verified|validate|validated|check(?:ed)?)\b`,
+  String.raw`\b(?:tests?|verification|validation|compilation|build)\s+(?:could not|couldn't|cannot|can't|was not|wasn't|were not|weren't)\s+(?:be\s+)?(?:run|completed|performed|verified)\b`,
+  String.raw`\b(?:not installed|missing dependency|missing toolchain)\b.{0,120}\b(?:test|verify|validation|compil|build|run)\b`,
+].join("|"), "i");
+
 const PRODUCTIVE_SUCCESS_LIVENESS_STATES = new Set<RunLivenessState>([
   "advanced",
   "completed",
@@ -302,6 +312,28 @@ function readString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+export function classifySuccessfulRunReportedDisposition(input: {
+  livenessState: RunLivenessState | null;
+  detectedProgressSummary: string | null;
+}): SuccessfulRunReportedDisposition {
+  if (input.livenessState === "blocked") return "blocked";
+  const summary = input.detectedProgressSummary ?? "";
+  if (EXPLICIT_BLOCKED_DISPOSITION_RE.test(summary)) return "blocked";
+  if (UNVERIFIED_WORK_RE.test(summary)) return "unverified";
+  if (input.livenessState === "needs_followup") return "no_control_plane_evidence";
+  return null;
+}
+
+export function successfulRunHandoffDoneGateReason(contextSnapshot: unknown, issueId?: string) {
+  const context = readRecord(contextSnapshot);
+  if (readString(context.wakeReason) !== FINISH_SUCCESSFUL_RUN_HANDOFF_REASON) return null;
+  const contextIssueId = readString(context.issueId) ?? readString(context.taskId);
+  if (issueId && contextIssueId !== issueId) return null;
+  if (context.doneDispositionAllowed !== false) return null;
+  const disposition = readString(context.sourceReportedDisposition) ?? "non_done";
+  return `Source run reported ${disposition} work; corrective handoff cannot mark the issue done`;
+}
+
 function isCorrectiveHandoffRun(run: HeartbeatRunRow) {
   const context = readRecord(run.contextSnapshot);
   return context.handoffRequired === true ||
@@ -334,18 +366,34 @@ function isProductiveSuccessfulRun(input: {
 export function buildSuccessfulRunHandoffInstruction(input: {
   issueIdentifier: string | null;
   sourceRunId: string;
+  sourceReportedDisposition?: SuccessfulRunReportedDisposition;
 }) {
   const issueLabel = input.issueIdentifier ?? "this issue";
+  const doneAllowed = input.sourceReportedDisposition == null;
   return [
     `Your previous run on ${issueLabel} succeeded, but the issue is still in \`in_progress\` and Paperclip cannot identify a valid issue disposition.`,
+    ...(doneAllowed
+      ? []
+      : [
+        "",
+        input.sourceReportedDisposition === "blocked"
+          ? "The source run reported that work is blocked. You must not mark this issue `done`; record a valid blocked or continuation disposition."
+          : input.sourceReportedDisposition === "unverified"
+            ? "The source run reported that verification could not be completed. You must not mark this issue `done`; keep it active or blocked until verification can occur."
+            : "The source run produced no durable control-plane evidence. You must not mark this issue `done`; keep it active or blocked and record a verifiable continuation path.",
+      ]),
     "",
     "This is a status-only retry to the original agent. Record a disposition; do not start new work.",
     "",
     "Resolve the missing disposition before creating or revising any new artifacts. Choose **exactly one** outcome and perform the matching Paperclip action:",
     "",
-    "**Is the issue finished?**",
-    "1. Mark it `done` (scope complete) or `cancelled` (intentionally stopped).",
-    "",
+    ...(doneAllowed
+      ? [
+        "**Is the issue finished?**",
+        "1. Mark it `done` (scope complete) or `cancelled` (intentionally stopped).",
+        "",
+      ]
+      : []),
     "**Does someone else need to look at it?**",
     "2. Move it to `in_review` with a real reviewer path — `executionState.currentParticipant`, a human owner via `assigneeUserId`, a pending issue-thread interaction, or a linked pending approval.",
     "",
@@ -420,9 +468,16 @@ export function decideSuccessfulRunHandoff(input: {
     return { kind: "skip", reason: "corrective handoff wake already exists for this source run" };
   }
 
+  const sourceReportedDisposition = classifySuccessfulRunReportedDisposition(input);
+  const doneDispositionAllowed = sourceReportedDisposition == null;
+  const validDispositionOptions = doneDispositionAllowed
+    ? [...SUCCESSFUL_RUN_HANDOFF_OPTIONS]
+    : SUCCESSFUL_RUN_HANDOFF_OPTIONS.filter((option) => option !== "mark_done_or_cancelled");
+
   const instruction = buildSuccessfulRunHandoffInstruction({
     issueIdentifier: issue.identifier,
     sourceRunId: run.id,
+    sourceReportedDisposition,
   });
   const payload = withRecoveryModelProfileHint({
     issueId: issue.id,
@@ -432,8 +487,15 @@ export function decideSuccessfulRunHandoff(input: {
     handoffRequired: true,
     handoffReason: SUCCESSFUL_RUN_MISSING_STATE_REASON,
     missingDisposition: "clear_next_step",
-    validDispositionOptions: [...SUCCESSFUL_RUN_HANDOFF_OPTIONS],
+    validDispositionOptions,
     detectedProgressSummary: input.detectedProgressSummary,
+    sourceReportedDisposition,
+    doneDispositionAllowed,
+    verificationEvidenceStatus: sourceReportedDisposition === "unverified"
+      ? "reported_missing"
+      : sourceReportedDisposition === "no_control_plane_evidence"
+        ? "control_plane_evidence_missing"
+        : "not_recorded",
     handoffAttempt: 1,
     maxHandoffAttempts: DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS,
     resumeIntent: true,

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -395,7 +395,11 @@ export function buildSuccessfulRunHandoffInstruction(input: {
         "1. Mark it `done` (scope complete) or `cancelled` (intentionally stopped).",
         "",
       ]
-      : []),
+      : [
+        "**Was the issue intentionally stopped?**",
+        "1. Mark it `cancelled`. The source evidence forbids `done`, but intentional cancellation remains a valid terminal disposition.",
+        "",
+      ]),
     "**Does someone else need to look at it?**",
     "2. Move it to `in_review` with a real reviewer path — `executionState.currentParticipant`, a human owner via `assigneeUserId`, a pending issue-thread interaction, or a linked pending approval.",
     "",

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -17,7 +17,8 @@ export const LEGACY_SUCCESSFUL_RUN_HANDOFF_NOTICE_PREFIXES = [
 ] as const;
 
 export const SUCCESSFUL_RUN_HANDOFF_OPTIONS = [
-  "mark_done_or_cancelled",
+  "mark_done",
+  "mark_cancelled",
   "send_for_review_or_ask_for_input",
   "mark_blocked",
   "delegate_or_continue_from_checkpoint",
@@ -473,7 +474,7 @@ export function decideSuccessfulRunHandoff(input: {
   const doneDispositionAllowed = sourceReportedDisposition == null;
   const validDispositionOptions = doneDispositionAllowed
     ? [...SUCCESSFUL_RUN_HANDOFF_OPTIONS]
-    : SUCCESSFUL_RUN_HANDOFF_OPTIONS.filter((option) => option !== "mark_done_or_cancelled");
+    : SUCCESSFUL_RUN_HANDOFF_OPTIONS.filter((option) => option !== "mark_done");
 
   const instruction = buildSuccessfulRunHandoffInstruction({
     issueIdentifier: issue.identifier,

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -28,8 +28,8 @@ export type SuccessfulRunReportedDisposition = "blocked" | "unverified" | "no_co
 const EXPLICIT_BLOCKED_DISPOSITION_RE = /(?:^|\n)\s*(?:#{1,6}\s*)?(?:\*{1,2})?blocked(?:\*{1,2})?\s*(?:[-—:：]|$)/im;
 const UNVERIFIED_WORK_RE = new RegExp([
   String.raw`\bunverified\b`,
-  String.raw`\b(?:could not|couldn't|cannot|can't|unable to|was not|wasn't|were not|weren't|not)\s+(?:be\s+)?(?:run|execute|compile|build|test(?:ed)?|verify|verified|validate|validated|check(?:ed)?)\b`,
-  String.raw`\b(?:tests?|verification|validation|compilation|build)\s+(?:could not|couldn't|cannot|can't|was not|wasn't|were not|weren't)\s+(?:be\s+)?(?:run|completed|performed|verified)\b`,
+  String.raw`\b(?:could not|couldn't|cannot|can't|unable to)\s+(?:be\s+)?(?:run|execute|compile|build|test(?:ed)?|verify|verified|validate|validated|check(?:ed)?)\b`,
+  String.raw`\b(?:tests?|verification|validation|compilation|build)\s+(?:could not|couldn't|cannot|can't)\s+(?:be\s+)?(?:run|completed|performed|verified)\b`,
   String.raw`\b(?:not installed|missing dependency|missing toolchain)\b.{0,120}\b(?:test|verify|validation|compil|build|run)\b`,
 ].join("|"), "i");
 
@@ -331,7 +331,8 @@ export function successfulRunHandoffDoneGateReason(contextSnapshot: unknown, iss
   if (issueId && contextIssueId !== issueId) return null;
   if (context.doneDispositionAllowed !== false) return null;
   const disposition = readString(context.sourceReportedDisposition) ?? "non_done";
-  return `Source run reported ${disposition} work; corrective handoff cannot mark the issue done`;
+  const dispositionLabel = disposition.replace(/_/g, " ");
+  return `Source run reported ${dispositionLabel} work; corrective handoff cannot mark the issue done`;
 }
 
 function isCorrectiveHandoffRun(run: HeartbeatRunRow) {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -30,7 +30,7 @@ const UNVERIFIED_WORK_RE = new RegExp([
   String.raw`\bunverified\b`,
   String.raw`\b(?:could not|couldn't|cannot|can't|unable to)\s+(?:be\s+)?(?:run|execute|compile|build|test(?:ed)?|verify|verified|validate|validated|check(?:ed)?)\b`,
   String.raw`\b(?:tests?|verification|validation|compilation|build)\s+(?:could not|couldn't|cannot|can't)\s+(?:be\s+)?(?:run|completed|performed|verified)\b`,
-  String.raw`\b(?:not installed|missing dependency|missing toolchain)\b.{0,120}\b(?:test|verify|validation|compil|build|run)\b`,
+  String.raw`\b(?:not installed|missing dependency|missing toolchain)\b.{0,120}\b(?:test|verify|validation|build|run)\b`,
 ].join("|"), "i");
 
 const PRODUCTIVE_SUCCESS_LIVENESS_STATES = new Set<RunLivenessState>([

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { agentWakeupRequests, agents, heartbeatRuns, issues } from "@paperclipai/db";
 import type { IssueCommentMetadata, IssueCommentPresentation, RunLivenessState } from "@paperclipai/shared";
 import { withRecoveryModelProfileHint } from "./model-profile-hint.js";
+import { hasConcreteActionEvidence, type RunLivenessEvidenceInput } from "../run-liveness.js";
 
 export const FINISH_SUCCESSFUL_RUN_HANDOFF_REASON = "finish_successful_run_handoff";
 export const SUCCESSFUL_RUN_MISSING_STATE_REASON = "successful_run_missing_state";
@@ -33,13 +34,6 @@ const UNVERIFIED_WORK_RE = new RegExp([
   String.raw`\b(?:tests?|verification|validation|compilation|build)\s+(?:could not|couldn't|cannot|can't)\s+(?:be\s+)?(?:run|completed|performed|verified)\b`,
   String.raw`\b(?:not installed|missing dependency|missing toolchain)\b.{0,120}\b(?:test|verify|validation|build|run)\b`,
 ].join("|"), "i");
-
-const PRODUCTIVE_SUCCESS_LIVENESS_STATES = new Set<RunLivenessState>([
-  "advanced",
-  "completed",
-  "blocked",
-  "needs_followup",
-]);
 
 const IDEMPOTENT_HANDOFF_WAKE_STATUSES = [
   "queued",
@@ -331,7 +325,10 @@ export function successfulRunHandoffDoneGateReason(contextSnapshot: unknown, iss
   const contextIssueId = readString(context.issueId) ?? readString(context.taskId);
   if (issueId && contextIssueId !== issueId) return null;
   if (context.doneDispositionAllowed !== false) return null;
-  const disposition = readString(context.sourceReportedDisposition) ?? "non_done";
+  const disposition = readString(context.sourceReportedDisposition);
+  if (!disposition) {
+    return "Source run lacks affirmative structured completion and verification evidence; corrective handoff cannot mark the issue done";
+  }
   const dispositionLabel = disposition.replace(/_/g, " ");
   return `Source run reported ${dispositionLabel} work; corrective handoff cannot mark the issue done`;
 }
@@ -357,21 +354,22 @@ function isCommentDrivenWake(run: HeartbeatRunRow) {
     wakeReason === "issue_reopened_via_comment";
 }
 
-function isProductiveSuccessfulRun(input: {
+export function hasAffirmativeSuccessfulRunCompletionEvidence(input: {
   livenessState: RunLivenessState | null;
-  detectedProgressSummary: string | null;
+  evidence: Partial<RunLivenessEvidenceInput> | null;
 }) {
-  if (input.livenessState && PRODUCTIVE_SUCCESS_LIVENESS_STATES.has(input.livenessState)) return true;
-  return Boolean(input.detectedProgressSummary);
+  if (input.livenessState !== "advanced" && input.livenessState !== "completed") return false;
+  return hasConcreteActionEvidence(input.evidence);
 }
 
 export function buildSuccessfulRunHandoffInstruction(input: {
   issueIdentifier: string | null;
   sourceRunId: string;
   sourceReportedDisposition?: SuccessfulRunReportedDisposition;
+  doneDispositionAllowed: boolean;
 }) {
   const issueLabel = input.issueIdentifier ?? "this issue";
-  const doneAllowed = input.sourceReportedDisposition == null;
+  const doneAllowed = input.doneDispositionAllowed;
   return [
     `Your previous run on ${issueLabel} succeeded, but the issue is still in \`in_progress\` and Paperclip cannot identify a valid issue disposition.`,
     ...(doneAllowed
@@ -382,7 +380,7 @@ export function buildSuccessfulRunHandoffInstruction(input: {
           ? "The source run reported that work is blocked. You must not mark this issue `done`; record a valid blocked or continuation disposition."
           : input.sourceReportedDisposition === "unverified"
             ? "The source run reported that verification could not be completed. You must not mark this issue `done`; keep it active or blocked until verification can occur."
-            : "The source run produced no durable control-plane evidence. You must not mark this issue `done`; keep it active or blocked and record a verifiable continuation path.",
+            : "The source run lacks affirmative structured completion and verification evidence. You must not mark this issue `done`; keep it active or blocked and record a verifiable continuation path.",
       ]),
     "",
     "This is a status-only retry to the original agent. Record a disposition; do not start new work.",
@@ -419,6 +417,7 @@ export function decideSuccessfulRunHandoff(input: {
   agent: AgentRow | null;
   livenessState: RunLivenessState | null;
   detectedProgressSummary: string | null;
+  evidence: Partial<RunLivenessEvidenceInput> | null;
   taskKey: string | null;
   hasActiveExecutionPath: boolean;
   hasQueuedWake: boolean;
@@ -457,9 +456,6 @@ export function decideSuccessfulRunHandoff(input: {
   if (input.hasActiveRoutineContinuation) {
     return { kind: "skip", reason: "active routine continuation owns the next action" };
   }
-  if (!isProductiveSuccessfulRun(input)) {
-    return { kind: "skip", reason: "successful run did not produce handoff-relevant progress" };
-  }
   if (input.hasActiveExecutionPath) return { kind: "skip", reason: "issue already has an active execution path" };
   if (input.hasQueuedWake) return { kind: "skip", reason: "issue already has a queued or deferred wake" };
   if (input.hasPendingInteractionOrApproval) {
@@ -475,7 +471,7 @@ export function decideSuccessfulRunHandoff(input: {
   }
 
   const sourceReportedDisposition = classifySuccessfulRunReportedDisposition(input);
-  const doneDispositionAllowed = sourceReportedDisposition == null;
+  const doneDispositionAllowed = hasAffirmativeSuccessfulRunCompletionEvidence(input);
   const validDispositionOptions = doneDispositionAllowed
     ? [...SUCCESSFUL_RUN_HANDOFF_OPTIONS]
     : SUCCESSFUL_RUN_HANDOFF_OPTIONS.filter((option) => option !== "mark_done");
@@ -484,6 +480,7 @@ export function decideSuccessfulRunHandoff(input: {
     issueIdentifier: issue.identifier,
     sourceRunId: run.id,
     sourceReportedDisposition,
+    doneDispositionAllowed,
   });
   const payload = withRecoveryModelProfileHint({
     issueId: issue.id,
@@ -497,7 +494,9 @@ export function decideSuccessfulRunHandoff(input: {
     detectedProgressSummary: input.detectedProgressSummary,
     sourceReportedDisposition,
     doneDispositionAllowed,
-    verificationEvidenceStatus: sourceReportedDisposition === "unverified"
+    verificationEvidenceStatus: doneDispositionAllowed
+      ? "affirmative"
+      : sourceReportedDisposition === "unverified"
       ? "reported_missing"
       : sourceReportedDisposition === "no_control_plane_evidence"
         ? "control_plane_evidence_missing"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that coordinates autonomous agent work and records whether tasks are actually complete.
> - Heartbeat process success and issue completion are separate facts: a clean process exit does not prove the assigned work is done.
> - Successful-run handoff recovery currently asks an agent to repair a missing disposition, but its context does not prevent `done` after the source reported a blocker, missing verification, or no durable control-plane evidence.
> - That gap can turn blocked or unverifiable work into a false completion and hide the next action from the board.
> - This pull request carries a machine-readable source disposition into corrective handoff runs and enforces it on issue status mutations.
> - The benefit is that blocked and unverified work stays active or blocked instead of being silently recorded as complete.

## Linked Issues or Issue Description

Refs: #1683

### Pre-submission checklist

- [x] I searched existing open and closed issues and pull requests; #1683 is related but does not cover this successful-run corrective-handoff path.
- [x] The bug reproduces on the `master` recovery implementation before this change.
- [x] The failure is in Paperclip's core issue/recovery behavior, not an adapter or provider configuration.

### What happened?

A successful heartbeat that leaves an issue in progress can trigger a status-only corrective handoff. If the source final message reports blocked work, missing verification, or has no durable control-plane evidence, that corrective run can still mark the issue `done`.

### Expected behavior

Corrective handoffs should record the missing verification/evidence state and reject `done`; the issue should remain active or move to a valid blocked, review, or continuation disposition.

### Steps to reproduce

1. Run an assigned issue to a clean adapter exit while leaving the issue in progress.
2. Return a final message such as `Blocked — target is not mounted` or `compiler is not installed, so verification could not run`.
3. Allow the successful-run handoff retry to execute.
4. Observe that the corrective handoff can accept a `done` mutation despite the source run's non-done outcome.

### Paperclip version or commit

Reproduced against the successful-run handoff implementation on `master` before commit `83de00f18b`.

### Deployment mode

Local dev / server recovery path; this is a core, adapter-independent bug.

## What Changed

- Classify successful-run final summaries as blocked, unverified, or missing durable control-plane evidence.
- Carry `doneDispositionAllowed`, source disposition, and verification-evidence status in corrective handoff payloads and context.
- Remove the completion option and strengthen status-only instructions when the source outcome is non-done.
- Reject agent `done` mutations from matching corrective handoff runs while leaving unrelated issue mutations unaffected.
- Add focused regression coverage and document the completion gate in the implementation specification.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/successful-run-handoff.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts -t "queues one finish-handoff wake|queues one missing-disposition handoff for artifact-producing"`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low-to-moderate behavioral risk: corrective handoff runs with weak evidence can no longer close an issue directly and must record a blocked, review, or continuation path instead.
- Text classification is intentionally conservative; ordinary advanced runs with durable control-plane evidence retain the existing completion option.
- No database migration or API schema change is required; the new fields live in existing JSON run context.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI using GPT-5.4 for implementation and `gpt-5.6-sol` for PR preparation/review, with high-reasoning mode, tool use, repository execution, and code-editing capabilities. The runtime did not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
