### PR TITLE
fix(issues): reject stale project references

### DIFF
--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -228,6 +228,22 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     expect(duplicate.body.id).not.toBe(first.body.id);
   });
 
+  it("rejects an unknown project before the issue insert", async () => {
+    const companyId = await seedCompany();
+    const app = createApp();
+
+    const response = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        projectId: randomUUID(),
+        title: "Do not turn stale project references into server errors",
+      })
+      .expect(404);
+
+    expect(response.body).toEqual({ error: "Project not found" });
+    expect(await db.select().from(issues)).toHaveLength(0);
+  });
+
   it("does not apply the route soft guard to internal service creates", async () => {
     const companyId = await seedCompany();
     const parent = await seedParent(companyId);

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -11,6 +11,7 @@ import {
   heartbeatRuns,
   issueCreateIdempotencyKeys,
   issues,
+  projects,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -50,6 +51,7 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     await db.delete(issues);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
+    await db.delete(projects);
     await db.delete(companies);
   });
 
@@ -113,6 +115,62 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
       deduplicationReason: "idempotency_key",
     });
     expect(await db.select().from(issueCreateIdempotencyKeys)).toHaveLength(1);
+  });
+
+  it("rejects an unknown project before replaying an idempotency key", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+    const idempotencyKey = "run-1:unknown-project-retry";
+
+    const first = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "Create the original issue", idempotencyKey })
+      .expect(201);
+    const response = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        parentId: parent.id,
+        title: "Do not replay around stale project validation",
+        projectId: randomUUID(),
+        idempotencyKey,
+      })
+      .expect(404);
+
+    expect(response.body).toEqual({ error: "Project not found" });
+    expect(await db.select().from(issues).where(eq(issues.parentId, parent.id))).toEqual([
+      expect.objectContaining({ id: first.body.id }),
+    ]);
+  });
+
+  it("rejects a cross-company project before replaying a duplicate title", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const otherCompanyId = await seedCompany();
+    const [otherCompanyProject] = await db.insert(projects).values({
+      companyId: otherCompanyId,
+      name: "Other company project",
+      status: "in_progress",
+    }).returning();
+    const app = createApp();
+
+    const first = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ parentId: parent.id, title: "Prevent unauthorized project reassignment" })
+      .expect(201);
+    const response = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        parentId: parent.id,
+        title: "  prevent unauthorized PROJECT reassignment ",
+        projectId: otherCompanyProject.id,
+      })
+      .expect(404);
+
+    expect(response.body).toEqual({ error: "Project not found" });
+    expect(await db.select().from(issues).where(eq(issues.parentId, parent.id))).toEqual([
+      expect.objectContaining({ id: first.body.id }),
+    ]);
   });
 
   it("expires old idempotency keys before replay lookup", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6935,6 +6935,9 @@ export function issueService(db: Db) {
           const idempotencyGuardKey = `issue-create:idempotency:${companyId}:${idempotencyKey}`;
           await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${idempotencyGuardKey}, 0))`);
         }
+        if (issueData.projectId != null) {
+          await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
+        }
 
         let existingIssue: typeof issues.$inferSelect | undefined;
         let deduplicationReason: "idempotency_key" | "recent_open_title" | null = null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1345,7 +1345,8 @@ async function getProjectDefaultGoalId(
     .from(projects)
     .where(and(eq(projects.id, projectId), eq(projects.companyId, companyId)))
     .then((rows) => rows[0] ?? null);
-  return row?.goalId ?? null;
+  if (!row) throw notFound("Project not found");
+  return row.goalId ?? null;
 }
 
 async function getWorkspaceInheritanceIssue(


### PR DESCRIPTION
## Thinking Path

> - Paperclip's issue service creates and updates work records associated with optional projects.
> - Project references must belong to the target company because the database enforces that relationship and project policy derives from it.
> - The shared project lookup previously returned `null` when a non-null project ID was missing or belonged to another company.
> - Issue creation then continued until PostgreSQL rejected the insert at the project foreign key, surfacing a client reference error as HTTP 500.
> - The same lookup is used while updating issue project assignments, so route-only handling would leave another path exposed.
> - This pull request makes the shared lookup authoritative and adds an embedded-PostgreSQL HTTP regression.
> - The benefit is a stable 404 contract, preserved company isolation, and no partial issue creation.

## Linked Issues or Issue Description

No exact duplicate found. I searched open PRs for `issue create project not found`, `issues project_id foreign key`, and `stale project reference issue`.

**What happened?**

Creating an issue with a stale, deleted, or foreign-company `projectId` reached the issue insert. PostgreSQL rejected it at the project foreign key and the API returned HTTP 500.

**Expected behavior**

A non-null project reference must resolve inside the target company before issue persistence. Missing and cross-company references should return `404 Project not found`, and no issue should be inserted.

**Steps to reproduce**

1. Create a company.
2. Submit `POST /api/companies/:companyId/issues` with a random or deleted `projectId` and a valid title.
3. Observe HTTP 500 from the issue insert instead of a not-found response.

**Environment**

- Paperclip server with PostgreSQL
- Reproduced with a real request and deterministic embedded-PostgreSQL route coverage

- [x] I searched open PRs for stale project references, project foreign-key failures, and issue-creation validation; no exact duplicate was found.

## What Changed

- Make the shared project/default-goal lookup throw `Project not found` when a non-null project ID is absent from the target company.
- Preserve the existing projectless-issue behavior.
- Protect both issue creation and project-changing issue updates through the shared lookup.
- Add an HTTP regression proving the response is 404 and no issue is persisted.

## Verification

- New regression failed before the fix with `expected 404, got 500`.
- Focused regression passed after the fix.
- `pnpm exec vitest run server/src/__tests__/issue-create-deduplication-routes.test.ts` — 9/9 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/server build` — passed in clean combined staging.
- `git diff --check` — passed.

## Risks

- Invalid project references change from HTTP 500 to HTTP 404.
- Valid project IDs and projectless issues are unchanged.
- The stricter lookup also causes invalid project changes during issue updates to fail before persistence, which is intentional.
- No schema or migration changes.
- Rollback is a single commit revert.

> This is a bug fix, not roadmap feature work.

## Model Used

OpenAI Codex `gpt-5.6-sol`, with tool use, code execution, repository inspection, and embedded-PostgreSQL regression testing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and described the search above
- [x] I have described the issue in-PR following the bug template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered documentation; no user-facing documentation change is required
- [x] I have considered and documented risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
