### PR TITLE
fix(sandbox): attribute exec-channel timeouts to the sandbox, not the adapter wall clock

### DIFF
--- a/packages/adapter-utils/src/sandbox-exec-timeout.test.ts
+++ b/packages/adapter-utils/src/sandbox-exec-timeout.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "./sandbox-exec-timeout.js";
+
+describe("detectSandboxExecTimeout", () => {
+  it("detects the execInPod watchdog marker", () => {
+    expect(
+      detectSandboxExecTimeout(
+        "execInPod timed out after 870000ms (pod=agent-abc, container=agent, cmd0=claude). The WebSocket likely dropped before the command produced a status frame.",
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      detectSandboxExecTimeout(
+        "EXECINPOD TIMED OUT AFTER 870000MS (pod=agent-abc, container=agent, cmd0=claude).",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a legitimate adapter wall-clock timeout message", () => {
+    expect(detectSandboxExecTimeout("Timed out after 14400s")).toBe(false);
+  });
+
+  it("does not match an unrelated RPC timeout string", () => {
+    expect(detectSandboxExecTimeout("RPC call timed out")).toBe(false);
+  });
+
+  it("returns false for null/undefined/empty input", () => {
+    expect(detectSandboxExecTimeout(null)).toBe(false);
+    expect(detectSandboxExecTimeout(undefined)).toBe(false);
+    expect(detectSandboxExecTimeout("")).toBe(false);
+  });
+});
+
+describe("extractSandboxExecTimeoutMessage", () => {
+  it("returns the first matching line, trimmed", () => {
+    const stderr = [
+      "some earlier noise",
+      "  execInPod timed out after 870000ms (pod=agent-abc, container=agent, cmd0=claude). The WebSocket likely dropped before the command produced a status frame.  ",
+      "trailing noise",
+    ].join("\n");
+
+    expect(extractSandboxExecTimeoutMessage(stderr)).toBe(
+      "execInPod timed out after 870000ms (pod=agent-abc, container=agent, cmd0=claude). The WebSocket likely dropped before the command produced a status frame.",
+    );
+  });
+
+  it("returns null when no line matches", () => {
+    expect(extractSandboxExecTimeoutMessage("RPC call timed out\nsome other error")).toBeNull();
+  });
+
+  it("returns null for empty stderr", () => {
+    expect(extractSandboxExecTimeoutMessage("")).toBeNull();
+  });
+});
+
+describe("SANDBOX_EXEC_TIMEOUT_ERROR_CODE", () => {
+  it("is a stable, descriptive error code", () => {
+    expect(SANDBOX_EXEC_TIMEOUT_ERROR_CODE).toBe("sandbox_exec_timeout");
+  });
+});

--- a/packages/adapter-utils/src/sandbox-exec-timeout.test.ts
+++ b/packages/adapter-utils/src/sandbox-exec-timeout.test.ts
@@ -30,6 +30,14 @@ describe("detectSandboxExecTimeout", () => {
     expect(detectSandboxExecTimeout("RPC call timed out")).toBe(false);
   });
 
+  it("does not match agent-authored output that echoes the watchdog phrase without the pod context", () => {
+    // A run that genuinely wall-clock-timed-out could have its own stderr
+    // contain text like this (e.g. the agent printing a log line it saw
+    // elsewhere). Without the "(pod=" context this must not be misattributed
+    // to a sandbox exec-channel timeout.
+    expect(detectSandboxExecTimeout("execInPod timed out after 5ms")).toBe(false);
+  });
+
   it("returns false for null/undefined/empty input", () => {
     expect(detectSandboxExecTimeout(null)).toBe(false);
     expect(detectSandboxExecTimeout(undefined)).toBe(false);

--- a/packages/adapter-utils/src/sandbox-exec-timeout.ts
+++ b/packages/adapter-utils/src/sandbox-exec-timeout.ts
@@ -1,0 +1,39 @@
+// The kubernetes sandbox provider's execInPod watchdog fires when the
+// WebSocket used to stream a command's stdout/stderr/status frames drops
+// silently (network blip, pod OOM-killed mid-exec, apiserver restart) before
+// the command produces a status frame. plugin.ts surfaces that as
+// `timedOut: true` with the watchdog's own message in stderr so the caller
+// can retry instead of hanging forever.
+//
+// Adapters previously treated every `timedOut: true` result as if the
+// configured adapter wall-clock budget had elapsed, stamping a fabricated
+// "Timed out after <configured>s" message even when the real cause was the
+// sandbox exec channel dying long before that budget was reached. This
+// helper lets adapters distinguish the two cases so the recorded error
+// attributes the failure to the sandbox, not the adapter's own timeout.
+export const SANDBOX_EXEC_TIMEOUT_ERROR_CODE = "sandbox_exec_timeout";
+
+const EXEC_TIMEOUT_RE = /execInPod timed out after \d+ms/i;
+
+/**
+ * True when `text` contains the kubernetes plugin's execInPod watchdog
+ * marker (packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts).
+ * Case-insensitive; safe to call with null/undefined stderr.
+ */
+export function detectSandboxExecTimeout(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return EXEC_TIMEOUT_RE.test(text);
+}
+
+/**
+ * Returns the first line of `stderr` that matches the execInPod watchdog
+ * marker, trimmed. Returns null when no line matches.
+ */
+export function extractSandboxExecTimeoutMessage(stderr: string): string | null {
+  if (!stderr) return null;
+  for (const line of stderr.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (EXEC_TIMEOUT_RE.test(trimmed)) return trimmed;
+  }
+  return null;
+}

--- a/packages/adapter-utils/src/sandbox-exec-timeout.ts
+++ b/packages/adapter-utils/src/sandbox-exec-timeout.ts
@@ -13,12 +13,26 @@
 // attributes the failure to the sandbox, not the adapter's own timeout.
 export const SANDBOX_EXEC_TIMEOUT_ERROR_CODE = "sandbox_exec_timeout";
 
-const EXEC_TIMEOUT_RE = /execInPod timed out after \d+ms/i;
+const EXEC_TIMEOUT_RE = /execInPod timed out after \d+ms \(pod=/i;
 
 /**
  * True when `text` contains the kubernetes plugin's execInPod watchdog
  * marker (packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts).
  * Case-insensitive; safe to call with null/undefined stderr.
+ *
+ * This is a heuristic string match over stderr, a channel the agent's own
+ * process also writes to. If a run's genuine output happens to reproduce the
+ * full watchdog signature (message plus the parenthesized "(pod=" context),
+ * it would be misattributed as a sandbox exec-channel timeout rather than
+ * the adapter's own wall-clock timeout. Requiring the "(pod=" context (not
+ * just the leading phrase) narrows this: it is the literal string pod-exec.ts
+ * emits, not a phrase an agent would plausibly produce on its own. The
+ * residual risk is accepted because this classification only affects error
+ * attribution and telemetry (which bucket a timeout is filed under), a
+ * cosmetic distinction. Callers must not attach irreversible semantics (for
+ * example, billing decisions or auto-retry policies with side effects) to
+ * this signal without a structured, out-of-band channel for the watchdog to
+ * report through instead of sharing stderr with agent-authored output.
  */
 export function detectSandboxExecTimeout(text: string | null | undefined): boolean {
   if (!text) return false;

--- a/packages/adapters/claude-local/src/server/execute.result-mapping.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.result-mapping.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+} = vi.hoisted(() => ({
+  ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+  ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+  resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "claude"),
+  runAdapterExecutionTargetProcess: vi.fn(),
+}));
+
+vi.mock("./acp.js", () => ({
+  createClaudeAcpExecutor: () => vi.fn(),
+  formatClaudeAcpFallbackMessage: (reason: string) => `[paperclip] ${reason}\n`,
+  resolveClaudeExecutionEngineForRun: async () => ({ engine: "cli" as const, explicit: true }),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildContext(config: Record<string, unknown> = {}) {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: { timeoutSec: 45, ...config },
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+describe("claude_local exec timeout attribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("attributes a dropped sandbox exec channel to the sandbox, not the adapter wall clock", async () => {
+    const watchdogMessage =
+      "execInPod timed out after 870000ms (pod=agent-abc, container=agent, cmd0=claude). " +
+      "The WebSocket likely dropped before the command produced a status frame.";
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: null,
+      signal: null,
+      timedOut: true,
+      stdout: "",
+      stderr: watchdogMessage,
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const ctx = buildContext();
+    const result = await execute(ctx as never);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("sandbox_exec_timeout");
+    expect(result.errorMessage).toBe(watchdogMessage);
+  });
+
+  it("keeps the legacy adapter wall-clock timeout message for a genuine timeout", async () => {
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: null,
+      signal: null,
+      timedOut: true,
+      stdout: "",
+      stderr: "some unrelated stderr noise",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const ctx = buildContext();
+    const result = await execute(ctx as never);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("timeout");
+    expect(result.errorMessage).toBe("Timed out after 45s");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -55,6 +55,11 @@ import {
   type LocalProcessSandboxOptions,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
   describeClaudeFailure,
@@ -950,12 +955,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         : undefined;
 
     if (proc.timedOut) {
+      const sandboxExecTimedOut = detectSandboxExecTimeout(proc.stderr);
       return {
         exitCode: proc.exitCode,
         signal: proc.signal,
         timedOut: true,
-        errorMessage: `Timed out after ${timeoutSec}s`,
-        errorCode: "timeout",
+        errorMessage: sandboxExecTimedOut
+          ? extractSandboxExecTimeoutMessage(proc.stderr) ?? "Sandbox exec channel timed out"
+          : `Timed out after ${timeoutSec}s`,
+        errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : "timeout",
         errorMeta,
         clearSession: Boolean(opts.clearSessionOnMissingSession),
       };

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import {
@@ -1193,11 +1198,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         };
       }
       if (attempt.proc.timedOut) {
+        const sandboxExecTimedOut = detectSandboxExecTimeout(attempt.proc.stderr);
         return {
           exitCode: attempt.proc.exitCode,
           signal: attempt.proc.signal,
           timedOut: true,
-          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorMessage: sandboxExecTimedOut
+            ? extractSandboxExecTimeoutMessage(attempt.proc.stderr) ?? "Sandbox exec channel timed out"
+            : `Timed out after ${timeoutSec}s`,
+          errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : undefined,
           clearSession: clearSessionOnMissingSession,
         };
       }

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
   overrideAdapterExecutionTargetRemoteCwd,
@@ -672,11 +677,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     clearSessionOnMissingSession = false,
   ): AdapterExecutionResult => {
     if (attempt.proc.timedOut) {
+      const sandboxExecTimedOut = detectSandboxExecTimeout(attempt.proc.stderr);
       return {
         exitCode: attempt.proc.exitCode,
         signal: attempt.proc.signal,
         timedOut: true,
-        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorMessage: sandboxExecTimedOut
+          ? extractSandboxExecTimeoutMessage(attempt.proc.stderr) ?? "Sandbox exec channel timed out"
+          : `Timed out after ${timeoutSec}s`,
+        errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : undefined,
         clearSession: clearSessionOnMissingSession,
       };
     }

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
   overrideAdapterExecutionTargetRemoteCwd,
@@ -648,16 +653,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const networkUnavailable = isGeminiTransientNetworkError(attempt.proc.stdout, attempt.proc.stderr);
 
     if (attempt.proc.timedOut) {
+      const sandboxExecTimedOut = detectSandboxExecTimeout(attempt.proc.stderr);
       return {
         exitCode: attempt.proc.exitCode,
         signal: attempt.proc.signal,
         timedOut: true,
-        errorMessage: `Timed out after ${timeoutSec}s`,
-        errorCode: authMeta.requiresAuth
-          ? "gemini_auth_required"
-          : networkUnavailable
-            ? "gemini_network_unavailable"
-            : null,
+        errorMessage: sandboxExecTimedOut
+          ? extractSandboxExecTimeoutMessage(attempt.proc.stderr) ?? "Sandbox exec channel timed out"
+          : `Timed out after ${timeoutSec}s`,
+        errorCode: sandboxExecTimedOut
+          ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE
+          : authMeta.requiresAuth
+            ? "gemini_auth_required"
+            : networkUnavailable
+              ? "gemini_network_unavailable"
+              : null,
         clearSession: clearSessionOnMissingSession,
       };
     }

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
   adapterExecutionTargetSessionIdentity,
@@ -500,11 +505,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       isRetry = false,
     ): AdapterExecutionResult => {
       if (attempt.proc.timedOut) {
+        const sandboxExecTimedOut = detectSandboxExecTimeout(attempt.proc.stderr);
         return {
           exitCode: attempt.proc.exitCode,
           signal: attempt.proc.signal,
           timedOut: true,
-          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorMessage: sandboxExecTimedOut
+            ? extractSandboxExecTimeoutMessage(attempt.proc.stderr) ?? "Sandbox exec channel timed out"
+            : `Timed out after ${timeoutSec}s`,
+          errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : undefined,
           clearSession: clearSessionOnMissingSession,
         };
       }

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
   overrideAdapterExecutionTargetRemoteCwd,
@@ -625,11 +630,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       clearSessionOnMissingSession = false,
     ): AdapterExecutionResult => {
       if (attempt.proc.timedOut) {
+        const sandboxExecTimedOut = detectSandboxExecTimeout(attempt.proc.stderr);
         return {
           exitCode: attempt.proc.exitCode,
           signal: attempt.proc.signal,
           timedOut: true,
-          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorMessage: sandboxExecTimedOut
+            ? extractSandboxExecTimeoutMessage(attempt.proc.stderr) ?? "Sandbox exec channel timed out"
+            : `Timed out after ${timeoutSec}s`,
+          errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : undefined,
           clearSession: clearSessionOnMissingSession,
         };
       }

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
   overrideAdapterExecutionTargetRemoteCwd,
@@ -737,11 +742,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       clearSessionOnMissingSession = false,
     ): AdapterExecutionResult => {
       if (attempt.proc.timedOut) {
+        const sandboxExecTimedOut = detectSandboxExecTimeout(attempt.proc.stderr);
         return {
           exitCode: attempt.proc.exitCode,
           signal: attempt.proc.signal,
           timedOut: true,
-          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorMessage: sandboxExecTimedOut
+            ? extractSandboxExecTimeoutMessage(attempt.proc.stderr) ?? "Sandbox exec channel timed out"
+            : `Timed out after ${timeoutSec}s`,
+          errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : undefined,
           clearSession: clearSessionOnMissingSession,
         };
       }

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -1,5 +1,10 @@
 import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
 import {
+  SANDBOX_EXEC_TIMEOUT_ERROR_CODE,
+  detectSandboxExecTimeout,
+  extractSandboxExecTimeoutMessage,
+} from "@paperclipai/adapter-utils/sandbox-exec-timeout";
+import {
   asString,
   asNumber,
   asStringArray,
@@ -70,11 +75,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
 
   if (proc.timedOut) {
+    const sandboxExecTimedOut = detectSandboxExecTimeout(proc.stderr);
     return {
       exitCode: proc.exitCode,
       signal: proc.signal,
       timedOut: true,
-      errorMessage: `Timed out after ${timeoutSec}s`,
+      errorMessage: sandboxExecTimedOut
+        ? extractSandboxExecTimeoutMessage(proc.stderr) ?? "Sandbox exec channel timed out"
+        : `Timed out after ${timeoutSec}s`,
+      errorCode: sandboxExecTimedOut ? SANDBOX_EXEC_TIMEOUT_ERROR_CODE : undefined,
     };
   }
 

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildHeartbeatRunStopMetadata,
   mergeHeartbeatRunStopMetadata,
+  resolveHeartbeatRunErrorCode,
   resolveHeartbeatRunTimeoutPolicy,
 } from "./heartbeat-stop-metadata.js";
 
@@ -128,5 +129,48 @@ describe("heartbeat stop metadata", () => {
       timeoutSource: "default",
       timeoutFired: false,
     });
+  });
+});
+
+describe("resolveHeartbeatRunErrorCode", () => {
+  it("honors the adapter's own errorCode for a timed_out outcome", () => {
+    expect(
+      resolveHeartbeatRunErrorCode({
+        outcome: "timed_out",
+        adapterErrorCode: "sandbox_exec_timeout",
+      }),
+    ).toBe("sandbox_exec_timeout");
+  });
+
+  it("defaults a timed_out outcome to 'timeout' when the adapter gave no errorCode", () => {
+    expect(resolveHeartbeatRunErrorCode({ outcome: "timed_out" })).toBe("timeout");
+    expect(
+      resolveHeartbeatRunErrorCode({ outcome: "timed_out", adapterErrorCode: null }),
+    ).toBe("timeout");
+  });
+
+  it("keeps cancelled outcome resolution unchanged", () => {
+    expect(
+      resolveHeartbeatRunErrorCode({ outcome: "cancelled", cancelledErrorCode: "budget_paused" }),
+    ).toBe("budget_paused");
+    expect(resolveHeartbeatRunErrorCode({ outcome: "cancelled" })).toBe("cancelled");
+  });
+
+  it("keeps failed outcome resolution unchanged", () => {
+    expect(
+      resolveHeartbeatRunErrorCode({ outcome: "failed", adapterErrorCode: "model_not_found" }),
+    ).toBe("model_not_found");
+    expect(
+      resolveHeartbeatRunErrorCode({
+        outcome: "failed",
+        responsibleUserDenialCode: "responsible_user_denied",
+      }),
+    ).toBe("responsible_user_denied");
+    expect(resolveHeartbeatRunErrorCode({ outcome: "failed" })).toBe("adapter_failed");
+  });
+
+  it("returns null for succeeded and interrupted outcomes", () => {
+    expect(resolveHeartbeatRunErrorCode({ outcome: "succeeded" })).toBeNull();
+    expect(resolveHeartbeatRunErrorCode({ outcome: "interrupted" })).toBeNull();
   });
 });

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -100,6 +100,34 @@ export function inferHeartbeatRunStopReason(input: {
   return "adapter_failed";
 }
 
+/**
+ * Resolves the `error_code` recorded on a heartbeat run.
+ *
+ * For `timed_out` outcomes this honors the adapter's own errorCode when set
+ * (e.g. `sandbox_exec_timeout` when the sandbox exec channel dropped before
+ * the adapter's configured wall-clock budget elapsed) and only falls back to
+ * the generic `"timeout"` when the adapter did not classify the timeout
+ * itself. Other outcomes are unchanged from prior behavior.
+ */
+export function resolveHeartbeatRunErrorCode(input: {
+  outcome: HeartbeatRunOutcome;
+  adapterErrorCode?: string | null;
+  cancelledErrorCode?: string | null;
+  responsibleUserDenialCode?: string | null;
+}): string | null {
+  const { outcome, adapterErrorCode, cancelledErrorCode, responsibleUserDenialCode } = input;
+  if (outcome === "timed_out") {
+    return adapterErrorCode ?? "timeout";
+  }
+  if (outcome === "cancelled") {
+    return cancelledErrorCode ?? "cancelled";
+  }
+  if (outcome === "failed") {
+    return adapterErrorCode ?? responsibleUserDenialCode ?? "adapter_failed";
+  }
+  return null;
+}
+
 export function buildHeartbeatRunStopMetadata(input: {
   adapterType: string;
   adapterConfig: Record<string, unknown> | null | undefined;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -103,6 +103,7 @@ import {
   buildHeartbeatRunStopMetadata,
   mergeHeartbeatRunStopMetadata,
   normalizeMaxTurnStopReason,
+  resolveHeartbeatRunErrorCode,
 } from "./heartbeat-stop-metadata.js";
 import {
   classifyRunLiveness,
@@ -13793,14 +13794,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               );
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode(latestRun?.errorCode);
-      const runErrorCode =
-        outcome === "timed_out"
-          ? "timeout"
-          : outcome === "cancelled"
-            ? (latestRun?.errorCode ?? "cancelled")
-            : outcome === "failed"
-              ? (adapterResult.errorCode ?? recordedResponsibleUserDenialCode ?? "adapter_failed")
-              : null;
+      const runErrorCode = resolveHeartbeatRunErrorCode({
+        outcome,
+        adapterErrorCode: adapterResult.errorCode,
+        cancelledErrorCode: latestRun?.errorCode,
+        responsibleUserDenialCode: recordedResponsibleUserDenialCode,
+      });
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs on the Kubernetes sandbox execute every command through a plugin RPC (`execInPod`), which is bounded by a ~15-minute host RPC cap with a watchdog just under it
> - When that watchdog fires (the WebSocket drops before a status frame), the plugin catches it and returns a bare `{ timedOut: true }` — the same shape the adapter uses for its own wall-clock timeout
> - The adapter then stamps `Timed out after ${timeoutSec}s` / `timeout` from the configured budget, and the heartbeat hardcodes `error_code = "timeout"`
> - So an exec-channel timeout at ~870s is reported as the adapter's (unreachable) 14400s wall-clock timeout, and the real cause survives only in stderr
> - This PR distinguishes the two timeout kinds so the surfaced code and message match what actually fired
> - The benefit is honest, debuggable timeout attribution instead of a fabricated wall-clock message

## Linked Issues or Issue Description

No public GitHub issue exists; describing inline following the bug report template.

**What happened**

Runs killed at ~870s by the Kubernetes `execInPod` watchdog were recorded as `status=timed_out`, `error_code=timeout`, message "Timed out after 14400s" (derived from the configured adapter budget, not from what fired). The real cause (`execInPod timed out after 870000ms (pod=...)`) appeared only in stderr.

**Expected behavior**

An infrastructure exec-channel timeout should be attributed distinctly from the adapter's wall-clock timeout, with an accurate error code and message.

**Steps to reproduce**

Run a long agent command on the Kubernetes sandbox and let the `execInPod` RPC watchdog fire (the WebSocket drops before a status frame). The run is mislabeled as the adapter wall-clock timeout. The added helper and adapter tests reproduce the marker detection and mapping.

**Deployment mode**

Cloud multi-tenant execution (Kubernetes sandbox provider).

## What Changed

- Added a self-contained helper (`sandbox-exec-timeout.ts`): `detectSandboxExecTimeout` / `extractSandboxExecTimeoutMessage`, anchored to the full `execInPod timed out after <n>ms (pod=` watchdog signature so it cannot match adapter-authored echoes
- All eight adapter `timedOut` branches, when the marker is present in stderr, surface `sandbox_exec_timeout` with the real message; otherwise behavior is byte-identical
- The heartbeat `timed_out` branch now honors `adapterResult.errorCode ?? "timeout"` so the accurate code flows through (default preserved when absent)
- The helper documents that this is a heuristic over a shared stderr channel and must not carry irreversible semantics without a structured channel

## Verification

- `npx vitest run packages/adapter-utils/src/sandbox-exec-timeout.test.ts` — detection/extraction, non-match cases, agent-echo negative
- claude-local result-mapping test — marker yields `sandbox_exec_timeout` + real message; plain stderr keeps the legacy message/code
- `cd server && npx vitest run src/services/heartbeat-stop-metadata.test.ts` — adapter code honored; `timeout` default preserved when absent

## Risks

Low risk. The eight adapter edits are identical in shape and behavior-preserving when the marker is absent; the marker regex is anchored to the full watchdog signature to avoid false positives on agent output (covered by a negative test), and this is a classification/telemetry change only.
## Model Used

Claude (Anthropic) via Claude Code. Implementation and tests authored by a Claude Sonnet-class model (`claude-sonnet-5`) dispatched as isolated per-task implementer agents under a multi-agent orchestration workflow; root-cause investigation, planning, and two-stage adversarial code review performed by additional Claude agents. Extended thinking and tool use enabled throughout.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
