### PR TITLE
feat(plugins): support local path installs in UI

### DIFF
--- a/ui/src/pages/PluginManager.test.tsx
+++ b/ui/src/pages/PluginManager.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginManager } from "./PluginManager";
+
+const mockPluginsApi = vi.hoisted(() => ({
+  install: vi.fn(),
+  list: vi.fn(),
+  listBundled: vi.fn(),
+  uninstall: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+}));
+const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
+const mockPushToast = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/plugins", () => ({ pluginsApi: mockPluginsApi }));
+vi.mock("@/context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompany: { id: "company-1", name: "Paperclip" } }),
+}));
+vi.mock("@/context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: mockSetBreadcrumbs }),
+}));
+vi.mock("@/context/ToastContext", () => ({
+  useToastActions: () => ({ pushToast: mockPushToast }),
+}));
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function renderManager(container: HTMLDivElement) {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <PluginManager />
+      </QueryClientProvider>,
+    );
+  });
+  await flushReact();
+  return root;
+}
+
+describe("PluginManager", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockPluginsApi.list.mockResolvedValue([]);
+    mockPluginsApi.listBundled.mockResolvedValue([]);
+    mockPluginsApi.install.mockResolvedValue({ id: "plugin-1" });
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("installs a server-local plugin using the local-path API mode", async () => {
+    const root = await renderManager(container);
+
+    const openButton = [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("Install Plugin"));
+    expect(openButton).toBeTruthy();
+    await act(async () => openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const localPathButton = [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("Local path"));
+    expect(localPathButton).toBeTruthy();
+    await act(async () => localPathButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const pathInput = document.querySelector<HTMLInputElement>('input[placeholder="/plugins/my-plugin"]');
+    expect(pathInput).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(pathInput, "/plugins/ecs");
+      pathInput?.dispatchEvent(new Event("input", { bubbles: true }));
+      pathInput?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const installButton = [...document.querySelectorAll("button")].find((button) => button.textContent === "Install");
+    expect(installButton).toBeTruthy();
+    await act(async () => installButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    expect(mockPluginsApi.install).toHaveBeenCalledWith({ packageName: "/plugins/ecs", isLocalPath: true });
+
+    await act(async () => root.unmount());
+  });
+});

--- a/ui/src/pages/PluginManager.test.tsx
+++ b/ui/src/pages/PluginManager.test.tsx
@@ -100,4 +100,26 @@ describe("PluginManager", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("clears an npm package name when switching to local-path mode", async () => {
+    const root = await renderManager(container);
+
+    const openButton = [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("Install Plugin"));
+    await act(async () => openButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const npmInput = document.querySelector<HTMLInputElement>('input[placeholder="@paperclipai/plugin-example"]');
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(npmInput, "@example/plugin");
+      npmInput?.dispatchEvent(new Event("input", { bubbles: true }));
+      npmInput?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    const localPathButton = [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("Local path"));
+    await act(async () => localPathButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    expect(document.querySelector<HTMLInputElement>('input[placeholder="/plugins/my-plugin"]')?.value).toBe("");
+
+    await act(async () => root.unmount());
+  });
 });

--- a/ui/src/pages/PluginManager.tsx
+++ b/ui/src/pages/PluginManager.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PluginRecord } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
-import { AlertTriangle, FlaskConical, Plus, Power, Puzzle, Settings, Trash } from "lucide-react";
+import { AlertTriangle, FlaskConical, FolderOpen, Package, Plus, Power, Puzzle, Settings, Trash } from "lucide-react";
 import { useCompany } from "@/context/CompanyContext";
 import { useBreadcrumbs } from "@/context/BreadcrumbContext";
 import { pluginsApi } from "@/api/plugins";
@@ -73,7 +73,7 @@ function ExperimentalBadge() {
  *
  * Provides a management UI for the Paperclip plugin system:
  * - Lists all installed plugins with their status, version, and category badges.
- * - Allows installing new plugins by npm package name.
+ * - Allows installing new plugins by npm package name or local path.
  * - Provides per-plugin actions: enable, disable, navigate to settings.
  * - Uninstall with a two-step confirmation dialog to prevent accidental removal.
  *
@@ -92,6 +92,7 @@ export function PluginManager() {
   const { pushToast } = useToastActions();
 
   const [installPackage, setInstallPackage] = useState("");
+  const [isLocalPath, setIsLocalPath] = useState(false);
   const [installDialogOpen, setInstallDialogOpen] = useState(false);
   const [uninstallPluginId, setUninstallPluginId] = useState<string | null>(null);
   const [uninstallPluginName, setUninstallPluginName] = useState<string>("");
@@ -129,6 +130,7 @@ export function PluginManager() {
       invalidatePluginQueries();
       setInstallDialogOpen(false);
       setInstallPackage("");
+      setIsLocalPath(false);
       pushToast({ title: "Plugin installed successfully", tone: "success" });
     },
     onError: (err: Error) => {
@@ -208,24 +210,58 @@ export function PluginManager() {
             <DialogHeader>
               <DialogTitle>Install Plugin</DialogTitle>
               <DialogDescription>
-                Enter the npm package name of the plugin you wish to install.
+                Install a plugin from npm or from an existing local package path.
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors",
+                    !isLocalPath
+                      ? "border-foreground bg-accent text-foreground"
+                      : "border-border text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                  )}
+                  onClick={() => setIsLocalPath(false)}
+                >
+                  <Package className="h-3.5 w-3.5" />
+                  npm package
+                </button>
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs transition-colors",
+                    isLocalPath
+                      ? "border-foreground bg-accent text-foreground"
+                      : "border-border text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                  )}
+                  onClick={() => setIsLocalPath(true)}
+                >
+                  <FolderOpen className="h-3.5 w-3.5" />
+                  Local path
+                </button>
+              </div>
               <div className="grid gap-2">
-                <Label htmlFor="packageName">npm Package Name</Label>
+                <Label htmlFor="packageName">{isLocalPath ? "Path to plugin package" : "npm Package Name"}</Label>
                 <Input
                   id="packageName"
-                  placeholder="@paperclipai/plugin-example"
+                  className={isLocalPath ? "font-mono text-xs" : undefined}
+                  placeholder={isLocalPath ? "/plugins/my-plugin" : "@paperclipai/plugin-example"}
                   value={installPackage}
                   onChange={(e) => setInstallPackage(e.target.value)}
                 />
+                {isLocalPath && (
+                  <p className="text-xs text-muted-foreground">
+                    The path is resolved on the Paperclip server and must contain a Paperclip plugin manifest.
+                  </p>
+                )}
               </div>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setInstallDialogOpen(false)}>Cancel</Button>
               <Button
-                onClick={() => installMutation.mutate({ packageName: installPackage })}
+                onClick={() => installMutation.mutate({ packageName: installPackage, isLocalPath })}
                 disabled={!installPackage || installMutation.isPending}
               >
                 {installMutation.isPending ? "Installing..." : "Install"}

--- a/ui/src/pages/PluginManager.tsx
+++ b/ui/src/pages/PluginManager.tsx
@@ -223,7 +223,10 @@ export function PluginManager() {
                       ? "border-foreground bg-accent text-foreground"
                       : "border-border text-muted-foreground hover:text-foreground hover:bg-accent/50"
                   )}
-                  onClick={() => setIsLocalPath(false)}
+                  onClick={() => {
+                    setIsLocalPath(false);
+                    setInstallPackage("");
+                  }}
                 >
                   <Package className="h-3.5 w-3.5" />
                   npm package
@@ -236,7 +239,10 @@ export function PluginManager() {
                       ? "border-foreground bg-accent text-foreground"
                       : "border-border text-muted-foreground hover:text-foreground hover:bg-accent/50"
                   )}
-                  onClick={() => setIsLocalPath(true)}
+                  onClick={() => {
+                    setIsLocalPath(true);
+                    setInstallPackage("");
+                  }}
                 >
                   <FolderOpen className="h-3.5 w-3.5" />
                   Local path


### PR DESCRIPTION
## Thinking Path

> - Paperclip provides an instance-admin plugin manager backed by the existing plugin installation API.
> - That API already supports either an npm package name or a server-local package path using the isLocalPath flag.
> - The manager currently exposes only the npm form, leaving a mounted or otherwise pre-provisioned plugin unreachable without bypassing the UI.
> - This patch exposes the existing local-path mode with the same explicit source choice used by the adapter manager.
> - The installed path is still validated by the server-side plugin loader and remains limited to instance administrators.

## Linked Issues or Issue Description

Fixes #1299.

## What Changed

- Added npm package and Local path source choices to the Plugin Manager install dialog.
- Submit the existing isLocalPath flag when local mode is selected, while retaining the npm flow unchanged.
- Added a UI test that proves a local path is submitted with isLocalPath: true.

## Verification

- pnpm --filter @paperclipai/ui exec vitest run src/pages/PluginManager.test.tsx
- pnpm --filter @paperclipai/ui typecheck

## Risks

Low risk. This is an opt-in UI for an existing instance-admin API; npm installs retain their existing request shape.

## Model Used

OpenAI Codex (GPT-5.6), tool-assisted code editing, TypeScript typechecking, and Vitest.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked the existing public issue
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added a behavioral UI test
- [x] I have considered and documented risks above
