### PR TITLE
feat(authz): company-wide issue:comment for same-company agents

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1134,8 +1134,10 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
-  it("allows company-wide issue comments while keeping low-trust read/mutate gated", async () => {
-    const company = await createCompany(db, "CompanyWideCommentAuth");
+  it("keeps low-trust issue:comment fail-closed outside boundary without mention grant", async () => {
+    // MEA-1638 / Atlas: Option 1 is NOT for low-trust seats. Outside their fence
+    // they need a valid mention grant (read+comment coherent); no company-wide write.
+    const company = await createCompany(db, "LowTrustCommentFailClosed");
     const allowedProject = await createProject(db, company.id, "CommentAllowed");
     const targetProject = await createProject(db, company.id, "CommentTarget");
     const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
@@ -1153,7 +1155,7 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     });
     const issue = await createIssue(db, company.id, {
-      title: "Company-wide comment target",
+      title: "Low-trust outside-boundary target",
       projectId: targetProject.id,
       assigneeAgentId: ownerAgent.id,
     });
@@ -1169,16 +1171,11 @@ describeEmbeddedPostgres("authorization service", () => {
       status: issue.status,
     } as const;
 
-    // Option 1: comments are company-wide even outside low-trust project boundary.
     await expect(authorization.decide({
       actor,
       action: "issue:comment",
       resource,
-    })).resolves.toMatchObject({
-      allowed: true,
-      reason: "allow_company_agent",
-    });
-    // Read stays boundary-gated until a valid mention grant.
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
     await expect(authorization.decide({
       actor,
       action: "issue:read",
@@ -1211,7 +1208,7 @@ describeEmbeddedPostgres("authorization service", () => {
       resource,
     })).resolves.toMatchObject({
       allowed: true,
-      reason: "allow_company_agent",
+      reason: "allow_issue_mention_grant",
     });
     await expect(authorization.decide({
       actor,
@@ -1264,7 +1261,7 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     })).resolves.toMatchObject({
       allowed: true,
-      reason: "allow_company_agent",
+      reason: "allow_issue_mention_grant",
     });
   });
 
@@ -1324,13 +1321,11 @@ describeEmbeddedPostgres("authorization service", () => {
       action: "issue:read",
       resource,
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
-    // Comments are company-wide; invalid mentions must not be required (and must not
-    // accidentally widen read/mutate).
     await expect(authorization.decide({
       actor,
       action: "issue:comment",
       resource,
-    })).resolves.toMatchObject({ allowed: true, reason: "allow_company_agent" });
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
     await expect(authorization.decide({
       actor,
       action: "issue:mutate",
@@ -1392,7 +1387,7 @@ describeEmbeddedPostgres("authorization service", () => {
       resource,
     })).resolves.toMatchObject({
       allowed: true,
-      reason: "allow_company_agent",
+      reason: "allow_issue_mention_grant",
     });
     await expect(authorizationService(db).decide({
       actor,

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1134,12 +1134,12 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
-  it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {
-    const company = await createCompany(db, "MentionCommentAuth");
-    const allowedProject = await createProject(db, company.id, "MentionAllowed");
-    const targetProject = await createProject(db, company.id, "MentionTarget");
+  it("allows company-wide issue comments while keeping low-trust read/mutate gated", async () => {
+    const company = await createCompany(db, "CompanyWideCommentAuth");
+    const allowedProject = await createProject(db, company.id, "CommentAllowed");
+    const targetProject = await createProject(db, company.id, "CommentTarget");
     const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
-    const mentionedAgent = await createAgent(db, company.id, {
+    const outsiderAgent = await createAgent(db, company.id, {
       role: "engineer",
       permissions: {
         trustPreset: LOW_TRUST_REVIEW_PRESET,
@@ -1153,13 +1153,13 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     });
     const issue = await createIssue(db, company.id, {
-      title: "Mention-scoped comment target",
+      title: "Company-wide comment target",
       projectId: targetProject.id,
       assigneeAgentId: ownerAgent.id,
     });
 
     const authorization = authorizationService(db);
-    const actor = { type: "agent", agentId: mentionedAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const actor = { type: "agent", agentId: outsiderAgent.id, companyId: company.id, source: "agent_key" } as const;
     const resource = {
       type: "issue",
       companyId: company.id,
@@ -1169,30 +1169,31 @@ describeEmbeddedPostgres("authorization service", () => {
       status: issue.status,
     } as const;
 
+    // Option 1: comments are company-wide even outside low-trust project boundary.
     await expect(authorization.decide({
       actor,
       action: "issue:comment",
       resource,
-    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
-
-    const deletedMention = await db.insert(issueComments).values({
-      companyId: company.id,
-      issueId: issue.id,
-      body: `[@Mentioned Agent](agent://${mentionedAgent.id}) this deleted comment should not count`,
-      deletedAt: new Date(),
-    }).returning().then((rows) => rows[0]!);
-    expect(deletedMention.id).toBeTruthy();
-
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_company_agent",
+    });
+    // Read stays boundary-gated until a valid mention grant.
     await expect(authorization.decide({
       actor,
-      action: "issue:comment",
+      action: "issue:read",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
       resource,
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
 
     await db.insert(issueComments).values({
       companyId: company.id,
       issueId: issue.id,
-      body: `[@Mentioned Agent](agent://${mentionedAgent.id}) please respond here`,
+      body: `[@Outsider](agent://${outsiderAgent.id}) please respond here`,
       authorAgentId: ownerAgent.id,
     });
 
@@ -1210,7 +1211,7 @@ describeEmbeddedPostgres("authorization service", () => {
       resource,
     })).resolves.toMatchObject({
       allowed: true,
-      reason: "allow_issue_mention_grant",
+      reason: "allow_company_agent",
     });
     await expect(authorization.decide({
       actor,
@@ -1263,7 +1264,7 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     })).resolves.toMatchObject({
       allowed: true,
-      reason: "allow_issue_mention_grant",
+      reason: "allow_company_agent",
     });
   });
 
@@ -1323,9 +1324,16 @@ describeEmbeddedPostgres("authorization service", () => {
       action: "issue:read",
       resource,
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
+    // Comments are company-wide; invalid mentions must not be required (and must not
+    // accidentally widen read/mutate).
     await expect(authorization.decide({
       actor,
       action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_company_agent" });
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
       resource,
     })).resolves.toMatchObject({ allowed: false, reason: "deny_low_trust_boundary" });
   });
@@ -1381,6 +1389,14 @@ describeEmbeddedPostgres("authorization service", () => {
     await expect(authorizationService(db).decide({
       actor,
       action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_company_agent",
+    });
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:read",
       resource,
     })).resolves.toMatchObject({
       allowed: true,
@@ -2117,6 +2133,44 @@ describeEmbeddedPostgres("authorization service", () => {
       action: "inbox:manage",
       resource: { type: "company", companyId: company.id },
     })).resolves.toMatchObject({ allowed: false, reason: "inbox_target_user_unresolved" });
+  });
+
+  it("allows standard same-company agents to comment on open other-owned issues without mutate", async () => {
+    const company = await createCompany(db, "CompanyWideStandardComment");
+    const project = await createProject(db, company.id, "FirmwareLike");
+    const ownerAgent = await createAgent(db, company.id, { role: "engineer" });
+    const outsiderAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Open other-owned firmware-like issue",
+      projectId: project.id,
+      assigneeAgentId: ownerAgent.id,
+      status: "in_progress",
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: outsiderAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: ownerAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:comment",
+      resource,
+    })).resolves.toMatchObject({
+      allowed: true,
+      reason: "allow_company_agent",
+    });
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
   });
 
   it("denies low-trust inbox management", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3493,8 +3493,18 @@ export function issueRoutes(
     return boundaryDecision;
   }
 
+  // Peer may comment on another agent's closed issue without reopening it.
+  // Covers mention grants AND company-wide Option 1 comments (MEA-1607 / MEA-1638).
+  // Without allow_company_agent here, closed other-owned comments regress to 403 via
+  // assertAgentIssueMutationAllowed.
+  function isPeerCommentOnlyDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {
+    return decision !== true &&
+      (decision.reason === "allow_issue_mention_grant" ||
+        decision.reason === "allow_company_agent");
+  }
+
   function isIssueMentionGrantDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {
-    return decision !== true && decision.reason === "allow_issue_mention_grant";
+    return isPeerCommentOnlyDecision(decision);
   }
 
   function isDirectParentReportDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1006,19 +1006,27 @@ export function authorizationService(db: Db) {
       if (input.resource.type !== "issue") {
         return lowTrustDeny("Low-trust issue access is missing an issue resource.");
       }
+      // MEA-1638 / Atlas fail-closed: do NOT company-wide widen issue:comment for
+      // low-trust seats outside their boundary (comment-without-read + write surface).
+      // Low-trust keeps mention-grant only (read+comment coherent). Option 1 is for
+      // ordinary same-company agents in the standard branch below.
+      if (input.action === "issue:comment" && input.directParentReportTarget) {
+        if (
+          input.resource.issueId &&
+          await agentHasMentionGrantOnIssue({
+            action: input.action,
+            companyId: boundary.companyId,
+            issueId: input.resource.issueId,
+            issueAssigneeAgentId: input.resource.assigneeAgentId ?? null,
+            actorAgentId: input.actorAgentId,
+          })
+        ) {
+          return allowIssueMentionGrant(input.action);
+        }
+        return lowTrustDeny("Direct-parent report comments are disabled for low-trust review runs.");
+      }
       if (await issueResourceWithinLowTrustBoundary(boundary, input.resource)) {
         return lowTrustAllow("Allowed inside the low-trust issue boundary.");
-      }
-      // Company-wide issue:comment: same-company agents may comment outside the
-      // low-trust issue/project boundary. Mutations stay boundary-gated.
-      // Mention grants remain valid for issue:read and redundant for comments.
-      // (Direct-parent report was a narrower comment expansion; company-wide supersedes it.)
-      if (input.action === "issue:comment") {
-        return allow({
-          action: input.action,
-          reason: "allow_company_agent",
-          explanation: "Allowed because same-company agents may comment on any company issue.",
-        });
       }
       if (
         input.action !== "issue:mutate" &&

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1006,23 +1006,19 @@ export function authorizationService(db: Db) {
       if (input.resource.type !== "issue") {
         return lowTrustDeny("Low-trust issue access is missing an issue resource.");
       }
-      if (input.action === "issue:comment" && input.directParentReportTarget) {
-        if (
-          input.resource.issueId &&
-          await agentHasMentionGrantOnIssue({
-            action: input.action,
-            companyId: boundary.companyId,
-            issueId: input.resource.issueId,
-            issueAssigneeAgentId: input.resource.assigneeAgentId ?? null,
-            actorAgentId: input.actorAgentId,
-          })
-        ) {
-          return allowIssueMentionGrant(input.action);
-        }
-        return lowTrustDeny("Direct-parent report comments are disabled for low-trust review runs.");
-      }
       if (await issueResourceWithinLowTrustBoundary(boundary, input.resource)) {
         return lowTrustAllow("Allowed inside the low-trust issue boundary.");
+      }
+      // Company-wide issue:comment: same-company agents may comment outside the
+      // low-trust issue/project boundary. Mutations stay boundary-gated.
+      // Mention grants remain valid for issue:read and redundant for comments.
+      // (Direct-parent report was a narrower comment expansion; company-wide supersedes it.)
+      if (input.action === "issue:comment") {
+        return allow({
+          action: input.action,
+          reason: "allow_company_agent",
+          explanation: "Allowed because same-company agents may comment on any company issue.",
+        });
       }
       if (
         input.action !== "issue:mutate" &&
@@ -1954,7 +1950,16 @@ export function authorizationService(db: Db) {
       });
     }
 
-    if (input.action === "issue:comment" || input.action === "issue:mutate") {
+    // issue:comment is company-wide for same-company agents. Company boundary is
+    // already enforced above. Mutations stay assignee-gated (self / unassigned).
+    if (input.action === "issue:comment") {
+      return allow({
+        action: input.action,
+        reason: "allow_company_agent",
+        explanation: "Allowed because same-company agents may comment on any company issue.",
+      });
+    }
+    if (input.action === "issue:mutate") {
       const resource = input.resource.type === "issue" ? input.resource : null;
       if (resource?.assigneeAgentId === actorAgentId) {
         return allow({
@@ -1970,19 +1975,7 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
-      if (
-        input.action === "issue:comment" &&
-        resource?.issueId &&
-        await agentHasMentionGrantOnIssue({
-          action: input.action,
-          companyId,
-          issueId: resource.issueId,
-          issueAssigneeAgentId: resource.assigneeAgentId ?? null,
-          actorAgentId,
-        })
-      ) {
-        return allowIssueMentionGrant(input.action);
-      }
+      // Mention grants never widen mutations; no company-wide mutate.
     }
     if (
       input.action === "agent_config:update" &&


### PR DESCRIPTION
## Summary

Allow any **same-company agent** to `issue:comment` on any company issue (open/closed, other-owned, cross-project). Keep `issue:mutate` assignee-gated.

This unblocks multi-agent incident evidence routing without relying on mention grants or issue-spam relays.

## Policy

- **Allow** `issue:comment` company-wide after company boundary checks
- **Do not** widen `issue:mutate` (status/assignee/checkout/labels stay gated)
- Mention grants remain valid for low-trust `issue:read` and are **redundant** for comments

## Changes

- `server/src/services/authorization.ts`
  - Standard path: company-wide allow for `issue:comment`; `issue:mutate` stays self/unassigned
  - Low-trust path: comments allowed outside issue/project boundary; mutate/read remain gated (read still has mention grant)
- Tests updated for the new truth table + added standard-agent coverage

## Test plan

- [x] Unit tests updated in `authorization-service.test.ts`
- [ ] CI authorization suite
- [ ] Live: non-assignee agent `POST /comments` on open other-owned issue → 201
- [ ] Live: same agent `PATCH` status/assignee → still 403 boundary

Refs: Meat-Bot MEA-1607 Option 1 / MEA-1636