### PR TITLE
fix(task-watchdog): keep pending board waits live

### DIFF
--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -50,7 +50,7 @@ describe("task watchdog subtree classifier", () => {
     });
   });
 
-  it("treats terminal and waiting leaves as stopped work that needs verification", () => {
+  it("treats an in-review leaf with a pending interaction as live", () => {
     const result = classify({
       issues: [
         issue({ status: "done" }),
@@ -59,16 +59,96 @@ describe("task watchdog subtree classifier", () => {
       pendingInteractions: [{ companyId, issueId: childId, id: "interaction-1", status: "pending" }],
     });
 
+    expect(result).toMatchObject({ state: "live", liveIssueIds: [childId] });
+  });
+
+  it.each(["pending", "revision_requested"])(
+    "treats an in-review leaf with a %s approval as live",
+    (status) => {
+      const result = classify({
+        issues: [
+          issue({ status: "done" }),
+          issue({ id: childId, identifier: "PAP-2", parentId: sourceId, status: "in_review" }),
+        ],
+        pendingApprovals: [{ companyId, issueId: childId, id: "approval-1", status }],
+      });
+
+      expect(result).toMatchObject({ state: "live", liveIssueIds: [childId] });
+    },
+  );
+
+  it("ignores pending interactions attached to terminal leaves", () => {
+    const stoppedSiblingId = "child-2";
+    const result = classify({
+      issues: [
+        issue({ status: "done" }),
+        issue({ id: childId, identifier: "PAP-2", parentId: sourceId, status: "done" }),
+        issue({ id: stoppedSiblingId, identifier: "PAP-3", parentId: sourceId, status: "blocked" }),
+      ],
+      pendingInteractions: [{ companyId, issueId: childId, id: "interaction-1", status: "pending" }],
+    });
+
     expect(result.state).toBe("stopped");
     if (result.state !== "stopped") return;
-    expect(result.stopFingerprint).toMatch(/^task_watchdog_stop:/);
     expect(result.stoppedLeaves).toEqual([
-      expect.objectContaining({
-        issueId: childId,
-        status: "in_review",
-        pendingInteractionIds: ["interaction-1"],
-      }),
+      expect.objectContaining({ issueId: childId, pendingInteractionIds: ["interaction-1"] }),
+      expect.objectContaining({ issueId: stoppedSiblingId }),
     ]);
+  });
+
+  it("returns a new stopped fingerprint after a pending interaction resolves", () => {
+    const beforeInteraction = classify({
+      issues: [issue({ status: "in_review", updatedAt: new Date("2026-06-17T20:00:00.000Z") })],
+    });
+    expect(beforeInteraction.state).toBe("stopped");
+    if (beforeInteraction.state !== "stopped") return;
+
+    const waiting = classify({
+      issues: [issue({ status: "in_review", updatedAt: new Date("2026-06-17T20:00:00.000Z") })],
+      pendingInteractions: [{ companyId, issueId: sourceId, id: "interaction-1", status: "pending" }],
+    });
+    expect(waiting.state).toBe("live");
+
+    const resolved = classify({
+      issues: [issue({ status: "in_review", updatedAt: new Date("2026-06-17T20:05:00.000Z") })],
+    });
+    expect(resolved.state).toBe("stopped");
+    if (resolved.state !== "stopped") return;
+    expect(resolved.stopFingerprint).not.toBe(beforeInteraction.stopFingerprint);
+  });
+
+  it("stays live through sibling churn while a pending interaction remains", () => {
+    const waitingLeaf = issue({ id: childId, identifier: "PAP-2", parentId: sourceId, status: "in_review" });
+    const siblingId = "child-2";
+    const pendingInteractions = [
+      { companyId, issueId: childId, id: "interaction-1", status: "pending" },
+    ];
+
+    const beforeChurn = classify({
+      issues: [
+        issue({ status: "done" }),
+        waitingLeaf,
+        issue({ id: siblingId, identifier: "PAP-3", parentId: sourceId, status: "blocked" }),
+      ],
+      pendingInteractions,
+    });
+    const afterChurn = classify({
+      issues: [
+        issue({ status: "done" }),
+        waitingLeaf,
+        issue({
+          id: siblingId,
+          identifier: "PAP-3",
+          parentId: sourceId,
+          status: "blocked",
+          updatedAt: new Date("2026-06-17T20:10:00.000Z"),
+        }),
+      ],
+      pendingInteractions,
+    });
+
+    expect(beforeChurn).toMatchObject({ state: "live", liveIssueIds: [childId] });
+    expect(afterChurn).toMatchObject({ state: "live", liveIssueIds: [childId] });
   });
 
   it("suppresses an unchanged stopped fingerprint once the watchdog reviewed it", () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -11,6 +11,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueThreadInteractions,
   issueWorkProducts,
   issues,
   issueWatchdogs,
@@ -45,6 +46,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     await db.delete(issueDocuments);
     await db.delete(documents);
     await db.delete(issueComments);
+    await db.delete(issueThreadInteractions);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(issueWatchdogs);
@@ -342,6 +344,46 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "task_watchdog")));
     expect(watchdogIssues).toHaveLength(0);
+  });
+
+  it("does not trigger while a subtree leaf has a pending interaction, then triggers after resolution", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-INTERACTION", status: "done" });
+    const childId = await seedIssue(companyId, { parentId: sourceId, status: "in_review" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const [interaction] = await db
+      .insert(issueThreadInteractions)
+      .values({
+        companyId,
+        issueId: childId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        payload: { version: 1, prompt: "Proceed?" },
+      })
+      .returning();
+    const { service, wakes } = createService();
+
+    const waiting = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(waiting).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(0);
+
+    await db
+      .update(issueThreadInteractions)
+      .set({
+        status: "accepted",
+        result: { version: 1, outcome: "accepted" },
+        resolvedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(issueThreadInteractions.id, interaction!.id));
+
+    const stopped = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(stopped).toMatchObject({ checked: 1, triggered: 1, live: 0 });
+    expect(wakes).toHaveLength(1);
   });
 
   it("does not keep the source live for runs under a nested task-watchdog issue", async () => {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -320,15 +320,24 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
 
   const includedIds = included.map((issue) => issue.id);
   const includedIdSet = new Set(includedIds);
+  const nonTerminalIncludedIds = new Set(
+    included.filter((issue) => !isTerminalIssueStatus(issue.status)).map((issue) => issue.id),
+  );
+  const waitingIssueIds = [
+    ...pathIssueIds(input.pendingInteractions, input.watchdog.companyId),
+    ...pathIssueIds(input.pendingApprovals, input.watchdog.companyId),
+  ].filter((issueId) => nonTerminalIncludedIds.has(issueId));
   const liveIssueIds = [
     ...pathIssueIds(input.activeRuns, input.watchdog.companyId),
     ...pathIssueIds(input.queuedWakeRequests, input.watchdog.companyId),
+    ...waitingIssueIds,
   ].filter((issueId) => includedIdSet.has(issueId));
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
     return {
       state: "live",
-      reason: "At least one issue in the watched subtree has a live run, queued wake, or scheduled retry.",
+      reason:
+        "At least one issue in the watched subtree has a live run, queued wake, scheduled retry, scheduled monitor, or pending board interaction/approval.",
       includedIssueIds: includedIds,
       liveIssueIds: uniqueLiveIssueIds,
     };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous agent work moving through explicit execution and governance paths.
> - Task watchdogs inspect issue subtrees and wake a reviewer only when productive work has genuinely stopped.
> - Pending issue-thread interactions and pending or revision-requested approvals are explicit board waiting paths already included in the watchdog snapshot.
> - The classifier did not count those rows as live, so an `in_review` leaf waiting on the board could be misclassified as a stopped subtree.
> - This pull request extends the existing live-path composition only for non-terminal included issues, preserving terminal-leaf and fingerprint behavior.
> - The benefit is that watchdogs wait while board input is pending and self-heal into a stopped verdict after that input resolves without follow-up work.

## Linked Issues or Issue Description

- **Bug:** A task-watchdog subtree with a non-terminal leaf waiting on a pending issue-thread interaction, pending approval, or revision-requested approval could be classified as stopped even though the board wait was a live path.
- **Expected behavior:** Pending board interactions and approvals keep non-terminal included issues live; waiting rows attached to terminal issues do not mask a genuinely stopped sibling.
- **Reproduction:** Watch a subtree containing an `in_review` leaf, attach a pending request-confirmation or approval, and reconcile the watchdog without an active run or queued wake. Before this change the watchdog could trigger; after this change it remains live until the wait resolves.
- **Environment:** Server-side task-watchdog classifier and scheduler; no deployment-mode-specific behavior.
- Related overlap: #9452 edits the same live-path block for conditional rearming and may require a trivial rebase depending on merge order.

## What Changed

- Include pending issue-thread interactions and pending or revision-requested approvals in watchdog live-path classification for non-terminal subtree issues.
- Preserve stopped-leaf fingerprint fields and terminal-leaf behavior.
- Add pure classifier coverage for interactions, both approval states, terminal guards, resolution self-healing, and sibling churn.
- Add a database scheduler regression proving no wake occurs while an interaction is pending and a wake occurs after resolution without follow-up work.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/task-watchdogs-classifier.test.ts src/__tests__/task-watchdogs-scheduler.test.ts` — 2 files passed, 32 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.

## Risks

- Low risk: the behavior change is limited to the classifier's existing live-path set and uses snapshot rows already queried for the subtree.
- A pending board wait on a non-terminal issue now intentionally suppresses watchdog review until the wait resolves; terminal issues remain excluded from this guard.
- No schema, migration, API, or fingerprint-shape changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5.4, high-reasoning mode, repository/terminal tool use, code execution, and focused test verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
