### PR TITLE
fix(codex-local): terminate codex child on turn.completed to avoid post-completion hang

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -145,6 +145,25 @@ function signalCodexChild(
   return false;
 }
 
+// RENA-49746: Codex emits `{"type":"turn.completed",...}` on stdout once the turn's
+// work is fully done, but the child process can then hang for minutes before exiting.
+// Detecting this line lets the adapter terminate the child proactively instead of
+// waiting for the output-inactivity monitor (which mis-reports completed work as failed).
+export function stdoutChunkHasTurnCompleted(chunk: string): boolean {
+  if (typeof chunk !== "string" || chunk.indexOf("turn.completed") === -1) return false;
+  for (const rawLine of chunk.split(/\r?\n/)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed[0] !== "{") continue;
+    try {
+      const parsed = JSON.parse(trimmed) as { type?: unknown } | null;
+      if (parsed && parsed.type === "turn.completed") return true;
+    } catch {
+      // Not a complete JSON line (partial chunk); ignore.
+    }
+  }
+  return false;
+}
+
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
   return typeof raw === "string" && raw.trim().length > 0;
@@ -1047,6 +1066,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       let killTarget: { pid: number | null; processGroupId: number | null } | null = null;
       let sigkillTimer: ReturnType<typeof setTimeout> | null = null;
       let monitorLogPromise: Promise<unknown> | null = null;
+      // RENA-49746: set once we proactively terminate the child on turn.completed.
+      let turnCompletedTermination = false;
+      let turnCompletedSigkillTimer: ReturnType<typeof setTimeout> | null = null;
 
       const monitor =
         monitorResolution.mode === "disabled"
@@ -1108,6 +1130,32 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             monitor?.noteOutputChunk(stream, chunk);
             if (stream === "stdout") {
               await onLog(stream, chunk);
+              // RENA-49746: terminate proactively on turn.completed so we do not
+              // wait out the output-inactivity monitor for a run whose work is done.
+              if (!turnCompletedTermination && stdoutChunkHasTurnCompleted(chunk)) {
+                const target = killTarget;
+                // Only act once we have a real child to terminate. If the spawn
+                // target is not yet known, leave the inactivity monitor armed as
+                // the fallback and re-evaluate on the next stdout chunk.
+                if (target && (target.pid != null || target.processGroupId != null)) {
+                  turnCompletedTermination = true;
+                  // Stop the inactivity monitor so it cannot also fire and
+                  // mislabel this completed run as a monitor timeout.
+                  monitor?.stop();
+                  const logLine =
+                    "[paperclip] adapter.invoke detected codex turn.completed; " +
+                    "terminating codex child via SIGTERM (5s grace, then SIGKILL) to avoid post-completion hang.\n";
+                  monitorLogPromise = Promise.resolve(onLog("stderr", logLine)).catch(() => {});
+                  signalCodexChild(target, "SIGTERM");
+                  turnCompletedSigkillTimer = setTimeout(() => {
+                    turnCompletedSigkillTimer = null;
+                    signalCodexChild(target, "SIGKILL");
+                  }, CODEX_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS);
+                  if (typeof (turnCompletedSigkillTimer as { unref?: () => void }).unref === "function") {
+                    (turnCompletedSigkillTimer as { unref: () => void }).unref();
+                  }
+                }
+              }
               return;
             }
             const cleaned = stripCodexRolloutNoise(chunk);
@@ -1125,6 +1173,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           },
           rawStderr: proc.stderr,
           parsed: parseCodexJsonl(proc.stdout),
+          turnCompleted: turnCompletedTermination,
           monitor: monitorFired
             ? {
                 fired: true as const,
@@ -1140,6 +1189,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           clearTimeout(sigkillTimer);
           sigkillTimer = null;
         }
+        if (turnCompletedSigkillTimer) {
+          clearTimeout(turnCompletedSigkillTimer);
+          turnCompletedSigkillTimer = null;
+        }
         if (monitorLogPromise) {
           await monitorLogPromise;
           monitorLogPromise = null;
@@ -1152,6 +1205,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
         rawStderr: string;
         parsed: ReturnType<typeof parseCodexJsonl>;
+        turnCompleted?: boolean;
         monitor?:
           | { fired: false }
           | { fired: true; terminationSignal: NodeJS.Signals | null; elapsedMsSinceLastEvent: number; timeoutMs: number };
@@ -1159,7 +1213,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       clearSessionOnMissingSession = false,
       isRetry = false,
     ): AdapterExecutionResult => {
-      if (attempt.monitor?.fired) {
+      // RENA-49746: when we terminated the child ourselves after codex reported
+      // turn.completed, the turn's results are already complete. Treat it as a
+      // successful run regardless of the exit code/signal produced by our own kill,
+      // and never surface a monitor-timeout or transient error for it.
+      const gracefulTurnCompletion = attempt.turnCompleted === true;
+      if (attempt.monitor?.fired && !gracefulTurnCompletion) {
         const errorMessage = formatOutputInactivityMonitorErrorMessage(attempt.monitor.elapsedMsSinceLastEvent);
         return {
           exitCode: null,
@@ -1227,7 +1286,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderrLine ||
         `Codex exited with code ${attempt.proc.exitCode ?? -1}`;
       const transientRetryNotBefore =
-        (attempt.proc.exitCode ?? 0) !== 0
+        !gracefulTurnCompletion && (attempt.proc.exitCode ?? 0) !== 0
           ? extractCodexRetryNotBefore({
               stdout: attempt.proc.stdout,
               stderr: attempt.proc.stderr,
@@ -1235,7 +1294,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             })
           : null;
       const authRefreshFailure =
-        (attempt.proc.exitCode ?? 0) !== 0
+        !gracefulTurnCompletion && (attempt.proc.exitCode ?? 0) !== 0
           ? classifyCodexAuthRefreshFailure({
               stdout: attempt.proc.stdout,
               stderr: attempt.proc.stderr,
@@ -1243,6 +1302,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             })
           : null;
       const providerQuota =
+        !gracefulTurnCompletion &&
         (attempt.proc.exitCode ?? 0) !== 0 &&
         !authRefreshFailure &&
         isCodexProviderQuotaError({
@@ -1251,6 +1311,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           errorMessage: fallbackErrorMessage,
         });
       const transientUpstream =
+        !gracefulTurnCompletion &&
         (attempt.proc.exitCode ?? 0) !== 0 &&
         !authRefreshFailure &&
         !providerQuota &&
@@ -1266,7 +1327,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         signal: attempt.proc.signal,
         timedOut: false,
         errorMessage:
-          (attempt.proc.exitCode ?? 0) === 0
+          gracefulTurnCompletion || (attempt.proc.exitCode ?? 0) === 0
             ? null
             : fallbackErrorMessage,
         errorCode:

--- a/packages/adapters/codex-local/src/server/execute.turn-completed.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.turn-completed.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { stdoutChunkHasTurnCompleted } from "./execute.js";
+
+describe("stdoutChunkHasTurnCompleted", () => {
+  it("returns true for a complete turn.completed JSON line", () => {
+    expect(
+      stdoutChunkHasTurnCompleted('{"type":"turn.completed","usage":{"input_tokens":10}}\n'),
+    ).toBe(true);
+  });
+
+  it("returns true when turn.completed is one of several JSONL lines", () => {
+    const chunk =
+      '{"type":"item.completed","item":{"id":"1"}}\n' +
+      '{"type":"turn.completed","usage":{"input_tokens":5}}\n';
+    expect(stdoutChunkHasTurnCompleted(chunk)).toBe(true);
+  });
+
+  it("returns false for a partial JSON chunk that is not yet parseable", () => {
+    expect(stdoutChunkHasTurnCompleted('{"type":"turn.compl')).toBe(false);
+  });
+
+  it("returns false when 'turn.completed' only appears as a substring, not the type", () => {
+    expect(
+      stdoutChunkHasTurnCompleted('{"type":"agent_message","text":"the turn.completed event"}'),
+    ).toBe(false);
+  });
+
+  it("returns false for a JSON line with a different type", () => {
+    expect(stdoutChunkHasTurnCompleted('{"type":"turn.started"}\n')).toBe(false);
+  });
+
+  it("returns false for empty, non-JSON, or non-string input", () => {
+    expect(stdoutChunkHasTurnCompleted("")).toBe(false);
+    expect(stdoutChunkHasTurnCompleted("plain log line without json\n")).toBe(false);
+    // @ts-expect-error exercising the runtime guard for non-string input
+    expect(stdoutChunkHasTurnCompleted(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the codex-local adapter hang after `turn.completed` (internally tracked as RENA-49746 / RENA-49733). Previously the codex child process could stay alive after emitting `turn.completed`, and only the `codex_output_inactivity_monitor` would kill it ~7 minutes later, producing "no codex output for 7m" timeouts (111/24h at peak) that were misclassified as failures/retries.

## Changes (`packages/adapters/codex-local/src/server/execute.ts`)

- Add exported helper `stdoutChunkHasTurnCompleted(chunk)` — true only when a stdout JSON line has `type === "turn.completed"`; partial/substring-only chunks return false.
- In the stdout `onLog` path: on the first `turn.completed`, once a real kill target exists — stop the monitor, log the termination line, `SIGTERM` then `SIGKILL` after `CODEX_OUTPUT_INACTIVITY_MONITOR_SIGTERM_GRACE_MS`, `unref()` the timer (cleared in `finally`), and mark the attempt `turnCompleted: true`.
- In `toResult`: `gracefulTurnCompletion = attempt.turnCompleted === true` skips the `codex_output_inactivity_monitor` branch and suppresses transient-upstream / auth-refresh / provider-quota / retry classification, returning `errorMessage: null` (run succeeds).
- New test `execute.turn-completed.test.ts` covering the 6 detection edge cases.

## Verification

- `tsc --noEmit` on the package: clean (exit 0).
- `vitest run execute.turn-completed.test.ts`: 6/6 passed.
- `execute.test.ts` + inactivity-monitor tests: no new regressions (3 pre-existing Windows real-subprocess signal cases fail identically on pristine `master`).

This same change is already live as a hand-applied hotfix on the vendored dist in production; this PR lands it in the upstream TypeScript source so it survives the next package rebuild.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
