### PR TITLE
fix(adapter-config): enforce strict allowlist for agent-initiated adapterConfig writes (TEC-7237, TEC-7249, GH-10182)

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2784,6 +2784,27 @@ export function writePaperclipSkillSyncPreference(
   return next;
 }
 
+export function readAdapterConfigUserLocks(config: Record<string, unknown>): string[] {
+  const raw = config._userLocked;
+  if (!Array.isArray(raw)) return [];
+  return Array.from(new Set(raw.flatMap((value) => {
+    if (typeof value !== "string") return [];
+    const path = value.trim();
+    return path ? [path] : [];
+  })));
+}
+
+export function adapterConfigPathIsUserLocked(
+  config: Record<string, unknown>,
+  path: string,
+): boolean {
+  return readAdapterConfigUserLocks(config).some((lockedPath) =>
+    path === lockedPath
+    || path.startsWith(`${lockedPath}.`)
+    || lockedPath.startsWith(`${path}.`),
+  );
+}
+
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,

--- a/packages/shared/src/adapter-agnostic-keys.test.ts
+++ b/packages/shared/src/adapter-agnostic-keys.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_ADAPTER_AGNOSTIC_KEYS = [
   "graceSec",
   "bootstrapPromptTemplate",
   "paperclipSkillSync",
+  "_userLocked",
 ] as const;
 
 function readRepoFile(pathFromRoot: string) {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -89,6 +89,7 @@ export const ADAPTER_AGNOSTIC_KEYS = [
   "graceSec",
   "bootstrapPromptTemplate",
   "paperclipSkillSync",
+  "_userLocked",
 ] as const;
 export type AdapterAgnosticKey = (typeof ADAPTER_AGNOSTIC_KEYS)[number];
 

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -37,6 +37,17 @@ export const upsertAgentInstructionsFileSchema = z.object({
 export type UpsertAgentInstructionsFile = z.infer<typeof upsertAgentInstructionsFileSchema>;
 
 const adapterConfigSchema = z.record(z.string(), z.unknown()).superRefine((value, ctx) => {
+  const userLocked = value._userLocked;
+  if (userLocked !== undefined) {
+    const parsed = z.array(z.string().trim().min(1).max(200)).max(100).safeParse(userLocked);
+    if (!parsed.success || new Set(parsed.data).size !== parsed.data.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "adapterConfig._userLocked must be a unique array of non-empty field paths",
+        path: ["_userLocked"],
+      });
+    }
+  }
   const envValue = value.env;
   if (envValue === undefined) return;
   const parsed = envConfigSchema.safeParse(envValue);

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -607,7 +607,8 @@ describe("agent instructions bundle routes", () => {
       label: "user",
       actor: boardActor(),
       existingAdapterConfig: { model: "gpt-5.4" },
-      expectedModel: "gpt-5.6",
+      requestedAdapterConfig: { model: "gpt-5.6" },
+      expectedAdapterConfig: { model: "gpt-5.6", _userLocked: ["model"] },
       expectedActorType: "user",
     },
     {
@@ -618,14 +619,21 @@ describe("agent instructions bundle routes", () => {
         companyId: "company-1",
         source: "agent_key",
       },
-      existingAdapterConfig: { model: "gpt-5.4", _userLocked: ["model"] },
-      expectedModel: "gpt-5.4",
+      existingAdapterConfig: { paperclipSkillSync: { desiredSkills: ["research"] } },
+      requestedAdapterConfig: {
+        paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+      },
+      expectedAdapterConfig: {
+        paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        _userLocked: [],
+      },
       expectedActorType: "agent",
     },
   ])("uses canonical $label attribution for lock policy and activity", async ({
     actor,
     existingAdapterConfig,
-    expectedModel,
+    requestedAdapterConfig,
+    expectedAdapterConfig,
     expectedActorType,
   }) => {
     mockAgentService.getById.mockResolvedValue({
@@ -635,16 +643,13 @@ describe("agent instructions bundle routes", () => {
 
     const res = await requestApp(await createApp(actor), (baseUrl) => request(baseUrl)
       .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
-      .send({ adapterConfig: { model: "gpt-5.6" } }));
+      .send({ adapterConfig: requestedAdapterConfig }));
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(mockAgentService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
-        adapterConfig: expect.objectContaining({
-          model: expectedModel,
-          _userLocked: ["model"],
-        }),
+        adapterConfig: expect.objectContaining(expectedAdapterConfig),
       }),
       expect.any(Object),
     );

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -688,7 +688,42 @@ describe("agent instructions bundle routes", () => {
     );
   });
 
-  it("skips agent changes to locked fields and surfaces only redacted shapes", async () => {
+  it("allows agent changes to paperclipSkillSync.desiredSkills", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: { desiredSkills: ["research"] },
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      source: "agent_key",
+    }), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.4",
+          paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects agent changes to locked fields and surfaces only redacted shapes", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),
       adapterConfig: {
@@ -715,19 +750,9 @@ describe("agent instructions bundle routes", () => {
         },
       }));
 
-    expect(res.status, JSON.stringify(res.body)).toBe(200);
-    expect(mockAgentService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      expect.objectContaining({
-        adapterConfig: expect.objectContaining({
-          model: "gpt-5.4",
-          command: "codex --profile engineer",
-          env: { SECRET_TOKEN: "old-secret-value" },
-          _userLocked: ["model", "env"],
-        }),
-      }),
-      expect.any(Object),
-    );
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("user-locked fields outside the allowlist: env, model");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -738,8 +763,9 @@ describe("agent instructions bundle routes", () => {
             { path: "env", type: "object", count: 1 },
             { path: "model", type: "string", count: 1 },
           ]),
-          changedCount: 1,
+          changedCount: 0,
           skippedCount: 2,
+          strippedCount: 3,
         },
       }),
     );
@@ -747,7 +773,7 @@ describe("agent instructions bundle routes", () => {
     expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("new-secret-value");
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
       "44444444-4444-4444-8444-444444444444",
-      expect.stringContaining("Skipped user-locked fields: 2"),
+      expect.stringContaining("Stripped fields: 3 (`command`, `env`, `model`)"),
       {
         agentId: "agent-editor",
         runId: "55555555-5555-4555-8555-555555555555",
@@ -757,7 +783,60 @@ describe("agent instructions bundle routes", () => {
     expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("new-secret-value");
   });
 
-  it("preserves a nested locked field when an agent requests full replacement", async () => {
+  it("strips unlocked agent fields, records the strip, and does not introduce env values", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: { desiredSkills: ["research"] },
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        replaceAdapterConfig: true,
+        adapterConfig: {
+          env: { NEW_VAR: "test-placeholder" },
+          instructionsFilePath: "/tmp/untrusted",
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const updatePatch = mockAgentService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch.adapterConfig).toMatchObject({
+      model: "gpt-5.4",
+      paperclipSkillSync: { desiredSkills: ["research"] },
+      _userLocked: [],
+    });
+    expect(JSON.stringify(updatePatch)).not.toContain("NEW_VAR");
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_stripped",
+        details: expect.objectContaining({
+          changedCount: 0,
+          skippedCount: 0,
+          strippedCount: 2,
+        }),
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "44444444-4444-4444-8444-444444444444",
+      expect.stringContaining("Stripped fields: 2 (`env`, `instructionsFilePath`)"),
+      expect.any(Object),
+    );
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("test-placeholder");
+    expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("test-placeholder");
+  });
+
+  it("ignores replace semantics and preserves config when an agent sends only disallowed fields", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),
       adapterConfig: {
@@ -787,8 +866,8 @@ describe("agent instructions bundle routes", () => {
       expect.any(String),
       expect.objectContaining({
         adapterConfig: expect.objectContaining({
-          model: "gpt-5.6",
-          paperclipSkillSync: { desiredSkills: ["research"] },
+          model: "gpt-5.4",
+          paperclipSkillSync: expect.objectContaining({ desiredSkills: ["research"] }),
           _userLocked: ["paperclipSkillSync.desiredSkills"],
         }),
       }),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -841,6 +841,92 @@ describe("agent instructions bundle routes", () => {
     expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("test-placeholder");
   });
 
+  it("does not record a strip when an agent re-sends a value identical to the existing config", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: { desiredSkills: ["research"] },
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      source: "agent_key",
+    }), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          model: "gpt-5.4",
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const updatePatch = mockAgentService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch.adapterConfig).toMatchObject({ model: "gpt-5.4" });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_changed",
+        details: expect.objectContaining({
+          changedCount: 0,
+          skippedCount: 0,
+          strippedCount: 0,
+        }),
+      }),
+    );
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "agent.adapter_config_change_stripped" }),
+    );
+  });
+
+  it("still records a strip when an agent introduces a new value for a disallowed field", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          model: "gpt-5.6",
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const updatePatch = mockAgentService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch.adapterConfig).toMatchObject({ model: "gpt-5.4" });
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_stripped",
+        details: expect.objectContaining({
+          fields: [{ path: "model", type: "string", count: 1 }],
+          changedCount: 0,
+          skippedCount: 0,
+          strippedCount: 1,
+        }),
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "44444444-4444-4444-8444-444444444444",
+      expect.stringContaining("Stripped fields: 1 (`model`)"),
+      expect.any(Object),
+    );
+  });
+
   it("ignores replace semantics and preserves config when an agent sends only disallowed fields", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -602,6 +602,59 @@ describe("agent instructions bundle routes", () => {
     );
   });
 
+  it.each([
+    {
+      label: "user",
+      actor: boardActor(),
+      existingAdapterConfig: { model: "gpt-5.4" },
+      expectedModel: "gpt-5.6",
+      expectedActorType: "user",
+    },
+    {
+      label: "agent",
+      actor: {
+        type: "agent",
+        agentId: "agent-editor",
+        companyId: "company-1",
+        source: "agent_key",
+      },
+      existingAdapterConfig: { model: "gpt-5.4", _userLocked: ["model"] },
+      expectedModel: "gpt-5.4",
+      expectedActorType: "agent",
+    },
+  ])("uses canonical $label attribution for lock policy and activity", async ({
+    actor,
+    existingAdapterConfig,
+    expectedModel,
+    expectedActorType,
+  }) => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: existingAdapterConfig,
+    });
+
+    const res = await requestApp(await createApp(actor), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({ adapterConfig: { model: "gpt-5.6" } }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: expectedModel,
+          _userLocked: ["model"],
+        }),
+      }),
+      expect.any(Object),
+    );
+    const activityEntries = mockLogActivity.mock.calls.map(([, entry]) => entry);
+    expect(activityEntries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: "agent.updated", actorType: expectedActorType }),
+    ]));
+    expect(activityEntries.every((entry) => entry.actorType === expectedActorType)).toBe(true);
+  });
+
   it("allows an explicit unlock while locking fields changed in the same user patch", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -788,6 +788,36 @@ describe("agent instructions bundle routes", () => {
     expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("new-secret-value");
   });
 
+  it("authorizes before recording a denied agent adapter config attempt", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        _userLocked: ["model"],
+      },
+    });
+    mockAccessService.decide.mockResolvedValue({
+      allowed: false,
+      reason: "deny_missing_grant",
+      explanation: "Missing agent_config:update grant",
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({ adapterConfig: { model: "gpt-5.6" } }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
   it("strips unlocked agent fields, records the strip, and does not introduce env values", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -996,6 +996,109 @@ describe("agent instructions bundle routes", () => {
     );
   });
 
+  it("classifies an agent acting on behalf of a user as an agent for the lock policy (TEC-7267)", async () => {
+    // An agent JWT/key acting on behalf of a user populates `onBehalfOfUserId`.
+    // The lock policy must key off `req.actor.type`, not the presence of a
+    // responsible user id — otherwise the agent is misclassified as a user and
+    // the locked `paperclipSkillSync.desiredSkills` restore is bypassed.
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: { desiredSkills: ["research"] },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      onBehalfOfUserId: "88888888-8888-4888-8888-888888888888",
+      onBehalfOfMemberships: [
+        { companyId: "company-1", status: "active", membershipRole: "member" },
+      ],
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const updatePatch = mockAgentService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    // The locked value is restored: the agent's attempted change is discarded.
+    expect(updatePatch.adapterConfig).toMatchObject({
+      paperclipSkillSync: { desiredSkills: ["research"] },
+      _userLocked: ["paperclipSkillSync.desiredSkills"],
+    });
+    // The activity log records the skip rather than a persisted change.
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_skipped",
+        details: expect.objectContaining({
+          changedCount: 0,
+          skippedCount: 1,
+          strippedCount: 0,
+        }),
+      }),
+    );
+    // No `_userLocked` entry is authored for an agent attempt.
+    expect((updatePatch.adapterConfig as Record<string, unknown>)._userLocked)
+      .toEqual(["paperclipSkillSync.desiredSkills"]);
+  });
+
+  it("does not report an allowed nested desiredSkills write as a stripped path (TEC-7267)", async () => {
+    // The allowlist audit path enumeration must reach the leaf so the allowed
+    // `paperclipSkillSync.desiredSkills` write is not misreported as a strip of
+    // its top-level `paperclipSkillSync` parent.
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: { desiredSkills: ["research"] },
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    // The write is persisted as a normal change, not a strip.
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_changed",
+        details: expect.objectContaining({ strippedCount: 0 }),
+      }),
+    );
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "agent.adapter_config_change_stripped" }),
+    );
+    // The linked-parent comment must not report a stripped path.
+    const commentBodies = mockIssueService.addComment.mock.calls.map((call) => String(call[1]));
+    for (const body of commentBodies) {
+      expect(body).not.toContain("Stripped fields: 1");
+      expect(body).not.toContain("`paperclipSkillSync`");
+    }
+  });
+
   it("replaces adapter config when replaceAdapterConfig is true", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...makeAgent(),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -38,6 +38,7 @@ const mockEnvironmentService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockIssueService = vi.hoisted(() => ({ addComment: vi.fn() }));
 const mockSyncInstructionsBundleConfigFromFilePath = vi.hoisted(() => vi.fn());
 const mockFindServerAdapter = vi.hoisted(() => vi.fn());
 
@@ -52,7 +53,7 @@ vi.mock("../services/index.js", () => ({
   environmentService: () => mockEnvironmentService,
   heartbeatService: () => ({}),
   issueApprovalService: () => ({}),
-  issueService: () => ({}),
+  issueService: () => mockIssueService,
   logActivity: mockLogActivity,
   secretService: () => mockSecretService,
   syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
@@ -83,7 +84,7 @@ function registerModuleMocks() {
     budgetService: () => ({}),
     heartbeatService: () => ({}),
     issueApprovalService: () => ({}),
-    issueService: () => ({}),
+    issueService: () => mockIssueService,
     logActivity: mockLogActivity,
     secretService: () => mockSecretService,
     syncInstructionsBundleConfigFromFilePath: mockSyncInstructionsBundleConfigFromFilePath,
@@ -114,7 +115,10 @@ function boardActor() {
   };
 }
 
-async function createApp(actor: Record<string, unknown> = boardActor()) {
+async function createApp(
+  actor: Record<string, unknown> = boardActor(),
+  db: Record<string, unknown> = {},
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -125,7 +129,7 @@ async function createApp(actor: Record<string, unknown> = boardActor()) {
     (req as any).actor = actor;
     next();
   });
-  app.use("/api", agentRoutes({} as any));
+  app.use("/api", agentRoutes(db as any));
   app.use(errorHandler);
   return app;
 }
@@ -176,6 +180,25 @@ function makeAgent() {
   };
 }
 
+function linkedIssueDb() {
+  let selectCount = 0;
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => {
+          selectCount += 1;
+          return selectCount === 1
+            ? [{ contextSnapshot: { issueId: "33333333-3333-4333-8333-333333333333" } }]
+            : [{
+                id: "33333333-3333-4333-8333-333333333333",
+                parentId: "44444444-4444-4444-8444-444444444444",
+              }];
+        }),
+      })),
+    })),
+  };
+}
+
 function makeReflectionCoachAgent(overrides: Record<string, unknown> = {}) {
   return {
     ...makeAgent(),
@@ -199,6 +222,7 @@ describe("agent instructions bundle routes", () => {
     vi.doUnmock("../middleware/index.js");
     registerModuleMocks();
     vi.clearAllMocks();
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1" });
     mockBuiltInAgentService.ensureCompanyDefaultAgentGrants.mockResolvedValue(0);
     mockSyncInstructionsBundleConfigFromFilePath.mockImplementation((_agent, config) => config);
     mockFindServerAdapter.mockImplementation((_type: string) => ({ type: _type }));
@@ -470,6 +494,7 @@ describe("agent instructions bundle routes", () => {
       adapterConfig: {
         model: "claude-sonnet-4",
         paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
       },
     });
 
@@ -491,6 +516,7 @@ describe("agent instructions bundle routes", () => {
         adapterConfig: expect.objectContaining({
           model: "gpt-5.4",
           paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+          _userLocked: ["model", "paperclipSkillSync.desiredSkills"],
         }),
       }),
       expect.any(Object),
@@ -529,6 +555,188 @@ describe("agent instructions bundle routes", () => {
           instructionsRootPath: "/tmp/agent-1",
           instructionsEntryFile: "AGENTS.md",
           instructionsFilePath: "/tmp/agent-1/AGENTS.md",
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("records changed adapter config fields as user locks", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterType: "codex_local",
+      adapterConfig: {
+        model: "gpt-5.4",
+        env: { SAFE_FLAG: "before" },
+        paperclipSkillSync: {
+          desiredSkills: ["research"],
+          lastSyncedAt: "2026-07-24T00:00:00.000Z",
+        },
+      },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        adapterConfig: {
+          model: "gpt-5.6",
+          paperclipSkillSync: { desiredSkills: ["research", "code-review"] },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.6",
+          env: { SAFE_FLAG: "before" },
+          paperclipSkillSync: {
+            desiredSkills: ["research", "code-review"],
+            lastSyncedAt: "2026-07-24T00:00:00.000Z",
+          },
+          _userLocked: ["model", "paperclipSkillSync.desiredSkills"],
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows an explicit unlock while locking fields changed in the same user patch", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        command: "codex",
+        _userLocked: ["model"],
+      },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        adapterConfig: {
+          command: "codex --profile engineer",
+          _userLocked: [],
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.4",
+          command: "codex --profile engineer",
+          _userLocked: ["command"],
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("skips agent changes to locked fields and surfaces only redacted shapes", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        command: "codex",
+        env: { SECRET_TOKEN: "old-secret-value" },
+        _userLocked: ["model", "env"],
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      runId: "55555555-5555-4555-8555-555555555555",
+      source: "agent_key",
+    }, linkedIssueDb()), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        adapterConfig: {
+          model: "gpt-5.6",
+          command: "codex --profile engineer",
+          env: { SECRET_TOKEN: "new-secret-value" },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.4",
+          command: "codex --profile engineer",
+          env: { SECRET_TOKEN: "old-secret-value" },
+          _userLocked: ["model", "env"],
+        }),
+      }),
+      expect.any(Object),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_skipped",
+        details: {
+          fields: expect.arrayContaining([
+            { path: "command", type: "string", count: 1 },
+            { path: "env", type: "object", count: 1 },
+            { path: "model", type: "string", count: 1 },
+          ]),
+          changedCount: 1,
+          skippedCount: 2,
+        },
+      }),
+    );
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("old-secret-value");
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("new-secret-value");
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      "44444444-4444-4444-8444-444444444444",
+      expect.stringContaining("Skipped user-locked fields: 2"),
+      {
+        agentId: "agent-editor",
+        runId: "55555555-5555-4555-8555-555555555555",
+      },
+    );
+    expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("old-secret-value");
+    expect(JSON.stringify(mockIssueService.addComment.mock.calls)).not.toContain("new-secret-value");
+  });
+
+  it("preserves a nested locked field when an agent requests full replacement", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "gpt-5.4",
+        paperclipSkillSync: {
+          desiredSkills: ["research"],
+          lastSyncedAt: "2026-07-24T00:00:00.000Z",
+        },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
+      },
+    });
+
+    const res = await requestApp(await createApp({
+      type: "agent",
+      agentId: "agent-editor",
+      companyId: "company-1",
+      source: "agent_key",
+    }), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+      .send({
+        replaceAdapterConfig: true,
+        adapterConfig: { model: "gpt-5.6" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "gpt-5.6",
+          paperclipSkillSync: { desiredSkills: ["research"] },
+          _userLocked: ["paperclipSkillSync.desiredSkills"],
         }),
       }),
       expect.any(Object),

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -163,7 +163,16 @@ function createDb(requireBoardApprovalForNewAgents = false) {
   };
 }
 
-async function createApp(db: Record<string, unknown> = createDb()) {
+async function createApp(
+  db: Record<string, unknown> = createDb(),
+  actor: Record<string, unknown> = {
+    type: "board",
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  },
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -171,13 +180,7 @@ async function createApp(db: Record<string, unknown> = createDb()) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", agentRoutes(db as any));
@@ -596,6 +599,54 @@ describe.sequential("agent skill routes", () => {
         }),
       }),
       ["paperclipai/paperclip/paperclip"],
+    );
+  });
+
+  it("refuses an agent skill-sync change when desired skills are user locked", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent("acpx_local"),
+      adapterConfig: {
+        agent: "codex",
+        paperclipSkillSync: { desiredSkills: ["existing/skill"] },
+        _userLocked: ["paperclipSkillSync.desiredSkills"],
+      },
+    });
+    mockCompanySkillService.resolveRequestedSkillEntries.mockImplementationOnce(
+      async (_companyId: string, requested: Array<{ key: string; versionId?: string | null }>) => ({
+        resolved: requested.map((entry) => ({ key: entry.key, versionId: entry.versionId ?? null })),
+        unresolved: [],
+      }),
+    );
+
+    const res = await requestApp(
+      await createApp(createDb(), {
+        type: "agent",
+        agentId: "agent-editor",
+        companyId: "company-1",
+        source: "agent_key",
+      }),
+      (baseUrl) => request(baseUrl)
+        .post("/api/agents/11111111-1111-4111-8111-111111111111/skills/sync")
+        .send({ desiredSkills: ["paperclip"] }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.warnings).toContain("Skipped user-locked paperclipSkillSync.desiredSkills update.");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockAdapter.syncSkills).toHaveBeenCalledWith(
+      expect.any(Object),
+      ["existing/skill"],
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.adapter_config_change_skipped",
+        details: {
+          fields: [{ path: "paperclipSkillSync.desiredSkills", type: "array", count: 1 }],
+          changedCount: 0,
+          skippedCount: 1,
+        },
+      }),
     );
   });
 

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -1014,6 +1014,38 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(grantKeys).not.toContain("skills:create");
   });
 
+  it("does not restore a user-locked bundled skill during repeated reconciliation", async () => {
+    const companyId = await seedCompany();
+    await agentService(db).create(companyId, {
+      name: "CEO",
+      role: "ceo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: { model: "gpt-5.4" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const initial = await builtInAgentService(db).ensure(companyId, "reflection-coach");
+    const userConfig = {
+      ...initial.agent!.adapterConfig,
+      model: "gpt-5.6",
+      env: { SAFE_FLAG: "unchanged" },
+      paperclipSkillSync: { desiredSkills: [] },
+      _userLocked: ["model", "paperclipSkillSync.desiredSkills"],
+    };
+    await agentService(db).update(initial.agentId!, { adapterConfig: userConfig });
+    const expected = await agentService(db).getById(initial.agentId!);
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await builtInAgentService(db).ensure(companyId, "reflection-coach");
+    }
+
+    const persisted = await agentService(db).getById(initial.agentId!);
+    expect(persisted?.adapterConfig).toEqual(expected?.adapterConfig);
+    expect(readPaperclipSkillSyncPreference(persisted!.adapterConfig).desiredSkills).toEqual([]);
+  });
+
   it("materializes the Summarizer bundle paused on Claude Haiku with a disabled routine", async () => {
     const companyId = await seedCompany();
     const root = await agentService(db).create(companyId, {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1133,13 +1133,13 @@ export function agentRoutes(
   };
 
   function applyAdapterConfigUserLockPolicy(input: {
-    actorType: "board" | "agent" | "none";
+    actorType: "user" | "agent";
     existing: Record<string, unknown>;
     requested: Record<string, unknown>;
     effective: Record<string, unknown>;
   }): { config: Record<string, unknown>; mutation: AdapterConfigMutation | null } {
     const attemptedPaths = changedAdapterConfigPaths(input.existing, input.effective);
-    if (input.actorType === "board") {
+    if (input.actorType === "user") {
       const baseLocks = hasOwn(input.requested, "_userLocked")
         ? readAdapterConfigUserLocks(input.requested)
         : readAdapterConfigUserLocks(input.existing);
@@ -3184,6 +3184,7 @@ export function agentRoutes(
     }
 
     const patchData = { ...(req.body as Record<string, unknown>) };
+    const actor = getActorInfo(req);
     let adapterConfigMutation: AdapterConfigMutation | null = null;
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
     delete patchData.replaceAdapterConfig;
@@ -3254,7 +3255,7 @@ export function agentRoutes(
       }
       if (requestedAdapterConfig) {
         const lockPolicy = applyAdapterConfigUserLockPolicy({
-          actorType: req.actor.type,
+          actorType: actor.actorType,
           existing: existingAdapterConfig,
           requested: requestedAdapterConfig,
           effective: rawEffectiveAdapterConfig,
@@ -3309,7 +3310,6 @@ export function agentRoutes(
       await assertCanUpdateAgent(req, existing);
     }
 
-    const actor = getActorInfo(req);
     const agent = await svc.update(id, patchData, {
       recordRevision: {
         createdByAgentId: actor.agentId,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1147,8 +1147,21 @@ export function agentRoutes(
       return { requested: input.requested, strippedPaths: [], lockedPaths: [], fields: [] };
     }
 
+    // Compare each requested path against the existing config so that a no-op
+    // patch (an agent re-sending a value identical to the current one) is not
+    // recorded as a strip. `changedAdapterConfigPaths({}, requested)` yields the
+    // top-level keys the agent actually sent; we intentionally keep that
+    // key-space (a partial patch must not treat omitted existing keys as
+    // changes) and drop paths whose requested value already matches existing.
     const requestedPaths = changedAdapterConfigPaths({}, input.requested);
-    const strippedPaths = requestedPaths.filter((path) => path !== "paperclipSkillSync.desiredSkills");
+    const strippedPaths = requestedPaths.filter(
+      (path) =>
+        path !== "paperclipSkillSync.desiredSkills" &&
+        !isDeepStrictEqual(
+          readAdapterConfigPath(input.existing, path),
+          readAdapterConfigPath(input.requested, path),
+        ),
+    );
     const lockedPaths = strippedPaths.filter((path) =>
       adapterConfigPathIsUserLocked(input.existing, path),
     );

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -56,7 +56,7 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
-import { conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
+import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, buildActorSecretContext, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -1129,8 +1129,44 @@ export function agentRoutes(
   type AdapterConfigMutation = {
     changedPaths: string[];
     skippedPaths: string[];
+    strippedPaths: string[];
     fields: Array<{ path: string; type: string; count: number }>;
   };
+
+  function enforceAgentAdapterConfigAllowlist(input: {
+    existing: Record<string, unknown>;
+    requested: Record<string, unknown>;
+    responsibleUserId: string | null;
+  }): {
+    requested: Record<string, unknown>;
+    strippedPaths: string[];
+    lockedPaths: string[];
+    fields: Array<{ path: string; type: string; count: number }>;
+  } {
+    if (input.responsibleUserId !== null) {
+      return { requested: input.requested, strippedPaths: [], lockedPaths: [], fields: [] };
+    }
+
+    const requestedPaths = changedAdapterConfigPaths({}, input.requested);
+    const strippedPaths = requestedPaths.filter((path) => path !== "paperclipSkillSync.desiredSkills");
+    const lockedPaths = strippedPaths.filter((path) =>
+      adapterConfigPathIsUserLocked(input.existing, path),
+    );
+    const skillSync = asRecord(input.requested.paperclipSkillSync);
+    const requested = skillSync && hasOwn(skillSync, "desiredSkills")
+      ? { paperclipSkillSync: { desiredSkills: skillSync.desiredSkills } }
+      : {};
+
+    return {
+      requested,
+      strippedPaths,
+      lockedPaths,
+      fields: strippedPaths.map((path) => ({
+        path,
+        ...adapterConfigValueShape(readAdapterConfigPath(input.requested, path)),
+      })),
+    };
+  }
 
   function applyAdapterConfigUserLockPolicy(input: {
     actorType: "user" | "agent";
@@ -1172,6 +1208,7 @@ export function agentRoutes(
         skippedPaths: attemptedPaths.filter((path) =>
           adapterConfigPathIsUserLocked(input.existing, path),
         ),
+        strippedPaths: [],
         fields: attemptedPaths.map((path) => ({
           path,
           ...adapterConfigValueShape(readAdapterConfigPath(config, path)),
@@ -1187,6 +1224,7 @@ export function agentRoutes(
     runId: string | null;
     changedPaths: string[];
     skippedPaths: string[];
+    strippedPaths: string[];
     fields: Array<{ path: string; type: string; count: number }>;
   }) {
     if (!input.runId) return;
@@ -1217,6 +1255,7 @@ export function agentRoutes(
         ...fieldRows,
         `- Changed fields: ${input.changedPaths.length}`,
         `- Skipped user-locked fields: ${input.skippedPaths.length}`,
+        `- Stripped fields: ${input.strippedPaths.length}${input.strippedPaths.length > 0 ? ` (${input.strippedPaths.map((path) => `\`${path}\``).join(", ")})` : ""}`,
       ].join("\n"),
       { agentId: input.agentId, runId: input.runId },
     );
@@ -2171,6 +2210,7 @@ export function agentRoutes(
         const adapterConfigMutation = {
           changedPaths: desiredSkillsLocked ? [] : ["paperclipSkillSync.desiredSkills"],
           skippedPaths: desiredSkillsLocked ? ["paperclipSkillSync.desiredSkills"] : [],
+          strippedPaths: [],
           fields: [{
             path: "paperclipSkillSync.desiredSkills",
             type: "array",
@@ -3185,7 +3225,9 @@ export function agentRoutes(
 
     const patchData = { ...(req.body as Record<string, unknown>) };
     const actor = getActorInfo(req);
+    const responsibleUserId = req.actor.userId ?? req.actor.onBehalfOfUserId ?? null;
     let adapterConfigMutation: AdapterConfigMutation | null = null;
+    let strippedAdapterConfigMutation: Pick<AdapterConfigMutation, "strippedPaths" | "fields"> | null = null;
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
     delete patchData.replaceAdapterConfig;
     if (hasOwn(patchData, "adapterConfig")) {
@@ -3194,12 +3236,55 @@ export function agentRoutes(
         res.status(422).json({ error: "adapterConfig must be an object" });
         return;
       }
-      assertNoAgentAdapterConfigMutation(req, adapterConfig);
-      const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(adapterConfig);
+      const allowlist = enforceAgentAdapterConfigAllowlist({
+        existing: asRecord(existing.adapterConfig) ?? {},
+        requested: adapterConfig,
+        responsibleUserId,
+      });
+      if (allowlist.lockedPaths.length > 0) {
+        const refusedMutation: AdapterConfigMutation = {
+          changedPaths: [],
+          skippedPaths: allowlist.lockedPaths,
+          strippedPaths: allowlist.strippedPaths,
+          fields: allowlist.fields,
+        };
+        await logActivity(db, {
+          companyId: existing.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          action: "agent.adapter_config_change_skipped",
+          entityType: "agent",
+          entityId: existing.id,
+          details: {
+            fields: refusedMutation.fields,
+            changedCount: 0,
+            skippedCount: refusedMutation.skippedPaths.length,
+            strippedCount: refusedMutation.strippedPaths.length,
+          },
+        });
+        await commentOnLinkedParentForAdapterConfigMutation({
+          companyId: existing.companyId,
+          agentId: actor.agentId!,
+          agentName: existing.name,
+          runId: actor.runId ?? null,
+          ...refusedMutation,
+        });
+        throw badRequest(
+          `Agent-initiated adapterConfig update includes user-locked fields outside the allowlist: ${allowlist.lockedPaths.join(", ")}`,
+        );
+      }
+      strippedAdapterConfigMutation = allowlist.strippedPaths.length > 0
+        ? { strippedPaths: allowlist.strippedPaths, fields: allowlist.fields }
+        : null;
+      assertNoAgentAdapterConfigMutation(req, allowlist.requested);
+      const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(allowlist.requested);
       if (changingInstructionsConfig) {
         await assertCanManageInstructionsPath(req, existing);
       }
-      patchData.adapterConfig = adapterConfig;
+      patchData.adapterConfig = allowlist.requested;
     }
 
     const requestedAdapterType = hasOwn(patchData, "adapterType")
@@ -3228,6 +3313,7 @@ export function agentRoutes(
       if (
         requestedAdapterConfig
         && replaceAdapterConfig
+        && responsibleUserId !== null
         && KNOWN_INSTRUCTIONS_BUNDLE_KEYS.some((key) =>
           existingAdapterConfig[key] !== undefined && requestedAdapterConfig[key] === undefined,
         )
@@ -3235,7 +3321,11 @@ export function agentRoutes(
         await assertCanManageInstructionsPath(req, existing);
       }
       let rawEffectiveAdapterConfig = requestedAdapterConfig ?? existingAdapterConfig;
-      if (requestedAdapterConfig && !changingAdapterType && !replaceAdapterConfig) {
+      if (
+        requestedAdapterConfig
+        && !changingAdapterType
+        && (!replaceAdapterConfig || responsibleUserId === null)
+      ) {
         rawEffectiveAdapterConfig = mergeAdapterConfigPatch(existingAdapterConfig, requestedAdapterConfig);
       }
       if (changingAdapterType) {
@@ -3255,13 +3345,21 @@ export function agentRoutes(
       }
       if (requestedAdapterConfig) {
         const lockPolicy = applyAdapterConfigUserLockPolicy({
-          actorType: actor.actorType,
+          actorType: responsibleUserId === null ? "agent" : "user",
           existing: existingAdapterConfig,
           requested: requestedAdapterConfig,
           effective: rawEffectiveAdapterConfig,
         });
         rawEffectiveAdapterConfig = lockPolicy.config;
         adapterConfigMutation = lockPolicy.mutation;
+        if (adapterConfigMutation && strippedAdapterConfigMutation) {
+          adapterConfigMutation = {
+            ...adapterConfigMutation,
+            strippedPaths: strippedAdapterConfigMutation.strippedPaths,
+            fields: [...adapterConfigMutation.fields, ...strippedAdapterConfigMutation.fields]
+              .sort((left, right) => left.path.localeCompare(right.path)),
+          };
+        }
       }
       const effectiveAdapterConfig = applyCodexLocalKeyIsolation(
         existing.companyId,
@@ -3345,13 +3443,16 @@ export function agentRoutes(
         agentApiKeyId: actor.agentApiKeyId,
         action: adapterConfigMutation.skippedPaths.length > 0
           ? "agent.adapter_config_change_skipped"
-          : "agent.adapter_config_changed",
+          : adapterConfigMutation.strippedPaths.length > 0
+            ? "agent.adapter_config_change_stripped"
+            : "agent.adapter_config_changed",
         entityType: "agent",
         entityId: agent.id,
         details: {
           fields: adapterConfigMutation.fields,
           changedCount: adapterConfigMutation.changedPaths.length,
           skippedCount: adapterConfigMutation.skippedPaths.length,
+          strippedCount: adapterConfigMutation.strippedPaths.length,
         },
       });
       await commentOnLinkedParentForAdapterConfigMutation({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1143,14 +1143,14 @@ export function agentRoutes(
   function enforceAgentAdapterConfigAllowlist(input: {
     existing: Record<string, unknown>;
     requested: Record<string, unknown>;
-    responsibleUserId: string | null;
+    isAgentCaller: boolean;
   }): {
     requested: Record<string, unknown>;
     strippedPaths: string[];
     lockedPaths: string[];
     fields: Array<{ path: string; type: string; count: number }>;
   } {
-    if (input.responsibleUserId !== null) {
+    if (!input.isAgentCaller) {
       return { requested: input.requested, strippedPaths: [], lockedPaths: [], fields: [] };
     }
 
@@ -3289,7 +3289,7 @@ export function agentRoutes(
       const allowlist = enforceAgentAdapterConfigAllowlist({
         existing: asRecord(existing.adapterConfig) ?? {},
         requested: adapterConfig,
-        responsibleUserId,
+        isAgentCaller: req.actor.type === "agent",
       });
       if (allowlist.lockedPaths.length > 0) {
         const refusedMutation: AdapterConfigMutation = {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3224,6 +3224,13 @@ export function agentRoutes(
     }
 
     const patchData = { ...(req.body as Record<string, unknown>) };
+    const touchesProfileFields = touchesAgentProfileChangeConsentFields(patchData);
+    const profileOnlyChange = touchesProfileFields && Object.keys(patchData).every((key) =>
+      (AGENT_PROFILE_CHANGE_CONSENT_FIELDS as readonly string[]).includes(key),
+    );
+    if (!profileOnlyChange) {
+      await assertCanUpdateAgent(req, existing);
+    }
     const actor = getActorInfo(req);
     const responsibleUserId = req.actor.userId ?? req.actor.onBehalfOfUserId ?? null;
     let adapterConfigMutation: AdapterConfigMutation | null = null;
@@ -3398,14 +3405,8 @@ export function agentRoutes(
         },
       );
     }
-    const touchesProfileFields = touchesAgentProfileChangeConsentFields(patchData);
-    const profileOnlyChange = touchesProfileFields && Object.keys(patchData).every((key) =>
-      (AGENT_PROFILE_CHANGE_CONSENT_FIELDS as readonly string[]).includes(key),
-    );
     if (profileOnlyChange) {
       await assertCanApplyAgentProfileChange(req, existing);
-    } else {
-      await assertCanUpdateAgent(req, existing);
     }
 
     const agent = await svc.update(id, patchData, {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1133,6 +1133,35 @@ export function agentRoutes(
     return value;
   }
 
+  // Enumerate every leaf path an agent actually sent in a requested adapterConfig
+  // so the allowlist can decide, per leaf, whether a write is the allowed
+  // `paperclipSkillSync.desiredSkills` or a stripped extra. Unlike
+  // `changedAdapterConfigPaths({}, requested)` (which stops at top-level keys
+  // because the empty `before` never recurses), this walks nested objects to the
+  // leaf. `env` is collapsed to a single leaf and `_userLocked` is skipped so
+  // individual environment variable names never surface in audit paths.
+  function enumerateRequestedAdapterConfigPaths(
+    config: Record<string, unknown>,
+    prefix = "",
+  ): string[] {
+    const paths: string[] = [];
+    for (const key of Object.keys(config)) {
+      if (key === "_userLocked") continue;
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (path === "env") {
+        paths.push(path);
+        continue;
+      }
+      const record = asRecord(config[key]);
+      if (record && Object.keys(record).length > 0) {
+        paths.push(...enumerateRequestedAdapterConfigPaths(record, path));
+      } else {
+        paths.push(path);
+      }
+    }
+    return paths.sort();
+  }
+
   type AdapterConfigMutation = {
     changedPaths: string[];
     skippedPaths: string[];
@@ -1154,13 +1183,14 @@ export function agentRoutes(
       return { requested: input.requested, strippedPaths: [], lockedPaths: [], fields: [] };
     }
 
-    // Compare each requested path against the existing config so that a no-op
-    // patch (an agent re-sending a value identical to the current one) is not
-    // recorded as a strip. `changedAdapterConfigPaths({}, requested)` yields the
-    // top-level keys the agent actually sent; we intentionally keep that
-    // key-space (a partial patch must not treat omitted existing keys as
+    // Compare each requested leaf path against the existing config so that a
+    // no-op patch (an agent re-sending a value identical to the current one) is
+    // not recorded as a strip, and — critically — so that an allowed nested
+    // write (`paperclipSkillSync.desiredSkills`) is not misreported as a strip
+    // of its top-level parent. We enumerate the full leaf key-space the agent
+    // actually sent (a partial patch must not treat omitted existing keys as
     // changes) and drop paths whose requested value already matches existing.
-    const requestedPaths = changedAdapterConfigPaths({}, input.requested);
+    const requestedPaths = enumerateRequestedAdapterConfigPaths(input.requested);
     const strippedPaths = requestedPaths.filter(
       (path) =>
         path !== "paperclipSkillSync.desiredSkills" &&
@@ -3253,7 +3283,6 @@ export function agentRoutes(
       await assertCanUpdateAgent(req, existing);
     }
     const actor = getActorInfo(req);
-    const responsibleUserId = req.actor.userId ?? req.actor.onBehalfOfUserId ?? null;
     let adapterConfigMutation: AdapterConfigMutation | null = null;
     let strippedAdapterConfigMutation: Pick<AdapterConfigMutation, "strippedPaths" | "fields"> | null = null;
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
@@ -3283,7 +3312,7 @@ export function agentRoutes(
       // User/board callers still gate instruction-path changes through the
       // protected-change permission. Agent callers never reach here for
       // sensitive keys (rejected above) and have path pointers stripped below.
-      if (responsibleUserId !== null && adapterConfigTouchesInstructionsConfig(adapterConfig)) {
+      if (req.actor.type !== "agent" && adapterConfigTouchesInstructionsConfig(adapterConfig)) {
         await assertCanManageInstructionsPath(req, existing);
       }
       const allowlist = enforceAgentAdapterConfigAllowlist({
@@ -3358,7 +3387,7 @@ export function agentRoutes(
       if (
         requestedAdapterConfig
         && replaceAdapterConfig
-        && responsibleUserId !== null
+        && req.actor.type !== "agent"
         && KNOWN_INSTRUCTIONS_BUNDLE_KEYS.some((key) =>
           existingAdapterConfig[key] !== undefined && requestedAdapterConfig[key] === undefined,
         )
@@ -3369,7 +3398,7 @@ export function agentRoutes(
       if (
         requestedAdapterConfig
         && !changingAdapterType
-        && (!replaceAdapterConfig || responsibleUserId === null)
+        && (!replaceAdapterConfig || req.actor.type === "agent")
       ) {
         rawEffectiveAdapterConfig = mergeAdapterConfigPatch(existingAdapterConfig, requestedAdapterConfig);
       }
@@ -3390,7 +3419,7 @@ export function agentRoutes(
       }
       if (requestedAdapterConfig) {
         const lockPolicy = applyAdapterConfigUserLockPolicy({
-          actorType: responsibleUserId === null ? "agent" : "user",
+          actorType: req.actor.type === "agent" ? "agent" : "user",
           existing: existingAdapterConfig,
           requested: requestedAdapterConfig,
           effective: rawEffectiveAdapterConfig,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
@@ -31,6 +32,8 @@ import {
 } from "@paperclipai/shared";
 import {
   resolvePaperclipInstanceRootForAdapter,
+  adapterConfigPathIsUserLocked,
+  readAdapterConfigUserLocks,
   readPaperclipSkillSyncPreference,
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -194,6 +197,7 @@ export function agentRoutes(
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
   const instructions = agentInstructionsService();
+  const issuesSvc = issueService(db);
   const companySkills = companySkillService(db);
   const workspaceOperations = workspaceOperationService(db);
   const instanceSettings = instanceSettingsService(db);
@@ -1042,6 +1046,182 @@ export function agentRoutes(
     return value as Record<string, unknown>;
   }
 
+  function mergeAdapterConfigPatch(
+    current: Record<string, unknown>,
+    patch: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const merged = { ...current };
+    for (const [key, value] of Object.entries(patch)) {
+      const currentRecord = asRecord(current[key]);
+      const patchRecord = asRecord(value);
+      merged[key] = currentRecord && patchRecord
+        ? mergeAdapterConfigPatch(currentRecord, patchRecord)
+        : value;
+    }
+    return merged;
+  }
+
+  function changedAdapterConfigPaths(
+    before: Record<string, unknown>,
+    after: Record<string, unknown>,
+    prefix = "",
+  ): string[] {
+    const paths: string[] = [];
+    for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+      if (key === "_userLocked") continue;
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (isDeepStrictEqual(before[key], after[key])) continue;
+      if (path === "env") {
+        paths.push(path);
+        continue;
+      }
+      const beforeRecord = asRecord(before[key]);
+      const afterRecord = asRecord(after[key]);
+      if (beforeRecord && afterRecord) {
+        const nested = changedAdapterConfigPaths(beforeRecord, afterRecord, path);
+        paths.push(...(nested.length > 0 ? nested : [path]));
+      } else {
+        paths.push(path);
+      }
+    }
+    return paths.sort();
+  }
+
+  function restoreAdapterConfigPath(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+    path: string,
+  ) {
+    const parts = path.split(".");
+    const leaf = parts.pop();
+    if (!leaf) return;
+    let targetCursor = target;
+    let sourceCursor = source;
+    for (const part of parts) {
+      const sourceChild = asRecord(sourceCursor[part]);
+      if (!sourceChild) return;
+      const targetChild = asRecord(targetCursor[part]);
+      targetCursor[part] = targetChild ? { ...targetChild } : {};
+      targetCursor = targetCursor[part] as Record<string, unknown>;
+      sourceCursor = sourceChild;
+    }
+    if (Object.hasOwn(sourceCursor, leaf)) targetCursor[leaf] = sourceCursor[leaf];
+    else delete targetCursor[leaf];
+  }
+
+  function adapterConfigValueShape(value: unknown) {
+    if (Array.isArray(value)) return { type: "array", count: value.length };
+    const record = asRecord(value);
+    if (record) return { type: "object", count: Object.keys(record).length };
+    return { type: value === null ? "null" : typeof value, count: value === undefined ? 0 : 1 };
+  }
+
+  function readAdapterConfigPath(config: Record<string, unknown>, path: string): unknown {
+    let value: unknown = config;
+    for (const part of path.split(".")) {
+      const record = asRecord(value);
+      if (!record) return undefined;
+      value = record[part];
+    }
+    return value;
+  }
+
+  type AdapterConfigMutation = {
+    changedPaths: string[];
+    skippedPaths: string[];
+    fields: Array<{ path: string; type: string; count: number }>;
+  };
+
+  function applyAdapterConfigUserLockPolicy(input: {
+    actorType: "board" | "agent" | "none";
+    existing: Record<string, unknown>;
+    requested: Record<string, unknown>;
+    effective: Record<string, unknown>;
+  }): { config: Record<string, unknown>; mutation: AdapterConfigMutation | null } {
+    const attemptedPaths = changedAdapterConfigPaths(input.existing, input.effective);
+    if (input.actorType === "board") {
+      const baseLocks = hasOwn(input.requested, "_userLocked")
+        ? readAdapterConfigUserLocks(input.requested)
+        : readAdapterConfigUserLocks(input.existing);
+      return {
+        config: {
+          ...input.effective,
+          _userLocked: Array.from(new Set([...baseLocks, ...attemptedPaths])).sort(),
+        },
+        mutation: null,
+      };
+    }
+
+    const existingLocks = readAdapterConfigUserLocks(input.existing);
+    const skippedLocks = Array.from(new Set(attemptedPaths.flatMap((attemptedPath) =>
+      existingLocks.filter((lockedPath) =>
+        attemptedPath === lockedPath
+        || attemptedPath.startsWith(`${lockedPath}.`)
+        || lockedPath.startsWith(`${attemptedPath}.`),
+      ),
+    )));
+    const config = { ...input.effective };
+    for (const lockedPath of skippedLocks) {
+      restoreAdapterConfigPath(config, input.existing, lockedPath);
+    }
+    config._userLocked = existingLocks;
+    return {
+      config,
+      mutation: {
+        changedPaths: changedAdapterConfigPaths(input.existing, config),
+        skippedPaths: attemptedPaths.filter((path) =>
+          adapterConfigPathIsUserLocked(input.existing, path),
+        ),
+        fields: attemptedPaths.map((path) => ({
+          path,
+          ...adapterConfigValueShape(readAdapterConfigPath(config, path)),
+        })),
+      },
+    };
+  }
+
+  async function commentOnLinkedParentForAdapterConfigMutation(input: {
+    companyId: string;
+    agentId: string;
+    agentName: string;
+    runId: string | null;
+    changedPaths: string[];
+    skippedPaths: string[];
+    fields: Array<{ path: string; type: string; count: number }>;
+  }) {
+    if (!input.runId) return;
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.id, input.runId), eq(heartbeatRuns.companyId, input.companyId)))
+      .then((rows) => rows[0] ?? null);
+    const linkedIssueId = readRunIssueId(asRecord(run?.contextSnapshot));
+    if (!linkedIssueId) return;
+    const linkedIssue = await db
+      .select({ id: issuesTable.id, parentId: issuesTable.parentId })
+      .from(issuesTable)
+      .where(and(eq(issuesTable.id, linkedIssueId), eq(issuesTable.companyId, input.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!linkedIssue) return;
+
+    const fieldRows = input.fields.map((field) =>
+      `- \`${field.path}\`: ${field.type}, count ${field.count}`,
+    );
+    await issuesSvc.addComment(
+      linkedIssue.parentId ?? linkedIssue.id,
+      [
+        "## Agent adapter config update",
+        "",
+        `Agent \`${input.agentName}\` attempted an adapter configuration update.`,
+        "",
+        ...fieldRows,
+        `- Changed fields: ${input.changedPaths.length}`,
+        `- Skipped user-locked fields: ${input.skippedPaths.length}`,
+      ].join("\n"),
+      { agentId: input.agentId, runId: input.runId },
+    );
+  }
+
   function asNonEmptyString(value: unknown): string | null {
     if (typeof value !== "string") return null;
     const trimmed = value.trim();
@@ -1887,7 +2067,15 @@ export function agentRoutes(
       if (!agent) return;
       await assertCanUpdateAgent(req, agent);
 
-      const requestedSkills = normalizeDesiredSkillSelections(req.body.desiredSkills);
+      const actor = getActorInfo(req);
+      const desiredSkillsLocked = actor.actorType === "agent"
+        && adapterConfigPathIsUserLocked(
+          agent.adapterConfig as Record<string, unknown>,
+          "paperclipSkillSync.desiredSkills",
+        );
+      const requestedSkills = desiredSkillsLocked
+        ? readPaperclipSkillSyncPreference(agent.adapterConfig as Record<string, unknown>).desiredSkillEntries
+        : normalizeDesiredSkillSelections(req.body.desiredSkills);
       const {
         adapterConfig: nextAdapterConfig,
         desiredSkills,
@@ -1906,16 +2094,17 @@ export function agentRoutes(
       if (!desiredSkills || !desiredSkillEntries || !runtimeSkillEntries) {
         throw unprocessable("Skill sync requires desiredSkills.");
       }
-      const actor = getActorInfo(req);
-      const updated = await svc.update(agent.id, {
-        adapterConfig: nextAdapterConfig,
-      }, {
-        recordRevision: {
-          createdByAgentId: actor.agentId,
-          createdByUserId: actor.actorType === "user" ? actor.actorId : null,
-          source: "skill-sync",
-        },
-      });
+      const updated = desiredSkillsLocked
+        ? agent
+        : await svc.update(agent.id, {
+            adapterConfig: nextAdapterConfig,
+          }, {
+            recordRevision: {
+              createdByAgentId: actor.agentId,
+              createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+              source: "skill-sync",
+            },
+          });
       if (!updated) {
         res.status(404).json({ error: "Agent not found" });
         return;
@@ -1932,7 +2121,7 @@ export function agentRoutes(
         ...runtimeConfig,
         paperclipRuntimeSkills: runtimeSkillEntries,
       };
-      const snapshot = adapter?.syncSkills
+      const rawSnapshot = adapter?.syncSkills
         ? await adapter.syncSkills({
             agentId: updated.id,
             companyId: updated.companyId,
@@ -1947,6 +2136,15 @@ export function agentRoutes(
               config: runtimeSkillConfig,
             })
           : buildUnsupportedSkillSnapshot(updated.adapterType, desiredSkillEntries);
+      const snapshot = desiredSkillsLocked
+        ? {
+            ...rawSnapshot,
+            warnings: [
+              ...rawSnapshot.warnings,
+              "Skipped user-locked paperclipSkillSync.desiredSkills update.",
+            ],
+          }
+        : rawSnapshot;
 
       await logActivity(db, {
         companyId: updated.companyId,
@@ -1968,6 +2166,43 @@ export function agentRoutes(
           warningCount: snapshot.warnings.length,
         },
       });
+
+      if (actor.actorType === "agent") {
+        const adapterConfigMutation = {
+          changedPaths: desiredSkillsLocked ? [] : ["paperclipSkillSync.desiredSkills"],
+          skippedPaths: desiredSkillsLocked ? ["paperclipSkillSync.desiredSkills"] : [],
+          fields: [{
+            path: "paperclipSkillSync.desiredSkills",
+            type: "array",
+            count: requestedSkills?.length ?? 0,
+          }],
+        };
+        await logActivity(db, {
+          companyId: updated.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          action: desiredSkillsLocked
+            ? "agent.adapter_config_change_skipped"
+            : "agent.adapter_config_changed",
+          entityType: "agent",
+          entityId: updated.id,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          details: {
+            fields: adapterConfigMutation.fields,
+            changedCount: adapterConfigMutation.changedPaths.length,
+            skippedCount: adapterConfigMutation.skippedPaths.length,
+          },
+        });
+        await commentOnLinkedParentForAdapterConfigMutation({
+          companyId: updated.companyId,
+          agentId: actor.agentId!,
+          agentName: updated.name,
+          runId: actor.runId ?? null,
+          ...adapterConfigMutation,
+        });
+      }
 
       res.json(snapshot);
     },
@@ -2949,6 +3184,7 @@ export function agentRoutes(
     }
 
     const patchData = { ...(req.body as Record<string, unknown>) };
+    let adapterConfigMutation: AdapterConfigMutation | null = null;
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
     delete patchData.replaceAdapterConfig;
     if (hasOwn(patchData, "adapterConfig")) {
@@ -2999,7 +3235,7 @@ export function agentRoutes(
       }
       let rawEffectiveAdapterConfig = requestedAdapterConfig ?? existingAdapterConfig;
       if (requestedAdapterConfig && !changingAdapterType && !replaceAdapterConfig) {
-        rawEffectiveAdapterConfig = { ...existingAdapterConfig, ...requestedAdapterConfig };
+        rawEffectiveAdapterConfig = mergeAdapterConfigPatch(existingAdapterConfig, requestedAdapterConfig);
       }
       if (changingAdapterType) {
         // Preserve adapter-agnostic keys (env, cwd, etc.) from the existing config
@@ -3015,6 +3251,16 @@ export function agentRoutes(
           existingAdapterConfig,
           rawEffectiveAdapterConfig,
         );
+      }
+      if (requestedAdapterConfig) {
+        const lockPolicy = applyAdapterConfigUserLockPolicy({
+          actorType: req.actor.type,
+          existing: existingAdapterConfig,
+          requested: requestedAdapterConfig,
+          effective: rawEffectiveAdapterConfig,
+        });
+        rawEffectiveAdapterConfig = lockPolicy.config;
+        adapterConfigMutation = lockPolicy.mutation;
       }
       const effectiveAdapterConfig = applyCodexLocalKeyIsolation(
         existing.companyId,
@@ -3088,6 +3334,34 @@ export function agentRoutes(
       entityId: agent.id,
       details: summarizeAgentUpdateDetails(patchData),
     });
+
+    if (adapterConfigMutation) {
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        action: adapterConfigMutation.skippedPaths.length > 0
+          ? "agent.adapter_config_change_skipped"
+          : "agent.adapter_config_changed",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          fields: adapterConfigMutation.fields,
+          changedCount: adapterConfigMutation.changedPaths.length,
+          skippedCount: adapterConfigMutation.skippedPaths.length,
+        },
+      });
+      await commentOnLinkedParentForAdapterConfigMutation({
+        companyId: agent.companyId,
+        agentId: actor.agentId!,
+        agentName: agent.name,
+        runId: actor.runId ?? null,
+        ...adapterConfigMutation,
+      });
+    }
 
     res.json(agent);
   });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -180,6 +180,13 @@ export function agentRoutes(
     "agentsMdPath",
   ] as const;
   const KNOWN_INSTRUCTIONS_BUNDLE_KEY_SET: ReadonlySet<string> = new Set(KNOWN_INSTRUCTIONS_BUNDLE_KEYS);
+  // Instruction *bundle-definition* keys an agent must never set — these point
+  // the managed instructions bundle at an arbitrary host location and must be
+  // rejected with 403, not silently stripped. Concrete path pointers
+  // (instructionsFilePath/agentsMdPath) are NOT sensitive: they are dropped by
+  // the agent adapterConfig allowlist like any other non-allowlisted field.
+  const AGENT_SENSITIVE_INSTRUCTIONS_BUNDLE_KEYS: readonly string[] = KNOWN_INSTRUCTIONS_BUNDLE_KEYS
+    .filter((key) => !KNOWN_INSTRUCTIONS_PATH_KEYS.has(key));
 
   const router = Router();
   const svc = agentService(db);
@@ -1701,9 +1708,10 @@ export function agentRoutes(
     req: Request,
     adapterConfig: Record<string, unknown> | null | undefined,
     path = "adapterConfig",
+    keys: readonly string[] = KNOWN_INSTRUCTIONS_BUNDLE_KEYS,
   ) {
     if (req.actor.type !== "agent" || !adapterConfig) return;
-    const changedSensitiveKeys = KNOWN_INSTRUCTIONS_BUNDLE_KEYS
+    const changedSensitiveKeys = keys
       .filter((key) => adapterConfig[key] !== undefined)
       .map((key) => `${path}.${key}`);
     if (changedSensitiveKeys.length === 0) return;
@@ -3256,6 +3264,28 @@ export function agentRoutes(
         res.status(422).json({ error: "adapterConfig must be an object" });
         return;
       }
+      // Security-sensitive fields must be rejected with 403 by the existing
+      // permission checks — not silently stripped by the allowlist. Evaluate
+      // the ORIGINAL requested config (before the allowlist drops non-sensitive
+      // extras) so the allowlist can never neuter these boundaries. Host-executed
+      // workspace commands and instruction *bundle-definition* keys are rejected;
+      // concrete path pointers and other non-sensitive fields stay strippable.
+      assertNoAgentHostWorkspaceCommandMutation(
+        req,
+        collectAgentAdapterWorkspaceCommandPaths(adapterConfig),
+      );
+      assertNoAgentInstructionsConfigMutation(
+        req,
+        adapterConfig,
+        "adapterConfig",
+        AGENT_SENSITIVE_INSTRUCTIONS_BUNDLE_KEYS,
+      );
+      // User/board callers still gate instruction-path changes through the
+      // protected-change permission. Agent callers never reach here for
+      // sensitive keys (rejected above) and have path pointers stripped below.
+      if (responsibleUserId !== null && adapterConfigTouchesInstructionsConfig(adapterConfig)) {
+        await assertCanManageInstructionsPath(req, existing);
+      }
       const allowlist = enforceAgentAdapterConfigAllowlist({
         existing: asRecord(existing.adapterConfig) ?? {},
         requested: adapterConfig,
@@ -3299,11 +3329,6 @@ export function agentRoutes(
       strippedAdapterConfigMutation = allowlist.strippedPaths.length > 0
         ? { strippedPaths: allowlist.strippedPaths, fields: allowlist.fields }
         : null;
-      assertNoAgentAdapterConfigMutation(req, allowlist.requested);
-      const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(allowlist.requested);
-      if (changingInstructionsConfig) {
-        await assertCanManageInstructionsPath(req, existing);
-      }
       patchData.adapterConfig = allowlist.requested;
     }
 

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -3,7 +3,11 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readPaperclipSkillSyncPreference, writePaperclipSkillSyncPreference } from "@paperclipai/adapter-utils/server-utils";
+import {
+  adapterConfigPathIsUserLocked,
+  readPaperclipSkillSyncPreference,
+  writePaperclipSkillSyncPreference,
+} from "@paperclipai/adapter-utils/server-utils";
 import { and, desc, eq, ne } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, builtInManagedResources, companies, issueThreadInteractions, issues, routines, routineTriggers } from "@paperclipai/db";
@@ -1062,12 +1066,32 @@ export function builtInAgentService(db: Db) {
   }
 
   async function syncBundledSkillToAgent(agent: Agent, skill: CompanySkill) {
-    const desired = readPaperclipSkillSyncPreference(agent.adapterConfig as Record<string, unknown>).desiredSkillEntries;
+    const currentConfig = agent.adapterConfig as Record<string, unknown>;
+    if (adapterConfigPathIsUserLocked(currentConfig, "paperclipSkillSync.desiredSkills")) {
+      console.warn(
+        `Built-in skill sync skipped user-locked paperclipSkillSync.desiredSkills for agent ${agent.id}`,
+      );
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "system",
+        actorId: "built-in-agent-service",
+        action: "agent.adapter_config_change_skipped",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          fields: [{ path: "paperclipSkillSync.desiredSkills", type: "array", count: 1 }],
+          changedCount: 0,
+          skippedCount: 1,
+        },
+      });
+      return agent;
+    }
+    const desired = readPaperclipSkillSyncPreference(currentConfig).desiredSkillEntries;
     const nextDesired = [
       ...desired.filter((entry) => entry.key !== skill.key),
       { key: skill.key, versionId: skill.currentVersionId ?? null },
     ];
-    const adapterConfig = writePaperclipSkillSyncPreference(agent.adapterConfig as Record<string, unknown>, nextDesired);
+    const adapterConfig = writePaperclipSkillSyncPreference(currentConfig, nextDesired);
     const updated = await agentSvc.update(agent.id, { adapterConfig }, {
       allowBuiltInAgentMetadata: true,
       recordRevision: { source: "built-in-bundle:skill-sync" },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for managing AI-agent companies and their runtime configuration
> - Agent adapter configuration is mutable through the shared agent PATCH route
> - User locks prevent changes to selected fields, but the existing policy still accepted arbitrary unlocked fields from agents
> - Full-replacement requests could therefore introduce environment or instructions-path fields outside the skill-sync contract
> - The route must constrain agent-initiated writes before replacement, merge, authorization, and lock-policy processing
> - This pull request allows only `paperclipSkillSync.desiredSkills`, rejects locked disallowed paths, and strips other disallowed paths with redacted audit evidence
> - The benefit is strict server-side enforcement of the adapter write boundary without changing user-initiated updates

## Linked Issues or Issue Description

- Closes #10182
- Refs #10193
- Refs #10198

## What Changed

- Added an agent-initiated adapterConfig allowlist that retains only `paperclipSkillSync.desiredSkills`
- Rejects disallowed paths that overlap `_userLocked` with HTTP 400 before persistence
- Ignores agent `replaceAdapterConfig` semantics for stripped fields so existing config remains intact
- Records stripped path counts and redacted path shapes in activity logs and linked-parent comments
- Added route coverage for allowed writes, locked rejection, unlocked stripping, user writes, attribution, and adversarial full replacement

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-instructions-routes.test.ts server/src/__tests__/agent-skills-routes.test.ts server/src/__tests__/built-in-agents.test.ts` — 71 passed
- `pnpm --filter @paperclipai/server typecheck` — passed
- `git diff --check` — passed
- `pnpm lint` — unavailable; this repository has no root or server lint script
- `pnpm test` — 2,993 passed, 1 skipped, 8 unrelated local infrastructure failures in workspace path/provisioning/runtime tests
- `pnpm audit --audit-level high` — reports pre-existing workspace dependency advisories; this PR changes no dependencies

## Risks

- Agent callers that relied on undocumented adapterConfig fields will now have those fields stripped or rejected when user locked; this is the intended security boundary
- The branch is stacked on #10198 to preserve its canonical actor-attribution change; the diff will shrink when that PR merges
- Redacted audit records include field paths, types, and counts but never submitted values

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI `openai/gpt-5.6-sol` with reasoning, repository tools, code execution, and test execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable: no user-facing documentation change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge