### PR TITLE
fix(heartbeat): expire runs stuck in queue beyond a bounded age

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4114,6 +4114,98 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(run?.errorCode).toBeNull();
   });
 
+  it("cancels an issue-linked queue-expired run and releases the issue's execution lock via the same-sweep reconciliation", async () => {
+    const { companyId, agentId, runId, wakeupRequestId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      // includeIssue defaults to true: the fixture links the issue's
+      // executionRunId (and checkoutRunId) to this run, per the wiring at
+      // seedRunFixture's `includeIssue !== false` branch above.
+    });
+    const staleCreatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ createdAt: staleCreatedAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const issueBeforeReap = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueBeforeReap?.status).toBe("in_progress");
+    expect(issueBeforeReap?.executionRunId).toBe(runId);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("queue_expired");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
+
+    // The queue-expiry backstop itself does not touch the issue: it only
+    // cancels the run and its wakeup (see heartbeat.ts's queue-expired reap
+    // block). The issue's executionRunId lock is expected to still point at
+    // the now-cancelled run until the reconciliation self-heal runs.
+    const issueImmediatelyAfterReap = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueImmediatelyAfterReap?.executionRunId).toBe(runId);
+
+    // Mirror the periodic scheduler sweep order in server/src/index.ts
+    // (reapOrphanedRuns -> promoteDueScheduledRetries -> resumeQueuedRuns ->
+    // reconcileStrandedAssignedIssues) so the self-heal path that owns
+    // releasing the issue lock actually runs.
+    await heartbeat.promoteDueScheduledRetries();
+    await heartbeat.resumeQueuedRuns();
+    const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(reconciled.continuationRequeued).toBe(1);
+    expect(reconciled.issueIds).toEqual([issueId]);
+
+    await waitForHeartbeatIdle(db);
+
+    const replacementRun = await waitForValue(async () =>
+      db
+        .select()
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)))
+        .then((rows) => rows[0] ?? null),
+    );
+    if (!replacementRun) throw new Error("Expected the reconciliation self-heal to queue a replacement run");
+    expect(replacementRun.agentId).toBe(agentId);
+    expect(["queued", "running", "succeeded"]).toContain(replacementRun.status);
+
+    const issueAfterReconcile = await waitForValue(async () =>
+      db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => {
+          const row = rows[0] ?? null;
+          return row && row.executionRunId !== runId ? row : null;
+        }),
+    );
+    if (!issueAfterReconcile) throw new Error("Expected the issue's executionRunId to move off the cancelled run");
+    // Terminal pointer state: the stale lock on the cancelled run must be
+    // gone. It either points at the fresh replacement run, or has been
+    // cleared entirely pending the replacement run starting (Fix A lazy
+    // locking stamps it once the run actually starts).
+    expect([replacementRun.id, null]).toContain(issueAfterReconcile.executionRunId);
+    expect(issueAfterReconcile.status).not.toBe("blocked");
+  });
+
   it("blocks a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
     mockAdapterExecute.mockClear();
     const { companyId, agentId, runId, issueId } =

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -233,6 +233,48 @@ async function waitForHeartbeatIdle(
   }
 }
 
+// Wraps a Drizzle query-builder chain (e.g. the object returned by
+// `db.select()`) so that whichever call in the chain ends up being the
+// terminal thenable (`.from(...).where(...)`, `.limit(...)`, etc.) has an
+// async side effect spliced in right before it resolves. Used to simulate a
+// concurrent DB write landing in the exact window between a SELECT and a
+// later guarded UPDATE keyed off that SELECT's results -- a race that is
+// otherwise impossible to reproduce deterministically from a single-threaded
+// test without controlling the query builder itself. Drizzle builders return
+// a fresh object per chained call (`.from()` doesn't mutate and return
+// `this`), so the proxy has to follow the chain rather than patching `.then`
+// once on the object `db.select()` itself returns.
+function wrapQueryChainWithConcurrentSideEffect<T extends object>(
+  target: T,
+  // Receives the rows the wrapped query resolved to, so a caller can identify
+  // the query it means to race by what came back rather than by call order.
+  sideEffect: (rows: unknown) => Promise<void>,
+): T {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      const value = Reflect.get(obj, prop, receiver);
+      if (typeof value !== "function") return value;
+      if (prop === "then") {
+        return (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+          (value as (...a: unknown[]) => unknown).call(
+            obj,
+            async (rows: unknown) => {
+              await sideEffect(rows);
+              return onFulfilled ? onFulfilled(rows) : rows;
+            },
+            onRejected,
+          );
+      }
+      return (...args: unknown[]) => {
+        const result = (value as (...a: unknown[]) => unknown).apply(obj, args);
+        return result && typeof result === "object"
+          ? wrapQueryChainWithConcurrentSideEffect(result as object, sideEffect)
+          : result;
+      };
+    },
+  }) as T;
+}
+
 async function cancelActiveRunsForCleanup(
   db: ReturnType<typeof createDb>,
   timeoutMs = 3_000,
@@ -4114,6 +4156,80 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(run?.errorCode).toBeNull();
   });
 
+  it("does not cancel a queued run that is concurrently claimed between the reaper's select and its cancellation", async () => {
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      includeIssue: false,
+    });
+    const staleCreatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ createdAt: staleCreatedAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // Simulate a concurrent claim: another scheduler pass (or a manual
+    // resume) flips this exact stale-queued run to "running" in the window
+    // between the reaper's SELECT of expired queued runs and its
+    // cancellation UPDATE. The queued -> cancelled transition must be
+    // guarded on the row still being "queued" at UPDATE time, or the reaper
+    // clobbers a run that is now legitimately executing (and cancels its
+    // wakeup and appends a queue_expired event to a run no longer queued).
+    //
+    // Identify the queue-expiry backstop's own select by what it returns
+    // rather than by its position in the call order: reapOrphanedRuns issues a
+    // varying number of selects (native finalization reconciliation, question
+    // cancellation recovery, the "running" activeRuns sweep), so a positional
+    // index silently drifts. The expiredQueuedRuns select is the only
+    // full-row (`db.select()` with no projection) query that returns this
+    // still-queued run, so fire the race exactly once when we see it, right
+    // after it resolves and before the loop reaches this run's cancellation.
+    const originalSelect = db.select.bind(db);
+    let raceInjected = false;
+    const selectSpy = vi.spyOn(db, "select").mockImplementation((...args: unknown[]) => {
+      const builder = (originalSelect as (...a: unknown[]) => object)(...args);
+      if (args.length > 0) return builder;
+      return wrapQueryChainWithConcurrentSideEffect(builder, async (rows: unknown) => {
+        if (raceInjected) return;
+        const returned = Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+        if (!returned.some((row) => row?.id === runId && row?.status === "queued")) return;
+        raceInjected = true;
+        await db
+          .update(heartbeatRuns)
+          .set({ status: "running", updatedAt: new Date() })
+          .where(eq(heartbeatRuns.id, runId));
+      });
+    });
+
+    const heartbeat = heartbeatService(db);
+    let result: Awaited<ReturnType<typeof heartbeat.reapOrphanedRuns>>;
+    try {
+      result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+    } finally {
+      selectSpy.mockRestore();
+    }
+
+    expect(result.reaped).toBe(0);
+    expect(result.runIds).toEqual([]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBeNull();
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("claimed");
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(events.some((event) => event.message?.includes("waited in queue"))).toBe(false);
+  });
+
   it("cancels an issue-linked queue-expired run and releases the issue's execution lock via the same-sweep reconciliation", async () => {
     const { companyId, agentId, runId, wakeupRequestId, issueId } = await seedRunFixture({
       agentStatus: "idle",
@@ -4187,22 +4303,50 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(replacementRun.agentId).toBe(agentId);
     expect(["queued", "running", "succeeded"]).toContain(replacementRun.status);
 
-    const issueAfterReconcile = await waitForValue(async () =>
-      db
+    // Terminal pointer state: assert the INVARIANT, not a specific captured
+    // run id. Reconciliation can produce more than one generation of
+    // replacement run under CI timing (e.g. a continuation retry that itself
+    // gets superseded again before the pointer settles), so the live run the
+    // issue ends up pointing at need not be `replacementRun` -- asserting
+    // `[replacementRun.id, null]).toContain(...)` against that single
+    // captured id was the source of the flake in the serialized CI shard
+    // (a later generation's id is neither of those two values). What must
+    // always hold: the stale lock on the now-cancelled run is gone, and
+    // whatever the issue points at next (if anything) is a live run, never
+    // the cancelled one.
+    const issueAfterReconcile = await waitForValue(async () => {
+      const issueRow = await db
         .select()
         .from(issues)
         .where(eq(issues.id, issueId))
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          return row && row.executionRunId !== runId ? row : null;
-        }),
-    );
-    if (!issueAfterReconcile) throw new Error("Expected the issue's executionRunId to move off the cancelled run");
-    // Terminal pointer state: the stale lock on the cancelled run must be
-    // gone. It either points at the fresh replacement run, or has been
-    // cleared entirely pending the replacement run starting (Fix A lazy
-    // locking stamps it once the run actually starts).
-    expect([replacementRun.id, null]).toContain(issueAfterReconcile.executionRunId);
+        .then((rows) => rows[0] ?? null);
+      if (!issueRow || issueRow.executionRunId === runId) return null;
+      if (issueRow.executionRunId === null) return issueRow;
+      const pointedRun = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, issueRow.executionRunId))
+        .then((rows) => rows[0] ?? null);
+      const isLiveReplacement =
+        pointedRun !== null && ["queued", "running", "scheduled_retry"].includes(pointedRun.status);
+      return isLiveReplacement ? issueRow : null;
+    });
+    if (!issueAfterReconcile) {
+      throw new Error(
+        "Expected the issue's executionRunId to move off the cancelled run: either cleared, or " +
+          "pointing at a live (queued/running/scheduled_retry) replacement run",
+      );
+    }
+    expect(issueAfterReconcile.executionRunId).not.toBe(runId);
+    if (issueAfterReconcile.executionRunId !== null) {
+      const pointedRun = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, issueAfterReconcile.executionRunId))
+        .then((rows) => rows[0] ?? null);
+      expect(pointedRun?.status).not.toBe("cancelled");
+      expect(["queued", "running", "scheduled_retry"]).toContain(pointedRun?.status);
+    }
     expect(issueAfterReconcile.status).not.toBe("blocked");
   });
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4066,6 +4066,54 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     mockAdapterExecute.mockClear();
   });
 
+  it("cancels a queued run stuck past the queue-age threshold", async () => {
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      includeIssue: false,
+    });
+    const staleCreatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ createdAt: staleCreatedAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("queue_expired");
+    expect(run?.error).toContain("waited in queue");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
+  });
+
+  it("leaves a fresh queued run untouched by the queue-age reaper", async () => {
+    const { runId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      includeIssue: false,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("queued");
+    expect(run?.errorCode).toBeNull();
+  });
+
   it("blocks a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
     mockAdapterExecute.mockClear();
     const { companyId, agentId, runId, issueId } =

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -198,6 +198,46 @@ async function waitForHeartbeatIdle(
   }
 }
 
+// Wraps a Drizzle query-builder chain (e.g. the object returned by
+// `db.select()`) so that whichever call in the chain ends up being the
+// terminal thenable (`.from(...).where(...)`, `.limit(...)`, etc.) has an
+// async side effect spliced in right before it resolves. Used to simulate a
+// concurrent DB write landing in the exact window between a SELECT and a
+// later guarded UPDATE keyed off that SELECT's results -- a race that is
+// otherwise impossible to reproduce deterministically from a single-threaded
+// test without controlling the query builder itself. Drizzle builders return
+// a fresh object per chained call (`.from()` doesn't mutate and return
+// `this`), so the proxy has to follow the chain rather than patching `.then`
+// once on the object `db.select()` itself returns.
+function wrapQueryChainWithConcurrentSideEffect<T extends object>(
+  target: T,
+  sideEffect: () => Promise<void>,
+): T {
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      const value = Reflect.get(obj, prop, receiver);
+      if (typeof value !== "function") return value;
+      if (prop === "then") {
+        return (onFulfilled?: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) =>
+          (value as (...a: unknown[]) => unknown).call(
+            obj,
+            async (rows: unknown) => {
+              await sideEffect();
+              return onFulfilled ? onFulfilled(rows) : rows;
+            },
+            onRejected,
+          );
+      }
+      return (...args: unknown[]) => {
+        const result = (value as (...a: unknown[]) => unknown).apply(obj, args);
+        return result && typeof result === "object"
+          ? wrapQueryChainWithConcurrentSideEffect(result as object, sideEffect)
+          : result;
+      };
+    },
+  }) as T;
+}
+
 async function cancelActiveRunsForCleanup(
   db: ReturnType<typeof createDb>,
   timeoutMs = 3_000,
@@ -2600,6 +2640,77 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(run?.errorCode).toBeNull();
   });
 
+  it("does not cancel a queued run that is concurrently claimed between the reaper's select and its cancellation", async () => {
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      includeIssue: false,
+    });
+    const staleCreatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ createdAt: staleCreatedAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // Simulate a concurrent claim: another scheduler pass (or a manual
+    // resume) flips this exact stale-queued run to "running" in the window
+    // between the reaper's SELECT of expired queued runs and its
+    // cancellation UPDATE. The queued -> cancelled transition must be
+    // guarded on the row still being "queued" at UPDATE time, or the reaper
+    // clobbers a run that is now legitimately executing (and cancels its
+    // wakeup and appends a queue_expired event to a run no longer queued).
+    //
+    // The queue-expiry backstop's own select is the SECOND `db.select` call
+    // inside reapOrphanedRuns (the first is the unconditional "running"
+    // activeRuns select at the top of the function, which returns empty here
+    // since nothing is running yet) -- so intercepting call #2 targets
+    // exactly the expiredQueuedRuns select and injects the race right after
+    // it resolves, before the loop below reaches this run's cancellation.
+    const originalSelect = db.select.bind(db);
+    let selectCallCount = 0;
+    const selectSpy = vi.spyOn(db, "select").mockImplementation((...args: unknown[]) => {
+      selectCallCount += 1;
+      const builder = (originalSelect as (...a: unknown[]) => object)(...args);
+      if (selectCallCount === 2) {
+        return wrapQueryChainWithConcurrentSideEffect(builder, async () => {
+          await db
+            .update(heartbeatRuns)
+            .set({ status: "running", updatedAt: new Date() })
+            .where(eq(heartbeatRuns.id, runId));
+        });
+      }
+      return builder;
+    });
+
+    const heartbeat = heartbeatService(db);
+    let result: Awaited<ReturnType<typeof heartbeat.reapOrphanedRuns>>;
+    try {
+      result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+    } finally {
+      selectSpy.mockRestore();
+    }
+
+    expect(result.reaped).toBe(0);
+    expect(result.runIds).toEqual([]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBeNull();
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("claimed");
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(events.some((event) => event.message?.includes("waited in queue"))).toBe(false);
+  });
+
   it("cancels an issue-linked queue-expired run and releases the issue's execution lock via the same-sweep reconciliation", async () => {
     const { companyId, agentId, runId, wakeupRequestId, issueId } = await seedRunFixture({
       agentStatus: "idle",
@@ -2673,22 +2784,50 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(replacementRun.agentId).toBe(agentId);
     expect(["queued", "running", "succeeded"]).toContain(replacementRun.status);
 
-    const issueAfterReconcile = await waitForValue(async () =>
-      db
+    // Terminal pointer state: assert the INVARIANT, not a specific captured
+    // run id. Reconciliation can produce more than one generation of
+    // replacement run under CI timing (e.g. a continuation retry that itself
+    // gets superseded again before the pointer settles), so the live run the
+    // issue ends up pointing at need not be `replacementRun` -- asserting
+    // `[replacementRun.id, null]).toContain(...)` against that single
+    // captured id was the source of the flake in the serialized CI shard
+    // (a later generation's id is neither of those two values). What must
+    // always hold: the stale lock on the now-cancelled run is gone, and
+    // whatever the issue points at next (if anything) is a live run, never
+    // the cancelled one.
+    const issueAfterReconcile = await waitForValue(async () => {
+      const issueRow = await db
         .select()
         .from(issues)
         .where(eq(issues.id, issueId))
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          return row && row.executionRunId !== runId ? row : null;
-        }),
-    );
-    if (!issueAfterReconcile) throw new Error("Expected the issue's executionRunId to move off the cancelled run");
-    // Terminal pointer state: the stale lock on the cancelled run must be
-    // gone. It either points at the fresh replacement run, or has been
-    // cleared entirely pending the replacement run starting (Fix A lazy
-    // locking stamps it once the run actually starts).
-    expect([replacementRun.id, null]).toContain(issueAfterReconcile.executionRunId);
+        .then((rows) => rows[0] ?? null);
+      if (!issueRow || issueRow.executionRunId === runId) return null;
+      if (issueRow.executionRunId === null) return issueRow;
+      const pointedRun = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, issueRow.executionRunId))
+        .then((rows) => rows[0] ?? null);
+      const isLiveReplacement =
+        pointedRun !== null && ["queued", "running", "scheduled_retry"].includes(pointedRun.status);
+      return isLiveReplacement ? issueRow : null;
+    });
+    if (!issueAfterReconcile) {
+      throw new Error(
+        "Expected the issue's executionRunId to move off the cancelled run: either cleared, or " +
+          "pointing at a live (queued/running/scheduled_retry) replacement run",
+      );
+    }
+    expect(issueAfterReconcile.executionRunId).not.toBe(runId);
+    if (issueAfterReconcile.executionRunId !== null) {
+      const pointedRun = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, issueAfterReconcile.executionRunId))
+        .then((rows) => rows[0] ?? null);
+      expect(pointedRun?.status).not.toBe("cancelled");
+      expect(["queued", "running", "scheduled_retry"]).toContain(pointedRun?.status);
+    }
     expect(issueAfterReconcile.status).not.toBe("blocked");
   });
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2552,6 +2552,54 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     mockAdapterExecute.mockClear();
   });
 
+  it("cancels a queued run stuck past the queue-age threshold", async () => {
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      includeIssue: false,
+    });
+    const staleCreatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ createdAt: staleCreatedAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("queue_expired");
+    expect(run?.error).toContain("waited in queue");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
+  });
+
+  it("leaves a fresh queued run untouched by the queue-age reaper", async () => {
+    const { runId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      includeIssue: false,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("queued");
+    expect(run?.errorCode).toBeNull();
+  });
+
   it("blocks a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
     mockAdapterExecute.mockClear();
     const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2600,6 +2600,98 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(run?.errorCode).toBeNull();
   });
 
+  it("cancels an issue-linked queue-expired run and releases the issue's execution lock via the same-sweep reconciliation", async () => {
+    const { companyId, agentId, runId, wakeupRequestId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      runStatus: "queued",
+      // includeIssue defaults to true: the fixture links the issue's
+      // executionRunId (and checkoutRunId) to this run, per the wiring at
+      // seedRunFixture's `includeIssue !== false` branch above.
+    });
+    const staleCreatedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    await db
+      .update(heartbeatRuns)
+      .set({ createdAt: staleCreatedAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const issueBeforeReap = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueBeforeReap?.status).toBe("in_progress");
+    expect(issueBeforeReap?.executionRunId).toBe(runId);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns({ maxQueuedAgeMs: 60_000 });
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("queue_expired");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
+
+    // The queue-expiry backstop itself does not touch the issue: it only
+    // cancels the run and its wakeup (see heartbeat.ts's queue-expired reap
+    // block). The issue's executionRunId lock is expected to still point at
+    // the now-cancelled run until the reconciliation self-heal runs.
+    const issueImmediatelyAfterReap = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueImmediatelyAfterReap?.executionRunId).toBe(runId);
+
+    // Mirror the periodic scheduler sweep order in server/src/index.ts
+    // (reapOrphanedRuns -> promoteDueScheduledRetries -> resumeQueuedRuns ->
+    // reconcileStrandedAssignedIssues) so the self-heal path that owns
+    // releasing the issue lock actually runs.
+    await heartbeat.promoteDueScheduledRetries();
+    await heartbeat.resumeQueuedRuns();
+    const reconciled = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(reconciled.continuationRequeued).toBe(1);
+    expect(reconciled.issueIds).toEqual([issueId]);
+
+    await waitForHeartbeatIdle(db);
+
+    const replacementRun = await waitForValue(async () =>
+      db
+        .select()
+        .from(heartbeatRuns)
+        .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.retryOfRunId, runId)))
+        .then((rows) => rows[0] ?? null),
+    );
+    if (!replacementRun) throw new Error("Expected the reconciliation self-heal to queue a replacement run");
+    expect(replacementRun.agentId).toBe(agentId);
+    expect(["queued", "running", "succeeded"]).toContain(replacementRun.status);
+
+    const issueAfterReconcile = await waitForValue(async () =>
+      db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => {
+          const row = rows[0] ?? null;
+          return row && row.executionRunId !== runId ? row : null;
+        }),
+    );
+    if (!issueAfterReconcile) throw new Error("Expected the issue's executionRunId to move off the cancelled run");
+    // Terminal pointer state: the stale lock on the cancelled run must be
+    // gone. It either points at the fresh replacement run, or has been
+    // cleared entirely pending the replacement run starting (Fix A lazy
+    // locking stamps it once the run actually starts).
+    expect([replacementRun.id, null]).toContain(issueAfterReconcile.executionRunId);
+    expect(issueAfterReconcile.status).not.toBe("blocked");
+  });
+
   it("blocks a git-sensitive local adapter before launch when a project-workspace-linked issue is missing its project id", async () => {
     mockAdapterExecute.mockClear();
     const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1519,6 +1519,11 @@ export async function startServer(): Promise<StartedServer> {
     };
     await runRetentionSweep();
 
+    const heartbeatMaxQueuedRunAgeMs = Math.max(
+      1,
+      Number(process.env.PAPERCLIP_HEARTBEAT_MAX_QUEUED_RUN_AGE_MS) || 24 * 60 * 60 * 1000,
+    );
+
     startHeartbeatSchedulerInterval(() => {
       // Track the outer async callback as well as the work it starts. Shutdown
       // can then wait through an already-running suppression check before it
@@ -1649,10 +1654,11 @@ export async function startServer(): Promise<StartedServer> {
 
         if (heartbeatSchedulerStopped) return;
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
-          // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-          // persisted queued work is still being driven forward.
+          // Periodically reap orphaned runs (5-min staleness threshold for stuck "running"
+          // runs, bounded max-age for stuck "queued" runs) and make sure persisted queued
+          // work is still being driven forward.
           trackHeartbeatSchedulerWork(heartbeat
-            .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+            .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000, maxQueuedAgeMs: heartbeatMaxQueuedRunAgeMs })
             .then(() => heartbeat.promoteDueScheduledRetries())
             .then(async (promotion) => {
               await heartbeat.resumeQueuedRuns();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1010,6 +1010,11 @@ export async function startServer(): Promise<StartedServer> {
       logger.warn({ ...toolHealthSweep }, "startup tool connection health sweep found failing connections");
     }
 
+    const heartbeatMaxQueuedRunAgeMs = Math.max(
+      1,
+      Number(process.env.PAPERCLIP_HEARTBEAT_MAX_QUEUED_RUN_AGE_MS) || 24 * 60 * 60 * 1000,
+    );
+
     heartbeatSchedulerInterval = setInterval(() => {
       // Async so the suppression checks below can honor the override-aware
       // resolver (e.g. worktree run-execution opt-in). The gated work is still
@@ -1075,10 +1080,11 @@ export async function startServer(): Promise<StartedServer> {
 
         if (heartbeatSchedulerStopped) return;
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
-          // Periodically reap orphaned runs (5-min staleness threshold) and make sure
-          // persisted queued work is still being driven forward.
+          // Periodically reap orphaned runs (5-min staleness threshold for stuck "running"
+          // runs, bounded max-age for stuck "queued" runs) and make sure persisted queued
+          // work is still being driven forward.
           trackHeartbeatSchedulerWork(heartbeat
-            .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+            .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000, maxQueuedAgeMs: heartbeatMaxQueuedRunAgeMs })
             .then(() => heartbeat.promoteDueScheduledRetries())
             .then(async (promotion) => {
               await heartbeat.resumeQueuedRuns();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -17482,6 +17482,12 @@ export function heartbeatService(
 
     // Backstop for any cause of queue stranding (pause races, concurrency starvation,
     // invokability edge cases): a run should never wait in "queued" forever.
+    // This loop only cancels the run and its wakeup; for issue-linked runs it
+    // deliberately does not touch the issue's checkoutRunId/executionRunId
+    // lock columns. Releasing that lock is left to the same-sweep
+    // reconcileStrandedAssignedIssues() (and the enqueueWakeup self-heal it
+    // triggers), mirroring how sweepStaleIssueLocks documents its own
+    // reliance on that same reconciliation pass.
     const expiredQueuedRuns = await db
       .select()
       .from(heartbeatRuns)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11072,6 +11072,21 @@ export function heartbeatService(
     return terminalRun ?? run;
   }
 
+  // Mirrors setRunStatusIfRunning for the queued -> cancelled transition: the
+  // UPDATE itself carries the precondition (status = 'queued') so a concurrent
+  // claim of the same row (another scheduler pass, or a manual resume flipping
+  // it to "running") between the SELECT and this UPDATE cannot be clobbered
+  // back to "cancelled". `updated: false` tells the caller the row had already
+  // moved on, so it must not touch the run's wakeup or append a lifecycle
+  // event.
+  async function setRunStatusIfQueued(
+    runId: string,
+    status: string,
+    patch?: Partial<typeof heartbeatRuns.$inferInsert>,
+  ) {
+    return setRunStatusFromLive(runId, status, ["queued"], patch);
+  }
+
   function publishRunLifecyclePluginEvent(
     run: typeof heartbeatRuns.$inferSelect,
   ) {
@@ -17505,17 +17520,25 @@ export function heartbeatService(
     const queueExpiredMessage = `Cancelled because the run waited in queue longer than ${maxQueuedAgeHoursLabel} hours`;
 
     for (const run of expiredQueuedRuns) {
-      const cancelledRun = await setRunStatus(run.id, "cancelled", {
+      // Guard the cancellation on the row still being "queued": another
+      // scheduler pass or a manual resume can claim this exact run (queued ->
+      // running) between the SELECT above and this UPDATE. Without the guard
+      // we would blindly stamp a now-running/finished run back to
+      // "cancelled" and cancel its wakeup out from under it. Only touch the
+      // wakeup and append the lifecycle event when the guarded update
+      // actually transitioned the row.
+      const cancelResult = await setRunStatusIfQueued(run.id, "cancelled", {
         finishedAt: now,
         error: queueExpiredMessage,
         errorCode: "queue_expired",
       });
-      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+      if (!cancelResult.updated || !cancelResult.run) continue;
+      const cancelledRun = cancelResult.run;
+      await setWakeupStatus(cancelledRun.wakeupRequestId, "cancelled", {
         finishedAt: now,
         error: queueExpiredMessage,
       });
-      if (!cancelledRun) continue;
-      await appendRunEvent(cancelledRun, await nextRunEventSeq(cancelledRun.id), {
+      await appendRunEvent(cancelledRun, {
         eventType: "lifecycle",
         stream: "system",
         level: "warn",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -568,6 +568,7 @@ function pendingCleanupCapWarnedSql() {
 }
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_MAX_QUEUED_RUN_AGE_MS = 24 * 60 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
@@ -17010,8 +17011,9 @@ export function heartbeatService(
     ).catch(() => undefined);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; maxQueuedAgeMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const maxQueuedAgeMs = opts?.maxQueuedAgeMs ?? DEFAULT_MAX_QUEUED_RUN_AGE_MS;
     const now = new Date();
 
     // Complete persisted native results before generic orphan recovery. The
@@ -17194,7 +17196,7 @@ export function heartbeatService(
       }
     }
 
-    // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
+    // Find all runs stuck in "running" state (queued runs get a bounded wait below; resumeQueuedRuns handles normal dequeue)
     const activeRuns = await db
       .select({
         run: heartbeatRuns,
@@ -17476,6 +17478,44 @@ export function heartbeatService(
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
+    }
+
+    // Backstop for any cause of queue stranding (pause races, concurrency starvation,
+    // invokability edge cases): a run should never wait in "queued" forever.
+    const expiredQueuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "queued"),
+          lt(heartbeatRuns.createdAt, new Date(now.getTime() - maxQueuedAgeMs)),
+        ),
+      );
+
+    const maxQueuedAgeHours = maxQueuedAgeMs / (60 * 60 * 1000);
+    const maxQueuedAgeHoursLabel = Number.isInteger(maxQueuedAgeHours)
+      ? String(maxQueuedAgeHours)
+      : maxQueuedAgeHours.toFixed(2);
+    const queueExpiredMessage = `Cancelled because the run waited in queue longer than ${maxQueuedAgeHoursLabel} hours`;
+
+    for (const run of expiredQueuedRuns) {
+      const cancelledRun = await setRunStatus(run.id, "cancelled", {
+        finishedAt: now,
+        error: queueExpiredMessage,
+        errorCode: "queue_expired",
+      });
+      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+        finishedAt: now,
+        error: queueExpiredMessage,
+      });
+      if (!cancelledRun) continue;
+      await appendRunEvent(cancelledRun, await nextRunEventSeq(cancelledRun.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: queueExpiredMessage,
+      });
+      reaped.push(cancelledRun.id);
     }
 
     if (reaped.length > 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -314,6 +314,7 @@ const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_MAX_QUEUED_RUN_AGE_MS = 24 * 60 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
@@ -11380,11 +11381,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number; maxQueuedAgeMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
+    const maxQueuedAgeMs = opts?.maxQueuedAgeMs ?? DEFAULT_MAX_QUEUED_RUN_AGE_MS;
     const now = new Date();
 
-    // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
+    // Find all runs stuck in "running" state (queued runs get a bounded wait below; resumeQueuedRuns handles normal dequeue)
     const activeRuns = await db
       .select({
         run: heartbeatRuns,
@@ -11566,6 +11568,44 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       await startNextQueuedRunForAgent(run.agentId);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
+    }
+
+    // Backstop for any cause of queue stranding (pause races, concurrency starvation,
+    // invokability edge cases): a run should never wait in "queued" forever.
+    const expiredQueuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "queued"),
+          lt(heartbeatRuns.createdAt, new Date(now.getTime() - maxQueuedAgeMs)),
+        ),
+      );
+
+    const maxQueuedAgeHours = maxQueuedAgeMs / (60 * 60 * 1000);
+    const maxQueuedAgeHoursLabel = Number.isInteger(maxQueuedAgeHours)
+      ? String(maxQueuedAgeHours)
+      : maxQueuedAgeHours.toFixed(2);
+    const queueExpiredMessage = `Cancelled because the run waited in queue longer than ${maxQueuedAgeHoursLabel} hours`;
+
+    for (const run of expiredQueuedRuns) {
+      const cancelledRun = await setRunStatus(run.id, "cancelled", {
+        finishedAt: now,
+        error: queueExpiredMessage,
+        errorCode: "queue_expired",
+      });
+      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+        finishedAt: now,
+        error: queueExpiredMessage,
+      });
+      if (!cancelledRun) continue;
+      await appendRunEvent(cancelledRun, await nextRunEventSeq(cancelledRun.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: queueExpiredMessage,
+      });
+      reaped.push(cancelledRun.id);
     }
 
     if (reaped.length > 0) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7669,6 +7669,47 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { run: current, updated: false as const };
   }
 
+  // Mirrors setRunStatusIfRunning's guarded-update idiom (and claimQueuedRun's
+  // queued -> running flip) for the queued -> cancelled transition: the UPDATE
+  // itself carries the precondition (status = 'queued') so a concurrent claim
+  // of the same row (another scheduler pass, or a manual resume flipping it to
+  // "running") between the SELECT and this UPDATE cannot be clobbered back to
+  // "cancelled". `updated: false` tells the caller the row had already moved
+  // on, so it must not touch the run's wakeup or append a lifecycle event.
+  async function setRunStatusIfQueued(
+    runId: string,
+    status: string,
+    patch?: Partial<typeof heartbeatRuns.$inferInsert>,
+  ) {
+    const updated = await db
+      .update(heartbeatRuns)
+      .set({ status, ...patch, updatedAt: new Date() })
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "queued")))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+
+    if (updated) {
+      if (isHeartbeatRunTerminalStatus(updated.status)) {
+        clearHeartbeatRunRuntimeStatus(updated.id);
+      }
+      publishLiveEvent({
+        companyId: updated.companyId,
+        type: "heartbeat.run.status",
+        payload: buildHeartbeatRunStatusLiveEventPayload(updated),
+      });
+      publishRunLifecyclePluginEvent(updated);
+      return { run: updated, updated: true as const };
+    }
+
+    const current = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+
+    return { run: current, updated: false as const };
+  }
+
   function publishRunLifecyclePluginEvent(run: typeof heartbeatRuns.$inferSelect) {
     const eventType =
       run.status === "running"
@@ -11595,16 +11636,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const queueExpiredMessage = `Cancelled because the run waited in queue longer than ${maxQueuedAgeHoursLabel} hours`;
 
     for (const run of expiredQueuedRuns) {
-      const cancelledRun = await setRunStatus(run.id, "cancelled", {
+      // Guard the cancellation on the row still being "queued": another
+      // scheduler pass or a manual resume can claim this exact run (queued ->
+      // running) between the SELECT above and this UPDATE. Without the guard
+      // we would blindly stamp a now-running/finished run back to
+      // "cancelled" and cancel its wakeup out from under it. Only touch the
+      // wakeup and append the lifecycle event when the guarded update
+      // actually transitioned the row.
+      const cancelResult = await setRunStatusIfQueued(run.id, "cancelled", {
         finishedAt: now,
         error: queueExpiredMessage,
         errorCode: "queue_expired",
       });
-      await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+      if (!cancelResult.updated || !cancelResult.run) continue;
+      const cancelledRun = cancelResult.run;
+      await setWakeupStatus(cancelledRun.wakeupRequestId, "cancelled", {
         finishedAt: now,
         error: queueExpiredMessage,
       });
-      if (!cancelledRun) continue;
       await appendRunEvent(cancelledRun, await nextRunEventSeq(cancelledRun.id), {
         eventType: "lifecycle",
         stream: "system",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11572,6 +11572,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     // Backstop for any cause of queue stranding (pause races, concurrency starvation,
     // invokability edge cases): a run should never wait in "queued" forever.
+    // This loop only cancels the run and its wakeup; for issue-linked runs it
+    // deliberately does not touch the issue's checkoutRunId/executionRunId
+    // lock columns. Releasing that lock is left to the same-sweep
+    // reconcileStrandedAssignedIssues() (and the enqueueWakeup self-heal it
+    // triggers), mirroring how sweepStaleIssueLocks documents its own
+    // reliance on that same reconciliation pass.
     const expiredQueuedRuns = await db
       .select()
       .from(heartbeatRuns)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs are scheduled through a heartbeat queue: runs enter `queued`, then `startNextQueuedRunForAgent` dequeues them and `reapOrphanedRuns` cleans up strays
> - `reapOrphanedRuns` only sweeps `running` runs; its own comment says "queued runs are legitimately waiting; resumeQueuedRuns handles them"
> - But `resumeQueuedRuns` funnels every queued run through `startNextQueuedRunForAgent`, which returns early (no cancel) for a non-invokable agent (e.g. one paused after an auth failure)
> - So a run enqueued just before its agent becomes non-invokable is never started and never terminated; it can sit in `queued` indefinitely (observed: over three days)
> - This PR adds a bounded max-queue-age backstop so no run can be stranded in the queue forever, regardless of the stranding cause
> - The benefit is a self-healing safety net that terminates genuinely stuck queued runs with an honest, distinct error code

## Linked Issues or Issue Description

No public GitHub issue exists; describing inline following the bug report template. Related prior work (different approach, referenced for dedup): Refs #6163 (pre-enqueue terminal-issue skip + a bulk stale queued-run cancel API); this PR is a complementary periodic time-based reaper.

**What happened**

A run remained in `queued` status for over three days, never started and never cancelled, after its agent became non-invokable moments after the run was enqueued.

**Expected behavior**

A run that can never be dequeued should eventually be terminated with a clear, distinct reason rather than leaking in `queued` forever.

**Steps to reproduce**

Enqueue a run for an agent, make the agent non-invokable (for example a pause after an auth failure) before the run is dequeued, then let the periodic heartbeat sweep run. The reaper test added here deterministically reproduces the stranded-then-expired sequence.

**Deployment mode**

Cloud multi-tenant execution (heartbeat scheduler with the Kubernetes sandbox provider).

## What Changed

- `reapOrphanedRuns` now also cancels runs in `queued` older than `maxQueuedAgeMs` (default 24h; override `PAPERCLIP_HEARTBEAT_MAX_QUEUED_RUN_AGE_MS`), with error code `queue_expired` and a message stating how long the run waited
- Threaded the new option at the periodic caller alongside the existing running-run staleness threshold
- Updated the stale "queued runs are legitimately waiting" comment to reflect the new bounded wait
- Issue-lock release for issue-linked queued runs is intentionally delegated to the same-sweep `reconcileStrandedAssignedIssues()` / `enqueueWakeup` self-heal (documented inline), matching how `sweepStaleIssueLocks` handles stale locks

## Verification

- `cd server && npx vitest run src/__tests__/heartbeat-process-recovery.test.ts` — old queued run cancelled `queue_expired`; fresh queued run untouched; running-run reap unchanged; issue-linked queued run reconciled to a fresh run (not left dangling) after expiry
- `npx vitest run src/__tests__/heartbeat-stale-queue-invalidation.test.ts` — regression, unchanged

## Risks

Low risk. The reaper only acts on runs already past a 24h default age, a distinct terminal code (`queue_expired`) makes the action auditable, and running-run behavior is untouched. The one subtlety (issue-lock release delegated to the same-sweep reconciliation) is covered by a dedicated test.
## Model Used

Claude (Anthropic) via Claude Code. Implementation and tests authored by a Claude Sonnet-class model (`claude-sonnet-5`) dispatched as isolated per-task implementer agents under a multi-agent orchestration workflow; root-cause investigation, planning, and two-stage adversarial code review performed by additional Claude agents. Extended thinking and tool use enabled throughout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
