### PR TITLE
fix(kubernetes): honor exec cwd, explain signal-shaped exit statuses, declare timeoutMs

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -74,7 +74,7 @@ Common optional fields:
 | `serviceAccountAnnotations` | `{}` | Annotations applied to per-tenant ServiceAccount (e.g. IRSA `eks.amazonaws.com/role-arn`). |
 | `jobTtlSecondsAfterFinished` | `900` | Seconds after a Job completes before garbage-collection. |
 | `podActivityDeadlineSec` | `3600` | Hard ceiling on a single run's wall-clock time. |
-| `timeoutMs` | `30000` (server default) | RPC budget paperclip-server grants lease lifecycle calls. Raise it (e.g. `180000`) when a company's first dispatch has to bootstrap the tenant namespace and pull the runtime image. |
+| `timeoutMs` | `30000` (server default) | RPC budget paperclip-server grants lease lifecycle calls. Raise it (e.g. `180000`) when a company's first dispatch has to bootstrap the tenant namespace and pull the runtime image. Capped at 15 minutes by the server's plugin RPC ceiling. |
 
 Full JSON Schema in `src/manifest.ts`.
 

--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -74,6 +74,7 @@ Common optional fields:
 | `serviceAccountAnnotations` | `{}` | Annotations applied to per-tenant ServiceAccount (e.g. IRSA `eks.amazonaws.com/role-arn`). |
 | `jobTtlSecondsAfterFinished` | `900` | Seconds after a Job completes before garbage-collection. |
 | `podActivityDeadlineSec` | `3600` | Hard ceiling on a single run's wall-clock time. |
+| `timeoutMs` | `30000` (server default) | RPC budget paperclip-server grants lease lifecycle calls. Raise it (e.g. `180000`) when a company's first dispatch has to bootstrap the tenant namespace and pull the runtime image. |
 
 Full JSON Schema in `src/manifest.ts`.
 

--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -74,7 +74,7 @@ Common optional fields:
 | `serviceAccountAnnotations` | `{}` | Annotations applied to per-tenant ServiceAccount (e.g. IRSA `eks.amazonaws.com/role-arn`). |
 | `jobTtlSecondsAfterFinished` | `900` | Seconds after a Job completes before garbage-collection. |
 | `podActivityDeadlineSec` | `3600` | Hard ceiling on a single run's wall-clock time. |
-| `timeoutMs` | `30000` (server default) | RPC budget paperclip-server grants lease lifecycle calls. Raise it (e.g. `180000`) when a company's first dispatch has to bootstrap the tenant namespace and pull the runtime image. Capped at 15 minutes by the server's plugin RPC ceiling. |
+| `timeoutMs` | `30000` (server default) | RPC budget paperclip-server grants lease lifecycle calls. Raise it (e.g. `180000`) when a company's first dispatch has to bootstrap the tenant namespace and pull the runtime image. Rejected above `900000`, the 15 minute ceiling paperclip-server applies to every plugin RPC. |
 
 Full JSON Schema in `src/manifest.ts`.
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -102,7 +102,7 @@ const manifest: PaperclipPluginManifestV1 = {
             minimum: 1,
             maximum: 86400000,
             description:
-              "RPC budget in milliseconds for lease lifecycle calls (acquire/resume/release/execute). Default 30000 (paperclip-server default). Raise it for clusters where the first dispatch is slow to bootstrap the tenant namespace or pull the runtime image.",
+              "RPC budget in milliseconds for lease lifecycle calls (acquire/resume/release/execute). Default 30000 (paperclip-server default). Raise it for clusters where the first dispatch is slow to bootstrap the tenant namespace or pull the runtime image. Values above 900000 cannot take effect: paperclip-server caps every plugin RPC at 15 minutes.",
           },
           adapterType: {
             type: "string",

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -97,6 +97,13 @@ const manifest: PaperclipPluginManifestV1 = {
             minimum: 1,
             description: "Hard ceiling on a single run's wall-clock time (default: 3600).",
           },
+          timeoutMs: {
+            type: "integer",
+            minimum: 1,
+            maximum: 86400000,
+            description:
+              "RPC budget in milliseconds for lease lifecycle calls (acquire/resume/release/execute). Default 30000 (paperclip-server default). Raise it for clusters where the first dispatch is slow to bootstrap the tenant namespace or pull the runtime image.",
+          },
           adapterType: {
             type: "string",
             description:

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -100,9 +100,11 @@ const manifest: PaperclipPluginManifestV1 = {
           timeoutMs: {
             type: "integer",
             minimum: 1,
-            maximum: 86400000,
+            // Keep in step with HOST_MAX_RPC_TIMEOUT_MS in src/types.ts: paperclip-server
+            // caps every plugin RPC at 15 minutes, so a larger budget cannot take effect.
+            maximum: 900000,
             description:
-              "RPC budget in milliseconds for lease lifecycle calls (acquire/resume/release/execute). Default 30000 (paperclip-server default). Raise it for clusters where the first dispatch is slow to bootstrap the tenant namespace or pull the runtime image. Values above 900000 cannot take effect: paperclip-server caps every plugin RPC at 15 minutes.",
+              "RPC budget in milliseconds for lease lifecycle calls (acquire/resume/release/execute). Default 30000 (paperclip-server default). Raise it for clusters where the first dispatch is slow to bootstrap the tenant namespace or pull the runtime image. Capped at 900000 (15 minutes), the ceiling paperclip-server applies to every plugin RPC.",
           },
           adapterType: {
             type: "string",

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -85,6 +85,40 @@ function generateBootstrapToken(): string {
   return randomBytes(32).toString("hex");
 }
 
+// Exit codes a POSIX shell reports for a child killed by a signal: 128 + signal
+// number. The Kubernetes exec API surfaces only the exit code (its V1Status
+// carries no signal cause), so this is the one piece of information available to
+// tell "the process was killed" from "the process exited non-zero" — the
+// difference between an OOM-killed run (137 = SIGKILL, the common Kubernetes
+// case) and a run that simply failed. Only signals 1-15 are mapped: their
+// numbers are identical across the Linux ABIs sandbox pods run on, whereas
+// higher numbers are architecture-dependent. The mapping is a convention, not a
+// guarantee — a command is free to `exit 137` itself — so callers should treat
+// `signal` as diagnostic, exactly as they must for the providers that read it
+// off a real child process.
+const SIGNALS_BY_EXIT_CODE: Record<number, string> = {
+  129: "SIGHUP",
+  130: "SIGINT",
+  131: "SIGQUIT",
+  132: "SIGILL",
+  133: "SIGTRAP",
+  134: "SIGABRT",
+  135: "SIGBUS",
+  136: "SIGFPE",
+  137: "SIGKILL",
+  138: "SIGUSR1",
+  139: "SIGSEGV",
+  140: "SIGUSR2",
+  141: "SIGPIPE",
+  142: "SIGALRM",
+  143: "SIGTERM",
+};
+
+function signalFromExitCode(exitCode: number | null): string | null {
+  if (exitCode === null) return null;
+  return SIGNALS_BY_EXIT_CODE[exitCode] ?? null;
+}
+
 // One FastUploadInterceptor instance per active lease. Scoping per lease
 // prevents `releaseLease` from wiping in-flight upload buffers belonging to
 // other concurrent leases — a single shared singleton would do exactly that
@@ -661,6 +695,7 @@ const plugin = definePlugin({
     if (!lease.providerLeaseId) {
       return {
         exitCode: 1,
+        signal: null,
         timedOut: false,
         stdout: "",
         stderr: "No provider lease ID available for execution.",
@@ -727,6 +762,7 @@ const plugin = definePlugin({
           if (err instanceof SandboxCrTimeoutError) {
             return {
               exitCode: null,
+              signal: null,
               timedOut: true,
               stdout: "",
               stderr: `Sandbox pod did not become Ready within ${effectiveTimeoutMs}ms`,
@@ -754,6 +790,7 @@ const plugin = definePlugin({
       if (!podName) {
         return {
           exitCode: 1,
+          signal: null,
           timedOut: false,
           stdout: "",
           stderr: "Sandbox pod is Ready but podName could not be resolved.",
@@ -785,6 +822,7 @@ const plugin = definePlugin({
         if (decision.action === "ack") {
           return {
             exitCode: 0,
+            signal: null,
             timedOut: false,
             stdout: "",
             stderr: "",
@@ -834,6 +872,7 @@ const plugin = definePlugin({
           } catch (err) {
             return {
               exitCode: null,
+              signal: null,
               timedOut: true,
               stdout: "",
               stderr: `fast-upload flush failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -849,6 +888,7 @@ const plugin = definePlugin({
           }
           return {
             exitCode: flushResult.exitCode,
+            signal: signalFromExitCode(flushResult.exitCode),
             timedOut: false,
             stdout: flushResult.stdout,
             stderr: flushResult.stderr,
@@ -873,12 +913,16 @@ const plugin = definePlugin({
             ? ["/bin/sh", "-lc", command]
             : ["/bin/sh", "-l"];
 
-      // Apply the caller-provided run env (params.env) to the in-pod process. Without
-      // this the adapter's runtime env (e.g. XDG_CONFIG_HOME pointing at the shipped
-      // OpenCode config, plus helper settings like small_model/provider routing) never
-      // reaches the harness, which falls back to its in-image HOME config -> wrong or
-      // partial behaviour.
-      const execCommand = wrapCommandWithEnv(baseExecCommand, params.env);
+      // Apply the caller-provided working directory (params.cwd) and run env
+      // (params.env) to the in-pod process. Without the env the adapter's runtime env
+      // (e.g. XDG_CONFIG_HOME pointing at the shipped OpenCode config, plus helper
+      // settings like small_model/provider routing) never reaches the harness, which
+      // falls back to its in-image HOME config -> wrong or partial behaviour. Without
+      // the cwd the command runs in the image's WORKDIR, so any relative path the
+      // caller emits resolves against the wrong directory — the caller's own
+      // `cwd`/`remoteCwd` contract (adapter-utils execution-target) assumes the
+      // provider honors it, as the other sandbox providers do.
+      const execCommand = wrapCommandWithEnv(baseExecCommand, params.env, params.cwd);
 
       // Remaining share of the caller's budget after the readiness wait (floor
       // of 5s so an exec attempt is still made when readiness consumed most of
@@ -904,6 +948,7 @@ const plugin = definePlugin({
         // the caller can retry instead of hanging forever.
         return {
           exitCode: null,
+          signal: null,
           timedOut: true,
           stdout: "",
           stderr: appendNetworkEgressDenyHint(err instanceof Error ? err.message : String(err), scopedNetworkEgress),
@@ -919,6 +964,7 @@ const plugin = definePlugin({
 
       return {
         exitCode: execResult.exitCode,
+        signal: signalFromExitCode(execResult.exitCode),
         timedOut: false,
         stdout: execResult.stdout,
         stderr: appendNetworkEgressDenyHint(execResult.stderr, scopedNetworkEgress),
@@ -936,7 +982,8 @@ const plugin = definePlugin({
       // We do NOT re-exec command/args — instead we wait for the Job to finish
       // and collect its logs.
       //
-      // params.command / params.args / params.stdin are intentionally ignored.
+      // params.command / params.args / params.cwd / params.stdin are
+      // intentionally ignored.
 
       let status;
       let timedOut = false;
@@ -983,6 +1030,7 @@ const plugin = definePlugin({
 
       return {
         exitCode: timedOut ? null : status?.phase === "Succeeded" ? 0 : 1,
+        signal: null,
         timedOut,
         stdout: stdoutChunks.join(""),
         stderr: appendNetworkEgressDenyHint(stderrChunks.join(""), scopedNetworkEgress),

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -85,13 +85,6 @@ function generateBootstrapToken(): string {
   return randomBytes(32).toString("hex");
 }
 
-// Ceiling paperclip-server applies to every plugin RPC (MAX_RPC_TIMEOUT_MS in
-// server/src/services/plugin-worker-manager.ts). A larger `timeoutMs` on this
-// provider's config is accepted — the server's own environment config schema
-// accepts up to 24h — but cannot take effect, so validateConfig warns instead of
-// letting the operator believe a bigger budget applies.
-const HOST_MAX_RPC_TIMEOUT_MS = 15 * 60 * 1_000;
-
 // A Kubernetes exec reports only an exit code: the V1Status it ends with carries
 // an "ExitCode" cause and no termination signal, and the pod's container status
 // describes PID 1, not the process we exec'd. The provider therefore never fills
@@ -248,11 +241,6 @@ const plugin = definePlugin({
     }
     const warnings: string[] = [];
     const cfg = parsed.data;
-    if (cfg.timeoutMs !== undefined && cfg.timeoutMs > HOST_MAX_RPC_TIMEOUT_MS) {
-      warnings.push(
-        `timeoutMs=${cfg.timeoutMs} exceeds the ${HOST_MAX_RPC_TIMEOUT_MS} ms ceiling paperclip-server applies to every plugin RPC, so lease lifecycle calls will still be abandoned after ${HOST_MAX_RPC_TIMEOUT_MS} ms. Keep the sandbox startup path (namespace bootstrap plus image pull) inside that budget rather than raising this value further.`,
-      );
-    }
     const adapterDefaults = getAdapterDefaults(cfg.adapterType, cfg.adapters);
     const totalFqdns = [...adapterDefaults.allowFqdns, ...cfg.egressAllowFqdns];
     if (cfg.egressMode === "standard" && totalFqdns.length > 0) {

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -85,38 +85,30 @@ function generateBootstrapToken(): string {
   return randomBytes(32).toString("hex");
 }
 
-// Exit codes a POSIX shell reports for a child killed by a signal: 128 + signal
-// number. The Kubernetes exec API surfaces only the exit code (its V1Status
-// carries no signal cause), so this is the one piece of information available to
-// tell "the process was killed" from "the process exited non-zero" — the
-// difference between an OOM-killed run (137 = SIGKILL, the common Kubernetes
-// case) and a run that simply failed. Only signals 1-15 are mapped: their
-// numbers are identical across the Linux ABIs sandbox pods run on, whereas
-// higher numbers are architecture-dependent. The mapping is a convention, not a
-// guarantee — a command is free to `exit 137` itself — so callers should treat
-// `signal` as diagnostic, exactly as they must for the providers that read it
-// off a real child process.
-const SIGNALS_BY_EXIT_CODE: Record<number, string> = {
-  129: "SIGHUP",
-  130: "SIGINT",
-  131: "SIGQUIT",
-  132: "SIGILL",
-  133: "SIGTRAP",
-  134: "SIGABRT",
-  135: "SIGBUS",
-  136: "SIGFPE",
-  137: "SIGKILL",
-  138: "SIGUSR1",
-  139: "SIGSEGV",
-  140: "SIGUSR2",
-  141: "SIGPIPE",
-  142: "SIGALRM",
-  143: "SIGTERM",
+// Ceiling paperclip-server applies to every plugin RPC (MAX_RPC_TIMEOUT_MS in
+// server/src/services/plugin-worker-manager.ts). A larger `timeoutMs` on this
+// provider's config is accepted — the server's own environment config schema
+// accepts up to 24h — but cannot take effect, so validateConfig warns instead of
+// letting the operator believe a bigger budget applies.
+const HOST_MAX_RPC_TIMEOUT_MS = 15 * 60 * 1_000;
+
+// A Kubernetes exec reports only an exit code: the V1Status it ends with carries
+// an "ExitCode" cause and no termination signal, and the pod's container status
+// describes PID 1, not the process we exec'd. The provider therefore never fills
+// in `signal` — a POSIX 128+N exit status cannot be told apart from a command
+// that chose the same status, so reporting one would state an unobserved
+// termination as fact. The two statuses that do carry operational meaning on
+// Kubernetes instead get a hedged hint appended to stderr, the same way a likely
+// network-policy denial does (see appendNetworkEgressDenyHint).
+const EXIT_STATUS_HINTS: Record<number, string> = {
+  137: "Exit code 137 matches the POSIX 128+signal convention for SIGKILL, which on Kubernetes usually means the process hit the container memory limit.",
+  143: "Exit code 143 matches the POSIX 128+signal convention for SIGTERM, which usually means the pod was evicted, preempted, or asked to shut down.",
 };
 
-function signalFromExitCode(exitCode: number | null): string | null {
-  if (exitCode === null) return null;
-  return SIGNALS_BY_EXIT_CODE[exitCode] ?? null;
+function appendExitStatusHint(stderr: string, exitCode: number | null): string {
+  const hint = exitCode === null ? undefined : EXIT_STATUS_HINTS[exitCode];
+  if (!hint) return stderr;
+  return `${stderr.trimEnd()}\n${hint} The Kubernetes exec API reports no signal, so a command that deliberately exits with this status is indistinguishable.\n`;
 }
 
 // One FastUploadInterceptor instance per active lease. Scoping per lease
@@ -256,6 +248,11 @@ const plugin = definePlugin({
     }
     const warnings: string[] = [];
     const cfg = parsed.data;
+    if (cfg.timeoutMs !== undefined && cfg.timeoutMs > HOST_MAX_RPC_TIMEOUT_MS) {
+      warnings.push(
+        `timeoutMs=${cfg.timeoutMs} exceeds the ${HOST_MAX_RPC_TIMEOUT_MS} ms ceiling paperclip-server applies to every plugin RPC, so lease lifecycle calls will still be abandoned after ${HOST_MAX_RPC_TIMEOUT_MS} ms. Keep the sandbox startup path (namespace bootstrap plus image pull) inside that budget rather than raising this value further.`,
+      );
+    }
     const adapterDefaults = getAdapterDefaults(cfg.adapterType, cfg.adapters);
     const totalFqdns = [...adapterDefaults.allowFqdns, ...cfg.egressAllowFqdns];
     if (cfg.egressMode === "standard" && totalFqdns.length > 0) {
@@ -888,7 +885,7 @@ const plugin = definePlugin({
           }
           return {
             exitCode: flushResult.exitCode,
-            signal: signalFromExitCode(flushResult.exitCode),
+            signal: null,
             timedOut: false,
             stdout: flushResult.stdout,
             stderr: flushResult.stderr,
@@ -964,10 +961,13 @@ const plugin = definePlugin({
 
       return {
         exitCode: execResult.exitCode,
-        signal: signalFromExitCode(execResult.exitCode),
+        signal: null,
         timedOut: false,
         stdout: execResult.stdout,
-        stderr: appendNetworkEgressDenyHint(execResult.stderr, scopedNetworkEgress),
+        stderr: appendExitStatusHint(
+          appendNetworkEgressDenyHint(execResult.stderr, scopedNetworkEgress),
+          execResult.exitCode,
+        ),
         metadata: {
           provider: "kubernetes",
           backend: "sandbox-cr",

--- a/packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts
@@ -34,24 +34,30 @@ export function shQuote(segment: string): string {
   return `'${segment.replace(/'/g, "'\\''")}'`;
 }
 
-// Wrap a command so the given env vars are exported before it runs. The Kubernetes
-// exec API has no env field, so the only way to give an exec'd process additional
-// env is to run it under a shell that exports the vars and then `exec`s the real
-// command. PATH is deliberately skipped (the caller's PATH is the orchestrator's,
-// not the sandbox image's, and overriding it would break command resolution), and
-// only valid shell identifiers are exported. Returns the original command unchanged
-// when there is nothing to apply.
+// Wrap a command so the given working directory and env vars apply before it runs.
+// The Kubernetes exec API has neither a `cwd` nor an `env` field, so the only way
+// to give an exec'd process either is to run it under a shell that `cd`s, exports
+// the vars, and then `exec`s the real command. The `cd` is chained with `&&` so a
+// missing directory fails the exec loudly instead of silently running the command
+// somewhere else. PATH is deliberately skipped (the caller's PATH is the
+// orchestrator's, not the sandbox image's, and overriding it would break command
+// resolution), and only valid shell identifiers are exported. Returns the original
+// command unchanged when there is nothing to apply.
 export function wrapCommandWithEnv(
   command: string[],
   env: Record<string, string> | undefined | null,
+  cwd?: string | null,
 ): string[] {
   const entries = Object.entries(env && typeof env === "object" ? env : {}).filter(
     ([key, value]) =>
       typeof value === "string" && key !== "PATH" && /^[A-Za-z_][A-Za-z0-9_]*$/.test(key),
   );
-  if (entries.length === 0) return command;
+  const cdPrefix =
+    typeof cwd === "string" && cwd.trim().length > 0 ? `cd ${shQuote(cwd.trim())} && ` : "";
+  if (entries.length === 0 && cdPrefix === "") return command;
   const exports = entries.map(([k, v]) => `export ${k}=${shQuote(v)};`).join(" ");
-  return ["/bin/sh", "-c", `${exports} exec ${command.map(shQuote).join(" ")}`];
+  const body = `${exports}${exports ? " " : ""}exec ${command.map(shQuote).join(" ")}`;
+  return ["/bin/sh", "-c", `${cdPrefix}${body}`];
 }
 
 export async function execInPod(

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -34,6 +34,19 @@ export const kubernetesProviderConfigSchema = z
     podActivityDeadlineSec: z.number().int().positive().default(3600),
 
     /**
+     * RPC budget (ms) paperclip-server grants this environment's lease lifecycle
+     * calls (acquire / resume / release / realizeWorkspace / execute). The server
+     * reads the key off the driver config; without it the 30s default applies,
+     * which is tight for a first dispatch that bootstraps a whole tenant
+     * namespace (ServiceAccount, RBAC, quotas, network policies) and then waits
+     * on the runtime image pull. Declared here because the schema strips keys it
+     * does not know: an operator-set value would otherwise be dropped during
+     * normalization and never reach the server. Recommended: 180000 or more on
+     * clusters with slow first-dispatch bootstrap.
+     */
+    timeoutMs: z.number().int().positive().max(86_400_000).optional(),
+
+    /**
      * The adapter type that Jobs in this environment will run.
      * Each Kubernetes environment is bound to one adapter; create multiple
      * environments for different adapters.

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -43,6 +43,10 @@ export const kubernetesProviderConfigSchema = z
      * does not know: an operator-set value would otherwise be dropped during
      * normalization and never reach the server. Recommended: 180000 or more on
      * clusters with slow first-dispatch bootstrap.
+     *
+     * The bound matches the server's own environment config schema, but note
+     * that paperclip-server caps every plugin RPC at 15 minutes: a larger value
+     * is accepted and warned about by validateConfig rather than taking effect.
      */
     timeoutMs: z.number().int().positive().max(86_400_000).optional(),
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -4,6 +4,16 @@ import { KNOWN_ADAPTER_TYPES } from "./adapter-defaults.js";
 
 const cidrRegex = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/;
 
+/**
+ * Ceiling paperclip-server applies to every plugin RPC (MAX_RPC_TIMEOUT_MS in
+ * server/src/services/plugin-worker-manager.ts). A larger `timeoutMs` cannot
+ * take effect, and a validation warning would not reach the operator (the
+ * server only forwards warnings inside the error payload of a rejected config),
+ * so the schema rejects it rather than letting the host shorten it silently.
+ * Keep the manifest's JSON Schema `maximum` in step with this value.
+ */
+export const HOST_MAX_RPC_TIMEOUT_MS = 15 * 60 * 1_000;
+
 export const kubernetesProviderConfigSchema = z
   .object({
     inCluster: z.boolean().default(false),
@@ -42,13 +52,17 @@ export const kubernetesProviderConfigSchema = z
      * on the runtime image pull. Declared here because the schema strips keys it
      * does not know: an operator-set value would otherwise be dropped during
      * normalization and never reach the server. Recommended: 180000 or more on
-     * clusters with slow first-dispatch bootstrap.
-     *
-     * The bound matches the server's own environment config schema, but note
-     * that paperclip-server caps every plugin RPC at 15 minutes: a larger value
-     * is accepted and warned about by validateConfig rather than taking effect.
+     * clusters with slow first-dispatch bootstrap, up to HOST_MAX_RPC_TIMEOUT_MS.
      */
-    timeoutMs: z.number().int().positive().max(86_400_000).optional(),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .max(
+        HOST_MAX_RPC_TIMEOUT_MS,
+        `timeoutMs must not exceed ${HOST_MAX_RPC_TIMEOUT_MS} ms: paperclip-server caps every plugin RPC at 15 minutes, so a larger budget cannot take effect`,
+      )
+      .optional(),
 
     /**
      * The adapter type that Jobs in this environment will run.

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute.test.ts
@@ -96,36 +96,56 @@ describe("onEnvironmentExecute cwd", () => {
 });
 
 describe("onEnvironmentExecute signal", () => {
-  it("reports the terminating signal for a signal-shaped exit code", async () => {
-    h.execInPod.mockResolvedValue({ exitCode: 137, stdout: "", stderr: "" });
-    const result = await execute();
-    expect(result.exitCode).toBe(137);
-    expect(result.signal).toBe("SIGKILL");
-  });
-
-  it("reports no signal for a clean exit", async () => {
+  // The Kubernetes exec API reports no termination signal, so the provider
+  // reports the field explicitly as null rather than claiming an inferred one.
+  it("reports the signal field explicitly on a clean exit", async () => {
     const result = await execute();
     expect(result.exitCode).toBe(0);
     expect(result.signal).toBeNull();
   });
 
-  it("reports no signal for an ordinary non-zero exit", async () => {
-    h.execInPod.mockResolvedValue({ exitCode: 2, stdout: "", stderr: "" });
+  it("never claims a signal for a signal-shaped exit code it cannot observe", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 137, stdout: "", stderr: "" });
     const result = await execute();
+    expect(result.exitCode).toBe(137);
     expect(result.signal).toBeNull();
   });
 
-  it("reports no signal for an exit code outside the 128+N signal range", async () => {
-    h.execInPod.mockResolvedValue({ exitCode: 200, stdout: "", stderr: "" });
-    const result = await execute();
-    expect(result.signal).toBeNull();
-  });
-
-  it("reports no signal when the exec times out", async () => {
+  it("reports the signal field explicitly when the exec times out", async () => {
     h.execInPod.mockRejectedValue(new Error("execInPod timed out after 5000ms"));
     const result = await execute();
     expect(result.timedOut).toBe(true);
     expect(result.exitCode).toBeNull();
     expect(result.signal).toBeNull();
+  });
+});
+
+describe("onEnvironmentExecute exit-status hints", () => {
+  it("explains what exit code 137 usually means on Kubernetes", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 137, stdout: "", stderr: "boom\n" });
+    const result = await execute();
+    expect(result.stderr).toContain("boom");
+    expect(result.stderr).toContain("SIGKILL");
+    expect(result.stderr).toContain("memory limit");
+  });
+
+  it("explains what exit code 143 usually means on Kubernetes", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 143, stdout: "", stderr: "" });
+    const result = await execute();
+    expect(result.stderr).toContain("SIGTERM");
+  });
+
+  it("says the status is not proof of a termination", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 137, stdout: "", stderr: "" });
+    const result = await execute();
+    expect(result.stderr).toMatch(/reports no signal/);
+  });
+
+  it("leaves stderr untouched for exits that carry no such meaning", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 2, stdout: "", stderr: "usage: ls\n" });
+    expect((await execute()).stderr).toBe("usage: ls\n");
+
+    h.execInPod.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    expect((await execute()).stderr).toBe("");
   });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-execute.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PluginEnvironmentExecuteParams } from "@paperclipai/plugin-sdk";
+
+// Mock the kube-client module so onEnvironmentExecute runs against injected fake
+// API clients instead of a real cluster, and stub execInPod so the command the
+// plugin builds can be asserted without a pod. wrapCommandWithEnv is kept REAL:
+// these tests are about the command the exec path actually sends.
+const h = vi.hoisted(() => ({
+  clients: {} as Record<string, unknown>,
+  execInPod: vi.fn(),
+}));
+
+vi.mock("../../src/kube-client.js", () => ({
+  createKubeConfig: vi.fn(() => ({})),
+  makeKubeClients: vi.fn(() => h.clients),
+}));
+
+vi.mock("../../src/pod-exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/pod-exec.js")>()),
+  execInPod: h.execInPod,
+}));
+
+import plugin from "../../src/plugin.js";
+
+const CONFIG = { inCluster: true, backend: "sandbox-cr" };
+
+// The plugin caches "already observed Ready" sandboxes per lease id for the
+// worker's lifetime, so every call gets a fresh id to keep tests independent.
+let leaseSeq = 0;
+
+async function execute(overrides: Partial<PluginEnvironmentExecuteParams> = {}) {
+  const providerLeaseId = `pc-exec-${++leaseSeq}`;
+  return await plugin.definition.onEnvironmentExecute!({
+    driverKey: "kubernetes",
+    companyId: "acme",
+    environmentId: "env-1",
+    config: CONFIG,
+    lease: {
+      providerLeaseId,
+      metadata: {
+        namespace: "paperclip-acme",
+        jobName: providerLeaseId,
+        podName: "pc-exec-pod",
+        secretName: `${providerLeaseId}-env`,
+        phase: "Running",
+        backend: "sandbox-cr",
+      },
+    },
+    // Not `sh -c <script>`: that shape is claimed by the fast-upload
+    // interceptor, which is a different path from the one under test.
+    command: "ls",
+    args: ["-la"],
+    ...overrides,
+  });
+}
+
+/** The command array execInPod was called with (5th positional argument). */
+function execCommand(): string[] {
+  return h.execInPod.mock.calls[0]![4] as string[];
+}
+
+beforeEach(() => {
+  h.clients = {
+    custom: {
+      getNamespacedCustomObject: vi.fn().mockResolvedValue({
+        metadata: { uid: "uid-1" },
+        status: { phase: "Ready", podName: "pc-exec-pod" },
+      }),
+    },
+  };
+  h.execInPod.mockReset();
+  h.execInPod.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+});
+
+describe("onEnvironmentExecute cwd", () => {
+  it("runs the command in params.cwd", async () => {
+    await execute({ cwd: "/workspace/repo" });
+    expect(execCommand()).toEqual([
+      "/bin/sh",
+      "-c",
+      "cd '/workspace/repo' && exec 'ls' '-la'",
+    ]);
+  });
+
+  it("changes directory before applying params.env", async () => {
+    await execute({ cwd: "/workspace/repo", env: { FOO: "bar" } });
+    expect(execCommand()[2]).toBe(
+      "cd '/workspace/repo' && export FOO='bar'; exec 'ls' '-la'",
+    );
+  });
+
+  it("leaves the command unwrapped when no cwd and no env are given", async () => {
+    await execute();
+    expect(execCommand()).toEqual(["ls", "-la"]);
+  });
+});
+
+describe("onEnvironmentExecute signal", () => {
+  it("reports the terminating signal for a signal-shaped exit code", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 137, stdout: "", stderr: "" });
+    const result = await execute();
+    expect(result.exitCode).toBe(137);
+    expect(result.signal).toBe("SIGKILL");
+  });
+
+  it("reports no signal for a clean exit", async () => {
+    const result = await execute();
+    expect(result.exitCode).toBe(0);
+    expect(result.signal).toBeNull();
+  });
+
+  it("reports no signal for an ordinary non-zero exit", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 2, stdout: "", stderr: "" });
+    const result = await execute();
+    expect(result.signal).toBeNull();
+  });
+
+  it("reports no signal for an exit code outside the 128+N signal range", async () => {
+    h.execInPod.mockResolvedValue({ exitCode: 200, stdout: "", stderr: "" });
+    const result = await execute();
+    expect(result.signal).toBeNull();
+  });
+
+  it("reports no signal when the exec times out", async () => {
+    h.execInPod.mockRejectedValue(new Error("execInPod timed out after 5000ms"));
+    const result = await execute();
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBeNull();
+    expect(result.signal).toBeNull();
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
@@ -74,6 +74,27 @@ describe("plugin", () => {
     expect(result.normalizedConfig?.timeoutMs).toBe(180_000);
   });
 
+  // paperclip-server clamps every plugin RPC at 15 minutes, so a larger budget
+  // cannot take effect. Accepting it (the server's own environment config
+  // schema does) but warning is better than a silent truncation.
+  it("validateConfig warns when timeoutMs exceeds the host RPC ceiling", async () => {
+    const result = await plugin.definition.onEnvironmentValidateConfig!({
+      driverKey: "kubernetes",
+      config: { inCluster: true, egressMode: "cilium", timeoutMs: 1_800_000 },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings?.some((w) => w.includes("900000"))).toBe(true);
+  });
+
+  it("validateConfig does not warn for a timeoutMs the host can honor", async () => {
+    const result = await plugin.definition.onEnvironmentValidateConfig!({
+      driverKey: "kubernetes",
+      config: { inCluster: true, egressMode: "cilium", timeoutMs: 900_000 },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toBeUndefined();
+  });
+
   it("the driver manifest advertises timeoutMs so operators can set it", () => {
     const configSchema = manifest.environmentDrivers?.[0]?.configSchema as {
       properties?: Record<string, { type?: string }>;

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import plugin from "../../src/plugin.js";
 import manifest from "../../src/manifest.js";
+import { HOST_MAX_RPC_TIMEOUT_MS } from "../../src/types.js";
 
 describe("plugin", () => {
   it("exports the kubernetes driver", () => {
@@ -74,32 +75,27 @@ describe("plugin", () => {
     expect(result.normalizedConfig?.timeoutMs).toBe(180_000);
   });
 
-  // paperclip-server clamps every plugin RPC at 15 minutes, so a larger budget
-  // cannot take effect. Accepting it (the server's own environment config
-  // schema does) but warning is better than a silent truncation.
-  it("validateConfig warns when timeoutMs exceeds the host RPC ceiling", async () => {
+  // A validation warning would not reach the operator: the server only
+  // propagates warnings inside the error payload of a REJECTED config
+  // (validatePluginEnvironmentDriverConfig), and drops them on success. A
+  // timeout the host cannot honor therefore has to fail the save.
+  it("validateConfig rejects a timeoutMs above the host RPC ceiling", async () => {
     const result = await plugin.definition.onEnvironmentValidateConfig!({
       driverKey: "kubernetes",
-      config: { inCluster: true, egressMode: "cilium", timeoutMs: 1_800_000 },
+      config: { inCluster: true, timeoutMs: 1_800_000 },
     });
-    expect(result.ok).toBe(true);
-    expect(result.warnings?.some((w) => w.includes("900000"))).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.errors?.[0]).toMatch(/15 minutes/);
   });
 
-  it("validateConfig does not warn for a timeoutMs the host can honor", async () => {
-    const result = await plugin.definition.onEnvironmentValidateConfig!({
-      driverKey: "kubernetes",
-      config: { inCluster: true, egressMode: "cilium", timeoutMs: 900_000 },
-    });
-    expect(result.ok).toBe(true);
-    expect(result.warnings).toBeUndefined();
-  });
-
-  it("the driver manifest advertises timeoutMs so operators can set it", () => {
+  it("the driver manifest advertises timeoutMs with the ceiling the host enforces", () => {
     const configSchema = manifest.environmentDrivers?.[0]?.configSchema as {
-      properties?: Record<string, { type?: string }>;
+      properties?: Record<string, { type?: string; maximum?: number }>;
     };
     expect(configSchema.properties?.timeoutMs?.type).toBe("integer");
+    // Keep the operator-facing JSON Schema in step with the zod schema, so the
+    // form cannot offer a value the provider then rejects.
+    expect(configSchema.properties?.timeoutMs?.maximum).toBe(HOST_MAX_RPC_TIMEOUT_MS);
   });
 
   it("validateConfig rejects unknown backend value", async () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import plugin from "../../src/plugin.js";
+import manifest from "../../src/manifest.js";
 
 describe("plugin", () => {
   it("exports the kubernetes driver", () => {
@@ -58,6 +59,26 @@ describe("plugin", () => {
     });
     expect(result.ok).toBe(true);
     expect(result.normalizedConfig?.backend).toBe("job");
+  });
+
+  // paperclip-server reads `timeoutMs` off the normalized driver config to size
+  // the RPC budget for lease lifecycle calls. A key the schema does not declare
+  // is stripped during normalization, so an operator-set value would never
+  // reach the server.
+  it("validateConfig round-trips timeoutMs into normalizedConfig", async () => {
+    const result = await plugin.definition.onEnvironmentValidateConfig!({
+      driverKey: "kubernetes",
+      config: { inCluster: true, timeoutMs: 180_000 },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.normalizedConfig?.timeoutMs).toBe(180_000);
+  });
+
+  it("the driver manifest advertises timeoutMs so operators can set it", () => {
+    const configSchema = manifest.environmentDrivers?.[0]?.configSchema as {
+      properties?: Record<string, { type?: string }>;
+    };
+    expect(configSchema.properties?.timeoutMs?.type).toBe("integer");
   });
 
   it("validateConfig rejects unknown backend value", async () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -31,6 +31,21 @@ describe("kubernetesProviderConfigSchema", () => {
     ).toThrow();
   });
 
+  it("keeps timeoutMs, the RPC budget paperclip-server reads off the config", () => {
+    const parsed = parseKubernetesProviderConfig({ inCluster: true, timeoutMs: 180_000 });
+    expect(parsed.timeoutMs).toBe(180_000);
+  });
+
+  it("leaves timeoutMs absent when it is not configured (server default applies)", () => {
+    const parsed = parseKubernetesProviderConfig({ inCluster: true });
+    expect(parsed.timeoutMs).toBeUndefined();
+  });
+
+  it("rejects a non-positive or non-integer timeoutMs", () => {
+    expect(() => parseKubernetesProviderConfig({ inCluster: true, timeoutMs: 0 })).toThrow();
+    expect(() => parseKubernetesProviderConfig({ inCluster: true, timeoutMs: 1.5 })).toThrow();
+  });
+
   it("rejects egressAllowCidrs entries that are not valid CIDR", () => {
     expect(() =>
       parseKubernetesProviderConfig({ inCluster: true, egressAllowCidrs: ["not-a-cidr"] }),

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { kubernetesProviderConfigSchema, parseKubernetesProviderConfig } from "../../src/types.js";
+import {
+  HOST_MAX_RPC_TIMEOUT_MS,
+  kubernetesProviderConfigSchema,
+  parseKubernetesProviderConfig,
+} from "../../src/types.js";
 
 describe("kubernetesProviderConfigSchema", () => {
   it("accepts inCluster=true with no kubeconfig", () => {
@@ -44,6 +48,21 @@ describe("kubernetesProviderConfigSchema", () => {
   it("rejects a non-positive or non-integer timeoutMs", () => {
     expect(() => parseKubernetesProviderConfig({ inCluster: true, timeoutMs: 0 })).toThrow();
     expect(() => parseKubernetesProviderConfig({ inCluster: true, timeoutMs: 1.5 })).toThrow();
+  });
+
+  // paperclip-server clamps every plugin RPC at 15 minutes, so a larger budget
+  // cannot take effect. Reject it at save time instead of accepting a value the
+  // host will silently shorten.
+  it("accepts the largest timeoutMs the host can honor", () => {
+    expect(
+      parseKubernetesProviderConfig({ inCluster: true, timeoutMs: HOST_MAX_RPC_TIMEOUT_MS }).timeoutMs,
+    ).toBe(900_000);
+  });
+
+  it("rejects a timeoutMs above the host RPC ceiling", () => {
+    expect(() =>
+      parseKubernetesProviderConfig({ inCluster: true, timeoutMs: HOST_MAX_RPC_TIMEOUT_MS + 1 }),
+    ).toThrow(/15 minutes/);
   });
 
   it("rejects egressAllowCidrs entries that are not valid CIDR", () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/wrap-command-with-env.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/wrap-command-with-env.test.ts
@@ -41,4 +41,29 @@ describe("wrapCommandWithEnv", () => {
     const out = wrapCommandWithEnv(["opencode"], { V: "a'b" });
     expect(out[2]).toContain("export V='a'\\''b';");
   });
+
+  describe("cwd", () => {
+    it("prefixes cd when a cwd is given and there is no env", () => {
+      expect(wrapCommandWithEnv(["ls", "-la"], null, "/workspace/repo")).toEqual([
+        "/bin/sh",
+        "-c",
+        "cd '/workspace/repo' && exec 'ls' '-la'",
+      ]);
+    });
+
+    it("changes directory before exporting the env", () => {
+      const out = wrapCommandWithEnv(["node", "run.js"], { FOO: "bar" }, "/workspace");
+      expect(out[2]).toBe("cd '/workspace' && export FOO='bar'; exec 'node' 'run.js'");
+    });
+
+    it("shell-escapes single quotes in the cwd", () => {
+      const out = wrapCommandWithEnv(["ls"], null, "/tmp/a'b");
+      expect(out[2]).toContain("cd '/tmp/a'\\''b' &&");
+    });
+
+    it("returns the command unchanged when there is no env and no cwd", () => {
+      expect(wrapCommandWithEnv(["ls"], null, null)).toEqual(["ls"]);
+      expect(wrapCommandWithEnv(["ls"], null, "   ")).toEqual(["ls"]);
+    });
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute inside sandbox environments provided by sandbox-provider plugins; the first-party `kubernetes` plugin runs each company in its own namespace and execs commands into a Sandbox-CR pod
> - Callers hand every execute a working directory (`params.cwd`, always set from `remoteCwd` in `packages/adapter-utils/src/execution-target.ts`), but the Kubernetes exec path never applies it: the Kubernetes exec API has no `cwd` field and the plugin does not synthesize one, so commands run in whatever WORKDIR the runtime image happens to declare. Every other sandbox provider (daytona, e2b, modal, novita, exe-dev, cloudflare) honors it
> - The same path leaves `PluginEnvironmentExecuteResult.signal` undefined rather than reporting it, and a run that died on the container memory limit (exit 137, the most common Kubernetes failure) reaches the operator as a bare exit code with no explanation; exe-dev, cloudflare and novita all report the field explicitly
> - And `paperclip-server` reads `timeoutMs` off the driver config to size the RPC budget for lease lifecycle calls, but the plugin's config schema never declared it — zod strips unknown keys, so an operator-set value is dropped during normalization and the 30s default silently applies to a first dispatch that has to bootstrap a whole tenant namespace and pull the runtime image
> - This pull request applies `params.cwd` to the exec'd command, reports `signal` explicitly (always `null`, because the exec API cannot observe one) with a hedged stderr hint for the two exit statuses that carry operational meaning on Kubernetes, and declares `timeoutMs` in both the zod schema and the manifest `configSchema`
> - The benefit is that Kubernetes execution behaves like the other providers: relative paths resolve where the caller said they would, memory-limit kills are legible in run output without claiming a termination the API never reported, and the documented RPC-budget knob actually reaches the server

## Linked Issues or Issue Description

No existing public issue — described in-PR following the bug template. Refs #9002 (open, complementary: it fixes the host/plugin RPC *budget inversion*; this PR declares the config key the same budget is read from, which #9002 does not add).

**What happened?**

Three defects in the same execute path of `packages/plugins/sandbox-providers/kubernetes`:

1. `onEnvironmentExecute` builds its exec command with `wrapCommandWithEnv(baseExecCommand, params.env)` (`src/plugin.ts`) and never references `params.cwd`. The command therefore runs in the image's WORKDIR. It works today only because the shipped agent-runtime images declare a WORKDIR that happens to match the workspace directory — a latent break for any custom image, any `imageOverride`, and any caller that passes a cwd other than the workspace root.
2. Every result returned by `onEnvironmentExecute` omits `signal`, which the plugin protocol defines as `signal?: string | null`, so consumers cannot tell "no signal" from "this provider did not answer". Worse, a run killed on the container memory limit surfaces as a bare `exitCode: 137` with nothing in the run output explaining what that status means on Kubernetes.
3. `kubernetesProviderConfigSchema` does not declare `timeoutMs`. `resolvePluginSandboxRpcTimeoutMs` (`server/src/services/environment-runtime.ts`) and `resolvePluginExecuteRpcTimeoutMs` (`server/src/services/plugin-environment-driver.ts`) both read `config.timeoutMs`; without it every lifecycle RPC falls back to `DEFAULT_RPC_TIMEOUT_MS` (30s). `acquireLease` on a company's first dispatch creates the namespace, ServiceAccount, Role, RoleBinding, ResourceQuota, LimitRange and network policies, then creates the Sandbox CR and waits on an image pull. 30s is not enough, and because the schema strips undeclared keys, an operator who sets `timeoutMs` today has it removed from `normalizedConfig` with no error and no warning.

**Expected behavior**

`params.cwd` is honored, results report `signal` explicitly, an exit status that looks like a termination is explained rather than left bare, and `timeoutMs` survives config normalization.

## What Changed

- `wrapCommandWithEnv(command, env, cwd?)` now prefixes a shell-quoted `cd <cwd> && ` when a cwd is given, and `onEnvironmentExecute` passes `params.cwd`. The `cd` is chained with `&&` so a missing directory fails the exec loudly instead of silently running the command elsewhere. With neither env nor cwd the command is still returned unwrapped, exactly as before.
- Set `signal` explicitly on every `onEnvironmentExecute` return path. It is always `null` and deliberately never inferred: a Kubernetes exec ends in a `V1Status` carrying an `ExitCode` cause and no termination signal, and the pod's container status describes PID 1 rather than the exec'd process, so a `128 + N` status cannot be told apart from a command that chose the same status. Reporting one would state an unobserved termination as fact.
- Added a hedged stderr hint for exit 137 and exit 143 — the two statuses that carry real operational meaning on Kubernetes (memory-limit kill, termination/eviction) — in the same spirit as the existing `appendNetworkEgressDenyHint`. The hint says what the status usually means and that the API reports no signal, so it is not mistaken for proof.
- Declared `timeoutMs` in `kubernetesProviderConfigSchema` and in the manifest `configSchema`, so it survives normalization and is offered to operators. It is bounded by `HOST_MAX_RPC_TIMEOUT_MS` (900000), the ceiling `plugin-worker-manager` applies to every plugin RPC: a larger budget cannot take effect, and a warning would not reach the operator (the server forwards validation warnings only inside the error payload of a rejected config), so an oversized value is rejected at save time with an actionable message instead of being silently clamped. A test pins the manifest's JSON Schema `maximum` to the same constant.
- Documented `timeoutMs` in the provider README config table.
- Added unit tests for all three behaviors, including a new `test/unit/plugin-execute.test.ts` covering the exec path with mocked kube clients.

## Verification

- `pnpm --dir packages/plugins/sandbox-providers/kubernetes test` — 204 passed, 22 of them new. The 7 failures in `test/unit/file-sync.test.ts` are pre-existing on `master` in this environment and unrelated: those tests exercise `/proc/self/fd/<n>`, which does not exist on macOS (`realpath: /proc/self/fd/8: No such file or directory`). Verified by running the same suite on a clean checkout of `master`: identical 7 failures, 182 passed.
- `pnpm --dir packages/plugins/sandbox-providers/kubernetes typecheck` — passed.
- Each behavior was test-driven: the new tests were written first and observed failing (`expected [ 'ls', '-la' ] to deeply equal [ '/bin/sh', '-c', "cd '/workspace/repo' && exec 'ls' '-la'" ]`, `expected undefined to be null` for `signal`, `expected undefined to be 180000` for the normalized `timeoutMs`) before the implementation landed. The same applies to both review rounds: the "never claims a signal", stderr-hint, timeout-rejection and manifest-ceiling tests were each written and observed failing before their change.

## Risks

- Behavioral change: a command whose `cwd` does not exist in the sandbox now fails with the shell's `cd` error instead of silently running in the image WORKDIR. This is the intended fail-loud semantic and matches the other providers; callers already guarantee the directory exists (`ensureAbsoluteDirectory` in `packages/adapter-utils/src/execution-target.ts` creates or validates it, and rejects non-absolute paths, before any execute).
- The exit-status hint appends one line to stderr for exit 137 and exit 143 only, and is explicitly hedged, so it cannot be read as an observed signal. All other statuses leave stderr byte-identical.
- `timeoutMs` is optional with no default, so absent config keeps today's behavior exactly. No stored Kubernetes environment can carry the key today (the schema stripped it, and `validatePluginEnvironmentDriverConfig` persists the normalized config), so the new upper bound cannot invalidate an existing configuration. The 15 minute host ceiling is duplicated in the plugin as `HOST_MAX_RPC_TIMEOUT_MS`; if `MAX_RPC_TIMEOUT_MS` is ever raised, this bound has to be raised with it.
- The fast-upload interceptor path is deliberately left alone: it rewrites the caller's own script against the absolute target paths embedded in it, so it has no relative-path exposure.
- The `job` backend ignores `cwd` as it already ignores `command`/`args`/`stdin` (its entrypoint is baked into the Job spec); the comment there was updated to say so.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Anthropic Claude, exact model ID `claude-opus-5[1m]` (Opus 5, 1M context), extended thinking, with tool use and code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
