### PR TITLE
feat(plugin-kubernetes): reusable leases (reuseLease, reuse-aware release, supportsReusableLeases)

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -98,6 +98,11 @@ What to know before turning it on:
   report Ready within 30 seconds, the lease reports itself expired and the run
   falls back to a fresh provision. A Kubernetes pod cannot be revived in place
   the way a stopped VM-backed sandbox can.
+- **Only leases acquired while it was on are kept.** paperclip-server fixes a
+  lease's policy at acquisition, so turning `reuseLease` on takes effect from the
+  next lease onward. Leases already in flight are torn down on release as usual,
+  which is what keeps a mid-lease flip from stranding a pod the server has
+  already written off.
 - **Leases with a task-scoped egress grant are never reused** (below).
 
 ### Task-scoped egress grants

--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -61,6 +61,7 @@ Common optional fields:
 | Field | Default | Purpose |
 |---|---|---|
 | `backend` | `"sandbox-cr"` | `sandbox-cr` (alpha, requires agent-sandbox controller) or `job` (stable, one-shot entrypoint). |
+| `reuseLease` | `false` | Keep the sandbox pod alive on release so the next run resumes it. See [Lease reuse](#lease-reuse). |
 | `adapterType` | `"claude_local"` | One of the supported adapter types (claude_local, codex_local, gemini_local, cursor_local, opencode_local, pi_local). Determines runtime image + env keys + egress allow-list. |
 | `namespacePrefix` | `"paperclip-"` | Prefix for the per-company tenant namespace. |
 | `companySlug` | derived from companyId | Override the auto-derived company slug. |
@@ -76,6 +77,28 @@ Common optional fields:
 | `podActivityDeadlineSec` | `3600` | Hard ceiling on a single run's wall-clock time. |
 
 Full JSON Schema in `src/manifest.ts`.
+
+### Lease reuse
+
+By default every run provisions a fresh sandbox and tears it down on release, so
+each run pays a cold start: namespace bootstrap, pod scheduling, image pull, and
+the adapter install. Set `reuseLease: true` to keep the Sandbox CR, its pod, and
+the per-run Secret alive on release instead. The next run for the same
+environment, execution workspace, agent, and adapter resumes that pod and skips
+the provision entirely.
+
+What to know before turning it on:
+
+- **`sandbox-cr` only.** A Job's pod is terminal once the Job finishes, so a
+  `job` backend lease is always torn down on release regardless of the setting.
+- **The pod keeps running** (and keeps holding namespace quota and node capacity)
+  until paperclip-server destroys the lease. Size `ResourceQuota` for the number
+  of agents you expect to be idle, not just the number running.
+- **Resume is best-effort.** If the pod is gone, terminally failed, or does not
+  report Ready within 30 seconds, the lease reports itself expired and the run
+  falls back to a fresh provision. A Kubernetes pod cannot be revived in place
+  the way a stopped VM-backed sandbox can.
+- **Leases with a task-scoped egress grant are never reused** (below).
 
 ### Task-scoped egress grants
 
@@ -93,6 +116,8 @@ Keep provider-level egress defaults narrow, then grant only the destinations a t
 ```
 
 The provider creates a workload-owned policy selected by the task run label, so the additional destinations do not become reachable from other concurrent agent pods. Cilium mode enforces FQDNs directly. Standard NetworkPolicy mode cannot express FQDNs, so an FQDN grant permits public IPv4 TCP 80/443 for that run while excluding private, loopback, link-local, CGNAT, and multicast ranges. Network failures that look policy-related include the grant path in stderr, and the sandbox exposes the effective policy through `PAPERCLIP_NETWORK_EGRESS_*` environment variables.
+
+A grant is scoped to one run and never outlives it. The policy selects the pod by its run-id label, which is fixed at pod-creation time, so a lease that carried a grant is always torn down on release even when `reuseLease` is on: reusing that pod would hand the next run an egress allowance it never asked for. Workspaces that always request a grant therefore never reuse leases. In the other direction reuse is fail-closed: a resumed lease carries no grant, so a workspace that starts requesting one after the lease was taken sees its egress denied rather than silently widened.
 
 ## What gets created in your cluster
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -23,6 +23,10 @@ const manifest: PaperclipPluginManifestV1 = {
       displayName: "Kubernetes",
       description:
         "Dispatches agent runs in per-tenant Kubernetes namespaces. Default backend (sandbox-cr, alpha) uses kubernetes-sigs/agent-sandbox for multi-command exec; fallback backend (job) uses stable batch/v1 Job for clusters without agent-sandbox installed.",
+      // The driver implements onEnvironmentResumeLease; paperclip-server only
+      // reaches it when this flag is set. Reuse still has to be turned on per
+      // environment through the `reuseLease` config key below.
+      supportsReusableLeases: true,
       configSchema: {
         type: "object",
         properties: {
@@ -107,6 +111,12 @@ const manifest: PaperclipPluginManifestV1 = {
             enum: ["sandbox-cr", "job"],
             description:
               "sandbox-cr (default, alpha — requires kubernetes-sigs/agent-sandbox installed) | job (stable fallback — batch/v1 Job, one-shot entrypoint, no multi-command exec)",
+          },
+          reuseLease: {
+            type: "boolean",
+            description:
+              "Keep the sandbox pod alive on release so the next run resumes it instead of paying a cold provision. Requires backend `sandbox-cr`; the pod keeps running (and holding namespace quota) until the lease is destroyed. Leases that carried a task-scoped egress grant are always torn down. Default false.",
+            default: false,
           },
         },
         anyOf: [

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -482,6 +482,7 @@ const plugin = definePlugin({
       secretName,
       phase: "Pending",
       backend: config.backend,
+      acquiredForReuse: config.reuseLease,
       scopedNetworkPolicyName,
       scopedNetworkEgress,
       // Native file sync streams over a pod exec; only the sandbox-cr backend
@@ -557,6 +558,9 @@ const plugin = definePlugin({
       secretName,
       phase: check.phase,
       backend: leaseBackend,
+      // Carried, not re-derived from the current config: the acquisition-time
+      // decision is what the server's lease policy was fixed against.
+      acquiredForReuse: params.leaseMetadata?.acquiredForReuse === true,
       scopedNetworkPolicyName:
         typeof params.leaseMetadata?.scopedNetworkPolicyName === "string"
           ? params.leaseMetadata.scopedNetworkPolicyName
@@ -629,10 +633,19 @@ const plugin = definePlugin({
     // Only `sandbox-cr` qualifies: a Job's pod is terminal once the Job
     // finishes, so keeping it would leave a lease nothing can exec into.
     //
+    // Reuse must have been on at BOTH ends. The server fixes a lease's policy
+    // at acquisition and never revisits it, so a lease acquired while reuse was
+    // off stays `ephemeral` and is excluded from resume selection forever;
+    // keeping its workload because the config was flipped on mid-lease would
+    // strand a pod that nothing ever reclaims. Requiring the current config too
+    // keeps the mirror exact: the server also re-checks `reuseLease` before it
+    // will resume anything.
+    //
     // Decided before the API client is built: a kept lease issues no request,
     // so there is nothing to authenticate against.
     if (
       config.reuseLease &&
+      params.leaseMetadata?.acquiredForReuse === true &&
       leaseBackend === "sandbox-cr" &&
       !leaseCarriedTaskScopedEgress(params.leaseMetadata)
     ) {

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -119,6 +119,34 @@ const readySandboxesByLease = new Set<string>();
 const RESUME_READY_TIMEOUT_MS = 30_000;
 const RESUME_READY_POLL_MS = 1_000;
 
+/**
+ * True when the lease was granted a task-scoped egress allowance on top of the
+ * provider-level baseline (see createScopedNetworkEgressPolicy).
+ *
+ * Such a lease must ALWAYS be torn down on release, never kept for reuse. The
+ * scoped policy selects the pod by its `paperclip.io/run-id` label, which is
+ * baked in at pod-creation time and therefore stays with a kept-alive pod
+ * forever — a per-task network grant would silently widen egress for whichever
+ * run resumed the lease next. Tearing the workload down cascades the policy
+ * away with it (the policy is owned by the workload) and forces the next run
+ * through acquireLease, which grants exactly its own destinations.
+ *
+ * Both fields are checked: `scopedNetworkPolicyName` records the policy that
+ * was created, `scopedNetworkEgress` the grant that asked for it. They agree in
+ * practice, and requiring both to be empty keeps reuse fail-closed if they ever
+ * do not.
+ */
+function leaseCarriedTaskScopedEgress(
+  leaseMetadata: Record<string, unknown> | null | undefined,
+): boolean {
+  const policyName = leaseMetadata?.scopedNetworkPolicyName;
+  if (typeof policyName === "string" && policyName.length > 0) return true;
+  const grant = parseScopedNetworkEgressGrant({
+    networkEgress: leaseMetadata?.scopedNetworkEgress,
+  });
+  return grant.allowFqdns.length > 0 || grant.allowCidrs.length > 0;
+}
+
 // The workspace remote dir is the confinement root for native file sync. It is
 // recorded on the lease metadata at realizeWorkspace time (`remoteCwd`); require
 // it so a sync can never run without a concrete root to confine every sandbox
@@ -595,8 +623,26 @@ const plugin = definePlugin({
     // Drop the FastUploadInterceptor associated with THIS lease (only).
     // Each lease has its own interceptor instance via uploadInterceptorsByLease,
     // so unrelated concurrent leases keep their in-flight buffers intact.
+    // The readiness cache goes too: a kept-alive pod can still be evicted or
+    // restarted between runs, so the next use must re-confirm it is Ready.
     uploadInterceptorsByLease.delete(params.providerLeaseId);
     readySandboxesByLease.delete(params.providerLeaseId);
+
+    // Reuse: keep the Sandbox CR, its pod, and the per-run Secret so the next
+    // run can resume this lease (see onEnvironmentResumeLease) instead of
+    // paying a cold provision. paperclip-server decides whether to resume the
+    // lease or hard-delete it via onEnvironmentDestroyLease, so nothing is
+    // stranded when the lease stops matching.
+    //
+    // Only `sandbox-cr` qualifies: a Job's pod is terminal once the Job
+    // finishes, so keeping it would leave a lease nothing can exec into.
+    if (
+      config.reuseLease &&
+      leaseBackend === "sandbox-cr" &&
+      !leaseCarriedTaskScopedEgress(params.leaseMetadata)
+    ) {
+      return;
+    }
 
     try {
       await releaseOrchestrator.release(clients, namespace, params.providerLeaseId);

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -607,18 +607,10 @@ const plugin = definePlugin({
         ? params.leaseMetadata.namespace
         : deriveTenantNamespace(config, params.companyId);
 
-    const kc = createKubeConfig({
-      inCluster: config.inCluster,
-      kubeconfig: config.kubeconfig,
-    });
-    const clients = makeKubeClients(kc);
-
     const leaseBackend =
       typeof params.leaseMetadata?.backend === "string"
         ? (params.leaseMetadata.backend as "sandbox-cr" | "job")
         : config.backend;
-    const releaseOrchestrator =
-      leaseBackend === "sandbox-cr" ? sandboxCrOrchestrator : jobOrchestrator;
 
     // Drop the FastUploadInterceptor associated with THIS lease (only).
     // Each lease has its own interceptor instance via uploadInterceptorsByLease,
@@ -636,6 +628,9 @@ const plugin = definePlugin({
     //
     // Only `sandbox-cr` qualifies: a Job's pod is terminal once the Job
     // finishes, so keeping it would leave a lease nothing can exec into.
+    //
+    // Decided before the API client is built: a kept lease issues no request,
+    // so there is nothing to authenticate against.
     if (
       config.reuseLease &&
       leaseBackend === "sandbox-cr" &&
@@ -643,6 +638,14 @@ const plugin = definePlugin({
     ) {
       return;
     }
+
+    const kc = createKubeConfig({
+      inCluster: config.inCluster,
+      kubeconfig: config.kubeconfig,
+    });
+    const clients = makeKubeClients(kc);
+    const releaseOrchestrator =
+      leaseBackend === "sandbox-cr" ? sandboxCrOrchestrator : jobOrchestrator;
 
     try {
       await releaseOrchestrator.release(clients, namespace, params.providerLeaseId);

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -105,6 +105,18 @@ export interface KubernetesLeaseMetadata {
   phase: "Pending" | "Running" | "Succeeded" | "Failed";
   /** Which backend provisioned this lease. */
   backend: "sandbox-cr" | "job";
+  /**
+   * Whether `reuseLease` was on when this lease was acquired.
+   *
+   * paperclip-server fixes a lease's policy (`reuse_by_environment` vs
+   * `ephemeral`) at acquisition and never revisits it, so a lease acquired
+   * while reuse was off can never be resumed no matter what the config says
+   * later. Release therefore requires reuse to have been on at BOTH ends:
+   * turning `reuseLease` on mid-lease must not make release keep a workload
+   * the server has already written off as ephemeral, which nothing would ever
+   * reclaim. Absent (leases from before this field existed) means false.
+   */
+  acquiredForReuse: boolean;
   scopedNetworkPolicyName: string | null;
   scopedNetworkEgress: {
     allowFqdns: string[];

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -66,6 +66,21 @@ export const kubernetesProviderConfigSchema = z
      *   installed, or when you need stable (non-alpha) k8s APIs.
      */
     backend: z.enum(["sandbox-cr", "job"]).default("sandbox-cr"),
+
+    /**
+     * Keep the Sandbox CR and its pod alive on `releaseLease` so paperclip-server
+     * can resume the lease for a later run instead of paying a cold provision
+     * (see `supportsReusableLeases` on the driver manifest).
+     *
+     * Only the `sandbox-cr` backend can be reused: a Job's pod is terminal once
+     * the Job finishes, so there is nothing left to exec into. Leases that
+     * carried a task-scoped egress grant are always torn down on release, so a
+     * per-run network grant can never outlive its run.
+     *
+     * Default false: release tears the workload down, which is what every
+     * existing environment already does.
+     */
+    reuseLease: z.boolean().default(false),
   })
   .refine(
     (cfg) => cfg.inCluster || cfg.kubeconfig,

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/manifest.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/manifest.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import manifest from "../../src/manifest.js";
+
+const driver = manifest.environmentDrivers![0]!;
+
+describe("kubernetes driver manifest", () => {
+  it("declares reusable-lease support so the server can reach the resume path", () => {
+    // paperclip-server gates environmentResumeLease on `=== true`; without the
+    // declaration the plugin's onEnvironmentResumeLease is unreachable.
+    expect(driver.supportsReusableLeases).toBe(true);
+  });
+
+  it("publishes reuseLease in the driver config schema", () => {
+    const properties = (driver.configSchema as { properties: Record<string, unknown> }).properties;
+    expect(properties.reuseLease).toEqual(
+      expect.objectContaining({ type: "boolean", default: false }),
+    );
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../src/kube-client.js", () => ({
 }));
 
 import plugin from "../../src/plugin.js";
+import { createKubeConfig } from "../../src/kube-client.js";
 
 const CONFIG = { inCluster: true, backend: "sandbox-cr" };
 
@@ -41,6 +42,7 @@ function readySandboxCr(podName: string): Record<string, unknown> {
 
 beforeEach(() => {
   h.clients = {};
+  vi.mocked(createKubeConfig).mockClear();
 });
 
 describe("onEnvironmentResumeLease", () => {
@@ -319,6 +321,8 @@ describe("onEnvironmentReleaseLease", () => {
     expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
     expect(clients.core.deleteNamespacedPod).not.toHaveBeenCalled();
     expect(clients.core.deleteNamespacedSecret).not.toHaveBeenCalled();
+    // A kept lease issues no request at all, so it never even builds a client.
+    expect(createKubeConfig).not.toHaveBeenCalled();
   });
 
   it("destroys a lease that carried a task-scoped egress policy, even with reuseLease on", async () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
@@ -89,6 +89,52 @@ describe("onEnvironmentResumeLease", () => {
     );
   });
 
+  it("carries the acquisition-time reuse stamp onto the resumed lease", async () => {
+    h.clients = {
+      custom: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue(readySandboxCr("pc-abc-pod")),
+      },
+      core: {
+        readNamespacedPod: vi.fn().mockResolvedValue({ metadata: {}, status: { phase: "Running" } }),
+      },
+    };
+
+    const lease = await plugin.definition.onEnvironmentResumeLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: CONFIG,
+      providerLeaseId: "pc-abc",
+      leaseMetadata: leaseMetadata({ acquiredForReuse: true }),
+    });
+
+    // Re-deriving it from the current config would let a later config flip
+    // change how an already-acquired lease is released.
+    expect(lease.metadata?.acquiredForReuse).toBe(true);
+  });
+
+  it("does not invent a reuse stamp for a lease that never had one", async () => {
+    h.clients = {
+      custom: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue(readySandboxCr("pc-abc-pod")),
+      },
+      core: {
+        readNamespacedPod: vi.fn().mockResolvedValue({ metadata: {}, status: { phase: "Running" } }),
+      },
+    };
+
+    const lease = await plugin.definition.onEnvironmentResumeLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: { ...CONFIG, reuseLease: true },
+      providerLeaseId: "pc-abc",
+      leaseMetadata: leaseMetadata(),
+    });
+
+    expect(lease.metadata?.acquiredForReuse).toBe(false);
+  });
+
   it("flags a resumed job-backend lease as native-sync-unsupported so the server keeps the base64 fallback", async () => {
     h.clients = {
       batch: {
@@ -311,6 +357,7 @@ describe("onEnvironmentReleaseLease", () => {
     const clients = await release({
       config: { ...CONFIG, reuseLease: true },
       leaseMetadata: leaseMetadata({
+        acquiredForReuse: true,
         scopedNetworkPolicyName: null,
         scopedNetworkEgress: { allowFqdns: [], allowCidrs: [] },
       }),
@@ -331,6 +378,7 @@ describe("onEnvironmentReleaseLease", () => {
     const clients = await release({
       config: { ...CONFIG, reuseLease: true },
       leaseMetadata: leaseMetadata({
+        acquiredForReuse: true,
         scopedNetworkPolicyName: "pc-abc-egress",
         scopedNetworkEgress: { allowFqdns: ["github.com"], allowCidrs: [] },
       }),
@@ -345,6 +393,7 @@ describe("onEnvironmentReleaseLease", () => {
     const clients = await release({
       config: { ...CONFIG, reuseLease: true },
       leaseMetadata: leaseMetadata({
+        acquiredForReuse: true,
         scopedNetworkPolicyName: null,
         scopedNetworkEgress: { allowFqdns: [], allowCidrs: ["203.0.113.0/24"] },
       }),
@@ -356,7 +405,7 @@ describe("onEnvironmentReleaseLease", () => {
   it("treats an empty-string policy name as no grant and keeps the lease", async () => {
     const clients = await release({
       config: { ...CONFIG, reuseLease: true },
-      leaseMetadata: leaseMetadata({ scopedNetworkPolicyName: "" }),
+      leaseMetadata: leaseMetadata({ acquiredForReuse: true, scopedNetworkPolicyName: "" }),
     });
 
     expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
@@ -372,6 +421,7 @@ describe("onEnvironmentReleaseLease", () => {
         jobName: "pc-job",
         backend: "job",
         podName: "pc-job-pod",
+        acquiredForReuse: true,
         scopedNetworkPolicyName: null,
       }),
     });
@@ -385,9 +435,40 @@ describe("onEnvironmentReleaseLease", () => {
   it("keeps a sandbox-cr lease whose backend is only known from the config", async () => {
     const clients = await release({
       config: { ...CONFIG, reuseLease: true },
-      leaseMetadata: { namespace: "paperclip-acme" },
+      leaseMetadata: { namespace: "paperclip-acme", acquiredForReuse: true },
     });
 
     expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
+  });
+
+  it("destroys a lease acquired while reuse was off, even though reuseLease is on now", async () => {
+    // paperclip-server stamped that lease `ephemeral` and will never resume it,
+    // so keeping its workload would strand a pod nothing can reclaim.
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: leaseMetadata({ acquiredForReuse: false, scopedNetworkPolicyName: null }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "paperclip-acme", name: "pc-abc" }),
+    );
+  });
+
+  it("destroys a lease predating the acquiredForReuse stamp", async () => {
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: leaseMetadata({ scopedNetworkPolicyName: null }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).toHaveBeenCalled();
+  });
+
+  it("destroys a reuse-acquired lease once reuseLease is turned back off", async () => {
+    const clients = await release({
+      config: CONFIG,
+      leaseMetadata: leaseMetadata({ acquiredForReuse: true, scopedNetworkPolicyName: null }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).toHaveBeenCalled();
   });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
@@ -263,3 +263,127 @@ describe("onEnvironmentDestroyLease", () => {
     expect(deleteCr).not.toHaveBeenCalled();
   });
 });
+
+describe("onEnvironmentReleaseLease", () => {
+  function deleteClients() {
+    return {
+      custom: { deleteNamespacedCustomObject: vi.fn().mockResolvedValue({}) },
+      batch: { deleteNamespacedJob: vi.fn().mockResolvedValue({}) },
+      core: {
+        deleteNamespacedPod: vi.fn().mockResolvedValue({}),
+        deleteNamespacedSecret: vi.fn().mockResolvedValue({}),
+      },
+    };
+  }
+
+  async function release(input: {
+    config: Record<string, unknown>;
+    leaseMetadata: Record<string, unknown>;
+    providerLeaseId?: string;
+  }) {
+    const clients = deleteClients();
+    h.clients = clients;
+    await plugin.definition.onEnvironmentReleaseLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: input.config,
+      providerLeaseId: input.providerLeaseId ?? "pc-abc",
+      leaseMetadata: input.leaseMetadata,
+    });
+    return clients;
+  }
+
+  it("tears the Sandbox CR down by default (reuseLease unset)", async () => {
+    const clients = await release({
+      config: CONFIG,
+      leaseMetadata: leaseMetadata({ scopedNetworkPolicyName: null }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "paperclip-acme", name: "pc-abc" }),
+    );
+  });
+
+  it("keeps the Sandbox CR alive when reuseLease is on and the lease carried no task-scoped egress grant", async () => {
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: leaseMetadata({
+        scopedNetworkPolicyName: null,
+        scopedNetworkEgress: { allowFqdns: [], allowCidrs: [] },
+      }),
+    });
+
+    // The pod, its Sandbox CR, and the per-run Secret must all survive, or
+    // there is nothing left for onEnvironmentResumeLease to resume.
+    expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
+    expect(clients.core.deleteNamespacedPod).not.toHaveBeenCalled();
+    expect(clients.core.deleteNamespacedSecret).not.toHaveBeenCalled();
+  });
+
+  it("destroys a lease that carried a task-scoped egress policy, even with reuseLease on", async () => {
+    // A per-task network grant must never outlive its task: the scoped policy
+    // selects the pod by its run-id label, which a reused pod keeps forever.
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: leaseMetadata({
+        scopedNetworkPolicyName: "pc-abc-egress",
+        scopedNetworkEgress: { allowFqdns: ["github.com"], allowCidrs: [] },
+      }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "paperclip-acme", name: "pc-abc" }),
+    );
+  });
+
+  it("destroys a lease whose recorded egress grant is non-empty even if the policy name is missing", async () => {
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: leaseMetadata({
+        scopedNetworkPolicyName: null,
+        scopedNetworkEgress: { allowFqdns: [], allowCidrs: ["203.0.113.0/24"] },
+      }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).toHaveBeenCalled();
+  });
+
+  it("treats an empty-string policy name as no grant and keeps the lease", async () => {
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: leaseMetadata({ scopedNetworkPolicyName: "" }),
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
+  });
+
+  it("destroys job-backend leases regardless of reuseLease", async () => {
+    // The job backend has no resumable workload: a finished Job's pod is
+    // terminal, so keeping it would strand a lease nothing can resume.
+    const clients = await release({
+      config: { inCluster: true, backend: "job", reuseLease: true },
+      providerLeaseId: "pc-job",
+      leaseMetadata: leaseMetadata({
+        jobName: "pc-job",
+        backend: "job",
+        podName: "pc-job-pod",
+        scopedNetworkPolicyName: null,
+      }),
+    });
+
+    expect(clients.batch.deleteNamespacedJob).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "paperclip-acme", name: "pc-job" }),
+    );
+    expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
+  });
+
+  it("keeps a sandbox-cr lease whose backend is only known from the config", async () => {
+    const clients = await release({
+      config: { ...CONFIG, reuseLease: true },
+      leaseMetadata: { namespace: "paperclip-acme" },
+    });
+
+    expect(clients.custom.deleteNamespacedCustomObject).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -36,4 +36,14 @@ describe("kubernetesProviderConfigSchema", () => {
       parseKubernetesProviderConfig({ inCluster: true, egressAllowCidrs: ["not-a-cidr"] }),
     ).toThrow(/CIDR/i);
   });
+
+  it("defaults reuseLease to false so existing environments keep tearing down on release", () => {
+    expect(parseKubernetesProviderConfig({ inCluster: true }).reuseLease).toBe(false);
+  });
+
+  it("keeps an operator-set reuseLease through normalization", () => {
+    // The schema strips keys it does not declare, so an undeclared reuseLease
+    // would be dropped before the plugin's release path could ever read it.
+    expect(parseKubernetesProviderConfig({ inCluster: true, reuseLease: true }).reuseLease).toBe(true);
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run their work inside sandboxes that a provider plugin provisions, and every provision costs the run a cold start
> - The Kubernetes provider already implements `onEnvironmentResumeLease`, complete with a bounded readiness re-check and correct not-resumable semantics
> - But the driver manifest never declares `supportsReusableLeases`, and paperclip-server gates resume strictly on that flag, so the whole resume path is unreachable dead code, and `onEnvironmentReleaseLease` unconditionally deletes the workload anyway, so there would be nothing to resume even if the flag were set
> - This pull request declares the capability, adds an opt-in `reuseLease` config key, and makes release reuse-aware, with the rule that any lease which carried a task-scoped egress grant is always torn down
> - The benefit is that a Kubernetes environment can skip namespace bootstrap, pod scheduling, image pull, and adapter install on every run after the first, without a per-task network grant ever outliving its task

## Linked Issues or Issue Description

No public issue. Follows #10155 (task-scoped egress grants), whose lease metadata this PR reads to decide when reuse is unsafe.

**Problem / motivation**

Every Kubernetes-backed agent run pays a full cold provision: create the Sandbox CR, schedule the pod, pull the runtime image, install the adapter. The provider was clearly built for reuse, so this is not a missing feature so much as a disconnected one:

- `onEnvironmentResumeLease` is fully implemented in `plugin.ts`, including a 30s bounded readiness re-check and a correct "gone means not resumable" result that tells the server to fall back to `acquireLease`.
- `server/src/services/environment-runtime.ts` gates every resume decision on `driver.supportsReusableLeases === true`. The Kubernetes manifest does not set it, so it is `undefined` and the resume hook is never called.
- `onEnvironmentReleaseLease` deletes the workload unconditionally, so even with the flag set there would be no pod left to resume.

There is also a user-visible inconsistency: `GET /environments` capabilities report `supportsReusableLeases: driver.supportsReusableLeases ?? true`, so the UI already advertises reusable leases for this driver while the runtime, which requires `=== true`, never resumes one.

Daytona, e2b, modal, novita, exe-dev, and cloudflare all have a reuse-aware release path. Kubernetes was the outlier.

**Proposed solution**

- Declare `supportsReusableLeases: true` on the driver so the server can reach the resume hook that already exists.
- Add a `reuseLease` config key, declared in both the zod schema and the manifest JSON Schema. It must be in the zod schema: the schema strips keys it does not know, so an operator-set value would be dropped during normalization and never reach the plugin's release path.
- Make `onEnvironmentReleaseLease` keep the Sandbox CR, its pod, and the per-run Secret when reuse applies, and fall through to the existing teardown otherwise.

**Why `reuseLease` defaults to false**

Conservative on purpose. A reused pod stays Running and keeps holding namespace quota and node capacity until the lease is destroyed, which is a real resource-posture change for an operator who did not ask for it. Defaulting to false means no existing environment changes behavior on upgrade: release still tears down exactly as before, and an operator opts in per environment once they have sized their `ResourceQuota` for idle agents. This also matches Daytona's default for the same key.

**The safety rule: a task-scoped egress grant is never reused**

A grant from #10155 is enforced by a policy that selects the pod through its `paperclip.io/run-id` label. That label is fixed at pod-creation time and therefore stays with a kept-alive pod forever. Reusing such a pod would hand the next run an egress allowance it never requested. So a lease that carried a grant is always torn down on release, even with `reuseLease` on. Teardown cascades the policy away with it (the policy is workload-owned) and forces the next run through `acquireLease`, which grants exactly its own destinations.

The check reads both `scopedNetworkPolicyName` (the policy that was created) and `scopedNetworkEgress` (the grant that asked for it). They agree in practice; requiring both to be empty keeps reuse fail-closed if they ever do not.

Reuse is fail-closed in the other direction too: a resumed lease carries no grant, so a workspace that starts requesting one after the lease was taken sees its egress denied rather than silently widened.

**Alternatives considered**

- *Stop the pod on release and start it on resume*, the way the Daytona provider does. Kubernetes has no equivalent: a Sandbox pod that is deleted cannot be revived in place, and the provider's own resume path already documents this. Keeping the pod Running is the only shape reuse can take here.
- *Delete the scoped policy on release and keep the pod.* This still leaves the pod carrying the old run's `paperclip.io/run-id` label and its `PAPERCLIP_NETWORK_EGRESS_*` env from the acquiring run, so the next run's view of its own policy would be wrong. Destroying the lease is simpler and provably safe.
- *Default `reuseLease` to true.* Rejected: it would silently convert every existing Kubernetes environment's idle agents into pods that hold quota indefinitely.

**Roadmap alignment**

Extends the existing sandbox-provider lease lifecycle. No new roadmap surface, no schema or migration changes.

## What Changed

- `src/manifest.ts`: driver declares `supportsReusableLeases: true`; config schema publishes `reuseLease` (`default: false`).
- `src/types.ts`: `reuseLease: z.boolean().default(false)` on the provider config schema, so an operator-set value survives normalization.
- `src/plugin.ts`: `onEnvironmentReleaseLease` returns early, keeping the Sandbox CR, pod, and per-run Secret, when `reuseLease` is on, the lease backend is `sandbox-cr`, and the lease carried no task-scoped egress grant. Adds the `leaseCarriedTaskScopedEgress` helper that encodes the safety rule. Per-lease upload-interceptor buffers and the readiness cache are cleared on every release path, including the reuse path: a kept-alive pod can still be evicted between runs, so the next use must re-confirm Ready.
- `test/unit/plugin-lease-lifecycle.test.ts`: seven release-lifecycle cases (default teardown, reuse keeps CR/pod/Secret, scoped-policy forces teardown, non-empty recorded grant forces teardown, empty-string policy name is not a grant, job backend always tears down, backend inferred from config).
- `test/unit/manifest.test.ts` (new): the driver declares the capability and publishes the config key.
- `test/unit/types.test.ts`: `reuseLease` defaults to false and survives normalization.
- `README.md`: a "Lease reuse" section covering the `sandbox-cr` restriction, the standing quota cost, best-effort resume, and the egress-grant rule; plus the reciprocal note in the task-scoped egress section.

The `job` backend is deliberately excluded: a Job's pod is terminal once the Job finishes, so keeping it would strand a lease nothing can exec into.

## Verification

Note for reviewers: `pnpm-workspace.yaml` excludes `packages/plugins/sandbox-providers/**`, so CI does not run this plugin's unit tests. They were run locally.

- `pnpm --dir packages/plugins/sandbox-providers/kubernetes test` before implementing, with only the new tests added: **14 failed | 186 passed**, the 7 new assertions failing exactly as intended.
- Same command after implementing: **7 failed | 193 passed (200)**. All 11 new tests pass.
- The 7 remaining failures are pre-existing and environment-specific, all in `test/unit/file-sync.test.ts`, which shells out to GNU `tar` and `/proc/self/fd` and cannot pass on macOS. Confirmed identical on a clean `origin/master` checkout of the same worktree: **7 failed | 182 passed (189)**, same 7 tests.
- `pnpm --dir packages/plugins/sandbox-providers/kubernetes exec tsc --noEmit` — clean.

## Risks

**Low risk by construction: nothing changes unless an operator opts in.** `reuseLease` defaults to
false, so every existing Kubernetes environment keeps the exact release behavior it has today. No
schema change, no migration, no server-side change.

With `reuseLease: true` the risks are:

- **Standing resource cost.** A kept-alive pod stays Running and holds namespace quota and node
  capacity until paperclip-server destroys the lease. An operator who turns this on without room in
  their `ResourceQuota` can starve new runs. Documented in the README and in the config-key
  description so it is visible at the point of decision.
- **Stale in-pod state carries across runs.** A resumed pod keeps its `/workspace` emptyDir, its
  installed adapter, and the per-run Secret from the acquiring run. That is inherent to lease reuse
  and identical to what every other reuse-capable provider does; the server's lease fingerprint
  scopes reuse to the same company, environment, execution workspace, agent, and adapter.
- **Egress asymmetry.** A workspace that always requests a task-scoped grant will never reuse a
  lease, so it sees no start-latency benefit. In the reverse case (a workspace starts requesting a
  grant after the lease was taken) the resumed lease has no grant, so the run is denied rather than
  silently widened. Fail-closed in both directions, but the denial can look surprising, so both
  cases are documented.
- **Declaring `supportsReusableLeases: true` applies with the flag off.** It only enables the
  server's resume path, which is itself gated on `parsed.config.reuseLease` at every call site
  (`environment-runtime.ts` lines 822, 851, 889, 963). With `reuseLease` false the server computes
  no fingerprint, lists no reusable candidates, and stamps every lease `ephemeral` exactly as
  before. It also removes an existing inconsistency: the environments API already reported this
  driver as reuse-capable via `?? true`.

The blast radius if the reuse branch were wrong in the unsafe direction is a leaked network grant,
which is why that case is a hard, unconditional teardown with its own tests rather than a
configurable one.

## Model Used

Claude Opus 5 (Anthropic), model id `claude-opus-5[1m]`, 1M context window, extended thinking, with
tool use and code execution (repository exploration, local test runs).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — no duplicate exists. Nearest neighbors: #10263 (independent sibling on the same plugin, exec-path correctness, no overlap with the lease lifecycle), #10155 (task-scoped egress grants, whose lease metadata this PR reads), #7852 (single-flight lease acquisition for shared workspaces, a concurrency concern rather than reuse).
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`k8s-lease-reuse`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (see Verification — this plugin is excluded from the CI workspace, so local runs are the gate)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
