### PR TITLE
Fix task-watchdog self-fencing and add fingerprint refresh

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -620,6 +620,7 @@ Within the watched subtree, a watchdog run may perform only mutations that resto
 - reopen `done` or `cancelled` included issues only with explicit resume metadata and an audit comment when evidence shows the stopped disposition is wrong or incomplete
 - add, replace, or clear blockers on included issues when the blocker target is in the same company and the change makes the waiting path more accurate
 - set or refresh a one-shot monitor on an included issue when the current assignee owns the future check
+- explicitly refresh the run-scoped stopped fingerprint for the persisted watched root when new evidence has arrived
 - accept or reject eligible task-level plan confirmations as defined below
 - update the reusable watchdog issue itself to `done`, `in_review`, or `blocked` with the evidence for the watchdog decision
 
@@ -854,6 +855,7 @@ All endpoints are under `/api` and return JSON.
 - `GET /issues/:issueId/documents/:key/revisions`
 - `DELETE /issues/:issueId/documents/:key`
 - `POST /issues/:issueId/checkout`
+- `POST /issues/:issueId/watchdog/refresh` (task-watchdog run only; re-pins the current stopped fingerprint)
 - `POST /issues/:issueId/release`
 - `POST /issues/:issueId/admin/force-release` (board-only lock recovery)
 - `POST /issues/:issueId/comments`

--- a/server/src/__tests__/issue-watchdogs-routes.test.ts
+++ b/server/src/__tests__/issue-watchdogs-routes.test.ts
@@ -480,11 +480,97 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
       .where(and(eq(issueWatchdogs.companyId, companyId), eq(issueWatchdogs.issueId, watchedChildId)));
     expect(nestedWatchdogs).toHaveLength(0);
 
+    const finding = await request(app)
+      .post(`/api/issues/${watchedChildId}/comments`)
+      .send({ body: "Record the watchdog finding before creating follow-up work." });
+    expect(finding.status, JSON.stringify(finding.body)).toBe(201);
+
     const allowedChild = await request(app)
       .post(`/api/issues/${watchedChildId}/children`)
-      .send({ title: "Allowed watched child" });
+      .send({ title: "Allowed watched child", status: "done" });
     expect(allowedChild.status, JSON.stringify(allowedChild.body)).toBe(201);
     expect(allowedChild.body.parentId).toBe(watchedChildId);
+
+    const secondAllowedChild = await request(app)
+      .post(`/api/issues/${watchedChildId}/children`)
+      .send({ title: "Second allowed watched child" });
+    expect(secondAllowedChild.status, JSON.stringify(secondAllowedChild.body)).toBe(201);
+    expect(secondAllowedChild.body.parentId).toBe(watchedChildId);
+  });
+
+  it("lets a watchdog run explicitly refresh its pin after external stopped-subtree drift", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Refresh Watchdog" });
+    const watchedRootId = await seedIssue(companyId, {
+      title: "Watched root",
+      identifier: "WDOG-REFRESH",
+      status: "blocked",
+    });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Reusable watchdog issue",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const boardApp = createApp(companyId);
+    const externalComment = await request(boardApp)
+      .post(`/api/issues/${watchedRootId}/comments`)
+      .send({ body: "External evidence arrived after the watchdog wake." });
+    expect(externalComment.status, JSON.stringify(externalComment.body)).toBe(201);
+
+    const watchdogApp = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+    const refreshed = await request(watchdogApp)
+      .post(`/api/issues/${watchedRootId}/watchdog/refresh`)
+      .send({});
+
+    expect(refreshed.status, JSON.stringify(refreshed.body)).toBe(200);
+    expect(refreshed.body).toMatchObject({
+      state: "stopped",
+      repinned: true,
+    });
+    expect(refreshed.body.stopFingerprint).not.toBe(refreshed.body.previousStopFingerprint);
+
+    const [storedRun] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(storedRun?.contextSnapshot).toMatchObject({
+      taskWatchdog: {
+        watchedIssueId: watchedRootId,
+        stopFingerprint: refreshed.body.stopFingerprint,
+        stopFingerprintPinnedAt: expect.any(String),
+      },
+    });
+
+    const [refreshActivity] = await db
+      .select({ action: activityLog.action, runId: activityLog.runId })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.entityId, watchedRootId),
+        eq(activityLog.action, "issue.task_watchdog_fingerprint_refreshed"),
+      ));
+    expect(refreshActivity).toEqual({
+      action: "issue.task_watchdog_fingerprint_refreshed",
+      runId,
+    });
+
+    const firstChild = await request(watchdogApp)
+      .post(`/api/issues/${watchedRootId}/children`)
+      .send({ title: "First child after explicit refresh", status: "done" });
+    expect(firstChild.status, JSON.stringify(firstChild.body)).toBe(201);
   });
 
   it("routes watchdog-discovered product bugs outside the watched source tree with evidence links", async () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -187,6 +187,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
             "comment_on_watched_subtree_issues",
             "create_child_issues_under_non_watchdog_watched_subtree",
             "create_product_bug_followups_outside_watched_subtree",
+            "refresh_task_watchdog_stop_fingerprint",
             "update_reusable_watchdog_issue",
           ]),
           deniedOperations: expect.arrayContaining([
@@ -519,6 +520,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       watchdogId: watchdog!.id,
       companyId,
       watchedIssueId: sourceId,
+      runId: randomUUID(),
       stopFingerprint: originalFingerprint,
     });
 
@@ -531,6 +533,86 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       latestCommentAt: later.toISOString(),
       latestDocumentAt: new Date(later.getTime() + 1_000).toISOString(),
       latestWorkProductAt: new Date(later.getTime() + 2_000).toISOString(),
+    });
+  });
+
+  it("rolls a watchdog run fingerprint forward when all subtree drift belongs to that run", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-SELF-DRIFT", status: "blocked" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const originalFingerprint = watchdog!.lastObservedFingerprint!;
+    const runId = randomUUID();
+    const runStartedAt = new Date();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      startedAt: runStartedAt,
+      contextSnapshot: {
+        issueId: watchdog!.watchdogIssueId,
+        taskWatchdog: {
+          watchedIssueId: sourceId,
+          stopFingerprint: originalFingerprint,
+        },
+      },
+    });
+
+    const later = new Date(runStartedAt.getTime() + 1_000);
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: sourceId,
+      authorType: "agent",
+      authorAgentId: agentId,
+      createdByRunId: runId,
+      body: "Watchdog finding from this run.",
+      updatedAt: later,
+      createdAt: later,
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId,
+      action: "issue.comment_added",
+      entityType: "issue",
+      entityId: sourceId,
+      createdAt: later,
+    });
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: watchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      runId,
+      stopFingerprint: originalFingerprint,
+    });
+
+    expect(revalidated.allowed, JSON.stringify(revalidated)).toBe(true);
+    expect(revalidated).toMatchObject({
+      repinned: true,
+      previousStopFingerprint: originalFingerprint,
+    });
+    if (!revalidated.allowed) throw new Error("Expected watchdog mutation revalidation to succeed");
+    expect(revalidated.stopFingerprint).not.toBe(originalFingerprint);
+
+    const [storedRun] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(storedRun?.contextSnapshot).toMatchObject({
+      taskWatchdog: {
+        watchedIssueId: sourceId,
+        stopFingerprint: revalidated.stopFingerprint,
+        stopFingerprintPinnedAt: expect.any(String),
+      },
     });
   });
 
@@ -557,6 +639,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       watchdogId: watchdog!.id,
       companyId,
       watchedIssueId: sourceId,
+      runId: randomUUID(),
       stopFingerprint: originalFingerprint,
     });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -351,6 +351,10 @@ function noopTaskWatchdogService(): TaskWatchdogService {
         stoppedLeaves: [],
       },
     }),
+    refreshMutationScope: async () => ({
+      allowed: false,
+      reason: "Task watchdog service unavailable in this route context.",
+    }),
   };
 }
 
@@ -5459,6 +5463,81 @@ export function issueRoutes(
     if (!issue) return;
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
     res.json(await taskWatchdogsSvc.getActiveForIssue(issue.companyId, issue.id));
+  });
+
+  router.post("/issues/:id/watchdog/refresh", async (req, res) => {
+    const id = req.params.id as string;
+    const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+    if (!issue) return;
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+    if (req.actor.type !== "agent") {
+      res.status(403).json({ error: "Only task-watchdog agent runs can refresh a watchdog stop fingerprint." });
+      return;
+    }
+
+    const scope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    if (scope.kind !== "watchdog") {
+      res.status(403).json({
+        error: scope.kind === "invalid"
+          ? scope.detail
+          : "Only task-watchdog agent runs can refresh a watchdog stop fingerprint.",
+      });
+      return;
+    }
+    if (scope.companyId !== issue.companyId || scope.watchedIssueId !== issue.id) {
+      res.status(403).json({
+        error: "Task-watchdog runs can refresh only their persisted watched issue.",
+        details: {
+          watchedIssueId: scope.watchedIssueId,
+          requestedIssueId: issue.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return;
+    }
+
+    const refreshed = await taskWatchdogsSvc.refreshMutationScope(scope);
+    if (!refreshed.allowed) {
+      res.status(409).json({
+        error: refreshed.reason,
+        details: {
+          watchedIssueId: scope.watchedIssueId,
+          watchdogId: scope.watchdogId,
+          runStopFingerprint: scope.stopFingerprint,
+          currentState: refreshed.classification?.state ?? null,
+          currentStopFingerprint:
+            refreshed.classification && "stopFingerprint" in refreshed.classification
+              ? refreshed.classification.stopFingerprint
+              : null,
+        },
+      });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      agentApiKeyId: actor.agentApiKeyId,
+      action: "issue.task_watchdog_fingerprint_refreshed",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        watchdogId: scope.watchdogId,
+        previousStopFingerprint: refreshed.previousStopFingerprint,
+        stopFingerprint: refreshed.stopFingerprint,
+      },
+    });
+    res.json({
+      state: refreshed.classification.state,
+      previousStopFingerprint: refreshed.previousStopFingerprint,
+      stopFingerprint: refreshed.stopFingerprint,
+      repinned: refreshed.previousStopFingerprint !== refreshed.stopFingerprint,
+    });
   });
 
   router.put("/issues/:id/watchdog", validate(upsertIssueWatchdogSchema), async (req, res) => {

--- a/server/src/services/task-watchdog-scope.ts
+++ b/server/src/services/task-watchdog-scope.ts
@@ -27,6 +27,7 @@ export type TaskWatchdogMutationScope =
       companyId: string;
       watchedIssueId: string;
       watchdogIssueId: string | null;
+      runId: string;
       stopFingerprint: string | null;
     };
 
@@ -117,6 +118,7 @@ export async function resolveTaskWatchdogMutationScope(
     companyId: watchdog.companyId,
     watchedIssueId: watchdog.issueId,
     watchdogIssueId: watchdog.watchdogIssueId ?? null,
+    runId,
     stopFingerprint: taskWatchdog.stopFingerprint,
   };
 }

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { and, asc, eq, gte, inArray, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
+  activityLog,
   agentWakeupRequests,
   agents,
   approvals,
@@ -22,7 +23,10 @@ import { logActivity } from "./activity-log.js";
 import { evaluateAgentInvokabilityFromDb } from "./agent-invokability.js";
 import { issueService } from "./issues.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
-import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
+import {
+  TASK_WATCHDOG_ORIGIN_KIND,
+  type TaskWatchdogMutationScope,
+} from "./task-watchdog-scope.js";
 
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
 const TASK_WATCHDOG_SUBTREE_MAX_DEPTH = 100;
@@ -53,6 +57,11 @@ export type IssueWatchdogUpsertInput = {
 
 type IssueWatchdogRow = typeof issueWatchdogs.$inferSelect;
 type IssueRow = typeof issues.$inferSelect;
+type WatchdogMutationScope = Extract<TaskWatchdogMutationScope, { kind: "watchdog" }>;
+type WatchdogMutationRun = Pick<
+  typeof heartbeatRuns.$inferSelect,
+  "id" | "companyId" | "contextSnapshot" | "createdAt" | "startedAt"
+>;
 
 export type TaskWatchdogClassifierIssue = Pick<
   IssueRow,
@@ -557,6 +566,7 @@ function watchdogWakeContext(input: {
       watchedIssueIdentifier: input.sourceIssue.identifier,
       watchedIssueTitle: input.sourceIssue.title,
       stopFingerprint: input.classification.stopFingerprint,
+      stopFingerprintPinnedAt: new Date().toISOString(),
       capabilities: {
         targetScope: {
           watchedIssueId: input.sourceIssue.id,
@@ -572,6 +582,7 @@ function watchdogWakeContext(input: {
           "create_child_issues_under_non_watchdog_watched_subtree",
           "create_product_bug_followups_outside_watched_subtree",
           "resolve_eligible_request_confirmation_plan_interactions",
+          "refresh_task_watchdog_stop_fingerprint",
           "update_reusable_watchdog_issue",
         ],
         deniedOperations: [
@@ -1449,13 +1460,192 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       ));
   }
 
-  async function revalidateMutationScope(scope: {
-    kind: "watchdog";
-    watchdogId: string;
-    companyId: string;
-    watchedIssueId: string;
-    stopFingerprint: string | null;
-  }) {
+  function readRunStopFingerprint(contextSnapshot: unknown) {
+    const context = parseObject(contextSnapshot);
+    const taskWatchdog = parseObject(context.taskWatchdog);
+    const nested = typeof taskWatchdog.stopFingerprint === "string"
+      ? taskWatchdog.stopFingerprint.trim()
+      : "";
+    if (nested) return nested;
+    const legacy = typeof context.stopFingerprint === "string"
+      ? context.stopFingerprint.trim()
+      : "";
+    return legacy || null;
+  }
+
+  function readRunWatchedIssueId(contextSnapshot: unknown) {
+    const context = parseObject(contextSnapshot);
+    const taskWatchdog = parseObject(context.taskWatchdog);
+    const nested = typeof taskWatchdog.watchedIssueId === "string"
+      ? taskWatchdog.watchedIssueId.trim()
+      : "";
+    if (nested) return nested;
+    const legacy = typeof context.watchedIssueId === "string"
+      ? context.watchedIssueId.trim()
+      : "";
+    return legacy || null;
+  }
+
+  function readRunStopFingerprintPinnedAt(contextSnapshot: unknown) {
+    const context = parseObject(contextSnapshot);
+    const taskWatchdog = parseObject(context.taskWatchdog);
+    const raw = typeof taskWatchdog.stopFingerprintPinnedAt === "string"
+      ? taskWatchdog.stopFingerprintPinnedAt
+      : typeof context.stopFingerprintPinnedAt === "string"
+        ? context.stopFingerprintPinnedAt
+        : "";
+    const parsed = raw ? new Date(raw) : null;
+    return parsed && Number.isFinite(parsed.getTime()) ? parsed : null;
+  }
+
+  function withRunStopFingerprint(
+    contextSnapshot: unknown,
+    stopFingerprint: string,
+    stopFingerprintPinnedAt: Date,
+  ) {
+    const context = parseObject(contextSnapshot);
+    const taskWatchdog = parseObject(context.taskWatchdog);
+    const pinnedAt = stopFingerprintPinnedAt.toISOString();
+    return {
+      ...context,
+      ...("stopFingerprint" in context ? { stopFingerprint } : {}),
+      ...("stopFingerprintPinnedAt" in context ? { stopFingerprintPinnedAt: pinnedAt } : {}),
+      taskWatchdog: {
+        ...taskWatchdog,
+        stopFingerprint,
+        stopFingerprintPinnedAt: pinnedAt,
+      },
+    };
+  }
+
+  async function loadMutationRun(scope: WatchdogMutationScope): Promise<WatchdogMutationRun | null> {
+    return db
+      .select({
+        id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        createdAt: heartbeatRuns.createdAt,
+        startedAt: heartbeatRuns.startedAt,
+      })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.id, scope.runId),
+        eq(heartbeatRuns.companyId, scope.companyId),
+      ))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function repinMutationRun(
+    scope: WatchdogMutationScope,
+    run: WatchdogMutationRun,
+    stopFingerprint: string,
+  ) {
+    if (readRunWatchedIssueId(run.contextSnapshot) !== scope.watchedIssueId) return false;
+    const persistedFingerprint = readRunStopFingerprint(run.contextSnapshot);
+    if (persistedFingerprint === stopFingerprint) return true;
+    if (persistedFingerprint !== scope.stopFingerprint) return false;
+
+    const repinnedAt = new Date();
+    const updated = await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: withRunStopFingerprint(run.contextSnapshot, stopFingerprint, repinnedAt),
+        updatedAt: repinnedAt,
+      })
+      .where(and(
+        eq(heartbeatRuns.id, scope.runId),
+        eq(heartbeatRuns.companyId, scope.companyId),
+        sql`COALESCE(
+          ${heartbeatRuns.contextSnapshot}->'taskWatchdog'->>'stopFingerprint',
+          ${heartbeatRuns.contextSnapshot}->>'stopFingerprint'
+        ) = ${scope.stopFingerprint}`,
+      ))
+      .returning({ id: heartbeatRuns.id });
+    return updated.length > 0;
+  }
+
+  async function fingerprintDriftBelongsToRun(
+    scope: WatchdogMutationScope,
+    run: WatchdogMutationRun,
+    classification: Extract<TaskWatchdogClassifierResult, { state: "stopped" }>,
+  ) {
+    if (classification.includedIssueIds.length === 0) return false;
+    const pinTime = readRunStopFingerprintPinnedAt(run.contextSnapshot) ?? run.startedAt ?? run.createdAt;
+    const rows = await db
+      .select({
+        runId: activityLog.runId,
+      })
+      .from(activityLog)
+      .where(and(
+        eq(activityLog.companyId, scope.companyId),
+        eq(activityLog.entityType, "issue"),
+        inArray(activityLog.entityId, classification.includedIssueIds),
+        gte(activityLog.createdAt, pinTime),
+      ));
+    return rows.length > 0 && rows.every((row) => row.runId === scope.runId);
+  }
+
+  async function refreshMutationScope(scope: WatchdogMutationScope) {
+    if (!scope.stopFingerprint) {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog run context is missing the stopped fingerprint required for mutation revalidation.",
+      };
+    }
+
+    const watchdog = await db
+      .select()
+      .from(issueWatchdogs)
+      .where(and(
+        eq(issueWatchdogs.id, scope.watchdogId),
+        eq(issueWatchdogs.companyId, scope.companyId),
+        eq(issueWatchdogs.issueId, scope.watchedIssueId),
+        eq(issueWatchdogs.status, "active"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    if (!watchdog) {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog run context is not backed by an active persisted watchdog.",
+      };
+    }
+
+    const run = await loadMutationRun(scope);
+    if (!run) {
+      return {
+        allowed: false as const,
+        reason: "Task-watchdog run context is not backed by an active persisted heartbeat run.",
+      };
+    }
+
+    const input = await collectClassifierInput(watchdog.companyId, watchdog);
+    const classification = classifyTaskWatchdogSubtree(input);
+    if (classification.state !== "stopped") {
+      return {
+        allowed: false as const,
+        reason:
+          "Task-watchdog review cannot be refreshed because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path.",
+        classification,
+      };
+    }
+
+    const repinned = await repinMutationRun(scope, run, classification.stopFingerprint);
+    if (repinned) {
+      return {
+        allowed: true as const,
+        classification,
+        previousStopFingerprint: scope.stopFingerprint,
+        stopFingerprint: classification.stopFingerprint,
+      };
+    }
+    return {
+      allowed: false as const,
+      reason: "Task-watchdog run context changed while refreshing the watched subtree stop fingerprint.",
+      classification,
+    };
+  }
+
+  async function revalidateMutationScope(scope: WatchdogMutationScope) {
     if (!scope.stopFingerprint) {
       return {
         allowed: false as const,
@@ -1484,6 +1674,23 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     const classification = classifyTaskWatchdogSubtree(input);
     if (classification.state === "stopped" && classification.stopFingerprint === scope.stopFingerprint) {
       return { allowed: true as const, classification };
+    }
+
+    if (classification.state === "stopped") {
+      const run = await loadMutationRun(scope);
+      if (
+        run &&
+        await fingerprintDriftBelongsToRun(scope, run, classification) &&
+        await repinMutationRun(scope, run, classification.stopFingerprint)
+      ) {
+        return {
+          allowed: true as const,
+          classification,
+          previousStopFingerprint: scope.stopFingerprint,
+          stopFingerprint: classification.stopFingerprint,
+          repinned: true as const,
+        };
+      }
     }
 
     return {
@@ -1649,5 +1856,6 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     },
 
     revalidateMutationScope,
+    refreshMutationScope,
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous agent work governable and live
> - Task watchdogs review stopped issue subtrees and may restore an allowed live path
> - Each watchdog run pins a stopped-subtree fingerprint so external changes invalidate stale review authority
> - The fingerprint also includes the watchdog run's own comments and child issues, so a correct investigate → record → act sequence fences itself
> - The 409 response promises a refresh, but the server has no route that can re-pin the active run
> - This pull request attributes fingerprint drift to the active run, rolls self-authored drift forward, and adds the missing explicit refresh route
> - The benefit is that watchdogs retain protection from external mutation while being able to complete multiple sanctioned recovery writes in one run

## Linked Issues or Issue Description

Fixes: #10219

## What Changed

- Carry the watchdog heartbeat run id through persisted mutation scope resolution.
- Track when a run's stop fingerprint was pinned and use issue activity attribution since that pin to distinguish self-authored drift from external drift.
- Atomically advance the stored run fingerprint when every relevant activity row belongs to the same watchdog run.
- Add `POST /api/issues/:issueId/watchdog/refresh` for an explicit, scoped re-pin after external drift, with activity logging and capability metadata.
- Add scheduler and route regressions for self-authored comments, repeated subtree writes, external refresh, persisted context updates, and audit records.
- Document the watchdog refresh authority and REST endpoint in the V1 implementation contract.

## Verification

- `.\node_modules\.bin\tsc.cmd -p server/tsconfig.json --noEmit`
- `.\node_modules\.bin\vitest.cmd run server/src/__tests__/task-watchdogs-scheduler.test.ts` — 17 passed
- `.\node_modules\.bin\vitest.cmd run server/src/__tests__/issue-watchdogs-routes.test.ts` — 12 passed
- `git diff --check`

## Risks

- Low migration risk: this changes only JSON context data and adds no schema migration.
- Automatic re-pinning deliberately fails closed when there are no attributable activity rows or any relevant activity is from a different run.
- The explicit refresh route can accept genuinely external stopped-state drift, but only for the authenticated task-watchdog run, its persisted watchdog, company, and watched root.
- Pin timestamps fall back to the heartbeat run start/create time for runs created before this change.

> This is a focused bug fix within the roadmap's shipped task-watchdog capability; it does not add a competing roadmap feature.

## Model Used

- OpenAI GPT-5 via the Codex agent environment (exact deployment revision and context-window size are not exposed), using reasoning, repository tools, GitHub tooling, code execution, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
