### PR TITLE
feat(status-cards): single-message setup drives query and update prompt

### DIFF
--- a/docs/guides/board-operator/status-cards.md
+++ b/docs/guides/board-operator/status-cards.md
@@ -3,7 +3,7 @@ title: Status Cards
 summary: Experimental watched-query summaries, refresh policies, costs, and agent authoring
 ---
 
-Status cards are an experimental company-wide board of persistent summaries. Each card starts with an interest prompt such as “blocked launch work updated this week.” Paperclip's Summarizer compiles that prose into bounded company-search queries, stores the effective query set, and produces a Markdown summary.
+Status cards are an experimental company-wide board of persistent summaries. Each card is set up with a single message such as “blocked launch work updated this week — tell me the next decision.” The card's agent (the built-in Summarizer by default, or a per-card override chosen at creation or in settings) compiles that prose into bounded company-search queries, stores the effective query set, and follows the same message as the instructions for every summary it writes. There is no separate summarization prompt to append to or replace.
 
 Enable **Status Cards** from **Instance Settings > Experimental**. When `enableStatusCards` is off, the UI routes and REST API return not found; the feature does not leak into non-enabled instances.
 
@@ -17,7 +17,7 @@ Status cards use SQL change detection before spending model tokens. Paperclip re
 - **Active hours** batch changes outside the configured window into a later update.
 - **Daily token caps** pause automatic work when the card reaches its budget. Manual refresh remains available.
 
-Incremental updates receive the previous summary and only the changed tasks. Paperclip uses a full rebuild after query or instruction changes, large deltas, periodic drift guards, restore from archive, or an explicit full refresh. Archived cards are disarmed; restoring one leaves it stale and schedules a full refresh rather than silently resuming the old schedule.
+Incremental updates receive the previous summary and only the changed tasks. Paperclip uses a full rebuild after prompt or agent changes, large deltas, periodic drift guards, restore from archive, or an explicit full refresh. Archived cards are disarmed; restoring one leaves it stale and schedules a full refresh rather than silently resuming the old schedule.
 
 ## Cost model
 

--- a/packages/db/src/migrations/0190_status_card_single_prompt.sql
+++ b/packages/db/src/migrations/0190_status_card_single_prompt.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "status_cards" DROP COLUMN IF EXISTS "instructions_mode";--> statement-breakpoint
+ALTER TABLE "status_cards" DROP COLUMN IF EXISTS "instructions";

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1317,6 +1317,13 @@
       "when": 1784840937101,
       "tag": "0189_status_card_agent",
       "breakpoints": true
+    },
+    {
+      "idx": 190,
+      "version": "7",
+      "when": 1784916885226,
+      "tag": "0190_status_card_single_prompt",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/status_cards.ts
+++ b/packages/db/src/schema/status_cards.ts
@@ -38,8 +38,6 @@ export const statusCards = pgTable(
     queryVersion: integer("query_version").notNull().default(0),
     queryCompiledAt: timestamp("query_compiled_at", { withTimezone: true }),
     queryCompiledByAgentId: uuid("query_compiled_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
-    instructionsMode: text("instructions_mode").$type<"none" | "append" | "replace">().notNull().default("none"),
-    instructions: text("instructions"),
     // Per-card summarizer override; null means the company's built-in Summarizer.
     agentId: uuid("agent_id").references(() => agents.id, { onDelete: "set null" }),
     refreshPolicy: jsonb("refresh_policy").$type<StatusCardRefreshPolicy>().notNull(),

--- a/packages/shared/src/validators/status-card.ts
+++ b/packages/shared/src/validators/status-card.ts
@@ -13,7 +13,6 @@ function isValidTimeZone(timezone: string) {
   }
 }
 
-export const statusCardInstructionsModeSchema = z.enum(["none", "append", "replace"]);
 export const statusCardStateSchema = z.enum(["compiling", "active", "error", "paused_budget", "paused_hours"]);
 export const statusCardUpdateKindSchema = z.enum(["compile", "full", "incremental"]);
 export const statusCardUpdateTriggerSchema = z.enum(["manual", "interval", "reactive", "restore"]);
@@ -79,8 +78,6 @@ export const statusCardSchema = z.object({
   queryVersion: z.number().int().nonnegative(),
   queryCompiledAt: z.string().datetime().nullable(),
   queryCompiledByAgentId: z.string().uuid().nullable(),
-  instructionsMode: statusCardInstructionsModeSchema,
-  instructions: z.string().nullable(),
   agentId: z.string().uuid().nullable(),
   refreshPolicy: statusCardRefreshPolicySchema,
   state: statusCardStateSchema,
@@ -154,8 +151,7 @@ export const createStatusCardSchema = z.object({
   interestPrompt: z.string().trim().min(1).max(20_000),
   title: z.string().trim().min(1).max(300).optional(),
   titlePinned: z.boolean().default(false),
-  instructionsMode: statusCardInstructionsModeSchema.default("none"),
-  instructions: z.string().max(50_000).nullable().optional(),
+  agentId: z.string().uuid().nullable().optional(),
   refreshPolicy: statusCardRefreshPolicySchema.default(defaultStatusCardRefreshPolicy),
 });
 
@@ -164,8 +160,6 @@ export const patchStatusCardSchema = z
     interestPrompt: z.string().trim().min(1).max(20_000).optional(),
     title: z.string().trim().min(1).max(300).nullable().optional(),
     titlePinned: z.boolean().optional(),
-    instructionsMode: statusCardInstructionsModeSchema.optional(),
-    instructions: z.string().max(50_000).nullable().optional(),
     agentId: z.string().uuid().nullable().optional(),
     refreshPolicy: statusCardRefreshPolicySchema.optional(),
     archived: z.boolean().optional(),

--- a/packages/skills-catalog/catalog/bundled/paperclip-operations/status-card-query/SKILL.md
+++ b/packages/skills-catalog/catalog/bundled/paperclip-operations/status-card-query/SKILL.md
@@ -43,7 +43,7 @@ Creation returns `201` and queues compilation automatically. Save the returned c
 curl -sS -X PATCH \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"instructionsMode":"append","instructions":"Call out the single next decision."}' \
+  -d '{"interestPrompt":"Blocked or in-review launch work updated this week. Call out the single next decision."}' \
   "$PAPERCLIP_API_BASE/api/status-cards/$STATUS_CARD_ID"
 
 curl -sS -X POST \
@@ -133,5 +133,5 @@ Later generation issues use the same summary write-back endpoint and include `op
 
 - For `incremental`, patch the supplied previous Markdown using only the changed issues. Do not refetch the issue list.
 - For `full`, rebuild from the supplied bounded snapshot. Do not expand the scope with issue-list endpoint calls.
-- Keep the mechanical contract even when card instructions use `replace`: stream `STATUS:` lines and the `<<<SUMMARY-DRAFT>>>` block, then write the final Markdown to `PUT /api/status-cards/{statusCardId}/summary` from the assigned run.
-- `append` instructions follow the default Summarizer house format. `replace` changes the task-format section only; it never replaces the streaming or write-back requirements.
+- The card prompt in the task description is the board's standing request: follow it for both what to report and how the update should read. It never overrides the streaming or write-back requirements.
+- Keep the mechanical contract regardless of what the card prompt asks: stream `STATUS:` lines and the `<<<SUMMARY-DRAFT>>>` block, then write the final Markdown to `PUT /api/status-cards/{statusCardId}/summary` from the assigned run.

--- a/packages/skills-catalog/generated/catalog.json
+++ b/packages/skills-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/skills-catalog",
   "packageVersion": "0.3.1",
-  "generatedAt": "2026-07-23T21:19:42.449Z",
+  "generatedAt": "2026-07-24T18:19:49.696Z",
   "skills": [
     {
       "id": "paperclipai:bundled:docs:doc-maintenance",
@@ -137,11 +137,11 @@
         {
           "path": "SKILL.md",
           "kind": "skill",
-          "sizeBytes": 6318,
-          "sha256": "c3a5a81bfab4647899d8735220e2075dccbed30aad221c97ba511427621f9b26"
+          "sizeBytes": 6368,
+          "sha256": "0c6140f51d503cbadc98723ce54c0def48e7e31ea159b0935b8ad6369291498a"
         }
       ],
-      "contentHash": "sha256:10866419d69219e84d46558560fad92abb5dd17bd71ed2d645687d780ee94add"
+      "contentHash": "sha256:2b6e53bf8491f027afdbd6961ad84f677cfd385a0a6a73616ea84111ca8886ed"
     },
     {
       "id": "paperclipai:bundled:paperclip-operations:summarize-status",

--- a/server/src/__tests__/status-cards.test.ts
+++ b/server/src/__tests__/status-cards.test.ts
@@ -183,9 +183,9 @@ describeEmbeddedPostgres("status card routes", () => {
 
     const patched = await request(app)
       .patch(`/api/status-cards/${created.body.id}`)
-      .send({ title: "Launch health", titlePinned: true, instructionsMode: "append", instructions: "Call out blockers." });
+      .send({ title: "Launch health", titlePinned: true });
     expect(patched.status).toBe(200);
-    expect(patched.body).toMatchObject({ title: "Launch health", titlePinned: true, instructionsMode: "append" });
+    expect(patched.body).toMatchObject({ title: "Launch health", titlePinned: true });
 
     const scheduled = await request(app)
       .patch(`/api/status-cards/${created.body.id}`)
@@ -266,7 +266,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Recently updated launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: { mode: "manual" },
       },
       { agentId: null, userId: "board-user" },
@@ -305,7 +304,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Recently updated launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: { mode: "manual" },
       },
       { agentId: null, userId: "board-user" },
@@ -339,7 +337,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: defaultStatusCardRefreshPolicy,
       },
       { agentId: null, userId: "board-user" },
@@ -460,7 +457,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Recently updated launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: defaultStatusCardRefreshPolicy,
       },
       { agentId: null, userId: "board-user" },
@@ -485,6 +481,12 @@ describeEmbeddedPostgres("status card routes", () => {
       trigger: "restore",
       generationIssueId: restored.body.generatingIssueId,
     });
+
+    // The card's single prompt doubles as the update instructions.
+    const updateIssue = await db.select().from(issues).where(eq(issues.id, restored.body.generatingIssueId)).then((rows) => rows[0]!);
+    expect(updateIssue.description).toContain('<untrusted-data name="card-prompt">');
+    expect(updateIssue.description).toContain("Recently updated launch tasks");
+    expect(updateIssue.description).not.toContain("Board-provided summary preferences");
   });
 
   it("cancels refresh tasks when assignment wakeup fails", async () => {
@@ -497,7 +499,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Recently updated launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: defaultStatusCardRefreshPolicy,
       },
       { agentId: null, userId: "board-user" },
@@ -538,7 +539,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Recently updated launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: defaultStatusCardRefreshPolicy,
       },
       { agentId: null, userId: "board-user" },
@@ -585,7 +585,6 @@ describeEmbeddedPostgres("status card routes", () => {
       {
         interestPrompt: "Recently updated launch tasks",
         titlePinned: false,
-        instructionsMode: "none",
         refreshPolicy: { mode: "manual" },
       },
       { agentId: null, userId: "board-user" },
@@ -811,6 +810,18 @@ describeEmbeddedPostgres("status card routes", () => {
       .send({ interestPrompt: "Blocked launch tasks" });
     expect(created.status).toBe(201);
     expect(created.body.agentId).toBeNull();
+
+    expect((await request(app)
+      .post(`/api/companies/${company.id}/status-cards`)
+      .send({ interestPrompt: "Blocked launch tasks", agentId: foreignAgent.id })).status).toBe(422);
+
+    const createdWithAgent = await request(app)
+      .post(`/api/companies/${company.id}/status-cards`)
+      .send({ interestPrompt: "Launch tasks owned by Fable", agentId: override.id });
+    expect(createdWithAgent.status).toBe(201);
+    expect(createdWithAgent.body.agentId).toBe(override.id);
+    const setupIssue = await db.select().from(issues).where(eq(issues.id, createdWithAgent.body.generatingIssueId)).then((rows) => rows[0]!);
+    expect(setupIssue.assigneeAgentId).toBe(override.id);
 
     expect((await request(app).patch(`/api/status-cards/${created.body.id}`).send({ agentId: foreignAgent.id })).status).toBe(422);
 

--- a/server/src/services/status-cards.ts
+++ b/server/src/services/status-cards.ts
@@ -87,15 +87,14 @@ function updateDescription(input: {
   snapshot: CompanySearchIssueSummary[];
 }) {
   const mechanical = `Return the completed Markdown through \`PUT /api/status-cards/${input.card.id}/summary\` with \`generationIssueId\`, a short non-empty \`changeSummary\`, and the model id. Do not call issue-list endpoints. Preserve the streaming STATUS and <<<SUMMARY-DRAFT>>> sentinels used by the Summarizer.`;
-  const defaultTask = input.kind === "incremental"
-    ? `Patch the previous status summary using only the changed issues. Keep the Summarizer house format: start with **Decide:**, then **Recent work:**, use few links, and stay colloquial and action-oriented. Target roughly 300–500 output tokens.`
-    : `Rebuild the status summary from the bounded issue snapshot. Keep the Summarizer house format: start with **Decide:**, then **Recent work:**, use few links, and stay colloquial and action-oriented.`;
-  const task = input.card.instructionsMode === "replace" && input.card.instructions
-    ? "Produce the summary using the board-provided preferences when they are compatible with the trusted task and mechanical requirements."
-    : defaultTask;
-  const preferenceBlock = input.card.instructions
-    ? `\n\n## Board-provided summary preferences\n\n${untrustedPromptBlock("status-card-instructions", input.card.instructions)}`
-    : "";
+  // The card prompt is the board's single standing request: it already says
+  // what to watch and how the update should read, so it doubles as the
+  // summary instructions — there is no separate default prompt to append to
+  // or replace.
+  const task = `${input.kind === "incremental"
+    ? "Patch the previous status summary using only the changed issues."
+    : "Rebuild the status summary from the bounded issue snapshot."} Write the update the way the card prompt below asks — it describes what the board is watching and how they want the update written. Honor it when compatible with the trusted mechanical requirements, and default to roughly 300–500 output tokens when it does not say otherwise.`;
+  const promptBlock = `\n\n## Card prompt (board-provided)\n\n${untrustedPromptBlock("card-prompt", input.card.interestPrompt)}`;
   const payload = {
     operation: "update",
     statusCardId: input.card.id,
@@ -108,7 +107,7 @@ function updateDescription(input: {
     changes: input.changes.map(({ issueId, identifier, from, to, changeKind }) => ({ issueId, identifier, from, to, changeKind })),
     queryVersion: input.card.queryVersion,
   };
-  return `Update this Paperclip status card.\n\n${UNTRUSTED_PROMPT_RULE}\n\n${task}${preferenceBlock}\n\n${mechanical}\n\n## Previous summary\n\n${untrustedPromptBlock("previous-summary", input.previousSummary ?? null)}\n\n## Changed issues\n\n${untrustedPromptBlock("changed-issues", input.changes.map(({ issueId, identifier, title, from, to, changeKind }) => ({ issueId, identifier, title, from, to, changeKind })))}\n\n${input.kind === "full" ? `## Bounded snapshot\n\n${untrustedPromptBlock("bounded-snapshot", input.snapshot.map(({ id, identifier, title, status }) => ({ id, identifier, title, status })))}` : ""}\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
+  return `Update this Paperclip status card.\n\n${UNTRUSTED_PROMPT_RULE}\n\n${task}${promptBlock}\n\n${mechanical}\n\n## Previous summary\n\n${untrustedPromptBlock("previous-summary", input.previousSummary ?? null)}\n\n## Changed issues\n\n${untrustedPromptBlock("changed-issues", input.changes.map(({ issueId, identifier, title, from, to, changeKind }) => ({ issueId, identifier, title, from, to, changeKind })))}\n\n${input.kind === "full" ? `## Bounded snapshot\n\n${untrustedPromptBlock("bounded-snapshot", input.snapshot.map(({ id, identifier, title, status }) => ({ id, identifier, title, status })))}` : ""}\n\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
 }
 
 function compileDescription(card: StatusCardRow, generationIssueId: string | null, hash: string) {
@@ -209,6 +208,14 @@ export function statusCardService(
   }
 
   async function create(companyId: string, input: CreateStatusCard, actor: StatusCardActor) {
+    if (input.agentId) {
+      const summarizer = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.id, input.agentId), eq(agents.companyId, companyId)))
+        .then((rows) => rows[0] ?? null);
+      if (!summarizer) throw unprocessable("Summarizer agent must belong to this company");
+    }
     const values = {
       companyId,
       createdByAgentId: actor.agentId,
@@ -216,8 +223,7 @@ export function statusCardService(
       title: input.title ?? null,
       titlePinned: input.titlePinned,
       interestPrompt: input.interestPrompt,
-      instructionsMode: input.instructionsMode,
-      instructions: input.instructions ?? null,
+      agentId: input.agentId ?? null,
       refreshPolicy: input.refreshPolicy,
       state: "compiling" as const,
     };
@@ -267,12 +273,11 @@ export function statusCardService(
       ...(input.interestPrompt !== undefined
         ? { interestPrompt: input.interestPrompt, state: "compiling", failureReason: null }
         : {}),
-      ...(input.instructionsMode !== undefined ? { instructionsMode: input.instructionsMode } : {}),
-      ...(input.instructions !== undefined ? { instructions: input.instructions } : {}),
       ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
-      // A new summarizer (like new instructions) invalidates the incremental
-      // chain, so the next update rebuilds from scratch.
-      ...(input.instructionsMode !== undefined || input.instructions !== undefined || agentChanged ? { lastUpdateRunKind: null } : {}),
+      // A new summarizer or a new card prompt (which doubles as the summary
+      // instructions) invalidates the incremental chain, so the next update
+      // rebuilds from scratch.
+      ...(input.interestPrompt !== undefined || agentChanged ? { lastUpdateRunKind: null } : {}),
       ...(input.refreshPolicy !== undefined
         ? {
             refreshPolicy: input.refreshPolicy,

--- a/ui/src/pages/StatusCards/CreateStatusCardDialog.tsx
+++ b/ui/src/pages/StatusCards/CreateStatusCardDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { StatusCard } from "@paperclipai/shared";
+import { defaultStatusCardRefreshPolicy } from "@paperclipai/shared";
 import { Loader2 } from "lucide-react";
 
 import { statusCardsApi } from "@/api/statusCards";
@@ -16,9 +16,13 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { InlineBanner } from "@/components/InlineBanner";
 import { queryKeys } from "@/lib/queryKeys";
-import { StatusCardSettingsForm, defaultSettingsValue, type StatusCardSettingsValue } from "./StatusCardSettingsForm";
+import { SummarizerAgentSelect } from "./SummarizerAgentSelect";
 
-const EXAMPLES = ["issues about evals", "everything blocked this week", "ship feature X"];
+const EXAMPLES = [
+  "issues about evals",
+  "everything blocked this week",
+  "is feature X live? if not, the exact next actions to ship it",
+];
 
 export function CreateStatusCardDialog({
   companyId,
@@ -30,154 +34,105 @@ export function CreateStatusCardDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
-  const [step, setStep] = useState<1 | 2>(1);
-  const [interest, setInterest] = useState("");
-  const [createdCard, setCreatedCard] = useState<StatusCard | null>(null);
-  const [settings, setSettings] = useState<StatusCardSettingsValue>(defaultSettingsValue());
+  const [prompt, setPrompt] = useState("");
+  // "" → the built-in Summarizer; otherwise the id of the override agent.
+  const [agentId, setAgentId] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   function reset() {
-    setStep(1);
-    setInterest("");
-    setCreatedCard(null);
-    setSettings(defaultSettingsValue());
+    setPrompt("");
+    setAgentId("");
     setError(null);
   }
 
   function close() {
     onOpenChange(false);
-    // Delay reset so the closing animation does not flash step 1.
+    // Delay reset so the closing animation does not flash cleared fields.
     window.setTimeout(reset, 200);
   }
-
-  const invalidateBoard = () =>
-    Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.statusCards.list(companyId, false) }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.statusCards.list(companyId, true) }),
-    ]);
 
   const createMutation = useMutation({
     mutationFn: () =>
       statusCardsApi.create(companyId, {
-        interestPrompt: interest.trim(),
+        interestPrompt: prompt.trim(),
         titlePinned: false,
-        instructionsMode: "none",
-        instructions: null,
-        refreshPolicy: settings.refreshPolicy,
-      }),
-    onMutate: () => setError(null),
-    onSuccess: async (card) => {
-      setCreatedCard(card);
-      setStep(2);
-      await invalidateBoard();
-    },
-    onError: (err) => setError(err instanceof Error ? err.message : "Could not create the card."),
-  });
-
-  const saveSettingsMutation = useMutation({
-    mutationFn: () =>
-      statusCardsApi.patch(createdCard!.id, {
-        instructionsMode: settings.instructionsMode,
-        instructions: settings.instructionsMode === "none" ? null : settings.instructions.trim() || null,
-        refreshPolicy: settings.refreshPolicy,
+        agentId: agentId || null,
+        refreshPolicy: defaultStatusCardRefreshPolicy,
       }),
     onMutate: () => setError(null),
     onSuccess: async () => {
-      await invalidateBoard();
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.statusCards.list(companyId, false) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.statusCards.list(companyId, true) }),
+      ]);
       close();
     },
-    onError: (err) => setError(err instanceof Error ? err.message : "Could not save settings."),
+    onError: (err) => setError(err instanceof Error ? err.message : "Could not create the card."),
   });
 
   return (
     <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
       <DialogContent className="sm:max-w-2xl">
-        {step === 1 ? (
-          <>
-            <DialogHeader>
-              <DialogTitle>New status card</DialogTitle>
-              <DialogDescription>Step 1 of 2</DialogDescription>
-            </DialogHeader>
+        <DialogHeader>
+          <DialogTitle>New card</DialogTitle>
+          <DialogDescription>
+            One message sets up the whole card: say what you want to watch and what each update
+            should tell you. The agent builds the query from it and writes every update against it.
+          </DialogDescription>
+        </DialogHeader>
 
-            {error ? <InlineBanner tone="danger" title="Create failed">{error}</InlineBanner> : null}
+        {error ? <InlineBanner tone="danger" title="Create failed">{error}</InlineBanner> : null}
 
-            <div className="space-y-3">
-              <label htmlFor="status-card-interest" className="block pb-1 text-sm font-semibold">
-                What do you want to keep an eye on?
-              </label>
-              <Textarea
-                id="status-card-interest"
-                value={interest}
-                onChange={(event) => setInterest(event.target.value)}
-                rows={5}
-                autoFocus
-                placeholder="Issues in the Cloud, ID and Content projects that were recently updated. Tell me what I need to do next and what your advice is."
-                className="text-sm"
-              />
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-xs font-medium text-muted-foreground">Examples</span>
-                {EXAMPLES.map((example) => (
-                  <button
-                    key={example}
-                    type="button"
-                    onClick={() => setInterest(example)}
-                    className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/40"
-                  >
-                    {example}
-                  </button>
-                ))}
-              </div>
-            </div>
+        <div className="space-y-3">
+          <label htmlFor="status-card-prompt" className="block pb-1 text-sm font-semibold">
+            What do you want to keep an eye on?
+          </label>
+          <Textarea
+            id="status-card-prompt"
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            rows={5}
+            autoFocus
+            placeholder="Keep an eye on the ID and Cloud projects. Tell me whether the service is live, and if not, the exact three actions needed to get it to production."
+            className="text-sm"
+          />
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground">Examples</span>
+            {EXAMPLES.map((example) => (
+              <button
+                key={example}
+                type="button"
+                onClick={() => setPrompt(example)}
+                className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/40"
+              >
+                {example}
+              </button>
+            ))}
+          </div>
+        </div>
 
-            <DialogFooter>
-              <div className="flex gap-2">
-                <Button variant="outline" onClick={close} disabled={createMutation.isPending}>
-                  Cancel
-                </Button>
-                <Button
-                  onClick={() => createMutation.mutate()}
-                  disabled={interest.trim().length === 0 || createMutation.isPending}
-                >
-                  {createMutation.isPending ? <Loader2 className="animate-spin" /> : null}
-                  Create →
-                </Button>
-              </div>
-            </DialogFooter>
-          </>
-        ) : (
-          <>
-            <DialogHeader>
-              <DialogTitle>Configure card</DialogTitle>
-              <DialogDescription>Step 2 of 2</DialogDescription>
-            </DialogHeader>
+        <div className="space-y-2">
+          <label className="block text-sm font-semibold">Agent</label>
+          <SummarizerAgentSelect companyId={companyId} value={agentId} onChange={setAgentId} enabled={open} />
+          <p className="text-xs text-muted-foreground">
+            Runs this card's setup and updates. Leave on the default unless another agent should own it.
+          </p>
+        </div>
 
-            {error ? <InlineBanner tone="danger" title="Save failed">{error}</InlineBanner> : null}
-
-            <div className="rounded-md bg-muted px-3 py-2 text-xs">
-              <div className="flex items-center gap-2 text-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-pulse text-muted-foreground" />
-                Setting up your card… the first summary will follow automatically.
-              </div>
-              <p className="mt-1 text-muted-foreground">“{createdCard?.interestPrompt}”</p>
-            </div>
-
-            <div className="max-h-(--sz-60vh) overflow-y-auto pr-1">
-              <StatusCardSettingsForm value={settings} onChange={setSettings} />
-            </div>
-
-            <DialogFooter>
-              <div className="flex gap-2">
-                <Button variant="outline" onClick={close} disabled={saveSettingsMutation.isPending}>
-                  Skip
-                </Button>
-                <Button onClick={() => saveSettingsMutation.mutate()} disabled={saveSettingsMutation.isPending}>
-                  {saveSettingsMutation.isPending ? <Loader2 className="animate-spin" /> : null}
-                  Done
-                </Button>
-              </div>
-            </DialogFooter>
-          </>
-        )}
+        <DialogFooter>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={close} disabled={createMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => createMutation.mutate()}
+              disabled={prompt.trim().length === 0 || createMutation.isPending}
+            >
+              {createMutation.isPending ? <Loader2 className="animate-spin" /> : null}
+              Create card
+            </Button>
+          </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/ui/src/pages/StatusCards/StatusCardDetailDrawer.tsx
+++ b/ui/src/pages/StatusCards/StatusCardDetailDrawer.tsx
@@ -5,10 +5,6 @@ import type { CompanySearchIssueSummary, StatusCardUpdate, SummarySlotIssueRef }
 import { AlertTriangle, ChevronDown, ExternalLink, History, Loader2, RefreshCw, Wand2 } from "lucide-react";
 
 import { statusCardsApi, type StatusCardDryRun } from "@/api/statusCards";
-import { agentsApi } from "@/api/agents";
-import { AgentIcon } from "@/components/AgentIconPicker";
-import { InlineEntitySelector, type InlineEntityOption } from "@/components/InlineEntitySelector";
-import { isAgentTaskTarget } from "@/lib/company-members";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import { useSummaryDraftStream } from "@/components/useSummaryDraftStream";
 import { Badge } from "@/components/ui/badge";
@@ -33,6 +29,7 @@ import {
   defaultSettingsValue,
   type StatusCardSettingsValue,
 } from "./StatusCardSettingsForm";
+import { SummarizerAgentSelect } from "./SummarizerAgentSelect";
 import {
   formatCents,
   formatTokens,
@@ -72,11 +69,7 @@ export function StatusCardDetailDrawer({
 
   useEffect(() => {
     if (card) {
-      setSettings({
-        instructionsMode: card.instructionsMode,
-        instructions: card.instructions ?? "",
-        refreshPolicy: card.refreshPolicy,
-      });
+      setSettings({ refreshPolicy: card.refreshPolicy });
       setTitle(card.title ?? "");
       setInterest(card.interestPrompt);
       setSummarizerAgentId(card.agentId ?? "");
@@ -107,27 +100,6 @@ export function StatusCardDetailDrawer({
     queryFn: () => statusCardsApi.dryRun(card!.id),
     enabled: Boolean(card && open && tab === "watched" && card.queries.length > 0),
   });
-  const agentsQuery = useQuery({
-    queryKey: card ? queryKeys.agents.list(card.companyId) : ["agents", "none"],
-    queryFn: () => agentsApi.list(card!.companyId),
-    enabled: Boolean(card && open),
-  });
-  const agentById = useMemo(
-    () => new Map((agentsQuery.data ?? []).map((agent) => [agent.id, agent])),
-    [agentsQuery.data],
-  );
-  const agentOptions = useMemo<InlineEntityOption[]>(
-    () =>
-      (agentsQuery.data ?? [])
-        .filter(isAgentTaskTarget)
-        .map((agent) => ({
-          id: `agent:${agent.id}`,
-          label: agent.name,
-          searchText: `${agent.name} ${agent.role} ${agent.title ?? ""}`,
-        })),
-    [agentsQuery.data],
-  );
-
   const lifecycle = card ? deriveStatusCardLifecycle(card) : "fresh";
   const generatingIssue = useMemo<SummarySlotIssueRef | null>(
     () =>
@@ -182,10 +154,8 @@ export function StatusCardDetailDrawer({
         // clearing it hands naming back to the compiler.
         title: trimmedTitle || null,
         titlePinned: trimmedTitle.length > 0,
-        // Editing the interest text ("query") triggers a server-side recompile.
+        // Editing the card prompt triggers a server-side recompile.
         ...(interestChanged ? { interestPrompt: trimmedInterest } : {}),
-        instructionsMode: settings.instructionsMode,
-        instructions: settings.instructionsMode === "none" ? null : settings.instructions.trim() || null,
         agentId: summarizerAgentId || null,
         refreshPolicy: settings.refreshPolicy,
       });
@@ -477,52 +447,27 @@ export function StatusCardDetailDrawer({
               </section>
 
               <section className="space-y-2">
-                <h3 className="text-sm font-semibold">What this card watches</h3>
+                <h3 className="text-sm font-semibold">What this card watches & reports</h3>
                 <Textarea
                   value={interest}
                   onChange={(event) => setInterest(event.target.value)}
                   rows={3}
                   className="text-sm"
-                  aria-label="What this card watches"
+                  aria-label="What this card watches & reports"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Editing this updates what the card watches and refreshes the summary.
+                  This one message drives the whole card: the agent compiles the watch query from it
+                  and follows it as the instructions for every update. Editing it rebuilds the card.
                 </p>
               </section>
 
               <section className="space-y-2">
-                <h3 className="text-sm font-semibold">Summarizer agent</h3>
-                <InlineEntitySelector
-                  value={summarizerAgentId ? `agent:${summarizerAgentId}` : ""}
-                  options={agentOptions}
-                  placeholder="Summarizer (default)"
-                  noneLabel="Summarizer (default)"
-                  searchPlaceholder="Search agents..."
-                  emptyMessage="No agents found."
-                  onChange={(next) =>
-                    setSummarizerAgentId(next.startsWith("agent:") ? next.slice("agent:".length) : "")
-                  }
-                  className="h-8 text-sm"
-                  renderTriggerValue={(option) => {
-                    if (!option) return <span>Summarizer (default)</span>;
-                    const agent = option.id.startsWith("agent:") ? agentById.get(option.id.slice("agent:".length)) : null;
-                    return (
-                      <>
-                        {agent ? <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : null}
-                        <span className="truncate">{option.label}</span>
-                      </>
-                    );
-                  }}
-                  renderOption={(option) => {
-                    if (!option.id) return <span className="truncate">{option.label}</span>;
-                    const agent = option.id.startsWith("agent:") ? agentById.get(option.id.slice("agent:".length)) : null;
-                    return (
-                      <>
-                        {agent ? <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : null}
-                        <span className="truncate">{option.label}</span>
-                      </>
-                    );
-                  }}
+                <h3 className="text-sm font-semibold">Agent</h3>
+                <SummarizerAgentSelect
+                  companyId={card.companyId}
+                  value={summarizerAgentId}
+                  onChange={setSummarizerAgentId}
+                  enabled={open}
                 />
               </section>
 

--- a/ui/src/pages/StatusCards/StatusCardSettingsForm.tsx
+++ b/ui/src/pages/StatusCards/StatusCardSettingsForm.tsx
@@ -1,27 +1,20 @@
 import type { StatusCardRefreshPolicy } from "@paperclipai/shared";
-import { Check, ChevronDown } from "lucide-react";
-
-type StatusCardInstructionsMode = "none" | "append" | "replace";
+import { ChevronDown } from "lucide-react";
 
 import { Checkbox } from "@/components/ui/checkbox";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { estimateStatusCardCost } from "./format";
 
 export interface StatusCardSettingsValue {
-  instructionsMode: StatusCardInstructionsMode;
-  instructions: string;
   refreshPolicy: StatusCardRefreshPolicy;
 }
 
 export function defaultSettingsValue(): StatusCardSettingsValue {
   return {
-    instructionsMode: "none",
-    instructions: "",
     refreshPolicy: {
       mode: "manual",
       triggers: {
@@ -37,16 +30,6 @@ export function defaultSettingsValue(): StatusCardSettingsValue {
 
 const INTERVAL_OPTIONS = [5, 15, 30, 60];
 const DEBOUNCE_OPTIONS = [30, 60, 120, 300];
-
-/**
- * The house-format instructions the Summarizer runs with by default (mirrors
- * the server-side compile/update prompt). Shown read-only so the board can see
- * what "Append" adds to, or "Replace" swaps out, without being able to edit it.
- */
-const DEFAULT_SUMMARY_PROMPT =
-  "Rebuild the status summary from the matched issues (or patch the previous summary for incremental updates). " +
-  "Keep the Summarizer house format: start with **Decide:**, then **Recent work:**. " +
-  "Use few links, stay colloquial and action-oriented, and target roughly 300–500 output tokens.";
 
 type TriggerKey = keyof StatusCardRefreshPolicy["triggers"];
 
@@ -98,11 +81,9 @@ function RadioRow({
 export function StatusCardSettingsForm({
   value,
   onChange,
-  showInstructions = true,
 }: {
   value: StatusCardSettingsValue;
   onChange: (next: StatusCardSettingsValue) => void;
-  showInstructions?: boolean;
 }) {
   const { refreshPolicy: policy } = value;
   // Change triggers, active-hours, and the daily token cap only govern
@@ -137,55 +118,6 @@ export function StatusCardSettingsForm({
 
   return (
     <div className="space-y-6">
-      {showInstructions ? (
-        <section className="space-y-2">
-          <h3 className="text-sm font-semibold">Extra instructions for the summarizer</h3>
-          <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Instruction mode">
-            {(
-              [
-                { mode: "append" as const, label: "Append to the default prompt" },
-                { mode: "replace" as const, label: "Replace the default prompt" },
-                { mode: "none" as const, label: "No extra instructions" },
-              ]
-            ).map((option) => {
-              const selected = value.instructionsMode === option.mode;
-              return (
-                <button
-                  key={option.mode}
-                  type="button"
-                  role="radio"
-                  aria-checked={selected}
-                  onClick={() => onChange({ ...value, instructionsMode: option.mode })}
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs transition-colors",
-                    selected ? "border-primary bg-primary/10 text-foreground" : "border-border text-muted-foreground hover:bg-accent/40",
-                  )}
-                >
-                  {selected ? <Check className="h-3 w-3" /> : null}
-                  {option.label}
-                </button>
-              );
-            })}
-          </div>
-          <Textarea
-            value={value.instructions}
-            onChange={(event) => onChange({ ...value, instructions: event.target.value })}
-            placeholder={'e.g. Always end with "what should Dotta do next". Keep it under 8 bullets.'}
-            disabled={value.instructionsMode === "none"}
-            rows={3}
-            className="text-sm"
-          />
-          {value.instructionsMode !== "none" ? (
-            <div className="rounded-md border border-border bg-muted/40 px-3 py-2">
-              <p className="text-xs font-medium text-muted-foreground">
-                {value.instructionsMode === "append" ? "Added on top of the default prompt:" : "Replaces the default prompt:"}
-              </p>
-              <p className="mt-1 text-xs leading-5 text-muted-foreground">{DEFAULT_SUMMARY_PROMPT}</p>
-            </div>
-          ) : null}
-        </section>
-      ) : null}
-
       <section className="space-y-2">
         <h3 className="text-sm font-semibold">Auto-update policy</h3>
         <div className="space-y-2">

--- a/ui/src/pages/StatusCards/StatusCardTile.test.tsx
+++ b/ui/src/pages/StatusCards/StatusCardTile.test.tsx
@@ -40,8 +40,6 @@ function baseCard(overrides: Partial<StatusCardView>): StatusCardView {
     queryVersion: 1,
     queryCompiledAt: "2026-07-22T10:00:00.000Z",
     queryCompiledByAgentId: null,
-    instructionsMode: "none",
-    instructions: null,
     agentId: null,
     refreshPolicy: {
       mode: "interval",

--- a/ui/src/pages/StatusCards/SummarizerAgentSelect.tsx
+++ b/ui/src/pages/StatusCards/SummarizerAgentSelect.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { agentsApi } from "@/api/agents";
+import { AgentIcon } from "@/components/AgentIconPicker";
+import { InlineEntitySelector, type InlineEntityOption } from "@/components/InlineEntitySelector";
+import { isAgentTaskTarget } from "@/lib/company-members";
+import { queryKeys } from "@/lib/queryKeys";
+
+/**
+ * Picker for the agent that runs a card's updates. `value` is the override
+ * agent id, or "" for the company's built-in Summarizer (the default).
+ */
+export function SummarizerAgentSelect({
+  companyId,
+  value,
+  onChange,
+  enabled = true,
+}: {
+  companyId: string | null | undefined;
+  value: string;
+  onChange: (agentId: string) => void;
+  enabled?: boolean;
+}) {
+  const agentsQuery = useQuery({
+    queryKey: companyId ? queryKeys.agents.list(companyId) : ["agents", "none"],
+    queryFn: () => agentsApi.list(companyId!),
+    enabled: Boolean(companyId) && enabled,
+  });
+  const agentById = useMemo(
+    () => new Map((agentsQuery.data ?? []).map((agent) => [agent.id, agent])),
+    [agentsQuery.data],
+  );
+  const agentOptions = useMemo<InlineEntityOption[]>(
+    () =>
+      (agentsQuery.data ?? [])
+        .filter(isAgentTaskTarget)
+        .map((agent) => ({
+          id: `agent:${agent.id}`,
+          label: agent.name,
+          searchText: `${agent.name} ${agent.role} ${agent.title ?? ""}`,
+        })),
+    [agentsQuery.data],
+  );
+
+  const renderAgent = (option: InlineEntityOption | null) => {
+    if (!option || !option.id) return <span>Summarizer (default)</span>;
+    const agent = option.id.startsWith("agent:") ? agentById.get(option.id.slice("agent:".length)) : null;
+    return (
+      <>
+        {agent ? <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : null}
+        <span className="truncate">{option.label}</span>
+      </>
+    );
+  };
+
+  return (
+    <InlineEntitySelector
+      value={value ? `agent:${value}` : ""}
+      options={agentOptions}
+      placeholder="Summarizer (default)"
+      noneLabel="Summarizer (default)"
+      searchPlaceholder="Search agents..."
+      emptyMessage="No agents found."
+      onChange={(next) => onChange(next.startsWith("agent:") ? next.slice("agent:".length) : "")}
+      className="h-8 text-sm"
+      renderTriggerValue={renderAgent}
+      renderOption={(option) => renderAgent(option)}
+    />
+  );
+}

--- a/ui/src/pages/StatusCards/index.tsx
+++ b/ui/src/pages/StatusCards/index.tsx
@@ -33,7 +33,7 @@ export function StatusCards() {
   const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Status cards" }]);
+    setBreadcrumbs([{ label: "Status" }]);
   }, [setBreadcrumbs]);
 
   const activeQuery = useQuery({
@@ -116,7 +116,7 @@ export function StatusCards() {
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <h1 className="text-xl font-bold">Status cards</h1>
+          <h1 className="text-xl font-bold">Status</h1>
           <Badge variant="secondary" className="gap-1">
             <FlaskConical className="h-3 w-3" />
             Experimental


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies and their ongoing work.
> - Status cards turn a standing question into recurring, agent-generated summaries on the board.
> - The existing setup split intent across a watch prompt and separate update instructions, which made creation and later behavior harder to understand.
> - A status card should have one durable source of truth for both deciding what to watch and telling the summarizer what each update must contain.
> - This pull request makes the card prompt that source of truth, simplifies creation to one step, and lets operators choose the running agent immediately.
> - The benefit is a smaller mental model, fewer configuration modes, and consistent update instructions throughout the card lifecycle.

## Linked Issues or Issue Description

Status cards currently require operators to express the same intent in two places: the watch prompt and optional update instructions with append/replace/none modes. This feature simplifies the experimental status-card workflow so a single prompt defines both the watch query and every generated update. The create flow must also support selecting the responsible agent without a second setup step.

Related prior status-card work: #10101.

## What Changed

- Use the status card's single prompt to compile the watch query and directly instruct every summary update.
- Add migration `0190_status_card_single_prompt` to remove `status_cards.instructions_mode` and `status_cards.instructions`.
- Add `agentId` to `createStatusCardSchema`, validate company membership, and default new cards to the built-in Summarizer.
- Replace the two-step create flow with one prompt-and-agent dialog and extract a shared `SummarizerAgentSelect` for create/settings surfaces.
- Remove the extra-instructions settings section, reset incremental history when the prompt changes, and rename the board page to "Status".
- Update the bundled `status-card-query` skill and board-operator documentation, then regenerate the skills catalog manifest.

## Verification

- Server status-card suites: 29/29 passing.
- UI `StatusCards` suites: 22/22 passing.
- Skills catalog suite: 20/20 passing.
- `tsc -b` passes for server, UI, shared, and database packages.
- `pnpm check:migrations` passes.
- Light and dark mode screenshots cover the new create dialog and settings tab.

## Risks

- Migration `0190` intentionally drops existing separate instruction text. Existing card prompts remain and become the update instructions under the new model; status cards are experimental and feature-flagged.
- Prompt edits now reset the incremental summary chain and trigger a full rebuild, which is intentional because the prompt is also the update contract.
- Agent selection is company-scoped; invalid agent ids return a validation error rather than creating a misrouted card.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Implementation: Anthropic Claude via the `claude_local` adapter, agent label "Claude Fable 5"; extended reasoning, tool use, and code execution. The exact provider model id and context-window value were not retained in the task metadata.
- PR preparation: OpenAI GPT-5.4 through Codex CLI, with reasoning, repository inspection, GitHub CLI, and Paperclip API tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
