### PR TITLE
fix(ssh): keep runtime credentials out of argv

### DIFF
--- a/packages/adapter-utils/src/remote-execution-env.ts
+++ b/packages/adapter-utils/src/remote-execution-env.ts
@@ -1,19 +1,26 @@
-const REMOTE_EXECUTION_ENV_IDENTITY_KEYS = new Set([
-  "PATH",
-  "HOME",
-  "PWD",
-  "SHELL",
-  "USER",
-  "LOGNAME",
-  "NVM_DIR",
-  "TMPDIR",
-  "TMP",
-  "TEMP",
-  "XDG_CONFIG_HOME",
-  "XDG_CACHE_HOME",
-  "XDG_DATA_HOME",
-  "XDG_STATE_HOME",
-  "XDG_RUNTIME_DIR",
+const REMOTE_EXECUTION_INHERITED_ENV_ALLOWLIST = new Set([
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_DEFAULT_REGION",
+  "AWS_PROFILE",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AZURE_OPENAI_API_KEY",
+  "AZURE_OPENAI_ENDPOINT",
+  "CODEX_API_KEY",
+  "GEMINI_API_KEY",
+  "GITHUB_TOKEN",
+  "GOOGLE_API_KEY",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_GEMINI_BASE_URL",
+  "NINEROUTER_API_KEY",
+  "NINEROUTER_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "XAI_API_KEY",
 ]);
 
 function readEnvValueCaseInsensitive(env: NodeJS.ProcessEnv, key: string): string | undefined {
@@ -34,16 +41,14 @@ export function sanitizeRemoteExecutionEnv(
 ): Record<string, string> {
   const sanitized: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
-    const normalizedKey = key.toUpperCase();
-    if (!REMOTE_EXECUTION_ENV_IDENTITY_KEYS.has(normalizedKey)) {
+    const inheritedValue = readEnvValueCaseInsensitive(inheritedEnv, key);
+    if (typeof inheritedValue !== "string" || inheritedValue !== value) {
       sanitized[key] = value;
       continue;
     }
-    const inheritedValue = readEnvValueCaseInsensitive(inheritedEnv, key);
-    if (typeof inheritedValue === "string" && inheritedValue === value) {
-      continue;
+    if (REMOTE_EXECUTION_INHERITED_ENV_ALLOWLIST.has(key.toUpperCase())) {
+      sanitized[key] = value;
     }
-    sanitized[key] = value;
   }
   return sanitized;
 }

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -74,7 +74,7 @@ describe("buildInvocationEnvForLogs", () => {
 });
 
 describe("sanitizeSshRemoteEnv", () => {
-  it("drops inherited host shell identity variables for SSH remote execution", () => {
+  it("drops inherited host variables outside the remote compatibility allowlist", () => {
     expect(
       sanitizeSshRemoteEnv(
         {
@@ -83,6 +83,7 @@ describe("sanitizeSshRemoteEnv", () => {
           NVM_DIR: "/Users/local/.nvm",
           TMPDIR: "/var/folders/local/T",
           XDG_CONFIG_HOME: "/Users/local/.config",
+          PAPERCLIP_HOST_SECRET_SENTINEL: "must-not-cross-host-boundary",
           SAFE_VALUE: "visible",
         },
         {
@@ -91,10 +92,30 @@ describe("sanitizeSshRemoteEnv", () => {
           NVM_DIR: "/Users/local/.nvm",
           TMPDIR: "/var/folders/local/T",
           XDG_CONFIG_HOME: "/Users/local/.config",
+          PAPERCLIP_HOST_SECRET_SENTINEL: "must-not-cross-host-boundary",
+          SAFE_VALUE: "visible",
+        },
+      ),
+    ).toEqual({});
+  });
+
+  it("preserves inherited credentials named by the remote compatibility allowlist", () => {
+    expect(
+      sanitizeSshRemoteEnv(
+        {
+          OPENAI_API_KEY: "sentinel-openai-key",
+          GITHUB_TOKEN: "sentinel-github-token",
+          UNLISTED_API_KEY: "sentinel-unlisted-key",
+        },
+        {
+          OPENAI_API_KEY: "sentinel-openai-key",
+          GITHUB_TOKEN: "sentinel-github-token",
+          UNLISTED_API_KEY: "sentinel-unlisted-key",
         },
       ),
     ).toEqual({
-      SAFE_VALUE: "visible",
+      OPENAI_API_KEY: "sentinel-openai-key",
+      GITHUB_TOKEN: "sentinel-github-token",
     });
   });
 

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   buildSshSpawnTarget,
   buildSshEnvLabFixtureConfig,
+  createSshCommandManagedRuntimeRunner,
   getSshEnvLabSupport,
   prepareWorkspaceForSshExecution,
   readSshEnvLabFixtureStatus,
@@ -191,6 +192,28 @@ describe("ssh env-lab fixture", () => {
       }),
     ).rejects.toThrow("Invalid SSH environment variable key: BAD KEY");
   });
+
+  it("passes managed runtime environment through secure transport", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const sentinel = "paperclip-managed-runtime-secret-sentinel";
+    const runner = createSshCommandManagedRuntimeRunner({
+      spec: { ...config, remoteCwd: started.workspaceDir },
+    });
+    const result = await runner.execute({
+      command: "sh",
+      args: ["-c", 'printf "%s" "$SSH_MANAGED_SECRET_SENTINEL"'],
+      cwd: started.workspaceDir,
+      env: { SSH_MANAGED_SECRET_SENTINEL: sentinel },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(sentinel);
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("passes command environment through secure transport", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -278,6 +278,7 @@ describe("ssh env-lab fixture", () => {
     });
 
     expect(target.args.join(" ")).not.toContain(sentinel);
+    expect(target.args.at(-1)).toMatch(/^exec sh \/tmp\/paperclip-ssh-launch-/);
     const result = await new Promise<string>((resolve, reject) => {
       execFile(target.command, target.args, (error, stdout) => {
         if (error) reject(error);

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -193,6 +193,31 @@ describe("ssh env-lab fixture", () => {
     ).rejects.toThrow("Invalid SSH environment variable key: BAD KEY");
   });
 
+  it("does not create a remote launcher for spawn targets without environment variables", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const target = await buildSshSpawnTarget({
+      spec: { ...config, remoteCwd: started.workspaceDir },
+      command: "printf",
+      args: ["launcher-free"],
+      env: {},
+    });
+
+    expect(target.args.join(" ")).not.toContain("paperclip-ssh-launch-");
+    const result = await new Promise<string>((resolve, reject) => {
+      execFile(target.command, target.args, (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      });
+    });
+    expect(result).toBe("launcher-free");
+    await target.cleanup();
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
   it("passes managed runtime environment through secure transport", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -213,7 +213,10 @@ describe("ssh env-lab fixture", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe(sentinel);
-    const launchers = await runSshCommand(config, "find /tmp -maxdepth 1 -name 'paperclip-ssh-command-*' -print");
+    const launchers = await runSshCommand(
+      config,
+      "find /tmp -maxdepth 1 \\( -name 'paperclip-ssh-command-*' -o -name 'paperclip-ssh-launch-*' \\) -print",
+    );
     expect(launchers.stdout).toBe("");
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -278,7 +278,7 @@ describe("ssh env-lab fixture", () => {
     });
 
     expect(target.args.join(" ")).not.toContain(sentinel);
-    expect(target.args.at(-1)).toMatch(/^exec sh \/tmp\/paperclip-ssh-launch-/);
+    expect(target.args.at(-1)).toMatch(/^exec sh '\/tmp\/paperclip-ssh-launch-/);
     const result = await new Promise<string>((resolve, reject) => {
       execFile(target.command, target.args, (error, stdout) => {
         if (error) reject(error);

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -192,6 +192,49 @@ describe("ssh env-lab fixture", () => {
     ).rejects.toThrow("Invalid SSH environment variable key: BAD KEY");
   });
 
+  it("passes command environment through secure transport", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const sentinel = "paperclip-run-command-secret-sentinel";
+    const result = await runSshCommand(config, 'printf "%s:%s" "$SSH_COMMAND_SECRET_SENTINEL" "$(cat)"', {
+      env: { SSH_COMMAND_SECRET_SENTINEL: sentinel },
+      stdin: "stdin-payload",
+      timeoutMs: 30_000,
+    });
+
+    expect(result.stdout).toBe(`${sentinel}:stdin-payload`);
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
+  it("keeps remote environment secrets out of SSH argv", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
+    cleanupDirs.push(rootDir);
+    const statePath = path.join(rootDir, "state.json");
+    const started = await startSshEnvLabFixtureOrSkip(statePath, "SSH env-lab fixture test");
+    if (!started) return;
+    const config = await buildSshEnvLabFixtureConfig(started);
+    const sentinel = "paperclip-ssh-argv-secret-sentinel";
+    const target = await buildSshSpawnTarget({
+      spec: { ...config, remoteCwd: started.workspaceDir },
+      command: "sh",
+      args: ["-c", 'printf "%s" "$SSH_ARGV_SECRET_SENTINEL"'],
+      env: { SSH_ARGV_SECRET_SENTINEL: sentinel },
+    });
+
+    expect(target.args.join(" ")).not.toContain(sentinel);
+    const result = await new Promise<string>((resolve, reject) => {
+      execFile(target.command, target.args, (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      });
+    });
+    expect(result).toBe(sentinel);
+    await target.cleanup();
+  }, SSH_FIXTURE_TEST_TIMEOUT_MS);
+
   it("syncs a local directory into the remote fixture workspace", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-ssh-fixture-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -213,6 +213,8 @@ describe("ssh env-lab fixture", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe(sentinel);
+    const launchers = await runSshCommand(config, "find /tmp -maxdepth 1 -name 'paperclip-ssh-command-*' -print");
+    expect(launchers.stdout).toBe("");
   }, SSH_FIXTURE_TEST_TIMEOUT_MS);
 
   it("passes command environment through secure transport", async () => {

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1172,31 +1172,65 @@ export async function runSshCommand(
     // / NVM_DIR / etc. would silently undo the explicit env passed in here.
     const envArgs = envEntries.map(([key, value]) => `${key}=${shellQuote(value)}`);
     const remoteScript = [
+      "#!/bin/sh",
       'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
       'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; fi',
       'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
       envArgs.length > 0
         ? `exec env ${envArgs.join(" ")} sh -c ${shellQuote(remoteCommand)}`
         : `exec sh -c ${shellQuote(remoteCommand)}`,
-    ].join(" && ");
+    ].join("\n");
+    const remoteLauncher = envArgs.length > 0
+      ? `/tmp/paperclip-ssh-command-${randomUUID()}`
+      : null;
+
+    if (remoteLauncher) {
+      const uploadArgs = [
+        ...auth.args,
+        "-p",
+        String(config.port),
+        `${config.username}@${config.host}`,
+        `umask 077; cat > ${shellQuote(remoteLauncher)}; chmod 700 ${shellQuote(remoteLauncher)}`,
+      ];
+      await spawnText("ssh", uploadArgs, {
+        stdin: remoteScript,
+        timeout: options.timeoutMs ?? 15_000,
+        maxBuffer: 16 * 1024,
+      });
+    }
 
     sshArgs.push(
       "-p",
       String(config.port),
       `${config.username}@${config.host}`,
-      `sh -c ${shellQuote(remoteScript)}`,
+      remoteLauncher
+        ? `exec ${shellQuote(remoteLauncher)}`
+        : `sh -c ${shellQuote(remoteScript)}`,
     );
 
-    return options.stdin != null
-      ? await spawnText("ssh", sshArgs, {
-          stdin: options.stdin,
-          timeout: options.timeoutMs ?? 15_000,
-          maxBuffer: options.maxBuffer ?? 1024 * 128,
-        })
-      : await execFileText("ssh", sshArgs, {
-          timeout: options.timeoutMs ?? 15_000,
-          maxBuffer: options.maxBuffer ?? 1024 * 128,
-        });
+    try {
+      return options.stdin != null
+        ? await spawnText("ssh", sshArgs, {
+            stdin: options.stdin,
+            timeout: options.timeoutMs ?? 15_000,
+            maxBuffer: options.maxBuffer ?? 1024 * 128,
+          })
+        : await execFileText("ssh", sshArgs, {
+            timeout: options.timeoutMs ?? 15_000,
+            maxBuffer: options.maxBuffer ?? 1024 * 128,
+          });
+    } finally {
+      if (remoteLauncher) {
+        const removeArgs = [
+          ...auth.args,
+          "-p",
+          String(config.port),
+          `${config.username}@${config.host}`,
+          `rm -f -- ${shellQuote(remoteLauncher)}`,
+        ];
+        await execFileText("ssh", removeArgs, { timeout: 15_000, maxBuffer: 16 * 1024 }).catch(() => undefined);
+      }
+    }
   } finally {
     await cleanup();
   }
@@ -1224,6 +1258,7 @@ export async function buildSshSpawnTarget(input: {
     .map(([key, value]) => `${key}=${shellQuote(value)}`);
   const remoteCommandParts = [shellQuote(input.command), ...input.args.map((arg) => shellQuote(arg))].join(" ");
   const remoteScript = [
+    "#!/bin/sh",
     'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
     'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; fi',
     'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
@@ -1233,19 +1268,37 @@ export async function buildSshSpawnTarget(input: {
     envArgs.length > 0
       ? `exec env ${envArgs.join(" ")} ${remoteCommandParts}`
       : `exec ${remoteCommandParts}`,
-  ].join(" && ");
+  ].join("\n");
+  const remoteLauncher = `/tmp/paperclip-ssh-launch-${randomUUID()}`;
+
+  try {
+    await runSshCommand(
+      input.spec,
+      `umask 077; cat > ${shellQuote(remoteLauncher)}; chmod 700 ${shellQuote(remoteLauncher)}`,
+      { stdin: remoteScript, timeoutMs: 15_000, maxBuffer: 16 * 1024 },
+    );
+  } catch (error) {
+    await auth.cleanup();
+    throw error;
+  }
 
   sshArgs.push(
     "-p",
     String(input.spec.port),
     `${input.spec.username}@${input.spec.host}`,
-    `sh -c ${shellQuote(remoteScript)}`,
+    `exec ${shellQuote(remoteLauncher)}`,
   );
 
   return {
     command: "ssh",
     args: sshArgs,
-    cleanup: auth.cleanup,
+    cleanup: async () => {
+      await runSshCommand(input.spec, `rm -f -- ${shellQuote(remoteLauncher)}`, {
+        timeoutMs: 15_000,
+        maxBuffer: 16 * 1024,
+      }).catch(() => undefined);
+      await auth.cleanup();
+    },
   };
 }
 

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1223,7 +1223,9 @@ export async function runSshCommand(
           `${config.username}@${config.host}`,
           `rm -f -- ${shellQuote(remoteLauncher)}`,
         ];
-        await execFileText("ssh", removeArgs, { timeout: 15_000, maxBuffer: 16 * 1024 }).catch(() => undefined);
+        await execFileText("ssh", removeArgs, { timeout: 15_000, maxBuffer: 16 * 1024 }).catch((error) => {
+          console.warn(`[paperclip] Failed to remove remote SSH launcher ${remoteLauncher}: ${error instanceof Error ? error.message : String(error)}`);
+        });
       }
     }
   } finally {
@@ -1264,34 +1266,44 @@ export async function buildSshSpawnTarget(input: {
       ? `exec env ${envArgs.join(" ")} ${remoteCommandParts}`
       : `exec ${remoteCommandParts}`,
   ].join("\n");
-  const remoteLauncher = `/tmp/paperclip-ssh-launch-${randomUUID()}`;
+  const remoteLauncher = envArgs.length > 0
+    ? `/tmp/paperclip-ssh-launch-${randomUUID()}`
+    : null;
 
-  try {
-    await runSshCommand(
-      input.spec,
-      `umask 077; cat > ${shellQuote(remoteLauncher)}; chmod 700 ${shellQuote(remoteLauncher)}`,
-      { stdin: remoteScript, timeoutMs: 15_000, maxBuffer: 16 * 1024 },
-    );
-  } catch (error) {
-    await auth.cleanup();
-    throw error;
+  if (remoteLauncher) {
+    try {
+      await runSshCommand(
+        input.spec,
+        `umask 077; cat > ${shellQuote(remoteLauncher)}; chmod 700 ${shellQuote(remoteLauncher)}`,
+        { stdin: remoteScript, timeoutMs: 15_000, maxBuffer: 16 * 1024 },
+      );
+    } catch (error) {
+      await auth.cleanup();
+      throw error;
+    }
   }
 
   sshArgs.push(
     "-p",
     String(input.spec.port),
     `${input.spec.username}@${input.spec.host}`,
-    `exec ${shellQuote(remoteLauncher)}`,
+    remoteLauncher
+      ? `exec ${shellQuote(remoteLauncher)}`
+      : `sh -c ${shellQuote(remoteScript)}`,
   );
 
   return {
     command: "ssh",
     args: sshArgs,
     cleanup: async () => {
-      await runSshCommand(input.spec, `rm -f -- ${shellQuote(remoteLauncher)}`, {
-        timeoutMs: 15_000,
-        maxBuffer: 16 * 1024,
-      }).catch(() => undefined);
+      if (remoteLauncher) {
+        await runSshCommand(input.spec, `rm -f -- ${shellQuote(remoteLauncher)}`, {
+          timeoutMs: 15_000,
+          maxBuffer: 16 * 1024,
+        }).catch((error) => {
+          console.warn(`[paperclip] Failed to remove remote SSH launcher ${remoteLauncher}: ${error instanceof Error ? error.message : String(error)}`);
+        });
+      }
       await auth.cleanup();
     },
   };

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1288,7 +1288,7 @@ export async function buildSshSpawnTarget(input: {
     String(input.spec.port),
     `${input.spec.username}@${input.spec.host}`,
     remoteLauncher
-      ? `exec ${shellQuote(remoteLauncher)}`
+      ? `exec sh ${shellQuote(remoteLauncher)}`
       : `sh -c ${shellQuote(remoteScript)}`,
   );
 

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1199,7 +1199,7 @@ export async function runSshCommand(
       String(config.port),
       `${config.username}@${config.host}`,
       remoteLauncher
-        ? `exec ${shellQuote(remoteLauncher)}`
+        ? `exec sh ${shellQuote(remoteLauncher)}`
         : `sh -c ${shellQuote(remoteScript)}`,
     );
 

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -54,21 +54,16 @@ export function createSshCommandManagedRuntimeRunner(input: {
       const cwd = commandInput.cwd?.trim() || defaultCwd;
       const envEntries = Object.entries(commandInput.env ?? {})
         .filter((entry): entry is [string, string] => typeof entry[1] === "string");
-      const envPrefix = envEntries.length > 0
-        ? `env ${envEntries.map(([key, value]) => `${key}=${shellQuote(value)}`).join(" ")} `
-        : "";
-      const exportPrefix = envEntries.length > 0
-        ? envEntries.map(([key, value]) => `export ${key}=${shellQuote(value)};`).join(" ") + " "
-        : "";
       const commandScript = command === "sh" || command === "bash"
         ? (args[0] === "-c" || args[0] === "-lc") && typeof args[1] === "string"
-          ? `${exportPrefix}${args[1]}`
-          : `${envPrefix}exec ${[shellQuote(command), ...args.map((arg) => shellQuote(arg))].join(" ")}`
-        : `${envPrefix}exec ${[shellQuote(command), ...args.map((arg) => shellQuote(arg))].join(" ")}`;
+          ? args[1]
+          : `exec ${[shellQuote(command), ...args.map((arg) => shellQuote(arg))].join(" ")}`
+        : `exec ${[shellQuote(command), ...args.map((arg) => shellQuote(arg))].join(" ")}`;
       const remoteCommand = `cd ${shellQuote(cwd)} && ${commandScript}`;
 
       try {
         const result = await runSshCommand(input.spec, remoteCommand, {
+          env: Object.fromEntries(envEntries),
           stdin: commandInput.stdin,
           timeoutMs: commandInput.timeoutMs,
           maxBuffer: maxBufferBytes,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI-agent work and launches adapters locally or over remote execution targets.
> - SSH execution forwards selected runtime environment needed by adapter CLIs.
> - Existing sanitization removed only inherited shell identity keys, allowing unrelated host environment into remote runs.
> - Existing SSH command construction serialized environment values into local `ssh` process argv.
> - Process argv can be inspected by other local processes and must not carry runtime credentials.
> - This pull request narrows inherited forwarding to an explicit compatibility allowlist and transports generated launchers over stdin.
> - Sentinel tests cover direct commands, spawn targets, and managed runtime execution.
> - Benefit: remote adapters keep required credential compatibility without broad host-env inheritance or argv exposure.

## Linked Issues or Issue Description

No public issue exists. Inline bug report:

### Pre-submission checklist

- [x] Searched existing open/closed issues and PRs; no duplicate found.
- [x] Reproduced on `master` at `cca2806e5`.
- [x] Confirmed bug originates in Paperclip SSH execution, not adapter/provider/config.

### What happened?

SSH remote runs inherited unrelated host environment variables, and environment values were embedded in local SSH argv.

### Expected behavior

Only explicitly compatible inherited credentials cross host boundary; all runtime environment values use non-argv transport.

### Steps to reproduce

1. Set inherited sentinel environment in Paperclip server process.
2. Execute SSH target and inspect remote environment; unrelated sentinel appears.
3. Execute SSH target with credential sentinel and inspect local SSH argv; sentinel appears.

### Paperclip version or commit

`cca2806e5`

### Deployment mode

Self-hosted server, authenticated/private remote-agent runtime.

### Installation method

npm global install for canonical runtime; source worktree for reproduction.

### Agent adapter(s) involved

Not adapter-specific; core SSH execution bug.

### Database mode

Not database-related.

### Access context

Agent.

### Operating system

Linux canonical runtime.

### Privacy checklist

- [x] Reviewed all output for PII and secrets; no secret values included.

## What Changed

- Replaced broad inherited remote environment propagation with explicit credential compatibility allowlist.
- Uploaded per-run mode-0700 launcher scripts through SSH stdin for direct command, spawn-target, and managed-runtime paths.
- Added sentinel regressions covering inherited filtering, secure command transport, spawn argv, and managed runtime transport.

## Verification

- `vitest run packages/adapter-utils/src/server-utils.test.ts packages/adapter-utils/src/execution-target.test.ts packages/adapter-utils/src/command-managed-runtime.test.ts` — 105 passed.
- `vitest run packages/adapter-utils/src/ssh-fixture.test.ts` — 18 passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `pnpm typecheck` — passed before follow-up; adapter-utils typecheck rerun after follow-up.
- `pnpm check:tokens` — passed.

## Risks

- Compatibility risk: inherited variables absent from allowlist no longer reach SSH targets. Explicit adapter/runtime values remain preserved.
- Temporary launcher cleanup is best-effort after abnormal host termination; unique mode-0700 files remain inaccessible to other users and use no secret-bearing filename.
- No DB migration, blob mutation, recovery cleanup, service restart, or deployment in this PR.

## Model Used

- OpenCode high, model ID `9router/high`, tool use and code execution enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] Documentation impact reviewed; no user-facing docs change required
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
