### PR TITLE
fix(adapter-utils): tolerate transient reads in the process-session bridge poll loop

### DIFF
--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -156,6 +156,60 @@ describe("sandbox adapter execution targets", () => {
     };
   }
 
+  // Simulates transient sandbox shell failures for the process-session
+  // bridge's event polling: reading/removing a specific event file, or
+  // listing the events directory itself, can be made to fail on demand
+  // while every other shell call passes through to the real local runner.
+  function createProcessSessionEventFaultInjectingRunner(input: {
+    base: ReturnType<typeof createLocalSandboxRunner>;
+    failRead?: (fileName: string, attempt: number) => boolean;
+    failRemove?: (fileName: string, attempt: number) => boolean;
+    failList?: (attempt: number) => boolean;
+  }) {
+    const readAttempts = new Map<string, number>();
+    const removeAttempts = new Map<string, number>();
+    let listAttempts = 0;
+    const failResult = (message: string) => ({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: message,
+      pid: null,
+      startedAt: new Date().toISOString(),
+    });
+    return {
+      execute: async (execInput: Parameters<ReturnType<typeof createLocalSandboxRunner>["execute"]>[0]) => {
+        const script = (execInput.args?.[1] ?? "").trim();
+        const readMatch = /^base64 < '([^']*\/events\/[^']+\.json)'$/.exec(script);
+        if (readMatch) {
+          const fileName = path.posix.basename(readMatch[1]);
+          const attempt = (readAttempts.get(fileName) ?? 0) + 1;
+          readAttempts.set(fileName, attempt);
+          if (input.failRead?.(fileName, attempt)) {
+            return failResult(`simulated transient read failure for ${fileName}`);
+          }
+        }
+        const removeMatch = /^rm -rf '([^']*\/events\/[^']+\.json)'$/.exec(script);
+        if (removeMatch) {
+          const fileName = path.posix.basename(removeMatch[1]);
+          const attempt = (removeAttempts.get(fileName) ?? 0) + 1;
+          removeAttempts.set(fileName, attempt);
+          if (input.failRemove?.(fileName, attempt)) {
+            return failResult(`simulated remove failure for ${fileName}`);
+          }
+        }
+        if (/for file in '[^']*\/events'\/\*\.json;/.test(script)) {
+          listAttempts += 1;
+          if (input.failList?.(listAttempts)) {
+            return failResult("simulated event listing failure");
+          }
+        }
+        return input.base.execute(execInput);
+      },
+    };
+  }
+
   async function readRuntimeTextFiles(rootDir: string): Promise<string[]> {
     const entries = await readdir(rootDir, { withFileTypes: true }).catch(() => []);
     const contents: string[] = [];
@@ -1692,6 +1746,351 @@ describe("sandbox adapter execution targets", () => {
         await bridge?.stop();
       }
     });
+  });
+
+  it("logs and recovers from a transient mid-batch event read failure without losing order or escalating", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-mid-batch-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "mid-batch-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('AAA\\n');",
+        "setTimeout(() => process.stdout.write('BBB\\n'), 20);",
+        "setTimeout(() => process.stdout.write('CCC\\n'), 40);",
+        "setTimeout(() => process.exit(0), 400);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // Fail the very first read of the second event file (000000000002.json)
+    // exactly once. The poll loop must not throw, must not deliver the third
+    // event ahead of it, and must retry it (and anything after it) on the
+    // next cycle.
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failRead: (fileName, attempt) => fileName === "000000000002.json" && attempt === 1,
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-mid-batch",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("AAA\nBBB\nCCC\n");
+      expect(result.stderr).toBe("");
+      // A single-file read failure must still count as a failed poll cycle
+      // (the events read before it, AAA, are still delivered), but since the
+      // very next cycle successfully reads and delivers the rest, the streak
+      // resets to 0 and the session never escalates to the fatal teardown.
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(1);
+      expect(failureLogLines[0]).toContain("000000000002.json");
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("escalates to the fatal frame after 5 consecutive cycles of a persistently failing single event file", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-persistent-bad-file-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "persistent-bad-file-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('EARLY\\n');",
+        "setTimeout(() => process.stdout.write('LATER\\n'), 20);",
+        "setTimeout(() => process.exit(0), 10_000);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // The second event file never reads successfully, on any attempt. Every
+    // poll cycle after the first therefore stops the batch at that same
+    // file forever: this is the livelock this fix closes, so it must be
+    // reported (logged, counted) rather than silently retried at 100ms with
+    // no escalation.
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failRead: (fileName) => fileName === "000000000002.json",
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-persistent-bad-file",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      // The first event (EARLY) is delivered exactly once before the batch
+      // reader hits the permanently bad file and stops; LATER is never
+      // reached (it sits behind the bad file in sequence order) and the
+      // session tears itself down with the fatal frame instead of looping
+      // forever.
+      expect(result.stdout).toBe("EARLY\n");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("000000000002.json");
+
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(5);
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+      expect(failureLogLines[4]).toContain("(attempt 5/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("stops delivering at a mid-batch malformed event, keeps the watermark behind it, and re-delivers on retry", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-malformed-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "malformed-event-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('FIRST\\n');",
+        "setTimeout(() => process.stdout.write('SECOND\\n'), 20);",
+        "setTimeout(() => process.exit(0), 400);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // Corrupt the body of the second event file on its first read only (the
+    // read itself succeeds, but the JSON is garbage), then let subsequent
+    // reads through untouched so the retry on the next cycle sees the real
+    // (valid) body. This simulates a JSON.parse throw mid-batch, distinct
+    // from a read failure: readRemoteJsonFiles hands the event back to
+    // poll() as successfully read, and it is poll()'s own parse/delivery
+    // step that fails.
+    let corrupted = false;
+    const base = createLocalSandboxRunner();
+    const runner = {
+      execute: async (execInput: Parameters<typeof base.execute>[0]) => {
+        const result = await base.execute(execInput);
+        const script = (execInput.args?.[1] ?? "").trim();
+        const readMatch = /^base64 < '([^']*\/events\/000000000002\.json)'$/.exec(script);
+        if (readMatch && !corrupted && result.exitCode === 0) {
+          corrupted = true;
+          return { ...result, stdout: Buffer.from("not valid json", "utf8").toString("base64") };
+        }
+        return result;
+      },
+    };
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-malformed",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(0);
+      // Both events are eventually delivered in order, exactly once: the
+      // corrupted read is retried (with valid JSON) on the next cycle
+      // rather than being skipped or duplicated.
+      expect(result.stdout).toBe("FIRST\nSECOND\n");
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(1);
+      expect(failureLogLines[0]).toContain("000000000002.json");
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("tolerates transient poll failures, resets the streak on success, and escalates only after 5 consecutive failures", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-poll-failures-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "silent-acp-child.mjs");
+    await writeFile(childPath, "setTimeout(() => process.exit(0), 10_000);", "utf8");
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // Fail cycles 1-2, succeed cycle 3 (must reset the consecutive-failure
+    // counter back to 0), then fail 5 cycles in a row (4-8) to cross the
+    // escalation threshold on the 5th consecutive failure.
+    const failingCycles = new Set([1, 2, 4, 5, 6, 7, 8]);
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failList: (attempt) => failingCycles.has(attempt),
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-poll-failures",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      // A single transient failure (well under the threshold) must not tear
+      // the session down: the proxy connects and simply waits, since no
+      // fatal frame is delivered yet at cycle 1 or 2.
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("simulated event listing failure");
+
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(7);
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+      expect(failureLogLines[1]).toContain("(attempt 2/5)");
+      // Cycle 3 succeeded, so the streak restarts from 1 rather than
+      // continuing to 3.
+      expect(failureLogLines[2]).toContain("(attempt 1/5)");
+      expect(failureLogLines[3]).toContain("(attempt 2/5)");
+      expect(failureLogLines[4]).toContain("(attempt 3/5)");
+      expect(failureLogLines[5]).toContain("(attempt 4/5)");
+      expect(failureLogLines[6]).toContain("(attempt 5/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("logs a warning and never re-delivers an event whose remove call keeps failing", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-remove-failure-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "single-shot-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('hello\\n');",
+        "setTimeout(() => process.exit(0), 500);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // The remove call always fails, so the event file is left on disk on
+    // every cycle. Without a delivery watermark this would cause the same
+    // event to be re-listed, re-read, and re-delivered indefinitely.
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failRemove: () => true,
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-remove-failure",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(0);
+      // "hello" must be delivered exactly once even though its event file
+      // was never successfully removed and kept being re-listed.
+      expect(result.stdout).toBe("hello\n");
+      expect(combinedStream(logs, "stderr")).toMatch(
+        /failed to remove processed event file.*000000000001\.json/,
+      );
+    } finally {
+      await bridge?.stop();
+    }
   });
 
   it("applies the remote sandbox fallback when adapter timeoutSec is unset", () => {

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -71,6 +71,60 @@ describe("sandbox adapter execution targets", () => {
     };
   }
 
+  // Simulates transient sandbox shell failures for the process-session
+  // bridge's event polling: reading/removing a specific event file, or
+  // listing the events directory itself, can be made to fail on demand
+  // while every other shell call passes through to the real local runner.
+  function createProcessSessionEventFaultInjectingRunner(input: {
+    base: ReturnType<typeof createLocalSandboxRunner>;
+    failRead?: (fileName: string, attempt: number) => boolean;
+    failRemove?: (fileName: string, attempt: number) => boolean;
+    failList?: (attempt: number) => boolean;
+  }) {
+    const readAttempts = new Map<string, number>();
+    const removeAttempts = new Map<string, number>();
+    let listAttempts = 0;
+    const failResult = (message: string) => ({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: message,
+      pid: null,
+      startedAt: new Date().toISOString(),
+    });
+    return {
+      execute: async (execInput: Parameters<ReturnType<typeof createLocalSandboxRunner>["execute"]>[0]) => {
+        const script = (execInput.args?.[1] ?? "").trim();
+        const readMatch = /^base64 < '([^']*\/events\/[^']+\.json)'$/.exec(script);
+        if (readMatch) {
+          const fileName = path.posix.basename(readMatch[1]);
+          const attempt = (readAttempts.get(fileName) ?? 0) + 1;
+          readAttempts.set(fileName, attempt);
+          if (input.failRead?.(fileName, attempt)) {
+            return failResult(`simulated transient read failure for ${fileName}`);
+          }
+        }
+        const removeMatch = /^rm -rf '([^']*\/events\/[^']+\.json)'$/.exec(script);
+        if (removeMatch) {
+          const fileName = path.posix.basename(removeMatch[1]);
+          const attempt = (removeAttempts.get(fileName) ?? 0) + 1;
+          removeAttempts.set(fileName, attempt);
+          if (input.failRemove?.(fileName, attempt)) {
+            return failResult(`simulated remove failure for ${fileName}`);
+          }
+        }
+        if (/for file in '[^']*\/events'\/\*\.json;/.test(script)) {
+          listAttempts += 1;
+          if (input.failList?.(listAttempts)) {
+            return failResult("simulated event listing failure");
+          }
+        }
+        return input.base.execute(execInput);
+      },
+    };
+  }
+
   async function readRuntimeTextFiles(rootDir: string): Promise<string[]> {
     const entries = await readdir(rootDir, { withFileTypes: true }).catch(() => []);
     const contents: string[] = [];
@@ -485,6 +539,196 @@ describe("sandbox adapter execution targets", () => {
         child.kill("SIGKILL");
         await exitPromise.catch(() => undefined);
       }
+      await bridge?.stop();
+    }
+  });
+
+  it("skips a mid-batch event read failure without losing order and retries it next cycle", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-mid-batch-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "mid-batch-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('AAA\\n');",
+        "setTimeout(() => process.stdout.write('BBB\\n'), 20);",
+        "setTimeout(() => process.stdout.write('CCC\\n'), 40);",
+        "setTimeout(() => process.exit(0), 400);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // Fail the very first read of the second event file (000000000002.json)
+    // exactly once. The poll loop must not throw, must not deliver the third
+    // event ahead of it, and must retry it (and anything after it) on the
+    // next cycle.
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failRead: (fileName, attempt) => fileName === "000000000002.json" && attempt === 1,
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-mid-batch",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(0);
+      expect(result.stdout).toBe("AAA\nBBB\nCCC\n");
+      expect(result.stderr).toBe("");
+      // A skipped-and-retried single file read must never surface as a
+      // poll-level failure (that log line, and the fatal escalation it
+      // gates, are reserved for failures the batch reader cannot recover
+      // from on its own, e.g. the directory listing itself failing).
+      expect(combinedStream(logs, "stderr")).not.toContain("ACP process session bridge poll failed");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("tolerates transient poll failures, resets the streak on success, and escalates only after 5 consecutive failures", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-poll-failures-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "silent-acp-child.mjs");
+    await writeFile(childPath, "setTimeout(() => process.exit(0), 10_000);", "utf8");
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // Fail cycles 1-2, succeed cycle 3 (must reset the consecutive-failure
+    // counter back to 0), then fail 5 cycles in a row (4-8) to cross the
+    // escalation threshold on the 5th consecutive failure.
+    const failingCycles = new Set([1, 2, 4, 5, 6, 7, 8]);
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failList: (attempt) => failingCycles.has(attempt),
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-poll-failures",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      // A single transient failure (well under the threshold) must not tear
+      // the session down: the proxy connects and simply waits, since no
+      // fatal frame is delivered yet at cycle 1 or 2.
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("simulated event listing failure");
+
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(7);
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+      expect(failureLogLines[1]).toContain("(attempt 2/5)");
+      // Cycle 3 succeeded, so the streak restarts from 1 rather than
+      // continuing to 3.
+      expect(failureLogLines[2]).toContain("(attempt 1/5)");
+      expect(failureLogLines[3]).toContain("(attempt 2/5)");
+      expect(failureLogLines[4]).toContain("(attempt 3/5)");
+      expect(failureLogLines[5]).toContain("(attempt 4/5)");
+      expect(failureLogLines[6]).toContain("(attempt 5/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("logs a warning and never re-delivers an event whose remove call keeps failing", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-remove-failure-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "single-shot-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('hello\\n');",
+        "setTimeout(() => process.exit(0), 500);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // The remove call always fails, so the event file is left on disk on
+    // every cycle. Without a delivery watermark this would cause the same
+    // event to be re-listed, re-read, and re-delivered indefinitely.
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failRemove: () => true,
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-remove-failure",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(0);
+      // "hello" must be delivered exactly once even though its event file
+      // was never successfully removed and kept being re-listed.
+      expect(result.stdout).toBe("hello\n");
+      expect(combinedStream(logs, "stderr")).toMatch(
+        /failed to remove processed event file.*000000000001\.json/,
+      );
+    } finally {
       await bridge?.stop();
     }
   });

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -543,7 +543,7 @@ describe("sandbox adapter execution targets", () => {
     }
   });
 
-  it("skips a mid-batch event read failure without losing order and retries it next cycle", async () => {
+  it("logs and recovers from a transient mid-batch event read failure without losing order or escalating", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-mid-batch-"));
     cleanupDirs.push(rootDir);
     const childPath = path.join(rootDir, "mid-batch-acp-child.mjs");
@@ -597,11 +597,166 @@ describe("sandbox adapter execution targets", () => {
       expect(result.code).toBe(0);
       expect(result.stdout).toBe("AAA\nBBB\nCCC\n");
       expect(result.stderr).toBe("");
-      // A skipped-and-retried single file read must never surface as a
-      // poll-level failure (that log line, and the fatal escalation it
-      // gates, are reserved for failures the batch reader cannot recover
-      // from on its own, e.g. the directory listing itself failing).
-      expect(combinedStream(logs, "stderr")).not.toContain("ACP process session bridge poll failed");
+      // A single-file read failure must still count as a failed poll cycle
+      // (the events read before it, AAA, are still delivered), but since the
+      // very next cycle successfully reads and delivers the rest, the streak
+      // resets to 0 and the session never escalates to the fatal teardown.
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(1);
+      expect(failureLogLines[0]).toContain("000000000002.json");
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("escalates to the fatal frame after 5 consecutive cycles of a persistently failing single event file", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-persistent-bad-file-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "persistent-bad-file-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('EARLY\\n');",
+        "setTimeout(() => process.stdout.write('LATER\\n'), 20);",
+        "setTimeout(() => process.exit(0), 10_000);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // The second event file never reads successfully, on any attempt. Every
+    // poll cycle after the first therefore stops the batch at that same
+    // file forever: this is the livelock this fix closes, so it must be
+    // reported (logged, counted) rather than silently retried at 100ms with
+    // no escalation.
+    const runner = createProcessSessionEventFaultInjectingRunner({
+      base: createLocalSandboxRunner(),
+      failRead: (fileName) => fileName === "000000000002.json",
+    });
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-persistent-bad-file",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      // The first event (EARLY) is delivered exactly once before the batch
+      // reader hits the permanently bad file and stops; LATER is never
+      // reached (it sits behind the bad file in sequence order) and the
+      // session tears itself down with the fatal frame instead of looping
+      // forever.
+      expect(result.stdout).toBe("EARLY\n");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("000000000002.json");
+
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(5);
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
+      expect(failureLogLines[4]).toContain("(attempt 5/5)");
+    } finally {
+      await bridge?.stop();
+    }
+  });
+
+  it("stops delivering at a mid-batch malformed event, keeps the watermark behind it, and re-delivers on retry", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-malformed-"));
+    cleanupDirs.push(rootDir);
+    const childPath = path.join(rootDir, "malformed-event-acp-child.mjs");
+    await writeFile(
+      childPath,
+      [
+        "process.stdout.write('FIRST\\n');",
+        "setTimeout(() => process.stdout.write('SECOND\\n'), 20);",
+        "setTimeout(() => process.exit(0), 400);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+    // Corrupt the body of the second event file on its first read only (the
+    // read itself succeeds, but the JSON is garbage), then let subsequent
+    // reads through untouched so the retry on the next cycle sees the real
+    // (valid) body. This simulates a JSON.parse throw mid-batch, distinct
+    // from a read failure: readRemoteJsonFiles hands the event back to
+    // poll() as successfully read, and it is poll()'s own parse/delivery
+    // step that fails.
+    let corrupted = false;
+    const base = createLocalSandboxRunner();
+    const runner = {
+      execute: async (execInput: Parameters<typeof base.execute>[0]) => {
+        const result = await base.execute(execInput);
+        const script = (execInput.args?.[1] ?? "").trim();
+        const readMatch = /^base64 < '([^']*\/events\/000000000002\.json)'$/.exec(script);
+        if (readMatch && !corrupted && result.exitCode === 0) {
+          corrupted = true;
+          return { ...result, stdout: Buffer.from("not valid json", "utf8").toString("base64") };
+        }
+        return result;
+      },
+    };
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-test",
+      remoteCwd: rootDir,
+      timeoutMs: 30_000,
+      runner,
+    };
+
+    const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+      runId: "run-process-session-malformed",
+      target,
+      runtimeRootDir: path.posix.join(rootDir, ".paperclip-runtime", "acpx"),
+      adapterKey: "acpx",
+      command: process.execPath,
+      args: [childPath],
+      cwd: rootDir,
+      env: {},
+      timeoutSec: 5,
+      onLog: async (stream, chunk) => {
+        logs.push({ stream, chunk });
+      },
+    });
+    expect(bridge).not.toBeNull();
+
+    try {
+      const result = await runProxyWithInput(bridge!.agentCommand, "");
+      expect(result.code).toBe(0);
+      // Both events are eventually delivered in order, exactly once: the
+      // corrupted read is retried (with valid JSON) on the next cycle
+      // rather than being skipped or duplicated.
+      expect(result.stdout).toBe("FIRST\nSECOND\n");
+      const failureLogLines = combinedStream(logs, "stderr")
+        .split("\n")
+        .filter((line) => line.includes("ACP process session bridge poll failed"));
+      expect(failureLogLines).toHaveLength(1);
+      expect(failureLogLines[0]).toContain("000000000002.json");
+      expect(failureLogLines[0]).toContain("(attempt 1/5)");
     } finally {
       await bridge?.stop();
     }

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1619,19 +1619,61 @@ async function syncProcessSessionRemoteScript(input: {
   return { uploaded };
 }
 
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
+// Event files are named with a monotonic zero-padded sequence
+// ("000000000001.json", "000000000002.json", ...) written by a serial,
+// atomic (tmp+rename) writer, so string comparison of names is equivalent
+// to sequence order. This lets the reader stop the batch at the first bad
+// file it finds, rather than skipping past it, so events are never
+// delivered out of order.
+//
+// Removing a file is the caller's responsibility (see poll()): this
+// function only reads and reports, so a file can never be removed before
+// the caller has actually delivered its event.
 async function readRemoteJsonFiles(input: {
   client: ReturnType<typeof createCommandManagedSandboxCallbackBridgeQueueClient>;
   dir: string;
-}): Promise<Array<{ name: string; body: string }>> {
-  const names = await input.client.listJsonFiles(input.dir);
+  afterName: string | null;
+}): Promise<{
+  events: Array<{ name: string; body: string }>;
+  // Set when the batch stopped before exhausting every listed name (a read
+  // failure or an empty body). The caller must treat this as a failed
+  // cycle for escalation purposes, even though the events read before the
+  // stop point are still delivered normally.
+  stoppedEarly: { name: string; error: unknown } | null;
+}> {
+  const listedNames = await input.client.listJsonFiles(input.dir);
+  const names = input.afterName
+    ? listedNames.filter((name) => name > input.afterName!)
+    : listedNames;
   const out: Array<{ name: string; body: string }> = [];
+  let stoppedEarly: { name: string; error: unknown } | null = null;
   for (const name of names) {
     const filePath = path.posix.join(input.dir, name);
-    const body = await input.client.readTextFile(filePath);
-    await input.client.remove(filePath).catch(() => undefined);
+    let body: string;
+    try {
+      body = await input.client.readTextFile(filePath);
+    } catch (error) {
+      // Stop the batch at the first file that fails to read (missing,
+      // non-zero exit, or otherwise) rather than skipping past it. Events
+      // must be delivered in filename (sequence) order: if file N fails but
+      // N+1 happens to succeed, delivering N+1 before N would reorder
+      // events. The file is left in place (nothing here removes it), so
+      // the next poll cycle re-lists it (names are monotonic, nothing was
+      // skipped over) and retries from exactly this point.
+      stoppedEarly = { name, error };
+      break;
+    }
+    // Treat an empty read the same as a failed one: a momentarily-empty or
+    // partially observed file must not be delivered as a real event.
+    if (!body.trim()) {
+      stoppedEarly = { name, error: new Error("event file was empty") };
+      break;
+    }
     out.push({ name, body });
   }
-  return out;
+  return { events: out, stoppedEarly };
 }
 
 async function waitForLocalServerListen(server: net.Server): Promise<number> {
@@ -1961,16 +2003,47 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     });
   });
 
+  // In-memory per session/poll-loop instance: a fresh bridge (and thus a
+  // fresh watermark and failure streak) starts on every run, which is fine.
+  // There is nothing to recover across restarts, since the whole point of
+  // the watermark is to dedupe within a single still-running poll loop.
+  let lastDeliveredEventName: string | null = null;
+  let consecutivePollFailures = 0;
+
+  const logPollFailure = async (message: string) => {
+    consecutivePollFailures += 1;
+    await onLog(
+      "stderr",
+      `[paperclip] ACP process session bridge poll failed: ${message} ` +
+        `(attempt ${consecutivePollFailures}/${MAX_CONSECUTIVE_POLL_FAILURES})\n`,
+    );
+    // A single failed poll cycle (e.g. the directory listing itself
+    // failing, a single event file that will not read, or a malformed
+    // event body) is treated as transient: only tear the session down once
+    // MAX_CONSECUTIVE_POLL_FAILURES full cycles have failed back to back.
+    // Any cycle that completes without a failure resets the streak to 0.
+    if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+      deliverRemoteEvent({ type: "error", message });
+      return true;
+    }
+    return false;
+  };
+
   const poll = async () => {
     if (stopping) return;
     try {
       // Read every file this tick fetched before this loop decides whether to
       // keep polling. A `shutdownAck` can land in the same batch right after
       // an `exit` event; deliver it too, so this tick never drops an
-      // already-fetched (and already-removed-from-disk) event.
-      const events = await readRemoteJsonFiles({ client, dir: eventsDir });
+      // already-fetched event.
+      const { events, stoppedEarly } = await readRemoteJsonFiles({
+        client,
+        dir: eventsDir,
+        afterName: lastDeliveredEventName,
+      });
+      let midBatchFailure: string | null = null;
       for (const event of events) {
-        const parsed = JSON.parse(event.body) as {
+        let parsed: {
           type?: string;
           stream?: "stdout" | "stderr";
           data?: string;
@@ -1978,13 +2051,50 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
           signal?: string | null;
           message?: string;
         };
-        deliverRemoteEvent(parsed);
+        try {
+          parsed = JSON.parse(event.body) as typeof parsed;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          midBatchFailure = `failed to parse ACP process session event file ${event.name}: ${message}`;
+          break;
+        }
+        try {
+          deliverRemoteEvent(parsed);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          midBatchFailure = `failed to deliver ACP process session event file ${event.name}: ${message}`;
+          break;
+        }
+        // Only now that the event has actually been handed to the caller do
+        // we advance the watermark and attempt to remove the remote file. A
+        // throw above (parse or deliver) leaves both untouched, so the file
+        // is re-read from exactly this point on the next cycle and nothing
+        // already delivered is ever repeated.
+        lastDeliveredEventName = event.name;
+        const filePath = path.posix.join(eventsDir, event.name);
+        try {
+          await client.remove(filePath);
+        } catch (removeError) {
+          const removeMessage = removeError instanceof Error ? removeError.message : String(removeError);
+          await onLog(
+            "stderr",
+            `[paperclip] ACP process session bridge failed to remove processed event file ${event.name}; ` +
+              `relying on the delivery watermark to avoid re-sending it: ${removeMessage}\n`,
+          );
+        }
+      }
+      if (midBatchFailure) {
+        if (await logPollFailure(midBatchFailure)) return;
+      } else if (stoppedEarly) {
+        const error = stoppedEarly.error;
+        const message = error instanceof Error ? error.message : String(error);
+        if (await logPollFailure(`failed to read ACP process session event file ${stoppedEarly.name}: ${message}`)) return;
+      } else {
+        consecutivePollFailures = 0;
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      await onLog("stderr", `[paperclip] ACP process session bridge poll failed: ${message}\n`);
-      deliverRemoteEvent({ type: "error", message });
-      return;
+      if (await logPollFailure(message)) return;
     } finally {
       if (!stopping) {
         schedulePoll();
@@ -2147,7 +2257,10 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     if (stopReadingForShutdownAck) return;
     void (async () => {
       try {
-        const events = await readRemoteJsonFiles({ client, dir: eventsDir });
+        // Read from the start of the directory: this bounded reader is
+        // independent of the poll loop's delivery watermark and only looks for
+        // a `shutdownAck`, which the poll loop never removes on its behalf.
+        const { events } = await readRemoteJsonFiles({ client, dir: eventsDir, afterName: null });
         if (stopReadingForShutdownAck) return;
         for (const event of events) {
           try {

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1244,19 +1244,61 @@ async function syncProcessSessionRemoteScript(input: {
   await input.client.writeTextFile(input.remoteScriptPath, getProcessSessionRemoteSource());
 }
 
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+
+// Event files are named with a monotonic zero-padded sequence
+// ("000000000001.json", "000000000002.json", ...) written by a serial,
+// atomic (tmp+rename) writer, so string comparison of names is equivalent
+// to sequence order. This lets the reader skip-and-retry a single bad file
+// without ever losing or reordering events.
 async function readRemoteJsonFiles(input: {
   client: ReturnType<typeof createCommandManagedSandboxCallbackBridgeQueueClient>;
   dir: string;
-}): Promise<Array<{ name: string; body: string }>> {
-  const names = await input.client.listJsonFiles(input.dir);
+  afterName: string | null;
+  onRemoveFailed?: (name: string, error: unknown) => Promise<void> | void;
+}): Promise<{ events: Array<{ name: string; body: string }>; lastName: string | null }> {
+  const listedNames = await input.client.listJsonFiles(input.dir);
+  const names = input.afterName
+    ? listedNames.filter((name) => name > input.afterName!)
+    : listedNames;
   const out: Array<{ name: string; body: string }> = [];
   for (const name of names) {
     const filePath = path.posix.join(input.dir, name);
-    const body = await input.client.readTextFile(filePath);
-    await input.client.remove(filePath).catch(() => undefined);
+    let body: string;
+    try {
+      body = await input.client.readTextFile(filePath);
+    } catch {
+      // Stop the batch at the first file that fails to read (missing,
+      // non-zero exit, or otherwise) rather than skipping past it. Events
+      // must be delivered in filename (sequence) order: if file N fails but
+      // N+1 happens to succeed, delivering N+1 before N would reorder
+      // events. The file is only removed after a successful read, so
+      // leaving it in place here is lossless -- the next poll cycle
+      // re-lists it (names are monotonic, nothing was skipped over) and
+      // retries from exactly this point.
+      break;
+    }
+    // Treat an empty read the same as a failed one: a momentarily-empty or
+    // partially observed file must not be delivered as a real event.
+    if (!body.trim()) break;
     out.push({ name, body });
   }
-  return out;
+  // Only remove files we are actually about to hand back to the caller.
+  // A remove failure must never re-surface as a delivery failure -- the
+  // caller advances its watermark (see poll()'s `afterName`) past every
+  // file in `out` regardless of whether the remove below succeeds, so a
+  // lingering un-removable file is simply skipped by the `afterName` filter
+  // on every future cycle instead of being re-read and re-delivered.
+  for (const item of out) {
+    const filePath = path.posix.join(input.dir, item.name);
+    try {
+      await input.client.remove(filePath);
+    } catch (error) {
+      await input.onRemoveFailed?.(item.name, error);
+    }
+  }
+  const lastName = out.length > 0 ? out[out.length - 1]!.name : input.afterName;
+  return { events: out, lastName };
 }
 
 async function waitForLocalServerListen(server: net.Server): Promise<number> {
@@ -1456,10 +1498,30 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     });
   });
 
+  // In-memory per session/poll-loop instance: a fresh bridge (and thus a
+  // fresh watermark and failure streak) starts on every run, which is fine
+  // -- there is nothing to recover across restarts since the whole point of
+  // the watermark is to dedupe within a single still-running poll loop.
+  let lastDeliveredEventName: string | null = null;
+  let consecutivePollFailures = 0;
+
   const poll = async () => {
     if (stopping) return;
     try {
-      const events = await readRemoteJsonFiles({ client, dir: eventsDir });
+      const { events, lastName } = await readRemoteJsonFiles({
+        client,
+        dir: eventsDir,
+        afterName: lastDeliveredEventName,
+        onRemoveFailed: async (name, error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          await onLog(
+            "stderr",
+            `[paperclip] ACP process session bridge failed to remove processed event file ${name}; ` +
+              `relying on the delivery watermark to avoid re-sending it: ${message}\n`,
+          );
+        },
+      });
+      lastDeliveredEventName = lastName;
       for (const event of events) {
         const parsed = JSON.parse(event.body) as {
           type?: string;
@@ -1472,11 +1534,23 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
         deliverRemoteEvent(parsed);
         if (parsed.type === "exit" || parsed.type === "error") return;
       }
+      consecutivePollFailures = 0;
     } catch (error) {
+      consecutivePollFailures += 1;
       const message = error instanceof Error ? error.message : String(error);
-      await onLog("stderr", `[paperclip] ACP process session bridge poll failed: ${message}\n`);
-      deliverRemoteEvent({ type: "error", message });
-      return;
+      await onLog(
+        "stderr",
+        `[paperclip] ACP process session bridge poll failed: ${message} ` +
+          `(attempt ${consecutivePollFailures}/${MAX_CONSECUTIVE_POLL_FAILURES})\n`,
+      );
+      // A single failed poll cycle (e.g. the directory listing itself
+      // failing) is treated as transient: only tear the session down once
+      // MAX_CONSECUTIVE_POLL_FAILURES full cycles have failed back to back.
+      // Any successful cycle above resets the streak to 0.
+      if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+        deliverRemoteEvent({ type: "error", message });
+        return;
+      }
     } finally {
       if (!stopping) {
         pollTimer = setTimeout(() => void poll(), 100);

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1249,56 +1249,56 @@ const MAX_CONSECUTIVE_POLL_FAILURES = 5;
 // Event files are named with a monotonic zero-padded sequence
 // ("000000000001.json", "000000000002.json", ...) written by a serial,
 // atomic (tmp+rename) writer, so string comparison of names is equivalent
-// to sequence order. This lets the reader skip-and-retry a single bad file
-// without ever losing or reordering events.
+// to sequence order. This lets the reader stop the batch at the first bad
+// file it finds, rather than skipping past it, so events are never
+// delivered out of order.
+//
+// Removing a file is the caller's responsibility (see poll()): this
+// function only reads and reports, so a file can never be removed before
+// the caller has actually delivered its event.
 async function readRemoteJsonFiles(input: {
   client: ReturnType<typeof createCommandManagedSandboxCallbackBridgeQueueClient>;
   dir: string;
   afterName: string | null;
-  onRemoveFailed?: (name: string, error: unknown) => Promise<void> | void;
-}): Promise<{ events: Array<{ name: string; body: string }>; lastName: string | null }> {
+}): Promise<{
+  events: Array<{ name: string; body: string }>;
+  // Set when the batch stopped before exhausting every listed name (a read
+  // failure or an empty body). The caller must treat this as a failed
+  // cycle for escalation purposes, even though the events read before the
+  // stop point are still delivered normally.
+  stoppedEarly: { name: string; error: unknown } | null;
+}> {
   const listedNames = await input.client.listJsonFiles(input.dir);
   const names = input.afterName
     ? listedNames.filter((name) => name > input.afterName!)
     : listedNames;
   const out: Array<{ name: string; body: string }> = [];
+  let stoppedEarly: { name: string; error: unknown } | null = null;
   for (const name of names) {
     const filePath = path.posix.join(input.dir, name);
     let body: string;
     try {
       body = await input.client.readTextFile(filePath);
-    } catch {
+    } catch (error) {
       // Stop the batch at the first file that fails to read (missing,
       // non-zero exit, or otherwise) rather than skipping past it. Events
       // must be delivered in filename (sequence) order: if file N fails but
       // N+1 happens to succeed, delivering N+1 before N would reorder
-      // events. The file is only removed after a successful read, so
-      // leaving it in place here is lossless -- the next poll cycle
-      // re-lists it (names are monotonic, nothing was skipped over) and
-      // retries from exactly this point.
+      // events. The file is left in place (nothing here removes it), so
+      // the next poll cycle re-lists it (names are monotonic, nothing was
+      // skipped over) and retries from exactly this point.
+      stoppedEarly = { name, error };
       break;
     }
     // Treat an empty read the same as a failed one: a momentarily-empty or
     // partially observed file must not be delivered as a real event.
-    if (!body.trim()) break;
+    if (!body.trim()) {
+      stoppedEarly = { name, error: new Error("event file was empty") };
+      break;
+    }
     out.push({ name, body });
   }
-  // Only remove files we are actually about to hand back to the caller.
-  // A remove failure must never re-surface as a delivery failure -- the
-  // caller advances its watermark (see poll()'s `afterName`) past every
-  // file in `out` regardless of whether the remove below succeeds, so a
-  // lingering un-removable file is simply skipped by the `afterName` filter
-  // on every future cycle instead of being re-read and re-delivered.
-  for (const item of out) {
-    const filePath = path.posix.join(input.dir, item.name);
-    try {
-      await input.client.remove(filePath);
-    } catch (error) {
-      await input.onRemoveFailed?.(item.name, error);
-    }
-  }
-  const lastName = out.length > 0 ? out[out.length - 1]!.name : input.afterName;
-  return { events: out, lastName };
+  return { events: out, stoppedEarly };
 }
 
 async function waitForLocalServerListen(server: net.Server): Promise<number> {
@@ -1499,31 +1499,42 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
   });
 
   // In-memory per session/poll-loop instance: a fresh bridge (and thus a
-  // fresh watermark and failure streak) starts on every run, which is fine
-  // -- there is nothing to recover across restarts since the whole point of
+  // fresh watermark and failure streak) starts on every run, which is fine.
+  // There is nothing to recover across restarts, since the whole point of
   // the watermark is to dedupe within a single still-running poll loop.
   let lastDeliveredEventName: string | null = null;
   let consecutivePollFailures = 0;
 
+  const logPollFailure = async (message: string) => {
+    consecutivePollFailures += 1;
+    await onLog(
+      "stderr",
+      `[paperclip] ACP process session bridge poll failed: ${message} ` +
+        `(attempt ${consecutivePollFailures}/${MAX_CONSECUTIVE_POLL_FAILURES})\n`,
+    );
+    // A single failed poll cycle (e.g. the directory listing itself
+    // failing, a single event file that will not read, or a malformed
+    // event body) is treated as transient: only tear the session down once
+    // MAX_CONSECUTIVE_POLL_FAILURES full cycles have failed back to back.
+    // Any cycle that completes without a failure resets the streak to 0.
+    if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+      deliverRemoteEvent({ type: "error", message });
+      return true;
+    }
+    return false;
+  };
+
   const poll = async () => {
     if (stopping) return;
     try {
-      const { events, lastName } = await readRemoteJsonFiles({
+      const { events, stoppedEarly } = await readRemoteJsonFiles({
         client,
         dir: eventsDir,
         afterName: lastDeliveredEventName,
-        onRemoveFailed: async (name, error) => {
-          const message = error instanceof Error ? error.message : String(error);
-          await onLog(
-            "stderr",
-            `[paperclip] ACP process session bridge failed to remove processed event file ${name}; ` +
-              `relying on the delivery watermark to avoid re-sending it: ${message}\n`,
-          );
-        },
       });
-      lastDeliveredEventName = lastName;
+      let midBatchFailure: string | null = null;
       for (const event of events) {
-        const parsed = JSON.parse(event.body) as {
+        let parsed: {
           type?: string;
           stream?: "stdout" | "stderr";
           data?: string;
@@ -1531,26 +1542,51 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
           signal?: string | null;
           message?: string;
         };
-        deliverRemoteEvent(parsed);
+        try {
+          parsed = JSON.parse(event.body) as typeof parsed;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          midBatchFailure = `failed to parse ACP process session event file ${event.name}: ${message}`;
+          break;
+        }
+        try {
+          deliverRemoteEvent(parsed);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          midBatchFailure = `failed to deliver ACP process session event file ${event.name}: ${message}`;
+          break;
+        }
+        // Only now that the event has actually been handed to the caller do
+        // we advance the watermark and attempt to remove the remote file. A
+        // throw above (parse or deliver) leaves both untouched, so the file
+        // is re-read from exactly this point on the next cycle and nothing
+        // already delivered is ever repeated.
+        lastDeliveredEventName = event.name;
+        const filePath = path.posix.join(eventsDir, event.name);
+        try {
+          await client.remove(filePath);
+        } catch (removeError) {
+          const removeMessage = removeError instanceof Error ? removeError.message : String(removeError);
+          await onLog(
+            "stderr",
+            `[paperclip] ACP process session bridge failed to remove processed event file ${event.name}; ` +
+              `relying on the delivery watermark to avoid re-sending it: ${removeMessage}\n`,
+          );
+        }
         if (parsed.type === "exit" || parsed.type === "error") return;
       }
-      consecutivePollFailures = 0;
-    } catch (error) {
-      consecutivePollFailures += 1;
-      const message = error instanceof Error ? error.message : String(error);
-      await onLog(
-        "stderr",
-        `[paperclip] ACP process session bridge poll failed: ${message} ` +
-          `(attempt ${consecutivePollFailures}/${MAX_CONSECUTIVE_POLL_FAILURES})\n`,
-      );
-      // A single failed poll cycle (e.g. the directory listing itself
-      // failing) is treated as transient: only tear the session down once
-      // MAX_CONSECUTIVE_POLL_FAILURES full cycles have failed back to back.
-      // Any successful cycle above resets the streak to 0.
-      if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
-        deliverRemoteEvent({ type: "error", message });
-        return;
+      if (midBatchFailure) {
+        if (await logPollFailure(midBatchFailure)) return;
+      } else if (stoppedEarly) {
+        const error = stoppedEarly.error;
+        const message = error instanceof Error ? error.message : String(error);
+        if (await logPollFailure(`failed to read ACP process session event file ${stoppedEarly.name}: ${message}`)) return;
+      } else {
+        consecutivePollFailures = 0;
       }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (await logPollFailure(message)) return;
     } finally {
       if (!stopping) {
         pollTimer = setTimeout(() => void poll(), 100);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs on remote sandboxes stream ACP events through a process-session bridge: a remote writer publishes numbered `events/NNNN.json` files and a local poll loop reads, delivers, and removes them
> - The writer is already robust (atomic tmp+rename, serial write chain, ordered exit frame)
> - The reader was not: the poll loop turned any single transient file-read failure into a fatal error that tore down the whole session
> - One failed `base64 < events/NNNN.json` (a sandbox exec hiccup) therefore killed an otherwise healthy run and dropped every not-yet-forwarded event, including the child exit frame
> - This PR makes the reader tolerant of transient read failures while preserving strict event ordering and still failing fast on genuine crashes
> - The benefit is that a momentary exec-channel blip no longer terminates a healthy run

## Linked Issues or Issue Description

No public GitHub issue exists; describing inline following the bug report template.

**What happened**

A healthy run died when a single transient read of one process-session bridge event file failed; the poll loop escalated that one failure to a fatal session teardown and dropped the remaining buffered events, including the child exit frame.

**Expected behavior**

A transient per-file read failure should be retried on the next poll, not kill the session; only genuine child error/exit events (or sustained failure) should terminate it.

**Steps to reproduce**

Run an ACP agent on a remote sandbox and cause one `base64 < events/NNNN.json` read to fail transiently (a sandbox exec-channel hiccup). Before this change the session is torn down immediately. The added tests reproduce the single-read failure and the persistent-failure escalation.

**Deployment mode**

Cloud multi-tenant execution (remote sandbox process-session bridge).

## What Changed

- A per-file read failure now stops the batch at that file (preserving strict sequence order) and retries it on the next poll
- The delivered-event watermark advances per successfully delivered event, so a mid-batch delivery/parse throw re-reads the tail rather than silently skipping it
- A cycle that stops early or fails mid-delivery counts toward `MAX_CONSECUTIVE_POLL_FAILURES = 5`; only after five consecutive failed cycles does the session escalate to the fatal error frame (idle cycles reset the counter)
- Remove failures are logged instead of silently swallowed; a delivered-then-remove-failed file is never re-delivered (name watermark)
- Genuine child error/exit events still terminate the session promptly

## Verification

- `npx vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts` — mid-batch read failure preserves order and retries; persistent single-file failure escalates after 5 cycles (idle cycles do not); mid-batch malformed event re-reads the tail; remove failure logs without double delivery

## Risks

Low risk on the tolerance side (writer is untouched and atomic; watermark bounds memory and prevents double delivery). The main behavioral shift is that a truly wedged bridge now takes up to 5 poll cycles to fail instead of 1; this is bounded and intentional, and real child exit/error events are unaffected.
## Model Used

Claude (Anthropic) via Claude Code. Implementation and tests authored by a Claude Sonnet-class model (`claude-sonnet-5`) dispatched as isolated per-task implementer agents under a multi-agent orchestration workflow; root-cause investigation, planning, and two-stage adversarial code review performed by additional Claude agents. Extended thinking and tool use enabled throughout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
