### PR TITLE
Make new-company portability imports atomic

### DIFF
--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -74,6 +74,7 @@ const secretSvc = {
 const agentInstructionsSvc = {
   exportFiles: vi.fn(),
   materializeManagedBundle: vi.fn(),
+  removeManagedBundle: vi.fn(),
 };
 
 vi.mock("../services/companies.js", () => ({
@@ -142,6 +143,7 @@ describe("company portability", () => {
       config,
       secretKeys: new Set<string>(),
     }));
+    agentInstructionsSvc.removeManagedBundle.mockResolvedValue(undefined);
     issueSvc.listComments.mockResolvedValue([]);
     issueSvc.addComment.mockResolvedValue({
       id: "comment-imported",
@@ -2552,6 +2554,116 @@ describe("company portability", () => {
       name: "ClaudeCoder",
       adapterType: "process",
     }));
+  });
+
+  it("rejects unavailable explicit agent models during preview", async () => {
+    const previousBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
+    const previousRegion = process.env.AWS_REGION;
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "eu-west-1";
+    try {
+      const portability = companyPortabilityService({} as any);
+      const preview = await portability.previewImport({
+        source: {
+          type: "inline",
+          files: {
+            "COMPANY.md": "---\nname: Import\nincludes:\n  - agents/coder/AGENTS.md\n---\n",
+            "agents/coder/AGENTS.md": "---\nname: Coder\nslug: coder\n---\n",
+            ".paperclip.yaml": [
+              "schema: paperclip/v1",
+              "agents:",
+              "  coder:",
+              "    adapter:",
+              "      type: claude_local",
+              "      config:",
+              "        model: eu.anthropic.claude-sonnet-5",
+              "",
+            ].join("\n"),
+          },
+        },
+        include: {
+          company: true,
+          agents: true,
+          projects: false,
+          issues: false,
+          skills: false,
+        },
+        target: {
+          mode: "new_company",
+          newCompanyName: "Import",
+        },
+        collisionStrategy: "rename",
+      });
+
+      expect(preview.errors).toContain(
+        'Agent coder model "eu.anthropic.claude-sonnet-5" is not available for adapter claude_local.',
+      );
+    } finally {
+      if (previousBedrock === undefined) delete process.env.CLAUDE_CODE_USE_BEDROCK;
+      else process.env.CLAUDE_CODE_USE_BEDROCK = previousBedrock;
+      if (previousRegion === undefined) delete process.env.AWS_REGION;
+      else process.env.AWS_REGION = previousRegion;
+    }
+  });
+
+  it("rolls back new-company imports and cleans managed instructions on failure", async () => {
+    const transaction = vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback({}));
+    companySvc.create.mockReset().mockResolvedValue({
+      id: "company-atomic",
+      name: "Atomic Company",
+      requireBoardApprovalForNewAgents: false,
+    });
+    agentSvc.list.mockResolvedValue([]);
+    agentSvc.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => ({
+      id: "agent-atomic",
+      companyId: "company-atomic",
+      name: input.name,
+      adapterType: input.adapterType,
+      adapterConfig: input.adapterConfig,
+      status: input.status,
+    }));
+    agentInstructionsSvc.materializeManagedBundle.mockResolvedValue({
+      adapterConfig: {},
+      bundle: {},
+    });
+    issueSvc.create.mockRejectedValueOnce(new Error("issue create failed"));
+    const portability = companyPortabilityService({ transaction } as any);
+
+    await expect(portability.importBundle({
+      source: {
+        type: "inline",
+        files: {
+          "COMPANY.md": [
+            "---",
+            "name: Atomic Company",
+            "includes:",
+            "  - agents/engineer/AGENTS.md",
+            "  - tasks/fail/TASK.md",
+            "---",
+            "",
+          ].join("\n"),
+          "agents/engineer/AGENTS.md": "---\nname: Engineer\nslug: engineer\n---\n",
+          "tasks/fail/TASK.md": "---\nname: Fail\nslug: fail\nassignee: engineer\n---\n",
+        },
+      },
+      include: {
+        company: true,
+        agents: true,
+        projects: false,
+        issues: true,
+        skills: false,
+      },
+      target: {
+        mode: "new_company",
+        newCompanyName: "Atomic Company",
+      },
+      collisionStrategy: "rename",
+    }, "user-1")).rejects.toThrow("issue create failed");
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(agentInstructionsSvc.removeManagedBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-atomic" }),
+    );
   });
 
   it("preserves agent role from frontmatter when extension block omits it", async () => {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -722,6 +722,10 @@ export function agentInstructionsService() {
     return { bundle, adapterConfig };
   }
 
+  async function removeManagedBundle(agent: AgentLike): Promise<void> {
+    await fs.rm(resolveManagedInstructionsRoot(agent), { recursive: true, force: true });
+  }
+
   return {
     getBundle,
     readFile,
@@ -731,5 +735,6 @@ export function agentInstructionsService() {
     exportFiles,
     ensureManagedBundle: ensureWritableBundle,
     materializeManagedBundle,
+    removeManagedBundle,
   };
 }

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -57,7 +57,7 @@ import {
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
 import { requireOpenCodeModelId } from "@paperclipai/adapter-opencode-local/server";
-import { findServerAdapter } from "../adapters/index.js";
+import { findServerAdapter, listAdapterModels } from "../adapters/index.js";
 import { forbidden, notFound, unprocessable } from "../errors.js";
 import { ghFetch, gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
 import type { StorageService } from "../storage/types.js";
@@ -640,6 +640,9 @@ type ImportMode = "board_full" | "agent_safe";
 type ImportBehaviorOptions = {
   mode?: ImportMode;
   sourceCompanyId?: string | null;
+  atomicContext?: {
+    compensations: Array<() => Promise<void>>;
+  };
 };
 
 type AgentLike = {
@@ -4081,6 +4084,21 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           warnings.push(`Agent ${agent.slug} references skill ${skillRef}, but that skill is not present in the package.`);
         }
       }
+      const model =
+        isPlainRecord(agent.adapterConfig) && typeof agent.adapterConfig.model === "string"
+          ? agent.adapterConfig.model.trim()
+          : "";
+      if (model) {
+        const availableModels = await listAdapterModels(agent.adapterType);
+        if (
+          availableModels.length > 0
+          && !availableModels.some((candidate) => candidate.id === model)
+        ) {
+          errors.push(
+            `Agent ${agent.slug} model "${model}" is not available for adapter ${agent.adapterType}.`,
+          );
+        }
+      }
     }
 
     if (include.projects) {
@@ -4408,6 +4426,30 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     actorUserId: string | null | undefined,
     options?: ImportBehaviorOptions,
   ): Promise<CompanyPortabilityImportResult> {
+    if (
+      input.target.mode === "new_company"
+      && !options?.atomicContext
+      && typeof (db as { transaction?: unknown }).transaction === "function"
+    ) {
+      const atomicContext = {
+        compensations: [] as Array<() => Promise<void>>,
+      };
+      try {
+        return await db.transaction(async (tx) =>
+          companyPortabilityService(tx as unknown as Db, storage).importBundle(
+            input,
+            actorUserId,
+            { ...options, atomicContext },
+          )
+        );
+      } catch (error) {
+        for (const compensate of atomicContext.compensations.reverse()) {
+          await compensate().catch(() => undefined);
+        }
+        throw error;
+      }
+    }
+
     const mode = resolveImportMode(options);
     const plan = await buildPreview(input, options);
     if (plan.preview.errors.length > 0) {
@@ -4474,6 +4516,14 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           ? (sourceManifest.company?.feedbackDataSharingTermsVersion ?? null)
           : null,
       });
+      if (options?.atomicContext) {
+        const provisionedAgents = await agents.list(created.id, { includeTerminated: true });
+        for (const provisionedAgent of provisionedAgents) {
+          options.atomicContext.compensations.push(
+            () => instructions.removeManagedBundle(provisionedAgent),
+          );
+        }
+      }
       if (mode === "agent_safe" && options?.sourceCompanyId) {
         await access.copyActiveUserMemberships(options.sourceCompanyId, created.id);
       } else {
@@ -4569,6 +4619,9 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
                   contentType,
                   body,
                 });
+                options?.atomicContext?.compensations.push(
+                  () => storage.deleteObject(targetCompany!.id, stored.objectKey),
+                );
                 const createdAsset = await assetRecords.create(targetCompany.id, {
                   provider: stored.provider,
                   objectKey: stored.objectKey,
@@ -4584,6 +4637,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
                 });
                 targetCompany = updated ?? targetCompany;
               } catch (err) {
+                if (options?.atomicContext) throw err;
                 warnings.push(`Failed to import company logo ${logoPath}: ${err instanceof Error ? err.message : String(err)}`);
               }
             }
@@ -4752,6 +4806,9 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             ...patch,
             status: createdStatus,
           });
+          options?.atomicContext?.compensations.push(
+            () => instructions.removeManagedBundle(created),
+          );
           await access.ensureMembership(targetCompany.id, "agent", created.id, "member", "active");
           await access.setPrincipalPermission(
             targetCompany.id,
@@ -4768,6 +4825,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             });
             created = await agents.update(created.id, { adapterConfig: materialized.adapterConfig }) ?? created;
           } catch (err) {
+            if (options?.atomicContext) throw err;
             warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
           }
           await applyImportedAgentPermissionGrants(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Company portability creates a graph of company, agent, skill, project, task, goal, secret, and asset records
> - A new-company import currently persists early records before later operations finish
> - Failures can therefore leave an inaccessible partial company and external artifacts
> - Database rollback alone is insufficient because storage and managed instruction files live outside Postgres
> - This pull request validates explicit models up front, wraps new-company writes in one transaction, and journals external cleanup
> - The benefit is an all-or-nothing new-company import with no orphan company after a failed apply

## Linked Issues or Issue Description

- Fixes: #10244

## What Changed

- Reject unavailable explicit agent models during import preview.
- Run `new_company` import database writes in one transaction.
- Journal and reverse storage-object and managed-instruction side effects when the transaction fails.
- Clean bundled-agent instruction directories created during company provisioning.
- Make logo and instruction materialization failures fatal for atomic new-company imports.
- Leave existing-company import behavior unchanged.

## Verification

- `pnpm exec vitest run server/src/__tests__/company-portability.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- New-company imports are intentionally stricter: a logo or managed-instruction write that previously produced a warning now aborts the import.
- Existing-company imports retain their prior best-effort warning behavior.
- Compensation is best-effort and runs in reverse creation order after database rollback.

## Model Used

- OpenAI Codex, GPT-5 family, with repository, shell, GitHub, and code-execution tools. Exact serving model ID and context-window size were not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked existing issues or described the issue
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
