### PR TITLE
fix(heartbeat): skip stale deferred wakes in the finalization promotion loop

### DIFF
--- a/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
@@ -1,0 +1,497 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companySkills,
+  companies,
+  createDb,
+  environmentLeases,
+  environments,
+  executionWorkspaces,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Deferred handoff staleness test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres deferred handoff staleness tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
+const DEFERRED_CONTEXT_KEY = "_paperclipWakeContext";
+
+describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-deferred-handoff-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
+      if (!hasActiveRun) {
+        idlePolls += 1;
+        if (idlePolls >= 3) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    const runIds = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .then((runs) => runs.map((run) => run.id));
+    await Promise.all(runIds.map((runId) => heartbeat.waitForRunExecutionDrain(runId)));
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Deferred handoff staleness test run.",
+      provider: "test",
+      model: "test-model",
+    }));
+    runningProcesses.clear();
+    await db.delete(environmentLeases);
+    await db.delete(activityLog);
+    await db.delete(companySkills);
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(environments);
+    await db.delete(workspaceOperations);
+    await db.delete(executionWorkspaces);
+    await db.delete(environmentLeases);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      try {
+        await db.transaction(async (tx) => {
+          await tx.delete(companySkills);
+          await tx.delete(companies);
+        });
+        break;
+      } catch (error) {
+        if (attempt === 4) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgents() {
+    const companyId = randomUUID();
+    const producerId = randomUUID();
+    const reviewerId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    for (const [agentId, name] of [
+      [producerId, "Producer"],
+      [reviewerId, "Reviewer"],
+    ] as const) {
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name,
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: 2,
+          },
+        },
+        permissions: {},
+      });
+    }
+    return { companyId, producerId, reviewerId };
+  }
+
+  it("promotes a changes-requested handoff wake past a stale deferred reviewer wake", async () => {
+    const { companyId, producerId, reviewerId } = await seedCompanyAndAgents();
+    const issueId = randomUUID();
+    const stageId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Packet under review",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: reviewerId,
+      responsibleUserId: "responsible-user",
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerId, userId: null },
+        returnAssignee: { type: "agent", agentId: producerId, userId: null },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        reviewRequest: null,
+      },
+    });
+
+    // Leftover reviewer wake from a previous cycle: the stage has since moved on,
+    // so promoting it can only produce a run that is immediately stale-cancelled.
+    const staleWakeId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: staleWakeId,
+      companyId,
+      agentId: reviewerId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      status: "deferred_issue_execution",
+      requestedAt: new Date(Date.now() - 60 * 60_000),
+      payload: {
+        issueId,
+        mutation: "update",
+        [DEFERRED_CONTEXT_KEY]: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_review_requested",
+          source: "issue.execution_stage",
+        },
+      },
+    });
+
+    // The reviewer run requests changes mid-run: the issue flips to the producer
+    // and the producer's handoff wake is parked behind the stale head.
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await db
+        .update(issues)
+        .set({
+          status: "in_progress",
+          assigneeAgentId: producerId,
+          executionState: {
+            status: "changes_requested",
+            currentStageId: null,
+            currentStageType: "review",
+            currentParticipant: null,
+            returnAssignee: { type: "agent", agentId: producerId, userId: null },
+            completedStageIds: [],
+            lastDecisionId: randomUUID(),
+            lastDecisionOutcome: "changes_requested",
+            reviewRequest: null,
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      const handoffWake = await heartbeat.wakeup(producerId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "execution_changes_requested",
+        payload: {
+          issueId,
+          mutation: "update",
+          executionStage: {
+            stageId,
+            wakeRole: "executor",
+            stageType: "review",
+            allowedActions: ["address_changes", "resubmit"],
+          },
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_changes_requested",
+          source: "issue.execution_stage",
+        },
+      });
+      expect(handoffWake).toBeNull();
+
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Reviewer requested changes.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    await heartbeat.wakeup(reviewerId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "execution_review_requested",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "execution_review_requested",
+        source: "issue.execution_stage",
+      },
+    });
+
+    const producerRan = await waitForCondition(async () => {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.agentId, producerId), eq(heartbeatRuns.companyId, companyId)));
+      return runs.some((run) => run.status === "succeeded" || run.status === "running");
+    });
+    expect(producerRan).toBe(true);
+
+    const staleWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, staleWakeId))
+      .then((rows) => rows[0]);
+    expect(staleWake.status).toBe("skipped");
+    expect(staleWake.runId).toBeNull();
+    expect(staleWake.error).toContain("assignee changed");
+
+    const staleRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.wakeupRequestId, staleWakeId));
+    expect(staleRuns).toHaveLength(0);
+
+    const handoffWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, producerId),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .then((rows) => rows[0]);
+    expect(handoffWake.status).not.toBe("deferred_issue_execution");
+  }, 30_000);
+
+  it("promotes a resubmission review wake past a stale deferred executor wake", async () => {
+    const { companyId, producerId, reviewerId } = await seedCompanyAndAgents();
+    const issueId = randomUUID();
+    const stageId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Packet being remediated",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: producerId,
+      responsibleUserId: "responsible-user",
+      executionState: {
+        status: "changes_requested",
+        currentStageId: null,
+        currentStageType: "review",
+        currentParticipant: null,
+        returnAssignee: { type: "agent", agentId: producerId, userId: null },
+        completedStageIds: [],
+        lastDecisionId: randomUUID(),
+        lastDecisionOutcome: "changes_requested",
+        reviewRequest: null,
+      },
+    });
+
+    // Stale executor wake from the earlier changes_requested cycle.
+    const staleWakeId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: staleWakeId,
+      companyId,
+      agentId: producerId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      status: "deferred_issue_execution",
+      requestedAt: new Date(Date.now() - 60 * 60_000),
+      payload: {
+        issueId,
+        mutation: "update",
+        [DEFERRED_CONTEXT_KEY]: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_changes_requested",
+          source: "issue.execution_stage",
+        },
+      },
+    });
+
+    // The producer resubmits mid-run: issue flips back to in_review with the
+    // reviewer as participant, and the reviewer wake is parked behind the stale head.
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      await db
+        .update(issues)
+        .set({
+          status: "in_review",
+          assigneeAgentId: reviewerId,
+          executionState: {
+            status: "pending",
+            currentStageId: stageId,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: reviewerId, userId: null },
+            returnAssignee: { type: "agent", agentId: producerId, userId: null },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: "changes_requested",
+            reviewRequest: null,
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      const reviewWake = await heartbeat.wakeup(reviewerId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "execution_review_requested",
+        payload: {
+          issueId,
+          mutation: "update",
+          executionStage: {
+            stageId,
+            wakeRole: "reviewer",
+            stageType: "review",
+            allowedActions: ["approve", "request_changes"],
+          },
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "execution_review_requested",
+          source: "issue.execution_stage",
+        },
+      });
+      expect(reviewWake).toBeNull();
+
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Producer resubmitted.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    await heartbeat.wakeup(producerId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    const reviewerRan = await waitForCondition(async () => {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.agentId, reviewerId), eq(heartbeatRuns.companyId, companyId)));
+      return runs.some((run) => run.status === "succeeded" || run.status === "running");
+    });
+    expect(reviewerRan).toBe(true);
+
+    const staleWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, staleWakeId))
+      .then((rows) => rows[0]);
+    expect(staleWake.status).toBe("skipped");
+    expect(staleWake.runId).toBeNull();
+
+    const staleRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.wakeupRequestId, staleWakeId));
+    expect(staleRuns).toHaveLength(0);
+  }, 30_000);
+});

--- a/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
@@ -494,4 +494,110 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
       .where(eq(heartbeatRuns.wakeupRequestId, staleWakeId));
     expect(staleRuns).toHaveLength(0);
   }, 30_000);
+
+  it("promotes a deferred unblock-owner wake even though the owner is not the assignee", async () => {
+    const { companyId, producerId, reviewerId } = await seedCompanyAndAgents();
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Packet that will block mid-run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: producerId,
+      responsibleUserId: "responsible-user",
+    });
+
+    // Mid-run the executor blocks the issue and names the reviewer as unblock
+    // owner. The owner wake is requested while the producer run is active, so
+    // it parks as deferred behind that run.
+    mockAdapterExecute.mockImplementationOnce(async () => {
+      const unblockDescriptor = {
+        owner: { agentId: reviewerId },
+        action: "Decide the unblock path",
+      };
+      await db
+        .update(issues)
+        .set({
+          status: "blocked",
+          blockedTransitionAt: new Date(),
+          unblockDescriptor,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, issueId));
+
+      const ownerWake = await heartbeat.wakeup(reviewerId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_unblock_requested",
+        payload: {
+          issueId,
+          action: unblockDescriptor.action,
+        },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_unblock_requested",
+          wakeSource: "automation",
+        },
+      });
+      expect(ownerWake).toBeNull();
+
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Producer blocked the issue.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    await heartbeat.wakeup(producerId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    // The finalization promotion loop must not cancel the parked owner wake on
+    // an assignee mismatch: the unblock owner is deliberately not the assignee.
+    // Promotion links the wake to a run (runId set). Whether that run then
+    // survives the claim-time gates is the claim path's own judgment.
+    const promoted = await waitForCondition(async () => {
+      const wake = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, reviewerId),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .then((rows) => rows[0]);
+      return wake?.runId != null || wake?.status === "completed";
+    });
+    expect(promoted).toBe(true);
+
+    const unblockWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, reviewerId),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .then((rows) => rows[0]);
+    expect(unblockWake.runId).not.toBeNull();
+  }, 30_000);
 });

--- a/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
@@ -546,6 +546,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
           taskId: issueId,
           wakeReason: "issue_unblock_requested",
           wakeSource: "automation",
+          skipIssueComment: true,
         },
       });
       expect(ownerWake).toBeNull();
@@ -576,11 +577,22 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
 
     // The finalization promotion loop must not cancel the parked owner wake on
     // an assignee mismatch: the unblock owner is deliberately not the assignee.
-    // Promotion links the wake to a run (runId set). Whether that run then
-    // survives the claim-time gates is the claim path's own judgment.
-    const promoted = await waitForCondition(async () => {
+    // The claim-time gate must preserve that same exact, still-blocked owner
+    // wake through adapter execution instead of merely assigning it a runId
+    // before cancelling it as stale.
+    const ownerRunSucceeded = await waitForCondition(async () => {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.agentId, reviewerId), eq(heartbeatRuns.companyId, companyId)));
+      return runs.some((run) => run.status === "succeeded");
+    });
+    expect(ownerRunSucceeded).toBe(true);
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(2);
+
+    const unblockWakeCompleted = await waitForCondition(async () => {
       const wake = await db
-        .select()
+        .select({ status: agentWakeupRequests.status })
         .from(agentWakeupRequests)
         .where(
           and(
@@ -590,9 +602,9 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
           ),
         )
         .then((rows) => rows[0]);
-      return wake?.runId != null || wake?.status === "completed";
+      return wake?.status === "completed";
     });
-    expect(promoted).toBe(true);
+    expect(unblockWakeCompleted).toBe(true);
 
     const unblockWake = await db
       .select()
@@ -605,6 +617,87 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
         ),
       )
       .then((rows) => rows[0]);
+    expect(unblockWake.status).toBe("completed");
+    expect(unblockWake.error).toBeNull();
     expect(unblockWake.runId).not.toBeNull();
+
+    const unblockRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, unblockWake.runId!))
+      .then((rows) => rows[0]);
+    expect(unblockRun.status).toBe("succeeded");
+  }, 30_000);
+
+  it("cancels an unblock wake when its non-assignee target is not the exact blocked owner", async () => {
+    const { companyId, producerId, reviewerId } = await seedCompanyAndAgents();
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Packet with a different unblock owner",
+      status: "blocked",
+      priority: "high",
+      assigneeAgentId: producerId,
+      responsibleUserId: "responsible-user",
+      blockedTransitionAt: new Date(),
+      unblockDescriptor: {
+        owner: { agentId: producerId },
+        action: "Decide the unblock path",
+      },
+    });
+
+    await heartbeat.wakeup(reviewerId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_unblock_requested",
+      payload: { issueId, action: "Decide the unblock path" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_unblock_requested",
+        wakeSource: "automation",
+      },
+    });
+
+    const mismatchWakeWasSkipped = await waitForCondition(async () => {
+      const wake = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, reviewerId),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .then((rows) => rows[0]);
+      return wake?.status === "skipped";
+    });
+    expect(mismatchWakeWasSkipped).toBe(true);
+
+    const mismatchWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, reviewerId),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .then((rows) => rows[0]);
+    expect(mismatchWake.error).toContain("assignee changed");
+    expect(mismatchWake.runId).not.toBeNull();
+
+    const mismatchRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, mismatchWake.runId!))
+      .then((rows) => rows[0]);
+    expect(mismatchRun.status).toBe("cancelled");
+    expect(mismatchRun.errorCode).toBe("issue_assignee_changed");
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
   }, 30_000);
 });

--- a/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
@@ -241,6 +241,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
           taskId: issueId,
           wakeReason: "execution_review_requested",
           source: "issue.execution_stage",
+          skipIssueComment: true,
         },
       },
     });
@@ -287,6 +288,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
           taskId: issueId,
           wakeReason: "execution_changes_requested",
           source: "issue.execution_stage",
+          skipIssueComment: true,
         },
       });
       expect(handoffWake).toBeNull();
@@ -312,6 +314,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
         taskId: issueId,
         wakeReason: "execution_review_requested",
         source: "issue.execution_stage",
+        skipIssueComment: true,
       },
     });
 
@@ -398,6 +401,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
           taskId: issueId,
           wakeReason: "execution_changes_requested",
           source: "issue.execution_stage",
+          skipIssueComment: true,
         },
       },
     });
@@ -444,6 +448,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
           taskId: issueId,
           wakeReason: "execution_review_requested",
           source: "issue.execution_stage",
+          skipIssueComment: true,
         },
       });
       expect(reviewWake).toBeNull();
@@ -468,6 +473,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
         issueId,
         taskId: issueId,
         wakeReason: "issue_assigned",
+        skipIssueComment: true,
       },
     });
 
@@ -564,6 +570,7 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
         issueId,
         taskId: issueId,
         wakeReason: "issue_assigned",
+        skipIssueComment: true,
       },
     });
 

--- a/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
+++ b/server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts
@@ -23,7 +23,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { heartbeatService } from "../services/heartbeat.ts";
+import { WORKSPACE_BUSY_RETRY_REASON, heartbeatService } from "../services/heartbeat.ts";
 import { runningProcesses } from "../adapters/index.ts";
 
 const mockAdapterExecute = vi.hoisted(() =>
@@ -193,6 +193,31 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
       });
     }
     return { companyId, producerId, reviewerId };
+  }
+
+  async function insertDeferredWake(input: {
+    companyId: string;
+    issueId: string;
+    agentId: string;
+    contextSnapshot: Record<string, unknown>;
+  }) {
+    const id = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      status: "deferred_issue_execution",
+      requestedAt: new Date(Date.now() - 60 * 60_000),
+      payload: {
+        issueId: input.issueId,
+        mutation: "update",
+        [DEFERRED_CONTEXT_KEY]: input.contextSnapshot,
+      },
+    });
+    return id;
   }
 
   it("promotes a changes-requested handoff wake past a stale deferred reviewer wake", async () => {
@@ -499,6 +524,132 @@ describeEmbeddedPostgres("heartbeat deferred handoff wake staleness", () => {
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.wakeupRequestId, staleWakeId));
     expect(staleRuns).toHaveLength(0);
+  }, 30_000);
+
+  it("promotes and runs a deferred non-assignee workspace-busy retry", async () => {
+    const { companyId, producerId, reviewerId } = await seedCompanyAndAgents();
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Packet with a deferred non-assignee retry",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: producerId,
+      responsibleUserId: "responsible-user",
+    });
+
+    const workspaceBusyWakeId = await insertDeferredWake({
+      companyId,
+      issueId,
+      agentId: reviewerId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "workspace_busy_retry",
+        retryReason: WORKSPACE_BUSY_RETRY_REASON,
+        workspaceBusyDeferredWhileAssignee: false,
+        skipIssueComment: true,
+      },
+    });
+
+    await heartbeat.wakeup(producerId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+        skipIssueComment: true,
+      },
+    });
+
+    const workspaceBusyWakeCompleted = await waitForCondition(async () => {
+      const wake = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, workspaceBusyWakeId))
+        .then((rows) => rows[0]);
+      return wake?.status === "completed";
+    });
+    expect(workspaceBusyWakeCompleted).toBe(true);
+
+    const workspaceBusyWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, workspaceBusyWakeId))
+      .then((rows) => rows[0]);
+    expect(workspaceBusyWake.status).toBe("completed");
+    expect(workspaceBusyWake.error).toBeNull();
+    expect(workspaceBusyWake.runId).not.toBeNull();
+
+    const workspaceBusyRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, workspaceBusyWake.runId!))
+      .then((rows) => rows[0]);
+    expect(workspaceBusyRun.status).toBe("succeeded");
+  }, 30_000);
+
+  it("still skips an ordinary deferred non-assignee wake", async () => {
+    const { companyId, producerId, reviewerId } = await seedCompanyAndAgents();
+    const issueId = randomUUID();
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Packet with a stale ordinary non-assignee wake",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: producerId,
+      responsibleUserId: "responsible-user",
+    });
+
+    const ordinaryWakeId = await insertDeferredWake({
+      companyId,
+      issueId,
+      agentId: reviewerId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+        skipIssueComment: true,
+      },
+    });
+
+    await heartbeat.wakeup(producerId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+        skipIssueComment: true,
+      },
+    });
+
+    const ordinaryWakeSkipped = await waitForCondition(async () => {
+      const wake = await db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, ordinaryWakeId))
+        .then((rows) => rows[0]);
+      return wake?.status === "skipped";
+    });
+    expect(ordinaryWakeSkipped).toBe(true);
+
+    const ordinaryWake = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, ordinaryWakeId))
+      .then((rows) => rows[0]);
+    expect(ordinaryWake.error).toContain("assignee changed");
+    expect(ordinaryWake.runId).toBeNull();
   }, 30_000);
 
   it("promotes a deferred unblock-owner wake even though the owner is not the assignee", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12651,6 +12651,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        unblockDescriptor: issues.unblockDescriptor,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -12669,6 +12670,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const isInteractionWake = allowsIssueInteractionWake(context);
     const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
+    // An unblock-owner wake is intentionally addressed to the blocked issue's
+    // descriptor owner rather than its assignee. Preserve only that exact,
+    // still-blocked agent wake through the ordinary claim-time staleness gate.
+    const unblockOwner = issue.unblockDescriptor?.owner;
+    const isExactBlockedUnblockOwnerWake =
+      wakeReason === "issue_unblock_requested" &&
+      issue.status === "blocked" &&
+      unblockOwner != null &&
+      unblockOwner !== "board" &&
+      typeof unblockOwner === "object" &&
+      "agentId" in unblockOwner &&
+      unblockOwner.agentId === run.agentId;
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
     const interactionResolvedAt = readNonEmptyString(context.interactionResolvedAt);
     const hasResolvedInteractionEvidence = interactionResolvedAt !== null && !Number.isNaN(Date.parse(interactionResolvedAt));
@@ -12714,7 +12727,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issue.assigneeAgentId !== run.agentId &&
       !isInteractionWake &&
       !isCurrentReviewParticipant &&
-      !isNonAssigneeWorkspaceBusyRetry(retryReason, context)
+      !isNonAssigneeWorkspaceBusyRetry(retryReason, context) &&
+      !isExactBlockedUnblockOwnerWake
     ) {
       return {
         stale: true,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16664,6 +16664,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        const deferredRetryReason = readNonEmptyString(deferredContextSeed.retryReason);
         // Local-CLI agents post comments under user auth, so a self-comment from
         // the run that is now ending would otherwise look like a real human
         // comment and trigger a reopen on the very issue this run just closed.
@@ -16784,6 +16785,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           !deferredIsInteractionWake &&
           !deferredIsCurrentReviewParticipant &&
           !deferredIsCommentDrivenWake &&
+          !isNonAssigneeWorkspaceBusyRetry(deferredRetryReason, deferredContextSeed) &&
           !deferredIsUnblockOwnerWake
             ? "Cancelled because issue assignee changed before the queued run could start; the new owner will be woken instead"
             : (issue.status === "done" || issue.status === "cancelled") &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16751,12 +16751,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const deferredIsCurrentReviewParticipant =
           deferredReviewParticipant?.type === "agent" &&
           deferredReviewParticipant.agentId === deferred.agentId;
+        // An unblock-owner wake targets the unblockDescriptor owner, who is
+        // deliberately not the assignee. Never cancel such a wake on assignee
+        // mismatch while the issue is still blocked under that same owner;
+        // its staleness is judged at claim time, like any other promoted wake.
+        const deferredOwner = issue.unblockDescriptor?.owner;
+        const deferredIsUnblockOwnerWake =
+          deferredWakeReason === "issue_unblock_requested" &&
+          issue.status === "blocked" &&
+          deferredOwner != null &&
+          deferredOwner !== "board" &&
+          typeof deferredOwner === "object" &&
+          "agentId" in deferredOwner &&
+          deferredOwner.agentId === deferred.agentId;
 
         const deferredStaleError =
           issue.assigneeAgentId !== deferred.agentId &&
           !deferredIsInteractionWake &&
           !deferredIsCurrentReviewParticipant &&
-          !deferredIsCommentDrivenWake
+          !deferredIsCommentDrivenWake &&
+          !deferredIsUnblockOwnerWake
             ? "Cancelled because issue assignee changed before the queued run could start; the new owner will be woken instead"
             : (issue.status === "done" || issue.status === "cancelled") &&
                 !deferredResumeIntent &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16724,6 +16724,64 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
 
+        // Staleness guard: a deferred wake whose target lost the issue while it
+        // was parked must not consume this finalization's promotion. Judge with
+        // the same predicates claimQueuedRun applies when a queued run claims;
+        // skipping a stale head here (instead of promoting it into a run that
+        // is immediately stale-cancelled) lets a fresh handoff wake parked
+        // behind it promote in the same pass rather than starving until
+        // unrelated issue activity.
+        const deferredResumeIntent =
+          deferredContextSeed.resumeIntent === true || deferredContextSeed.followUpRequested === true;
+        const deferredIsInteractionWake = allowsIssueInteractionWake(deferredContextSeed);
+        // Comment/mention wakes are issue-scoped rather than ownership-bound
+        // (see the promotion lock update below): they promote even when the
+        // issue is assigned to another agent, exactly as before this guard —
+        // the claim-time staleness gate remains their judge.
+        const deferredIsCommentDrivenWake =
+          deferredCommentIds.length > 0 ||
+          deferred.source === "comment" ||
+          deferred.triggerDetail === "mention" ||
+          deferredWakeReason === "issue_mention" ||
+          deferredWakeReason === "issue_commented" ||
+          deferredWakeReason === "issue_reopened_via_comment";
+        const deferredReviewExecutionState =
+          issue.status === "in_review" ? parseIssueExecutionState(issue.executionState) : null;
+        const deferredReviewParticipant = deferredReviewExecutionState?.currentParticipant ?? null;
+        const deferredIsCurrentReviewParticipant =
+          deferredReviewParticipant?.type === "agent" &&
+          deferredReviewParticipant.agentId === deferred.agentId;
+
+        const deferredStaleError =
+          issue.assigneeAgentId !== deferred.agentId &&
+          !deferredIsInteractionWake &&
+          !deferredIsCurrentReviewParticipant &&
+          !deferredIsCommentDrivenWake
+            ? "Cancelled because issue assignee changed before the queued run could start; the new owner will be woken instead"
+            : (issue.status === "done" || issue.status === "cancelled") &&
+                !deferredResumeIntent &&
+                deferredCommentIds.length === 0
+              ? `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`
+              : issue.status === "in_review" &&
+                  deferredReviewParticipant &&
+                  !deferredIsCurrentReviewParticipant &&
+                  deferredCommentIds.length === 0
+                ? "Cancelled because the in-review participant changed before the queued run could start; the current participant will be woken instead"
+                : null;
+
+        if (deferredStaleError) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "skipped",
+              finishedAt: new Date(),
+              error: deferredStaleError,
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
+
         const promotedReason = readNonEmptyString(deferred.reason) ?? "issue_execution_promoted";
         const promotedSource =
           (readNonEmptyString(deferred.source) as WakeupOptions["source"]) ?? "automation";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service owns deferred issue wakes and queued-run claim checks.
> - A blocked issue can name a different agent as its unblock owner.
> - The finalization path now promotes that owner wake, but the claim-time assignee check then cancelled it.
> - This pull request preserves only an exact `issue_unblock_requested` wake for the current blocked agent owner.
> - The owner run now reaches the adapter. Other non-assignee wakes still cancel.

## Linked Issues or Issue Description

- Fixes: #10195
- Refs: #9677, #7488

## What Changed

- `server/src/services/heartbeat.ts`: claim-time staleness now reads `unblockDescriptor` and exempts only a wake that is `issue_unblock_requested`, targets the exact `{ agentId }` owner, and finds the issue still `blocked`.
- `server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts`: the deferred unblock-owner regression now waits for adapter execution, a succeeded run, and a completed wake. It no longer accepts a pre-cancellation `runId` as proof of success.
- Added a negative regression. A non-assignee `issue_unblock_requested` wake for a different owner remains skipped. Its run is cancelled with `issue_assignee_changed`, and the adapter does not run.

## Verification

- Strict TDD RED: the strengthened exact-owner test failed before the production change. The promoted run was cancelled with `issue_assignee_changed`; no owner run succeeded.
- Strict TDD GREEN: the exact-owner node passed after the change. The mismatch node also passed.
- `corepack pnpm exec vitest run --project @paperclipai/server --no-file-parallelism --maxWorkers=1 server/src/__tests__/heartbeat-deferred-handoff-staleness.test.ts` — 4 passed.
- Related heartbeat suites — `heartbeat-stale-queue-invalidation`, `heartbeat-issue-liveness-escalation`, and `issue-liveness` — 64 passed.
- `corepack pnpm exec vitest run --project @paperclipai/ui ui/src/lib/blockedInbox.test.ts` — 10 passed.
- `corepack pnpm run preflight:workspace-links` passed. It repaired one ignored stale workspace link only.
- `git diff --check` and the staged security scan passed.
- A fresh read-only reviewer approved the exact staged patch. It reran the 4-test regression successfully.
- The local server TypeScript check was killed with exit 137 because the shared host had 1.9 GiB free RAM and full swap. CI must run the full typecheck.

## Risks

- Low and narrow. The exception applies only to the existing claim-time staleness evaluation for a currently blocked issue with an exact agent owner.
- Board and human owners do not match this exception. Owner mismatches, ordinary non-assignee wakes, dependency gates, terminal checks, review checks, and the queued-to-running compare-and-set remain unchanged.
- No schema, API, or migration change exists.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI `gpt-5.6-terra` through the `openai-codex` provider. The work used tool execution, Corepack pnpm, embedded Postgres tests, and an independent Codex CLI review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (inline comments only; no documentation surface change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending for the new head)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending for the new head)
- [x] I will address all Greptile and reviewer comments before requesting merge
