### PR TITLE
Add execution causal trace run events

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2136,6 +2136,30 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       ]),
     );
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
+    const initialRunEvents = await db
+      .select({
+        eventType: heartbeatRunEvents.eventType,
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(initialRunEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        eventType: "causal.wake",
+        payload: expect.objectContaining({
+          wakeReason: "issue_assigned",
+          issueId,
+        }),
+      }),
+      expect.objectContaining({
+        eventType: "causal.recovery_context",
+        payload: expect.objectContaining({
+          issueId,
+          taskId: issueId,
+        }),
+      }),
+    ]));
 
     const issue = await db
       .select()
@@ -2811,6 +2835,23 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(activityLog)
       .where(eq(activityLog.entityId, issueId));
     expect(activity.some((event) => event.action === "issue.successful_run_handoff_required")).toBe(true);
+    const causalEvents = await db
+      .select({
+        eventType: heartbeatRunEvents.eventType,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(causalEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        eventType: "causal.handoff",
+        payload: expect.objectContaining({
+          handoffKind: "successful_run_recovery",
+          sourceIssueId: issueId,
+          sourceRunId: runId,
+        }),
+      }),
+    ]));
   });
 
   it("requeues a missing-disposition handoff when the previous corrective wake was cancelled", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -46,6 +46,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { runningProcesses } from "../adapters/index.ts";
+import { EXECUTION_CAUSAL_TRACE_KEY } from "../services/execution-causal-trace.js";
 const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
 const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
 const mockTerminateLocalService = vi.hoisted(() => vi.fn());
@@ -2124,6 +2125,16 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(retryRun?.contextSnapshot).toMatchObject({
       codexTransientFallbackMode: "same_session",
     });
+    expect((retryRun?.contextSnapshot as Record<string, unknown> | null)?.[EXECUTION_CAUSAL_TRACE_KEY]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "retry",
+          reason: "transient_failure",
+          retryOfRunId: runId,
+          issueId,
+        }),
+      ]),
+    );
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
 
     const issue = await db

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -122,6 +122,7 @@ import {
 } from "../services/index.js";
 import { buildPlanReviewContext } from "../services/plan-review-context.js";
 import { hydrateSuccessfulRunHandoffLiveness } from "../services/successful-run-handoff-state.js";
+import { appendExecutionCausalRunEventForExistingRun, executionCausalEventType } from "../services/execution-causal-trace.js";
 import {
   TASK_WATCHDOG_ORIGIN_KIND,
   resolveTaskWatchdogMutationScope,
@@ -7130,6 +7131,22 @@ export function issueRoutes(
         }),
       },
     });
+    if (actor.runId && actor.agentId && issue.parentId) {
+      await appendExecutionCausalRunEventForExistingRun(db, {
+        runId: actor.runId,
+        eventType: executionCausalEventType("handoff"),
+        message: `created child issue: ${issue.identifier}`,
+        payload: {
+          traceVersion: 1,
+          handoffKind: "child_issue_delegation",
+          sourceIssueId: issue.parentId,
+          childIssueId: issue.id,
+          childIssueIdentifier: issue.identifier,
+          childIssueTitle: issue.title,
+          assigneeAgentId: issue.assigneeAgentId ?? null,
+        },
+      });
+    }
 
     if (executionPolicy?.monitor) {
       await logActivity(db, {

--- a/server/src/services/execution-causal-trace.test.ts
+++ b/server/src/services/execution-causal-trace.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExecutionCausalWakePayload,
+  buildExecutionRecoveryContextPayload,
+  buildExecutionToolSpanPayload,
+} from "./execution-causal-trace.js";
+
+describe("execution causal trace helpers", () => {
+  it("summarizes carried recovery context for the next heartbeat", () => {
+    const payload = buildExecutionRecoveryContextPayload({
+      issueId: "issue-1",
+      taskId: "issue-1",
+      wakeReason: "finish_successful_run_handoff",
+      retryOfRunId: "run-0",
+      recoveryActionId: "recovery-1",
+      handoffRequired: true,
+      handoffReason: "successful_run_missing_state",
+      handoffAttempt: 1,
+      paperclipSessionHandoffMarkdown: "Paperclip session handoff",
+      executionCausalTrace: [
+        {
+          version: 1,
+          kind: "retry",
+          recordedAt: "2026-07-24T00:00:00.000Z",
+          reason: "transient_failure",
+          source: "automation",
+          triggerDetail: "system",
+          issueId: "issue-1",
+          taskId: "issue-1",
+          runId: "run-0",
+          retryOfRunId: "run-0",
+          recoveryActionId: null,
+          originKind: null,
+          originId: null,
+        },
+      ],
+    });
+
+    expect(payload).toMatchObject({
+      issueId: "issue-1",
+      taskId: "issue-1",
+      retryOfRunId: "run-0",
+      recoveryActionId: "recovery-1",
+      priorTraceCount: 1,
+      handoffRequired: true,
+      handoffReason: "successful_run_missing_state",
+      handoffAttempt: 1,
+      carriedContextKeys: expect.arrayContaining([
+        "issueId",
+        "taskId",
+        "wakeReason",
+        "retryOfRunId",
+        "recoveryActionId",
+        "handoffRequired",
+        "handoffReason",
+        "handoffAttempt",
+        "paperclipSessionHandoffMarkdown",
+      ]),
+    });
+  });
+
+  it("builds wake and tool span payloads with stable causal fields", () => {
+    const wake = buildExecutionCausalWakePayload({
+      issueId: "issue-1",
+      taskId: "issue-1",
+      wakeReason: "issue_continuation_needed",
+      wakeSource: "assignment",
+      wakeTriggerDetail: "system",
+      executionCausalTrace: [
+        {
+          version: 1,
+          kind: "wake",
+          recordedAt: "2026-07-24T00:00:00.000Z",
+          reason: "issue_continuation_needed",
+          source: "assignment",
+          triggerDetail: "system",
+          issueId: "issue-1",
+          taskId: "issue-1",
+          runId: null,
+          retryOfRunId: null,
+          recoveryActionId: null,
+          originKind: null,
+          originId: null,
+        },
+      ],
+    });
+    const toolSpan = buildExecutionToolSpanPayload({
+      invocationId: "inv-1",
+      actionRequestId: "action-1",
+      toolName: "web.search",
+      phase: "end",
+      resultClass: "failed",
+      errorClass: "tool_timeout",
+      outcome: "timeout",
+      reasonCode: "tool_timeout",
+    });
+
+    expect(wake).toMatchObject({
+      wakeReason: "issue_continuation_needed",
+      wakeSource: "assignment",
+      wakeTriggerDetail: "system",
+      issueId: "issue-1",
+      taskId: "issue-1",
+      latestTraceEntry: expect.objectContaining({
+        kind: "wake",
+        reason: "issue_continuation_needed",
+      }),
+    });
+    expect(toolSpan).toEqual({
+      traceVersion: 1,
+      invocationId: "inv-1",
+      actionRequestId: "action-1",
+      toolName: "web.search",
+      phase: "end",
+      resultClass: "failed",
+      errorClass: "tool_timeout",
+      outcome: "timeout",
+      reasonCode: "tool_timeout",
+    });
+  });
+});

--- a/server/src/services/execution-causal-trace.ts
+++ b/server/src/services/execution-causal-trace.ts
@@ -1,5 +1,17 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRunEvents, heartbeatRuns } from "@paperclipai/db";
+
 const EXECUTION_CAUSAL_TRACE_VERSION = 1 as const;
 const MAX_EXECUTION_CAUSAL_TRACE_ENTRIES = 16;
+const MAX_CAUSAL_MESSAGE_CHARS = 240;
+const EXECUTION_CAUSAL_EVENT_TYPES = {
+  wake: "causal.wake",
+  recoveryContext: "causal.recovery_context",
+  toolSpan: "causal.tool_span",
+  handoff: "causal.handoff",
+  guardrail: "causal.guardrail",
+} as const;
 
 export const EXECUTION_CAUSAL_TRACE_KEY = "executionCausalTrace";
 
@@ -21,6 +33,23 @@ export interface ExecutionCausalTraceEntry {
   originId: string | null;
 }
 
+export type ExecutionCausalRunEventType =
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.wake
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.recoveryContext
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.toolSpan
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.handoff
+  | typeof EXECUTION_CAUSAL_EVENT_TYPES.guardrail;
+
+export type ExecutionCausalRunEventInput = {
+  companyId: string;
+  runId: string;
+  agentId: string;
+  eventType: ExecutionCausalRunEventType;
+  message: string;
+  level?: "info" | "warn" | "error";
+  payload?: Record<string, unknown> | null;
+};
+
 type ExecutionCausalTraceEntryInput = Omit<ExecutionCausalTraceEntry, "version" | "recordedAt"> & {
   recordedAt?: string | null;
 };
@@ -31,6 +60,12 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function readNonEmptyString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function truncateMessage(message: string) {
+  const normalized = message.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_CAUSAL_MESSAGE_CHARS) return normalized;
+  return `${normalized.slice(0, MAX_CAUSAL_MESSAGE_CHARS - 3)}...`;
 }
 
 function normalizeEntry(value: unknown): ExecutionCausalTraceEntry | null {
@@ -114,4 +149,135 @@ export function inferExecutionCausalTraceKind(input: {
   }
   if (input.retryOfRunId || input.reason?.includes("retry")) return "retry" as const;
   return "wake" as const;
+}
+
+export function executionCausalEventType(kind: keyof typeof EXECUTION_CAUSAL_EVENT_TYPES) {
+  return EXECUTION_CAUSAL_EVENT_TYPES[kind];
+}
+
+export function buildExecutionCausalWakePayload(contextSnapshot: Record<string, unknown>) {
+  const trace = readExecutionCausalTrace(contextSnapshot[EXECUTION_CAUSAL_TRACE_KEY]);
+  const latest = trace[trace.length - 1] ?? null;
+  return {
+    traceVersion: EXECUTION_CAUSAL_TRACE_VERSION,
+    wakeReason: readNonEmptyString(contextSnapshot.wakeReason),
+    retryReason: readNonEmptyString(contextSnapshot.retryReason),
+    wakeSource: readNonEmptyString(contextSnapshot.wakeSource),
+    wakeTriggerDetail: readNonEmptyString(contextSnapshot.wakeTriggerDetail),
+    issueId: readNonEmptyString(contextSnapshot.issueId),
+    taskId: readNonEmptyString(contextSnapshot.taskId),
+    retryOfRunId: readNonEmptyString(contextSnapshot.retryOfRunId),
+    recoveryActionId: readNonEmptyString(contextSnapshot.recoveryActionId),
+    sourceIssueId: readNonEmptyString(contextSnapshot.sourceIssueId),
+    sourceRunId: readNonEmptyString(contextSnapshot.sourceRunId),
+    latestTraceEntry: latest,
+  };
+}
+
+export function buildExecutionRecoveryContextPayload(contextSnapshot: Record<string, unknown>) {
+  const trace = readExecutionCausalTrace(contextSnapshot[EXECUTION_CAUSAL_TRACE_KEY]);
+  const carriedKeys = Object.keys(contextSnapshot).filter((key) =>
+    [
+      "issueId",
+      "taskId",
+      "wakeReason",
+      "retryReason",
+      "retryOfRunId",
+      "recoveryActionId",
+      "source",
+      "sourceIssueId",
+      "sourceRunId",
+      "originKind",
+      "originId",
+      "scheduledRetryAttempt",
+      "scheduledRetryAt",
+      "providerQuotaRetryNotBefore",
+      "interactionId",
+      "interactionKind",
+      "continuationPolicy",
+      "handoffRequired",
+      "handoffReason",
+      "handoffAttempt",
+      "workspaceValidationRecovery",
+      "paperclipSessionHandoffMarkdown",
+    ].includes(key)
+  );
+  return {
+    traceVersion: EXECUTION_CAUSAL_TRACE_VERSION,
+    issueId: readNonEmptyString(contextSnapshot.issueId),
+    taskId: readNonEmptyString(contextSnapshot.taskId),
+    retryOfRunId: readNonEmptyString(contextSnapshot.retryOfRunId),
+    recoveryActionId: readNonEmptyString(contextSnapshot.recoveryActionId),
+    carriedContextKeys: carriedKeys,
+    priorTraceCount: trace.length,
+    handoffRequired: contextSnapshot.handoffRequired === true,
+    handoffReason: readNonEmptyString(contextSnapshot.handoffReason),
+    handoffAttempt: typeof contextSnapshot.handoffAttempt === "number" ? contextSnapshot.handoffAttempt : null,
+  };
+}
+
+export function buildExecutionToolSpanPayload(input: {
+  invocationId?: string | null;
+  actionRequestId?: string | null;
+  toolName: string;
+  phase: "start" | "end";
+  resultClass: "started" | "succeeded" | "failed" | "denied" | "approval_requested" | "approval_resolved";
+  errorClass?: string | null;
+  outcome?: string | null;
+  reasonCode?: string | null;
+}) {
+  return {
+    traceVersion: EXECUTION_CAUSAL_TRACE_VERSION,
+    invocationId: input.invocationId ?? null,
+    actionRequestId: input.actionRequestId ?? null,
+    toolName: input.toolName,
+    phase: input.phase,
+    resultClass: input.resultClass,
+    errorClass: input.errorClass ?? null,
+    outcome: input.outcome ?? null,
+    reasonCode: input.reasonCode ?? null,
+  };
+}
+
+export async function appendExecutionCausalRunEvent(
+  db: Db,
+  input: ExecutionCausalRunEventInput,
+) {
+  const [row] = await db
+    .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+    .from(heartbeatRunEvents)
+    .where(eq(heartbeatRunEvents.runId, input.runId));
+  const seq = Number(row?.maxSeq ?? 0) + 1;
+  await db.insert(heartbeatRunEvents).values({
+    companyId: input.companyId,
+    runId: input.runId,
+    agentId: input.agentId,
+    seq,
+    eventType: input.eventType,
+    stream: "system",
+    level: input.level ?? "info",
+    message: truncateMessage(input.message),
+    payload: input.payload ?? null,
+  });
+  return seq;
+}
+
+export async function appendExecutionCausalRunEventForExistingRun(
+  db: Db,
+  input: Omit<ExecutionCausalRunEventInput, "companyId" | "agentId">,
+) {
+  const run = await db
+    .select({
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+    })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, input.runId))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return null;
+  return appendExecutionCausalRunEvent(db, {
+    ...input,
+    companyId: run.companyId,
+    agentId: run.agentId,
+  });
 }

--- a/server/src/services/execution-causal-trace.ts
+++ b/server/src/services/execution-causal-trace.ts
@@ -1,0 +1,117 @@
+const EXECUTION_CAUSAL_TRACE_VERSION = 1 as const;
+const MAX_EXECUTION_CAUSAL_TRACE_ENTRIES = 16;
+
+export const EXECUTION_CAUSAL_TRACE_KEY = "executionCausalTrace";
+
+export type ExecutionCausalTraceKind = "wake" | "retry" | "recovery";
+
+export interface ExecutionCausalTraceEntry {
+  version: typeof EXECUTION_CAUSAL_TRACE_VERSION;
+  kind: ExecutionCausalTraceKind;
+  recordedAt: string;
+  reason: string | null;
+  source: string | null;
+  triggerDetail: string | null;
+  issueId: string | null;
+  taskId: string | null;
+  runId: string | null;
+  retryOfRunId: string | null;
+  recoveryActionId: string | null;
+  originKind: string | null;
+  originId: string | null;
+}
+
+type ExecutionCausalTraceEntryInput = Omit<ExecutionCausalTraceEntry, "version" | "recordedAt"> & {
+  recordedAt?: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function readNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function normalizeEntry(value: unknown): ExecutionCausalTraceEntry | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const recordedAt = readNonEmptyString(record.recordedAt);
+  const kind = readNonEmptyString(record.kind);
+  if (!recordedAt || (kind !== "wake" && kind !== "retry" && kind !== "recovery")) return null;
+  return {
+    version: EXECUTION_CAUSAL_TRACE_VERSION,
+    kind,
+    recordedAt,
+    reason: readNonEmptyString(record.reason),
+    source: readNonEmptyString(record.source),
+    triggerDetail: readNonEmptyString(record.triggerDetail),
+    issueId: readNonEmptyString(record.issueId),
+    taskId: readNonEmptyString(record.taskId),
+    runId: readNonEmptyString(record.runId),
+    retryOfRunId: readNonEmptyString(record.retryOfRunId),
+    recoveryActionId: readNonEmptyString(record.recoveryActionId),
+    originKind: readNonEmptyString(record.originKind),
+    originId: readNonEmptyString(record.originId),
+  };
+}
+
+function sameEntry(a: ExecutionCausalTraceEntry | null | undefined, b: ExecutionCausalTraceEntry) {
+  return Boolean(a) &&
+    a.kind === b.kind &&
+    a.reason === b.reason &&
+    a.source === b.source &&
+    a.triggerDetail === b.triggerDetail &&
+    a.issueId === b.issueId &&
+    a.taskId === b.taskId &&
+    a.runId === b.runId &&
+    a.retryOfRunId === b.retryOfRunId &&
+    a.recoveryActionId === b.recoveryActionId &&
+    a.originKind === b.originKind &&
+    a.originId === b.originId;
+}
+
+export function readExecutionCausalTrace(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeEntry(entry))
+    .filter((entry): entry is ExecutionCausalTraceEntry => entry !== null);
+}
+
+export function appendExecutionCausalTrace(
+  target: Record<string, unknown>,
+  entry: ExecutionCausalTraceEntryInput,
+) {
+  const nextEntry: ExecutionCausalTraceEntry = {
+    version: EXECUTION_CAUSAL_TRACE_VERSION,
+    kind: entry.kind,
+    recordedAt: entry.recordedAt ?? new Date().toISOString(),
+    reason: entry.reason ?? null,
+    source: entry.source ?? null,
+    triggerDetail: entry.triggerDetail ?? null,
+    issueId: entry.issueId ?? null,
+    taskId: entry.taskId ?? null,
+    runId: entry.runId ?? null,
+    retryOfRunId: entry.retryOfRunId ?? null,
+    recoveryActionId: entry.recoveryActionId ?? null,
+    originKind: entry.originKind ?? null,
+    originId: entry.originId ?? null,
+  };
+  const trace = readExecutionCausalTrace(target[EXECUTION_CAUSAL_TRACE_KEY]);
+  if (!sameEntry(trace[trace.length - 1], nextEntry)) trace.push(nextEntry);
+  target[EXECUTION_CAUSAL_TRACE_KEY] = trace.slice(-MAX_EXECUTION_CAUSAL_TRACE_ENTRIES);
+  return target;
+}
+
+export function inferExecutionCausalTraceKind(input: {
+  reason?: string | null;
+  retryOfRunId?: string | null;
+  recoveryActionId?: string | null;
+  originKind?: string | null;
+}) {
+  if (input.recoveryActionId || input.originKind?.includes("recovery") || input.reason?.includes("recovery")) {
+    return "recovery" as const;
+  }
+  if (input.retryOfRunId || input.reason?.includes("retry")) return "retry" as const;
+  return "wake" as const;
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -259,7 +259,11 @@ import {
   touchHeartbeatRunRuntimeStatus,
 } from "./heartbeat-run-runtime-status.js";
 import {
+  appendExecutionCausalRunEvent,
   appendExecutionCausalTrace,
+  buildExecutionCausalWakePayload,
+  buildExecutionRecoveryContextPayload,
+  executionCausalEventType,
   inferExecutionCausalTraceKind,
 } from "./execution-causal-trace.js";
 import {
@@ -8148,6 +8152,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       requestedByActorId: "heartbeat",
     });
     if (!handoffRun) return;
+    await appendExecutionCausalRunEvent(db, {
+      companyId: run.companyId,
+      runId: run.id,
+      agentId: run.agentId,
+      eventType: executionCausalEventType("handoff"),
+      message: "queued corrective handoff heartbeat",
+      payload: {
+        traceVersion: 1,
+        handoffKind: "successful_run_recovery",
+        sourceIssueId: issue.id,
+        sourceIssueIdentifier: issue.identifier,
+        sourceRunId: run.id,
+        targetRunId: handoffRun.id,
+        targetAgentId: decision.targetAgentId,
+        reason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
+        missingDisposition: "clear_next_step",
+      },
+    });
 
     await addSuccessfulRunHandoffCommentOnce({
       issue,
@@ -13199,6 +13221,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         stream: "system",
         level: "info",
         message: "run started",
+      });
+      await appendExecutionCausalRunEvent(db, {
+        companyId: currentRun.companyId,
+        runId: currentRun.id,
+        agentId: currentRun.agentId,
+        eventType: executionCausalEventType("wake"),
+        message: `wake received: ${readNonEmptyString(context.wakeReason) ?? "unspecified"}`,
+        payload: buildExecutionCausalWakePayload(context),
+      });
+      await appendExecutionCausalRunEvent(db, {
+        companyId: currentRun.companyId,
+        runId: currentRun.id,
+        agentId: currentRun.agentId,
+        eventType: executionCausalEventType("recoveryContext"),
+        message: "recovery context received for heartbeat execution",
+        payload: buildExecutionRecoveryContextPayload(context),
       });
 
       handle = await runLogStore.begin({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -259,6 +259,10 @@ import {
   touchHeartbeatRunRuntimeStatus,
 } from "./heartbeat-run-runtime-status.js";
 import {
+  appendExecutionCausalTrace,
+  inferExecutionCausalTraceKind,
+} from "./execution-causal-trace.js";
+import {
   readHotRestartIntent,
   removeHotRestartIntent,
   shouldHonorHotRestartIntentForProcess,
@@ -4237,6 +4241,23 @@ function enrichWakeContextSnapshot(input: {
   }
   normalizeModelProfileWakeContext({ contextSnapshot, payload });
   normalizeInteractionContinuationWakeContext(contextSnapshot, payload);
+  appendExecutionCausalTrace(contextSnapshot, {
+    kind: inferExecutionCausalTraceKind({
+      reason: readNonEmptyString(contextSnapshot["retryReason"]) ?? readNonEmptyString(contextSnapshot["wakeReason"]) ?? reason,
+      retryOfRunId: readNonEmptyString(contextSnapshot["retryOfRunId"]) ?? readNonEmptyString(payload?.["retryOfRunId"]),
+      recoveryActionId: readNonEmptyString(contextSnapshot["recoveryActionId"]) ?? readNonEmptyString(payload?.["recoveryActionId"]),
+      originKind: readNonEmptyString(contextSnapshot["source"]),
+    }),
+    reason: readNonEmptyString(contextSnapshot["retryReason"]) ?? readNonEmptyString(contextSnapshot["wakeReason"]) ?? reason,
+    source,
+    triggerDetail,
+    issueId: readNonEmptyString(contextSnapshot["issueId"]) ?? issueIdFromPayload,
+    taskId: readNonEmptyString(contextSnapshot["taskId"]) ?? issueIdFromPayload,
+    retryOfRunId: readNonEmptyString(contextSnapshot["retryOfRunId"]) ?? readNonEmptyString(payload?.["retryOfRunId"]),
+    recoveryActionId: readNonEmptyString(contextSnapshot["recoveryActionId"]) ?? readNonEmptyString(payload?.["recoveryActionId"]),
+    originKind: readNonEmptyString(contextSnapshot["source"]),
+    originId: readNonEmptyString(contextSnapshot["sourceIssueId"]),
+  });
 
   return {
     contextSnapshot,
@@ -8379,13 +8400,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
-    const retryContextSnapshot = withRecoveryModelProfileHint({
+    const retryContextSnapshot = appendExecutionCausalTrace(withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason: "missing_issue_comment",
       retryReason: "missing_issue_comment",
       missingIssueCommentForRunId: run.id,
-    }, "status_only");
+    }, "status_only"), {
+      kind: "retry",
+      reason: "missing_issue_comment",
+      source: "automation",
+      triggerDetail: "system",
+      issueId,
+      taskId: issueId,
+      runId: run.id,
+      retryOfRunId: run.id,
+    });
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const now = new Date();
 
@@ -8409,11 +8439,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "automation",
           triggerDetail: "system",
           reason: "missing_issue_comment",
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             issueId,
             retryOfRunId: run.id,
             retryReason: "missing_issue_comment",
-          }, "status_only"),
+          }, "status_only"), {
+            kind: "retry",
+            reason: "missing_issue_comment",
+            source: "automation",
+            triggerDetail: "system",
+            issueId,
+            taskId: issueId,
+            runId: run.id,
+            retryOfRunId: run.id,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -8643,12 +8682,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : "process_lost";
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
-    const retryContextSnapshot = withRecoveryModelProfileHint({
+    const retryContextSnapshot = appendExecutionCausalTrace(withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason: "process_lost_retry",
       retryReason,
-    }, "normal_model");
+    }, "normal_model"), {
+      kind: "retry",
+      reason: retryReason,
+      source: "automation",
+      triggerDetail: "system",
+      issueId,
+      taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+      runId: run.id,
+      retryOfRunId: run.id,
+    });
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
     const queued = await db.transaction(async (tx) => {
@@ -8660,10 +8708,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "automation",
           triggerDetail: "system",
           reason: "process_lost_retry",
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "retry",
+            reason: retryReason,
+            source: "automation",
+            triggerDetail: "system",
+            issueId,
+            taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+            runId: run.id,
+            retryOfRunId: run.id,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -9654,7 +9711,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const shouldQuarantineWorkspaceForRetry =
       workspaceValidationRetryPayload !== null &&
       Object.keys(workspaceValidationRetryPayload).length > 0;
-    const retryContextSnapshot: Record<string, unknown> = withRecoveryModelProfileHint({
+    const retryContextSnapshot: Record<string, unknown> = appendExecutionCausalTrace(withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason,
@@ -9678,7 +9735,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
         : {}),
       ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
-    }, "normal_model");
+    }, "normal_model"), {
+      kind: "retry",
+      reason: retryReason,
+      source: "automation",
+      triggerDetail: "system",
+      issueId,
+      taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+      runId: run.id,
+      retryOfRunId: run.id,
+    });
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
     const continuationRetryIdempotencyKey = retryReason === MAX_TURN_CONTINUATION_RETRY_REASON
       ? `max-turn-continuation:${run.companyId}:${issueId ?? "no-issue"}:${run.id}:${schedule.attempt}`
@@ -9897,7 +9963,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           source: "automation",
           triggerDetail: "system",
           reason: wakeReason,
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
             ...interactionContinuationPayload,
@@ -9910,7 +9976,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ? { providerQuotaRetryNotBefore: transientRetryNotBefore.toISOString() }
               : {}),
             ...(codexTransientFallbackMode ? { codexTransientFallbackMode } : {}),
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "retry",
+            reason: retryReason,
+            source: "automation",
+            triggerDetail: "system",
+            issueId,
+            taskId: readNonEmptyString(contextSnapshot.taskId) ?? issueId,
+            runId: run.id,
+            retryOfRunId: run.id,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -15102,7 +15177,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const triggerDetail = opts.triggerDetail ?? null;
     const contextSnapshot: Record<string, unknown> = { ...(opts.contextSnapshot ?? {}) };
     const reason = opts.reason ?? null;
-    const payload = opts.payload ?? null;
+    const rawPayload = opts.payload ?? null;
     const {
       contextSnapshot: enrichedContextSnapshot,
       issueIdFromPayload,
@@ -15113,8 +15188,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       reason,
       source,
       triggerDetail,
-      payload,
+      payload: rawPayload,
     });
+    const payload = rawPayload
+      ? appendExecutionCausalTrace({ ...rawPayload }, {
+        kind: inferExecutionCausalTraceKind({
+          reason: readNonEmptyString(enrichedContextSnapshot.retryReason) ?? readNonEmptyString(enrichedContextSnapshot.wakeReason) ?? reason,
+          retryOfRunId: readNonEmptyString(enrichedContextSnapshot.retryOfRunId) ?? readNonEmptyString(rawPayload.retryOfRunId),
+          recoveryActionId: readNonEmptyString(enrichedContextSnapshot.recoveryActionId) ?? readNonEmptyString(rawPayload.recoveryActionId),
+          originKind: readNonEmptyString(enrichedContextSnapshot.source),
+        }),
+        reason: readNonEmptyString(enrichedContextSnapshot.retryReason) ?? readNonEmptyString(enrichedContextSnapshot.wakeReason) ?? reason,
+        source,
+        triggerDetail,
+        issueId: readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload,
+        taskId: readNonEmptyString(enrichedContextSnapshot.taskId) ?? issueIdFromPayload,
+        retryOfRunId: readNonEmptyString(enrichedContextSnapshot.retryOfRunId) ?? readNonEmptyString(rawPayload.retryOfRunId),
+        recoveryActionId: readNonEmptyString(enrichedContextSnapshot.recoveryActionId) ?? readNonEmptyString(rawPayload.recoveryActionId),
+        originKind: readNonEmptyString(enrichedContextSnapshot.source),
+        originId: readNonEmptyString(enrichedContextSnapshot.sourceIssueId),
+      })
+      : null;
     let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
 
     const agent = await getAgent(agentId);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -74,6 +74,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { appendExecutionCausalTrace } from "../execution-causal-trace.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -2923,12 +2924,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           source: "automation",
           triggerDetail: "system",
           reason: "provider_quota_recovery",
-          payload: withRecoveryModelProfileHint({
+          payload: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             issueId: input.issue.id,
             retryOfRunId: input.latestRun?.id ?? null,
             retryReason: "provider_quota_recovery",
             providerQuotaRetryNotBefore: retryAt.toISOString(),
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "recovery",
+            reason: "provider_quota_recovery",
+            source: "automation",
+            triggerDetail: "system",
+            issueId: input.issue.id,
+            taskId: input.issue.id,
+            runId: input.latestRun?.id ?? null,
+            retryOfRunId: input.latestRun?.id ?? null,
+            recoveryActionId: input.actionId,
+          }),
           status: "queued",
           requestedByActorType: "system",
           requestedByActorId: null,
@@ -2950,13 +2961,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           scheduledRetryAt: retryAt,
           scheduledRetryAttempt: 1,
           scheduledRetryReason: "provider_quota_recovery",
-          contextSnapshot: withRecoveryModelProfileHint({
+          contextSnapshot: appendExecutionCausalTrace(withRecoveryModelProfileHint({
             issueId: input.issue.id,
             taskId: input.issue.id,
             wakeReason: "provider_quota_recovery",
             retryReason: "provider_quota_recovery",
             providerQuotaRetryNotBefore: retryAt.toISOString(),
-          }, "normal_model"),
+          }, "normal_model"), {
+            kind: "recovery",
+            reason: "provider_quota_recovery",
+            source: "automation",
+            triggerDetail: "system",
+            issueId: input.issue.id,
+            taskId: input.issue.id,
+            runId: input.latestRun?.id ?? null,
+            retryOfRunId: input.latestRun?.id ?? null,
+            recoveryActionId: input.actionId,
+          }),
           updatedAt: now,
         })
         .returning()

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -65,6 +65,11 @@ import {
 } from "./tool-runtime-supervisor.js";
 import { recordToolRuntimeAuditWriteFailure } from "./tool-runtime-metrics.js";
 import {
+  appendExecutionCausalRunEvent,
+  buildExecutionToolSpanPayload,
+  executionCausalEventType,
+} from "./execution-causal-trace.js";
+import {
   canonicalToolArguments,
   readSignedToolArgumentsPayload,
   signToolArguments,
@@ -1350,7 +1355,7 @@ export function createToolGatewayService(
     resultSummary?: ReturnType<typeof summarizeToolValue> | null;
     metadata?: Record<string, unknown> | null;
     tool?: ToolGatewayDescriptor | null;
-  }) {
+    }) {
     const metadata = input.tool ? toolAuditMetadata(input.tool) : {};
     await db.insert(toolCallEvents).values({
       companyId: input.session.companyId,
@@ -1385,6 +1390,86 @@ export function createToolGatewayService(
           }
         : null,
     });
+    if (input.session.runId && input.session.agentId) {
+      if (input.eventType === "call_started") {
+        await appendExecutionCausalRunEvent(db, {
+          companyId: input.session.companyId,
+          runId: input.session.runId,
+          agentId: input.session.agentId,
+          eventType: executionCausalEventType("toolSpan"),
+          message: `tool started: ${input.toolName}`,
+          payload: buildExecutionToolSpanPayload({
+            invocationId: input.invocationId ?? null,
+            actionRequestId: input.actionRequestId ?? null,
+            toolName: input.toolName,
+            phase: "start",
+            resultClass: "started",
+            outcome: input.outcome,
+            reasonCode: input.reasonCode,
+          }),
+        });
+      }
+
+      if (input.eventType === "call_completed" || input.eventType === "call_failed") {
+        await appendExecutionCausalRunEvent(db, {
+          companyId: input.session.companyId,
+          runId: input.session.runId,
+          agentId: input.session.agentId,
+          eventType: executionCausalEventType("toolSpan"),
+          level: input.eventType === "call_failed" ? "warn" : "info",
+          message: input.eventType === "call_completed"
+            ? `tool completed: ${input.toolName}`
+            : `tool failed: ${input.toolName}`,
+          payload: buildExecutionToolSpanPayload({
+            invocationId: input.invocationId ?? null,
+            actionRequestId: input.actionRequestId ?? null,
+            toolName: input.toolName,
+            phase: "end",
+            resultClass: input.eventType === "call_completed" ? "succeeded" : "failed",
+            errorClass: input.eventType === "call_failed" ? input.reasonCode ?? "tool_execution_failed" : null,
+            outcome: input.outcome,
+            reasonCode: input.reasonCode,
+          }),
+        });
+      }
+
+      if (
+        input.eventType === "approval_requested" ||
+        input.eventType === "approval_resolved" ||
+        input.eventType === "call_denied"
+      ) {
+        await appendExecutionCausalRunEvent(db, {
+          companyId: input.session.companyId,
+          runId: input.session.runId,
+          agentId: input.session.agentId,
+          eventType: executionCausalEventType("guardrail"),
+          level: input.eventType === "call_denied" ? "warn" : "info",
+          message: input.eventType === "approval_requested"
+            ? `approval requested for tool: ${input.toolName}`
+            : input.eventType === "approval_resolved"
+              ? `approval resolved for tool: ${input.toolName}`
+              : `tool denied by guardrail: ${input.toolName}`,
+          payload: {
+            ...buildExecutionToolSpanPayload({
+              invocationId: input.invocationId ?? null,
+              actionRequestId: input.actionRequestId ?? null,
+              toolName: input.toolName,
+              phase: input.eventType === "call_denied" ? "end" : "start",
+              resultClass: input.eventType === "approval_requested"
+                ? "approval_requested"
+                : input.eventType === "approval_resolved"
+                  ? "approval_resolved"
+                  : "denied",
+              errorClass: input.eventType === "call_denied" ? input.reasonCode ?? "guardrail_denied" : null,
+              outcome: input.outcome,
+              reasonCode: input.reasonCode,
+            }),
+            guardrailEventType: input.eventType,
+            policyDecision: input.policyDecision ?? null,
+          },
+        });
+      }
+    }
   }
 
   async function reflectToolActionInteractionLifecycle(input: {
@@ -5730,6 +5815,18 @@ export function createToolGatewayService(
           argumentsSummary: effectiveArgumentsSummary,
         },
       });
+      await writeToolCallEvent({
+        invocationId,
+        actionRequestId: input.approvedActionRequestId ?? null,
+        session,
+        eventType: "call_started",
+        outcome: "pending",
+        toolName: tool.name,
+        policyDecision: input.approvedActionRequestId ? "allow" : "allow",
+        reasonCode: input.approvedActionRequestId ? "approved_action_request" : "profile_allows_tool",
+        argumentsSummary: effectiveArgumentsSummary,
+        tool,
+      });
 
       try {
         const executionTimeoutMs = timeoutMs(input.timeoutMs);
@@ -6048,6 +6145,17 @@ export function createToolGatewayService(
           ...toolAuditMetadata(tool),
           argumentsSummary: argumentValidation.summary,
         },
+      });
+      await writeToolCallEvent({
+        invocationId,
+        session: sessionLike,
+        eventType: "call_started",
+        outcome: "pending",
+        toolName: tool.name,
+        policyDecision: "allow",
+        reasonCode: "profile_allows_tool",
+        argumentsSummary: argumentValidation.summary,
+        tool,
       });
 
       const startedAt = Date.now();


### PR DESCRIPTION
## Summary
- persist execution causal trace context across wake, retry, and recovery payloads
- emit first-class causal run events for wake/recovery context, tool spans, guardrails, and handoff edges
- cover the new causal edges with focused helper and heartbeat recovery tests

## Testing
- pnpm vitest run server/src/services/execution-causal-trace.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts -t "causal"