### PR TITLE
fix(gemini-local): classify quota exhaustion with a dedicated error code

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.result-mapping.test.ts
+++ b/packages/adapters/gemini-local/src/server/execute.result-mapping.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  readPaperclipRuntimeSkillEntries,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+  executeGeminiAcp,
+} = vi.hoisted(() => ({
+  ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+  ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+  readPaperclipRuntimeSkillEntries: vi.fn(async () => []),
+  resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "gemini"),
+  runAdapterExecutionTargetProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({ type: "init", session_id: "gemini-session-1" }),
+      JSON.stringify({ type: "message", role: "assistant", content: "hello" }),
+      JSON.stringify({
+        type: "result",
+        status: "success",
+        stats: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  executeGeminiAcp: vi.fn(),
+}));
+
+vi.mock("./acp.js", () => ({
+  createGeminiAcpExecutor: () => executeGeminiAcp,
+  formatGeminiAcpFallbackMessage: (reason: string) =>
+    `[paperclip] Gemini ACP default unavailable; falling back to Gemini CLI. ${reason} Set engine=acp to require ACP or engine=cli to silence this fallback.\n`,
+  resolveGeminiExecutionEngineForRun: async (ctx: { config: Record<string, unknown> }) =>
+    ({ engine: "cli", explicit: true }),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    readPaperclipRuntimeSkillEntries,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildContext(config: Record<string, unknown> = {}) {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Gemini Coder",
+      adapterType: "gemini_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      engine: "cli",
+      env: { GEMINI_API_KEY: "test-key" },
+      ...config,
+    },
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+describe("gemini_local execute result-mapping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("classifies quota exhaustion with dedicated error code when stderr contains quota message", async () => {
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: 44,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "Quota exceeded. Check your plan and billing details.",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute(buildContext() as never);
+
+    expect(result.exitCode).toBe(44);
+    expect(result.errorCode).toBe("gemini_quota_exhausted");
+  });
+
+  it("preserves null error code for failed runs without quota text", async () => {
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "Some other error occurred",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute(buildContext() as never);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBeNull();
+  });
+});

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -52,6 +52,7 @@ import { DEFAULT_GEMINI_LOCAL_MODEL, SANDBOX_INSTALL_COMMAND } from "../index.js
 import {
   describeGeminiFailure,
   detectGeminiAuthRequired,
+  detectGeminiQuotaExhausted,
   isGeminiTransientNetworkError,
   isGeminiTurnLimitResult,
   isGeminiSessionUnrecoverableError,
@@ -645,6 +646,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       stdout: attempt.proc.stdout,
       stderr: attempt.proc.stderr,
     });
+    const quotaMeta = detectGeminiQuotaExhausted({
+      parsed: attempt.parsed.resultEvent,
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+    });
     const networkUnavailable = isGeminiTransientNetworkError(attempt.proc.stdout, attempt.proc.stderr);
 
     if (attempt.proc.timedOut) {
@@ -715,6 +721,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         ? "max_turns_exhausted"
         : failed && networkUnavailable
         ? "gemini_network_unavailable"
+        : failed && quotaMeta.exhausted
+        ? "gemini_quota_exhausted"
         : null,
       usage: attempt.parsed.usage,
       sessionId: resolvedSessionId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each agent run uses an adapter (here `gemini-local`) that shells out to a provider CLI and maps its exit into a structured run result with an `errorCode`
> - When the Gemini CLI hits a plan/billing quota limit it exits non-zero with "Quota exceeded. Check your plan and billing details."
> - The adapter's result mapping had no arm for this, so quota failures were stored with `errorCode: null` — indistinguishable from any other unclassified failure
> - A detector for exactly this condition (`detectGeminiQuotaExhausted`) already existed but was only wired into the environment preflight, not the runtime result mapping
> - This PR wires the existing detector into the result mapping so quota exhaustion gets a dedicated, actionable error code
> - The benefit is that a customer-actionable, non-retryable failure class becomes visible to downstream handling and telemetry

## Linked Issues or Issue Description

No public GitHub issue exists; describing inline following the bug report template. Related prior work (referenced for dedup): Refs #3160 (detect quota exhaustion and auto-retry after reset); this PR is narrower and only adds the dedicated classification.

**What happened**

Gemini CLI runs that failed with quota exhaustion (exit 44, "Quota exceeded. Check your plan and billing details.") were classified with `errorCode: null`, indistinguishable from any other failure.

**Expected behavior**

Quota exhaustion is a distinct, customer-actionable, non-retryable class and should carry its own error code.

**Steps to reproduce**

Run a `gemini-local` agent whose provider account is over quota; the CLI exits 44 with the quota message and the run result is stored with `errorCode: null`. The added result-mapping test reproduces the classification.

**Deployment mode**

Any deployment using the `gemini-local` adapter.

## What Changed

- Added one classification arm to the `gemini-local` CLI result mapping: a failed run whose output matches `detectGeminiQuotaExhausted` gets `errorCode: "gemini_quota_exhausted"`
- Placed after the auth / turn-limit / network arms and before the `null` fallthrough, so an auth failure that also mentions quota still classifies as `gemini_auth_required`
- Message and all other result fields are unchanged

## Verification

- `npx vitest run packages/adapters/gemini-local/src/server/execute.result-mapping.test.ts` — quota text yields `gemini_quota_exhausted`; a non-quota failure keeps its prior classification

## Risks

Low risk. Single added ternary arm reusing an existing, tested detector; precedence preserves prior auth/turn-limit/network classifications; no message or control-flow change.
## Model Used

Claude (Anthropic) via Claude Code. Implementation and tests authored by a Claude Sonnet-class model (`claude-sonnet-5`) dispatched as isolated per-task implementer agents under a multi-agent orchestration workflow; root-cause investigation, planning, and two-stage adversarial code review performed by additional Claude agents. Extended thinking and tool use enabled throughout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
