### PR TITLE
feat(ui): resolve company URLs by issuePrefix or optional slugAliases

### DIFF
--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -8,6 +8,14 @@ export interface Company {
   pauseReason: PauseReason | null;
   pausedAt: Date | null;
   issuePrefix: string;
+  /**
+   * Optional alternate URL slugs that also resolve to this company in the web
+   * app. Not persisted on the company row: a deployment may attach aliases
+   * when serving the company (for example a hosting gateway's tenant slug).
+   * `issuePrefix` stays the canonical URL prefix; the SPA redirects alias URLs
+   * to it. Matching is case-insensitive, like prefix matching.
+   */
+  slugAliases?: string[];
   issueCounter: number;
   budgetMonthlyCents: number;
   spentMonthlyCents: number;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -92,6 +92,7 @@ import {
   shouldRedirectCompanylessRouteToOnboarding,
 } from "./lib/onboarding-route";
 import { normalizeRememberedInstanceSettingsPath } from "./lib/instance-settings";
+import { findCompanyByUrlSegment } from "./lib/company-routes";
 
 function boardRoutes() {
   return (
@@ -293,9 +294,7 @@ function LegacySkillStudioRedirect() {
   if (loading) return null;
 
   const targetCompany =
-    (companyPrefix
-      ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase())
-      : null) ??
+    findCompanyByUrlSegment(companies, companyPrefix) ??
     selectedCompany ??
     companies[0] ??
     null;
@@ -322,9 +321,7 @@ function LegacySettingsRedirect() {
   }
 
   const targetCompany =
-    (companyPrefix
-      ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase())
-      : null) ??
+    findCompanyByUrlSegment(companies, companyPrefix) ??
     selectedCompany ??
     companies[0] ??
     null;
@@ -385,9 +382,7 @@ function OnboardingRoutePage() {
   if (isOnboardingWizardActive({ onboardingOpen, routeDismissed: onboardingRouteDismissed })) {
     return null;
   }
-  const matchedCompany = companyPrefix
-    ? companies.find((company) => company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase()) ?? null
-    : null;
+  const matchedCompany = findCompanyByUrlSegment(companies, companyPrefix);
 
   const title = matchedCompany
     ? `Add another agent to ${matchedCompany.name}`

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -224,7 +224,7 @@ export function Layout() {
 
     if (companyPrefix !== matchedCompany.issuePrefix) {
       const suffix = location.pathname.replace(/^\/[^/]+/, "");
-      navigate(`/${matchedCompany.issuePrefix}${suffix}${location.search}`, { replace: true });
+      navigate(`/${matchedCompany.issuePrefix}${suffix}${location.search}${location.hash}`, { replace: true });
       return;
     }
 
@@ -244,6 +244,7 @@ export function Layout() {
     matchedCompany,
     location.pathname,
     location.search,
+    location.hash,
     navigate,
     selectionSource,
     selectedCompanyId,

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -34,6 +34,7 @@ import { useCompanyPageMemory } from "../hooks/useCompanyPageMemory";
 import { healthApi } from "../api/health";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { shouldSyncCompanySelectionFromRoute } from "../lib/company-selection";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 import {
   applyMainContentScrollTop,
   NavigationScrollMemory,
@@ -124,11 +125,10 @@ export function Layout() {
   const activeScrollKey = useRef<string>(location.key);
   const [mobileNavVisible, setMobileNavVisible] = useState(true);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const matchedCompany = useMemo(() => {
-    if (!companyPrefix) return null;
-    const requestedPrefix = companyPrefix.toUpperCase();
-    return companies.find((company) => company.issuePrefix.toUpperCase() === requestedPrefix) ?? null;
-  }, [companies, companyPrefix]);
+  const matchedCompany = useMemo(
+    () => findCompanyByUrlSegment(companies, companyPrefix),
+    [companies, companyPrefix],
+  );
   const hasUnknownCompanyPrefix =
     Boolean(companyPrefix) && !companiesLoading && companies.length > 0 && !matchedCompany;
   const pluginRoutePath = useMemo(

--- a/ui/src/components/SidebarCompanyMenu.tsx
+++ b/ui/src/components/SidebarCompanyMenu.tsx
@@ -39,6 +39,7 @@ import { queryKeys } from "@/lib/queryKeys";
 import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "@/lib/utils";
 import { useSidebar } from "../context/SidebarContext";
 import { CompanyPatternIcon } from "./CompanyPatternIcon";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 
 interface SidebarCompanyMenuProps {
   open?: boolean;
@@ -185,10 +186,8 @@ export function SidebarCompanyMenu({ open: controlledOpen, onOpenChange }: Sideb
   }
 
   function selectCompany(company: Company) {
-    const pathPrefix = location.pathname.split("/")[1]?.toUpperCase();
-    const isCompanyRoute = sidebarCompanies.some((sidebarCompany) => (
-      sidebarCompany.issuePrefix.toUpperCase() === pathPrefix
-    ));
+    const pathPrefix = location.pathname.split("/")[1];
+    const isCompanyRoute = findCompanyByUrlSegment(sidebarCompanies, pathPrefix) != null;
     const shouldLeaveCurrentRoute = company.id !== selectedCompany?.id
       && (location.pathname.startsWith("/instance/") || isCompanyRoute);
 

--- a/ui/src/lib/company-routes.test.ts
+++ b/ui/src/lib/company-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyCompanyPrefix,
   extractCompanyPrefixFromPath,
+  findCompanyByUrlSegment,
   isBoardPathWithoutPrefix,
   toCompanyRelativePath,
 } from "./company-routes";
@@ -137,5 +138,41 @@ describe("company routes", () => {
     );
     // Already-prefixed paths are returned untouched.
     expect(applyCompanyPrefix("/PAP/artifacts", "PAP")).toBe("/PAP/artifacts");
+  });
+});
+
+describe("findCompanyByUrlSegment", () => {
+  const acme = { id: "c1", issuePrefix: "ACME" };
+  const beta = { id: "c2", issuePrefix: "BETA", slugAliases: ["beta-labs", "beta-inc"] };
+  const companies = [acme, beta];
+
+  it("matches the canonical issue prefix case-insensitively", () => {
+    expect(findCompanyByUrlSegment(companies, "ACME")).toBe(acme);
+    expect(findCompanyByUrlSegment(companies, "acme")).toBe(acme);
+    expect(findCompanyByUrlSegment(companies, "AcMe")).toBe(acme);
+  });
+
+  it("matches a slug alias case-insensitively", () => {
+    expect(findCompanyByUrlSegment(companies, "beta-labs")).toBe(beta);
+    expect(findCompanyByUrlSegment(companies, "BETA-LABS")).toBe(beta);
+    expect(findCompanyByUrlSegment(companies, "beta-inc")).toBe(beta);
+  });
+
+  it("prefers a canonical prefix over another company's alias", () => {
+    const shadowing = { id: "c3", issuePrefix: "OTHER", slugAliases: ["acme"] };
+    expect(findCompanyByUrlSegment([shadowing, ...companies], "acme")).toBe(acme);
+  });
+
+  it("returns null for unknown, empty, or missing segments", () => {
+    expect(findCompanyByUrlSegment(companies, "nope")).toBeNull();
+    expect(findCompanyByUrlSegment(companies, "")).toBeNull();
+    expect(findCompanyByUrlSegment(companies, null)).toBeNull();
+    expect(findCompanyByUrlSegment(companies, undefined)).toBeNull();
+    expect(findCompanyByUrlSegment([], "acme")).toBeNull();
+  });
+
+  it("leaves companies without aliases matched by prefix only", () => {
+    expect(findCompanyByUrlSegment([acme], "acme")).toBe(acme);
+    expect(findCompanyByUrlSegment([acme], "acme-inc")).toBeNull();
   });
 });

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -36,6 +36,34 @@ export function normalizeCompanyPrefix(prefix: string): string {
   return prefix.trim().toUpperCase();
 }
 
+export interface UrlAddressableCompany {
+  issuePrefix: string;
+  /** Optional alternate URL slugs that also resolve to this company (Company.slugAliases). */
+  slugAliases?: string[];
+}
+
+/**
+ * Resolve the company addressed by a URL's first path segment. A segment
+ * matches a company's canonical `issuePrefix` or any of its optional
+ * `slugAliases`, case-insensitively. Canonical prefixes always win over
+ * aliases so an alias can never shadow another company's prefix; callers that
+ * canonicalize the URL should redirect alias matches to `issuePrefix`.
+ */
+export function findCompanyByUrlSegment<T extends UrlAddressableCompany>(
+  companies: readonly T[],
+  segment: string | null | undefined,
+): T | null {
+  if (!segment) return null;
+  const requested = segment.toUpperCase();
+  const byPrefix = companies.find((company) => company.issuePrefix.toUpperCase() === requested);
+  if (byPrefix) return byPrefix;
+  return (
+    companies.find((company) =>
+      (company.slugAliases ?? []).some((alias) => alias.toUpperCase() === requested),
+    ) ?? null
+  );
+}
+
 function splitPath(path: string): { pathname: string; search: string; hash: string } {
   const match = path.match(/^([^?#]*)(\?[^#]*)?(#.*)?$/);
   return {

--- a/ui/src/lib/onboarding-route.ts
+++ b/ui/src/lib/onboarding-route.ts
@@ -1,6 +1,9 @@
+import { findCompanyByUrlSegment } from "./company-routes";
+
 type OnboardingRouteCompany = {
   id: string;
   issuePrefix: string;
+  slugAliases?: string[];
 };
 
 export function isOnboardingPath(pathname: string): boolean {
@@ -30,11 +33,7 @@ export function resolveRouteOnboardingOptions(params: {
     return { initialStep: 1 };
   }
 
-  const matchedCompany =
-    companies.find(
-      (company) =>
-        company.issuePrefix.toUpperCase() === companyPrefix.toUpperCase(),
-    ) ?? null;
+  const matchedCompany = findCompanyByUrlSegment(companies, companyPrefix);
 
   if (!matchedCompany) {
     return { initialStep: 1 };

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -119,6 +119,7 @@ import {
   useResourceMemberships,
 } from "../hooks/useResourceMemberships";
 import { Badge } from "@/components/ui/badge";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 
 const runStatusIcons: Record<string, { icon: typeof CheckCircle2; color: string }> = {
   succeeded: { icon: CheckCircle2, color: "text-green-600 dark:text-green-400" },
@@ -709,9 +710,7 @@ export function AgentDetail() {
   const { isMobile } = useSidebar();
   const routeAgentRef = agentId ?? "";
   const routeCompanyId = useMemo(() => {
-    if (!companyPrefix) return null;
-    const requestedPrefix = companyPrefix.toUpperCase();
-    return companies.find((company) => company.issuePrefix.toUpperCase() === requestedPrefix)?.id ?? null;
+    return findCompanyByUrlSegment(companies, companyPrefix)?.id ?? null;
   }, [companies, companyPrefix]);
   const lookupCompanyId = routeCompanyId ?? selectedCompanyId ?? undefined;
   const canFetchAgent = routeAgentRef.length > 0 && (isUuidLike(routeAgentRef) || Boolean(lookupCompanyId));

--- a/ui/src/pages/CompanySettingsPluginPage.tsx
+++ b/ui/src/pages/CompanySettingsPluginPage.tsx
@@ -4,6 +4,7 @@ import { useBreadcrumbs } from "@/context/BreadcrumbContext";
 import { useCompany } from "@/context/CompanyContext";
 import { PluginSlotMount, usePluginSlots } from "@/plugins/slots";
 import { NotFoundPage } from "./NotFound";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 
 export function CompanySettingsPluginPage() {
   const params = useParams<{
@@ -15,9 +16,7 @@ export function CompanySettingsPluginPage() {
   const { setBreadcrumbs } = useBreadcrumbs();
 
   const routeCompany = useMemo(() => {
-    if (!routeCompanyPrefix) return null;
-    const requested = routeCompanyPrefix.toUpperCase();
-    return companies.find((company) => company.issuePrefix.toUpperCase() === requested) ?? null;
+    return findCompanyByUrlSegment(companies, routeCompanyPrefix);
   }, [companies, routeCompanyPrefix]);
   const hasInvalidCompanyPrefix = Boolean(routeCompanyPrefix) && !routeCompany;
   const resolvedCompanyId = routeCompany?.id ?? (routeCompanyPrefix ? null : selectedCompanyId ?? null);

--- a/ui/src/pages/PluginPage.tsx
+++ b/ui/src/pages/PluginPage.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { NotFoundPage } from "./NotFound";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 
 /**
  * Company-context plugin page. Renders a plugin's `page` slot at
@@ -34,9 +35,7 @@ export function PluginPage() {
   const { companies, selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const routeCompany = useMemo(() => {
-    if (!routeCompanyPrefix) return null;
-    const requested = routeCompanyPrefix.toUpperCase();
-    return companies.find((c) => c.issuePrefix.toUpperCase() === requested) ?? null;
+    return findCompanyByUrlSegment(companies, routeCompanyPrefix);
   }, [companies, routeCompanyPrefix]);
   const hasInvalidCompanyPrefix = Boolean(routeCompanyPrefix) && !routeCompany;
 

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -39,6 +39,7 @@ import { cn } from "@/lib/utils";
 import { Tabs } from "@/components/ui/tabs";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
 import { PluginSlotMount, PluginSlotOutlet, usePluginSlots } from "@/plugins/slots";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 import {
   isStarred,
   resourceMembershipState,
@@ -384,9 +385,7 @@ export function ProjectDetail() {
   const fieldSaveTimers = useRef<Partial<Record<ProjectConfigFieldKey, ReturnType<typeof setTimeout>>>>({});
   const routeProjectRef = projectId ?? "";
   const routeCompanyId = useMemo(() => {
-    if (!companyPrefix) return null;
-    const requestedPrefix = companyPrefix.toUpperCase();
-    return companies.find((company) => company.issuePrefix.toUpperCase() === requestedPrefix)?.id ?? null;
+    return findCompanyByUrlSegment(companies, companyPrefix)?.id ?? null;
   }, [companies, companyPrefix]);
   const lookupCompanyId = routeCompanyId ?? selectedCompanyId ?? undefined;
   const canFetchProject = routeProjectRef.length > 0 && (isUuidLike(routeProjectRef) || Boolean(lookupCompanyId));

--- a/ui/src/pages/ProjectWorkspaceDetail.tsx
+++ b/ui/src/pages/ProjectWorkspaceDetail.tsx
@@ -21,6 +21,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useCompany } from "../context/CompanyContext";
 import { queryKeys } from "../lib/queryKeys";
 import { projectRouteRef, projectWorkspaceUrl } from "../lib/utils";
+import { findCompanyByUrlSegment } from "../lib/company-routes";
 
 type WorkspaceFormState = {
   name: string;
@@ -263,9 +264,7 @@ export function ProjectWorkspaceDetail() {
   const activeTab = useMemo(() => projectWorkspaceTabFromSearch(location.search), [location.search]);
 
   const routeCompanyId = useMemo(() => {
-    if (!companyPrefix) return null;
-    const requestedPrefix = companyPrefix.toUpperCase();
-    return companies.find((company) => company.issuePrefix.toUpperCase() === requestedPrefix)?.id ?? null;
+    return findCompanyByUrlSegment(companies, companyPrefix)?.id ?? null;
   }, [companies, companyPrefix]);
 
   const lookupCompanyId = routeCompanyId ?? selectedCompanyId ?? undefined;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its web app addresses every company-scoped page under a URL whose first segment is the company's `issuePrefix` (for example `/PAP/dashboard`)
> - Deployments that front Paperclip with a routing gateway can serve the app under an external URL slug (for example a hosted tenant slug), so users land on `/<external-slug>/...`
> - The SPA matches that first segment against `issuePrefix` only, so a slug URL deterministically renders the "Company not found" page even though the company exists and the user has access
> - Every match site repeats the same inline `issuePrefix.toUpperCase()` comparison, so there is no single seam where a deployment could teach the router an alternate slug
> - This pull request adds an optional `slugAliases` field to the company API payload and one shared `findCompanyByUrlSegment` helper that matches a URL segment against the canonical prefix or any alias, then canonicalizes alias URLs to the `issuePrefix` URL
> - The benefit is that gateway-fronted deployments can hand the app an alias per company and deep links under that alias resolve instead of dead-ending, while installs without aliases behave exactly as before

## Linked Issues or Issue Description

No existing public issue; the underlying problem, following the bug report template:

### What happened?

Behind a routing gateway that serves the app under an external slug, opening `/<external-slug>/...` renders the "Company not found" (`invalid_company_prefix`) page even though the company is provisioned and the signed-in user is a member. The SPA matches the first URL segment against `company.issuePrefix` only, so the external slug never resolves.

### Expected behavior

The URL resolves to the company and the app redirects to the canonical `/<issuePrefix>/...` URL, preserving the remaining subpath, query, and hash.

### Steps to reproduce

1. Serve the app behind a proxy that forwards `/<some-slug>/...` verbatim for a valid company
2. Sign in as a member of that company
3. Open `/<some-slug>/dashboard`
4. The "Company not found" page renders because `<some-slug>` matches no `issuePrefix`

### Paperclip version

Current `master` (reproduced at the merge base of this branch).

### Deployment mode

Any deployment fronted by a routing gateway or reverse proxy that serves the app under an external per-company slug; self-hosted installs without such a gateway are unaffected.

## What Changed

- `packages/shared/src/types/company.ts`: optional `slugAliases?: string[]` on the `Company` API payload (serve-time only, not persisted); documents that `issuePrefix` stays the canonical URL prefix and matching is case-insensitive
- `ui/src/lib/company-routes.ts`: new `findCompanyByUrlSegment` helper; matches a URL segment against `issuePrefix` or any alias, case-insensitively, with canonical prefixes always winning over aliases so an alias can never shadow another company's prefix
- All URL-segment-to-company match sites now share the helper: `Layout` (`matchedCompany`), the `App.tsx` legacy redirects and onboarding route page, `SidebarCompanyMenu`, `onboarding-route.ts`, and the detail pages that derive `routeCompanyId` from the prefix (`ProjectDetail`, `AgentDetail`, `ProjectWorkspaceDetail`, `PluginPage`, `CompanySettingsPluginPage`)
- `Layout`'s existing canonicalization redirects alias matches to the `issuePrefix` URL; it now preserves `location.hash` alongside the subpath and query (previously the redirect dropped the fragment)

## Verification

- `cd ui && npx vitest run src/lib/company-routes.test.ts src/lib/onboarding-route.test.ts src/App.test.tsx src/App.cases-routing.test.tsx src/components/Layout.test.tsx src/components/SidebarCompanyMenu.test.tsx src/pages/PluginPage.test.tsx src/pages/CompanySettingsPluginPage.test.tsx` — all pass
- New unit tests in `ui/src/lib/company-routes.test.ts`: prefix matching stays case-insensitive, alias matching is case-insensitive, canonical prefix beats another company's alias, unknown/empty/missing segments return null, alias-free companies match by prefix only
- `pnpm --filter @paperclipai/shared build`, `pnpm --filter @paperclipai/ui typecheck`, `pnpm --filter @paperclipai/ui build` — all green
- Manual: with a company payload carrying `slugAliases: ["my-slug"]`, opening `/my-slug/dashboard#anchor` redirects to `/<issuePrefix>/dashboard#anchor`

## Risks

- Low risk: `slugAliases` is optional and absent everywhere today, so every existing install takes the exact pre-change code path (prefix-only matching); no server, persistence, or migration changes
- Alias shadowing is prevented by construction: canonical `issuePrefix` matches are checked before aliases
- The only behavioral delta for alias-free installs is the canonicalization redirect now carrying `location.hash`, which previously was dropped

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider: Anthropic
- Model: Claude Fable 5 (model id `claude-fable-5`)
- Mode: agentic coding via Claude Code (tool use: file edits, shell for tests/builds); no fine-tuning, standard context window

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
