### PR TITLE
Skip unchanged company skill imports

### DIFF
--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -431,10 +431,16 @@ describeEmbeddedPostgres("companySkillService.list", () => {
       .set({ updatedAt: preservedUpdatedAt })
       .where(eq(companySkills.id, skillId));
 
+    const updateSpy = vi.spyOn(db, "update");
     await svc.importFromSource(companyId, skillDir);
     const stored = await svc.getById(companyId, skillId);
+    const companySkillUpdateCount = updateSpy.mock.calls
+      .filter(([table]) => table === companySkills)
+      .length;
+    updateSpy.mockRestore();
 
     expect(stored?.updatedAt.toISOString()).toBe(preservedUpdatedAt.toISOString());
+    expect(companySkillUpdateCount).toBe(0);
   });
 
   it("refreshes local-path imports with legacy null metadata fields", async () => {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -239,7 +239,6 @@ type ImportedSkillPersistValues = Pick<
 > & {
   fileInventory: Array<Record<string, unknown>>;
   metadata: Record<string, unknown>;
-  updatedAt: Date;
 };
 
 type PackageSkillConflictStrategy = "replace" | "rename" | "skip";
@@ -5580,7 +5579,6 @@ export function companySkillService(db: Db) {
         sharingScope: existing?.sharingScope ?? "company",
         installCount: existing?.installCount ?? 1,
         metadata,
-        updatedAt: new Date(),
       };
       if (existing && importedSkillPersistValuesMatchExisting(existing, values)) {
         out.push(existing);
@@ -5589,7 +5587,7 @@ export function companySkillService(db: Db) {
       const row = existing
         ? await db
           .update(companySkills)
-          .set(values)
+          .set({ ...values, updatedAt: new Date() })
           .where(eq(companySkills.id, existing.id))
           .returning()
           .then((rows) => rows[0] ?? null)


### PR DESCRIPTION
## Summary
- avoid updating company skill rows when local-path import payload is unchanged
- preserve `updatedAt` for no-op imports
- assert no company skill update is issued for unchanged local-path imports

## Checks
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm vitest run server/src/__tests__/company-skills-service.test.ts -t "does not retouch unchanged local-path imports"` (embedded Postgres unsupported in this local run, file skipped by test harness)