### PR TITLE
fix(issues): default agent-authored creates to the creating agent (null-assignee guard)

### DIFF
--- a/server/src/__tests__/issue-create-null-assignee-guard-routes.test.ts
+++ b/server/src/__tests__/issue-create-null-assignee-guard-routes.test.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueCreateIdempotencyKeys,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres null-assignee guard route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+/**
+ * ALAA-2113 (regression of ALAA-766). ALAA-766 was closed on intent, not on
+ * evidence: it shipped without a test, silently stopped taking effect, and 32
+ * dormant issues accumulated before a drift scan found them.
+ *
+ * A null-assignee issue is invisible work -- nothing wakes an agent for it.
+ * These tests pin the guard on every agent-reachable create path. The original
+ * ALAA-2113 plan named only the top-level route; the child paths carry the same
+ * hole, and the one live drift instance on the board came through a child path.
+ */
+describeEmbeddedPostgres("agent issue create null-assignee guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-null-assignee-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueCreateIdempotencyKeys);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use(actorMiddleware(db, { deploymentMode: "local_trusted" }));
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `D${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(companyId: string, name = "Null Assignee Agent") {
+    const [agent] = await db.insert(agents).values({
+      companyId,
+      name,
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    }).returning();
+    return agent!;
+  }
+
+  async function seedParent(companyId: string) {
+    const [parent] = await db.insert(issues).values({
+      companyId,
+      title: "Parent issue",
+      status: "todo",
+      priority: "medium",
+    }).returning();
+    return parent!;
+  }
+
+  function asAgent(agent: { id: string; adapterType: string }, companyId: string) {
+    const runId = randomUUID();
+    const token = createLocalAgentJwt(agent.id, companyId, agent.adapterType, runId);
+    return { token, runId };
+  }
+
+  it("defaults the assignee to the creating agent on top-level create", async () => {
+    const companyId = await seedCompany();
+    const agent = await seedAgent(companyId);
+    const { token, runId } = asAgent(agent, companyId);
+
+    const res = await request(createApp())
+      .post(`/api/companies/${companyId}/issues`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId)
+      .send({ title: "Agent create with no assignee" })
+      .expect(201);
+
+    expect(res.body.assigneeAgentId).toBe(agent.id);
+    expect(res.headers["x-paperclip-issue-autoassigned"]).toBe("creator");
+  });
+
+  it("defaults the assignee to the creating agent on child create", async () => {
+    const companyId = await seedCompany();
+    const agent = await seedAgent(companyId);
+    const parent = await seedParent(companyId);
+    const { token, runId } = asAgent(agent, companyId);
+
+    const res = await request(createApp())
+      .post(`/api/issues/${parent.id}/children`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId)
+      .send({ title: "Child create with no assignee" })
+      .expect(201);
+
+    expect(res.body.assigneeAgentId).toBe(agent.id);
+    expect(res.headers["x-paperclip-issue-autoassigned"]).toBe("creator");
+  });
+
+  it("leaves an explicit agent assignee untouched", async () => {
+    const companyId = await seedCompany();
+    const creator = await seedAgent(companyId, "Creator");
+    const delegate = await seedAgent(companyId, "Delegate");
+    const { token, runId } = asAgent(creator, companyId);
+
+    const res = await request(createApp())
+      .post(`/api/companies/${companyId}/issues`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId)
+      .send({ title: "Explicit delegation", assigneeAgentId: delegate.id })
+      .expect(201);
+
+    expect(res.body.assigneeAgentId).toBe(delegate.id);
+    expect(res.headers["x-paperclip-issue-autoassigned"]).toBeUndefined();
+  });
+
+  it("leaves board-authored creates unassigned so human triage still works", async () => {
+    const companyId = await seedCompany();
+
+    const res = await request(createApp())
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Human triage item" })
+      .expect(201);
+
+    expect(res.body.assigneeAgentId).toBeNull();
+    expect(res.body.assigneeUserId ?? null).toBeNull();
+    expect(res.headers["x-paperclip-issue-autoassigned"]).toBeUndefined();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3363,6 +3363,33 @@ export function issueRoutes(
     return req.actor.type === "agent" && req.actor.keyScope?.kind === "skill_test";
   }
 
+  /**
+   * ALAA-2113 (regression of ALAA-766): an agent-authored create that omits both
+   * assignee fields yields an issue nobody is ever woken for, so the work is
+   * silently invisible until a drift scan finds it.
+   *
+   * Deliberately a default rather than a 422: human/UI creates legitimately leave
+   * an issue unassigned for triage, and every observed drift instance was
+   * agent-authored.
+   *
+   * Self-assignment intentionally does NOT go through assertCanAssignTasks. An
+   * agent taking its own work needs no tasks:assign grant -- the same carve-out
+   * the checkout and return-to-creator paths already make -- and requiring one
+   * would fail creates that succeed today.
+   */
+  function agentCreatorAutoAssigneeAgentId(
+    req: Request,
+    body: { assigneeAgentId?: unknown; assigneeUserId?: unknown },
+  ): string | null {
+    if (req.actor.type !== "agent" || !req.actor.agentId) return null;
+    if (body.assigneeAgentId || body.assigneeUserId) return null;
+    return req.actor.agentId;
+  }
+
+  function markIssueAutoAssignedToCreator(res: Response) {
+    res.setHeader("X-Paperclip-Issue-Autoassigned", "creator");
+  }
+
   function taskBridgeOriginForActor(req: Request) {
     return isTaskBridgeKeyActor(req) && req.actor.keyId
       ? { originKind: "task_bridge", originId: req.actor.keyId }
@@ -6997,6 +7024,11 @@ export function issueRoutes(
       companyId,
       rawCreateBody.assigneeAgentId as string | null | undefined,
     );
+    const autoAssigneeAgentId = agentCreatorAutoAssigneeAgentId(req, {
+      assigneeAgentId: normalizedAssigneeAgentId ?? rawCreateBody.assigneeAgentId,
+      assigneeUserId: rawCreateBody.assigneeUserId,
+    });
+    if (autoAssigneeAgentId) markIssueAutoAssignedToCreator(res);
     const actor = getActorInfo(req);
     const runWorkspaceInheritanceSourceIssueId = hasExplicitIssueWorkspaceCreateSelection(rawCreateBody)
       ? null
@@ -7005,6 +7037,7 @@ export function issueRoutes(
       ...rawCreateBody,
       parentId: effectiveParentId,
       ...(normalizedAssigneeAgentId !== undefined ? { assigneeAgentId: normalizedAssigneeAgentId } : {}),
+      ...(autoAssigneeAgentId ? { assigneeAgentId: autoAssigneeAgentId } : {}),
       ...(runWorkspaceInheritanceSourceIssueId
         ? { inheritExecutionWorkspaceFromIssueId: runWorkspaceInheritanceSourceIssueId }
         : {}),
@@ -7212,9 +7245,15 @@ export function issueRoutes(
       parent.companyId,
       sanitizedBody.assigneeAgentId as string | null | undefined,
     );
+    const childAutoAssigneeAgentId = agentCreatorAutoAssigneeAgentId(req, {
+      assigneeAgentId: normalizedAssigneeAgentId ?? sanitizedBody.assigneeAgentId,
+      assigneeUserId: sanitizedBody.assigneeUserId,
+    });
+    if (childAutoAssigneeAgentId) markIssueAutoAssignedToCreator(res);
     const createBody = {
       ...sanitizedBody,
       ...(normalizedAssigneeAgentId !== undefined ? { assigneeAgentId: normalizedAssigneeAgentId } : {}),
+      ...(childAutoAssigneeAgentId ? { assigneeAgentId: childAutoAssigneeAgentId } : {}),
     };
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, parent, createBody))) return;
     const childAssignmentScope = {
@@ -7388,9 +7427,15 @@ export function issueRoutes(
         sourceIssue.companyId,
         sanitizedChild.assigneeAgentId as string | null | undefined,
       );
+      const decompositionAutoAssigneeAgentId = agentCreatorAutoAssigneeAgentId(req, {
+        assigneeAgentId: normalizedAssigneeAgentId ?? sanitizedChild.assigneeAgentId,
+        assigneeUserId: sanitizedChild.assigneeUserId,
+      });
+      if (decompositionAutoAssigneeAgentId) markIssueAutoAssignedToCreator(res);
       const childBody = {
         ...sanitizedChild,
         ...(normalizedAssigneeAgentId !== undefined ? { assigneeAgentId: normalizedAssigneeAgentId } : {}),
+        ...(decompositionAutoAssigneeAgentId ? { assigneeAgentId: decompositionAutoAssigneeAgentId } : {}),
       };
       requestedChildren.push(childBody);
       assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(childBody));


### PR DESCRIPTION
## Problem

An agent-authored issue create that omits **both** `assigneeAgentId` and `assigneeUserId` produces an issue that nobody is ever woken for. Nothing schedules or notifies against a null-assignee issue, so the work is silently invisible — it only surfaces when an out-of-band drift scan finds it.

In `server/src/routes/issues.ts`, all three agent-reachable create paths guard assignment with the same shape:

```ts
if (req.body.assigneeAgentId || req.body.assigneeUserId) {
  await assertCanAssignTasks(req, ...);
}
```

Omitting the assignee skips every assignment check **and** creates silently. `assigneeAgentId` is `z.string().uuid().optional().nullable()`, so an absent value is fully valid at the schema layer.

This is exactly how a prior fix could be marked "done" while never taking effect — it shipped with no test, silently regressed, and 32 dormant, unassigned issues accumulated on our board before a drift scan caught them. One of those drift instances came in through a **child** create path, not the top-level route.

## Fix

When the actor is an agent and both assignee fields are null/absent, default `assigneeAgentId` to the creating agent's id and set response header `X-Paperclip-Issue-Autoassigned: creator`.

Applied to **all three** agent-reachable create paths (the original scoping named only the first):

- `POST /companies/:companyId/issues`
- `POST /issues/:id/children`  ← high-traffic delegation path; the one observed live drift instance came through here
- `POST /issues/:id/accepted-plan-decompositions`

### Design choices

- **Default, not a 422.** Human/UI creates legitimately leave an issue unassigned for triage. Every observed drift instance was agent-authored, so defaulting the agent case is sufficient and non-breaking for humans.
- **Self-assignment does not go through `assertCanAssignTasks`.** An agent taking its own work needs no `tasks:assign` grant — the same carve-out the checkout and return-to-creator paths already make. Requiring one would 403 creates that succeed today.

## Test

Adds `server/src/__tests__/issue-create-null-assignee-guard-routes.test.ts` — the regression test the original fix never had. Covers:

- top-level agent create with no assignee → defaults to creator, sets the header
- child agent create with no assignee → defaults to creator, sets the header
- explicit `assigneeAgentId` delegation → left untouched, no header
- board/UI-authored unassigned create → left unassigned (triage case preserved)

> Note: the embedded-Postgres suite skips on hosts where embedded PG is unavailable (`describeEmbeddedPostgres`), so verify in CI where embedded PG runs.

## Rollback

Revert the defaulting block. Downstream operators who run a nightly null-assignee drift scan keep that as a safety net, so rollback only widens detection latency rather than reopening the hole.

---

Filed upstream per operator request. Internal ref: ALAA-2113 (regression of ALAA-766).
