### PR TITLE
feat(infra): add server-update pre-flight gate + runbook

### DIFF
--- a/docs/deploy/server-update-runbook.md
+++ b/docs/deploy/server-update-runbook.md
@@ -1,0 +1,78 @@
+# Server-Update Runbook — resetting the live serving tree to origin/master
+
+Operational runbook for a self-hosted deploy workflow that keeps a live control-plane serving tree in sync by resetting it to `origin/master`. Written after the same durable-loss failure bit twice.
+
+Companion to [dev-plane-restart-hygiene.md](dev-plane-restart-hygiene.md) (which covers *how* to restart without killing in-flight runs). This doc covers *what to check before the reset* so it never silently deletes an un-landed fix.
+
+## Why this matters
+
+`git reset --hard origin/master` is a **destructive rebuild** of the serving tree. Anything present only as local state that is not on `origin/master` is wiped. Two ways this bites in practice:
+
+- A runtime **hotpatch applied only to the live tree**, never merged. A later reset reverts it and the original outage recurs.
+- A fix **marked "done" on uncommitted live-tree state** and never merged. The next reset wipes it; if you're lucky it survives as an orphaned stash on a backup branch, but the live tree no longer runs it.
+
+Root pattern: **"done on the live tree" ≠ durable.** A fix is only durable once it is on `origin/master`.
+
+## The two rules
+
+### Rule 1 — "done" gate for infra hotfixes
+
+A fix that touches server runtime (anything the live tree serves) **must not be marked done on the basis of live-tree local state alone.** Require one of:
+
+- a **merged commit SHA on `origin/master`** (the normal path), or
+- an explicit, ticketed exception: *"live-hotpatch applied now, durable deploy tracked in #NNN"* — kept open with that follow-up as a first-class blocker, **not** closed.
+
+If it isn't on `origin/master` and there's no tracked follow-up, it is one reset away from silent regression. Don't close it.
+
+### Rule 2 — pre-flight before every reset
+
+Before `git reset --hard origin/master`, run the pre-flight gate. It refuses (exit 2) when the tree carries divergence the reset would destroy or abandon and that hasn't been acknowledged:
+
+```bash
+node scripts/preflight-server-update.mjs          # targets $PAPERCLIP_LIVE_TREE or ~/Paperclip, fetches first
+```
+
+What it classifies (built on `reset --hard` semantics):
+
+| State | Reset behavior | Verdict |
+|-------|----------------|---------|
+| Tracked uncommitted changes (staged/unstaged edits to tracked files) | **destroyed** | **block** |
+| Commits ahead of `origin/master` | abandoned from branch ref (reflog/backup only) | **block** |
+| Stashes | survive | warn |
+| Untracked files | survive | info |
+
+- **Exit 0** — clean (or blocking divergence explicitly acked). Safe to reset.
+- **Exit 2** — blocked. Capture the blocking items on a backup branch and land them on `origin/master` (or track the durable deploy in a ticket), then re-run.
+- The audited exception: `--ack "reason + #NNN ticket"` downgrades a block to `acked` (exit 0) and echoes the reason to the run log. Use a real ticket id.
+
+Other flags: `--tree <path>` to inspect a different tree, `--no-fetch` to skip the `git fetch origin master`, `--json` for a machine-readable verdict.
+
+## Full safe reset procedure
+
+The live control plane runs from the primary checkout (`~/Paperclip` by default: launchd → `pnpm dev` → `dev-runner.ts watch` → inner `tsx watch src/index.ts` on `:3100`). Verify authoritatively with `lsof -nP -iTCP:3100 -sTCP:LISTEN` and `/api/health` `servingTree.head`.
+
+0. **Pre-flight (Rule 2):** `node scripts/preflight-server-update.mjs`. Do not proceed on a `BLOCKED` verdict without capturing/ticketing the blocking items.
+1. `npx paperclipai db:backup` **first** — pending migrations auto-apply to the live DB on restart.
+2. Preserve divergent work: `git branch backups/server-update-<date> <HEAD>`. Note: a branch snapshot captures **committed** state only — it does **not** capture uncommitted working-tree edits or stashes. Those must be committed/stashed explicitly, which is exactly what the pre-flight forces you to notice.
+3. `git fetch origin master && git reset --hard origin/master`; verify `HEAD == origin/master` and a clean tree.
+4. `pnpm install` — **required** across a big jump or the restart crash-loops on missing imports (the supervisor does not run install). If this step bumps the `tsx` package itself, do **not** rely on a touch-file nudge to respawn — fully cycle the service: `pnpm run dev:stop` then `pnpm run dev:watch` (a running `tsx watch` supervisor holds deleted-file inodes from the old version and every child respawn then crashes on the vanished `preflight.cjs`).
+5. Migrations auto-apply (`PAPERCLIP_MIGRATION_AUTO_APPLY=true`), or run `pnpm db:migrate`. UI is served via Vite dev middleware from source — no `pnpm build` needed.
+6. Restart is gated on active agent runs (a DB count). To force a fresh worker during an agent run, make a real content change to a watched src file then revert (an mtime-only `touch` is not detected by tsx watch).
+
+## After the reset — reconciliation check (closes the loop for Rule 1)
+
+Once the API is back healthy, **diff the backup branch against `origin/master`** to catch any fix that was live-only and just got reverted:
+
+```bash
+git log --oneline origin/master..backups/server-update-<date>
+git diff --stat origin/master backups/server-update-<date>
+```
+
+Any hunk that is a real runtime fix and is **not** on `origin/master` → spin out a re-land follow-up issue and link it. Only then close the reset task.
+
+Also confirm end state: `/api/health` `servingTree.head == origin/master`, a single `:3100` listener, the notifier/gateway plugin reconnected (check `~/.paperclip/gateway-liveness.json` freshness separately from `/api/health` — the plugin worker's lifecycle is not tied 1:1 to `src/index.ts` reloads), and a recent DB backup.
+
+## See also
+
+- [dev-plane-restart-hygiene.md](dev-plane-restart-hygiene.md) — restarting without killing in-flight runs.
+- `scripts/preflight-server-update.mjs` — the pre-flight gate (Rule 2), with `--json` / `--ack` / `--tree` / `--no-fetch`.

--- a/scripts/preflight-server-update.mjs
+++ b/scripts/preflight-server-update.mjs
@@ -150,11 +150,15 @@ function git(tree, args) {
   });
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const opts = { tree: DEFAULT_TREE, fetch: true, json: false, ack: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--tree") opts.tree = argv[++i];
+    if (a === "--tree") {
+      const v = argv[++i];
+      if (v === undefined) throw new Error("--tree requires a path argument");
+      opts.tree = v;
+    }
     else if (a === "--no-fetch") opts.fetch = false;
     else if (a === "--json") opts.json = true;
     else if (a === "--ack") opts.ack = argv[++i] ?? "";

--- a/scripts/preflight-server-update.mjs
+++ b/scripts/preflight-server-update.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * preflight-server-update.mjs
+ *
+ * Pre-flight gate for a self-hosted deploy workflow that keeps a live
+ * control-plane serving tree in sync by resetting it to `origin/master` via
+ * `git reset --hard` (the primary checkout, `~/Paperclip` by default).
+ *
+ * Why this exists:
+ *   A `git reset --hard origin/master` is a DESTRUCTIVE rebuild of the serving
+ *   tree. Anything present only as local state that is NOT on `origin/master`
+ *   is silently wiped. In practice this bites when a runtime fix is applied as
+ *   a live hotpatch, or marked "done" on the basis of uncommitted local edits,
+ *   but never merged upstream — the next reset reverts it with no warning.
+ *   Root pattern: "done on the live tree" != durable.
+ *
+ * What it does:
+ *   Inspects the target tree for local divergence the reset would destroy or
+ *   abandon relative to `origin/master`, and REFUSES (non-zero exit) when it
+ *   finds blocking divergence that has not been explicitly acknowledged.
+ *
+ *   Reset semantics this check is built on:
+ *     - `git reset --hard` DESTROYS tracked uncommitted changes (staged +
+ *       unstaged edits/deletes to tracked files)               -> BLOCK
+ *     - it ABANDONS commits ahead of origin/master from the branch ref
+ *       (recoverable via reflog / a backup branch, but not on master) -> BLOCK
+ *     - it does NOT touch stashes                               -> WARN
+ *     - it does NOT touch untracked files                       -> INFO
+ *
+ * Exit codes:
+ *   0  safe to reset (clean, or blocking divergence explicitly acked)
+ *   2  blocked: local divergence not on origin/master and not acknowledged
+ *   1  usage / git error
+ *
+ * Target tree resolution: --tree <path>, else $PAPERCLIP_LIVE_TREE, else
+ * ~/Paperclip (the primary checkout on this instance).
+ *
+ * Usage:
+ *   node scripts/preflight-server-update.mjs                 # target = live tree, fetch first
+ *   node scripts/preflight-server-update.mjs --tree /path    # inspect another tree
+ *   node scripts/preflight-server-update.mjs --no-fetch      # skip `git fetch origin master`
+ *   node scripts/preflight-server-update.mjs --json          # machine-readable verdict
+ *   node scripts/preflight-server-update.mjs --ack "live-hotpatch, durable deploy tracked in #1234"
+ *
+ * The `--ack "<reason>"` escape hatch is the explicit, audited exception path
+ * for a legitimate live hotpatch whose durable deploy is tracked elsewhere.
+ * The reason string is echoed to stdout so it lands in the run log. Use a real
+ * ticket id; a reset that regresses an un-ticketed fix is the exact failure
+ * this gate exists to prevent.
+ */
+
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+// The live serving tree is the primary checkout. Resolved at runtime so no
+// operator-specific absolute path is baked into the repo.
+const DEFAULT_TREE =
+  process.env.PAPERCLIP_LIVE_TREE || path.join(os.homedir(), "Paperclip");
+const UPSTREAM = "origin/master";
+
+export const SEVERITY = { BLOCK: "block", WARN: "warn", INFO: "info" };
+
+/**
+ * Pure verdict function. Takes an already-gathered git state snapshot and
+ * returns { verdict, findings, blocking } with no I/O — this is the part unit
+ * tests exercise.
+ *
+ * @param {object} state
+ * @param {string[]} state.aheadCommits  one-line summaries of origin/master..HEAD
+ * @param {string[]} state.trackedUncommitted  porcelain lines for tracked changes (no `??`)
+ * @param {string[]} state.untracked  porcelain paths for untracked files (`??`)
+ * @param {string[]} state.stashes  `git stash list` lines
+ * @param {string|null} state.ack  acknowledgement reason, or null
+ */
+export function evaluatePreflight(state) {
+  const {
+    aheadCommits = [],
+    trackedUncommitted = [],
+    untracked = [],
+    stashes = [],
+    ack = null,
+  } = state;
+
+  const findings = [];
+
+  if (trackedUncommitted.length > 0) {
+    findings.push({
+      kind: "tracked_uncommitted",
+      severity: SEVERITY.BLOCK,
+      count: trackedUncommitted.length,
+      detail: trackedUncommitted,
+      message:
+        "Tracked uncommitted changes will be DESTROYED by `reset --hard`. " +
+        "Commit them to a backup branch (and land via PR) before resetting.",
+    });
+  }
+
+  if (aheadCommits.length > 0) {
+    findings.push({
+      kind: "ahead_commits",
+      severity: SEVERITY.BLOCK,
+      count: aheadCommits.length,
+      detail: aheadCommits,
+      message:
+        `Local commits are ahead of ${UPSTREAM} and will be abandoned from the ` +
+        "branch. Each must already be on origin/master (landed via PR) or " +
+        "captured on a backup branch AND tracked by an open PR/issue.",
+    });
+  }
+
+  if (stashes.length > 0) {
+    findings.push({
+      kind: "stashes",
+      severity: SEVERITY.WARN,
+      count: stashes.length,
+      detail: stashes,
+      message:
+        "Stashes survive `reset --hard` but are easily orphaned. Confirm none " +
+        "carries an un-landed runtime fix — a fix preserved only as a stash " +
+        "still regresses on the live tree once the reset lands.",
+    });
+  }
+
+  if (untracked.length > 0) {
+    findings.push({
+      kind: "untracked",
+      severity: SEVERITY.INFO,
+      count: untracked.length,
+      detail: untracked,
+      message:
+        "Untracked files survive `reset --hard`. Usually runtime noise; scan " +
+        "for any stray source file that should be captured.",
+    });
+  }
+
+  const blocking = findings.filter((f) => f.severity === SEVERITY.BLOCK);
+  const acked = Boolean(ack && ack.trim());
+  const verdict =
+    blocking.length === 0 ? "clean" : acked ? "acked" : "blocked";
+
+  return { verdict, findings, blocking, ack: acked ? ack.trim() : null };
+}
+
+function git(tree, args) {
+  return execFileSync("git", ["-C", tree, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function parseArgs(argv) {
+  const opts = { tree: DEFAULT_TREE, fetch: true, json: false, ack: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--tree") opts.tree = argv[++i];
+    else if (a === "--no-fetch") opts.fetch = false;
+    else if (a === "--json") opts.json = true;
+    else if (a === "--ack") opts.ack = argv[++i] ?? "";
+    else if (a === "-h" || a === "--help") opts.help = true;
+    else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  return opts;
+}
+
+function gatherState(tree, { fetch }) {
+  // Confirm this is a git tree up front for a clean error.
+  git(tree, ["rev-parse", "--git-dir"]);
+
+  if (fetch) {
+    git(tree, ["fetch", "origin", "master", "--quiet"]);
+  }
+
+  const head = git(tree, ["rev-parse", "--short", "HEAD"]).trim();
+  const upstream = git(tree, ["rev-parse", "--short", UPSTREAM]).trim();
+
+  const aheadCommits = git(tree, ["log", "--oneline", `${UPSTREAM}..HEAD`])
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  const porcelain = git(tree, ["status", "--porcelain"])
+    .split("\n")
+    .filter((l) => l.length > 0);
+  const trackedUncommitted = porcelain.filter((l) => !l.startsWith("??"));
+  const untracked = porcelain.filter((l) => l.startsWith("??"));
+
+  const stashes = git(tree, ["stash", "list"])
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  return { head, upstream, aheadCommits, trackedUncommitted, untracked, stashes };
+}
+
+function render(state, result, opts) {
+  const lines = [];
+  lines.push("Server-update pre-flight");
+  lines.push(`  tree:     ${opts.tree}`);
+  lines.push(`  HEAD:     ${state.head}`);
+  lines.push(`  ${UPSTREAM}: ${state.upstream}`);
+  lines.push("");
+
+  if (result.findings.length === 0) {
+    lines.push("  ✓ clean — no local divergence. Safe to reset to origin/master.");
+  } else {
+    for (const f of result.findings) {
+      const icon =
+        f.severity === SEVERITY.BLOCK
+          ? "✗"
+          : f.severity === SEVERITY.WARN
+            ? "!"
+            : "·";
+      lines.push(`  ${icon} [${f.severity}] ${f.kind} (${f.count})`);
+      lines.push(`      ${f.message}`);
+      for (const d of f.detail.slice(0, 12)) lines.push(`        ${d}`);
+      if (f.detail.length > 12)
+        lines.push(`        … and ${f.detail.length - 12} more`);
+    }
+  }
+
+  lines.push("");
+  if (result.verdict === "clean") {
+    lines.push("VERDICT: SAFE TO RESET.");
+  } else if (result.verdict === "acked") {
+    lines.push(`VERDICT: ACKNOWLEDGED — proceeding despite blocking divergence.`);
+    lines.push(`  ack: ${result.ack}`);
+  } else {
+    lines.push("VERDICT: BLOCKED — do not reset.");
+    lines.push(
+      "  Capture the blocking items on a backup branch and land them on " +
+        "origin/master (or track the durable deploy in a ticket), then re-run.",
+    );
+    lines.push(
+      '  To override with an explicit audited exception: --ack "reason + ticket".',
+    );
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(String(err.message || err));
+    process.exit(1);
+  }
+
+  if (opts.help) {
+    console.log(
+      "Usage: node scripts/preflight-server-update.mjs " +
+        "[--tree <path>] [--no-fetch] [--json] [--ack <reason>]",
+    );
+    process.exit(0);
+  }
+
+  let state;
+  try {
+    state = gatherState(opts.tree, opts);
+  } catch (err) {
+    console.error(`git error while inspecting ${opts.tree}:`);
+    console.error(String(err.stderr || err.message || err).trim());
+    process.exit(1);
+  }
+
+  const result = evaluatePreflight({ ...state, ack: opts.ack });
+
+  if (opts.json) {
+    console.log(JSON.stringify({ ...state, ...result }, null, 2));
+  } else {
+    console.log(render(state, result, opts));
+  }
+
+  process.exit(result.verdict === "blocked" ? 2 : 0);
+}
+
+// Only run when invoked directly, not when imported by the test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/preflight-server-update.test.mjs
+++ b/scripts/preflight-server-update.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluatePreflight, SEVERITY } from "./preflight-server-update.mjs";
+
+test("clean tree is safe to reset", () => {
+  const r = evaluatePreflight({});
+  assert.equal(r.verdict, "clean");
+  assert.equal(r.findings.length, 0);
+  assert.equal(r.blocking.length, 0);
+});
+
+test("tracked uncommitted changes block (destroyed by reset --hard)", () => {
+  const r = evaluatePreflight({
+    trackedUncommitted: [" M server/src/heartbeat.ts", "A  scripts/new.mjs"],
+  });
+  assert.equal(r.verdict, "blocked");
+  assert.equal(r.blocking.length, 1);
+  assert.equal(r.blocking[0].kind, "tracked_uncommitted");
+  assert.equal(r.blocking[0].severity, SEVERITY.BLOCK);
+  assert.equal(r.blocking[0].count, 2);
+});
+
+test("commits ahead of origin/master block", () => {
+  const r = evaluatePreflight({
+    aheadCommits: ["abc1234 fix: local hotpatch", "def5678 chore: tweak"],
+  });
+  assert.equal(r.verdict, "blocked");
+  assert.equal(r.blocking.length, 1);
+  assert.equal(r.blocking[0].kind, "ahead_commits");
+});
+
+test("stashes warn but do not block (they survive reset --hard)", () => {
+  const r = evaluatePreflight({
+    stashes: ["stash@{0}: On master: wip before pre-merge"],
+  });
+  assert.equal(r.verdict, "clean");
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].severity, SEVERITY.WARN);
+  assert.equal(r.blocking.length, 0);
+});
+
+test("untracked files are informational only", () => {
+  const r = evaluatePreflight({ untracked: ["?? .codex/"] });
+  assert.equal(r.verdict, "clean");
+  assert.equal(r.findings[0].severity, SEVERITY.INFO);
+});
+
+test("--ack downgrades blocked to acked and records the reason", () => {
+  const r = evaluatePreflight({
+    aheadCommits: ["abc1234 fix: live hotpatch"],
+    ack: "live-hotpatch, durable deploy tracked in #1234",
+  });
+  assert.equal(r.verdict, "acked");
+  assert.equal(r.ack, "live-hotpatch, durable deploy tracked in #1234");
+});
+
+test("empty/whitespace ack does not satisfy the gate", () => {
+  const r = evaluatePreflight({
+    aheadCommits: ["abc1234 fix: live hotpatch"],
+    ack: "   ",
+  });
+  assert.equal(r.verdict, "blocked");
+  assert.equal(r.ack, null);
+});
+
+test("multiple divergence kinds are all reported; blocking drives the verdict", () => {
+  const r = evaluatePreflight({
+    trackedUncommitted: [" M server/src/index.ts"],
+    aheadCommits: ["abc1234 fix"],
+    stashes: ["stash@{0}: wip"],
+    untracked: ["?? tmp.log"],
+  });
+  assert.equal(r.findings.length, 4);
+  assert.equal(r.blocking.length, 2);
+  assert.equal(r.verdict, "blocked");
+});

--- a/scripts/preflight-server-update.test.mjs
+++ b/scripts/preflight-server-update.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { evaluatePreflight, SEVERITY } from "./preflight-server-update.mjs";
+import { evaluatePreflight, parseArgs, SEVERITY } from "./preflight-server-update.mjs";
 
 test("clean tree is safe to reset", () => {
   const r = evaluatePreflight({});
@@ -74,4 +74,16 @@ test("multiple divergence kinds are all reported; blocking drives the verdict", 
   assert.equal(r.findings.length, 4);
   assert.equal(r.blocking.length, 2);
   assert.equal(r.verdict, "blocked");
+});
+
+test("parseArgs: --tree without a value fails loudly instead of passing undefined to git", () => {
+  assert.throws(() => parseArgs(["--tree"]), /--tree requires a path argument/);
+});
+
+test("parseArgs: flags and values parse into opts", () => {
+  const opts = parseArgs(["--tree", "/srv/live", "--no-fetch", "--json", "--ack", "durable in PR #123"]);
+  assert.equal(opts.tree, "/srv/live");
+  assert.equal(opts.fetch, false);
+  assert.equal(opts.json, true);
+  assert.equal(opts.ack, "durable in PR #123");
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Self-hosters keep a live control-plane serving tree in sync by resetting it to `origin/master` (`git reset --hard`) on a recurring cadence
> - That reset is a destructive rebuild: any local state not on `origin/master` — a runtime hotpatch applied only to the live tree, or a fix marked "done" on uncommitted edits — is silently wiped
> - When that happens the original bug quietly recurs on the next reset, with no signal that a fix was lost
> - This pull request adds a pre-flight gate that refuses the reset when the tree carries divergence the reset would destroy or abandon, plus a runbook documenting the "merge before you call it done" rule
> - The benefit is that runtime fixes can no longer silently regress across a serving-tree reset

## Linked Issues or Issue Description

No public GitHub issue exists. Inline description (feature template):

### Problem

A self-hosted deploy workflow that syncs a live control-plane serving tree by resetting it to `origin/master` (`git reset --hard origin/master`) is a destructive rebuild. Any runtime fix present only as local state — a hotpatch applied to the live tree, or a fix marked "done" on uncommitted edits — that never merged upstream is silently reverted by the next reset, and the original bug recurs with no signal. Observed twice independently (a subprocess-adapter hotpatch; an execution-workspace reconcile fix).

### Proposed solution

A pre-flight gate that inspects the target tree before the reset and refuses (exit `2`) when it carries divergence the reset would destroy (tracked uncommitted changes) or abandon (commits ahead of `origin/master`), unless it is explicitly acknowledged. Plus a runbook codifying two rules: require a merged `origin/master` SHA before marking an infra hotfix done, and run the pre-flight before every reset.

### Alternatives considered

Rely on discipline / memory alone (already failed twice); or a git pre-commit hook (wrong layer — the loss happens at reset time on the serving tree, not at commit time). A reset-time gate is the smallest thing that actually catches the failure.

### Roadmap alignment

Operational hardening for self-hosted deployments; no core product surface. Companion to the existing `docs/deploy/dev-plane-restart-hygiene.md` runbook.

## What Changed

- **`scripts/preflight-server-update.mjs`** — pre-flight gate. Refuses (exit `2`) to reset when the target tree has divergence `reset --hard` would **destroy** (tracked uncommitted changes) or **abandon** (commits ahead of `origin/master`) and it has not been acknowledged. Stashes → warn, untracked → info (both survive a reset). `--ack "<reason + ticket>"` is an explicit, audited exception path (echoed to the run log). Flags: `--tree`, `--no-fetch`, `--json`. Pure `evaluatePreflight()` classifier separated from the git-gathering side for testability; live-tree path resolved at runtime (`$PAPERCLIP_LIVE_TREE` or `~/Paperclip`), no absolute path baked in.
- **`scripts/preflight-server-update.test.mjs`** — 8 `node --test` cases over the classifier (clean / block-on-uncommitted / block-on-ahead / stash-warn / untracked-info / ack-override / whitespace-ack-rejected / multi-kind). Bare-runnable, no install.
- **`docs/deploy/server-update-runbook.md`** — companion to `dev-plane-restart-hygiene.md`: the two rules, the full safe reset procedure, and a post-reset backup-branch reconciliation check.

## Verification

```
node --test scripts/preflight-server-update.test.mjs   # 8 pass, 0 fail
```

Manual, against real trees:
- Clean tree at `HEAD == origin/master` → `VERDICT: SAFE TO RESET`, exit `0`.
- A tree with commits ahead of `origin/master` → `[block] ahead_commits`, `VERDICT: BLOCKED`, exit `2`.
- Same tree with `--ack "reason"` → `VERDICT: ACKNOWLEDGED`, exit `0`, reason echoed.

No product code paths touched — scripts + docs only.

## Risks

Low risk. Adds a standalone advisory script (does not itself run any reset), its test, and a docs page. No runtime/server code, no dependency, `package.json`, or lockfile changes. The script is read-only on the target tree except for the default `git fetch origin master` (skippable with `--no-fetch`).

## Checklist

- [x] I searched the GitHub PR list (open + closed) for similar or duplicate PRs and confirmed this is not a duplicate.

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, agentic tool use via the Paperclip control plane.
