### PR TITLE
Add first-class issue resource references

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -41,6 +41,15 @@ export {
   type OriginatingActor,
 } from "./issue-attribution.js";
 export {
+  extractIssueResourceLinks,
+  parseIssueResourceLink,
+  type ExtractedIssueResourceLink,
+  type IssueDocumentReference,
+  type IssueResourceReference,
+  type IssueResourceReferenceKind,
+  type IssueWorkProductReference,
+} from "./issue-resource-links.js";
+export {
   RESPONSIBLE_USER_DENIAL_CODES,
   describeResponsibleUserDenial,
   isResponsibleUserDenialCode,

--- a/packages/shared/src/issue-resource-links.test.ts
+++ b/packages/shared/src/issue-resource-links.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { extractIssueResourceLinks, parseIssueResourceLink } from "./issue-resource-links.js";
+
+describe("parseIssueResourceLink", () => {
+  it("parses prefixed issue document links", () => {
+    expect(parseIssueResourceLink("/PAP/issues/RES-30#document-plan")).toEqual({
+      href: "/PAP/issues/RES-30#document-plan",
+      issuePathId: "RES-30",
+      target: {
+        kind: "issue_document",
+        documentKey: "plan",
+      },
+    });
+  });
+
+  it("parses work product links with a fallback issue path id", () => {
+    expect(parseIssueResourceLink("#work-product-1234", { fallbackIssuePathId: "RES-34" })).toEqual({
+      href: "#work-product-1234",
+      issuePathId: "RES-34",
+      target: {
+        kind: "work_product",
+        workProductId: "1234",
+      },
+    });
+  });
+
+  it("ignores non-resource hashes", () => {
+    expect(parseIssueResourceLink("/PAP/issues/RES-30#comment-1")).toBeNull();
+  });
+});
+
+describe("extractIssueResourceLinks", () => {
+  it("finds both document and work product references", () => {
+    expect(
+      extractIssueResourceLinks(
+        "See [plan](/PAP/issues/RES-30#document-plan) and https://paperclip.test/PAP/issues/RES-30#work-product-abc",
+      ),
+    ).toEqual([
+      {
+        href: "/PAP/issues/RES-30#document-plan",
+        issuePathId: "RES-30",
+        target: {
+          kind: "issue_document",
+          documentKey: "plan",
+        },
+      },
+      {
+        href: "https://paperclip.test/PAP/issues/RES-30#work-product-abc",
+        issuePathId: "RES-30",
+        target: {
+          kind: "work_product",
+          workProductId: "abc",
+        },
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/issue-resource-links.ts
+++ b/packages/shared/src/issue-resource-links.ts
@@ -1,0 +1,131 @@
+import type { IssueWorkProductReviewState, IssueWorkProductType } from "./types/work-product.js";
+
+export type IssueResourceReferenceKind = "issue_document" | "work_product";
+
+export interface IssueResourceReferenceBase {
+  kind: IssueResourceReferenceKind;
+  href: string;
+  issueId: string;
+  issueIdentifier: string | null;
+  issueTitle: string | null;
+}
+
+export interface IssueDocumentReference extends IssueResourceReferenceBase {
+  kind: "issue_document";
+  documentKey: string;
+  documentTitle: string | null;
+  latestRevisionNumber: number | null;
+}
+
+export interface IssueWorkProductReference extends IssueResourceReferenceBase {
+  kind: "work_product";
+  workProductId: string;
+  workProductTitle: string;
+  workProductType: IssueWorkProductType | string;
+  workProductStatus: string;
+  reviewState: IssueWorkProductReviewState;
+}
+
+export type IssueResourceReference = IssueDocumentReference | IssueWorkProductReference;
+
+export interface ExtractedIssueResourceLink {
+  href: string;
+  issuePathId: string | null;
+  target:
+    | {
+      kind: "issue_document";
+      documentKey: string;
+    }
+    | {
+      kind: "work_product";
+      workProductId: string;
+    };
+}
+
+function decodePart(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeHrefPath(href: string) {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed, "https://paperclip.local");
+    return {
+      pathname: parsed.pathname,
+      hash: parsed.hash,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseIssuePathId(pathname: string) {
+  const segments = pathname.split("/").filter(Boolean);
+  const issueIndex = segments.findIndex((segment) => segment === "issues");
+  if (issueIndex === -1 || issueIndex === segments.length - 1) return null;
+  return decodePart(segments[issueIndex + 1] ?? "") || null;
+}
+
+function parseHashTarget(hash: string) {
+  const normalized = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!normalized) return null;
+  if (normalized.startsWith("document-")) {
+    const documentKey = decodePart(normalized.slice("document-".length)).trim();
+    return documentKey
+      ? { kind: "issue_document" as const, documentKey }
+      : null;
+  }
+  if (normalized.startsWith("work-product-")) {
+    const workProductId = decodePart(normalized.slice("work-product-".length)).trim();
+    return workProductId
+      ? { kind: "work_product" as const, workProductId }
+      : null;
+  }
+  return null;
+}
+
+const ISSUE_RESOURCE_LINK_RE = /(?:https?:\/\/[^\s<>()\]]+|\/[^\s<>()\]]+|#[A-Za-z0-9][^\s<>()\]]*)/g;
+
+export function parseIssueResourceLink(
+  href: string | null | undefined,
+  options?: { fallbackIssuePathId?: string | null },
+): ExtractedIssueResourceLink | null {
+  if (!href) return null;
+  const normalized = normalizeHrefPath(href);
+  if (!normalized) return null;
+  const target = parseHashTarget(normalized.hash);
+  if (!target) return null;
+  const issuePathId = parseIssuePathId(normalized.pathname) ?? options?.fallbackIssuePathId ?? null;
+  if (!issuePathId) return null;
+  return {
+    href: href.trim(),
+    issuePathId,
+    target,
+  };
+}
+
+export function extractIssueResourceLinks(
+  text: string | null | undefined,
+  options?: { fallbackIssuePathId?: string | null },
+): ExtractedIssueResourceLink[] {
+  if (!text) return [];
+  const seen = new Set<string>();
+  const matches = text.match(ISSUE_RESOURCE_LINK_RE) ?? [];
+  const results: ExtractedIssueResourceLink[] = [];
+  for (const token of matches) {
+    const parsed = parseIssueResourceLink(token, options);
+    if (!parsed) continue;
+    const dedupeKey = `${parsed.issuePathId}:${parsed.target.kind}:${
+      parsed.target.kind === "issue_document" ? parsed.target.documentKey : parsed.target.workProductId
+    }:${parsed.href}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    results.push(parsed);
+  }
+  return results;
+}

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -31,6 +31,7 @@ import type { Goal } from "./goal.js";
 import type { Project, ProjectWorkspace } from "./project.js";
 import type { ExecutionWorkspace, IssueExecutionWorkspaceSettings } from "./workspace-runtime.js";
 import type { IssueWorkProduct } from "./work-product.js";
+import type { IssueResourceReference } from "../issue-resource-links.js";
 import type {
   LowTrustReviewPresetPolicy,
   SourceTrustMetadata,
@@ -865,6 +866,7 @@ export interface IssueComment {
   derivedCreatedByRunId?: string | null;
   derivedAuthorSource?: IssueCommentDerivedAuthorSource | null;
   body: string;
+  referencedResources?: IssueResourceReference[];
   presentation: IssueCommentPresentation | null;
   metadata: IssueCommentMetadata | null;
   deletedAt?: Date | null;

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2136,6 +2136,30 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       ]),
     );
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
+    const initialRunEvents = await db
+      .select({
+        eventType: heartbeatRunEvents.eventType,
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(initialRunEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        eventType: "causal.wake",
+        payload: expect.objectContaining({
+          wakeReason: "issue_assigned",
+          issueId,
+        }),
+      }),
+      expect.objectContaining({
+        eventType: "causal.recovery_context",
+        payload: expect.objectContaining({
+          issueId,
+          taskId: issueId,
+        }),
+      }),
+    ]));
 
     const issue = await db
       .select()
@@ -2811,6 +2835,23 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(activityLog)
       .where(eq(activityLog.entityId, issueId));
     expect(activity.some((event) => event.action === "issue.successful_run_handoff_required")).toBe(true);
+    const causalEvents = await db
+      .select({
+        eventType: heartbeatRunEvents.eventType,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(causalEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        eventType: "causal.handoff",
+        payload: expect.objectContaining({
+          handoffKind: "successful_run_recovery",
+          sourceIssueId: issueId,
+          sourceRunId: runId,
+        }),
+      }),
+    ]));
   });
 
   it("requeues a missing-disposition handoff when the previous corrective wake was cancelled", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -46,6 +46,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { runningProcesses } from "../adapters/index.ts";
+import { EXECUTION_CAUSAL_TRACE_KEY } from "../services/execution-causal-trace.js";
 const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
 const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
 const mockTerminateLocalService = vi.hoisted(() => vi.fn());
@@ -2124,6 +2125,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(retryRun?.contextSnapshot).toMatchObject({
       codexTransientFallbackMode: "same_session",
     });
+    expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.[EXECUTION_CAUSAL_TRACE_KEY]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "retry",
+          reason: "transient_failure",
+          retryOfRunId: runId,
+          issueId,
+        }),
+      ]),
+    );
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
 
     const issue = await db

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -122,6 +122,7 @@ import {
 } from "../services/index.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
 import { hydrateSuccessfulRunHandoffLiveness } from "../services/successful-run-handoff-state.js";
+import { appendExecutionCausalRunEventForExistingRun, executionCausalEventType } from "../services/execution-causal-trace.js";
 import {
   TASK_WATCHDOG_ORIGIN_KIND,
   resolveTaskWatchdogMutationScope,
@@ -7130,6 +7131,22 @@ export function issueRoutes(
         }),
       },
     });
+    if (actor.runId && actor.agentId && issue.parentId) {
+      await appendExecutionCausalRunEventForExistingRun(db, {
+        runId: actor.runId,
+        eventType: executionCausalEventType("handoff"),
+        message: `created child issue: ${issue.identifier}`,
+        payload: {
+          traceVersion: 1,
+          handoffKind: "child_issue_delegation",
+          sourceIssueId: issue.parentId,
+          childIssueId: issue.id,
+          childIssueIdentifier: issue.identifier,
+          childIssueTitle: issue.title,
+          assigneeAgentId: issue.assigneeAgentId ?? null,
+        },
+      });
+    }
 
     if (executionPolicy?.monitor) {
       await logActivity(db, {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -121,6 +121,7 @@ import {
   workProductService,
 } from "../services/index.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
+import { issueResourceReferenceService } from "../services/issue-resource-references.js";
 import { hydrateSuccessfulRunHandoffLiveness } from "../services/successful-run-handoff-state.js";
 import { appendExecutionCausalRunEventForExistingRun, executionCausalEventType } from "../services/execution-causal-trace.js";
 import {
@@ -2599,6 +2600,7 @@ export function issueRoutes(
   const executionWorkspacesSvc = executionWorkspaceServiceDirect(db);
   const workProductsSvc = workProductService(db);
   const documentsSvc = documentService(db);
+  const issueResourceRefs = issueResourceReferenceService(db);
   const companySkillsSvc = companySkillService(db);
   const documentAnnotationsSvc = documentAnnotationService(db);
   const decisionTrainingSvc = decisionTrainingService(db);
@@ -5127,6 +5129,18 @@ export function issueRoutes(
       continuationSummary && redactLowTrust
         ? redactQuarantinedBodyForHigherTrust(continuationSummary)
         : continuationSummary;
+    const [issueReferencedResources, wakeCommentReferencedResources] = await issueResourceRefs.resolveForTexts([
+      {
+        companyId: issue.companyId,
+        text: issue.description,
+        fallbackIssuePathId: issue.identifier ?? issue.id,
+      },
+      {
+        companyId: issue.companyId,
+        text: safeWakeComment?.body ?? null,
+        fallbackIssuePathId: issue.identifier ?? issue.id,
+      },
+    ]);
     const planReviewContext = await buildPlanReviewContext({
       db,
       companyId: issue.companyId,
@@ -5143,6 +5157,7 @@ export function issueRoutes(
         description: issue.description,
         status: issue.status,
         workMode: issue.workMode,
+        referencedResources: issueReferencedResources,
         ...(blockerAttention ? { blockerAttention } : {}),
         productivityReview,
         scheduledRetry,
@@ -5184,7 +5199,12 @@ export function issueRoutes(
           }
         : null,
       commentCursor,
-      wakeComment: safeWakeComment,
+      wakeComment: safeWakeComment
+        ? {
+            ...safeWakeComment,
+            referencedResources: wakeCommentReferencedResources,
+          }
+        : null,
       attachments: attachments.map((a) => ({
         id: a.id,
         filename: a.originalFilename,

--- a/server/src/services/execution-causal-trace.test.ts
+++ b/server/src/services/execution-causal-trace.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExecutionCausalWakePayload,
+  buildExecutionRecoveryContextPayload,
+  buildExecutionToolSpanPayload,
+} from "./execution-causal-trace.js";
+
+describe("execution causal trace helpers", () => {
+  it("summarizes carried recovery context for the next heartbeat", () => {
+    const payload = buildExecutionRecoveryContextPayload({
+      issueId: "issue-1",
+      taskId: "issue-1",
+      wakeReason: "finish_successful_run_handoff",
+      retryOfRunId: "run-0",
+      recoveryActionId: "recovery-1",
+      handoffRequired: true,
+      handoffReason: "successful_run_missing_state",
+      handoffAttempt: 1,
+      paperclipSessionHandoffMarkdown: "Paperclip session handoff",
+      executionCausalTrace: [
+        {
+          version: 1,
+          kind: "retry",
+          recordedAt: "2026-07-24T00:00:00.000Z",
+          reason: "transient_failure",
+          source: "automation",
+          triggerDetail: "system",
+          issueId: "issue-1",
+          taskId: "issue-1",
+          runId: "run-0",
+          retryOfRunId: "run-0",
+          recoveryActionId: null,
+          originKind: null,
+          originId: null,
+        },
+      ],
+    });
+
+    expect(payload).toMatchObject({
+      issueId: "issue-1",
+      taskId: "issue-1",
+      retryOfRunId: "run-0",
+      recoveryActionId: "recovery-1",
+      priorTraceCount: 1,
+      handoffRequired: true,
+      handoffReason: "successful_run_missing_state",
+      handoffAttempt: 1,
+      carriedContextKeys: expect.arrayContaining([
+        "issueId",
+        "taskId",
+        "wakeReason",
+        "retryOfRunId",
+        "recoveryActionId",
+        "handoffRequired",
+        "handoffReason",
+        "handoffAttempt",
+        "paperclipSessionHandoffMarkdown",
+      ]),
+    });
+  });
+
+  it("builds wake and tool span payloads with stable causal fields", () => {
+    const wake = buildExecutionCausalWakePayload({
+      issueId: "issue-1",
+      taskId: "issue-1",
+      wakeReason: "issue_continuation_needed",
+      wakeSource: "assignment",
+      wakeTriggerDetail: "system",
+      executionCausalTrace: [
+        {
+          version: 1,
+          kind: "wake",
+          recordedAt: "2026-07-24T00:00:00.000Z",
+          reason: "issue_continuation_needed",
+          source: "assignment",
+          triggerDetail: "system",
+          issueId: "issue-1",
+          taskId: "issue-1",
+          runId: null,
+          retryOfRunId: null,
+          recoveryActionId: null,
+          originKind: null,
+          originId: null,
+        },
+      ],
+    });
+    const toolSpan = buildExecutionToolSpanPayload({
+      invocationId: "inv-1",
+      actionRequestId: "action-1",
+      toolName: "web.search",
+      phase: "end",
+      resultClass: "failed",
+      errorClass: "tool_timeout",
+      outcome: "timeout",
+      reasonCode: "tool_timeout",
+    });
+
+    expect(wake).toMatchObject({
+      wakeReason: "issue_continuation_needed",
+      wakeSource: "assignment",
+      wakeTriggerDetail: "system",
+      issueId: "issue-1",
+      taskId: "issue-1",
+      latestTraceEntry: expect.objectContaining({
+        kind: "wake",
+        reason: "issue_continuation_needed",
+      }),
+    });
+    expect(toolSpan).toEqual({
+      traceVersion: 1,
+      invocationId: "inv-1",
+      actionRequestId: "action-1",
+      toolName: "web.search",
+      phase: "end",
+      resultClass: "failed",
+      errorClass: "tool_timeout",
+      outcome: "timeout",
+      reasonCode: "tool_timeout",
+    });
+  });
+});

--- a/server/src/services/execution-causal-trace.ts
+++ b/server/src/services/execution-causal-trace.ts
@@ -1,5 +1,17 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRunEvents, heartbeatRuns } from "@paperclipai/db";
+
 const EXECUTION_CAUSAL_TRACE_VERSION = 1 as const;
 const MAX_EXECUTION_CAUSAL_TRACE_ENTRIES = 16;
+const MAX_CAUSAL_MESSAGE_CHARS = 240;
+const EXECUTION_CAUSAL_EVENT_TYPES = {
+  wake: "causal.wake",
+  recoveryContext: "causal.recovery_context",
+  toolSpan: "causal.tool_span",
+  handoff: "causal.handoff",
+  guardrail: "causal.guardrail",
+} as const;
 
 export const EXECUTION_CAUSAL_TRACE_KEY = "executionCausalTrace";
 
@@ -21,6 +33,23 @@ export interface ExecutionCausalTraceEntry {
   originId: string | null;
 }
 
+export type ExecutionCausalRunEventType =
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.wake
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.recoveryContext
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.toolSpan
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.handoff
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.guardrail;
+
+export type ExecutionCausalRunEventInput = {
+  companyId: string;
+  runId: string;
+  agentId: string;
+  eventType: ExecutionCausalRunEventType;
+  message: string;
+  level?: "info" | "warn" | "error";
+  payload?: Record<string, unknown> | null;
+};
+
 type ExecutionCausalTraceEntryInput = Omit<ExecutionCausalTraceEntry, "version" | "recordedAt"> & {
   recordedAt?: string | null;
 };
@@ -31,6 +60,12 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function readNonEmptyString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function truncateMessage(message: string) {
+  const normalized = message.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_CAUSAL_MESSAGE_CHARS) return normalized;
+  return `${normalized.slice(0, MAX_CAUSAL_MESSAGE_CHARS - 3)}...`;
 }
 
 function normalizeEntry(value: unknown): ExecutionCausalTraceEntry | null {
@@ -114,4 +149,135 @@ export function inferExecutionCausalTraceKind(input: {
   }
   if (input.retryOfRunId || input.reason?.includes("retry")) return "retry" as const;
   return "wake" as const;
+}
+
+export function executionCausalEventType(kind: keyof typeof EXECUTION_CAUSAL_EVENT_TYPES) {
+  return EXECUTION_CAUSAL_EVENT_TYPES[kind];
+}
+
+export function buildExecutionCausalWakePayload(contextSnapshot: Record<string, unknown>) {
+  const trace = readExecutionCausalTrace(contextSnapshot[EXECUTION_CAUSAL_TRACE_KEY]);
+  const latest = trace[trace.length - 1] ?? null;
+  return {
+    traceVersion: EXECUTION_CAUSAL_TRACE_VERSION,
+    wakeReason: readNonEmptyString(contextSnapshot.wakeReason),
+    retryReason: readNonEmptyString(contextSnapshot.retryReason),
+    wakeSource: readNonEmptyString(contextSnapshot.wakeSource),
+    wakeTriggerDetail: readNonEmptyString(contextSnapshot.wakeTriggerDetail),
+    issueId: readNonEmptyString(contextSnapshot.issueId),
+    taskId: readNonEmptyString(contextSnapshot.taskId),
+    retryOfRunId: readNonEmptyString(contextSnapshot.retryOfRunId),
+    recoveryActionId: readNonEmptyString(contextSnapshot.recoveryActionId),
+    sourceIssueId: readNonEmptyString(contextSnapshot.sourceIssueId),
+    sourceRunId: readNonEmptyString(contextSnapshot.sourceRunId),
+    latestTraceEntry: latest,
+  };
+}
+
+export function buildExecutionRecoveryContextPayload(contextSnapshot: Record<string, unknown>) {
+  const trace = readExecutionCausalTrace(contextSnapshot[EXECUTION_CAUSAL_TRACE_KEY]);
+  const carriedKeys = Object.keys(contextSnapshot).filter((key) =>
+    [
+      "issueId",
+      "taskId",
+      "wakeReason",
+      "retryReason",
+      "retryOfRunId",
+      "recoveryActionId",
+      "source",
+      "sourceIssueId",
+      "sourceRunId",
+      "originKind",
+      "originId",
+      "scheduledRetryAttempt",
+      "scheduledRetryAt",
+      "providerQuotaRetryNotBefore",
+      "interactionId",
+      "interactionKind",
+      "continuationPolicy",
+      "handoffRequired",
+      "handoffReason",
+      "handoffAttempt",
+      "workspaceValidationRecovery",
+      "paperclipSessionHandoffMarkdown",
+    ].includes(key)
+  );
+  return {
+    traceVersion: EXECUTION_CAUSAL_TRACE_VERSION,
+    issueId: readNonEmptyString(contextSnapshot.issueId),
+    taskId: readNonEmptyString(contextSnapshot.taskId),
+    retryOfRunId: readNonEmptyString(contextSnapshot.retryOfRunId),
+    recoveryActionId: readNonEmptyString(contextSnapshot.recoveryActionId),
+    carriedContextKeys: carriedKeys,
+    priorTraceCount: trace.length,
+    handoffRequired: contextSnapshot.handoffRequired === true,
+    handoffReason: readNonEmptyString(contextSnapshot.handoffReason),
+    handoffAttempt: typeof contextSnapshot.handoffAttempt === "number" ? contextSnapshot.handoffAttempt : null,
+  };
+}
+
+export function buildExecutionToolSpanPayload(input: {
+  invocationId?: string | null;
+  actionRequestId?: string | null;
+  toolName: string;
+  phase: "start" | "end";
+  resultClass: "started" | "succeeded" | "failed" | "denied" | "approval_requested" | "approval_resolved";
+  errorClass?: string | null;
+  outcome?: string | null;
+  reasonCode?: string | null;
+}) {
+  return {
+    traceVersion: EXECUTION_CAUSAL_TRACE_VERSION,
+    invocationId: input.invocationId ?? null,
+    actionRequestId: input.actionRequestId ?? null,
+    toolName: input.toolName,
+    phase: input.phase,
+    resultClass: input.resultClass,
+    errorClass: input.errorClass ?? null,
+    outcome: input.outcome ?? null,
+    reasonCode: input.reasonCode ?? null,
+  };
+}
+
+export async function appendExecutionCausalRunEvent(
+  db: Db,
+  input: ExecutionCausalRunEventInput,
+) {
+  const [row] = await db
+    .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+    .from(heartbeatRunEvents)
+    .where(eq(heartbeatRunEvents.runId, input.runId));
+  const seq = Number(row?.maxSeq ?? 0) + 1;
+  await db.insert(heartbeatRunEvents).values({
+    companyId: input.companyId,
+    runId: input.runId,
+    agentId: input.agentId,
+    seq,
+    eventType: input.eventType,
+    stream: "system",
+    level: input.level ?? "info",
+    message: truncateMessage(input.message),
+    payload: input.payload ?? null,
+  });
+  return seq;
+}
+
+export async function appendExecutionCausalRunEventForExistingRun(
+  db: Db,
+  input: Omit<ExecutionCausalRunEventInput, "companyId" | "agentId">,
+) {
+  const run = await db
+    .select({
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, input.runId))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return null;
+  return appendExecutionCausalRunEvent(db, {
+    ...input,
+    companyId: run.companyId,
+    agentId: run.agentId,
+  });
 }

--- a/server/src/services/execution-causal-trace.ts
+++ b/server/src/services/execution-causal-trace.ts
@@ -1,0 +1,117 @@
+const EXECUTION_CAUSAL_TRACE_VERSION = 1 as const;
+const MAX_EXECUTION_CAUSAL_TRACE_ENTRIES = 16;
+
+export const EXECUTION_CAUSAL_TRACE_KEY = "executionCausalTrace";
+
+export type ExecutionCausalTraceKind = "wake" | "retry" | "recovery";
+
+export interface ExecutionCausalTraceEntry {
+  version: typeof EXECUTION_CAUSAL_TRACE_VERSION;
+  kind: ExecutionCausalTraceKind;
+  recordedAt: string;
+  reason: string | null;
+  source: string | null;
+  triggerDetail: string | null;
+  issueId: string | null;
+  taskId: string | null;
+  runId: string | null;
+  retryOfRunId: string | null;
+  recoveryActionId: string | null;
+  originKind: string | null;
+  originId: string | null;
+}
+
+type ExecutionCausalTraceEntryInput = Omit<ExecutionCausalTraceEntry, "version" | "recordedAt"> & {
+  recordedAt?: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function readNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function normalizeEntry(value: unknown): ExecutionCausalTraceEntry | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const recordedAt = readNonEmptyString(record.recordedAt);
+  const kind = readNonEmptyString(record.kind);
+  if (!recordedAt || (kind !== "wake" && kind !== "retry" && kind !== "recovery")) return null;
+  return {
+    version: EXECUTION_CAUSAL_TRACE_VERSION,
+    kind,
+    recordedAt,
+    reason: readNonEmptyString(record.reason),
+    source: readNonEmptyString(record.source),
+    triggerDetail: readNonEmptyString(record.triggerDetail),
+    issueId: readNonEmptyString(record.issueId),
+    taskId: readNonEmptyString(record.taskId),
+    runId: readNonEmptyString(record.runId),
+    retryOfRunId: readNonEmptyString(record.retryOfRunId),
+    recoveryActionId: readNonEmptyString(record.recoveryActionId),
+    originKind: readNonEmptyString(record.originKind),
+    originId: readNonEmptyString(record.originId),
+  };
+}
+
+function sameEntry(a: ExecutionCausalTraceEntry | null | undefined, b: ExecutionCausalTraceEntry) {
+  return Boolean(a) &&
+    a.kind === b.kind &&
+    a.reason === b.reason &&
+    a.source === b.source &&
+    a.triggerDetail === b.triggerDetail &&
+    a.issueId === b.issueId &&
+    a.taskId === b.taskId &&
+    a.runId === b.runId &&
+    a.retryOfRunId === b.retryOfRunId &&
+    a.recoveryActionId === b.recoveryActionId &&
+    a.originKind === b.originKind &&
+    a.originId === b.originId;
+}
+
+export function readExecutionCausalTrace(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeEntry(entry))
+    .filter((entry): entry is ExecutionCausalTraceEntry => entry !== null);
+}
+
+export function appendExecutionCausalTrace(
+  target: Record<string, unknown>,
+  entry: ExecutionCausalTraceEntryInput,
+) {
+  const nextEntry: ExecutionCausalTraceEntry = {
+    version: EXECUTION_CAUSAL_TRACE_VERSION,
+    kind: entry.kind,
+    recordedAt: entry.recordedAt ?? new Date().toISOString(),
+    reason: entry.reason ?? null,
+    source: entry.source ?? null,
+    triggerDetail: entry.triggerDetail ?? null,
+    issueId: entry.issueId ?? null,
+    taskId: entry.taskId ?? null,
+    runId: entry.runId ?? null,
+    retryOfRunId: entry.retryOfRunId ?? null,
+    recoveryActionId: entry.recoveryActionId ?? null,
+    originKind: entry.originKind ?? null,
+    originId: entry.originId ?? null,
+  };
+  const trace = readExecutionCausalTrace(target[EXECUTION_CAUSAL_TRACE_KEY]);
+  if (!sameEntry(trace[trace.length - 1], nextEntry)) trace.push(nextEntry);
+  target[EXECUTION_CAUSAL_TRACE_KEY] = trace.slice(-MAX_EXECUTION_CAUSAL_TRACE_ENTRIES);
+  return target;
+}
+
+export function inferExecutionCausalTraceKind(input: {
+  reason?: string | null;
+  retryOfRunId?: string | null;
+  recoveryActionId?: string | null;
+  originKind?: string | null;
+}) {
+  if (input.recoveryActionId || input.originKind?.includes("recovery") || input.reason?.includes("recovery")) {
+    return "recovery" as const;
+  }
+  if (input.retryOfRunId || input.reason?.includes("retry")) return "retry" as const;
+  return "wake" as const;
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -259,7 +259,11 @@ import {
   touchHeartbeatRunRuntimeStatus,
 } from "./heartbeat-run-runtime-status.js";
 import {
+  appendExecutionCausalRunEvent,
   appendExecutionCausalTrace,
+  buildExecutionCausalWakePayload,
+  buildExecutionRecoveryContextPayload,
+  executionCausalEventType,
   inferExecutionCausalTraceKind,
 } from "./execution-causal-trace.js";
 import {
@@ -8148,6 +8152,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       requestedByActorId: "heartbeat",
     });
     if (!handoffRun) return;
+    await appendExecutionCausalRunEvent(db, {
+      companyId: run.companyId,
+      runId: run.id,
+      agentId: run.agentId,
+      eventType: executionCausalEventType("handoff"),
+      message: "queued corrective handoff heartbeat",
+      payload: {
+        traceVersion: 1,
+        handoffKind: "successful_run_recovery",
+        sourceIssueId: issue.id,
+        sourceIssueIdentifier: issue.identifier,
+        sourceRunId: run.id,
+        targetRunId: handoffRun.id,
+        targetAgentId: decision.targetAgentId,
+        reason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
+        missingDisposition: "clear_next_step",
+      },
+    });
 
     await addSuccessfulRunHandoffCommentOnce({
       issue,
@@ -13199,6 +13221,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         stream: "system",
         level: "info",
         message: "run started",
+      });
+      await appendExecutionCausalRunEvent(db, {
+        companyId: currentRun.companyId,
+        runId: currentRun.id,
+        agentId: currentRun.agentId,
+        eventType: executionCausalEventType("wake"),
+        message: `wake received: ${readNonEmptyString(context.wakeReason) ?? "unspecified"}`,
+        payload: buildExecutionCausalWakePayload(context),
+      });
+      await appendExecutionCausalRunEvent(db, {
+        companyId: currentRun.companyId,
+        runId: currentRun.id,
+        agentId: currentRun.agentId,
+        eventType: executionCausalEventType("recoveryContext"),
+        message: "recovery context received for heartbeat execution",
+        payload: buildExecutionRecoveryContextPayload(context),
       });
 
       handle = await runLogStore.begin({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -249,6 +249,7 @@ import { environmentRuntimeService } from "./environment-runtime.js";
 import { skillVersionSelectionMap } from "./runtime-skill-selections.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
 import { isUnsafeSessionWorkspaceCwd } from "./session-workspace-cwd.js";
+import { issueResourceReferenceService } from "./issue-resource-references.js";
 import {
   clearHeartbeatRunRuntimeStatus,
   getHeartbeatRunRuntimeStatus,
@@ -4950,6 +4951,17 @@ export function buildPaperclipTaskMarkdown(input: {
     title: string;
     workMode?: string | null;
     description?: string | null;
+    referencedResources?: Array<{
+      kind: "issue_document" | "work_product";
+      issueIdentifier: string | null;
+      issueTitle: string | null;
+      documentKey?: string;
+      documentTitle?: string | null;
+      latestRevisionNumber?: number | null;
+      workProductTitle?: string;
+      workProductType?: string;
+      workProductStatus?: string;
+    }>;
   } | null;
   ancestors?: Array<{
     id: string;
@@ -4961,6 +4973,17 @@ export function buildPaperclipTaskMarkdown(input: {
   wakeComment?: {
     id: string;
     body: string;
+    referencedResources?: Array<{
+      kind: "issue_document" | "work_product";
+      issueIdentifier: string | null;
+      issueTitle: string | null;
+      documentKey?: string;
+      documentTitle?: string | null;
+      latestRevisionNumber?: number | null;
+      workProductTitle?: string;
+      workProductType?: string;
+      workProductStatus?: string;
+    }>;
   } | null;
   interaction?: {
     kind?: string | null;
@@ -4968,7 +4991,22 @@ export function buildPaperclipTaskMarkdown(input: {
   } | null;
   acceptedPlanContinuation?: boolean;
 }) {
+  type TaskResourceReference = NonNullable<NonNullable<typeof input.issue>["referencedResources"]>[number];
   const quoteTaskScalar = (value: string) => JSON.stringify(value);
+  const formatResourceReference = (reference: TaskResourceReference) => {
+    const issueLabel = reference.issueIdentifier ?? "issue";
+    if (reference.kind === "issue_document") {
+      const docTitle = reference.documentTitle?.trim() || reference.documentKey;
+      const revision = typeof reference.latestRevisionNumber === "number"
+        ? ` (rev ${reference.latestRevisionNumber})`
+        : "";
+      return `- Document ref: ${quoteTaskScalar(`${issueLabel} / ${docTitle}${revision}`)}`;
+    }
+    const productTitle = reference.workProductTitle?.trim() || reference.workProductType || "work product";
+    const status = reference.workProductStatus ? ` [${reference.workProductStatus}]` : "";
+    const type = reference.workProductType ? ` (${reference.workProductType})` : "";
+    return `- Work product ref: ${quoteTaskScalar(`${issueLabel} / ${productTitle}${type}${status}`)}`;
+  };
   const fenceTaskText = (value: string) => {
     const longestBacktickRun = Math.max(
       2,
@@ -5037,6 +5075,12 @@ export function buildPaperclipTaskMarkdown(input: {
     if (description) {
       lines.push("", "Issue description:", fenceTaskText(description));
     }
+    if ((issue.referencedResources?.length ?? 0) > 0) {
+      lines.push("", "Issue-linked references:");
+      for (const reference of issue.referencedResources ?? []) {
+        lines.push(formatResourceReference(reference));
+      }
+    }
   }
   if (ancestors.length > 0) {
     lines.push("", "Authoritative parent / ancestor context:");
@@ -5051,8 +5095,15 @@ export function buildPaperclipTaskMarkdown(input: {
       lines.push(`- [ancestor context truncated after ${ancestors.length} entries]`);
     }
   }
-  if (wakeComment?.body.trim()) {
-    lines.push("", "Latest wake comment:", fenceTaskText(wakeComment.body.trim()));
+  const wakeCommentBody = wakeComment?.body?.trim();
+  if (wakeCommentBody) {
+    lines.push("", "Latest wake comment:", fenceTaskText(wakeCommentBody));
+  }
+  if ((wakeComment?.referencedResources?.length ?? 0) > 0) {
+    lines.push("", "Wake comment references:");
+    for (const reference of wakeComment.referencedResources ?? []) {
+      lines.push(formatResourceReference(reference));
+    }
   }
   lines.push("", "Use this task context as the current assignment.");
   return lines.join("\n");
@@ -12149,6 +12200,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } else {
       delete context[PAPERCLIP_WAKE_PAYLOAD_KEY];
     }
+    const [issueReferencedResources, wakeCommentReferencedResources] = issueRef
+      ? await issueResourceReferenceService(db).resolveForTexts([
+        {
+          companyId: agent.companyId,
+          text: issueRef.description,
+          fallbackIssuePathId: issueRef.identifier ?? issueRef.id,
+        },
+        {
+          companyId: agent.companyId,
+          text: safeWakeCommentContext?.body ?? null,
+          fallbackIssuePathId: issueRef.identifier ?? issueRef.id,
+        },
+      ])
+      : [[], []];
     const taskMarkdown = buildPaperclipTaskMarkdown({
       issue: issueRef
         ? {
@@ -12157,10 +12222,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             title: issueRef.title,
             workMode: issueRef.workMode,
             description: issueRef.description,
+            referencedResources: issueReferencedResources,
           }
         : null,
       ancestors: issueAncestors,
-      wakeComment: safeWakeCommentContext,
+      wakeComment: safeWakeCommentContext
+        ? {
+            ...safeWakeCommentContext,
+            referencedResources: wakeCommentReferencedResources,
+          }
+        : null,
       interaction: {
         kind: readNonEmptyString(context.interactionKind),
         status: readNonEmptyString(context.interactionStatus),
@@ -12176,12 +12247,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         title: issueRef.title,
         description: issueRef.description,
         workMode: issueRef.workMode,
+        referencedResources: issueReferencedResources,
       };
     } else {
       delete context.paperclipIssue;
     }
     if (wakeCommentContext) {
-      context.paperclipWakeComment = safeWakeCommentContext;
+      context.paperclipWakeComment = {
+        ...safeWakeCommentContext,
+        referencedResources: wakeCommentReferencedResources,
+      };
     } else {
       delete context.paperclipWakeComment;
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -259,6 +259,10 @@ import {
   touchHeartbeatRunRuntimeStatus,
 } from "./heartbeat-run-runtime-status.js";
 import {
+  appendExecutionCausalTrace,
+  inferExecutionCausalTraceKind,
+} from "./execution-causal-trace.js";
+import {
   readHotRestartIntent,
   removeHotRestartIntent,
   shouldHonorHotRestartIntentForProcess,
@@ -4237,6 +4241,23 @@ function enrichWakeContextSnapshot(input: {
   }
   normalizeModelProfileWakeContext({ contextSnapshot, payload });
   normalizeInteractionContinuationWakeContext(contextSnapshot, payload);
+  appendExecutionCausalTrace(contextSnapshot, {
+    kind: inferExecutionCausalTraceKind({
+      reason: readNonEmptyString(contextSnapshot["retryReason"]) ?? readNonEmptyString(contextSnapshot["wakeReason"]) ?? reason,
+      retryOfRunId: readNonEmptyString(contextSnapshot["retryOfRunId"]) ?? readNonEmptyString(payload?.["retryOfRunId"]),
+      recoveryActionId: readNonEmptyString(contextSnapshot["recoveryActionId"]) ?? readNonEmptyString(payload?.["recoveryActionId"]),
+      originKind: readNonEmptyString(contextSnapshot["source"]),
+    }),
+    reason: readNonEmptyString(contextSnapshot["retryReason"]) ?? readNonEmptyString(contextSnapshot["wakeReason"]) ?? reason,
+    source,
+    triggerDetail,
+    issueId: readNonEmptyString(contextSnapshot["issueId"]) ?? issueIdFromPayload,
+    taskId: readNonEmptyString(contextSnapshot["taskId"]) ?? issueIdFromPayload,
+    retryOfRunId: readNonEmptyString(contextSnapshot["retryOfRunId"]) ?? readNonEmptyString(payload?.["retryOfRunId"]),
+    recoveryActionId: readNonEmptyString(contextSnapshot["recoveryActionId"]) ?? readNonEmptyString(payload?.["recoveryActionId"]),
+    originKind: readNonEmptyString(contextSnapshot["source"]),
+    originId: readNonEmptyString(contextSnapshot["sourceIssueId"]),
+  });
 
   return {
     contextSnapshot,
@@ -8379,13 +8400,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
-    const retryContextSnapshot = withRecoveryModelProfileHint({
+    const retryContextSnapshot = appendExecutionCausalTrace(withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason: "missing_issue_comment",
       retryReason: "missing_issue_comment",
       missingIssueCommentForRunId: run.id,
-    }, "status_only");
+    }, "status_only"), {
+      kind: "retry",
+      reason: "missing_issue_comment",
+      source: "automation",
+      triggerDetail: "system",
+      issueId,
+      taskId: issueId,
+      runId: run.id,
+      retryOfRunId: run.id,
+    });
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const now = new Date();
 
@@ -8409,11 +8439,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "automation",
           triggerDetail: "system",
           reason: "missing_issue_comment",
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             issueId,
             retryOfRunId: run.id,
             retryReason: "missing_issue_comment",
-          }, "status_only"),
+          }, "status_only"), {
+            kind: "retry",
+            reason: "missing_issue_comment",
+            source: "automation",
+            triggerDetail: "system",
+            issueId,
+            taskId: issueId,
+            runId: run.id,
+            retryOfRunId: run.id,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -8643,12 +8682,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : "process_lost";
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
-    const retryContextSnapshot = withRecoveryModelProfileHint({
+    const retryContextSnapshot = appendExecutionCausalTrace(withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason: "process_lost_retry",
       retryReason,
-    }, "normal_model");
+    }, "normal_model"), {
+      kind: "retry",
+      reason: retryReason,
+      source: "automation",
+      triggerDetail: "system",
+      issueId,
+      taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+      runId: run.id,
+      retryOfRunId: run.id,
+    });
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
     const queued = await db.transaction(async (tx) => {
@@ -8660,10 +8708,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "automation",
           triggerDetail: "system",
           reason: "process_lost_retry",
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "retry",
+            reason: retryReason,
+            source: "automation",
+            triggerDetail: "system",
+            issueId,
+            taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+            runId: run.id,
+            retryOfRunId: run.id,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -9654,7 +9711,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const shouldQuarantineWorkspaceForRetry =
       workspaceValidationRetryPayload !== null &&
       Object.keys(workspaceValidationRetryPayload).length > 0;
-    const retryContextSnapshot: Record<string, unknown> = withRecoveryModelProfileHint({
+    const retryContextSnapshot: Record<string, unknown> = appendExecutionCausalTrace(withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason,
@@ -9678,7 +9735,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
         : {}),
       ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
-    }, "normal_model");
+    }, "normal_model"), {
+      kind: "retry",
+      reason: retryReason,
+      source: "automation",
+      triggerDetail: "system",
+      issueId,
+      taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+      runId: run.id,
+      retryOfRunId: run.id,
+    });
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const continuationRetryIdempotencyKey = retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
       ? `max-turn-continuation:${run.companyId}:${issueId ?? "no-issue"}:${run.id}:${schedule.attempt}`
@@ -9897,7 +9963,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "automation",
           triggerDetail: "system",
           reason: wakeReason,
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
             ...interactionContinuationPayload,
@@ -9910,7 +9976,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
               : {}),
             ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "retry",
+            reason: retryReason,
+            source: "automation",
+            triggerDetail: "system",
+            issueId,
+            taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+            runId: run.id,
+            retryOfRunId: run.id,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -15102,7 +15177,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const triggerDetail = opts.triggerDetail ?? null;
     const contextSnapshot: Record<string, unknown> = { ...(opts.contextSnapshot ?? {}) };
     const reason = opts.reason ?? null;
-    const payload = opts.payload ?? null;
+    const rawPayload = opts.payload ?? null;
     const {
       contextSnapshot: enrichedContextSnapshot,
       issueIdFromPayload,
@@ -15113,8 +15188,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       reason,
       source,
       triggerDetail,
-      payload,
+      payload: rawPayload,
     });
+    const payload = rawPayload
+      ? appendExecutionCausalTrace({ ...rawPayload }, {
+        kind: inferExecutionCausalTraceKind({
+          reason: readNonEmptyString(enrichedContextSnapshot.retryReason) ?? readNonEmptyString(enrichedContextSnapshot.wakeReason) ?? reason,
+          retryOfRunId: readNonEmptyString(enrichedContextSnapshot.retryOfRunId) ?? readNonEmptyString(rawPayload.retryOfRunId),
+          recoveryActionId: readNonEmptyString(enrichedContextSnapshot.recoveryActionId) ?? readNonEmptyString(rawPayload.recoveryActionId),
+          originKind: readNonEmptyString(enrichedContextSnapshot.source),
+        }),
+        reason: readNonEmptyString(enrichedContextSnapshot.retryReason) ?? readNonEmptyString(enrichedContextSnapshot.wakeReason) ?? reason,
+        source,
+        triggerDetail,
+        issueId: readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload,
+        taskId: readNonEmptyString(enrichedContextSnapshot.taskId) ?? issueIdFromPayload,
+        retryOfRunId: readNonEmptyString(enrichedContextSnapshot.retryOfRunId) ?? readNonEmptyString(rawPayload.retryOfRunId),
+        recoveryActionId: readNonEmptyString(enrichedContextSnapshot.recoveryActionId) ?? readNonEmptyString(rawPayload.recoveryActionId),
+        originKind: readNonEmptyString(enrichedContextSnapshot.source),
+        originId: readNonEmptyString(enrichedContextSnapshot.sourceIssueId),
+      })
+      : null;
     let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
 
     const agent = await getAgent(agentId);

--- a/server/src/services/issue-resource-references.ts
+++ b/server/src/services/issue-resource-references.ts
@@ -1,0 +1,194 @@
+import { and, eq, inArray, or } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { documents, issueDocuments, issueWorkProducts, issues } from "@paperclipai/db";
+import {
+  extractIssueResourceLinks,
+  type ExtractedIssueResourceLink,
+  type IssueResourceReference,
+  type IssueWorkProductReviewState,
+} from "@paperclipai/shared";
+
+type IssueRow = {
+  id: string;
+  identifier: string | null;
+  title: string;
+};
+
+export function issueResourceReferenceService(db: Db) {
+  async function resolveIssuePathIds(
+    companyId: string,
+    issuePathIds: readonly string[],
+  ) {
+    const normalized = [...new Set(issuePathIds.map((value) => value.trim()).filter(Boolean))];
+    if (normalized.length === 0) return new Map<string, IssueRow>();
+
+    const uuidLikeIds = normalized.filter((value) => /^[0-9a-f]{8}-[0-9a-f-]{27}$/i.test(value));
+    const identifiers = normalized.filter((value) => !uuidLikeIds.includes(value));
+    const identifierCondition = identifiers.length > 0 ? inArray(issues.identifier, identifiers) : null;
+    const uuidCondition = uuidLikeIds.length > 0 ? inArray(issues.id, uuidLikeIds) : null;
+    const pathCondition = identifierCondition && uuidCondition
+      ? or(identifierCondition, uuidCondition)
+      : identifierCondition ?? uuidCondition;
+    if (!pathCondition) return new Map<string, IssueRow>();
+    const rows = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        title: issues.title,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), pathCondition));
+
+    const byPathId = new Map<string, IssueRow>();
+    for (const row of rows) {
+      byPathId.set(row.id, row);
+      if (row.identifier) byPathId.set(row.identifier, row);
+    }
+    return byPathId;
+  }
+
+  async function resolveForText(input: {
+    companyId: string;
+    text: string | null | undefined;
+    fallbackIssuePathId?: string | null;
+  }): Promise<IssueResourceReference[]> {
+    const [resolved] = await resolveForTexts([input]);
+    return resolved ?? [];
+  }
+
+  async function resolveForTexts(inputs: Array<{
+    companyId: string;
+    text: string | null | undefined;
+    fallbackIssuePathId?: string | null;
+  }>): Promise<IssueResourceReference[][]> {
+    const extractedPerInput = inputs.map((input) => extractIssueResourceLinks(input.text, {
+      fallbackIssuePathId: input.fallbackIssuePathId ?? null,
+    }));
+    const companyId = inputs[0]?.companyId ?? null;
+    if (!companyId || extractedPerInput.every((items) => items.length === 0)) {
+      return inputs.map(() => []);
+    }
+    const extracted = extractedPerInput.flat();
+    const issueByPathId = await resolveIssuePathIds(
+      companyId,
+      extracted.map((item) => item.issuePathId).filter((value): value is string => Boolean(value)),
+    );
+    const targetIssueIds = [...new Set(
+      extracted
+        .map((item) => issueByPathId.get(item.issuePathId ?? "")?.id ?? null)
+        .filter((value): value is string => Boolean(value)),
+    )];
+    if (targetIssueIds.length === 0) return inputs.map(() => []);
+
+    const documentRows = await db
+      .select({
+        issueId: issueDocuments.issueId,
+        documentKey: issueDocuments.key,
+        documentTitle: documents.title,
+        latestRevisionNumber: documents.latestRevisionNumber,
+      })
+      .from(issueDocuments)
+      .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+      .where(inArray(issueDocuments.issueId, targetIssueIds));
+    const workProductRows = await db
+      .select({
+        id: issueWorkProducts.id,
+        issueId: issueWorkProducts.issueId,
+        title: issueWorkProducts.title,
+        type: issueWorkProducts.type,
+        status: issueWorkProducts.status,
+        reviewState: issueWorkProducts.reviewState,
+      })
+      .from(issueWorkProducts)
+      .where(inArray(issueWorkProducts.issueId, targetIssueIds));
+
+    const documentMap = new Map<string, (typeof documentRows)[number]>();
+    for (const row of documentRows) {
+      documentMap.set(`${row.issueId}:${row.documentKey}`, row);
+    }
+    const workProductMap = new Map<string, (typeof workProductRows)[number]>();
+    for (const row of workProductRows) {
+      workProductMap.set(`${row.issueId}:${row.id}`, row);
+    }
+
+    const resolveOne = (items: ExtractedIssueResourceLink[]) => {
+      const resolved: IssueResourceReference[] = [];
+      const seen = new Set<string>();
+      for (const item of items) {
+        const issue = item.issuePathId ? issueByPathId.get(item.issuePathId) ?? null : null;
+        if (!issue) continue;
+        if (item.target.kind === "issue_document") {
+          const document = documentMap.get(`${issue.id}:${item.target.documentKey}`);
+          if (!document) continue;
+          const dedupeKey = `doc:${issue.id}:${document.documentKey}`;
+          if (seen.has(dedupeKey)) continue;
+          seen.add(dedupeKey);
+          resolved.push({
+            kind: "issue_document",
+            href: item.href,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+            issueTitle: issue.title,
+            documentKey: document.documentKey,
+            documentTitle: document.documentTitle ?? null,
+            latestRevisionNumber: document.latestRevisionNumber ?? null,
+          });
+          continue;
+        }
+        const workProduct = workProductMap.get(`${issue.id}:${item.target.workProductId}`);
+        if (!workProduct) continue;
+        const dedupeKey = `wp:${issue.id}:${workProduct.id}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        resolved.push({
+          kind: "work_product",
+          href: item.href,
+          issueId: issue.id,
+          issueIdentifier: issue.identifier,
+          issueTitle: issue.title,
+          workProductId: workProduct.id,
+          workProductTitle: workProduct.title,
+          workProductType: workProduct.type,
+          workProductStatus: workProduct.status,
+          reviewState: workProduct.reviewState as IssueWorkProductReviewState,
+        });
+      }
+      return orderLikeExtraction(items, resolved, issueByPathId);
+    };
+
+    return extractedPerInput.map(resolveOne);
+  }
+
+  function orderLikeExtraction(
+    extracted: ExtractedIssueResourceLink[],
+    resolved: IssueResourceReference[],
+    issueByPathId: Map<string, IssueRow>,
+  ) {
+    const rank = new Map<string, number>();
+    extracted.forEach((item, index) => {
+      const issue = item.issuePathId ? issueByPathId.get(item.issuePathId) ?? null : null;
+      if (!issue) return;
+      if (item.target.kind === "issue_document") {
+        const key = `doc:${issue.id}:${item.target.documentKey}`;
+        if (!rank.has(key)) rank.set(key, index);
+        return;
+      }
+      const key = `wp:${issue.id}:${item.target.workProductId}`;
+      if (!rank.has(key)) rank.set(key, index);
+    });
+    return [...resolved].sort((left, right) => {
+      const leftKey = left.kind === "issue_document"
+        ? `doc:${left.issueId}:${left.documentKey}`
+        : `wp:${left.issueId}:${left.workProductId}`;
+      const rightKey = right.kind === "issue_document"
+        ? `doc:${right.issueId}:${right.documentKey}`
+        : `wp:${right.issueId}:${right.workProductId}`;
+      return (rank.get(leftKey) ?? Number.MAX_SAFE_INTEGER) - (rank.get(rightKey) ?? Number.MAX_SAFE_INTEGER);
+    });
+  }
+
+  return {
+    resolveForText,
+    resolveForTexts,
+  };
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -101,6 +101,7 @@ import {
   issueTreeControlService,
   type ActiveIssueTreePauseHoldGate,
 } from "./issue-tree-control.js";
+import { issueResourceReferenceService } from "./issue-resource-references.js";
 import {
   parseIssueGraphLivenessIncidentKey,
   RECOVERY_ORIGIN_KINDS,
@@ -3756,6 +3757,7 @@ async function countBlockedInboxIssues(dbOrTx: any, companyId: string, filters?:
 
 export function issueService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
+  const issueResourceRefs = issueResourceReferenceService(db);
   const treeControlSvc = issueTreeControlService(db);
 
   function normalizeCreateIssueTitle(title: string) {
@@ -3884,6 +3886,37 @@ export function issueService(db: Db) {
       presentation: issueCommentPresentationSchema.nullable().catch(null).parse(comment.presentation ?? null),
       metadata: issueCommentMetadataSchema.nullable().catch(null).parse(comment.metadata ?? null),
     };
+  }
+
+  async function withCommentResourceReferences<T extends {
+    companyId: string;
+    issueId: string;
+    body: string;
+    deletedAt?: Date | string | null;
+  }>(comments: readonly T[]) {
+    if (comments.length === 0) return [];
+    const issueIds = [...new Set(comments.map((comment) => comment.issueId))];
+    const issueRows = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+      })
+      .from(issues)
+      .where(inArray(issues.id, issueIds));
+    const issueIdentifierById = new Map(issueRows.map((row) => [row.id, row.identifier ?? row.id]));
+    const companyId = comments[0]?.companyId ?? null;
+    if (!companyId) return comments.map((comment) => ({ ...comment, referencedResources: [] }));
+    const resolved = await issueResourceRefs.resolveForTexts(
+      comments.map((comment) => ({
+        companyId,
+        text: comment.deletedAt ? null : comment.body,
+        fallbackIssuePathId: issueIdentifierById.get(comment.issueId) ?? comment.issueId,
+      })),
+    );
+    return comments.map((comment, index) => ({
+      ...comment,
+      referencedResources: resolved[index] ?? [],
+    }));
   }
 
   async function readRunLogText(run: {
@@ -7315,7 +7348,8 @@ export function issueService(db: Db) {
       const comments = limit ? await query.limit(limit) : await query;
       const { censorUsernameInLogs } = await instanceSettings.getGeneral();
       const enrichedComments = await enrichCommentsWithDerivedAgentAttribution(comments);
-      return enrichedComments.map((comment) => redactIssueComment(comment, censorUsernameInLogs));
+      const commentsWithRefs = await withCommentResourceReferences(enrichedComments);
+      return commentsWithRefs.map((comment) => redactIssueComment(comment, censorUsernameInLogs));
     },
 
     getCommentCursor: async (issueId: string) => {
@@ -7355,7 +7389,8 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!comment) return null;
       const [enrichedComment] = await enrichCommentsWithDerivedAgentAttribution([comment]);
-      return redactIssueComment(enrichedComment ?? comment, censorUsernameInLogs);
+      const [commentWithRefs] = await withCommentResourceReferences([enrichedComment ?? comment]);
+      return redactIssueComment(commentWithRefs ?? enrichedComment ?? comment, censorUsernameInLogs);
     },
 
     removeComment: async (commentId: string) => {
@@ -7376,7 +7411,8 @@ export function issueService(db: Db) {
           .set({ updatedAt: new Date() })
           .where(eq(issues.id, comment.issueId));
 
-        return redactIssueComment(comment, currentUserRedactionOptions.enabled);
+        const [commentWithRefs] = await withCommentResourceReferences([comment]);
+        return redactIssueComment(commentWithRefs ?? comment, currentUserRedactionOptions.enabled);
       });
     },
 
@@ -7491,7 +7527,8 @@ export function issueService(db: Db) {
         .set({ updatedAt: new Date() })
         .where(eq(issues.id, issueId));
 
-      return redactIssueComment(comment, currentUserRedactionOptions.enabled);
+      const [commentWithRefs] = await withCommentResourceReferences([comment]);
+      return redactIssueComment(commentWithRefs ?? comment, currentUserRedactionOptions.enabled);
     },
 
     createAttachment: async (input: {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -74,6 +74,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { appendExecutionCausalTrace } from "../execution-causal-trace.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -2923,12 +2924,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           source: "automation",
           triggerDetail: "system",
           reason: "provider_quota_recovery",
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             issueId: input.issue.id,
             retryOfRunId: input.latestRun?.id ?? null,
             retryReason: "provider_quota_recovery",
             providerQuotaRetryNotBefore: retryAt.toISOString(),
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "recovery",
+            reason: "provider_quota_recovery",
+            source: "automation",
+            triggerDetail: "system",
+            issueId: input.issue.id,
+            taskId: input.issue.id,
+            runId: input.latestRun?.id ?? null,
+            retryOfRunId: input.latestRun?.id ?? null,
+            recoveryActionId: input.actionId,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -2950,13 +2961,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           scheduledRetryAt: retryAt,
           scheduledRetryAttempt: 1,
           scheduledRetryReason: "provider_quota_recovery",
-          contextSnapshot: withRecoveryModelProfileHint({
+          contextSnapshot: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             issueId: input.issue.id,
             taskId: input.issue.id,
             wakeReason: "provider_quota_recovery",
             retryReason: "provider_quota_recovery",
             providerQuotaRetryNotBefore: retryAt.toISOString(),
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "recovery",
+            reason: "provider_quota_recovery",
+            source: "automation",
+            triggerDetail: "system",
+            issueId: input.issue.id,
+            taskId: input.issue.id,
+            runId: input.latestRun?.id ?? null,
+            retryOfRunId: input.latestRun?.id ?? null,
+            recoveryActionId: input.actionId,
+          }),
           updatedAt: now,
         })
         .returning()

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -65,6 +65,11 @@ import {
 } from "./tool-runtime-supervisor.js";
 import { recordToolRuntimeAuditWriteFailure } from "./tool-runtime-metrics.js";
 import {
+  appendExecutionCausalRunEvent,
+  buildExecutionToolSpanPayload,
+  executionCausalEventType,
+} from "./execution-causal-trace.js";
+import {
   canonicalToolArguments,
   readSignedToolArgumentsPayload,
   signToolArguments,
@@ -1350,7 +1355,7 @@ export function createToolGatewayService(
     resultSummary?: ReturnType<typeof summarizeToolValue> | null;
     metadata?: Record<string, unknown> | null;
     tool?: ToolGatewayDescriptor | null;
-  }) {
+    }) {
     const metadata = input.tool ? toolAuditMetadata(input.tool) : {};
     await db.insert(toolCallEvents).values({
       companyId: input.session.companyId,
@@ -1385,6 +1390,86 @@ export function createToolGatewayService(
           }
         : null,
     });
+    if (input.session.runId && input.session.agentId) {
+      if (input.eventType === "call_started") {
+        await appendExecutionCausalRunEvent(db, {
+          companyId: input.session.companyId,
+          runId: input.session.runId,
+          agentId: input.session.agentId,
+          eventType: executionCausalEventType("toolSpan"),
+          message: `tool started: ${input.toolName}`,
+          payload: buildExecutionToolSpanPayload({
+            invocationId: input.invocationId ?? null,
+            actionRequestId: input.actionRequestId ?? null,
+            toolName: input.toolName,
+            phase: "start",
+            resultClass: "started",
+            outcome: input.outcome,
+            reasonCode: input.reasonCode,
+          }),
+        });
+      }
+
+      if (input.eventType === "call_completed" || input.eventType === "call_failed") {
+        await appendExecutionCausalRunEvent(db, {
+          companyId: input.session.companyId,
+          runId: input.session.runId,
+          agentId: input.session.agentId,
+          eventType: executionCausalEventType("toolSpan"),
+          level: input.eventType === "call_failed" ? "warn" : "info",
+          message: input.eventType === "call_completed"
+            ? `tool completed: ${input.toolName}`
+            : `tool failed: ${input.toolName}`,
+          payload: buildExecutionToolSpanPayload({
+            invocationId: input.invocationId ?? null,
+            actionRequestId: input.actionRequestId ?? null,
+            toolName: input.toolName,
+            phase: "end",
+            resultClass: input.eventType === "call_completed" ? "succeeded" : "failed",
+            errorClass: input.eventType === "call_failed" ? input.reasonCode ?? "tool_execution_failed" : null,
+            outcome: input.outcome,
+            reasonCode: input.reasonCode,
+          }),
+        });
+      }
+
+      if (
+        input.eventType === "approval_requested" ||
+        input.eventType === "approval_resolved" ||
+        input.eventType === "call_denied"
+      ) {
+        await appendExecutionCausalRunEvent(db, {
+          companyId: input.session.companyId,
+          runId: input.session.runId,
+          agentId: input.session.agentId,
+          eventType: executionCausalEventType("guardrail"),
+          level: input.eventType === "call_denied" ? "warn" : "info",
+          message: input.eventType === "approval_requested"
+            ? `approval requested for tool: ${input.toolName}`
+            : input.eventType === "approval_resolved"
+              ? `approval resolved for tool: ${input.toolName}`
+              : `tool denied by guardrail: ${input.toolName}`,
+          payload: {
+            ...buildExecutionToolSpanPayload({
+              invocationId: input.invocationId ?? null,
+              actionRequestId: input.actionRequestId ?? null,
+              toolName: input.toolName,
+              phase: input.eventType === "call_denied" ? "end" : "start",
+              resultClass: input.eventType === "approval_requested"
+                ? "approval_requested"
+                : input.eventType === "approval_resolved"
+                  ? "approval_resolved"
+                  : "denied",
+              errorClass: input.eventType === "call_denied" ? input.reasonCode ?? "guardrail_denied" : null,
+              outcome: input.outcome,
+              reasonCode: input.reasonCode,
+            }),
+            guardrailEventType: input.eventType,
+            policyDecision: input.policyDecision ?? null,
+          },
+        });
+      }
+    }
   }
 
   async function reflectToolActionInteractionLifecycle(input: {
@@ -5730,6 +5815,18 @@ export function createToolGatewayService(
           argumentsSummary: effectiveArgumentsSummary,
         },
       });
+      await writeToolCallEvent({
+        invocationId,
+        actionRequestId: input.approvedActionRequestId ?? null,
+        session,
+        eventType: "call_started",
+        outcome: "pending",
+        toolName: tool.name,
+        policyDecision: input.approvedActionRequestId ? "allow" : "allow",
+        reasonCode: input.approvedActionRequestId ? "approved_action_request" : "profile_allows_tool",
+        argumentsSummary: effectiveArgumentsSummary,
+        tool,
+      });
 
       try {
         const executionTimeoutMs = timeoutMs(input.timeoutMs);
@@ -6048,6 +6145,17 @@ export function createToolGatewayService(
           ...toolAuditMetadata(tool),
           argumentsSummary: argumentValidation.summary,
         },
+      });
+      await writeToolCallEvent({
+        invocationId,
+        session: sessionLike,
+        eventType: "call_started",
+        outcome: "pending",
+        toolName: tool.name,
+        policyDecision: "allow",
+        reasonCode: "profile_allows_tool",
+        argumentsSummary: argumentValidation.summary,
+        tool,
       });
 
       const startedAt = Date.now();

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -39,6 +39,7 @@ import type {
   IssueBlockerAttention,
   IssueRecoveryAction,
   IssueRelationIssueSummary,
+  IssueResourceReference,
   IssueScheduledRetry,
   SuccessfulRunHandoffState,
   IssueWorkMode,
@@ -171,7 +172,7 @@ import { nextWorkMode, titleForPendingWorkMode, workModeMetaFor, workModeMetaLis
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
-import { AlertTriangle, ArrowRight, Brain, Check, ChevronDown, ClipboardList, Copy, Hammer, Loader2, MoreHorizontal, Paperclip, PauseCircle, Search, Square, ThumbsDown, ThumbsUp, Trash2 } from "lucide-react";
+import { AlertTriangle, ArrowRight, Brain, Check, ChevronDown, ClipboardList, Copy, FileText, Hammer, Loader2, MoreHorizontal, Package, Paperclip, PauseCircle, Search, Square, ThumbsDown, ThumbsUp, Trash2 } from "lucide-react";
 import { IssueBlockedNotice } from "./IssueBlockedNotice";
 import { IssueAssignedBacklogNotice } from "./IssueAssignedBacklogNotice";
 import {
@@ -1334,6 +1335,68 @@ const IssueChatTextParts = memo(function IssueChatTextParts({
   );
 });
 
+function isIssueResourceReference(value: unknown): value is IssueResourceReference {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  if (record.kind === "issue_document") {
+    return typeof record.issueId === "string" && typeof record.href === "string" && typeof record.documentKey === "string";
+  }
+  if (record.kind === "work_product") {
+    return (
+      typeof record.issueId === "string" &&
+      typeof record.href === "string" &&
+      typeof record.workProductId === "string" &&
+      typeof record.workProductTitle === "string"
+    );
+  }
+  return false;
+}
+
+function IssueChatResourceReferences({ references }: { references: IssueResourceReference[] }) {
+  if (references.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <div className="text-(length:--text-micro) font-medium uppercase tracking-(--tracking-eyebrow) text-muted-foreground">
+        References
+      </div>
+      <div className="space-y-1.5">
+        {references.map((reference) => {
+          const issuePathId = reference.issueIdentifier ?? reference.issueId;
+          const href = reference.kind === "issue_document"
+            ? `/issues/${issuePathId}#document-${encodeURIComponent(reference.documentKey)}`
+            : `/issues/${issuePathId}#work-product-${reference.workProductId}`;
+          return (
+            <Link
+              key={reference.kind === "issue_document"
+                ? `doc:${reference.issueId}:${reference.documentKey}`
+                : `wp:${reference.issueId}:${reference.workProductId}`}
+              to={href}
+              className="flex items-start gap-2 rounded-lg border border-border/70 bg-background/70 px-2.5 py-2 text-left transition-colors hover:bg-accent/40"
+            >
+              <span className="mt-0.5 shrink-0 text-muted-foreground">
+                {reference.kind === "issue_document" ? <FileText className="h-4 w-4" /> : <Package className="h-4 w-4" />}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-foreground">
+                  {reference.kind === "issue_document"
+                    ? reference.documentTitle?.trim() || reference.documentKey
+                    : reference.workProductTitle}
+                </span>
+                <span className="block text-(length:--text-micro) text-muted-foreground">
+                  {reference.issueIdentifier ?? "Issue"}
+                  {reference.kind === "issue_document"
+                    ? ` · document:${reference.documentKey}`
+                    : ` · ${reference.workProductType}${reference.workProductStatus ? ` · ${reference.workProductStatus}` : ""}`}
+                </span>
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function groupAssistantParts(
   content: readonly ThreadMessage["content"][number][],
 ): Array<
@@ -1428,6 +1491,9 @@ function IssueChatUserMessage({
   const queueBadgeLabel = queueReason === "hold" ? "\u23f8 Deferred wake" : "Queued";
   const pending = custom.clientStatus === "pending";
   const deleted = Boolean(custom.deletedAt);
+  const referencedResources = Array.isArray(custom.referencedResources)
+    ? custom.referencedResources.filter(isIssueResourceReference)
+    : [];
   const queueTargetRunId = typeof custom.queueTargetRunId === "string" ? custom.queueTargetRunId : null;
   const [copied, setCopied] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -1520,6 +1586,7 @@ function IssueChatUserMessage({
         ) : (
           <div className="min-w-0 max-w-full space-y-3">
             <IssueChatTextParts message={message} onAccent={isCurrentUser && !queued} />
+            <IssueChatResourceReferences references={referencedResources} />
           </div>
         )}
       </div>
@@ -1668,6 +1735,9 @@ function IssueChatAssistantMessage({
   const sourceTrust = isSourceTrustMetadata(custom.sourceTrust) ? custom.sourceTrust : null;
   const notices = Array.isArray(custom.notices)
     ? custom.notices.filter((notice): notice is string => typeof notice === "string" && notice.length > 0)
+    : [];
+  const referencedResources = Array.isArray(custom.referencedResources)
+    ? custom.referencedResources.filter(isIssueResourceReference)
     : [];
   const waitingText = typeof custom.waitingText === "string" ? custom.waitingText : "";
   const isRunning = message.role === "assistant" && message.status?.type === "running";
@@ -1874,6 +1944,7 @@ function IssueChatAssistantMessage({
             ) : (
               <div className="min-w-0 max-w-full space-y-3">
                 <IssueChatAssistantParts message={message} hasCoT={false} />
+                <IssueChatResourceReferences references={referencedResources} />
                 {notices.length > 0 ? (
                   <div className="space-y-2">
                     {notices.map((notice, index) => (
@@ -1952,6 +2023,7 @@ function IssueChatAssistantMessage({
             <>
               <div className="space-y-3">
                 <IssueChatAssistantParts message={message} hasCoT={hasCoT} />
+                <IssueChatResourceReferences references={referencedResources} />
                 {message.content.length === 0 && waitingText ? (
                   <div className="rounded-lg px-1 py-2">
                     <div className="flex min-w-0 items-center gap-2.5">

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -516,6 +516,7 @@ function createCommentMessage(args: {
     followUpRequested: comment.followUpRequested === true,
     presentation: comment.presentation ?? null,
     commentMetadata: comment.metadata ?? null,
+    referencedResources: comment.referencedResources ?? [],
     deletedAt: comment.deletedAt ? toDate(comment.deletedAt).toISOString() : null,
     deletedByType: comment.deletedByType ?? null,
     deletedByAgentId: comment.deletedByAgentId ?? null,


### PR DESCRIPTION
## Summary
- add shared parsing/resolution for issue document and work-product links
- surface compact referenced resource metadata in comment reads and heartbeat context
- render comment reference panels in the issue chat thread

## Testing
- pnpm exec vitest run packages/shared/src/issue-resource-links.test.ts server/src/__tests__/issues-goal-context-routes.test.ts
- node cli/node_modules/tsx/dist/cli.mjs --eval "void (async () => { const mod = await import('./server/src/services/heartbeat.ts'); console.log(typeof mod.buildPaperclipTaskMarkdown === 'function' ? 'heartbeat-ok' : 'heartbeat-missing'); })()"
- pnpm exec esbuild ui/src/components/IssueChatThread.tsx --bundle --platform=browser --format=esm --outfile=/tmp/issue-chat-thread.js

## Notes
- The full @paperclipai/ui IssueChatThread suite is currently failing on this branch due to an existing `act is not a function` test harness issue unrelated to this change.