### PR TITLE
fix(plugins): pass invocationScope.companyId to bundled plugin workers at activation

### DIFF
--- a/server/src/__tests__/plugin-lifecycle-start-worker.test.ts
+++ b/server/src/__tests__/plugin-lifecycle-start-worker.test.ts
@@ -112,8 +112,6 @@ describe("pluginLifecycleManager.startWorker", () => {
 
   it("uses the first config row's companyId when several are present", async () => {
     mockRegistry.getById.mockResolvedValue(pluginRecord);
-    // Ordered by companyId asc; the loader always passes configs sorted, so
-    // the first row is the canonical install origin.
     mockRegistry.listConfigs.mockResolvedValue([
       { companyId: "company-A", configJson: {} },
       { companyId: "company-B", configJson: {} },
@@ -162,10 +160,6 @@ describe("pluginLifecycleManager.startWorker", () => {
   });
 
   it("does not invent a scope when the plugin has no config rows", async () => {
-    // Pathological: an install that has not yet been configured for any
-    // company (e.g. install succeeded but no operator ever saved config).
-    // The lifecycle should not crash; it should pass options as-is and let
-    // downstream code surface the missing-scope error.
     mockRegistry.getById.mockResolvedValue(pluginRecord);
     mockRegistry.listConfigs.mockResolvedValue([]);
 
@@ -177,6 +171,30 @@ describe("pluginLifecycleManager.startWorker", () => {
 
     await lifecycle.startWorker("plugin-1", baseOptions);
 
+    const [, passedOptions] = (workerManager.startWorker as any).mock.calls[0];
+    expect(passedOptions.invocationScope).toBeUndefined();
+  });
+
+  it("does not abort when listConfigs rejects (transient DB blip)", async () => {
+    // Resilience regression: a registry.listConfigs rejection must NOT
+    // propagate into a hard activation failure. A transient DB blip
+    // during activation should leave the worker starting without a
+    // pre-seeded scope (same best-effort shape as plugin-loader). The
+    // worker's own init code will surface the missing-scope error if it
+    // really needs the company; we don't want activation to flip to
+    // status='error' here.
+    mockRegistry.getById.mockResolvedValue(pluginRecord);
+    mockRegistry.listConfigs.mockRejectedValue(new Error("DB unavailable"));
+
+    const { workerManager } = makeWorkerManagerStub();
+    const lifecycle = pluginLifecycleManager(
+      {} as never,
+      { loader: makeLoader(), workerManager },
+    );
+
+    await expect(lifecycle.startWorker("plugin-1", baseOptions)).resolves.toBeUndefined();
+
+    expect(workerManager.startWorker).toHaveBeenCalledTimes(1);
     const [, passedOptions] = (workerManager.startWorker as any).mock.calls[0];
     expect(passedOptions.invocationScope).toBeUndefined();
   });

--- a/server/src/__tests__/plugin-lifecycle-start-worker.test.ts
+++ b/server/src/__tests__/plugin-lifecycle-start-worker.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Regression test for bundled-plugin activation.
+ *
+ * Bundled plugins (e.g. paperclip-plugin-telegram v0.3.0 served from
+ * Paperclip's internal registry) failed to start with:
+ *
+ *   "Worker initialize failed: Plugin ... is not allowed to perform
+ *    config.get: company context is required"
+ *
+ * because the host passed no `invocationScope` to the worker. The first
+ * capability call the plugin makes during setup() (typically config.get)
+ * was rejected by the SDK's `host-client-factory.js` (the allowedCompanyId
+ * check), so the worker never reached `ready` and the install landed in
+ * `status='error'`.
+ *
+ * The fix is for `lifecycle.startWorker` to look up the install's company
+ * via `registry.listConfigs(pluginId)` and pass it on the options as
+ * `invocationScope: { companyId }`. The plugin's first config row carries
+ * the company that originated the install; a bundled plugin has exactly
+ * one.
+ *
+ * @see PLUGIN_SPEC.md §13 - Host-Worker Protocol
+ * @see packages/plugin-sdk/src/host-client-factory.js
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const pluginRecord = {
+  id: "plugin-1",
+  pluginKey: "example.bundled",
+  status: "ready",
+  manifestJson: { id: "example.bundled", capabilities: [] },
+  packageName: "@example/bundled",
+  version: "0.3.0",
+  packagePath: "/usr/local/lib/example/bundled",
+};
+
+const mockRegistry = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByKey: vi.fn(),
+  update: vi.fn(),
+  updateStatus: vi.fn(),
+  upsertConfig: vi.fn(),
+  getConfig: vi.fn(),
+  listConfigs: vi.fn(),
+  list: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock("../services/plugin-registry.js", () => ({
+  pluginRegistryService: () => mockRegistry,
+}));
+
+import { pluginLifecycleManager } from "../services/plugin-lifecycle.js";
+import type { PluginLoader } from "../services/plugin-loader.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+
+function makeWorkerManagerStub() {
+  return {
+    workerManager: {
+      getWorker: vi.fn().mockReturnValue(null),
+      isRunning: vi.fn().mockReturnValue(false),
+      startWorker: vi.fn().mockResolvedValue(undefined),
+      stopWorker: vi.fn().mockResolvedValue(undefined),
+      restartWorker: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PluginWorkerManager,
+  };
+}
+
+function makeLoader(overrides: Partial<PluginLoader> = {}): PluginLoader {
+  return {
+    hasRuntimeServices: vi.fn().mockReturnValue(false),
+    installPlugin: vi.fn(),
+    upgradePlugin: vi.fn(),
+    loadSingle: vi.fn(),
+    unloadSingle: vi.fn(),
+    isSupportedApiVersion: vi.fn().mockReturnValue(true),
+    removeRuntimeArtifacts: vi.fn(),
+    shutdownAll: vi.fn(),
+    ...overrides,
+  } as PluginLoader;
+}
+
+const baseOptions = {
+  entrypointPath: "/tmp/example.bundled/dist/worker.js",
+  manifest: pluginRecord.manifestJson as any,
+  config: {},
+  instanceInfo: { instanceId: "inst-1", hostVersion: "2026.720.0" },
+  apiVersion: 1,
+  hostHandlers: {} as any,
+};
+
+describe("pluginLifecycleManager.startWorker", () => {
+  it("passes invocationScope.companyId derived from the install's first config", async () => {
+    mockRegistry.getById.mockResolvedValue(pluginRecord);
+    mockRegistry.listConfigs.mockResolvedValue([
+      { companyId: "company-A", configJson: {} },
+    ]);
+
+    const { workerManager } = makeWorkerManagerStub();
+    const lifecycle = pluginLifecycleManager(
+      {} as never,
+      { loader: makeLoader(), workerManager },
+    );
+
+    await lifecycle.startWorker("plugin-1", baseOptions);
+
+    expect(workerManager.startWorker).toHaveBeenCalledTimes(1);
+    const [passedPluginId, passedOptions] = (workerManager.startWorker as any).mock.calls[0];
+    expect(passedPluginId).toBe("plugin-1");
+    expect(passedOptions.invocationScope).toEqual({ companyId: "company-A" });
+  });
+
+  it("uses the first config row's companyId when several are present", async () => {
+    mockRegistry.getById.mockResolvedValue(pluginRecord);
+    // Ordered by companyId asc; the loader always passes configs sorted, so
+    // the first row is the canonical install origin.
+    mockRegistry.listConfigs.mockResolvedValue([
+      { companyId: "company-A", configJson: {} },
+      { companyId: "company-B", configJson: {} },
+    ]);
+
+    const { workerManager } = makeWorkerManagerStub();
+    const lifecycle = pluginLifecycleManager(
+      {} as never,
+      { loader: makeLoader(), workerManager },
+    );
+
+    await lifecycle.startWorker("plugin-1", baseOptions);
+
+    const [, passedOptions] = (workerManager.startWorker as any).mock.calls[0];
+    expect(passedOptions.invocationScope).toEqual({ companyId: "company-A" });
+  });
+
+  it("preserves existing options when adding invocationScope", async () => {
+    mockRegistry.getById.mockResolvedValue(pluginRecord);
+    mockRegistry.listConfigs.mockResolvedValue([
+      { companyId: "company-A", configJson: {} },
+    ]);
+
+    const { workerManager } = makeWorkerManagerStub();
+    const lifecycle = pluginLifecycleManager(
+      {} as never,
+      { loader: makeLoader(), workerManager },
+    );
+
+    await lifecycle.startWorker("plugin-1", {
+      ...baseOptions,
+      config: { foo: "bar" },
+      rpcTimeoutMs: 5000,
+      autoRestart: false,
+      proactiveCompanyScopes: ["company-A"],
+    });
+
+    const [, passedOptions] = (workerManager.startWorker as any).mock.calls[0];
+    expect(passedOptions).toMatchObject({
+      rpcTimeoutMs: 5000,
+      autoRestart: false,
+      proactiveCompanyScopes: ["company-A"],
+      config: { foo: "bar" },
+      invocationScope: { companyId: "company-A" },
+    });
+  });
+
+  it("does not invent a scope when the plugin has no config rows", async () => {
+    // Pathological: an install that has not yet been configured for any
+    // company (e.g. install succeeded but no operator ever saved config).
+    // The lifecycle should not crash; it should pass options as-is and let
+    // downstream code surface the missing-scope error.
+    mockRegistry.getById.mockResolvedValue(pluginRecord);
+    mockRegistry.listConfigs.mockResolvedValue([]);
+
+    const { workerManager } = makeWorkerManagerStub();
+    const lifecycle = pluginLifecycleManager(
+      {} as never,
+      { loader: makeLoader(), workerManager },
+    );
+
+    await lifecycle.startWorker("plugin-1", baseOptions);
+
+    const [, passedOptions] = (workerManager.startWorker as any).mock.calls[0];
+    expect(passedOptions.invocationScope).toBeUndefined();
+  });
+});

--- a/server/src/services/plugin-lifecycle.ts
+++ b/server/src/services/plugin-lifecycle.ts
@@ -739,7 +739,27 @@ export function pluginLifecycleManager(
       // this scope the worker is rejected on its first capability call (e.g.
       // `config.get`) with "company context is required" and never reaches
       // `ready`. See PLUGIN_SPEC §13 - Host-Worker Protocol.
-      const configRows = await registry.listConfigs(pluginId);
+      //
+      // Best-effort: matches the pattern in plugin-loader.ts (lines ~2160): if the
+      // lookup fails (transient DB blip, race during install, etc.) we log at
+      // debug and proceed without a scope. The worker's own init code will
+      // surface the missing-scope error if it really needs the company to
+      // bootstrap; this prevents a momentary infra issue from turning a
+      // recoverable scope-population miss into a hard activation failure
+      // that leaves the plugin stuck in `status='error'`.
+      let configRows: Awaited<ReturnType<typeof registry.listConfigs>> = [];
+      try {
+        configRows = await registry.listConfigs(pluginId);
+      } catch (listErr) {
+        log.debug(
+          {
+            pluginId,
+            pluginKey: plugin.pluginKey,
+            err: listErr instanceof Error ? listErr.message : String(listErr),
+          },
+          "plugin lifecycle: could not resolve install company for invocationScope; starting worker without scope",
+        );
+      }
       const installCompanyId = configRows[0]?.companyId;
       const scopedOptions = installCompanyId
         ? { ...options, invocationScope: { companyId: installCompanyId } }

--- a/server/src/services/plugin-lifecycle.ts
+++ b/server/src/services/plugin-lifecycle.ts
@@ -733,7 +733,19 @@ export function pluginLifecycleManager(
         "plugin lifecycle: starting worker",
       );
 
-      await workerManager.startWorker(pluginId, options);
+      // Resolve the install's company so the worker starts with a populated
+      // `invocationScope`. The plugin's first config row carries the company
+      // that originated the install; a bundled plugin has exactly one. Without
+      // this scope the worker is rejected on its first capability call (e.g.
+      // `config.get`) with "company context is required" and never reaches
+      // `ready`. See PLUGIN_SPEC §13 - Host-Worker Protocol.
+      const configRows = await registry.listConfigs(pluginId);
+      const installCompanyId = configRows[0]?.companyId;
+      const scopedOptions = installCompanyId
+        ? { ...options, invocationScope: { companyId: installCompanyId } }
+        : options;
+
+      await workerManager.startWorker(pluginId, scopedOptions);
       emitDomain("plugin.worker_started", {
         pluginId,
         pluginKey: plugin.pluginKey,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The plugin subsystem loads community and bundled plugins as out-of-process workers that talk to the host through a JSON-RPC host client.
> - Bundled plugins (e.g. `paperclip-plugin-telegram` v0.3.0 served from Paperclip's internal registry) fail at activation with `Worker initialize failed: ... is not allowed to perform "config.get": company context is required`.
> - The SDK enforces `context.invocationScope.companyId` on every capability call; bundled plugins boot before the host has set up that scope, so the first `config.get` (issued by the plugin's own init code) is rejected.
> - This pull request changes `lifecycle.startWorker` so the host looks up the install's company via `registry.listConfigs(pluginId)` and passes it on the options as `invocationScope: { companyId }` before `startWorker(...)` runs, matching the contract the SDK already requires.
> - The benefit is that all bundled and pre-loaded plugins (`bundled`, `catalog`) can complete their init, read their per-company config, and serve traffic without operator workarounds.

## Linked Issues or Issue Description

No public issue exists. Describing the problem inline (path B from `CONTRIBUTING.md`).

- [x] Bug reported inline (no public issue required)

### What happened?

Installing a bundled plugin on Paperclip 2026.720.0 returns a `400` and the row in `plugins` is created with `status='error'`, `last_error='Activation failed: ... is not allowed to perform "config.get": company context is required'`. The plugin never reaches the `ready` state, so it can not serve any traffic.

### Expected behavior

A bundled plugin installed via `POST /api/plugins/install` should activate and reach `status='ready'`. The host should provide the activation context (the `companyId` of the company that owns the install) so the plugin's first capability call — including the implicit `config.get` the SDK issues during init — succeeds.

### Steps to reproduce

1. Start Paperclip 2026.720.0 with a company and an instance-admin user.
2. From a board operator session, run:
   ```sh
   curl -X POST http://127.0.0.1:3100/api/plugins/install \
     -H 'Content-Type: application/json' -H "Origin: http://127.0.0.1:3100" \
     -d '{"packageName":"paperclip-plugin-telegram","companyId":"<uuid>"}'
   ```
3. Inspect:
   ```sql
   SELECT id, plugin_key, version, status, last_error FROM plugins;
   ```
   `version='0.3.0'`, `status='error'`, `last_error` matches the message above.

### Paperclip version

`2026.720.0` (deployment mode `authenticated`).

## What Changed

- `server/src/services/plugin-lifecycle.ts` — `startWorker` now resolves the install's company via `registry.listConfigs(pluginId)` and merges it into the options as `invocationScope: { companyId }` before delegating to `workerManager.startWorker(...)`. The lookup is wrapped in `try/catch` (best-effort, matches the pattern in `plugin-loader.ts` lines ~2160) so a transient DB blip during activation does not turn a recoverable scope-population miss into a hard activation failure that leaves the plugin stuck in `status='error'`.
- `server/src/__tests__/plugin-lifecycle-start-worker.test.ts` — new regression tests covering:
  - single config row -> scope populated from the first row;
  - multiple config rows -> scope is the first row's `companyId` (rows are already sorted by `companyId asc` upstream);
  - existing options preserved (`rpcTimeoutMs`, `autoRestart`, `proactiveCompanyScopes`, `config` flow through unchanged);
  - no config rows -> no scope invented, options pass through (downstream "missing scope" error surfaces the real cause);
  - `listConfigs` rejects (transient DB blip) -> the worker still starts without a pre-seeded scope and `startWorker` resolves cleanly.

## Verification

1. Apply the diff (this PR).
2. From a board operator session, re-issue the install:
   ```sh
   curl -X POST http://127.0.0.1:3100/api/plugins/install \
     -H 'Content-Type: application/json' -H "Origin: http://127.0.0.1:3100" \
     -d '{"packageName":"paperclip-plugin-telegram","companyId":"<uuid>"}'
   ```
3. Confirm activation:
   ```sh
   curl http://127.0.0.1:3100/api/plugins | jq '.[] | select(.pluginKey=="paperclip-plugin-telegram") | {version, status, lastError}'
   ```
   Expected: `version="0.3.0"` (or newer), `status="ready"`, `lastError=null`.
4. Confirm the plugin can read its own config:
   ```sh
   curl http://127.0.0.1:3100/api/plugins/<plugin-id>/health
   ```
   Expected: `{"status":"ready","healthy":true,...}`.
5. Run `pnpm test` and confirm CI stays green.

## Risks

- **Low risk.** The change only widens the context the host provides to plugin workers on activation; it does not change any public API or remove any existing capability. Plugins that previously succeeded are unaffected. Plugins that previously failed (bundled) now reach `ready` and can begin serving requests, which is the intended behavior.
- **Watch-out:** if a plugin ever relies on `invocationScope.companyId` being `null` during init, this change would alter its startup. The SDK contract already requires the scope to be set before any capability call, so no plugin in the SDK's compatibility window is expected to rely on `null`.
- **Migration safety:** no DB migration required. No flag, env var, or feature toggle.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Provider: Anthropic
- Model: `claude-opus-4-8` (1M context window)
- Reasoning: extended thinking
- Tooling: gh CLI for PR creation, git for branch management

## Dedup search

I have searched GitHub for duplicate or related PRs and linked them above.

Related PRs that touched the same area (none supersedes this one):

- #9368 — `fix(plugins): register an unrestricted invocation scope for runJob dispatches`
- #8159 — `Keep plugin invocation scopes briefly after RPC settle`
- #8202 — `fix(plugin-worker-manager): recover when a worker's stdin command channel dies`
- #4076 — `fix(plugin-loader): resolve symlinks in worker entrypoint path`
- #10097 — `fix(plugins): normalize path-valued ESM loader exec args to file URLs for Windows plugin workers`

This PR is the only one addressing the specific failure mode in `Worker init` for bundled plugins.

## Tests

Added `server/src/__tests__/plugin-lifecycle-start-worker.test.ts` covering:

- single config row -> scope populated from the first row;
- multiple config rows -> scope is the first row's `companyId`;
- existing options preserved (`rpcTimeoutMs`, `autoRestart`, `proactiveCompanyScopes`, `config`);
- no config rows -> no scope invented, options pass through;
- `listConfigs` rejects (transient DB blip) -> the worker still starts without a pre-seeded scope and `startWorker` resolves cleanly.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
