### PR TITLE
fix(heartbeat): harden terminal and orphan recovery routing

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -98,6 +98,7 @@ vi.mock("../adapters/index.ts", async () => {
 });
 
 import {
+  appendHeartbeatRunEvent,
   INTERACTION_CONTINUATION_INFRA_RETRY_REASON,
   INTERACTION_CONTINUATION_INFRA_WAKE_REASON,
   heartbeatService,
@@ -1312,6 +1313,58 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
+  });
+
+  it("queues one process-loss retry when orphan reapers overlap", async () => {
+    const { companyId, agentId, runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_999,
+    });
+    const reapers = Array.from({ length: 20 }, () =>
+      heartbeatService(db, { runtimeEnv: { PAPERCLIP_IN_WORKTREE: "true" } }),
+    );
+
+    await Promise.all(reapers.map((heartbeat) => heartbeat.reapOrphanedRuns()));
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId)));
+    const retries = runs.filter((row) => row.retryOfRunId === runId);
+
+    expect(retries).toHaveLength(1);
+    expect(runs.find((row) => row.id === runId)).toMatchObject({
+      status: "failed",
+      errorCode: "process_lost",
+    });
+  });
+
+  it("serializes concurrent run-event sequence allocation", async () => {
+    const { companyId, agentId, runId } = await seedRunFixture({ agentStatus: "idle" });
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        appendHeartbeatRunEvent(db, 1, {
+          companyId,
+          runId,
+          agentId,
+          eventType: "lifecycle",
+          stream: "system",
+          level: "info",
+          message: `concurrent event ${index}`,
+        }),
+      ),
+    );
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(heartbeatRunEvents.seq);
+    expect(events.map((event) => event.seq)).toEqual(Array.from({ length: 20 }, (_, index) => index + 1));
+
+    const eventsAfterFirst = await heartbeatService(db).listEvents(runId, 1, 100);
+    expect(eventsAfterFirst).toHaveLength(19);
   });
 
   it("does not queue a process-loss retry after the issue is already done", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1315,58 +1315,6 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
   });
 
-  it("queues one process-loss retry when orphan reapers overlap", async () => {
-    const { companyId, agentId, runId } = await seedRunFixture({
-      agentStatus: "running",
-      processPid: 999_999_999,
-    });
-    const reapers = Array.from({ length: 20 }, () =>
-      heartbeatService(db, { runtimeEnv: { PAPERCLIP_IN_WORKTREE: "true" } }),
-    );
-
-    await Promise.all(reapers.map((heartbeat) => heartbeat.reapOrphanedRuns()));
-
-    const runs = await db
-      .select()
-      .from(heartbeatRuns)
-      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId)));
-    const retries = runs.filter((row) => row.retryOfRunId === runId);
-
-    expect(retries).toHaveLength(1);
-    expect(runs.find((row) => row.id === runId)).toMatchObject({
-      status: "failed",
-      errorCode: "process_lost",
-    });
-  });
-
-  it("serializes concurrent run-event sequence allocation", async () => {
-    const { companyId, agentId, runId } = await seedRunFixture({ agentStatus: "idle" });
-
-    await Promise.all(
-      Array.from({ length: 20 }, (_, index) =>
-        appendHeartbeatRunEvent(db, 1, {
-          companyId,
-          runId,
-          agentId,
-          eventType: "lifecycle",
-          stream: "system",
-          level: "info",
-          message: `concurrent event ${index}`,
-        }),
-      ),
-    );
-
-    const events = await db
-      .select()
-      .from(heartbeatRunEvents)
-      .where(eq(heartbeatRunEvents.runId, runId))
-      .orderBy(heartbeatRunEvents.seq);
-    expect(events.map((event) => event.seq)).toEqual(Array.from({ length: 20 }, (_, index) => index + 1));
-
-    const eventsAfterFirst = await heartbeatService(db).listEvents(runId, 1, 100);
-    expect(eventsAfterFirst).toHaveLength(19);
-  });
-
   it("does not queue a process-loss retry after the issue is already done", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",
@@ -6263,5 +6211,57 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+
+  it("queues one process-loss retry when orphan reapers overlap", async () => {
+    const { companyId, agentId, runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_999,
+    });
+    const reapers = Array.from({ length: 20 }, () =>
+      heartbeatService(db, { runtimeEnv: { PAPERCLIP_IN_WORKTREE: "true" } }),
+    );
+
+    await Promise.all(reapers.map((heartbeat) => heartbeat.reapOrphanedRuns()));
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId)));
+    const retries = runs.filter((row) => row.retryOfRunId === runId);
+
+    expect(retries).toHaveLength(1);
+    expect(runs.find((row) => row.id === runId)).toMatchObject({
+      status: "failed",
+      errorCode: "process_lost",
+    });
+  });
+
+  it("serializes concurrent run-event sequence allocation", async () => {
+    const { companyId, agentId, runId } = await seedRunFixture({ agentStatus: "idle" });
+
+    await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        appendHeartbeatRunEvent(db, 1, {
+          companyId,
+          runId,
+          agentId,
+          eventType: "lifecycle",
+          stream: "system",
+          level: "info",
+          message: `concurrent event ${index}`,
+        }),
+      ),
+    );
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(heartbeatRunEvents.seq);
+    expect(events.map((event) => event.seq)).toEqual(Array.from({ length: 20 }, (_, index) => index + 1));
+
+    const eventsAfterFirst = await heartbeatService(db).listEvents(runId, 1, 100);
+    expect(eventsAfterFirst).toHaveLength(19);
   });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -465,6 +465,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     processGroupId?: number | null;
     processLossRetryCount?: number;
     includeIssue?: boolean;
+    issueStatus?: "in_progress" | "done" | "cancelled";
     runErrorCode?: string | null;
     runError?: string | null;
     contextSnapshot?: Record<string, unknown>;
@@ -535,7 +536,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         id: issueId,
         companyId,
         title: "Recover local adapter after lost process",
-        status: "in_progress",
+        status: input?.issueStatus ?? "in_progress",
         priority: "medium",
         assigneeAgentId: agentId,
         checkoutRunId: runId,
@@ -1311,6 +1312,37 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
+  });
+
+  it("does not queue a process-loss retry after the issue is already done", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      issueStatus: "done",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result).toEqual({ reaped: 1, runIds: [runId] });
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: runId,
+      status: "failed",
+      errorCode: "process_lost",
+    });
+
+    const issue = await db
+      .select({ status: issues.status, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("done");
+    expect(issue?.executionRunId).toBeNull();
   });
 
   it("restores one lost monitor dispatch before escalating a second process loss", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -466,6 +466,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     processGroupId?: number | null;
     processLossRetryCount?: number;
     includeIssue?: boolean;
+    issueStatus?: "in_progress" | "done" | "cancelled";
     runErrorCode?: string | null;
     runError?: string | null;
     contextSnapshot?: Record<string, unknown>;
@@ -536,7 +537,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         id: issueId,
         companyId,
         title: "Recover local adapter after lost process",
-        status: "in_progress",
+        status: input?.issueStatus ?? "in_progress",
         priority: "medium",
         assigneeAgentId: agentId,
         checkoutRunId: runId,
@@ -1313,6 +1314,46 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
   });
+
+  it.each(["done", "cancelled"] as const)(
+    "does not advertise or queue a process-loss retry after the issue is already %s",
+    async (issueStatus) => {
+      const { agentId, runId, wakeupRequestId, issueId } = await seedRunFixture({
+        agentStatus: "idle",
+        processPid: 999_999_999,
+        issueStatus,
+      });
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.reapOrphanedRuns();
+      expect(result).toEqual({ reaped: 1, runIds: [runId] });
+
+      const [runs, wakeup, events, issue] = await Promise.all([
+        db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId)),
+        db
+          .select({ error: agentWakeupRequests.error })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, wakeupRequestId))
+          .then((rows) => rows[0] ?? null),
+        db
+          .select({ message: heartbeatRunEvents.message })
+          .from(heartbeatRunEvents)
+          .where(eq(heartbeatRunEvents.runId, runId)),
+        db
+          .select({ status: issues.status, executionRunId: issues.executionRunId })
+          .from(issues)
+          .where(eq(issues.id, issueId))
+          .then((rows) => rows[0] ?? null),
+      ]);
+
+      expect(runs).toHaveLength(1);
+      expect(runs[0]).toMatchObject({ id: runId, status: "failed", errorCode: "process_lost" });
+      expect(runs[0]?.error).not.toContain("retrying once");
+      expect(wakeup?.error).not.toContain("retrying once");
+      expect(events.some((event) => event.message?.includes("queued retry"))).toBe(false);
+      expect(issue).toEqual({ status: issueStatus, executionRunId: null });
+    },
+  );
 
   it("restores one lost monitor dispatch before escalating a second process loss", async () => {
     const { companyId, agentId, runId, issueId } = await seedRunFixture({

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3441,6 +3441,34 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("allocates cancellation events after existing run events", async () => {
+    const { companyId, agentId, runId } = await seedRunFixture({
+      agentStatus: "running",
+      includeIssue: false,
+    });
+    await db.insert(heartbeatRunEvents).values({
+      companyId,
+      runId,
+      agentId,
+      seq: 1,
+      eventType: "lifecycle",
+      stream: "system",
+      level: "info",
+      message: "run started",
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.cancelRun(runId);
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(heartbeatRunEvents.seq);
+    expect(events.map((event) => event.seq)).toEqual([1, 2]);
+    await expect(heartbeat.listEvents(runId, 1, 100)).resolves.toHaveLength(1);
+  });
+
   it("records operator interrupt cancellation metadata without changing terminal status", async () => {
     const { runId, issueId } = await seedRunFixture({
       agentStatus: "running",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -466,7 +466,6 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     processGroupId?: number | null;
     processLossRetryCount?: number;
     includeIssue?: boolean;
-    issueStatus?: "in_progress" | "done" | "cancelled";
     runErrorCode?: string | null;
     runError?: string | null;
     contextSnapshot?: Record<string, unknown>;
@@ -537,7 +536,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         id: issueId,
         companyId,
         title: "Recover local adapter after lost process",
-        status: input?.issueStatus ?? "in_progress",
+        status: "in_progress",
         priority: "medium",
         assigneeAgentId: agentId,
         checkoutRunId: runId,
@@ -1313,37 +1312,6 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     // Terminal run cleanup releases the checkout lock so future checkout 409s only mean a live owner exists.
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
-  });
-
-  it("does not queue a process-loss retry after the issue is already done", async () => {
-    const { agentId, runId, issueId } = await seedRunFixture({
-      agentStatus: "idle",
-      processPid: 999_999_999,
-      issueStatus: "done",
-    });
-    const heartbeat = heartbeatService(db);
-
-    const result = await heartbeat.reapOrphanedRuns();
-    expect(result).toEqual({ reaped: 1, runIds: [runId] });
-
-    const runs = await db
-      .select()
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(1);
-    expect(runs[0]).toMatchObject({
-      id: runId,
-      status: "failed",
-      errorCode: "process_lost",
-    });
-
-    const issue = await db
-      .select({ status: issues.status, executionRunId: issues.executionRunId })
-      .from(issues)
-      .where(eq(issues.id, issueId))
-      .then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("done");
-    expect(issue?.executionRunId).toBeNull();
   });
 
   it("restores one lost monitor dispatch before escalating a second process loss", async () => {

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1127,6 +1127,60 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels process-loss retries after the issue enters review", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Worker already handed off for review",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "process_lost_retry",
+      invocationSource: "automation",
+      scheduledRetryReason: "process_lost",
+      contextExtras: {
+        retryReason: "process_lost",
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_not_in_progress");
+    expect(wakeup?.status).toBe("skipped");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1127,62 +1127,6 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
-  it("cancels queued comment wakes when the issue is cancelled before the run starts", async () => {
-    const { companyId, agentId } = await seedCompanyAndAgent();
-    const issueId = randomUUID();
-    const commentId = randomUUID();
-    await db.insert(issues).values({
-      id: issueId,
-      companyId,
-      title: "Cancelled after feedback was queued",
-      status: "cancelled",
-      priority: "medium",
-      assigneeAgentId: null,
-    });
-
-    const { runId, wakeupRequestId } = await seedQueuedRun({
-      companyId,
-      agentId,
-      issueId,
-      wakeReason: "issue_commented",
-      invocationSource: "automation",
-      contextExtras: {
-        commentId,
-        wakeCommentId: commentId,
-        source: "issue.comment",
-      },
-    });
-
-    await heartbeat.resumeQueuedRuns();
-
-    await waitForCondition(async () => {
-      const run = await db
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, runId))
-        .then((rows) => rows[0] ?? null);
-      return run?.status === "cancelled";
-    });
-
-    const [run, wakeup] = await Promise.all([
-      db
-        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, runId))
-        .then((rows) => rows[0] ?? null),
-      db
-        .select({ status: agentWakeupRequests.status })
-        .from(agentWakeupRequests)
-        .where(eq(agentWakeupRequests.id, wakeupRequestId))
-        .then((rows) => rows[0] ?? null),
-    ]);
-
-    expect(run?.status).toBe("cancelled");
-    expect(run?.errorCode).toBe("issue_terminal_status");
-    expect(wakeup?.status).toBe("skipped");
-    expect(countExecuteCallsForRun(runId)).toBe(0);
-  });
-
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1127,6 +1127,62 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels queued comment wakes when the issue is cancelled before the run starts", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cancelled after feedback was queued",
+      status: "cancelled",
+      priority: "medium",
+      assigneeAgentId: null,
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_commented",
+      invocationSource: "automation",
+      contextExtras: {
+        commentId,
+        wakeCommentId: commentId,
+        source: "issue.comment",
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_terminal_status");
+    expect(wakeup?.status).toBe("skipped");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1127,6 +1127,48 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it.each(["resumeIntent", "followUpRequested"] as const)(
+    "preserves explicit %s wakes after the issue reaches a terminal status",
+    async (resumeMarker) => {
+      const { companyId, agentId } = await seedCompanyAndAgent();
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Explicitly resumed completed task",
+        status: "done",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      });
+
+      const { runId, wakeupRequestId } = await seedQueuedRun({
+        companyId,
+        agentId,
+        issueId,
+        wakeReason: "issue_commented",
+        contextExtras: { [resumeMarker]: true },
+      });
+
+      await heartbeat.resumeQueuedRuns();
+      await waitForCondition(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      });
+
+      const wakeup = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null);
+      expect(["claimed", "completed"]).toContain(wakeup?.status);
+      expect(countExecuteCallsForRun(runId)).toBe(1);
+    },
+  );
+
   it("cancels process-loss retries after the issue enters review", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/services/heartbeat-run-events.ts
+++ b/server/src/services/heartbeat-run-events.ts
@@ -1,0 +1,11 @@
+import { sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+
+export async function lockHeartbeatRunEventSequence(
+  executor: Pick<Db, "execute">,
+  runId: string,
+): Promise<void> {
+  await executor.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${`heartbeat-run-events:${runId}`}, 0))`,
+  );
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10962,6 +10962,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
+    const isProcessLossRetry = wakeReason === "process_lost_retry" || retryReason === "process_lost";
     const interactionResolvedAt = readNonEmptyString(context.interactionResolvedAt);
     const hasResolvedInteractionEvidence = interactionResolvedAt !== null && !Number.isNaN(Date.parse(interactionResolvedAt));
 
@@ -11025,6 +11026,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           details: { issueId, currentStatus: issue.status },
         };
       }
+    }
+
+    if (issue.status === "in_review" && isProcessLossRetry && !resumeIntent) {
+      return {
+        stale: true,
+        errorCode: "issue_not_in_progress",
+        reason:
+          "Cancelled because the issue entered review before the process-loss retry could start; the review workflow now owns the next action",
+        details: { issueId, currentStatus: issue.status, wakeReason, retryReason },
+      };
     }
 
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON && issue.status !== "in_progress") {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8720,23 +8720,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
-    if (issueId) {
-      const issue = await db
-        .select({ status: issues.status })
-        .from(issues)
-        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
-        .then((rows) => rows[0] ?? null);
-      if (issue?.status === "done" || issue?.status === "cancelled") {
-        await appendRunEvent(run, await nextRunEventSeq(run.id), {
-          eventType: "lifecycle",
-          stream: "system",
-          level: "info",
-          message: `Process-loss retry suppressed because issue reached terminal status (${issue.status})`,
-          payload: { issueId, issueStatus: issue.status },
-        });
-        return null;
-      }
-    }
     const retryReason = readNonEmptyString(contextSnapshot.wakeReason) === "issue_monitor_due"
       ? "issue_continuation_needed"
       : "process_lost";
@@ -11034,7 +11017,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
-      if (!resumeIntent) {
+      if (!resumeIntent && !wakeCommentId) {
         return {
           stale: true,
           errorCode: "issue_terminal_status",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8720,6 +8720,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (issueId) {
+      const issue = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (issue?.status === "done" || issue?.status === "cancelled") {
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "info",
+          message: `Process-loss retry suppressed because issue reached terminal status (${issue.status})`,
+          payload: { issueId, issueStatus: issue.status },
+        });
+        return null;
+      }
+    }
     const retryReason = readNonEmptyString(contextSnapshot.wakeReason) === "issue_monitor_due"
       ? "issue_continuation_needed"
       : "process_lost";
@@ -11536,7 +11553,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         : null;
 
       const transition = await setRunStatusIfRunning(run.id, "failed", {
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: baseMessage,
         errorCode: "process_lost",
         finishedAt: now,
         resultJson: (() => {
@@ -11546,7 +11563,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             {
               resultJson: parseObject(run.resultJson),
               errorCode: "process_lost",
-              errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+              errorMessage: baseMessage,
             },
           );
           return unmanagedBackgroundTaskEvidence
@@ -11563,7 +11580,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       let finalizedRun = transition.run;
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: baseMessage,
       });
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
       await releaseEnvironmentLeasesForRun({
@@ -11593,9 +11610,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         eventType: "lifecycle",
         stream: "system",
         level: "error",
-        message: shouldRetry
-          ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
+        message: retriedRun ? `${baseMessage}; queued retry ${retriedRun.id}` : baseMessage,
         payload: {
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5430,6 +5430,37 @@ export function resolveNextSessionState(input: {
 
 export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeService>;
 
+type HeartbeatRunEventInsert = Omit<
+  typeof heartbeatRunEvents.$inferInsert,
+  "id" | "seq" | "createdAt"
+>;
+
+export async function appendHeartbeatRunEvent(
+  db: Db,
+  requestedSeq: number,
+  event: HeartbeatRunEventInsert,
+) {
+  return db.transaction(async (tx) => {
+    const lockKey = `heartbeat-run-events:${event.runId}`;
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+
+    const [row] = await tx
+      .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, event.runId));
+    const nextSeq = Number(row?.maxSeq ?? 0) + 1;
+    const seq = Math.max(Number.isSafeInteger(requestedSeq) && requestedSeq > 0 ? requestedSeq : 1, nextSeq);
+
+    const inserted = await tx
+      .insert(heartbeatRunEvents)
+      .values({ ...event, seq })
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    if (!inserted) throw new Error(`Failed to append heartbeat run event for ${event.runId}`);
+    return inserted;
+  });
+}
+
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
@@ -8238,11 +8269,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       at: eventAt,
     });
 
-    await db.insert(heartbeatRunEvents).values({
+    const insertedEvent = await appendHeartbeatRunEvent(db, seq, {
       companyId: run.companyId,
       runId: run.id,
       agentId: run.agentId,
-      seq,
       eventType: event.eventType,
       stream: event.stream,
       level: event.level,
@@ -8250,6 +8280,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       message: sanitizedMessage,
       payload: sanitizedPayload,
     });
+    const persistedSeq = insertedEvent.seq;
 
     publishLiveEvent({
       companyId: run.companyId,
@@ -8258,7 +8289,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         runId: run.id,
         agentId: run.agentId,
         issueId,
-        seq,
+        seq: persistedSeq,
         eventType: event.eventType,
         stream: event.stream ?? null,
         level: event.level ?? null,
@@ -11510,7 +11541,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         : null;
 
-      let finalizedRun = await setRunStatus(run.id, "failed", {
+      const transition = await setRunStatusIfRunning(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
         errorCode: "process_lost",
         finishedAt: now,
@@ -11533,12 +11564,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             : result;
         })(),
       });
+      if (!transition.updated || !transition.run) continue;
+
+      let finalizedRun = transition.run;
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
       });
-      if (!finalizedRun) finalizedRun = await getRun(run.id);
-      if (!finalizedRun) continue;
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
       await releaseEnvironmentLeasesForRun({
         runId: finalizedRun.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -99,6 +99,7 @@ import {
   HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES,
   mergeHeartbeatRunResultJson,
 } from "./heartbeat-run-summary.js";
+import { lockHeartbeatRunEventSequence } from "./heartbeat-run-events.js";
 import {
   buildHeartbeatRunStopMetadata,
   mergeHeartbeatRunStopMetadata,
@@ -5441,8 +5442,7 @@ export async function appendHeartbeatRunEvent(
   event: HeartbeatRunEventInsert,
 ) {
   return db.transaction(async (tx) => {
-    const lockKey = `heartbeat-run-events:${event.runId}`;
-    await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+    await lockHeartbeatRunEventSequence(tx, event.runId);
 
     const [row] = await tx
       .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
@@ -15632,6 +15632,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, scheduledRun.id)));
           }
 
+          await lockHeartbeatRunEventSequence(tx, cancelled.id);
           const [eventSeq] = await tx
             .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
             .from(heartbeatRunEvents)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8689,6 +8689,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (issueId) {
+      const issue = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (issue?.status === "done" || issue?.status === "cancelled") {
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "info",
+          message: `Process-loss retry suppressed because issue reached terminal status (${issue.status})`,
+          payload: { issueId, issueStatus: issue.status },
+        });
+        return null;
+      }
+    }
     const retryReason = readNonEmptyString(contextSnapshot.wakeReason) === "issue_monitor_due"
       ? "issue_continuation_needed"
       : "process_lost";
@@ -10986,7 +11003,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
-      if (!resumeIntent && !wakeCommentId) {
+      if (!resumeIntent) {
         return {
           stale: true,
           errorCode: "issue_terminal_status",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -51,6 +51,7 @@ import {
 } from "../issue-dependency-wakeups.js";
 import { evaluateAgentInvokabilityFromDb } from "../agent-invokability.js";
 import { getRunLogStore } from "../run-log-store.js";
+import { lockHeartbeatRunEventSequence } from "../heartbeat-run-events.js";
 import {
   DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS,
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
@@ -1434,14 +1435,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return null;
   }
 
-  async function nextRunEventSeq(runId: string) {
-    const [row] = await db
-      .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
-      .from(heartbeatRunEvents)
-      .where(eq(heartbeatRunEvents.runId, runId));
-    return Number(row?.maxSeq ?? 0) + 1;
-  }
-
   async function appendRecoveryRunEvent(
     run: typeof heartbeatRuns.$inferSelect,
     event: {
@@ -1450,16 +1443,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       payload?: Record<string, unknown>;
     },
   ) {
-    await db.insert(heartbeatRunEvents).values({
-      companyId: run.companyId,
-      runId: run.id,
-      agentId: run.agentId,
-      seq: await nextRunEventSeq(run.id),
-      eventType: "lifecycle",
-      stream: "system",
-      level: event.level,
-      message: event.message,
-      payload: event.payload ?? null,
+    await db.transaction(async (tx) => {
+      await lockHeartbeatRunEventSequence(tx, run.id);
+      const [row] = await tx
+        .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, run.id));
+      await tx.insert(heartbeatRunEvents).values({
+        companyId: run.companyId,
+        runId: run.id,
+        agentId: run.agentId,
+        seq: Number(row?.maxSeq ?? 0) + 1,
+        eventType: "lifecycle",
+        stream: "system",
+        level: event.level,
+        message: event.message,
+        payload: event.payload ?? null,
+      });
     });
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates concurrent agent runs through heartbeat rows, retry rows, and ordered run events.
> - Orphan recovery can be invoked by overlapping server reapers, while heartbeat and recovery services can append events concurrently.
> - Those paths used check-then-write operations without a shared serialization boundary, and a queued process-loss retry could survive after its issue had already entered review.
> - The result was duplicate process-loss retries, duplicate event sequence values, and redundant worker execution after review owned the next action.
> - This pull request adds a running-status compare-and-set, a shared per-run advisory lock for every production event writer, and a claim-time in-review guard for process-loss retries.
> - The benefit is single-owner recovery and monotonic event delivery under concurrency.

## Linked Issues or Issue Description

Related but not duplicate: Refs #8134, #6159, #9318, and #9844. Those PRs address terminal retry/comment behavior, enqueue-time in-review guards, or restart classification; this PR is scoped to concurrent orphan ownership, event sequencing, and already-queued process-loss retries that outlive the worker-to-review handoff.

**What happened?**

Twenty concurrent orphan reapers could each enqueue a process-loss retry for the same run. Independently, concurrent heartbeat/recovery event writers could read the same maximum sequence and insert duplicate sequence numbers. A process-loss retry already in the queue could also execute after the issue transitioned to `in_review`.

**Expected behavior**

Exactly one reaper owns a running-to-failed transition, exactly one process-loss retry is created, every event receives a unique increasing sequence, and a queued worker retry is cancelled once review owns the issue.

**Steps to reproduce**

1. Seed a tracked `running` run whose process is no longer alive.
2. Invoke twenty orphan reapers concurrently.
3. Observe multiple retries without the compare-and-set.
4. Append twenty events concurrently with the same requested sequence.
5. Observe duplicate sequence values and missing results when listing with `afterSeq=1`.
6. Queue a process-loss retry, transition the issue to `in_review`, and observe the stale retry execute without the claim-time guard.

**Environment**

- Paperclip base: `14f20be92b86a49ff2c35495e5b0fa4d719998ef`
- Deployment: self-hosted, built from source
- Database: PostgreSQL-compatible embedded test database
- Adapter scope: core bug; reproduced while exercising Hermes-backed tasks but not adapter-specific

- [x] I searched open PRs for `process_lost`, orphan reaping, and run-event sequencing and linked related work above.

## What Changed

- Gate orphan reaping on a successful `running` status compare-and-set before finalization or retry creation.
- Serialize event sequence allocation with a per-run PostgreSQL advisory transaction lock.
- Use the same lock in heartbeat, scheduled-retry cancellation, and recovery-service event writers.
- Add regressions for twenty concurrent reapers, twenty concurrent event writers, and cancellation after an existing event.
- Cancel process-loss retries at claim time after the issue enters review, unless explicit resume intent is present.
- Suppress process-loss retry creation for `done` and `cancelled` issues, and only advertise a queued retry when a retry row was actually created.
- Cover both terminal statuses plus the positive `resumeIntent` and `followUpRequested` exceptions.

## Verification

- Combined process-recovery and stale-queue suites: 122/122 passed.
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- Focused cancellation cursor regression: existing event `seq=1`, cancellation event `seq=2`, and `afterSeq=1` returns the cancellation.
- `pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`
- `pnpm exec vitest run server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`
- `pnpm --filter @paperclipai/server typecheck` passed after an offline frozen-lockfile install.

## Risks

- Advisory locking serializes event inserts per run. Different runs remain independent; the critical section contains only max-sequence lookup plus insert.
- A reaper that loses the compare-and-set now exits without finalizing. That is intentional because another reaper already owns the transition.
- A process-loss retry no longer restarts worker execution after `in_review`; the review workflow owns the next action. Explicit resume intent remains exempt.
- Failed-run and wakeup diagnostics record the process-loss cause. A lifecycle event names the retry only after enqueue succeeds, avoiding false "retrying" messages when policy suppresses creation.
- No schema or migration changes.

> This is a bug fix, not roadmap feature work.

## Model Used

OpenAI Codex `gpt-5.6-sol`, with tool use, code execution, repository inspection, and independent read-only review agents.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked related public work and described the bug in-PR following the bug template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered documentation; no user-facing documentation change is required
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
