### PR TITLE
fix(recovery): classify provider credit exhaustion

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -331,6 +331,58 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("classifies result-only provider credit failures during direct escalation", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const latestRun = {
+      id: randomUUID(),
+      agentId: coderId,
+      status: "failed",
+      error: "Adapter failed",
+      errorCode: "adapter_failed",
+      contextSnapshot: { issueId: sourceIssue.id },
+      livenessState: "needs_followup",
+      resultJson: {
+        result:
+          "HTTP 402 ProviderError: This request requires more credits, or fewer max_tokens. " +
+          "You requested up to 262144 tokens but can only afford 6586. " +
+          "To increase, visit https://openrouter.ai/settings/credits.",
+      },
+    } as const;
+    await db.insert(heartbeatRuns).values({
+      id: latestRun.id,
+      companyId,
+      agentId: coderId,
+      invocationSource: "manual",
+      status: "failed",
+      error: latestRun.error,
+      errorCode: latestRun.errorCode,
+      resultJson: latestRun.resultJson,
+      contextSnapshot: latestRun.contextSnapshot,
+      livenessState: latestRun.livenessState,
+    });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action).toMatchObject({
+      ownerType: "system",
+      ownerAgentId: null,
+      returnOwnerAgentId: coderId,
+      cause: "provider_quota",
+      monitorPolicy: { type: "wait_recovery", retryAgentId: coderId },
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["process_lost", undefined, "coder"],
     ["adapter_failed", "successful_run_missing_state", "coder"],

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -383,6 +383,65 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
+  it("uses a nested provider-credit reset time during direct escalation", async () => {
+    const expectedRetryAt = new Date();
+    expectedRetryAt.setUTCMinutes(0, 0, 0);
+    expectedRetryAt.setUTCHours(expectedRetryAt.getUTCHours() + 2);
+    const resetHour = String(expectedRetryAt.getUTCHours()).padStart(2, "0");
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const latestRun = {
+      id: randomUUID(),
+      agentId: coderId,
+      status: "failed",
+      error:
+        "HTTP 402 ProviderError: This request requires more credits, or fewer max_tokens.",
+      errorCode: "adapter_failed",
+      contextSnapshot: { issueId: sourceIssue.id },
+      livenessState: "needs_followup",
+      resultJson: {
+        result: {
+          error: {
+            message: `HTTP 402 ProviderError: This request requires more credits, or fewer max_tokens. Try again at ${resetHour}:00 (UTC).`,
+          },
+        },
+      },
+    } as const;
+    await db.insert(heartbeatRuns).values({
+      id: latestRun.id,
+      companyId,
+      agentId: coderId,
+      invocationSource: "manual",
+      status: "failed",
+      error: latestRun.error,
+      errorCode: latestRun.errorCode,
+      resultJson: latestRun.resultJson,
+      contextSnapshot: latestRun.contextSnapshot,
+      livenessState: latestRun.livenessState,
+    });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun,
+    });
+
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(action?.monitorPolicy).toMatchObject({
+      type: "wait_recovery",
+      retryAgentId: coderId,
+      retryAt: expectedRetryAt.toISOString(),
+    });
+    const [scheduledRun] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "scheduled_retry"));
+    expect(scheduledRun?.scheduledRetryAt?.toISOString()).toBe(expectedRetryAt.toISOString());
+  });
+
   it.each([
     ["process_lost", undefined, "coder"],
     ["adapter_failed", "successful_run_missing_state", "coder"],

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -26,7 +26,10 @@ import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
 import { buildPaperclipWakePayload } from "../services/heartbeat.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
-import { recoveryService } from "../services/recovery/service.js";
+import {
+  PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS,
+  recoveryService,
+} from "../services/recovery/service.js";
 import { noticeMetadataReferencesRecoveryAction } from "../services/recovery/successful-run-handoff.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -440,6 +443,46 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.status, "scheduled_retry"));
     expect(scheduledRun?.scheduledRetryAt?.toISOString()).toBe(expectedRetryAt.toISOString());
+  });
+
+  it("schedules the default provider-quota retry when direct escalation lacks a latest run", async () => {
+    const { coderId, sourceIssue } = await seedCompany();
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const beforeEscalation = new Date();
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: null,
+      recoveryCause: "provider_quota",
+    });
+
+    const afterEscalation = new Date();
+    const [action] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    const [scheduledRun] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "scheduled_retry"));
+
+    expect(scheduledRun).toMatchObject({
+      agentId: coderId,
+      retryOfRunId: null,
+      scheduledRetryReason: "provider_quota_recovery",
+    });
+    expect(scheduledRun?.scheduledRetryAt?.getTime()).toBeGreaterThanOrEqual(
+      beforeEscalation.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS,
+    );
+    expect(scheduledRun?.scheduledRetryAt?.getTime()).toBeLessThanOrEqual(
+      afterEscalation.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS,
+    );
+    expect(action?.monitorPolicy).toMatchObject({
+      type: "wait_recovery",
+      retryAgentId: coderId,
+      retryAt: scheduledRun?.scheduledRetryAt?.toISOString(),
+    });
   });
 
   it.each([

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -35,6 +35,75 @@ describe("classifyAdapterFailureForRecovery", () => {
     });
   });
 
+  it("classifies provider HTTP 402 credit exhaustion from adapter result output", () => {
+    const now = new Date("2026-07-21T20:38:00.000Z");
+    const classification = classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "Adapter failed",
+      resultJson: {
+        result:
+          "HTTP 402: This request requires more credits, or fewer max_tokens. Add more credits to continue.",
+      },
+    }, now);
+
+    expect(classification).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date(now.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS),
+      parsedResetTime: false,
+    });
+  });
+
+  it.each([
+    "Insufficient credits to complete this request",
+    "Insufficient balance for this model request",
+    "Provider payment required before continuing",
+    "Not enough credits available",
+    "Credit balance is too low",
+  ])("classifies provider credit exhaustion: %s", (error) => {
+    const now = new Date("2026-07-21T20:38:00.000Z");
+    const classification = classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error,
+      resultJson: null,
+    }, now);
+
+    expect(classification).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date(now.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS),
+      parsedResetTime: false,
+    });
+  });
+
+  it.each([
+    "Customer invoice: payment required before delivery",
+    "Customer has insufficient balance to pay the invoice",
+    "Customer credit balance is too low to pay the invoice",
+    "The account payment required field applies to the vendor invoice",
+    "Our billing API returns HTTP 402 when the customer invoice is unpaid.",
+    "The customer account requires more credits before the invoice can be settled.",
+    "HTTP 4020: this customer record mentions max_tokens for documentation.",
+    "HTTP 402 Payment Required for an unpaid customer invoice.",
+  ])("does not classify unrelated business text as provider quota: %s", (result) => {
+    const classification = classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "Adapter failed",
+      resultJson: { result },
+    });
+
+    expect(classification).toBeNull();
+  });
+
+  it("does not combine unrelated result fields into provider credit evidence", () => {
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "Adapter failed",
+      resultJson: {
+        result: "The API documentation mentions HTTP 402.",
+        note: "The customer account requires more credits before settlement.",
+      },
+    })).toBeNull();
+  });
+
   it("treats timezone-less provider reset clocks as UTC", () => {
     const now = new Date("2026-07-15T20:00:00.000Z");
     const classification = classifyAdapterFailureForRecovery({

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -74,6 +74,14 @@ describe("classifyAdapterFailureForRecovery", () => {
     });
   });
 
+  it("does not classify HTTP 4020 from a direct adapter error as provider quota", () => {
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "HTTP 4020 is an internal documentation reference.",
+      resultJson: null,
+    })).toBeNull();
+  });
+
   it.each([
     "Customer invoice: payment required before delivery",
     "Customer has insufficient balance to pay the invoice",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3012,7 +3012,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   function readProviderQuotaRetryAt(latestRun: LatestIssueRun, now: Date) {
-    const classification = classifyAdapterFailureForRecovery(latestRun, now);
+    const classification = latestRun ? classifyAdapterFailureForRecovery(latestRun, now) : null;
     if (classification?.kind === "provider_quota") return classification.retryAt;
 
     const result = parseObject(latestRun?.resultJson);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -373,7 +373,7 @@ export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 const PROVIDER_QUOTA_ERROR_RE =
   /(?:you(?:'|’)ve hit your usage limit|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
 const PROVIDER_CREDIT_EXHAUSTION_ERROR_RE =
-  /(?:http\s*402|requires? more credits?|add more credits?|insufficient credits?|insufficient balance for (?:this )?(?:request|model|provider)|not enough credits?|(?:^|[\n"'=:]\s*)provider payment required|(?:^|[\n"'=:]\s*)(?:your )?credit balance (?:is )?(?:too low|insufficient))/i;
+  /(?:http\s*402\b|requires? more credits?|add more credits?|insufficient credits?|insufficient balance for (?:this )?(?:request|model|provider)|not enough credits?|(?:^|[\n"'=:]\s*)provider payment required|(?:^|[\n"'=:]\s*)(?:your )?credit balance (?:is )?(?:too low|insufficient))/i;
 const PROVIDER_CREDIT_EXHAUSTION_RESULT_SIGNATURE_RE =
   /(?:\bmax_tokens\b|can only afford|openrouter\.ai\/settings\/credits)/i;
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
@@ -3012,6 +3012,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   function readProviderQuotaRetryAt(latestRun: LatestIssueRun, now: Date) {
+    const classification = classifyAdapterFailureForRecovery(latestRun, now);
+    if (classification?.kind === "provider_quota") return classification.retryAt;
+
     const result = parseObject(latestRun?.resultJson);
     const context = parseObject(latestRun?.contextSnapshot);
     const raw = result.providerQuotaRetryNotBefore ??

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -259,7 +259,9 @@ function isProviderQuotaRecovery(latestRun: LatestIssueRun) {
   if (latestRun?.errorCode === "provider_quota") return true;
   if (readRecoveryRunErrorFamily(latestRun) === "provider_quota") return true;
   if (latestRun?.errorCode !== "adapter_failed") return false;
-  return /(?:usage|rate|quota) limit|quota (?:exceeded|reset)|try again after/i.test(latestRun.error ?? "");
+  const error = latestRun.error ?? "";
+  return /(?:usage|rate|quota) limit|quota (?:exceeded|reset)|try again after/i.test(error) ||
+    hasProviderCreditExhaustion(error, latestRun.resultJson);
 }
 
 function resolveStrandedRecoveryCause(
@@ -370,8 +372,22 @@ export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
 const PROVIDER_QUOTA_ERROR_RE =
   /(?:you(?:'|’)ve hit your usage limit|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
+const PROVIDER_CREDIT_EXHAUSTION_ERROR_RE =
+  /(?:http\s*402|requires? more credits?|add more credits?|insufficient credits?|insufficient balance for (?:this )?(?:request|model|provider)|not enough credits?|(?:^|[\n"'=:]\s*)provider payment required|(?:^|[\n"'=:]\s*)(?:your )?credit balance (?:is )?(?:too low|insufficient))/i;
+const PROVIDER_CREDIT_EXHAUSTION_RESULT_SIGNATURE_RE =
+  /(?:\bmax_tokens\b|can only afford|openrouter\.ai\/settings\/credits)/i;
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
   /(?:model_not_found|model [^\n]{0,120} not found|missing (?:api )?(?:key|credentials?)|credentials? (?:are |is )?missing|no (?:api )?(?:key|credentials?) (?:was |were )?(?:found|configured|provided)|api key (?:is )?(?:not set|unavailable))/i;
+
+function hasProviderCreditExhaustion(error: string | null | undefined, resultJson: unknown) {
+  if (PROVIDER_CREDIT_EXHAUSTION_ERROR_RE.test(error ?? "")) return true;
+  const resultText = readNonEmptyString(parseObject(resultJson).result);
+  return Boolean(
+    resultText &&
+    /http\s*402\b/i.test(resultText) &&
+    PROVIDER_CREDIT_EXHAUSTION_RESULT_SIGNATURE_RE.test(resultText),
+  );
+}
 
 export type AdapterFailureRecoveryClassification =
   | { kind: "provider_quota"; retryAt: Date; parsedResetTime: boolean }
@@ -462,7 +478,11 @@ export function classifyAdapterFailureForRecovery(
   if (latestRun.errorCode === "configuration_incomplete" || CONFIGURATION_INCOMPLETE_ERROR_RE.test(error)) {
     return { kind: "configuration_incomplete" };
   }
-  if (latestRun.errorCode !== "provider_quota" && !PROVIDER_QUOTA_ERROR_RE.test(error)) return null;
+  if (
+    latestRun.errorCode !== "provider_quota" &&
+    !PROVIDER_QUOTA_ERROR_RE.test(error) &&
+    !hasProviderCreditExhaustion(latestRun.error, resultJson)
+  ) return null;
 
   const persistedRetryAt = readNonEmptyString(resultJson.retryNotBefore) ??
     readNonEmptyString(resultJson.transientRetryNotBefore) ??


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous agents, so provider quota failures need to enter the recovery system as quota events rather than generic adapter failures.
> - Recovery already recognizes usage-limit and quota-exceeded language, parses reset times when available, and otherwise applies a bounded one-hour quota backoff.
> - Some providers instead return HTTP 402 credit-exhaustion text such as “requires more credits,” while adapters can persist that message inside `resultJson` with only a generic `adapter_failed` error.
> - The existing classifier scans the persisted error/result payload, but its vocabulary did not recognize those credit/balance/payment forms, so it returned `null` and skipped provider-quota recovery.
> - This change extends both existing quota-detection paths with explicit credit-exhaustion signals while retaining their prior behavior. Ambiguous balance/payment wording requires provider/model context so ordinary business output is not misclassified.
> - Focused regressions cover the observed OpenRouter HTTP 402 shape, common provider-credit variants, default backoff, and negative business-text cases.

## Linked Issues or Issue Description

No existing public issue covers this exact recovery-classification gap.

Refs #9051 — that PR makes `pi_local` surface turn-level provider errors as failed runs. This PR is complementary: once an adapter failure is persisted, it classifies credit exhaustion as `provider_quota` so the existing recovery/backoff path can act on it.

**What happened?**

A failed adapter run could persist an OpenRouter-style HTTP 402 message such as “This request requires more credits” in `resultJson`, with `errorCode: "adapter_failed"` and a generic top-level error. `classifyAdapterFailureForRecovery` did not recognize that wording and returned `null`, so provider-quota recovery was not scheduled.

**Expected behavior**

Explicit provider credit-exhaustion failures should be classified as `provider_quota`, use a parsed reset time when one exists, and otherwise receive the existing bounded default backoff. Unrelated business text mentioning invoices, payments, or customer balances should remain unclassified.

**Steps to reproduce**

1. Persist an adapter failure with `errorCode: "adapter_failed"` and an HTTP 402 credit-exhaustion message in its result payload.
2. Pass the run to `classifyAdapterFailureForRecovery`.
3. Observe current `master` returns `null` instead of a provider-quota classification.

## What Changed

- Extended top-level adapter-error detection with HTTP 402 and explicit credit-exhaustion wording.
- For nested `resultJson.result`, requires an exact HTTP 402 token plus an OpenRouter capacity signature (`max_tokens`, “can only afford,” or the credits URL), so arbitrary serialized business output is not treated as provider quota.
- Applied the same persisted failure evidence to direct stranded-issue escalation, including nested `resultJson` output.
- Required provider/model context for ambiguous payment/balance phrases to reduce false positives from serialized agent output.
- Added regression coverage for nested result payloads, direct escalation, direct provider messages, default backoff, and negative business-text cases.

## Verification

- Strict RED on current `master`: the HTTP 402 regression failed because the classifier returned `null`.
- Strict RED on current `master`: direct escalation created a generic `stranded_assigned_issue` recovery action instead of a monitor-only `provider_quota` action when credit evidence existed only in `resultJson`.
- Strict RED for false-positive protection: ordinary invoice/payment and customer-balance text was initially misclassified until the patterns were tightened.
- `pnpm exec vitest run server/src/services/recovery/provider-failure-classification.test.ts` — 24/24 passed.
- `pnpm exec vitest run server/src/services/recovery server/src/__tests__/issue-recovery-actions.test.ts --no-file-parallelism --maxWorkers=1` — 92/92 passed across five affected files.
- Touched source and test files transpiled successfully with esbuild.
- `git diff --check` — clean.
- Full local server typecheck could not complete on the shared host because the OS killed TypeScript at the current memory limit (`exit 137`); GitHub CI is the authoritative full typecheck.

## Risks

- Text classification is heuristic. The new patterns intentionally favor explicit HTTP/credit wording and contextualize ambiguous balance/payment language, but providers may introduce additional phrasings later.
- A newly recognized credit failure changes recovery from generic/none to the existing provider-quota backoff path. This is the intended behavior.
- No schema, migration, API, or UI changes.

## Model Used

- Nous Research Hermes Agent using OpenAI `gpt-5.6-sol` through the `openai-codex` provider.
- Tool-enabled coding session with repository, shell, test, Git, GitHub CLI, and independent review-agent access.
- Long-context debugging and test-driven implementation: regressions were demonstrated failing on current upstream `master` before production changes were applied.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked existing public work or described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] Documentation is not required for this internal recovery-classification change
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
