### PR TITLE
fix(watchdogs): deduplicate unchanged stopped-state wakes

### DIFF
--- a/packages/db/src/migrations/0191_task_watchdog_stop_snapshots.sql
+++ b/packages/db/src/migrations/0191_task_watchdog_stop_snapshots.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "issue_watchdogs" ADD COLUMN IF NOT EXISTS "last_observed_stop_snapshot" jsonb;--> statement-breakpoint
+ALTER TABLE "issue_watchdogs" ADD COLUMN IF NOT EXISTS "last_reviewed_stop_snapshot" jsonb;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1324,6 +1324,13 @@
       "when": 1784916885226,
       "tag": "0190_status_card_single_prompt",
       "breakpoints": true
+    },
+    {
+      "idx": 191,
+      "version": "7",
+      "when": 1784916886226,
+      "tag": "0191_task_watchdog_stop_snapshots",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue_watchdogs.ts
+++ b/packages/db/src/schema/issue_watchdogs.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { index, integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { index, integer, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
 import { agents } from "./agents.js";
 import { companies } from "./companies.js";
 import { heartbeatRuns } from "./heartbeat_runs.js";
@@ -17,6 +17,8 @@ export const issueWatchdogs = pgTable(
     watchdogIssueId: uuid("watchdog_issue_id").references(() => issues.id, { onDelete: "set null" }),
     lastObservedFingerprint: text("last_observed_fingerprint"),
     lastReviewedFingerprint: text("last_reviewed_fingerprint"),
+    lastObservedStopSnapshot: jsonb("last_observed_stop_snapshot"),
+    lastReviewedStopSnapshot: jsonb("last_reviewed_stop_snapshot"),
     lastTriggeredAt: timestamp("last_triggered_at", { withTimezone: true }),
     lastCompletedAt: timestamp("last_completed_at", { withTimezone: true }),
     triggerCount: integer("trigger_count").notNull().default(0),

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -56,7 +56,13 @@ describe("task watchdog subtree classifier", () => {
         issue({ status: "done" }),
         issue({ id: childId, identifier: "PAP-2", parentId: sourceId, status: "in_review" }),
       ],
-      pendingInteractions: [{ companyId, issueId: childId, id: "interaction-1", status: "pending" }],
+      pendingInteractions: [{
+        companyId,
+        issueId: childId,
+        id: "interaction-1",
+        kind: "request_confirmation",
+        status: "pending",
+      }],
     });
 
     expect(result.state).toBe("stopped");
@@ -69,6 +75,185 @@ describe("task watchdog subtree classifier", () => {
         pendingInteractionIds: ["interaction-1"],
       }),
     ]);
+    expect(result.stopSnapshot.waitsByIssueId).toEqual({
+      [childId]: {
+        pendingInteractionIds: ["interaction-1"],
+        pendingApprovalIds: [],
+      },
+    });
+    expect(result.pendingInteractionsByIssueId).toEqual({
+      [childId]: [{ id: "interaction-1", kind: "request_confirmation" }],
+    });
+  });
+
+  it("keeps the material fingerprint stable across metadata-only ticks", () => {
+    const initial = classify({
+      issues: [issue({
+        status: "blocked",
+        latestCommentAt: "2026-06-17T20:01:00.000Z",
+        latestDocumentAt: "2026-06-17T20:02:00.000Z",
+        latestWorkProductAt: "2026-06-17T20:03:00.000Z",
+      })],
+    });
+    const ticked = classify({
+      issues: [issue({
+        status: "blocked",
+        updatedAt: "2026-06-18T20:00:00.000Z",
+        latestCommentAt: "2026-06-18T20:01:00.000Z",
+        latestDocumentAt: "2026-06-18T20:02:00.000Z",
+        latestWorkProductAt: "2026-06-18T20:03:00.000Z",
+      })],
+    });
+
+    expect(initial.state).toBe("stopped");
+    expect(ticked.state).toBe("stopped");
+    if (initial.state !== "stopped" || ticked.state !== "stopped") return;
+    expect(ticked.stopFingerprint).toBe(initial.stopFingerprint);
+    expect(ticked.stoppedLeaves[0]?.updatedAt).not.toBe(initial.stoppedLeaves[0]?.updatedAt);
+  });
+
+  it("suppresses a shrink-only stopped state after a sibling completes", () => {
+    const siblingId = "child-2";
+    const initial = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "in_review" }),
+        issue({ id: siblingId, parentId: sourceId, status: "blocked" }),
+      ],
+      pendingInteractions: [{ companyId, issueId: childId, id: "interaction-1", status: "pending" }],
+    });
+    expect(initial.state).toBe("stopped");
+    if (initial.state !== "stopped") return;
+
+    const shrunk = classify({
+      watchdog: {
+        companyId,
+        issueId: sourceId,
+        lastReviewedFingerprint: initial.stopFingerprint,
+        lastReviewedStopSnapshot: initial.stopSnapshot,
+      },
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "in_review" }),
+        issue({ id: siblingId, parentId: sourceId, status: "done" }),
+      ],
+      pendingInteractions: [{ companyId, issueId: childId, id: "interaction-1", status: "pending" }],
+    });
+
+    expect(shrunk.state).toBe("already_reviewed");
+    if (shrunk.state !== "already_reviewed") return;
+    expect(shrunk.stopFingerprint).not.toBe(initial.stopFingerprint);
+  });
+
+  it("uses exact-hash behavior when the legacy reviewed snapshot is null", () => {
+    const siblingId = "child-2";
+    const initial = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked" }),
+        issue({ id: siblingId, parentId: sourceId, status: "blocked" }),
+      ],
+    });
+    expect(initial.state).toBe("stopped");
+    if (initial.state !== "stopped") return;
+
+    const changed = classify({
+      watchdog: {
+        companyId,
+        issueId: sourceId,
+        lastReviewedFingerprint: initial.stopFingerprint,
+        lastReviewedStopSnapshot: null,
+      },
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked" }),
+        issue({ id: siblingId, parentId: sourceId, status: "done" }),
+      ],
+    });
+
+    expect(changed.state).toBe("stopped");
+  });
+
+  it("includes waits on non-leaf issues in the material snapshot", () => {
+    const initial = classify({
+      issues: [
+        issue({ status: "in_review" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked" }),
+      ],
+      pendingApprovals: [{ companyId, issueId: sourceId, id: "approval-1", status: "pending" }],
+    });
+
+    expect(initial.state).toBe("stopped");
+    if (initial.state !== "stopped") return;
+    expect(initial.stopSnapshot.waitsByIssueId).toEqual({
+      [sourceId]: {
+        pendingInteractionIds: [],
+        pendingApprovalIds: ["approval-1"],
+      },
+    });
+
+    const changed = classify({
+      watchdog: {
+        companyId,
+        issueId: sourceId,
+        lastReviewedFingerprint: initial.stopFingerprint,
+        lastReviewedStopSnapshot: initial.stopSnapshot,
+      },
+      issues: [
+        issue({ status: "in_review" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked" }),
+      ],
+      pendingApprovals: [{ companyId, issueId: sourceId, id: "approval-2", status: "pending" }],
+    });
+
+    expect(changed.state).toBe("stopped");
+  });
+
+  it.each([
+    ["wait set", {
+      pendingInteractions: [{ companyId, issueId: childId, id: "interaction-2", status: "pending" }],
+    }],
+    ["leaf status", {
+      issues: [issue({ status: "in_progress" }), issue({ id: childId, parentId: sourceId, status: "todo" })],
+    }],
+    ["leaf assignee", {
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked", assigneeAgentId: "agent-2" }),
+      ],
+    }],
+    ["leaf blocker", {
+      blockers: [{ companyId, blockedIssueId: childId, blockerIssueId: "blocker-2" }],
+    }],
+    ["new stopped leaf", {
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked" }),
+        issue({ id: "child-2", parentId: sourceId, status: "blocked" }),
+      ],
+    }],
+  ])("triggers a fresh stop when the %s changes", (_label, overrides) => {
+    const baseInput = {
+      issues: [issue({ status: "in_progress" }), issue({ id: childId, parentId: sourceId, status: "blocked" })],
+      pendingInteractions: [{ companyId, issueId: childId, id: "interaction-1", status: "pending" }],
+      blockers: [{ companyId, blockedIssueId: childId, blockerIssueId: "blocker-1" }],
+    };
+    const initial = classify(baseInput);
+    expect(initial.state).toBe("stopped");
+    if (initial.state !== "stopped") return;
+
+    const changed = classify({
+      ...baseInput,
+      ...overrides,
+      watchdog: {
+        companyId,
+        issueId: sourceId,
+        lastReviewedFingerprint: initial.stopFingerprint,
+        lastReviewedStopSnapshot: initial.stopSnapshot,
+      },
+    });
+
+    expect(changed.state).toBe("stopped");
   });
 
   it("suppresses an unchanged stopped fingerprint once the watchdog reviewed it", () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -5,12 +5,15 @@ import {
   activityLog,
   agentWakeupRequests,
   agents,
+  approvals,
   companies,
   createDb,
   documents,
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueApprovals,
+  issueThreadInteractions,
   issueWorkProducts,
   issues,
   issueWatchdogs,
@@ -41,6 +44,9 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
 
   afterEach(async () => {
     await db.delete(activityLog);
+    await db.delete(issueApprovals);
+    await db.delete(approvals);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueWorkProducts);
     await db.delete(issueDocuments);
     await db.delete(documents);
@@ -173,6 +179,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(wakes).toHaveLength(1);
     expect(wakes[0]?.agentId).toBe(agentId);
     expect(wakes[0]?.opts?.reason).toBe("task_watchdog_stopped_subtree");
+    expect(wakes[0]?.opts?.idempotencyKey).toMatch(/^task_watchdog:[^:]+:task_watchdog_stop:/);
     expect(wakes[0]?.opts?.contextSnapshot).toMatchObject({
       taskWatchdog: {
         watchedIssueId: sourceId,
@@ -213,6 +220,12 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(watchdog?.watchdogIssueId).toBe(watchdogIssues[0]?.id);
     expect(watchdog?.lastObservedFingerprint).toMatch(/^task_watchdog_stop:/);
+    expect(watchdog?.lastObservedStopSnapshot).toMatchObject({
+      version: 2,
+      fingerprint: watchdog?.lastObservedFingerprint,
+      materialLeaves: [],
+      waitsByIssueId: {},
+    });
     expect(watchdog?.triggerCount).toBe(1);
   });
 
@@ -408,6 +421,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(reviewed).toMatchObject({ checked: 1, triggered: 0, alreadyReviewed: 1 });
     const [reviewedWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(reviewedWatchdog?.lastReviewedFingerprint).toBe(firstWatchdog?.lastObservedFingerprint);
+    expect(reviewedWatchdog?.lastReviewedStopSnapshot).toEqual(firstWatchdog?.lastObservedStopSnapshot);
 
     await db
       .update(issues)
@@ -490,7 +504,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(wakes.length).toBe(2);
   });
 
-  it("revalidates stale watchdog reviews against current source evidence before allowing mutations", async () => {
+  it("keeps watchdog mutation scope valid across metadata-only source evidence", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-REVALIDATE", status: "blocked" });
     const agentId = await seedAgent(companyId);
@@ -522,16 +536,81 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       stopFingerprint: originalFingerprint,
     });
 
-    expect(revalidated.allowed).toBe(false);
-    expect(revalidated.reason).toContain("stop fingerprint changed");
+    expect(revalidated.allowed).toBe(true);
     expect(revalidated.classification?.state).toBe("stopped");
     if (revalidated.classification?.state !== "stopped") throw new Error("Expected stopped classification");
-    expect(revalidated.classification.stopFingerprint).not.toBe(originalFingerprint);
+    expect(revalidated.classification.stopFingerprint).toBe(originalFingerprint);
     expect(revalidated.classification.stoppedLeaves[0]).toMatchObject({
       latestCommentAt: later.toISOString(),
       latestDocumentAt: new Date(later.getTime() + 1_000).toISOString(),
       latestWorkProductAt: new Date(later.getTime() + 2_000).toISOString(),
     });
+  });
+
+  it("surfaces pending interaction kinds and approval ids in the wake and watchdog comment", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-WAITS", status: "in_review" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const interactionId = randomUUID();
+    const approvalId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: sourceId,
+      kind: "request_confirmation",
+      status: "pending",
+      payload: { version: 1, prompt: "Confirm the reviewed stop." },
+      createdByAgentId: agentId,
+    });
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "request_board_approval",
+      requestedByAgentId: agentId,
+      status: "pending",
+      payload: { summary: "Approve the reviewed stop." },
+    });
+    await db.insert(issueApprovals).values({
+      companyId,
+      issueId: sourceId,
+      approvalId,
+      linkedByAgentId: agentId,
+    });
+    const { service, wakes } = createService();
+
+    const result = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(result).toMatchObject({ checked: 1, triggered: 1 });
+    expect(wakes[0]?.opts?.contextSnapshot).toMatchObject({
+      taskWatchdog: {
+        pendingInteractions: {
+          [sourceId]: [{ id: interactionId, kind: "request_confirmation" }],
+        },
+        pendingApprovals: {
+          [sourceId]: [approvalId],
+        },
+      },
+    });
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    expect(watchdog?.lastObservedStopSnapshot).toMatchObject({
+      waitsByIssueId: {
+        [sourceId]: {
+          pendingInteractionIds: [interactionId],
+          pendingApprovalIds: [approvalId],
+        },
+      },
+    });
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, watchdog!.watchdogIssueId!));
+    expect(comments.at(-1)?.body).toContain(`pending request_confirmation ${interactionId.slice(0, 8)}…`);
+    expect(comments.at(-1)?.body).toContain(`approval ${approvalId.slice(0, 8)}…`);
+    const metadata = comments.at(-1)?.metadata as { sections?: Array<{ rows?: unknown[] }> } | null;
+    expect(metadata?.sections?.[0]?.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: "Pending waits", text: "2" }),
+    ]));
   });
 
   it("revalidates a stale watchdog review as live when the source gets a fresh run path", async () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -487,6 +487,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     const [reviewedWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(reviewedWatchdog?.lastReviewedFingerprint).toBe(oldFingerprint);
     expect(reviewedWatchdog?.lastReviewedFingerprint).not.toBe(newerFingerprint);
+    expect(reviewedWatchdog?.lastReviewedStopSnapshot).toBeNull();
     const [reopenedWatchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdogIssueId));
     expect(reopenedWatchdogIssue).toMatchObject({
       status: "todo",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -349,6 +349,13 @@ function noopTaskWatchdogService(): TaskWatchdogService {
         includedIssueIds: [],
         stopFingerprint: "task_watchdog_stop:unavailable",
         stoppedLeaves: [],
+        stopSnapshot: {
+          version: 2,
+          fingerprint: "task_watchdog_stop:unavailable",
+          materialLeaves: [],
+          waitsByIssueId: {},
+        },
+        pendingInteractionsByIssueId: {},
       },
     }),
   };

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -87,6 +87,7 @@ export type TaskWatchdogClassifierWaitingPath = {
   companyId: string;
   issueId: string;
   id?: string | null;
+  kind?: string | null;
   status: string;
 };
 
@@ -99,7 +100,9 @@ export type TaskWatchdogClassifierRelation = {
 export type TaskWatchdogClassifierConfig = Pick<
   IssueWatchdogSummary,
   "companyId" | "issueId" | "lastReviewedFingerprint"
->;
+> & {
+  lastReviewedStopSnapshot?: TaskWatchdogStopSnapshot | null;
+};
 
 export type TaskWatchdogStoppedLeaf = {
   issueId: string;
@@ -116,6 +119,34 @@ export type TaskWatchdogStoppedLeaf = {
   latestDocumentAt: string | null;
   latestWorkProductAt: string | null;
 };
+
+export type TaskWatchdogMaterialLeaf = Pick<
+  TaskWatchdogStoppedLeaf,
+  | "issueId"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "blockerIssueIds"
+  | "pendingInteractionIds"
+  | "pendingApprovalIds"
+>;
+
+export type TaskWatchdogWaitsByIssueId = Record<string, {
+  pendingInteractionIds: string[];
+  pendingApprovalIds: string[];
+}>;
+
+export type TaskWatchdogStopSnapshot = {
+  version: 2;
+  fingerprint: string;
+  materialLeaves: TaskWatchdogMaterialLeaf[];
+  waitsByIssueId: TaskWatchdogWaitsByIssueId;
+};
+
+type TaskWatchdogPendingInteractionsByIssueId = Record<string, Array<{
+  id: string;
+  kind: string | null;
+}>>;
 
 export type TaskWatchdogClassifierResult =
   | {
@@ -141,6 +172,8 @@ export type TaskWatchdogClassifierResult =
     includedIssueIds: string[];
     stopFingerprint: string;
     stoppedLeaves: TaskWatchdogStoppedLeaf[];
+    stopSnapshot: TaskWatchdogStopSnapshot;
+    pendingInteractionsByIssueId: TaskWatchdogPendingInteractionsByIssueId;
   }
   | {
     state: "stopped";
@@ -148,6 +181,8 @@ export type TaskWatchdogClassifierResult =
     includedIssueIds: string[];
     stopFingerprint: string;
     stoppedLeaves: TaskWatchdogStoppedLeaf[];
+    stopSnapshot: TaskWatchdogStopSnapshot;
+    pendingInteractionsByIssueId: TaskWatchdogPendingInteractionsByIssueId;
   };
 
 export type TaskWatchdogClassifierInput = {
@@ -269,15 +304,54 @@ function waitingPathIds(
 function stableStopFingerprint(input: {
   companyId: string;
   watchedIssueId: string;
-  leaves: TaskWatchdogStoppedLeaf[];
+  materialLeaves: TaskWatchdogMaterialLeaf[];
+  waitsByIssueId: TaskWatchdogWaitsByIssueId;
 }) {
   const payload = JSON.stringify({
-    version: 1,
+    version: 2,
     companyId: input.companyId,
     watchedIssueId: input.watchedIssueId,
-    leaves: input.leaves,
+    materialLeaves: input.materialLeaves,
+    waitsByIssueId: input.waitsByIssueId,
   });
   return `task_watchdog_stop:${createHash("sha256").update(payload).digest("hex")}`;
+}
+
+function materialLeaf(leaf: TaskWatchdogStoppedLeaf): TaskWatchdogMaterialLeaf {
+  return {
+    issueId: leaf.issueId,
+    status: leaf.status,
+    assigneeAgentId: leaf.assigneeAgentId,
+    assigneeUserId: leaf.assigneeUserId,
+    blockerIssueIds: leaf.blockerIssueIds,
+    pendingInteractionIds: leaf.pendingInteractionIds,
+    pendingApprovalIds: leaf.pendingApprovalIds,
+  };
+}
+
+function parseStopSnapshot(value: unknown): TaskWatchdogStopSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<TaskWatchdogStopSnapshot>;
+  if (
+    candidate.version !== 2 ||
+    typeof candidate.fingerprint !== "string" ||
+    !Array.isArray(candidate.materialLeaves) ||
+    !candidate.waitsByIssueId ||
+    typeof candidate.waitsByIssueId !== "object"
+  ) return null;
+  return candidate as TaskWatchdogStopSnapshot;
+}
+
+function isShrinkOfReviewedSnapshot(
+  current: TaskWatchdogStopSnapshot,
+  reviewed: TaskWatchdogStopSnapshot | null | undefined,
+) {
+  if (!reviewed || JSON.stringify(current.waitsByIssueId) !== JSON.stringify(reviewed.waitsByIssueId)) return false;
+  const reviewedLeaves = new Map(reviewed.materialLeaves.map((leaf) => [leaf.issueId, leaf]));
+  return current.materialLeaves.every((leaf) => {
+    const previous = reviewedLeaves.get(leaf.issueId);
+    return previous != null && JSON.stringify(previous) === JSON.stringify(leaf);
+  });
 }
 
 export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput): TaskWatchdogClassifierResult {
@@ -380,8 +454,25 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
     blockersByIssueId.set(relation.blockedIssueId, list);
   }
 
+  const nonTerminalIssues = included
+    .filter((issue) => !isTerminalIssueStatus(issue.status))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const waitsByIssueId = Object.fromEntries(nonTerminalIssues
+    .map((issue) => [issue.id, {
+      pendingInteractionIds: waitingPathIds(input.pendingInteractions, input.watchdog.companyId, issue.id),
+      pendingApprovalIds: waitingPathIds(input.pendingApprovals, input.watchdog.companyId, issue.id),
+    }] as const)
+    .filter(([, waits]) => waits.pendingInteractionIds.length > 0 || waits.pendingApprovalIds.length > 0));
+  const pendingInteractionsByIssueId = Object.fromEntries(nonTerminalIssues
+    .map((issue) => [issue.id, (input.pendingInteractions ?? [])
+      .filter((path) => path.companyId === input.watchdog.companyId && path.issueId === issue.id)
+      .map((path) => ({ id: path.id ?? `${path.status}:${path.issueId}`, kind: path.kind ?? null }))
+      .sort((left, right) => left.id.localeCompare(right.id))] as const)
+    .filter(([, waits]) => waits.length > 0));
+
   const leaves = included
     .filter((issue) => (includedChildrenByParentId.get(issue.id) ?? []).length === 0)
+    .filter((issue) => !isTerminalIssueStatus(issue.status))
     .sort((left, right) => left.id.localeCompare(right.id))
     .map((issue) => ({
       issueId: issue.id,
@@ -398,19 +489,32 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
       latestDocumentAt: optionalIso(issue.latestDocumentAt),
       latestWorkProductAt: optionalIso(issue.latestWorkProductAt),
     }));
+  const materialLeaves = leaves.map(materialLeaf);
   const stopFingerprint = stableStopFingerprint({
     companyId: input.watchdog.companyId,
     watchedIssueId: input.watchdog.issueId,
-    leaves,
+    materialLeaves,
+    waitsByIssueId,
   });
+  const currentStopSnapshot: TaskWatchdogStopSnapshot = {
+    version: 2,
+    fingerprint: stopFingerprint,
+    materialLeaves,
+    waitsByIssueId,
+  };
 
-  if (input.watchdog.lastReviewedFingerprint === stopFingerprint) {
+  if (
+    input.watchdog.lastReviewedFingerprint === stopFingerprint ||
+    isShrinkOfReviewedSnapshot(currentStopSnapshot, input.watchdog.lastReviewedStopSnapshot)
+  ) {
     return {
       state: "already_reviewed",
       reason: "The current stopped subtree fingerprint was already reviewed by the watchdog.",
       includedIssueIds: includedIds,
       stopFingerprint,
       stoppedLeaves: leaves,
+      stopSnapshot: currentStopSnapshot,
+      pendingInteractionsByIssueId,
     };
   }
 
@@ -420,6 +524,8 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
     includedIssueIds: includedIds,
     stopFingerprint,
     stoppedLeaves: leaves,
+    stopSnapshot: currentStopSnapshot,
+    pendingInteractionsByIssueId,
   };
 }
 
@@ -501,11 +607,20 @@ function buildStoppedFingerprintComment(input: {
   sourceIssue: Pick<IssueRow, "identifier" | "id">;
   stopFingerprint: string;
   stoppedLeaves: TaskWatchdogStoppedLeaf[];
+  pendingInteractionsByIssueId: TaskWatchdogPendingInteractionsByIssueId;
   resumed: boolean;
 }) {
-  const leafLines = input.stoppedLeaves.slice(0, 12).map((leaf) =>
-    `- ${leaf.identifier ?? leaf.issueId}: ${leaf.status} (updated ${leaf.updatedAt})`
-  );
+  const shortId = (id: string) => id.length > 8 ? `${id.slice(0, 8)}…` : id;
+  const leafLines = input.stoppedLeaves.slice(0, 12).map((leaf) => {
+    const interactionKinds = new Map(
+      (input.pendingInteractionsByIssueId[leaf.issueId] ?? []).map((wait) => [wait.id, wait.kind]),
+    );
+    const waits = [
+      ...leaf.pendingInteractionIds.map((id) => `${interactionKinds.get(id) ?? "interaction"} ${shortId(id)}`),
+      ...leaf.pendingApprovalIds.map((id) => `approval ${shortId(id)}`),
+    ];
+    return `- ${leaf.identifier ?? leaf.issueId}: ${leaf.status}${waits.length > 0 ? ` (pending ${waits.join(", ")})` : ""}`;
+  });
   const more = input.stoppedLeaves.length > leafLines.length
     ? `\n- ...and ${input.stoppedLeaves.length - leafLines.length} more stopped leaves`
     : "";
@@ -524,8 +639,13 @@ function buildStoppedFingerprintComment(input: {
 function stoppedFingerprintMetadata(input: {
   sourceIssueId: string;
   stopFingerprint: string;
+  waitsByIssueId: TaskWatchdogWaitsByIssueId;
   resumed: boolean;
 }) {
+  const pendingWaitCount = Object.values(input.waitsByIssueId).reduce(
+    (count, waits) => count + waits.pendingInteractionIds.length + waits.pendingApprovalIds.length,
+    0,
+  );
   return {
     version: 1 as const,
     sections: [
@@ -534,6 +654,7 @@ function stoppedFingerprintMetadata(input: {
         rows: [
           { type: "text" as const, label: "Watched issue", text: input.sourceIssueId },
           { type: "text" as const, label: "Stopped fingerprint", text: input.stopFingerprint },
+          { type: "text" as const, label: "Pending waits", text: String(pendingWaitCount) },
           { type: "text" as const, label: "Resume intent", text: input.resumed ? "true" : "false" },
         ],
       },
@@ -557,6 +678,10 @@ function watchdogWakeContext(input: {
       watchedIssueIdentifier: input.sourceIssue.identifier,
       watchedIssueTitle: input.sourceIssue.title,
       stopFingerprint: input.classification.stopFingerprint,
+      pendingInteractions: input.classification.pendingInteractionsByIssueId,
+      pendingApprovals: Object.fromEntries(Object.entries(input.classification.stopSnapshot.waitsByIssueId)
+        .filter(([, waits]) => waits.pendingApprovalIds.length > 0)
+        .map(([issueId, waits]) => [issueId, waits.pendingApprovalIds])),
       capabilities: {
         targetScope: {
           watchedIssueId: input.sourceIssue.id,
@@ -877,6 +1002,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           companyId: issueThreadInteractions.companyId,
           issueId: issueThreadInteractions.issueId,
           id: issueThreadInteractions.id,
+          kind: issueThreadInteractions.kind,
           status: issueThreadInteractions.status,
         })
         .from(issueThreadInteractions)
@@ -953,7 +1079,10 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     const completedRunIssueIds = await collectCompletedRunIssueIds(companyId, freshIssueIds);
 
     return {
-      watchdog: summarizeIssueWatchdog(watchdog),
+      watchdog: {
+        ...summarizeIssueWatchdog(watchdog),
+        lastReviewedStopSnapshot: parseStopSnapshot(watchdog.lastReviewedStopSnapshot),
+      },
       issues: issueRows.map((issue) => ({
         ...issue,
         latestCommentAt: latestCommentByIssueId.get(issue.id) ?? null,
@@ -1136,11 +1265,20 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       : false;
     if (!isWatchdogReviewDisposition(watchdogIssue, hasPendingReviewPath)) return watchdog;
     const reviewedFingerprint = reviewedFingerprintForWatchdogIssue(watchdogIssue);
-    if (!reviewedFingerprint || watchdog.lastReviewedFingerprint === reviewedFingerprint) return watchdog;
+    if (!reviewedFingerprint) return watchdog;
+    const observedSnapshot = parseStopSnapshot(watchdog.lastObservedStopSnapshot);
+    const reviewedStopSnapshot = observedSnapshot?.fingerprint === reviewedFingerprint
+      ? observedSnapshot
+      : null;
+    if (
+      watchdog.lastReviewedFingerprint === reviewedFingerprint &&
+      JSON.stringify(parseStopSnapshot(watchdog.lastReviewedStopSnapshot)) === JSON.stringify(reviewedStopSnapshot)
+    ) return watchdog;
     const [updated] = await db
       .update(issueWatchdogs)
       .set({
         lastReviewedFingerprint: reviewedFingerprint,
+        lastReviewedStopSnapshot: reviewedStopSnapshot,
         lastCompletedAt: new Date(),
         updatedAt: new Date(),
       })
@@ -1161,6 +1299,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         watchdogIssueId: watchdogIssue.id,
         reviewedFingerprint,
         lastObservedFingerprint: watchdog.lastObservedFingerprint,
+        reviewedStopSnapshot,
         watchdogIssueStatus: watchdogIssue.status,
       },
     });
@@ -1214,6 +1353,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           sourceIssue: input.sourceIssue,
           stopFingerprint: input.classification.stopFingerprint,
           stoppedLeaves: input.classification.stoppedLeaves,
+          pendingInteractionsByIssueId: input.classification.pendingInteractionsByIssueId,
           resumed: true,
         }),
         { runId: input.runId ?? null },
@@ -1222,6 +1362,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           metadata: stoppedFingerprintMetadata({
             sourceIssueId: input.sourceIssue.id,
             stopFingerprint: input.classification.stopFingerprint,
+            waitsByIssueId: input.classification.stopSnapshot.waitsByIssueId,
             resumed: true,
           }),
         },
@@ -1263,6 +1404,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         sourceIssue: input.sourceIssue,
         stopFingerprint: input.classification.stopFingerprint,
         stoppedLeaves: input.classification.stoppedLeaves,
+        pendingInteractionsByIssueId: input.classification.pendingInteractionsByIssueId,
         resumed: false,
       }),
       { runId: input.runId ?? null },
@@ -1271,6 +1413,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         metadata: stoppedFingerprintMetadata({
           sourceIssueId: input.sourceIssue.id,
           stopFingerprint: input.classification.stopFingerprint,
+          waitsByIssueId: input.classification.stopSnapshot.waitsByIssueId,
           resumed: false,
         }),
       },
@@ -1305,6 +1448,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         .set({
           watchdogIssueId: existingWatchdogIssueId,
           lastObservedFingerprint: classification.stopFingerprint,
+          lastObservedStopSnapshot: classification.stopSnapshot,
           updatedAt: new Date(),
         })
         .where(eq(issueWatchdogs.id, watchdog.id));
@@ -1324,13 +1468,15 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     if (await sameFingerprintWatchdogReviewIsStillOpen(existingWatchdogIssue, classification.stopFingerprint)) {
       if (
         watchdog.watchdogIssueId !== existingWatchdogIssue!.id ||
-        watchdog.lastObservedFingerprint !== classification.stopFingerprint
+        watchdog.lastObservedFingerprint !== classification.stopFingerprint ||
+        JSON.stringify(parseStopSnapshot(watchdog.lastObservedStopSnapshot)) !== JSON.stringify(classification.stopSnapshot)
       ) {
         await db
           .update(issueWatchdogs)
           .set({
             watchdogIssueId: existingWatchdogIssue!.id,
             lastObservedFingerprint: classification.stopFingerprint,
+            lastObservedStopSnapshot: classification.stopSnapshot,
             updatedAt: new Date(),
           })
           .where(eq(issueWatchdogs.id, watchdog.id));
@@ -1354,6 +1500,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       .set({
         watchdogIssueId: watchdogIssue.id,
         lastObservedFingerprint: classification.stopFingerprint,
+        lastObservedStopSnapshot: classification.stopSnapshot,
         lastTriggeredAt: now,
         triggerCount: sql`${issueWatchdogs.triggerCount} + 1`,
         updatedAt: now,
@@ -1374,6 +1521,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         watchdogId: watchdog.id,
         watchdogIssueId: watchdogIssue.id,
         stopFingerprint: classification.stopFingerprint,
+        stopSnapshot: classification.stopSnapshot,
         stoppedLeaves: classification.stoppedLeaves,
       },
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI-agent companies and their work
> - Task watchdogs enforce outcomes by reviewing issue subtrees that appear to have stopped
> - Pending human interactions and approvals are valid stopped states that still require watchdog review, so treating them as live would hide real blockers
> - The existing stopped-state fingerprint included volatile metadata timestamps, causing the same material stop state to look new and wake repeatedly
> - Completed siblings can also shrink a previously reviewed stopped subtree without introducing any new reason to wake
> - This pull request fingerprints only review-material state, persists reviewed snapshots, and suppresses exact or shrink-only repeats while preserving stopped classification
> - The benefit is fewer duplicate watchdog wakes without weakening liveness or hiding pending human waits

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched existing open and closed issues and pull requests; this is not a duplicate.
- [x] The bug reproduces on `master`.
- [x] The error originates in Paperclip's core watchdog behavior, not an adapter, provider, or local configuration.

### What happened?

A task watchdog could repeatedly wake for an unchanged stopped subtree because comment, document, work-product, or issue timestamps changed. A pending interaction or approval also needed to remain visible as a stopped condition rather than being treated as live work.

### Expected behavior

Watchdogs should wake when a stopped subtree gains a new material condition, but suppress states already reviewed when the current material leaves only match or shrink and the pending wait set is unchanged.

### Steps to reproduce

1. Create a watched subtree with a non-terminal leaf waiting on a pending confirmation and no live run or queued wake.
2. Let the watchdog review that stopped state.
3. Update unrelated metadata or complete a stopped sibling without changing the pending wait set.
4. Observe that the old fingerprint schedules another wake even though no new review-material condition was added.

### Environment

- **Paperclip version or commit:** `master` before this PR.
- **Deployment mode:** Local dev.
- **Installation method:** Built from source.
- **Agent adapters involved:** Not adapter-specific; core bug.
- **Database mode:** Covered by service tests with the repository test database setup.
- **Access context:** Core scheduler behavior; not credential-specific.

### Additional context

The fix must preserve stopped classification for pending human waits. Treating those waits as live would hide real blockers rather than deduplicate unchanged review states.

## What Changed

- Added a versioned material stop snapshot containing non-terminal leaf state and pending waits across all included issues.
- Persisted observed and reviewed stop snapshots in two nullable `jsonb` watchdog columns with migration `0191`.
- Suppressed already-reviewed states on exact fingerprint matches or shrink-only material subsets with an unchanged wait set.
- Preserved pending interaction and approval states as stopped, while surfacing their IDs and interaction kinds in watchdog wake context and review comments.
- Added classifier and scheduler coverage for metadata stability, shrink-only suppression, fresh material changes, legacy null snapshots, non-leaf waits, snapshot promotion, and wake context.

## Verification

- `pnpm exec vitest run server/src/__tests__/task-watchdogs-classifier.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts` — 2 files, 36 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks

- Low migration risk: the two new `jsonb` columns are nullable and require no backfill; legacy rows retain exact-fingerprint behavior until a new snapshot is observed and reviewed.
- Behavioral risk is limited to watchdog wake deduplication. Pending waits still classify as stopped, and any new wait, leaf, status, assignee, or blocker change produces a fresh wake.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Codex CLI, with high-reasoning mode, repository/tool access, code execution, and test execution. The runtime does not expose a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated documentation where applicable, or confirmed no documentation changes are needed
- [x] I have considered backward compatibility and migration safety
- [x] My changes do not introduce secrets or private data
- [x] I have reviewed all pasted output for PII and redacted where necessary