### PR TITLE
Honor agent approval policy during company import

### DIFF
--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -76,6 +76,10 @@ const agentInstructionsSvc = {
   materializeManagedBundle: vi.fn(),
 };
 
+const approvalSvc = {
+  create: vi.fn(),
+};
+
 vi.mock("../services/companies.js", () => ({
   companyService: () => companySvc,
 }));
@@ -116,6 +120,10 @@ vi.mock("../services/agent-instructions.js", () => ({
   agentInstructionsService: () => agentInstructionsSvc,
 }));
 
+vi.mock("../services/approvals.js", () => ({
+  approvalService: () => approvalSvc,
+}));
+
 vi.mock("../routes/org-chart-svg.js", () => ({
   renderOrgChartPng: vi.fn(async () => Buffer.from("png")),
 }));
@@ -142,6 +150,7 @@ describe("company portability", () => {
       config,
       secretKeys: new Set<string>(),
     }));
+    approvalSvc.create.mockResolvedValue({ id: "approval-created" });
     issueSvc.listComments.mockResolvedValue([]);
     issueSvc.addComment.mockResolvedValue({
       id: "comment-imported",
@@ -3751,6 +3760,83 @@ describe("company portability", () => {
     }));
     expect(companySvc.create).toHaveBeenCalledWith(expect.objectContaining({
       requireBoardApprovalForNewAgents: false,
+    }));
+  });
+
+  it("creates imported agents pending approval when the company requires it", async () => {
+    companySvc.getById.mockReset().mockResolvedValue({
+      id: "company-gated",
+      name: "Gated Company",
+      requireBoardApprovalForNewAgents: true,
+    });
+    agentSvc.list.mockResolvedValue([]);
+    agentSvc.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => ({
+      id: "agent-gated",
+      name: input.name,
+      role: input.role,
+      title: input.title,
+      icon: input.icon,
+      reportsTo: input.reportsTo,
+      capabilities: input.capabilities,
+      adapterType: input.adapterType,
+      adapterConfig: input.adapterConfig,
+      runtimeConfig: input.runtimeConfig,
+      permissions: input.permissions,
+      budgetMonthlyCents: input.budgetMonthlyCents,
+      metadata: input.metadata,
+      status: input.status,
+    }));
+    const portability = companyPortabilityService({} as any);
+
+    await portability.importBundle({
+      source: {
+        type: "inline",
+        files: {
+          "COMPANY.md": [
+            "---",
+            'name: "Gated Company"',
+            "includes:",
+            '  - "agents/engineer/AGENTS.md"',
+            "---",
+            "",
+          ].join("\n"),
+          "agents/engineer/AGENTS.md": [
+            "---",
+            'name: "Engineer"',
+            'slug: "engineer"',
+            'role: "engineer"',
+            "---",
+            "",
+          ].join("\n"),
+        },
+      },
+      include: {
+        company: false,
+        agents: true,
+        projects: false,
+        issues: false,
+        skills: false,
+      },
+      target: {
+        mode: "existing_company",
+        companyId: "company-gated",
+      },
+      agents: "all",
+      collisionStrategy: "rename",
+    }, "user-1");
+
+    expect(agentSvc.create).toHaveBeenCalledWith("company-gated", expect.objectContaining({
+      status: "pending_approval",
+    }));
+    expect(approvalSvc.create).toHaveBeenCalledTimes(1);
+    expect(approvalSvc.create).toHaveBeenCalledWith("company-gated", expect.objectContaining({
+      type: "hire_agent",
+      requestedByUserId: "user-1",
+      status: "pending",
+      payload: expect.objectContaining({
+        agentId: "agent-gated",
+        name: "Engineer",
+      }),
     }));
   });
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -64,6 +64,7 @@ import type { StorageService } from "../storage/types.js";
 import { accessService } from "./access.js";
 import { agentService } from "./agents.js";
 import { agentInstructionsService } from "./agent-instructions.js";
+import { approvalService } from "./approvals.js";
 import { assetService } from "./assets.js";
 import { generateReadme } from "./company-export-readme.js";
 import { renderOrgChartPng, type OrgNode } from "../routes/org-chart-svg.js";
@@ -3015,6 +3016,7 @@ export function parseGitHubSourceUrl(rawUrl: string) {
 
 export function companyPortabilityService(db: Db, storage?: StorageService) {
   const companies = companyService(db);
+  const approvals = approvalService(db);
   const agents = agentService(db);
   const assetRecords = assetService(db);
   const instructions = agentInstructionsService();
@@ -4747,7 +4749,8 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             continue;
           }
 
-          const createdStatus = "idle";
+          const requiresApproval = Boolean(targetCompany.requireBoardApprovalForNewAgents);
+          const createdStatus = requiresApproval ? "pending_approval" : "idle";
           let created = await agents.create(targetCompany.id, {
             ...patch,
             status: createdStatus,
@@ -4776,6 +4779,33 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             manifestAgent.permissionGrants ?? [],
             actorUserId ?? null,
           );
+          if (requiresApproval) {
+            await approvals.create(targetCompany.id, {
+              type: "hire_agent",
+              requestedByAgentId: null,
+              requestedByUserId: actorUserId ?? null,
+              status: "pending",
+              payload: {
+                name: created.name,
+                role: created.role,
+                title: created.title,
+                icon: created.icon,
+                reportsTo: created.reportsTo,
+                capabilities: created.capabilities,
+                adapterType: created.adapterType,
+                adapterConfig: created.adapterConfig,
+                runtimeConfig: created.runtimeConfig,
+                permissions: created.permissions,
+                budgetMonthlyCents: created.budgetMonthlyCents,
+                metadata: created.metadata,
+                agentId: created.id,
+              },
+              decisionNote: null,
+              decidedByUserId: null,
+              decidedAt: null,
+              updatedAt: new Date(),
+            });
+          }
           agentStatusById.set(created.id, created.status ?? createdStatus);
           await secrets.syncEnvBindingsForTarget?.(
             targetCompany.id,

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -4633,7 +4633,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
       }
 
       if (include.agents) {
-        const pendingHireApprovalAgentIds: string[] = [];
+        const pendingHireApprovalAgents = new Map<string, Awaited<ReturnType<typeof agents.create>>>();
         for (const planAgent of plan.preview.plan.agentPlans) {
           const manifestAgent = plan.selectedAgents.find((agent) => agent.slug === planAgent.slug);
           if (!manifestAgent) continue;
@@ -4770,10 +4770,14 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
               clearLegacyPromptTemplate: true,
               replaceExisting: true,
             });
-            created = await agents.update(
-              created.id,
-              { adapterConfig: materialized.adapterConfig },
-              { allowPendingApprovalConfigUpdate: requiresApproval },
+            created = await (
+              requiresApproval
+                ? agents.update(
+                    created.id,
+                    { adapterConfig: materialized.adapterConfig },
+                    { allowPendingApprovalConfigUpdate: true },
+                  )
+                : agents.update(created.id, { adapterConfig: materialized.adapterConfig })
             ) ?? created;
           } catch (err) {
             warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
@@ -4785,7 +4789,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             actorUserId ?? null,
           );
           if (requiresApproval) {
-            pendingHireApprovalAgentIds.push(created.id);
+            pendingHireApprovalAgents.set(created.id, created);
           }
           agentStatusById.set(created.id, created.status ?? createdStatus);
           await secrets.syncEnvBindingsForTarget?.(
@@ -4828,11 +4832,18 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           if (!managerId || managerId === agentId) continue;
           try {
             const currentStatus = agentStatusById.get(agentId);
-            await agents.update(
-              agentId,
-              { reportsTo: managerId },
-              { allowPendingApprovalConfigUpdate: currentStatus === "pending_approval" },
+            const updated = await (
+              currentStatus === "pending_approval"
+                ? agents.update(
+                    agentId,
+                    { reportsTo: managerId },
+                    { allowPendingApprovalConfigUpdate: true },
+                  )
+                : agents.update(agentId, { reportsTo: managerId })
             );
+            if (updated && pendingHireApprovalAgents.has(agentId)) {
+              pendingHireApprovalAgents.set(agentId, updated);
+            }
           } catch {
             const managerRef =
               managerSlug
@@ -4844,9 +4855,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
 
         // Approval payloads must describe the fully materialized agent,
         // including managed instructions and reporting links.
-        for (const agentId of pendingHireApprovalAgentIds) {
-          const created = await agents.getById(agentId);
-          if (!created) throw notFound(`Imported agent ${agentId} disappeared before approval creation.`);
+        for (const created of pendingHireApprovalAgents.values()) {
           await approvals.create(targetCompany.id, {
             type: "hire_agent",
             requestedByAgentId: null,

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -4633,6 +4633,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
       }
 
       if (include.agents) {
+        const pendingHireApprovalAgentIds: string[] = [];
         for (const planAgent of plan.preview.plan.agentPlans) {
           const manifestAgent = plan.selectedAgents.find((agent) => agent.slug === planAgent.slug);
           if (!manifestAgent) continue;
@@ -4769,7 +4770,11 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
               clearLegacyPromptTemplate: true,
               replaceExisting: true,
             });
-            created = await agents.update(created.id, { adapterConfig: materialized.adapterConfig }) ?? created;
+            created = await agents.update(
+              created.id,
+              { adapterConfig: materialized.adapterConfig },
+              { allowPendingApprovalConfigUpdate: requiresApproval },
+            ) ?? created;
           } catch (err) {
             warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
           }
@@ -4780,31 +4785,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             actorUserId ?? null,
           );
           if (requiresApproval) {
-            await approvals.create(targetCompany.id, {
-              type: "hire_agent",
-              requestedByAgentId: null,
-              requestedByUserId: actorUserId ?? null,
-              status: "pending",
-              payload: {
-                name: created.name,
-                role: created.role,
-                title: created.title,
-                icon: created.icon,
-                reportsTo: created.reportsTo,
-                capabilities: created.capabilities,
-                adapterType: created.adapterType,
-                adapterConfig: created.adapterConfig,
-                runtimeConfig: created.runtimeConfig,
-                permissions: created.permissions,
-                budgetMonthlyCents: created.budgetMonthlyCents,
-                metadata: created.metadata,
-                agentId: created.id,
-              },
-              decisionNote: null,
-              decidedByUserId: null,
-              decidedAt: null,
-              updatedAt: new Date(),
-            });
+            pendingHireApprovalAgentIds.push(created.id);
           }
           agentStatusById.set(created.id, created.status ?? createdStatus);
           await secrets.syncEnvBindingsForTarget?.(
@@ -4846,7 +4827,12 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
               : null);
           if (!managerId || managerId === agentId) continue;
           try {
-            await agents.update(agentId, { reportsTo: managerId });
+            const currentStatus = agentStatusById.get(agentId);
+            await agents.update(
+              agentId,
+              { reportsTo: managerId },
+              { allowPendingApprovalConfigUpdate: currentStatus === "pending_approval" },
+            );
           } catch {
             const managerRef =
               managerSlug
@@ -4854,6 +4840,38 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
               ?? manifestAgent.reportsToExistingAgentId;
             warnings.push(`Could not assign manager ${managerRef} for imported agent ${manifestAgent.slug}.`);
           }
+        }
+
+        // Approval payloads must describe the fully materialized agent,
+        // including managed instructions and reporting links.
+        for (const agentId of pendingHireApprovalAgentIds) {
+          const created = await agents.getById(agentId);
+          if (!created) throw notFound(`Imported agent ${agentId} disappeared before approval creation.`);
+          await approvals.create(targetCompany.id, {
+            type: "hire_agent",
+            requestedByAgentId: null,
+            requestedByUserId: actorUserId ?? null,
+            status: "pending",
+            payload: {
+              name: created.name,
+              role: created.role,
+              title: created.title,
+              icon: created.icon,
+              reportsTo: created.reportsTo,
+              capabilities: created.capabilities,
+              adapterType: created.adapterType,
+              adapterConfig: created.adapterConfig,
+              runtimeConfig: created.runtimeConfig,
+              permissions: created.permissions,
+              budgetMonthlyCents: created.budgetMonthlyCents,
+              metadata: created.metadata,
+              agentId: created.id,
+            },
+            decisionNote: null,
+            decidedByUserId: null,
+            decidedAt: null,
+            updatedAt: new Date(),
+          });
         }
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Company policy can require board approval before a newly hired agent becomes active
> - Portability import is another agent-creation path and must enforce the same policy
> - Imported agents currently bypass the gate and start idle/active
> - The stale implementation in #7337 identified the correct approval record but now conflicts with `master`
> - This pull request rebuilds the behavior on current `master` and tests the gated and ungated paths
> - The benefit is consistent governance regardless of how an agent enters a company

## Linked Issues or Issue Description

- Fixes: #7245
- Replaces and credits the original work in #7337

## What Changed

- Create imported agents as `pending_approval` when the target company requires board approval.
- Mint one pending `hire_agent` approval that references the already-created agent.
- Preserve the existing immediate `idle` behavior when approval is disabled.
- Add focused importer coverage for approval creation and payload identity.

## Verification

- `pnpm exec vitest run server/src/__tests__/company-portability.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Imported agents in gated companies no longer accept work until approved; this is the intended policy behavior.
- Existing-agent replacement remains unchanged and does not mint duplicate hire approvals.

## Model Used

- OpenAI Codex, GPT-5 family, with repository, shell, GitHub, and code-execution tools. Exact serving model ID and context-window size were not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
