### PR TITLE
fix(adapter-config): centralize actor attribution on getActorInfo(req) in lock policy (TEC-7237, TEC-7250, GH-10182)

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2784,6 +2784,27 @@ export function writePaperclipSkillSyncPreference(
   return next;
 }
 
+export function readAdapterConfigUserLocks(config: Record<string, unknown>): string[] {
+  const raw = config._userLocked;
+  if (!Array.isArray(raw)) return [];
+  return Array.from(new Set(raw.flatMap((value) => {
+    if (typeof value !== "string") return [];
+    const path = value.trim();
+    return path ? [path] : [];
+  })));
+}
+
+export function adapterConfigPathIsUserLocked(
+  config: Record<string, unknown>,
+  path: string,
+): boolean {
+  return readAdapterConfigUserLocks(config).some((lockedPath) =>
+    path === lockedPath
+    || path.startsWith(`${lockedPath}.`)
+    || lockedPath.startsWith(`${path}.`),
+  );
+}
+
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,

--- a/packages/shared/src/adapter-agnostic-keys.test.ts
+++ b/packages/shared/src/adapter-agnostic-keys.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_ADAPTER_AGNOSTIC_KEYS = [
   "graceSec",
   "bootstrapPromptTemplate",
   "paperclipSkillSync",
+  "_userLocked",
 ] as const;
 
 function readRepoFile(pathFromRoot: string) {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -89,6 +89,7 @@ export const ADAPTER_AGNOSTIC_KEYS = [
   "graceSec",
   "bootstrapPromptTemplate",
   "paperclipSkillSync",
+  "_userLocked",
 ] as const;
 export type AdapterAgnosticKey = (typeof ADAPTER_AGNOSTIC_KEYS)[number];
 

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -37,6 +37,17 @@ export const upsertAgentInstructionsFileSchema = z.object({
 export type UpsertAgentInstructionsFile = z.infer<typeof upsertAgentInstructionsFileSchema>;
 
 const adapterConfigSchema = z.record(z.string(), z.unknown()).superRefine((value, ctx) => {
+  const userLocked = value._userLocked;
+  if (userLocked !== undefined) {
+    const parsed = z.array(z.string().trim().min(1).max(200)).max(100).safeParse(userLocked);
+    if (!parsed.success || new Set(parsed.data).size !== parsed.data.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "adapterConfig._userLocked must be a unique array of non-empty field paths",
+        path: ["_userLocked"],
+      });
+    }
+  }
   const envValue = value.env;
   if (envValue === undefined) return;
   const parsed = envConfigSchema.safeParse(envValue);

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -602,6 +602,59 @@ describe("agent instructions bundle routes", () => {
     );
   });
 
+  it.each([
+    {
+      label: "user",
+      actor: boardActor(),
+      existingAdapterConfig: { model: "gpt-5.4" },
+      expectedModel: "gpt-5.6",
+      expectedActorType: "user",
+    },
+    {
+      label: "agent",
+      actor: {
+        type: "agent",
+        agentId: "agent-editor",
+        companyId: "company-1",
+        source: "agent_key",
+      },
+      existingAdapterConfig: { model: "gpt-5.4", _userLocked: ["model"] },
+      expectedModel: "gpt-5.4",
+      expectedActorType: "agent",
+    },
+  ])("uses canonical $label attribution for lock policy and activity", async ({
+    actor,
+    existingAdapterConfig,
+    expectedModel,
+    expectedActorType,
+  }) => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: existingAdapterConfig,
+    });
+
+    const res = await requestApp(await createApp(actor), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({ adapterConfig: { model: "gpt-5.6" } }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: expectedModel,
+          _userLocked: ["model"],
+        }),
+      }),
+      expect.any(Object),
+    );
+    const activityEntries = mockLogActivity.mock.calls.map(([, entry]) => entry);
+    expect(activityEntries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: "agent.updated", actorType: expectedActorType }),
+    ]));
+    expect(activityEntries.every((entry) => entry.actorType === expectedActorType)).toBe(true);
+  });
+
   it("allows an explicit unlock while locking fields changed in the same user patch", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -38,6 +38,7 @@ const mockEnvironmentService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockIssueService = vi.hoisted(() => ({ addComment: vi.fn() }));
 const mockSyncInstructionsBundleConfigFromFilePath = vi.hoisted(() => vi.fn());
 const mockFindServerAdapter = vi.hoisted(() => vi.fn());
 
@@ -52,7 +53,7 @@ vi.mock("../services/index.js", () => ({
   environmentService: () => mockEnvironmentService,
   heartbeatService: () => ({}),
   issueApprovalService: () => ({}),
-  issueService: () => ({}),
+  issueService: () => mockIssueService,
   logActivity: mockLogActivity,
   secretService: () => mockSecretService,
   syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
@@ -83,7 +84,7 @@ function registerModuleMocks() {
     budgetService: () => ({}),
     heartbeatService: () => ({}),
     issueApprovalService: () => ({}),
-    issueService: () => ({}),
+    issueService: () => mockIssueService,
     logActivity: mockLogActivity,
     secretService: () => mockSecretService,
     syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
@@ -114,7 +115,10 @@ function boardActor() {
   };
 }
 
-async function createApp(actor: Record<string, unknown> = boardActor()) {
+async function createApp(
+  actor: Record<string, unknown> = boardActor(),
+  db: Record<string, unknown> = {},
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -125,7 +129,7 @@ async function createApp(actor: Record<string, unknown> = boardActor()) {
     (req as any).actor = actor;
     next();
   });
-  app.use("/api", agentRoutes({} as any));
+  app.use("/api", agentRoutes(db as any));
   app.use(errorHandler);
   return app;
 }
@@ -176,6 +180,25 @@ function makeAgent() {
   };
 }
 
+function linkedIssueDb() {
+  let selectCount = 0;
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => {
+          selectCount += 1;
+          return selectCount === 1
+            ? [{ contextSnapshot: { issueId: "33333333-3333-4333-8333-333333333333" } }]
+            : [{
+                id: "33333333-3333-4333-8333-333333333333",
+                parentId: "44444444-4444-4444-8444-444444444444",
+              }];
+        }),
+      })),
+    })),
+  };
+}
+
 function makeReflectionCoachAgent(overrides: Record<string, unknown> = {}) {
   return {
     ...makeAgent(),
@@ -199,6 +222,7 @@ describe("agent instructions bundle routes", () => {
     vi.doUnmock("../middleware/index.js");
     registerModuleMocks();
     vi.clearAllMocks();
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1" });
     mockBuiltInAgentService.ensureCompanyDefaultAgentGrants.mockResolvedValue(0);
     mockSyncInstructionsBundleConfigFromFilePath.mockImplementation((_agent, config) => config);
     mockFindServerAdapter.mockImplementation((_type: string) => ({ type: _type }));
@@ -470,6 +494,7 @@ describe("agent instructions bundle routes", () => {
       adapterConfig: {
         model: "claude-sonnet-4",
         paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
       },
     });
 
@@ -491,6 +516,7 @@ describe("agent instructions bundle routes", () => {
         adapterConfig: expect.objectContaining({
           model: "gpt-5.4",
           paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+          _userLocked: ["model", "paperclipSkillSync.desiredSkills"],
         }),
       }),
       expect.any(Object),
@@ -529,6 +555,188 @@ describe("agent instructions bundle routes", () => {
           instructionsRootPath: "/tmp/agent-1",
           instructionsEntryFile: "AGENTS.md",
           instructionsFilePath: "/tmp/agent-1/AGENTS.md",
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("records changed adapter config fields as user locks", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterType: "codex_local",
+      adapterConfig: {
+        model: "gpt-5.4",
+        env: { SAFE_FLAG: "before" },
+        paperclipSkillSync: {
+          desiredSkills: ["research"],
+          lastSyncedAt: "2026-07-24T00:00:00.000Z",
+        },
+      },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        adapterConfig: {
+          model: "gpt-5.6",
+          paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.6",
+          env: { SAFE_FLAG: "before" },
+          paperclipSkillSync: {
+            desiredSkills: ["research", "code-review"],
+            lastSyncedAt: "2026-07-24T00:00:00.000Z",
+          },
+          _userLocked: ["model", "paperclipSkillSync.desiredSkills"],
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows an explicit unlock while locking fields changed in the same user patch", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        command: "codex",
+        _userLocked: ["model"],
+      },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        adapterConfig: {
+          command: "codex --profile engineer",
+          _userLocked: [],
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.4",
+          command: "codex --profile engineer",
+          _userLocked: ["command"],
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("skips agent changes to locked fields and surfaces only redacted shapes", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        command: "codex",
+        env: { SECRET_TOKEN: "old-secret-value" },
+        _userLocked: ["model", "env"],
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          model: "gpt-5.6",
+          command: "codex --profile engineer",
+          env: { SECRET_TOKEN: "new-secret-value" },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.4",
+          command: "codex --profile engineer",
+          env: { SECRET_TOKEN: "old-secret-value" },
+          _userLocked: ["model", "env"],
+        }),
+      }),
+      expect.any(Object),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_skipped",
+        details: {
+          fields: expect.arrayContaining([
+            { path: "command", type: "string", count: 1 },
+            { path: "env", type: "object", count: 1 },
+            { path: "model", type: "string", count: 1 },
+          ]),
+          changedCount: 1,
+          skippedCount: 2,
+        },
+      }),
+    );
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("old-secret-value");
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("new-secret-value");
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "44444444-4444-4444-8444-444444444444",
+      expect.stringContaining("Skipped user-locked fields: 2"),
+      {
+        agentId: "agent-editor",
+        runId: "55555555-5555-4555-8555-555555555555",
+      },
+    );
+    expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("old-secret-value");
+    expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("new-secret-value");
+  });
+
+  it("preserves a nested locked field when an agent requests full replacement", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: {
+          desiredSkills: ["research"],
+          lastSyncedAt: "2026-07-24T00:00:00.000Z",
+        },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      source: "agent_key",
+    }), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        replaceAdapterConfig: true,
+        adapterConfig: { model: "gpt-5.6" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.6",
+          paperclipSkillSync: { desiredSkills: ["research"] },
+          _userLocked: ["paperclipSkillSync.desiredSkills"],
         }),
       }),
       expect.any(Object),

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -163,7 +163,16 @@ function createDb(requireBoardApprovalForNewAgents = false) {
   };
 }
 
-async function createApp(db: Record<string, unknown> = createDb()) {
+async function createApp(
+  db: Record<string, unknown> = createDb(),
+  actor: Record<string, unknown> = {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  },
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -171,13 +180,7 @@ async function createApp(db: Record<string, unknown> = createDb()) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", agentRoutes(db as any));
@@ -596,6 +599,54 @@ describe.sequential("agent skill routes", () => {
         }),
       }),
       ["paperclipai/paperclip/paperclip"],
+    );
+  });
+
+  it("refuses an agent skill-sync change when desired skills are user locked", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent("acpx_local"),
+      adapterConfig: {
+        agent: "codex",
+        paperclipSkillSync: { desiredSkills: ["existing/skill"] },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
+      },
+    });
+    mockCompanySkillService.resolveRequestedSkillEntries.mockImplementationOnce(
+      async (_companyId: string, requested: Array<{ key: string; versionId?: string | null }>) => ({
+        resolved: requested.map((entry) => ({ key: entry.key, versionId: entry.versionId ?? null })),
+        unresolved: [],
+      }),
+    );
+
+    const res = await requestApp(
+      await createApp(createDb(), {
+        type: "agent",
+        agentId: "agent-editor",
+        companyId: "company-1",
+        source: "agent_key",
+      }),
+      (baseUrl) => request(baseUrl)
+        .post("/api/agents/11111111-1111-4111-8111-111111111111/skills/sync")
+        .send({ desiredSkills: ["paperclip"] }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.warnings).toContain("Skipped user-locked paperclipSkillSync.desiredSkills update.");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockAdapter.syncSkills).toHaveBeenCalledWith(
+      expect.any(Object),
+      ["existing/skill"],
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_skipped",
+        details: {
+          fields: [{ path: "paperclipSkillSync.desiredSkills", type: "array", count: 1 }],
+          changedCount: 0,
+          skippedCount: 1,
+        },
+      }),
     );
   });
 

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -1014,6 +1014,38 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(grantKeys).not.toContain("skills:create");
   });
 
+  it("does not restore a user-locked bundled skill during repeated reconciliation", async () => {
+    const companyId = await seedCompany();
+    await agentService(db).create(companyId, {
+      name: "CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: { model: "gpt-5.4" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const initial = await builtInAgentService(db).ensure(companyId, "reflection-coach");
+    const userConfig = {
+      ...initial.agent!.adapterConfig,
+      model: "gpt-5.6",
+      env: { SAFE_FLAG: "unchanged" },
+      paperclipSkillSync: { desiredSkills: [] },
+      _userLocked: ["model", "paperclipSkillSync.desiredSkills"],
+    };
+    await agentService(db).update(initial.agentId!, { adapterConfig: userConfig });
+    const expected = await agentService(db).getById(initial.agentId!);
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await builtInAgentService(db).ensure(companyId, "reflection-coach");
+    }
+
+    const persisted = await agentService(db).getById(initial.agentId!);
+    expect(persisted?.adapterConfig).toEqual(expected?.adapterConfig);
+    expect(readPaperclipSkillSyncPreference(persisted!.adapterConfig).desiredSkills).toEqual([]);
+  });
+
   it("materializes the Summarizer bundle paused on Claude Haiku with a disabled routine", async () => {
     const companyId = await seedCompany();
     const root = await agentService(db).create(companyId, {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1133,13 +1133,13 @@ export function agentRoutes(
   };
 
   function applyAdapterConfigUserLockPolicy(input: {
-    actorType: "board" | "agent" | "none";
+    actorType: "user" | "agent";
     existing: Record<string, unknown>;
     requested: Record<string, unknown>;
     effective: Record<string, unknown>;
   }): { config: Record<string, unknown>; mutation: AdapterConfigMutation | null } {
     const attemptedPaths = changedAdapterConfigPaths(input.existing, input.effective);
-    if (input.actorType === "board") {
+    if (input.actorType === "user") {
       const baseLocks = hasOwn(input.requested, "_userLocked")
         ? readAdapterConfigUserLocks(input.requested)
         : readAdapterConfigUserLocks(input.existing);
@@ -3184,6 +3184,7 @@ export function agentRoutes(
     }
 
     const patchData = { ...(req.body as Record<string, unknown>) };
+    const actor = getActorInfo(req);
     let adapterConfigMutation: AdapterConfigMutation | null = null;
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
     delete patchData.replaceAdapterConfig;
@@ -3254,7 +3255,7 @@ export function agentRoutes(
       }
       if (requestedAdapterConfig) {
         const lockPolicy = applyAdapterConfigUserLockPolicy({
-          actorType: req.actor.type,
+          actorType: actor.actorType,
           existing: existingAdapterConfig,
           requested: requestedAdapterConfig,
           effective: rawEffectiveAdapterConfig,
@@ -3309,7 +3310,6 @@ export function agentRoutes(
       await assertCanUpdateAgent(req, existing);
     }
 
-    const actor = getActorInfo(req);
     const agent = await svc.update(id, patchData, {
       recordRevision: {
         createdByAgentId: actor.agentId,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
@@ -31,6 +32,8 @@ import {
 } from "@paperclipai/shared";
 import {
   resolvePaperclipInstanceRootForAdapter,
+  adapterConfigPathIsUserLocked,
+  readAdapterConfigUserLocks,
   readPaperclipSkillSyncPreference,
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -194,6 +197,7 @@ export function agentRoutes(
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
   const instructions = agentInstructionsService();
+  const issuesSvc = issueService(db);
   const companySkills = companySkillService(db);
   const workspaceOperations = workspaceOperationService(db);
   const instanceSettings = instanceSettingsService(db);
@@ -1042,6 +1046,182 @@ export function agentRoutes(
     return value as Record<string, unknown>;
   }
 
+  function mergeAdapterConfigPatch(
+    current: Record<string, unknown>,
+    patch: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const merged = { ...current };
+    for (const [key, value] of Object.entries(patch)) {
+      const currentRecord = asRecord(current[key]);
+      const patchRecord = asRecord(value);
+      merged[key] = currentRecord && patchRecord
+        ? mergeAdapterConfigPatch(currentRecord, patchRecord)
+        : value;
+    }
+    return merged;
+  }
+
+  function changedAdapterConfigPaths(
+    before: Record<string, unknown>,
+    after: Record<string, unknown>,
+    prefix = "",
+  ): string[] {
+    const paths: string[] = [];
+    for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+      if (key === "_userLocked") continue;
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (isDeepStrictEqual(before[key], after[key])) continue;
+      if (path === "env") {
+        paths.push(path);
+        continue;
+      }
+      const beforeRecord = asRecord(before[key]);
+      const afterRecord = asRecord(after[key]);
+      if (beforeRecord && afterRecord) {
+        const nested = changedAdapterConfigPaths(beforeRecord, afterRecord, path);
+        paths.push(...(nested.length > 0 ? nested : [path]));
+      } else {
+        paths.push(path);
+      }
+    }
+    return paths.sort();
+  }
+
+  function restoreAdapterConfigPath(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+    path: string,
+  ) {
+    const parts = path.split(".");
+    const leaf = parts.pop();
+    if (!leaf) return;
+    let targetCursor = target;
+    let sourceCursor = source;
+    for (const part of parts) {
+      const sourceChild = asRecord(sourceCursor[part]);
+      if (!sourceChild) return;
+      const targetChild = asRecord(targetCursor[part]);
+      targetCursor[part] = targetChild ? { ...targetChild } : {};
+      targetCursor = targetCursor[part] as Record<string, unknown>;
+      sourceCursor = sourceChild;
+    }
+    if (Object.hasOwn(sourceCursor, leaf)) targetCursor[leaf] = sourceCursor[leaf];
+    else delete targetCursor[leaf];
+  }
+
+  function adapterConfigValueShape(value: unknown) {
+    if (Array.isArray(value)) return { type: "array", count: value.length };
+    const record = asRecord(value);
+    if (record) return { type: "object", count: Object.keys(record).length };
+    return { type: value === null ? "null" : typeof value, count: value === undefined ? 0 : 1 };
+  }
+
+  function readAdapterConfigPath(config: Record<string, unknown>, path: string): unknown {
+    let value: unknown = config;
+    for (const part of path.split(".")) {
+      const record = asRecord(value);
+      if (!record) return undefined;
+      value = record[part];
+    }
+    return value;
+  }
+
+  type AdapterConfigMutation = {
+    changedPaths: string[];
+    skippedPaths: string[];
+    fields: Array<{ path: string; type: string; count: number }>;
+  };
+
+  function applyAdapterConfigUserLockPolicy(input: {
+    actorType: "board" | "agent" | "none";
+    existing: Record<string, unknown>;
+    requested: Record<string, unknown>;
+    effective: Record<string, unknown>;
+  }): { config: Record<string, unknown>; mutation: AdapterConfigMutation | null } {
+    const attemptedPaths = changedAdapterConfigPaths(input.existing, input.effective);
+    if (input.actorType === "board") {
+      const baseLocks = hasOwn(input.requested, "_userLocked")
+        ? readAdapterConfigUserLocks(input.requested)
+        : readAdapterConfigUserLocks(input.existing);
+      return {
+        config: {
+          ...input.effective,
+          _userLocked: Array.from(new Set([...baseLocks, ...attemptedPaths])).sort(),
+        },
+        mutation: null,
+      };
+    }
+
+    const existingLocks = readAdapterConfigUserLocks(input.existing);
+    const skippedLocks = Array.from(new Set(attemptedPaths.flatMap((attemptedPath) =>
+      existingLocks.filter((lockedPath) =>
+        attemptedPath === lockedPath
+        || attemptedPath.startsWith(`${lockedPath}.`)
+        || lockedPath.startsWith(`${attemptedPath}.`),
+      ),
+    )));
+    const config = { ...input.effective };
+    for (const lockedPath of skippedLocks) {
+      restoreAdapterConfigPath(config, input.existing, lockedPath);
+    }
+    config._userLocked = existingLocks;
+    return {
+      config,
+      mutation: {
+        changedPaths: changedAdapterConfigPaths(input.existing, config),
+        skippedPaths: attemptedPaths.filter((path) =>
+          adapterConfigPathIsUserLocked(input.existing, path),
+        ),
+        fields: attemptedPaths.map((path) => ({
+          path,
+          ...adapterConfigValueShape(readAdapterConfigPath(config, path)),
+        })),
+      },
+    };
+  }
+
+  async function commentOnLinkedParentForAdapterConfigMutation(input: {
+    companyId: string;
+    agentId: string;
+    agentName: string;
+    runId: string | null;
+    changedPaths: string[];
+    skippedPaths: string[];
+    fields: Array<{ path: string; type: string; count: number }>;
+  }) {
+    if (!input.runId) return;
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.id, input.runId), eq(heartbeatRuns.companyId, input.companyId)))
+      .then((rows) => rows[0] ?? null);
+    const linkedIssueId = readRunIssueId(asRecord(run?.contextSnapshot));
+    if (!linkedIssueId) return;
+    const linkedIssue = await db
+      .select({ id: issuesTable.id, parentId: issuesTable.parentId })
+      .from(issuesTable)
+      .where(and(eq(issuesTable.id, linkedIssueId), eq(issuesTable.companyId, input.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!linkedIssue) return;
+
+    const fieldRows = input.fields.map((field) =>
+      `- \`${field.path}\`: ${field.type}, count ${field.count}`,
+    );
+    await issuesSvc.addComment(
+      linkedIssue.parentId ?? linkedIssue.id,
+      [
+        "## Agent adapter config update",
+        "",
+        `Agent \`${input.agentName}\` attempted an adapter configuration update.`,
+        "",
+        ...fieldRows,
+        `- Changed fields: ${input.changedPaths.length}`,
+        `- Skipped user-locked fields: ${input.skippedPaths.length}`,
+      ].join("\n"),
+      { agentId: input.agentId, runId: input.runId },
+    );
+  }
+
   function asNonEmptyString(value: unknown): string | null {
     if (typeof value !== "string") return null;
     const trimmed = value.trim();
@@ -1887,7 +2067,15 @@ export function agentRoutes(
       if (!agent) return;
       await assertCanUpdateAgent(req, agent);
 
-      const requestedSkills = normalizeDesiredSkillSelections(req.body.desiredSkills);
+      const actor = getActorInfo(req);
+      const desiredSkillsLocked = actor.actorType === "agent"
+        && adapterConfigPathIsUserLocked(
+          agent.adapterConfig as Record<string, unknown>,
+          "paperclipSkillSync.desiredSkills",
+        );
+      const requestedSkills = desiredSkillsLocked
+        ? readPaperclipSkillSyncPreference(agent.adapterConfig as Record<string, unknown>).desiredSkillEntries
+        : normalizeDesiredSkillSelections(req.body.desiredSkills);
       const {
         adapterConfig: nextAdapterConfig,
         desiredSkills,
@@ -1906,16 +2094,17 @@ export function agentRoutes(
       if (!desiredSkills || !desiredSkillEntries || !runtimeSkillEntries) {
         throw unprocessable("Skill sync requires desiredSkills.");
       }
-      const actor = getActorInfo(req);
-      const updated = await svc.update(agent.id, {
-        adapterConfig: nextAdapterConfig,
-      }, {
-        recordRevision: {
-          createdByAgentId: actor.agentId,
-          createdByUserId: actor.actorType === "user" ? actor.actorId : null,
-          source: "skill-sync",
-        },
-      });
+      const updated = desiredSkillsLocked
+        ? agent
+        : await svc.update(agent.id, {
+            adapterConfig: nextAdapterConfig,
+          }, {
+            recordRevision: {
+              createdByAgentId: actor.agentId,
+              createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+              source: "skill-sync",
+            },
+          });
       if (!updated) {
         res.status(404).json({ error: "Agent not found" });
         return;
@@ -1932,7 +2121,7 @@ export function agentRoutes(
         ...runtimeConfig,
         paperclipRuntimeSkills: runtimeSkillEntries,
       };
-      const snapshot = adapter?.syncSkills
+      const rawSnapshot = adapter?.syncSkills
         ? await adapter.syncSkills({
             agentId: updated.id,
             companyId: updated.companyId,
@@ -1947,6 +2136,15 @@ export function agentRoutes(
               config: runtimeSkillConfig,
             })
           : buildUnsupportedSkillSnapshot(updated.adapterType, desiredSkillEntries);
+      const snapshot = desiredSkillsLocked
+        ? {
+            ...rawSnapshot,
+            warnings: [
+              ...rawSnapshot.warnings,
+              "Skipped user-locked paperclipSkillSync.desiredSkills update.",
+            ],
+          }
+        : rawSnapshot;
 
       await logActivity(db, {
         companyId: updated.companyId,
@@ -1968,6 +2166,43 @@ export function agentRoutes(
           warningCount: snapshot.warnings.length,
         },
       });
+
+      if (actor.actorType === "agent") {
+        const adapterConfigMutation = {
+          changedPaths: desiredSkillsLocked ? [] : ["paperclipSkillSync.desiredSkills"],
+          skippedPaths: desiredSkillsLocked ? ["paperclipSkillSync.desiredSkills"] : [],
+          fields: [{
+            path: "paperclipSkillSync.desiredSkills",
+            type: "array",
+            count: requestedSkills?.length ?? 0,
+          }],
+        };
+        await logActivity(db, {
+          companyId: updated.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          action: desiredSkillsLocked
+            ? "agent.adapter_config_change_skipped"
+            : "agent.adapter_config_changed",
+          entityType: "agent",
+          entityId: updated.id,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          details: {
+            fields: adapterConfigMutation.fields,
+            changedCount: adapterConfigMutation.changedPaths.length,
+            skippedCount: adapterConfigMutation.skippedPaths.length,
+          },
+        });
+        await commentOnLinkedParentForAdapterConfigMutation({
+          companyId: updated.companyId,
+          agentId: actor.agentId!,
+          agentName: updated.name,
+          runId: actor.runId ?? null,
+          ...adapterConfigMutation,
+        });
+      }
 
       res.json(snapshot);
     },
@@ -2949,6 +3184,7 @@ export function agentRoutes(
     }
 
     const patchData = { ...(req.body as Record<string, unknown>) };
+    let adapterConfigMutation: AdapterConfigMutation | null = null;
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
     delete patchData.replaceAdapterConfig;
     if (hasOwn(patchData, "adapterConfig")) {
@@ -2999,7 +3235,7 @@ export function agentRoutes(
       }
       let rawEffectiveAdapterConfig = requestedAdapterConfig ?? existingAdapterConfig;
       if (requestedAdapterConfig && !changingAdapterType && !replaceAdapterConfig) {
-        rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...requestedAdapterConfig };
+        rawEffectiveAdapterConfig = mergeAdapterConfigPatch(existingAdapterConfig, requestedAdapterConfig);
       }
       if (changingAdapterType) {
         // Preserve adapter-agnostic keys (env, cwd, etc.) from the existing config
@@ -3015,6 +3251,16 @@ export function agentRoutes(
           existingAdapterConfig,
           rawEffectiveAdapterConfig,
         );
+      }
+      if (requestedAdapterConfig) {
+        const lockPolicy = applyAdapterConfigUserLockPolicy({
+          actorType: req.actor.type,
+          existing: existingAdapterConfig,
+          requested: requestedAdapterConfig,
+          effective: rawEffectiveAdapterConfig,
+        });
+        rawEffectiveAdapterConfig = lockPolicy.config;
+        adapterConfigMutation = lockPolicy.mutation;
       }
       const effectiveAdapterConfig = applyCodexLocalKeyIsolation(
         existing.companyId,
@@ -3088,6 +3334,34 @@ export function agentRoutes(
       entityId: agent.id,
       details: summarizeAgentUpdateDetails(patchData),
     });
+
+    if (adapterConfigMutation) {
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        action: adapterConfigMutation.skippedPaths.length > 0
+          ? "agent.adapter_config_change_skipped"
+          : "agent.adapter_config_changed",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          fields: adapterConfigMutation.fields,
+          changedCount: adapterConfigMutation.changedPaths.length,
+          skippedCount: adapterConfigMutation.skippedPaths.length,
+        },
+      });
+      await commentOnLinkedParentForAdapterConfigMutation({
+        companyId: agent.companyId,
+        agentId: actor.agentId!,
+        agentName: agent.name,
+        runId: actor.runId ?? null,
+        ...adapterConfigMutation,
+      });
+    }
 
     res.json(agent);
   });

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -3,7 +3,11 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readPaperclipSkillSyncPreference, writePaperclipSkillSyncPreference } from "@paperclipai/adapter-utils/server-utils";
+import {
+  adapterConfigPathIsUserLocked,
+  readPaperclipSkillSyncPreference,
+  writePaperclipSkillSyncPreference,
+} from "@paperclipai/adapter-utils/server-utils";
 import { and, desc, eq, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, builtInManagedResources, companies, issueThreadInteractions, issues, routines, routineTriggers } from "@paperclipai/db";
@@ -1062,12 +1066,32 @@ export function builtInAgentService(db: Db) {
   }
 
   async function syncBundledSkillToAgent(agent: Agent, skill: CompanySkill) {
-    const desired = readPaperclipSkillSyncPreference(agent.adapterConfig as Record<string, unknown>).desiredSkillEntries;
+    const currentConfig = agent.adapterConfig as Record<string, unknown>;
+    if (adapterConfigPathIsUserLocked(currentConfig, "paperclipSkillSync.desiredSkills")) {
+      console.warn(
+        `Built-in skill sync skipped user-locked paperclipSkillSync.desiredSkills for agent ${agent.id}`,
+      );
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "system",
+        actorId: "built-in-agent-service",
+        action: "agent.adapter_config_change_skipped",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          fields: [{ path: "paperclipSkillSync.desiredSkills", type: "array", count: 1 }],
+          changedCount: 0,
+          skippedCount: 1,
+        },
+      });
+      return agent;
+    }
+    const desired = readPaperclipSkillSyncPreference(currentConfig).desiredSkillEntries;
     const nextDesired = [
       ...desired.filter((entry) => entry.key !== skill.key),
       { key: skill.key, versionId: skill.currentVersionId ?? null },
     ];
-    const adapterConfig = writePaperclipSkillSyncPreference(agent.adapterConfig as Record<string, unknown>, nextDesired);
+    const adapterConfig = writePaperclipSkillSyncPreference(currentConfig, nextDesired);
     const updated = await agentSvc.update(agent.id, { adapterConfig }, {
       allowBuiltInAgentMetadata: true,
       recordRevision: { source: "built-in-bundle:skill-sync" },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for managing AI-agent companies and their runtime configuration
> - Agent adapter configuration mutations are protected by a user-lock policy and recorded in the activity log
> - The PATCH route derived policy attribution directly from `req.actor.type` while audit attribution used `getActorInfo(req)`
> - Board callers therefore appeared as `board` to policy code but as `user` to the canonical audit path
> - This pull request computes canonical actor information once and supplies it consistently to policy, revision, and activity code
> - The benefit is one attribution contract with regression coverage for both user and agent callers

## Linked Issues or Issue Description

- Closes #10182
- Refs #10193

## What Changed

- Changed the adapter-config user-lock policy to consume canonical `user | agent` actor types from `getActorInfo(req)`
- Reused one actor value throughout the agent PATCH handler
- Added route tests proving lock behavior and activity attribution agree for user and agent PATCH requests

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-instructions-routes.test.ts` (15 passed)
- `pnpm typecheck` (passed)
- `git diff --check` (passed)
- `pnpm lint` is unavailable because this repository has no root lint script
- `pnpm test` encountered unrelated failures in `heartbeat-workspace-branch-containment.test.ts` and `issue-monitor-scheduler.test.ts`, then exceeded 10 minutes

## Risks

- Low risk: this narrows policy input to the canonical actor vocabulary without changing authorization decisions
- Repository-wide test failures remain for maintainers to assess; the focused route suite and full typecheck are green

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI `openai/gpt-5.6-sol` with reasoning, repository tools, code execution, and test execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: no user-facing contract changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
