### PR TITLE
fix(codex-local): classify OpenAI invalid-key 401s as codex_auth_required

### DIFF
--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -1002,7 +1002,7 @@ describe("codex_local ACP lane", () => {
         [],
         {
           status: "failed",
-          error: { message: "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA." },
+          error: { message: "unexpected status 401 Unauthorized: Incorrect API key provided: sk-proj-a***AA." },
         } as unknown as FakeRuntimeTurnResult,
       ) as never,
     });

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -994,6 +994,26 @@ describe("codex_local ACP lane", () => {
     expect(result.resultJson).not.toHaveProperty("codexCredentialTelemetry");
   });
 
+  it("classifies an ACP rejected OpenAI API key as codex_auth_required", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-invalid-api-key-");
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(
+        options,
+        [],
+        {
+          status: "failed",
+          error: { message: "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA." },
+        } as unknown as FakeRuntimeTurnResult,
+      ) as never,
+    });
+
+    const result = await execute(buildContext(root));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("codex_auth_required");
+    expect(result.errorFamily ?? null).toBeNull();
+  });
+
   it("resumes compatible ACP sessions on later Codex ACP runs", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-resume-");
     const runtimes: FakeRuntime[] = [];

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -1270,7 +1270,7 @@ describe("codex_local ACP lane", () => {
         [],
         {
           status: "failed",
-          error: { message: "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA." },
+          error: { message: "unexpected status 401 Unauthorized: Incorrect API key provided: sk-proj-a***AA." },
         } as unknown as FakeRuntimeTurnResult,
       ) as never,
     });

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -1262,6 +1262,26 @@ describe("codex_local ACP lane", () => {
     expect(result.resultJson).not.toHaveProperty("codexCredentialTelemetry");
   });
 
+  it("classifies an ACP rejected OpenAI API key as codex_auth_required", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-invalid-api-key-");
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(
+        options,
+        [],
+        {
+          status: "failed",
+          error: { message: "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA." },
+        } as unknown as FakeRuntimeTurnResult,
+      ) as never,
+    });
+
+    const result = await execute(buildContext(root));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("codex_auth_required");
+    expect(result.errorFamily ?? null).toBeNull();
+  });
+
   it("resumes compatible ACP sessions on later Codex ACP runs", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-resume-");
     const runtimes: FakeRuntime[] = [];

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -35,7 +35,7 @@ import {
   asString,
   parseObject,
 } from "@paperclipai/adapter-utils/server-utils";
-import { classifyCodexAuthRefreshFailure } from "./parse.js";
+import { classifyCodexAuthRefreshFailure, isCodexInvalidApiKeyError } from "./parse.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import {
@@ -260,27 +260,38 @@ function withCodexAcpDefaults(options: CodexAcpExecutorOptions): AcpxEngineExecu
   };
 }
 
-function withCodexAuthRefreshFailureClassification(result: AdapterExecutionResult): AdapterExecutionResult {
+function withCodexAuthFailureClassification(result: AdapterExecutionResult): AdapterExecutionResult {
   if ((result.exitCode ?? 0) === 0) return result;
   const resultJson = parseObject(result.resultJson);
   const stopReason = asString(resultJson.stopReason, "");
-  const authFailure = classifyCodexAuthRefreshFailure({
-    errorMessage: [result.errorMessage ?? "", result.summary ?? "", stopReason]
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .join("\n"),
-  });
-  if (!authFailure) return result;
-
-  return {
-    ...result,
-    errorCode: authFailure,
-    errorFamily: authFailure,
-    resultJson: {
-      ...(result.resultJson ?? {}),
+  const errorMessage = [result.errorMessage ?? "", result.summary ?? "", stopReason]
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  const authFailure = classifyCodexAuthRefreshFailure({ errorMessage });
+  if (authFailure) {
+    return {
+      ...result,
+      errorCode: authFailure,
       errorFamily: authFailure,
-    },
-  };
+      resultJson: {
+        ...(result.resultJson ?? {}),
+        errorFamily: authFailure,
+      },
+    };
+  }
+
+  // A rejected/missing OpenAI API key is a permanent auth failure: surface it
+  // as codex_auth_required (no errorFamily; it is not a retry contract), the
+  // codex analog of claude-local's claude_auth_required.
+  if (isCodexInvalidApiKeyError({ errorMessage })) {
+    return {
+      ...result,
+      errorCode: "codex_auth_required",
+    };
+  }
+
+  return result;
 }
 
 /**
@@ -330,7 +341,7 @@ export function createCodexAcpExecutor(options: CodexAcpExecutorOptions = {}): C
       ...ctx,
       config: buildCodexAcpConfig(ctx.config),
     });
-    return withCodexAuthRefreshFailureClassification(result);
+    return withCodexAuthFailureClassification(result);
   };
 }
 

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -37,7 +37,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { createWorkspaceRestoreTeardown } from "@paperclipai/adapter-utils/workspace-restore-teardown";
 import { normalizeCodexModel } from "../index.js";
-import { classifyCodexAuthRefreshFailure } from "./parse.js";
+import { classifyCodexAuthRefreshFailure, isCodexInvalidApiKeyError } from "./parse.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import {
@@ -276,27 +276,38 @@ function withCodexAcpDefaults(options: CodexAcpExecutorOptions): AcpxEngineExecu
   };
 }
 
-function withCodexAuthRefreshFailureClassification(result: AdapterExecutionResult): AdapterExecutionResult {
+function withCodexAuthFailureClassification(result: AdapterExecutionResult): AdapterExecutionResult {
   if ((result.exitCode ?? 0) === 0) return result;
   const resultJson = parseObject(result.resultJson);
   const stopReason = asString(resultJson.stopReason, "");
-  const authFailure = classifyCodexAuthRefreshFailure({
-    errorMessage: [result.errorMessage ?? "", result.summary ?? "", stopReason]
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .join("\n"),
-  });
-  if (!authFailure) return result;
-
-  return {
-    ...result,
-    errorCode: authFailure,
-    errorFamily: authFailure,
-    resultJson: {
-      ...(result.resultJson ?? {}),
+  const errorMessage = [result.errorMessage ?? "", result.summary ?? "", stopReason]
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  const authFailure = classifyCodexAuthRefreshFailure({ errorMessage });
+  if (authFailure) {
+    return {
+      ...result,
+      errorCode: authFailure,
       errorFamily: authFailure,
-    },
-  };
+      resultJson: {
+        ...(result.resultJson ?? {}),
+        errorFamily: authFailure,
+      },
+    };
+  }
+
+  // A rejected/missing OpenAI API key is a permanent auth failure: surface it
+  // as codex_auth_required (no errorFamily; it is not a retry contract), the
+  // codex analog of claude-local's claude_auth_required.
+  if (isCodexInvalidApiKeyError({ errorMessage })) {
+    return {
+      ...result,
+      errorCode: "codex_auth_required",
+    };
+  }
+
+  return result;
 }
 
 /**
@@ -346,7 +357,7 @@ export function createCodexAcpExecutor(options: CodexAcpExecutorOptions = {}): C
       ...ctx,
       config: buildCodexAcpConfig(ctx.config),
     });
-    return withCodexAuthRefreshFailureClassification(result);
+    return withCodexAuthFailureClassification(result);
   };
 }
 

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -53,6 +53,7 @@ import {
   parseCodexJsonl,
   classifyCodexAuthRefreshFailure,
   extractCodexRetryNotBefore,
+  isCodexInvalidApiKeyError,
   isCodexProviderQuotaError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
@@ -1242,9 +1243,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
               errorMessage: fallbackErrorMessage,
             })
           : null;
+      const invalidApiKey =
+        (attempt.proc.exitCode ?? 0) !== 0 &&
+        !authRefreshFailure &&
+        isCodexInvalidApiKeyError({
+          stdout: attempt.proc.stdout,
+          stderr: attempt.proc.stderr,
+          errorMessage: fallbackErrorMessage,
+        });
       const providerQuota =
         (attempt.proc.exitCode ?? 0) !== 0 &&
         !authRefreshFailure &&
+        !invalidApiKey &&
         isCodexProviderQuotaError({
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
@@ -1253,6 +1263,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const transientUpstream =
         (attempt.proc.exitCode ?? 0) !== 0 &&
         !authRefreshFailure &&
+        !invalidApiKey &&
         !providerQuota &&
         isCodexTransientUpstreamError({
           stdout: attempt.proc.stdout,
@@ -1272,6 +1283,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorCode:
           authRefreshFailure
             ? authRefreshFailure
+            : invalidApiKey
+            ? "codex_auth_required"
             : providerQuota
             ? "provider_quota"
             : transientUpstream

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -62,6 +62,7 @@ import {
   classifyCodexAuthRefreshFailure,
   extractCodexRetryNotBefore,
   isCodexHarnessCrash,
+  isCodexInvalidApiKeyError,
   isCodexProviderQuotaError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
@@ -1448,9 +1449,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
               errorMessage: fallbackErrorMessage,
             })
           : null;
+      const invalidApiKey =
+        (attempt.proc.exitCode ?? 0) !== 0 &&
+        !authRefreshFailure &&
+        isCodexInvalidApiKeyError({
+          stdout: attempt.proc.stdout,
+          stderr: attempt.proc.stderr,
+          errorMessage: fallbackErrorMessage,
+        });
       const providerQuota =
         (attempt.proc.exitCode ?? 0) !== 0 &&
         !authRefreshFailure &&
+        !invalidApiKey &&
         isCodexProviderQuotaError({
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
@@ -1459,6 +1469,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const transientUpstream =
         (attempt.proc.exitCode ?? 0) !== 0 &&
         !authRefreshFailure &&
+        !invalidApiKey &&
         !providerQuota &&
         isCodexTransientUpstreamError({
           stdout: attempt.proc.stdout,
@@ -1467,6 +1478,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         });
       const harnessCrash =
         !authRefreshFailure &&
+        // A rejected OpenAI key exits non-zero before any protocol terminal
+        // event, which otherwise looks exactly like a harness crash. Excluding
+        // it here keeps errorFamily off "transient_upstream" so the permanent
+        // auth failure is not retried.
+        !invalidApiKey &&
         !providerQuota &&
         !transientUpstream &&
         isCodexHarnessCrash({
@@ -1494,6 +1510,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             ? attempt.proc.errorCode
             : authRefreshFailure
             ? authRefreshFailure
+            : invalidApiKey
+            ? "codex_auth_required"
             : providerQuota
             ? "provider_quota"
             : transientUpstream

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -95,11 +95,11 @@ describe("classifyCodexAuthRefreshFailure", () => {
 });
 
 describe("isCodexInvalidApiKeyError", () => {
-  it("detects OpenAI invalid-key 401 phrasings", () => {
+  it("detects OpenAI-distinctive invalid-key phrasings without further context", () => {
     expect(
       isCodexInvalidApiKeyError({
         errorMessage:
-          "Incorrect API key provided: sk-ant-a***AA. You can find your API key at https://platform.openai.com/account/api-keys.",
+          "Incorrect API key provided: sk-proj-a***AA. You can find your API key at https://platform.openai.com/account/api-keys.",
       }),
     ).toBe(true);
     expect(
@@ -109,12 +109,20 @@ describe("isCodexInvalidApiKeyError", () => {
       }),
     ).toBe(true);
     expect(isCodexInvalidApiKeyError({ stdout: "error code: invalid_api_key" })).toBe(true);
-    expect(isCodexInvalidApiKeyError({ errorMessage: "No API key provided." })).toBe(true);
+  });
+
+  it("detects generic missing/invalid-key phrasings only near an OpenAI marker", () => {
     expect(
       isCodexInvalidApiKeyError({
-        errorMessage: "You didn't provide an API key. You need to provide your API key in an Authorization header.",
+        errorMessage: "No API key provided. You can find your API key at https://platform.openai.com/account/api-keys.",
       }),
     ).toBe(true);
+    expect(
+      isCodexInvalidApiKeyError({
+        errorMessage: "You didn't provide an API key. Obtain one at https://platform.openai.com/account/api-keys.",
+      }),
+    ).toBe(true);
+    expect(isCodexInvalidApiKeyError({ stderr: "openai: api key is invalid" })).toBe(true);
   });
 
   it("detects a 401 anchored to api.openai.com", () => {
@@ -123,6 +131,17 @@ describe("isCodexInvalidApiKeyError", () => {
         stderr: "request to https://api.openai.com/v1/responses failed: 401 Unauthorized",
       }),
     ).toBe(true);
+  });
+
+  it("does not classify third-party invalid/missing-key errors", () => {
+    expect(isCodexInvalidApiKeyError({ errorMessage: "POST https://example.com/v1 failed: No API key provided" })).toBe(
+      false,
+    );
+    expect(isCodexInvalidApiKeyError({ errorMessage: "stripe: invalid api key" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ stderr: "weather-api: api key is expired" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "You didn't provide an API key for the search tool." })).toBe(
+      false,
+    );
   });
 
   it("does not swallow unrelated failures", () => {

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   classifyCodexAuthRefreshFailure,
   extractCodexRetryNotBefore,
+  isCodexInvalidApiKeyError,
   isCodexProviderQuotaError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
@@ -90,6 +91,46 @@ describe("classifyCodexAuthRefreshFailure", () => {
   it("does not classify bare 401 or quota messages as auth-refresh failures", () => {
     expect(classifyCodexAuthRefreshFailure({ errorMessage: "chatgpt wham api returned 401" })).toBeNull();
     expect(classifyCodexAuthRefreshFailure({ errorMessage: "You've hit your usage limit for GPT-5." })).toBeNull();
+  });
+});
+
+describe("isCodexInvalidApiKeyError", () => {
+  it("detects OpenAI invalid-key 401 phrasings", () => {
+    expect(
+      isCodexInvalidApiKeyError({
+        errorMessage:
+          "Incorrect API key provided: sk-ant-a***AA. You can find your API key at https://platform.openai.com/account/api-keys.",
+      }),
+    ).toBe(true);
+    expect(
+      isCodexInvalidApiKeyError({
+        stderr:
+          'unexpected status 401 Unauthorized: {"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}',
+      }),
+    ).toBe(true);
+    expect(isCodexInvalidApiKeyError({ stdout: "error code: invalid_api_key" })).toBe(true);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "No API key provided." })).toBe(true);
+    expect(
+      isCodexInvalidApiKeyError({
+        errorMessage: "You didn't provide an API key. You need to provide your API key in an Authorization header.",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a 401 anchored to api.openai.com", () => {
+    expect(
+      isCodexInvalidApiKeyError({
+        stderr: "request to https://api.openai.com/v1/responses failed: 401 Unauthorized",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not swallow unrelated failures", () => {
+    expect(isCodexInvalidApiKeyError({ errorMessage: "You've hit your usage limit for GPT-5." })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "server overloaded, try again later" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "chatgpt wham api returned 401" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ stderr: "some tool call to https://example.com returned 401" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "Codex exited with code 1" })).toBe(false);
   });
 });
 

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -3,6 +3,7 @@ import {
   classifyCodexAuthRefreshFailure,
   extractCodexRetryNotBefore,
   isCodexHarnessCrash,
+  isCodexInvalidApiKeyError,
   isCodexProviderQuotaError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
@@ -163,6 +164,46 @@ describe("classifyCodexAuthRefreshFailure", () => {
   it("does not classify bare 401 or quota messages as auth-refresh failures", () => {
     expect(classifyCodexAuthRefreshFailure({ errorMessage: "chatgpt wham api returned 401" })).toBeNull();
     expect(classifyCodexAuthRefreshFailure({ errorMessage: "You've hit your usage limit for GPT-5." })).toBeNull();
+  });
+});
+
+describe("isCodexInvalidApiKeyError", () => {
+  it("detects OpenAI invalid-key 401 phrasings", () => {
+    expect(
+      isCodexInvalidApiKeyError({
+        errorMessage:
+          "Incorrect API key provided: sk-ant-a***AA. You can find your API key at https://platform.openai.com/account/api-keys.",
+      }),
+    ).toBe(true);
+    expect(
+      isCodexInvalidApiKeyError({
+        stderr:
+          'unexpected status 401 Unauthorized: {"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}',
+      }),
+    ).toBe(true);
+    expect(isCodexInvalidApiKeyError({ stdout: "error code: invalid_api_key" })).toBe(true);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "No API key provided." })).toBe(true);
+    expect(
+      isCodexInvalidApiKeyError({
+        errorMessage: "You didn't provide an API key. You need to provide your API key in an Authorization header.",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a 401 anchored to api.openai.com", () => {
+    expect(
+      isCodexInvalidApiKeyError({
+        stderr: "request to https://api.openai.com/v1/responses failed: 401 Unauthorized",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not swallow unrelated failures", () => {
+    expect(isCodexInvalidApiKeyError({ errorMessage: "You've hit your usage limit for GPT-5." })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "server overloaded, try again later" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "chatgpt wham api returned 401" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ stderr: "some tool call to https://example.com returned 401" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "Codex exited with code 1" })).toBe(false);
   });
 });
 

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -168,11 +168,11 @@ describe("classifyCodexAuthRefreshFailure", () => {
 });
 
 describe("isCodexInvalidApiKeyError", () => {
-  it("detects OpenAI invalid-key 401 phrasings", () => {
+  it("detects OpenAI-distinctive invalid-key phrasings without further context", () => {
     expect(
       isCodexInvalidApiKeyError({
         errorMessage:
-          "Incorrect API key provided: sk-ant-a***AA. You can find your API key at https://platform.openai.com/account/api-keys.",
+          "Incorrect API key provided: sk-proj-a***AA. You can find your API key at https://platform.openai.com/account/api-keys.",
       }),
     ).toBe(true);
     expect(
@@ -182,12 +182,20 @@ describe("isCodexInvalidApiKeyError", () => {
       }),
     ).toBe(true);
     expect(isCodexInvalidApiKeyError({ stdout: "error code: invalid_api_key" })).toBe(true);
-    expect(isCodexInvalidApiKeyError({ errorMessage: "No API key provided." })).toBe(true);
+  });
+
+  it("detects generic missing/invalid-key phrasings only near an OpenAI marker", () => {
     expect(
       isCodexInvalidApiKeyError({
-        errorMessage: "You didn't provide an API key. You need to provide your API key in an Authorization header.",
+        errorMessage: "No API key provided. You can find your API key at https://platform.openai.com/account/api-keys.",
       }),
     ).toBe(true);
+    expect(
+      isCodexInvalidApiKeyError({
+        errorMessage: "You didn't provide an API key. Obtain one at https://platform.openai.com/account/api-keys.",
+      }),
+    ).toBe(true);
+    expect(isCodexInvalidApiKeyError({ stderr: "openai: api key is invalid" })).toBe(true);
   });
 
   it("detects a 401 anchored to api.openai.com", () => {
@@ -196,6 +204,17 @@ describe("isCodexInvalidApiKeyError", () => {
         stderr: "request to https://api.openai.com/v1/responses failed: 401 Unauthorized",
       }),
     ).toBe(true);
+  });
+
+  it("does not classify third-party invalid/missing-key errors", () => {
+    expect(isCodexInvalidApiKeyError({ errorMessage: "POST https://example.com/v1 failed: No API key provided" })).toBe(
+      false,
+    );
+    expect(isCodexInvalidApiKeyError({ errorMessage: "stripe: invalid api key" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ stderr: "weather-api: api key is expired" })).toBe(false);
+    expect(isCodexInvalidApiKeyError({ errorMessage: "You didn't provide an API key for the search tool." })).toBe(
+      false,
+    );
   });
 
   it("does not swallow unrelated failures", () => {

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -25,10 +25,23 @@ const CODEX_OAUTH_INVALID_GRANT_RE = /\binvalid_grant\b/i;
 // map this to errorCode "codex_auth_required" (the codex analog of
 // claude-local's claude_auth_required) so a bad or missing API key surfaces
 // as a distinct auth failure instead of a generic error that gets retried.
-// The bare-401 alternatives are anchored to api.openai.com so unrelated 401s
-// (e.g. a tool the agent ran against some other service) are not swallowed.
-const CODEX_INVALID_API_KEY_RE =
-  /(?:incorrect\s+api\s+key\s+provided|\binvalid_api_key\b|invalid\s+api\s+key|no\s+api\s+key\s+provided|you\s+didn(?:'|’)?t\s+provide\s+an\s+api\s+key|api\s+key\s+(?:is\s+)?(?:invalid|incorrect|expired|revoked|disabled)|(?:\b401\b|\bunauthori[sz]ed\b)[\s\S]{0,120}?api\.openai\.com|api\.openai\.com[\s\S]{0,120}?(?:\b401\b|\bunauthori[sz]ed\b))/i;
+// Only these two phrasings are distinctive enough to match on their own:
+// "Incorrect API key provided" and the invalid_api_key error code are
+// OpenAI's exact wordings.
+const CODEX_INVALID_API_KEY_DISTINCTIVE_RE =
+  /(?:incorrect\s+api\s+key\s+provided|\binvalid_api_key\b)/i;
+// Generic invalid/missing-key phrasings and bare 401s appear verbatim in
+// third-party API errors too (an agent's tool call against some other
+// service returning "No API key provided" must not masquerade as a Codex
+// credential failure), so they only classify when an OpenAI marker appears
+// within a bounded window of the phrase.
+const CODEX_INVALID_API_KEY_GENERIC_SRC =
+  "(?:invalid\\s+api\\s+key|no\\s+api\\s+key\\s+provided|you\\s+didn(?:'|’)?t\\s+provide\\s+an\\s+api\\s+key|api\\s+key\\s+(?:is\\s+)?(?:invalid|incorrect|expired|revoked|disabled))";
+const OPENAI_MARKER_SRC = "(?:api\\.openai\\.com|\\bopenai\\b)";
+const CODEX_CONTEXTUAL_INVALID_API_KEY_RE = new RegExp(
+  `(?:${CODEX_INVALID_API_KEY_GENERIC_SRC}[\\s\\S]{0,120}?${OPENAI_MARKER_SRC}|${OPENAI_MARKER_SRC}[\\s\\S]{0,120}?${CODEX_INVALID_API_KEY_GENERIC_SRC}|(?:\\b401\\b|\\bunauthori[sz]ed\\b)[\\s\\S]{0,120}?api\\.openai\\.com|api\\.openai\\.com[\\s\\S]{0,120}?(?:\\b401\\b|\\bunauthori[sz]ed\\b))`,
+  "i",
+);
 const CODEX_CONTEXTUAL_REFRESH_AUTH_INVALIDATED_RE =
   /(?:(?:oauth|refresh|access[_\s-]?token|bearer|credential).{0,80}(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b)|(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b).{0,80}(?:oauth|refresh|access[_\s-]?token|bearer|credential))/i;
 
@@ -148,7 +161,10 @@ export function isCodexInvalidApiKeyError(input: {
   errorMessage?: string | null;
 }): boolean {
   const haystack = buildCodexErrorHaystack(input);
-  return CODEX_INVALID_API_KEY_RE.test(haystack);
+  return (
+    CODEX_INVALID_API_KEY_DISTINCTIVE_RE.test(haystack) ||
+    CODEX_CONTEXTUAL_INVALID_API_KEY_RE.test(haystack)
+  );
 }
 
 function readTimeZoneParts(date: Date, timeZone: string) {

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -19,6 +19,16 @@ const CODEX_REFRESH_TOKEN_EXPIRED_RE =
 const CODEX_REFRESH_TOKEN_INVALIDATED_RE =
   /(?:refresh[_\s-]?token[_\s-]?(?:invalidated|revoked|invalid)|refresh token (?:has been )?(?:invalidated|revoked|invalid)|invalid refresh token|missing bearer)/i;
 const CODEX_OAUTH_INVALID_GRANT_RE = /\binvalid_grant\b/i;
+// A presented OpenAI API key the provider rejected outright (401
+// invalid_api_key family), or no key at all. Distinct from the OAuth
+// refresh-token classes above, which cover ChatGPT subscription auth; callers
+// map this to errorCode "codex_auth_required" (the codex analog of
+// claude-local's claude_auth_required) so a bad or missing API key surfaces
+// as a distinct auth failure instead of a generic error that gets retried.
+// The bare-401 alternatives are anchored to api.openai.com so unrelated 401s
+// (e.g. a tool the agent ran against some other service) are not swallowed.
+const CODEX_INVALID_API_KEY_RE =
+  /(?:incorrect\s+api\s+key\s+provided|\binvalid_api_key\b|invalid\s+api\s+key|no\s+api\s+key\s+provided|you\s+didn(?:'|’)?t\s+provide\s+an\s+api\s+key|api\s+key\s+(?:is\s+)?(?:invalid|incorrect|expired|revoked|disabled)|(?:\b401\b|\bunauthori[sz]ed\b)[\s\S]{0,120}?api\.openai\.com|api\.openai\.com[\s\S]{0,120}?(?:\b401\b|\bunauthori[sz]ed\b))/i;
 const CODEX_CONTEXTUAL_REFRESH_AUTH_INVALIDATED_RE =
   /(?:(?:oauth|refresh|access[_\s-]?token|bearer|credential).{0,80}(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b)|(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b).{0,80}(?:oauth|refresh|access[_\s-]?token|bearer|credential))/i;
 
@@ -130,6 +140,15 @@ export function classifyCodexAuthRefreshFailure(input: {
   if (CODEX_OAUTH_INVALID_GRANT_RE.test(haystack)) return "refresh_token_invalidated";
   if (CODEX_CONTEXTUAL_REFRESH_AUTH_INVALIDATED_RE.test(haystack)) return "refresh_token_invalidated";
   return null;
+}
+
+export function isCodexInvalidApiKeyError(input: {
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const haystack = buildCodexErrorHaystack(input);
+  return CODEX_INVALID_API_KEY_RE.test(haystack);
 }
 
 function readTimeZoneParts(date: Date, timeZone: string) {

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -19,6 +19,16 @@ const CODEX_REFRESH_TOKEN_EXPIRED_RE =
 const CODEX_REFRESH_TOKEN_INVALIDATED_RE =
   /(?:refresh[_\s-]?token[_\s-]?(?:invalidated|revoked|invalid)|refresh token (?:has been )?(?:invalidated|revoked|invalid)|invalid refresh token|missing bearer)/i;
 const CODEX_OAUTH_INVALID_GRANT_RE = /\binvalid_grant\b/i;
+// A presented OpenAI API key the provider rejected outright (401
+// invalid_api_key family), or no key at all. Distinct from the OAuth
+// refresh-token classes above, which cover ChatGPT subscription auth; callers
+// map this to errorCode "codex_auth_required" (the codex analog of
+// claude-local's claude_auth_required) so a bad or missing API key surfaces
+// as a distinct auth failure instead of a generic error that gets retried.
+// The bare-401 alternatives are anchored to api.openai.com so unrelated 401s
+// (e.g. a tool the agent ran against some other service) are not swallowed.
+const CODEX_INVALID_API_KEY_RE =
+  /(?:incorrect\s+api\s+key\s+provided|\binvalid_api_key\b|invalid\s+api\s+key|no\s+api\s+key\s+provided|you\s+didn(?:'|’)?t\s+provide\s+an\s+api\s+key|api\s+key\s+(?:is\s+)?(?:invalid|incorrect|expired|revoked|disabled)|(?:\b401\b|\bunauthori[sz]ed\b)[\s\S]{0,120}?api\.openai\.com|api\.openai\.com[\s\S]{0,120}?(?:\b401\b|\bunauthori[sz]ed\b))/i;
 const CODEX_CONTEXTUAL_REFRESH_AUTH_INVALIDATED_RE =
   /(?:(?:oauth|refresh|access[_\s-]?token|bearer|credential).{0,80}(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b)|(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b).{0,80}(?:oauth|refresh|access[_\s-]?token|bearer|credential))/i;
 
@@ -157,6 +167,15 @@ export function classifyCodexAuthRefreshFailure(input: {
   if (CODEX_OAUTH_INVALID_GRANT_RE.test(haystack)) return "refresh_token_invalidated";
   if (CODEX_CONTEXTUAL_REFRESH_AUTH_INVALIDATED_RE.test(haystack)) return "refresh_token_invalidated";
   return null;
+}
+
+export function isCodexInvalidApiKeyError(input: {
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const haystack = buildCodexErrorHaystack(input);
+  return CODEX_INVALID_API_KEY_RE.test(haystack);
 }
 
 function readTimeZoneParts(date: Date, timeZone: string) {

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -25,10 +25,23 @@ const CODEX_OAUTH_INVALID_GRANT_RE = /\binvalid_grant\b/i;
 // map this to errorCode "codex_auth_required" (the codex analog of
 // claude-local's claude_auth_required) so a bad or missing API key surfaces
 // as a distinct auth failure instead of a generic error that gets retried.
-// The bare-401 alternatives are anchored to api.openai.com so unrelated 401s
-// (e.g. a tool the agent ran against some other service) are not swallowed.
-const CODEX_INVALID_API_KEY_RE =
-  /(?:incorrect\s+api\s+key\s+provided|\binvalid_api_key\b|invalid\s+api\s+key|no\s+api\s+key\s+provided|you\s+didn(?:'|’)?t\s+provide\s+an\s+api\s+key|api\s+key\s+(?:is\s+)?(?:invalid|incorrect|expired|revoked|disabled)|(?:\b401\b|\bunauthori[sz]ed\b)[\s\S]{0,120}?api\.openai\.com|api\.openai\.com[\s\S]{0,120}?(?:\b401\b|\bunauthori[sz]ed\b))/i;
+// Only these two phrasings are distinctive enough to match on their own:
+// "Incorrect API key provided" and the invalid_api_key error code are
+// OpenAI's exact wordings.
+const CODEX_INVALID_API_KEY_DISTINCTIVE_RE =
+  /(?:incorrect\s+api\s+key\s+provided|\binvalid_api_key\b)/i;
+// Generic invalid/missing-key phrasings and bare 401s appear verbatim in
+// third-party API errors too (an agent's tool call against some other
+// service returning "No API key provided" must not masquerade as a Codex
+// credential failure), so they only classify when an OpenAI marker appears
+// within a bounded window of the phrase.
+const CODEX_INVALID_API_KEY_GENERIC_SRC =
+  "(?:invalid\\s+api\\s+key|no\\s+api\\s+key\\s+provided|you\\s+didn(?:'|’)?t\\s+provide\\s+an\\s+api\\s+key|api\\s+key\\s+(?:is\\s+)?(?:invalid|incorrect|expired|revoked|disabled))";
+const OPENAI_MARKER_SRC = "(?:api\\.openai\\.com|\\bopenai\\b)";
+const CODEX_CONTEXTUAL_INVALID_API_KEY_RE = new RegExp(
+  `(?:${CODEX_INVALID_API_KEY_GENERIC_SRC}[\\s\\S]{0,120}?${OPENAI_MARKER_SRC}|${OPENAI_MARKER_SRC}[\\s\\S]{0,120}?${CODEX_INVALID_API_KEY_GENERIC_SRC}|(?:\\b401\\b|\\bunauthori[sz]ed\\b)[\\s\\S]{0,120}?api\\.openai\\.com|api\\.openai\\.com[\\s\\S]{0,120}?(?:\\b401\\b|\\bunauthori[sz]ed\\b))`,
+  "i",
+);
 const CODEX_CONTEXTUAL_REFRESH_AUTH_INVALIDATED_RE =
   /(?:(?:oauth|refresh|access[_\s-]?token|bearer|credential).{0,80}(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b)|(?:\b401\b|unauthori[sz]ed|\binvalid[\s-]grant\b).{0,80}(?:oauth|refresh|access[_\s-]?token|bearer|credential))/i;
 
@@ -175,7 +188,10 @@ export function isCodexInvalidApiKeyError(input: {
   errorMessage?: string | null;
 }): boolean {
   const haystack = buildCodexErrorHaystack(input);
-  return CODEX_INVALID_API_KEY_RE.test(haystack);
+  return (
+    CODEX_INVALID_API_KEY_DISTINCTIVE_RE.test(haystack) ||
+    CODEX_CONTEXTUAL_INVALID_API_KEY_RE.test(haystack)
+  );
 }
 
 function readTimeZoneParts(date: Date, timeZone: string) {

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -820,7 +820,7 @@ describe("codex execute", () => {
     await fs.mkdir(workspace, { recursive: true });
     await writeFailingCodexCommand(
       commandPath,
-      "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA.",
+      "unexpected status 401 Unauthorized: Incorrect API key provided: sk-proj-a***AA.",
     );
 
     const previousHome = process.env.HOME;

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -813,6 +813,58 @@ describe("codex execute", () => {
     }
   });
 
+  it("classifies a rejected OpenAI API key as codex_auth_required", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-invalid-api-key-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingCodexCommand(
+      commandPath,
+      "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA.",
+    );
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    await seedSharedCodexAuth(root);
+
+    try {
+      const result = await execute({
+        runId: "run-invalid-api-key",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("codex_auth_required");
+      expect(result.errorFamily).toBeNull();
+      expect(result.resultJson).not.toHaveProperty("errorFamily");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("uses safer invocation settings and a fresh-session handoff for codex transient fallback retries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-fallback-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -875,6 +875,58 @@ process.exit(1);
     }
   });
 
+  it("classifies a rejected OpenAI API key as codex_auth_required", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-invalid-api-key-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingCodexCommand(
+      commandPath,
+      "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA.",
+    );
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    await seedSharedCodexAuth(root);
+
+    try {
+      const result = await execute({
+        runId: "run-invalid-api-key",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("codex_auth_required");
+      expect(result.errorFamily).toBeNull();
+      expect(result.resultJson).not.toHaveProperty("errorFamily");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("uses safer invocation settings and a fresh-session handoff for codex transient fallback retries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-fallback-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -882,7 +882,7 @@ process.exit(1);
     await fs.mkdir(workspace, { recursive: true });
     await writeFailingCodexCommand(
       commandPath,
-      "unexpected status 401 Unauthorized: Incorrect API key provided: sk-ant-a***AA.",
+      "unexpected status 401 Unauthorized: Incorrect API key provided: sk-proj-a***AA.",
     );
 
     const previousHome = process.env.HOME;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run through provider adapters; codex_local drives the OpenAI Codex CLI and ACP lanes, and each run's outcome is classified in the adapter's server code (parse.ts, execute.ts, acp.ts)
> - When a run fails because the OPENAI_API_KEY is invalid or missing, OpenAI's 401 output matches none of the existing classifiers (OAuth refresh-token classes, provider_quota, transient upstream), so the run ends with a null errorCode
> - Callers therefore cannot tell "fix the credential" apart from "retry", and automated re-invocations burn the same 401 on every attempt
> - claude-local already solves this for Anthropic credentials with the claude_auth_required errorCode, so codex-local should have a symmetric permanent-auth classification
> - This pull request adds isCodexInvalidApiKeyError to codex-local and maps matching failures to a new codex_auth_required errorCode in both the CLI and ACP lanes, with OpenAI-context anchoring so third-party API errors the agent encounters are not swallowed
> - The benefit is that a bad or missing OpenAI key surfaces as a distinct, actionable auth failure instead of a generic error, matching the claude-local precedent

## Linked Issues or Issue Description

No public issue exists; describing the bug here following `.github/ISSUE_TEMPLATE/bug_report.yml`:

**What happened?**

A codex_local agent configured with an invalid OPENAI_API_KEY (for example an Anthropic key pasted by mistake) fails every run. OpenAI returns 401 with "Incorrect API key provided" / `invalid_api_key`, but codex-local classifies the run as a generic failure with `errorCode: null`, so nothing downstream can route the user to fix the credential.

**Expected behavior**

The run should carry a distinct auth errorCode, the way claude-local emits `claude_auth_required` for rejected Anthropic credentials, so callers and UI can offer credential recovery instead of retrying the same 401.

**Steps to reproduce**

1. Configure a codex_local agent with `OPENAI_API_KEY=sk-invalid` (API-key billing path, CLI or ACP engine).
2. Trigger a run.
3. Observe the failed run has `errorCode: null` and automated retries reproduce the same 401.

**Paperclip version**

Reproducible on current `master` (this PR's base).

**Deployment mode**

Any; observed with the codex_local adapter on both the CLI and ACP execution lanes.

## What Changed

- `packages/adapters/codex-local/src/server/parse.ts`: new exported `isCodexInvalidApiKeyError`. OpenAI-distinctive phrasings ("Incorrect API key provided", `invalid_api_key`) match on their own; generic invalid/missing-key phrasings ("invalid api key", "No API key provided", "You didn't provide an API key", "API key is invalid/incorrect/expired/revoked/disabled") and bare 401/unauthorized only classify when an OpenAI marker (`api.openai.com` or the word `openai`) appears within a bounded window, so errors from third-party APIs the agent itself called are not misclassified.
- `packages/adapters/codex-local/src/server/execute.ts` (CLI lane): failing runs matching the detector get `errorCode: "codex_auth_required"`, checked after the OAuth refresh-token classes and before `provider_quota` / `codex_transient_upstream`. No errorFamily is set: this is a permanent auth failure, not a retry contract.
- `packages/adapters/codex-local/src/server/acp.ts` (ACP lane): the post-run auth classification wrapper applies the same mapping (renamed to `withCodexAuthFailureClassification` since it now covers more than refresh tokens).
- Tests in `parse.test.ts`, `acp.test.ts`, and `server/src/__tests__/codex-local-execute.test.ts` covering both lanes, positive phrasings, and negatives (quota, transient, bare 401, third-party API errors like `POST https://example.com/v1 failed: No API key provided`).

## Verification

- `cd packages/adapters/codex-local && npx vitest run` (full adapter suite, includes the new `parse.test.ts` and `acp.test.ts` cases)
- `cd server && npx vitest run src/__tests__/codex-local-execute.test.ts` (CLI-lane run failing with "401 Unauthorized: Incorrect API key provided" yields `codex_auth_required` with no errorFamily)
- `pnpm --filter @paperclipai/adapter-codex-local typecheck && pnpm --filter @paperclipai/adapter-codex-local build && pnpm --filter @paperclipai/server typecheck`
- Manual: configure a codex_local agent with an invalid `OPENAI_API_KEY`, run it, and confirm the failed run reports `codex_auth_required`.

## Risks

- Low risk. The new detector runs only on already-failing runs (nonzero exit) and only adds an errorCode where there was none; refresh-token, quota, and transient classifications keep precedence.
- Main hazard would be over-matching unrelated errors; mitigated by anchoring the generic phrasings and bare 401s to an OpenAI marker within a bounded window, with negative tests for third-party phrasings ("stripe: invalid api key", 401s from other hosts).
- No schema, migration, or API surface changes; `codex_auth_required` is a new errorCode string value consumers can opt into.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider and model: Anthropic, Claude Fable 5
- Exact model ID: claude-fable-5
- Reasoning mode: extended thinking (interleaved with tool use)
- Capabilities used: agentic coding via Claude Code (tool use: file edits, shell, test execution)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
