### PR TITLE
feat(plugin-kubernetes): agent-sandbox v1beta1 support via served-version auto-detection; graduate the plugin out of alpha

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -1,18 +1,23 @@
-# @paperclipai/plugin-kubernetes (alpha)
+# @paperclipai/plugin-kubernetes
 
 First-party Paperclip sandbox-provider plugin for Kubernetes.
 
-**Alpha:** the default backend (`sandbox-cr`) is built on `kubernetes-sigs/agent-sandbox` v1alpha1 — expect breaking changes as that CRD evolves toward Beta. A stable fallback backend (`job`, using `batch/v1` Job) is available for clusters without agent-sandbox installed, but it does NOT support multi-command exec (paperclip-server's adapter-install pattern requires sandbox-cr).
+**Maturity:** `sandbox-cr` is the default and fully supported backend. It runs on the
+[`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox)
+controller, which graduated its API to `v1beta1` in v0.5.0. The plugin discovers which
+version a cluster serves and addresses that one, so both a current controller (v0.5.0+,
+`v1beta1`) and an older one (`v1alpha1`) work without configuration. `job` is a
+dispatch-only backend for clusters that cannot run the controller.
 
 ## Prerequisites
 
 ### For `sandbox-cr` backend (default, recommended)
 
 1. A Kubernetes cluster running k8s 1.27+
-2. [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox) controller installed in the cluster (alpha — installs the `sandboxes.agents.x-k8s.io/v1alpha1` CRD and controller)
+2. [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox) controller installed in the cluster (installs the `sandboxes.agents.x-k8s.io` CRD and controller). v0.5.0 or newer serves `v1beta1`; older releases serve `v1alpha1` and are addressed as such.
 3. Paperclip-server running with access to the cluster (in-cluster via `inCluster: true` or external via `kubeconfig`)
 
-### For `job` backend (stable fallback)
+### For `job` backend (dispatch-only)
 
 1. A Kubernetes cluster running k8s 1.27+
 2. Paperclip-server with cluster access — no additional controllers or CRDs required
@@ -33,18 +38,18 @@ paperclipai plugin install --local /path/to/paperclip/packages/plugins/sandbox-p
 
 The plugin supports two backend modes, selected via the `backend` config field:
 
-| Backend | Default | Stability | Multi-command exec | Requires |
+| Backend | Default | Multi-command exec | Native file sync | Requires |
 |---|---|---|---|---|
-| `sandbox-cr` | Yes | Alpha | Yes | `kubernetes-sigs/agent-sandbox` controller |
-| `job` | No | Stable | No | Nothing beyond k8s 1.27+ |
+| `sandbox-cr` | Yes | Yes | Yes | `kubernetes-sigs/agent-sandbox` controller |
+| `job` | No | No | No | Nothing beyond k8s 1.27+ |
 
-**`sandbox-cr` (default):** Creates a `Sandbox` CR (`agents.x-k8s.io/v1alpha1`) whose controller provisions a long-lived pod running `sleep infinity`. paperclip-server execs individual commands into the running pod — this is the multi-command adapter-install pattern. When you `releaseLease`, the Sandbox CR is deleted and the controller tears down the pod.
+**`sandbox-cr` (default):** Creates a `Sandbox` CR in the `agents.x-k8s.io` group whose controller provisions a long-lived pod running `sleep infinity`. paperclip-server execs individual commands into the running pod — this is the multi-command adapter-install pattern. The API version is picked per cluster from discovery (`v1beta1` preferred, `v1alpha1` otherwise) and recorded on the lease, so a worker restart or a controller upgrade mid-lease still addresses the object it created. When you `releaseLease`, the Sandbox CR is deleted and the controller tears down the pod.
 
-**`job` (stable fallback):** Creates a `batch/v1` Job. The container entrypoint runs once and exits — no multi-command exec possible. Use this when you cannot install agent-sandbox, or when you need strictly stable Kubernetes APIs. Note: paperclip-server's adapter-install pattern will not work in job mode.
+**`job` (dispatch-only):** Creates a `batch/v1` Job. The container entrypoint runs once and exits, so there is no exec channel: no multi-command adapter install, and no native file sync (the server keeps its base64 fallback). Use it where the agent-sandbox controller cannot be installed, paired with a runtime image that already carries its adapter.
 
 ### Migrating from `job` to `sandbox-cr`
 
-1. Install the agent-sandbox controller: `kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/install.yaml`
+1. Install the agent-sandbox controller: `kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml`
 2. Update your environment config to set `backend: "sandbox-cr"` (or remove `backend` since `sandbox-cr` is the default)
 3. New leases will use the Sandbox CR backend. Existing leases created with `job` mode continue to use job semantics until they are released.
 
@@ -60,7 +65,7 @@ Common optional fields:
 
 | Field | Default | Purpose |
 |---|---|---|
-| `backend` | `"sandbox-cr"` | `sandbox-cr` (alpha, requires agent-sandbox controller) or `job` (stable, one-shot entrypoint). |
+| `backend` | `"sandbox-cr"` | `sandbox-cr` (requires the agent-sandbox controller; CR API version auto-detected) or `job` (dispatch-only, one-shot entrypoint). |
 | `adapterType` | `"claude_local"` | One of the supported adapter types (claude_local, codex_local, gemini_local, cursor_local, opencode_local, pi_local). Determines runtime image + env keys + egress allow-list. |
 | `namespacePrefix` | `"paperclip-"` | Prefix for the per-company tenant namespace. |
 | `companySlug` | derived from companyId | Override the auto-derived company slug. |
@@ -113,7 +118,7 @@ NetworkPolicy      paperclip-egress-allow         (DNS + paperclip-server callba
 For each agent run (sandbox-cr backend):
 
 ```
-Sandbox CR         pc-{ulid}                       (agents.x-k8s.io/v1alpha1; explicit delete on release)
+Sandbox CR         pc-{ulid}                       (agents.x-k8s.io, version auto-detected; explicit delete on release)
 Pod                pc-{ulid}-{podSuffix}           (managed by Sandbox controller; torn down on CR delete)
 Secret             pc-{ulid}-env                   (owned by Sandbox CR; cascade-deleted)
 ```
@@ -151,7 +156,7 @@ For stronger isolation, install [Kata Containers](https://github.com/kata-contai
 - **Phase A (done):** `sandbox-cr` backend — multi-command exec via agent-sandbox Sandbox CRD.
 - **Phase B:** Warm pool support — pre-provisioned Sandbox CRs for sub-second cold starts. The `SandboxOrchestrator` interface reserves optional `pause?`/`resume?` extension slots.
 - **Phase C:** Kata-FC + snapshots — `runtimeClassName: kata-fc` with VM snapshot for fast restore.
-- **Phase D:** Contribute back to agent-sandbox upstream if their Beta model diverges from our needs. The `SandboxOrchestrator` interface (`src/sandbox-orchestrator.ts`) is the clean swap point — a new implementation can be added without touching `plugin.ts` business logic.
+- **Phase D:** Contribute back to agent-sandbox upstream where their model diverges from our needs. The `SandboxOrchestrator` interface (`src/sandbox-orchestrator.ts`) is the clean swap point — a new implementation can be added without touching `plugin.ts` business logic.
 
 ## Lessons learned (from openclaw-operator)
 

--- a/packages/plugins/sandbox-providers/kubernetes/package.json
+++ b/packages/plugins/sandbox-providers/kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/plugin-kubernetes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Kubernetes sandbox provider plugin for Paperclip environments",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",

--- a/packages/plugins/sandbox-providers/kubernetes/src/kube-client.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/kube-client.ts
@@ -1,5 +1,6 @@
 import {
   KubeConfig,
+  ApisApi,
   CoreV1Api,
   BatchV1Api,
   CustomObjectsApi,
@@ -26,6 +27,8 @@ export function createKubeConfig(input: CreateKubeConfigInput): KubeConfig {
 }
 
 export interface KubeClients {
+  /** Discovery: which API groups/versions this cluster serves. */
+  apis: ApisApi;
   core: CoreV1Api;
   batch: BatchV1Api;
   custom: CustomObjectsApi;
@@ -35,10 +38,22 @@ export interface KubeClients {
 
 export function makeKubeClients(kc: KubeConfig): KubeClients {
   return {
+    apis: kc.makeApiClient(ApisApi),
     core: kc.makeApiClient(CoreV1Api),
     batch: kc.makeApiClient(BatchV1Api),
     custom: kc.makeApiClient(CustomObjectsApi),
     networking: kc.makeApiClient(NetworkingV1Api),
     rbac: kc.makeApiClient(RbacAuthorizationV1Api),
   };
+}
+
+/**
+ * Cache key identifying the cluster behind a KubeConfig. Served API versions
+ * are a property of the API server, so its URL is the right granularity: two
+ * environments pointing at the same cluster share one discovery result, and a
+ * kubeconfig switched to a different cluster gets its own.
+ */
+export function apiServerUrl(kc: KubeConfig): string {
+  const server = kc.getCurrentCluster()?.server;
+  return server && server.length > 0 ? server : "in-cluster";
 }

--- a/packages/plugins/sandbox-providers/kubernetes/src/lease-lifecycle.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/lease-lifecycle.ts
@@ -18,6 +18,7 @@
 
 import type { KubeClients } from "./kube-client.js";
 import { deleteJob, findPodForJob, getJobStatus } from "./job-orchestrator.js";
+import type { SandboxApiVersion } from "./sandbox-api-version.js";
 import {
   deleteSandboxCr,
   findPodForSandbox,
@@ -43,15 +44,29 @@ export type ResumeCheckResult =
   | { resumable: true; podName: string | null; phase: "Pending" | "Running" }
   | { resumable: false; reason: string };
 
-export interface ResumeCheckInput {
+interface LeaseWorkloadRef {
   namespace: string;
   /** Workload resource name (Sandbox CR name or Job name) == providerLeaseId. */
   name: string;
-  backend: "sandbox-cr" | "job";
-  /** Bounded wait for an existing Sandbox pod to report Ready. */
-  readyTimeoutMs?: number;
-  pollMs?: number;
 }
+
+/**
+ * Which API version to address a Sandbox CR with. Modelled as part of the
+ * backend discriminant rather than an optional field: the version is only
+ * meaningful for `sandbox-cr` (a Job is `batch/v1` and always has been), and
+ * requiring it there makes it impossible to reach a CR without a version the
+ * caller resolved from cluster discovery.
+ */
+type LeaseBackendRef =
+  | { backend: "sandbox-cr"; sandboxApiVersion: SandboxApiVersion }
+  | { backend: "job" };
+
+export type ResumeCheckInput = LeaseWorkloadRef &
+  LeaseBackendRef & {
+    /** Bounded wait for an existing Sandbox pod to report Ready. */
+    readyTimeoutMs?: number;
+    pollMs?: number;
+  };
 
 /**
  * Check whether the workload behind a lease is still alive and exec-able.
@@ -69,10 +84,16 @@ export async function checkLeaseResumable(
     // fast on Failed/Terminating; a timeout means the pod never came up. None
     // of those states are resumable — k8s pods cannot be restarted in place.
     try {
-      await waitForSandboxReady(clients, input.namespace, input.name, {
-        timeoutMs: input.readyTimeoutMs ?? 30_000,
-        pollMs: input.pollMs ?? 1_000,
-      });
+      await waitForSandboxReady(
+        clients,
+        input.namespace,
+        input.name,
+        {
+          timeoutMs: input.readyTimeoutMs ?? 30_000,
+          pollMs: input.pollMs ?? 1_000,
+        },
+        input.sandboxApiVersion,
+      );
     } catch (err) {
       if (isKubeNotFoundError(err)) {
         return { resumable: false, reason: "Sandbox CR no longer exists" };
@@ -85,7 +106,12 @@ export async function checkLeaseResumable(
 
     let podName: string | null;
     try {
-      podName = await findPodForSandbox(clients, input.namespace, input.name);
+      podName = await findPodForSandbox(
+        clients,
+        input.namespace,
+        input.name,
+        input.sandboxApiVersion,
+      );
     } catch (err) {
       // CR deleted between the readiness check and the pod lookup.
       if (isKubeNotFoundError(err)) {
@@ -149,14 +175,11 @@ export async function checkLeaseResumable(
   };
 }
 
-export interface DestroyLeaseInput {
-  namespace: string;
-  /** Workload resource name (Sandbox CR name or Job name) == providerLeaseId. */
-  name: string;
-  backend: "sandbox-cr" | "job";
-  podName: string | null;
-  secretName: string | null;
-}
+export type DestroyLeaseInput = LeaseWorkloadRef &
+  LeaseBackendRef & {
+    podName: string | null;
+    secretName: string | null;
+  };
 
 /**
  * Forcibly delete every resource acquireLease created for this lease.
@@ -170,7 +193,9 @@ export async function destroyLeaseResources(
   input: DestroyLeaseInput,
 ): Promise<void> {
   if (input.backend === "sandbox-cr") {
-    await ignoreNotFound(deleteSandboxCr(clients, input.namespace, input.name));
+    await ignoreNotFound(
+      deleteSandboxCr(clients, input.namespace, input.name, input.sandboxApiVersion),
+    );
   } else {
     await ignoreNotFound(deleteJob(clients, input.namespace, input.name));
   }

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -1,15 +1,18 @@
 import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
 
 const PLUGIN_ID = "paperclip.kubernetes-sandbox-provider";
-const PLUGIN_VERSION = "0.1.0-alpha.1";
+// Keep in step with the package.json "version" field: paperclip-server registers
+// the plugin under THIS value, so the two disagreeing makes the installed
+// package and the registered plugin report different versions.
+const PLUGIN_VERSION = "0.2.0";
 
 const manifest: PaperclipPluginManifestV1 = {
   id: PLUGIN_ID,
   apiVersion: 1,
   version: PLUGIN_VERSION,
-  displayName: "Kubernetes Sandbox (alpha)",
+  displayName: "Kubernetes Sandbox",
   description:
-    "Built on kubernetes-sigs/agent-sandbox (v1alpha1). ALPHA — expect breaking changes as the upstream CRD evolves. Falls back to stable batch/v1 Job mode for clusters without agent-sandbox installed. First-party Paperclip sandbox-provider plugin for Kubernetes.",
+    "Self-hostable Kubernetes sandbox provider. The default backend (sandbox-cr) runs agent pods through the kubernetes-sigs/agent-sandbox controller, addressing whichever API version the cluster serves (v1beta1 preferred, v1alpha1 for older controllers). The job backend uses batch/v1 Job for dispatch-only clusters without that controller. First-party Paperclip sandbox-provider plugin for Kubernetes.",
   author: "Paperclip",
   categories: ["automation"],
   capabilities: ["environment.drivers.register"],
@@ -22,7 +25,7 @@ const manifest: PaperclipPluginManifestV1 = {
       kind: "sandbox_provider",
       displayName: "Kubernetes",
       description:
-        "Dispatches agent runs in per-tenant Kubernetes namespaces. Default backend (sandbox-cr, alpha) uses kubernetes-sigs/agent-sandbox for multi-command exec; fallback backend (job) uses stable batch/v1 Job for clusters without agent-sandbox installed.",
+        "Dispatches agent runs in per-tenant Kubernetes namespaces, each with its own ServiceAccount, RBAC, quotas and deny-all network baseline. The default backend (sandbox-cr) uses kubernetes-sigs/agent-sandbox for multi-command exec; the job backend uses batch/v1 Job for clusters without that controller.",
       configSchema: {
         type: "object",
         properties: {
@@ -106,7 +109,7 @@ const manifest: PaperclipPluginManifestV1 = {
             type: "string",
             enum: ["sandbox-cr", "job"],
             description:
-              "sandbox-cr (default, alpha — requires kubernetes-sigs/agent-sandbox installed) | job (stable fallback — batch/v1 Job, one-shot entrypoint, no multi-command exec)",
+              "sandbox-cr (default — requires the kubernetes-sigs/agent-sandbox controller; the plugin addresses whichever version the cluster serves, v1beta1 preferred with v1alpha1 fallback) | job (batch/v1 Job, dispatch-only: the entrypoint runs once and exits, so no multi-command exec and no native file sync)",
           },
         },
         anyOf: [

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import type { KubeConfig } from "@kubernetes/client-node";
 import { definePlugin } from "@paperclipai/plugin-sdk";
 import type {
   PluginEnvironmentAcquireLeaseParams,
@@ -23,7 +24,12 @@ import {
   type KubernetesProviderConfig,
   type KubernetesLeaseMetadata,
 } from "./types.js";
-import { createKubeConfig, makeKubeClients } from "./kube-client.js";
+import {
+  apiServerUrl,
+  createKubeConfig,
+  makeKubeClients,
+  type KubeClients,
+} from "./kube-client.js";
 import { getAdapterDefaults, buildAdapterEnv, resolveRunAdapterType } from "./adapter-defaults.js";
 import { resolveImage } from "./image-allowlist.js";
 import { buildJobManifest } from "./pod-spec-builder.js";
@@ -33,9 +39,15 @@ import { createPerRunSecret } from "./secret-manager.js";
 import { FastUploadInterceptor } from "./upload-interceptor.js";
 import { jobOrchestrator, JobTimeoutError } from "./job-orchestrator.js";
 import {
-  sandboxCrOrchestrator,
+  makeSandboxCrOrchestrator,
   SandboxCrTimeoutError,
 } from "./sandbox-cr-orchestrator.js";
+import {
+  isSandboxApiVersion,
+  resolveSandboxApiVersion,
+  SANDBOX_GROUP,
+  type SandboxApiVersion,
+} from "./sandbox-api-version.js";
 import { execInPod, execInPodStreaming, wrapCommandWithEnv } from "./pod-exec.js";
 import { performSyncIn, performSyncOut, type PodStreamExec } from "./file-sync.js";
 import { checkLeaseResumable, destroyLeaseResources } from "./lease-lifecycle.js";
@@ -119,6 +131,28 @@ const readySandboxesByLease = new Set<string>();
 const RESUME_READY_TIMEOUT_MS = 30_000;
 const RESUME_READY_POLL_MS = 1_000;
 
+/**
+ * The Sandbox API version to address an EXISTING lease's CR with.
+ *
+ * Prefer the version recorded on the lease at acquisition: a worker that
+ * restarts mid-lease, or an operator who upgrades the agent-sandbox controller
+ * while a lease is live, must still address the object through the version it
+ * was created with rather than whatever discovery now prefers. Leases acquired
+ * before this field existed carry nothing, so fall back to discovery — the
+ * cluster still serves the version those CRs were created with (agent-sandbox
+ * keeps `v1alpha1` served and convertible), and discovery is cached per API
+ * server, so this costs at most one request per worker.
+ */
+async function resolveLeaseSandboxApiVersion(
+  clients: KubeClients,
+  kc: KubeConfig,
+  leaseMetadata: Record<string, unknown> | null | undefined,
+): Promise<SandboxApiVersion> {
+  const recorded = leaseMetadata?.sandboxApiVersion;
+  if (isSandboxApiVersion(recorded)) return recorded;
+  return await resolveSandboxApiVersion(clients, apiServerUrl(kc));
+}
+
 // The workspace remote dir is the confinement root for native file sync. It is
 // recorded on the lease metadata at realizeWorkspace time (`remoteCwd`); require
 // it so a sync can never run without a concrete root to confine every sandbox
@@ -169,12 +203,15 @@ async function resolveSyncPodExec(
     kubeconfig: config.kubeconfig,
   });
   const clients = makeKubeClients(kc);
+  const orchestrator = makeSandboxCrOrchestrator(
+    await resolveLeaseSandboxApiVersion(clients, kc, lease.metadata),
+  );
   const timeoutMs = config.podActivityDeadlineSec * 1000;
 
   // Ensure the Sandbox pod is Ready (wait only the first time for this lease),
   // then resolve the pod name — mirrors the onEnvironmentExecute resolution.
   if (!readySandboxesByLease.has(lease.providerLeaseId)) {
-    await sandboxCrOrchestrator.waitForCompletion(clients, namespace, lease.providerLeaseId, {
+    await orchestrator.waitForCompletion(clients, namespace, lease.providerLeaseId, {
       timeoutMs,
       pollMs: 2000,
     });
@@ -184,7 +221,7 @@ async function resolveSyncPodExec(
   const podName =
     typeof lease.metadata?.podName === "string" && lease.metadata.podName
       ? lease.metadata.podName
-      : await sandboxCrOrchestrator.findPod(clients, namespace, lease.providerLeaseId);
+      : await orchestrator.findPod(clients, namespace, lease.providerLeaseId);
   if (!podName) {
     throw new Error("Kubernetes file sync could not resolve the Sandbox pod name.");
   }
@@ -332,6 +369,18 @@ const plugin = definePlugin({
     });
     const clients = makeKubeClients(kc);
 
+    // Which Sandbox API version this cluster serves, resolved once per API
+    // server and reused for the lease's whole lifetime (recorded on the lease
+    // metadata below). Resolved BEFORE any tenant resource is created so a
+    // cluster without the agent-sandbox controller fails with "install the
+    // controller, or set backend: job" instead of leaving a provisioned
+    // namespace behind. Null for the `job` backend, which addresses `batch/v1`
+    // and must never require the CRD to be present.
+    const sandboxApiVersion: SandboxApiVersion | null =
+      config.backend === "sandbox-cr"
+        ? await resolveSandboxApiVersion(clients, apiServerUrl(kc))
+        : null;
+
     // Ensure the tenant namespace and all its RBAC / network policy resources
     // exist before we try to create the Job.
     const adapterDefaults = getAdapterDefaults(effectiveAdapterType, config.adapters);
@@ -366,11 +415,16 @@ const plugin = definePlugin({
     );
 
     // Pick the orchestrator and build the appropriate manifest based on backend.
-    const isSandboxCrBackend = config.backend === "sandbox-cr";
-    const orchestrator = isSandboxCrBackend ? sandboxCrOrchestrator : jobOrchestrator;
+    // Branching on `sandboxApiVersion` rather than the backend string keeps the
+    // resolved version and the sandbox-cr path inseparable: there is no way to
+    // reach a CR call site without one.
+    const orchestrator = sandboxApiVersion
+      ? makeSandboxCrOrchestrator(sandboxApiVersion)
+      : jobOrchestrator;
 
-    const manifest = isSandboxCrBackend
+    const manifest = sandboxApiVersion
       ? buildSandboxCrManifest({
+          apiVersion: sandboxApiVersion,
           namespace,
           sandboxName: jobName,
           adapterType: effectiveAdapterType,
@@ -407,8 +461,10 @@ const plugin = definePlugin({
         runId: params.runId,
         workloadName: jobName,
         ownerReference: {
-          apiVersion: isSandboxCrBackend ? "agents.x-k8s.io/v1alpha1" : "batch/v1",
-          kind: isSandboxCrBackend ? "Sandbox" : "Job",
+          // An ownerReference is matched on apiVersion + kind + uid, so it has
+          // to name the version the object was created through.
+          apiVersion: sandboxApiVersion ? `${SANDBOX_GROUP}/${sandboxApiVersion}` : "batch/v1",
+          kind: sandboxApiVersion ? "Sandbox" : "Job",
           name: jobName,
           uid: ownerUid,
           controller: false,
@@ -437,8 +493,8 @@ const plugin = definePlugin({
       namespace,
       secretName,
       runId: params.runId,
-      ownerKind: isSandboxCrBackend ? "Sandbox" : "Job",
-      ownerApiVersion: isSandboxCrBackend ? "agents.x-k8s.io/v1alpha1" : "batch/v1",
+      ownerKind: sandboxApiVersion ? "Sandbox" : "Job",
+      ownerApiVersion: sandboxApiVersion ? `${SANDBOX_GROUP}/${sandboxApiVersion}` : "batch/v1",
       ownerName: jobName,
       ownerUid,
       bootstrapToken,
@@ -454,6 +510,10 @@ const plugin = definePlugin({
       secretName,
       phase: "Pending",
       backend: config.backend,
+      // Recorded so every later call on this lease addresses the CR through the
+      // version it was created with, even if the worker restarts or the
+      // controller is upgraded mid-lease.
+      sandboxApiVersion: sandboxApiVersion ?? undefined,
       scopedNetworkPolicyName,
       scopedNetworkEgress,
       // Native file sync streams over a pod exec; only the sandbox-cr backend
@@ -493,10 +553,17 @@ const plugin = definePlugin({
     });
     const clients = makeKubeClients(kc);
 
+    const sandboxApiVersion =
+      leaseBackend === "sandbox-cr"
+        ? await resolveLeaseSandboxApiVersion(clients, kc, params.leaseMetadata)
+        : null;
+
     const check = await checkLeaseResumable(clients, {
       namespace,
       name: params.providerLeaseId,
-      backend: leaseBackend,
+      ...(sandboxApiVersion
+        ? { backend: "sandbox-cr" as const, sandboxApiVersion }
+        : { backend: "job" as const }),
       readyTimeoutMs: RESUME_READY_TIMEOUT_MS,
       pollMs: RESUME_READY_POLL_MS,
     });
@@ -529,6 +596,9 @@ const plugin = definePlugin({
       secretName,
       phase: check.phase,
       backend: leaseBackend,
+      // Carried forward so the resumed lease keeps addressing the CR through
+      // the version it was created with (see resolveLeaseSandboxApiVersion).
+      sandboxApiVersion: sandboxApiVersion ?? undefined,
       scopedNetworkPolicyName:
         typeof params.leaseMetadata?.scopedNetworkPolicyName === "string"
           ? params.leaseMetadata.scopedNetworkPolicyName
@@ -590,7 +660,11 @@ const plugin = definePlugin({
         ? (params.leaseMetadata.backend as "sandbox-cr" | "job")
         : config.backend;
     const releaseOrchestrator =
-      leaseBackend === "sandbox-cr" ? sandboxCrOrchestrator : jobOrchestrator;
+      leaseBackend === "sandbox-cr"
+        ? makeSandboxCrOrchestrator(
+            await resolveLeaseSandboxApiVersion(clients, kc, params.leaseMetadata),
+          )
+        : jobOrchestrator;
 
     // Drop the FastUploadInterceptor associated with THIS lease (only).
     // Each lease has its own interceptor instance via uploadInterceptorsByLease,
@@ -642,12 +716,19 @@ const plugin = definePlugin({
     });
     const clients = makeKubeClients(kc);
 
+    const sandboxApiVersion =
+      leaseBackend === "sandbox-cr"
+        ? await resolveLeaseSandboxApiVersion(clients, kc, params.leaseMetadata)
+        : null;
+
     // Forcibly delete everything acquireLease created (Sandbox CR / Job, pod,
     // per-run Secret). 404s are success — destroy must be idempotent.
     await destroyLeaseResources(clients, {
       namespace,
       name: params.providerLeaseId,
-      backend: leaseBackend,
+      ...(sandboxApiVersion
+        ? { backend: "sandbox-cr" as const, sandboxApiVersion }
+        : { backend: "job" as const }),
       podName,
       secretName,
     });
@@ -695,9 +776,14 @@ const plugin = definePlugin({
 
     if (leaseBackend === "sandbox-cr") {
       // ── Sandbox-CR backend ──────────────────────────────────────────────────
+      // 0. Address the CR through the version it was created with.
       // 1. Ensure the Sandbox pod is Ready (wait only on first exec for this lease).
       // 2. Exec the command into the running pod.
       // 3. Return exec result directly (no log scraping needed).
+
+      const sandboxCrOrchestrator = makeSandboxCrOrchestrator(
+        await resolveLeaseSandboxApiVersion(clients, kc, lease.metadata),
+      );
 
       let podName =
         typeof lease.metadata?.podName === "string" && lease.metadata.podName

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-api-version.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-api-version.ts
@@ -1,0 +1,95 @@
+/**
+ * Which version of the kubernetes-sigs/agent-sandbox Sandbox API to address a
+ * cluster with.
+ *
+ * agent-sandbox graduated its APIs to `v1beta1` in v0.5.0 and now serves both
+ * versions from one CRD — `v1beta1` as the storage version and `v1alpha1`
+ * deprecated-but-served behind a conversion webhook. Clusters running an older
+ * controller serve only `v1alpha1`. Hard-coding either version breaks half the
+ * installed base, so the plugin discovers what the cluster actually serves and
+ * prefers the newest version it knows how to address.
+ *
+ * The Sandbox manifest this plugin builds sets only `spec.podTemplate`, which
+ * is required and identically shaped in both versions, so the same manifest is
+ * valid either way. (The graduation replaced `spec.replicas` with
+ * `spec.operatingMode`; the plugin sets neither.)
+ */
+
+import type { KubeClients } from "./kube-client.js";
+
+/** API group the Sandbox CRD is served under. */
+export const SANDBOX_GROUP = "agents.x-k8s.io";
+
+/**
+ * Versions this plugin can address, newest first. Resolution picks the first
+ * entry the cluster serves.
+ */
+export const SANDBOX_API_VERSION_PREFERENCE = ["v1beta1", "v1alpha1"] as const;
+
+export type SandboxApiVersion = (typeof SANDBOX_API_VERSION_PREFERENCE)[number];
+
+/** Narrow a value read back from lease metadata (untyped JSON) to a version. */
+export function isSandboxApiVersion(value: unknown): value is SandboxApiVersion {
+  return (SANDBOX_API_VERSION_PREFERENCE as readonly unknown[]).includes(value);
+}
+
+/**
+ * Resolution is cached per API-server URL for the worker's lifetime: served
+ * versions only change when an operator upgrades the controller, and a worker
+ * restart (or a plugin reload) re-discovers. The PROMISE is cached rather than
+ * the value so concurrent first callers share a single discovery request.
+ */
+const cacheByServer = new Map<string, Promise<SandboxApiVersion>>();
+
+/** Test seam: drop every cached resolution. */
+export function __clearSandboxApiVersionCache(): void {
+  cacheByServer.clear();
+}
+
+interface DiscoveryGroupList {
+  groups?: { name?: string; versions?: { version?: string }[] }[];
+}
+
+/**
+ * Resolve the best served version of the Sandbox API on the cluster behind
+ * `clients`, keyed by `serverUrl` (the API-server URL the clients talk to).
+ *
+ * Throws a message naming the fix when the group is absent (controller not
+ * installed) or serves nothing this plugin can address (controller too new to
+ * still serve `v1alpha1` and too old to be known here). A rejected promise is
+ * evicted from the cache so a transient discovery failure does not wedge the
+ * worker into permanently failing every lease.
+ */
+export function resolveSandboxApiVersion(
+  clients: KubeClients,
+  serverUrl: string,
+): Promise<SandboxApiVersion> {
+  const cached = cacheByServer.get(serverUrl);
+  if (cached) return cached;
+
+  const resolution = (async (): Promise<SandboxApiVersion> => {
+    const list = (await clients.apis.getAPIVersions()) as DiscoveryGroupList;
+    const group = (list.groups ?? []).find((g) => g.name === SANDBOX_GROUP);
+    if (!group) {
+      throw new Error(
+        `API group ${SANDBOX_GROUP} is not served by this cluster. Install the kubernetes-sigs/agent-sandbox controller, or set backend: "job" to dispatch runs as batch/v1 Jobs instead.`,
+      );
+    }
+    const served = new Set((group.versions ?? []).map((v) => v.version));
+    const pick = SANDBOX_API_VERSION_PREFERENCE.find((version) => served.has(version));
+    if (!pick) {
+      throw new Error(
+        `API group ${SANDBOX_GROUP} serves none of [${SANDBOX_API_VERSION_PREFERENCE.join(", ")}] (serves: ${[...served].join(", ") || "nothing"}). Upgrade the agent-sandbox controller, or set backend: "job".`,
+      );
+    }
+    return pick;
+  })();
+
+  cacheByServer.set(serverUrl, resolution);
+  // Keep the failure out of the cache without turning it into an unhandled
+  // rejection: this handler swallows nothing the caller sees, it only evicts.
+  resolution.catch(() => {
+    if (cacheByServer.get(serverUrl) === resolution) cacheByServer.delete(serverUrl);
+  });
+  return resolution;
+}

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-builder.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-builder.ts
@@ -13,10 +13,20 @@
  *
  * NOTE: paperclip-server runs OUTSIDE the cluster, so we cannot set ownerReferences
  * on the Sandbox CR (the owner would need to be an in-cluster resource). The
- * release path is explicit delete via sandboxCrOrchestrator.release().
+ * release path is explicit delete via the Sandbox CR orchestrator's release().
  */
 
+import { SANDBOX_GROUP, type SandboxApiVersion } from "./sandbox-api-version.js";
+
 export interface BuildSandboxCrManifestInput {
+  /**
+   * Served Sandbox API version to address the cluster with, resolved from
+   * discovery (see sandbox-api-version.ts). The manifest body is the same
+   * either way: `spec.podTemplate` is required and identically shaped in both
+   * versions, and this builder sets neither the v1alpha1 `spec.replicas` nor
+   * the v1beta1 `spec.operatingMode` that replaced it.
+   */
+  apiVersion: SandboxApiVersion;
   namespace: string;
   sandboxName: string;
   adapterType: string;
@@ -40,7 +50,7 @@ export function buildSandboxCrManifest(
     "paperclip.io/role": "agent",
   };
   return {
-    apiVersion: "agents.x-k8s.io/v1alpha1",
+    apiVersion: `${SANDBOX_GROUP}/${input.apiVersion}`,
     kind: "Sandbox",
     metadata: {
       name: input.sandboxName,

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-orchestrator.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-orchestrator.ts
@@ -1,6 +1,12 @@
 /**
  * SandboxOrchestrator implementation backed by the kubernetes-sigs/agent-sandbox
- * Sandbox CRD (agents.x-k8s.io/v1alpha1).
+ * Sandbox CRD (agents.x-k8s.io).
+ *
+ * Which version of that CRD to address is NOT decided here: the caller resolves
+ * it from cluster discovery (see sandbox-api-version.ts) and passes it in, so
+ * the plugin works against both a v1beta1 controller (agent-sandbox >= v0.5.0)
+ * and an older v1alpha1 one. `makeSandboxCrOrchestrator` binds a resolved
+ * version into the version-agnostic SandboxOrchestrator interface.
  *
  * The Sandbox CR creates a long-lived pod that paperclip-server can exec into
  * for multi-command adapter-install workflows — the key architectural win over
@@ -22,10 +28,9 @@
  */
 
 import type { KubeClients } from "./kube-client.js";
+import { SANDBOX_GROUP, type SandboxApiVersion } from "./sandbox-api-version.js";
 import type { SandboxOrchestrator, SandboxStatus } from "./sandbox-orchestrator.js";
 
-const SANDBOX_GROUP = "agents.x-k8s.io";
-const SANDBOX_VERSION = "v1alpha1";
 const SANDBOX_PLURAL = "sandboxes";
 
 export class SandboxCrTimeoutError extends Error {
@@ -98,10 +103,11 @@ export async function createSandboxCr(
   clients: KubeClients,
   namespace: string,
   manifest: Record<string, unknown>,
+  apiVersion: SandboxApiVersion,
 ): Promise<{ uid: string }> {
   const result = await clients.custom.createNamespacedCustomObject({
     group: SANDBOX_GROUP,
-    version: SANDBOX_VERSION,
+    version: apiVersion,
     namespace,
     plural: SANDBOX_PLURAL,
     body: manifest,
@@ -115,10 +121,11 @@ export async function getSandboxCrStatus(
   clients: KubeClients,
   namespace: string,
   name: string,
+  apiVersion: SandboxApiVersion,
 ): Promise<SandboxStatus> {
   const result = await clients.custom.getNamespacedCustomObject({
     group: SANDBOX_GROUP,
-    version: SANDBOX_VERSION,
+    version: apiVersion,
     namespace,
     plural: SANDBOX_PLURAL,
     name,
@@ -136,11 +143,12 @@ export async function findPodForSandbox(
   clients: KubeClients,
   namespace: string,
   name: string,
+  apiVersion: SandboxApiVersion,
 ): Promise<string | null> {
   // Primary: read status.podName from the Sandbox CR
   const cr = await clients.custom.getNamespacedCustomObject({
     group: SANDBOX_GROUP,
-    version: SANDBOX_VERSION,
+    version: apiVersion,
     namespace,
     plural: SANDBOX_PLURAL,
     name,
@@ -224,10 +232,11 @@ export async function deleteSandboxCr(
   clients: KubeClients,
   namespace: string,
   name: string,
+  apiVersion: SandboxApiVersion,
 ): Promise<void> {
   await clients.custom.deleteNamespacedCustomObject({
     group: SANDBOX_GROUP,
-    version: SANDBOX_VERSION,
+    version: apiVersion,
     namespace,
     plural: SANDBOX_PLURAL,
     name,
@@ -252,6 +261,7 @@ export async function waitForSandboxReady(
     timeoutMs: 120_000,
     pollMs: 2000,
   },
+  apiVersion: SandboxApiVersion,
 ): Promise<SandboxStatus> {
   const deadline = Date.now() + opts.timeoutMs;
   const pollMs = opts.pollMs ?? 2000;
@@ -259,15 +269,16 @@ export async function waitForSandboxReady(
   while (Date.now() < deadline) {
     const cr = await clients.custom.getNamespacedCustomObject({
       group: SANDBOX_GROUP,
-      version: SANDBOX_VERSION,
+      version: apiVersion,
       namespace,
       plural: SANDBOX_PLURAL,
       name,
     }) as Record<string, unknown>;
 
     const status = (cr.status as Record<string, unknown>) ?? {};
-    // agent-sandbox v1alpha1 uses status.conditions[type=Ready,status=True],
-    // not status.phase. Fall back to phase for forward-compat.
+    // agent-sandbox reports readiness through
+    // status.conditions[type=Ready,status=True] in both served versions, not
+    // status.phase. Fall back to phase for forward-compat.
     const conditions = Array.isArray(status.conditions) ? status.conditions as Array<Record<string, unknown>> : [];
     const readyCondition = conditions.find((c) => c.type === "Ready");
     const failedCondition = conditions.find((c) => c.type === "Failed" || (c.type === "Ready" && c.status === "False" && typeof c.reason === "string" && /failed/i.test(c.reason)));
@@ -300,17 +311,29 @@ export async function waitForSandboxReady(
 }
 
 /**
- * Sandbox CR-backed conformance to SandboxOrchestrator.
+ * Sandbox CR-backed conformance to SandboxOrchestrator, bound to one resolved
+ * served API version. SandboxOrchestrator is deliberately version-agnostic (the
+ * Job backend has no such notion), so the version is closed over here rather
+ * than threaded through every call site.
  *
  * waitForCompletion semantics change: for this backend, "completion" means
  * "pod is up and Ready to exec into" — NOT "workload finished". The actual
  * command execution and its completion is handled by execInPod().
  */
-export const sandboxCrOrchestrator: SandboxOrchestrator = {
-  claim: createSandboxCr,
-  getStatus: getSandboxCrStatus,
-  findPod: findPodForSandbox,
-  streamLogs: streamSandboxLogs,
-  release: deleteSandboxCr,
-  waitForCompletion: waitForSandboxReady,
-};
+export function makeSandboxCrOrchestrator(
+  apiVersion: SandboxApiVersion,
+): SandboxOrchestrator {
+  return {
+    claim: (clients, namespace, manifest) =>
+      createSandboxCr(clients, namespace, manifest, apiVersion),
+    getStatus: (clients, namespace, name) =>
+      getSandboxCrStatus(clients, namespace, name, apiVersion),
+    findPod: (clients, namespace, name) =>
+      findPodForSandbox(clients, namespace, name, apiVersion),
+    streamLogs: streamSandboxLogs,
+    release: (clients, namespace, name) =>
+      deleteSandboxCr(clients, namespace, name, apiVersion),
+    waitForCompletion: (clients, namespace, name, opts) =>
+      waitForSandboxReady(clients, namespace, name, opts, apiVersion),
+  };
+}

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { adapterRegistrySchema } from "./adapter-registry.js";
 import { KNOWN_ADAPTER_TYPES } from "./adapter-defaults.js";
+import type { SandboxApiVersion } from "./sandbox-api-version.js";
 
 const cidrRegex = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/;
 
@@ -56,14 +57,18 @@ export const kubernetesProviderConfigSchema = z
     /**
      * The sandbox backend to use.
      *
-     * - `"sandbox-cr"` (default, alpha) — uses the kubernetes-sigs/agent-sandbox
-     *   Sandbox CRD (agents.x-k8s.io/v1alpha1). Creates a long-lived pod that
-     *   paperclip-server can exec into for multi-command adapter-install workflows.
-     *   Requires the agent-sandbox controller to be installed in the cluster.
+     * - `"sandbox-cr"` (default) — uses the kubernetes-sigs/agent-sandbox Sandbox
+     *   CRD (`agents.x-k8s.io`). Creates a long-lived pod that paperclip-server
+     *   can exec into for multi-command adapter-install workflows. Requires the
+     *   agent-sandbox controller in the cluster; the served API version is
+     *   discovered per cluster (`v1beta1` preferred, `v1alpha1` for controllers
+     *   older than agent-sandbox v0.5.0).
      *
-     * - `"job"` — uses batch/v1 Job (stable fallback). One-shot entrypoint; does
-     *   NOT support multi-command exec. Use this for clusters without agent-sandbox
-     *   installed, or when you need stable (non-alpha) k8s APIs.
+     * - `"job"` — uses batch/v1 Job. Dispatch-only: the container entrypoint runs
+     *   once and exits, so there is no exec channel and therefore no
+     *   multi-command adapter install and no native file sync. Use it on clusters
+     *   where the agent-sandbox controller cannot be installed, and pair it with a
+     *   runtime image that carries its adapter preinstalled.
      */
     backend: z.enum(["sandbox-cr", "job"]).default("sandbox-cr"),
   })
@@ -90,6 +95,14 @@ export interface KubernetesLeaseMetadata {
   phase: "Pending" | "Running" | "Succeeded" | "Failed";
   /** Which backend provisioned this lease. */
   backend: "sandbox-cr" | "job";
+  /**
+   * Served Sandbox API version this lease's CR was created through
+   * (`v1beta1` or `v1alpha1`), recorded at acquisition so every later call
+   * addresses the same object even after a worker restart or a controller
+   * upgrade mid-lease. Absent on `job` leases (no CR) and on leases acquired
+   * before this field existed, where the version is rediscovered instead.
+   */
+  sandboxApiVersion?: SandboxApiVersion;
   scopedNetworkPolicyName: string | null;
   scopedNetworkEgress: {
     allowFqdns: string[];

--- a/packages/plugins/sandbox-providers/kubernetes/test/integration/end-to-end-run.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/integration/end-to-end-run.test.ts
@@ -9,7 +9,7 @@
  *        docker tag alpine:3.20 localhost/paperclip-agent:latest
  *        kind load docker-image localhost/paperclip-agent:latest --name paperclip
  *   3. For the sandbox-cr backend test, the agent-sandbox controller must be installed:
- *        kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/install.yaml
+ *        kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml
  *      And a tini-bearing image pre-loaded (e.g. the same localhost/paperclip-agent:latest
  *      if it includes /usr/bin/tini and /bin/sh).
  *   4. Set the env var and run:
@@ -21,9 +21,10 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import plugin from "../../src/plugin.js";
-import { createKubeConfig } from "../../src/kube-client.js";
+import { apiServerUrl, createKubeConfig } from "../../src/kube-client.js";
 import { execInPod } from "../../src/pod-exec.js";
-import { sandboxCrOrchestrator } from "../../src/sandbox-cr-orchestrator.js";
+import { resolveSandboxApiVersion } from "../../src/sandbox-api-version.js";
+import { makeSandboxCrOrchestrator } from "../../src/sandbox-cr-orchestrator.js";
 import { deleteNamespaceIfExists, kubectl, readKindKubeconfig } from "./_kind-harness.js";
 
 const NAMESPACE = "paperclip-spike-e2e";
@@ -111,7 +112,7 @@ describe("plugin-kubernetes end-to-end", () => {
     180_000,
   );
 
-  // ── Sandbox-CR backend (alpha, requires agent-sandbox controller) ──────────
+  // ── Sandbox-CR backend (requires the agent-sandbox controller) ─────────────
 
   it.runIf(process.env.RUN_K8S_INTEGRATION_TESTS === "1")(
     "[sandbox-cr backend] acquireLease creates Sandbox CR + supporting resources; pod becomes Ready; execInPod runs echo hello; releaseLease deletes CR",
@@ -152,6 +153,11 @@ describe("plugin-kubernetes end-to-end", () => {
       const kc = createKubeConfig({ inCluster: false, kubeconfig });
       const { makeKubeClients } = await import("../../src/kube-client.js");
       const clients = makeKubeClients(kc);
+      // Address the CR through whichever version this cluster's controller
+      // serves, exactly as the plugin itself did when it created the object.
+      const sandboxCrOrchestrator = makeSandboxCrOrchestrator(
+        await resolveSandboxApiVersion(clients, apiServerUrl(kc)),
+      );
 
       await sandboxCrOrchestrator.waitForCompletion(
         clients,

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/lease-lifecycle.test.ts
@@ -6,7 +6,9 @@ import {
 } from "../../src/lease-lifecycle.js";
 
 const SANDBOX_GROUP = "agents.x-k8s.io";
-const SANDBOX_VERSION = "v1alpha1";
+// The caller resolves the served version from cluster discovery and passes it
+// in; these tests pin the modern one and assert it reaches the API.
+const SANDBOX_VERSION = "v1beta1";
 const SANDBOX_PLURAL = "sandboxes";
 
 function notFound(): Error {
@@ -52,6 +54,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "paperclip-acme",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       readyTimeoutMs: 1_000,
       pollMs: 10,
     });
@@ -60,6 +63,11 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "paperclip-acme",
       name: "pc-abc-pod",
     });
+    // The CR is addressed with the version the caller resolved, not a
+    // hard-coded one — a resume must reach the same object acquisition created.
+    for (const call of clients.custom.getNamespacedCustomObject.mock.calls) {
+      expect(call[0]).toMatchObject({ group: SANDBOX_GROUP, version: SANDBOX_VERSION });
+    }
   });
 
   it("is not resumable when the Sandbox CR is gone (404)", async () => {
@@ -71,6 +79,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "ns",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       readyTimeoutMs: 1_000,
       pollMs: 10,
     });
@@ -97,6 +106,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "ns",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       readyTimeoutMs: 1_000,
       pollMs: 10,
     });
@@ -118,6 +128,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "ns",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       readyTimeoutMs: 30,
       pollMs: 5,
     });
@@ -136,6 +147,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "ns",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       readyTimeoutMs: 1_000,
       pollMs: 10,
     });
@@ -159,6 +171,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
       namespace: "ns",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       readyTimeoutMs: 1_000,
       pollMs: 10,
     });
@@ -182,6 +195,7 @@ describe("checkLeaseResumable (sandbox-cr backend)", () => {
         namespace: "ns",
         name: "pc-abc",
         backend: "sandbox-cr",
+        sandboxApiVersion: SANDBOX_VERSION,
         readyTimeoutMs: 1_000,
         pollMs: 10,
       }),
@@ -260,6 +274,7 @@ describe("destroyLeaseResources", () => {
       namespace: "paperclip-acme",
       name: "pc-abc",
       backend: "sandbox-cr",
+      sandboxApiVersion: SANDBOX_VERSION,
       podName: "pc-abc-pod",
       secretName: "pc-abc-env",
     });
@@ -318,6 +333,7 @@ describe("destroyLeaseResources", () => {
         namespace: "ns",
         name: "pc-abc",
         backend: "sandbox-cr",
+        sandboxApiVersion: SANDBOX_VERSION,
         podName: "pc-abc-pod",
         secretName: "pc-abc-env",
       }),
@@ -340,6 +356,7 @@ describe("destroyLeaseResources", () => {
         namespace: "ns",
         name: "pc-abc",
         backend: "sandbox-cr",
+        sandboxApiVersion: SANDBOX_VERSION,
         podName: null,
         secretName: null,
       }),

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/manifest-version.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/manifest-version.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import manifest from "../../src/manifest.js";
+
+const packageJson = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../../package.json", import.meta.url)), "utf8"),
+) as { version: string };
+
+describe("plugin manifest", () => {
+  // These drifted apart once already (package 0.1.0 vs manifest 0.1.0-alpha.1).
+  // paperclip-server registers the plugin under the MANIFEST version, so a
+  // disagreement makes the installed package and the registered plugin report
+  // different versions to operators.
+  it("declares the same version as package.json", () => {
+    expect(manifest.version).toBe(packageJson.version);
+  });
+
+  it("carries no alpha labelling: the plugin no longer depends on an alpha API", () => {
+    const surfaces = [
+      manifest.displayName,
+      manifest.description,
+      manifest.version,
+      ...manifest.environmentDrivers!.flatMap((driver) => [
+        driver.displayName,
+        driver.description,
+        ...Object.values(
+          (driver.configSchema as { properties?: Record<string, { description?: string }> })
+            .properties ?? {},
+        ).map((property) => property.description ?? ""),
+      ]),
+    ];
+    for (const surface of surfaces) {
+      // `v1alpha1` is the name of a Kubernetes API version the plugin can still
+      // address, not a maturity claim about the plugin, so it is not stripped
+      // from the copy — only from this check.
+      const withoutApiVersionNames = String(surface).replaceAll("v1alpha1", "");
+      expect(withoutApiVersionNames.toLowerCase()).not.toContain("alpha");
+    }
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-lease-lifecycle.test.ts
@@ -4,12 +4,27 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // fake API clients instead of a real cluster. h.clients is swapped per test.
 const h = vi.hoisted(() => ({ clients: {} as Record<string, unknown> }));
 
-vi.mock("../../src/kube-client.js", () => ({
-  createKubeConfig: vi.fn(() => ({})),
+vi.mock("../../src/kube-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/kube-client.js")>()),
+  createKubeConfig: vi.fn(() => ({
+    getCurrentCluster: () => ({ server: "https://test-cluster.example" }),
+  })),
   makeKubeClients: vi.fn(() => h.clients),
 }));
 
 import plugin from "../../src/plugin.js";
+import { __clearSandboxApiVersionCache } from "../../src/sandbox-api-version.js";
+
+/** Discovery stub reporting the sandbox API group with the given versions. */
+function discovery(versions: string[]) {
+  return {
+    getAPIVersions: vi.fn().mockResolvedValue({
+      groups: [
+        { name: "agents.x-k8s.io", versions: versions.map((version) => ({ version })) },
+      ],
+    }),
+  };
+}
 
 const CONFIG = { inCluster: true, backend: "sandbox-cr" };
 
@@ -21,6 +36,7 @@ function leaseMetadata(overrides: Record<string, unknown> = {}): Record<string, 
     secretName: "pc-abc-env",
     phase: "Pending",
     backend: "sandbox-cr",
+    sandboxApiVersion: "v1beta1",
     ...overrides,
   };
 }
@@ -41,6 +57,7 @@ function readySandboxCr(podName: string): Record<string, unknown> {
 
 beforeEach(() => {
   h.clients = {};
+  __clearSandboxApiVersionCache();
 });
 
 describe("onEnvironmentResumeLease", () => {
@@ -261,5 +278,91 @@ describe("onEnvironmentDestroyLease", () => {
       expect.objectContaining({ namespace: "paperclip-acme", name: "pc-job" }),
     );
     expect(deleteCr).not.toHaveBeenCalled();
+  });
+});
+
+describe("Sandbox API version on an existing lease", () => {
+  it("addresses the CR through the version recorded at acquisition, without re-running discovery", async () => {
+    const getCr = vi.fn().mockResolvedValue(readySandboxCr("pc-abc-pod"));
+    const apis = discovery(["v1beta1"]);
+    h.clients = {
+      apis,
+      custom: { getNamespacedCustomObject: getCr },
+      core: {
+        readNamespacedPod: vi.fn().mockResolvedValue({ metadata: {}, status: { phase: "Running" } }),
+      },
+    };
+
+    const lease = await plugin.definition.onEnvironmentResumeLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: CONFIG,
+      providerLeaseId: "pc-abc",
+      // A lease taken while the cluster still served only v1alpha1. Discovery
+      // now prefers v1beta1, but this CR must keep being addressed as created.
+      leaseMetadata: leaseMetadata({ sandboxApiVersion: "v1alpha1" }),
+    });
+
+    expect(getCr).toHaveBeenCalledWith(expect.objectContaining({ version: "v1alpha1" }));
+    expect(apis.getAPIVersions).not.toHaveBeenCalled();
+    expect(lease.metadata?.sandboxApiVersion).toBe("v1alpha1");
+  });
+
+  it("rediscovers the served version for a lease taken before the version was recorded", async () => {
+    const deleteCr = vi.fn().mockResolvedValue({});
+    const apis = discovery(["v1alpha1", "v1beta1"]);
+    h.clients = {
+      apis,
+      custom: { deleteNamespacedCustomObject: deleteCr },
+      core: {
+        deleteNamespacedPod: vi.fn().mockResolvedValue({}),
+        deleteNamespacedSecret: vi.fn().mockResolvedValue({}),
+      },
+      batch: { deleteNamespacedJob: vi.fn() },
+    };
+
+    const legacy = leaseMetadata();
+    delete legacy.sandboxApiVersion;
+
+    await plugin.definition.onEnvironmentDestroyLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: CONFIG,
+      providerLeaseId: "pc-abc",
+      leaseMetadata: legacy,
+    });
+
+    expect(apis.getAPIVersions).toHaveBeenCalledTimes(1);
+    expect(deleteCr).toHaveBeenCalledWith(expect.objectContaining({ version: "v1beta1" }));
+  });
+
+  it("never runs Sandbox discovery for a job-backend lease (the CRD need not be installed)", async () => {
+    const apis = discovery([]);
+    const deleteJob = vi.fn().mockResolvedValue({});
+    h.clients = {
+      apis,
+      custom: { deleteNamespacedCustomObject: vi.fn() },
+      core: {
+        deleteNamespacedPod: vi.fn().mockResolvedValue({}),
+        deleteNamespacedSecret: vi.fn().mockResolvedValue({}),
+      },
+      batch: { deleteNamespacedJob: deleteJob },
+    };
+
+    await plugin.definition.onEnvironmentDestroyLease!({
+      driverKey: "kubernetes",
+      companyId: "acme",
+      environmentId: "env-1",
+      config: { inCluster: true, backend: "job" },
+      providerLeaseId: "pc-job",
+      leaseMetadata: leaseMetadata({ jobName: "pc-job", backend: "job", sandboxApiVersion: undefined }),
+    });
+
+    expect(apis.getAPIVersions).not.toHaveBeenCalled();
+    expect(deleteJob).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "paperclip-acme", name: "pc-job" }),
+    );
   });
 });

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-sandbox-api-version.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin-sandbox-api-version.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Acquisition is driven against injected fake API clients. Tenant bootstrap and
+// per-run Secret creation are stubbed: this file is about ONE thing, which
+// Sandbox API version every object acquisition emits is stamped with.
+const h = vi.hoisted(() => ({
+  clients: {} as Record<string, unknown>,
+  ensureTenant: vi.fn(),
+  createPerRunSecret: vi.fn(),
+}));
+
+vi.mock("../../src/kube-client.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/kube-client.js")>()),
+  createKubeConfig: vi.fn(() => ({
+    getCurrentCluster: () => ({ server: "https://test-cluster.example" }),
+  })),
+  makeKubeClients: vi.fn(() => h.clients),
+}));
+
+vi.mock("../../src/tenant-orchestrator.js", () => ({ ensureTenant: h.ensureTenant }));
+vi.mock("../../src/secret-manager.js", () => ({ createPerRunSecret: h.createPerRunSecret }));
+
+import plugin from "../../src/plugin.js";
+import { __clearSandboxApiVersionCache } from "../../src/sandbox-api-version.js";
+
+function discovery(versions: string[]) {
+  return {
+    getAPIVersions: vi.fn().mockResolvedValue({
+      groups: [
+        { name: "agents.x-k8s.io", versions: versions.map((version) => ({ version })) },
+      ],
+    }),
+  };
+}
+
+function clients(versions: string[]) {
+  return {
+    apis: discovery(versions),
+    custom: {
+      createNamespacedCustomObject: vi.fn().mockResolvedValue({ metadata: { uid: "sandbox-uid" } }),
+      getNamespacedCustomObject: vi.fn().mockResolvedValue({
+        metadata: { uid: "sandbox-uid" },
+        status: { conditions: [{ type: "Ready", status: "True" }], podName: "pc-pod" },
+      }),
+      deleteNamespacedCustomObject: vi.fn().mockResolvedValue({}),
+    },
+    core: { readNamespacedPod: vi.fn(), listNamespacedPod: vi.fn() },
+    networking: { createNamespacedNetworkPolicy: vi.fn().mockResolvedValue({}) },
+  };
+}
+
+async function acquire(config: Record<string, unknown> = { inCluster: true }) {
+  return await plugin.definition.onEnvironmentAcquireLease!({
+    driverKey: "kubernetes",
+    companyId: "acme",
+    environmentId: "env-1",
+    runId: "run-1",
+    config,
+    // A task-scoped grant makes the provider create the run-scoped egress
+    // policy, whose ownerReference has to name the Sandbox by the same version.
+    executionWorkspaceSettings: { networkEgress: { allowCidrs: ["10.9.0.0/16"] } },
+  } as never);
+}
+
+beforeEach(() => {
+  __clearSandboxApiVersionCache();
+  h.ensureTenant.mockReset().mockResolvedValue(undefined);
+  h.createPerRunSecret.mockReset().mockResolvedValue(undefined);
+});
+
+describe("onEnvironmentAcquireLease Sandbox API version", () => {
+  it("creates the Sandbox through v1beta1 on a graduated controller and records it on the lease", async () => {
+    const c = clients(["v1alpha1", "v1beta1"]);
+    h.clients = c;
+
+    const lease = await acquire();
+
+    const created = c.custom.createNamespacedCustomObject.mock.calls[0]![0] as {
+      version: string;
+      body: { apiVersion: string };
+    };
+    expect(created.version).toBe("v1beta1");
+    expect(created.body.apiVersion).toBe("agents.x-k8s.io/v1beta1");
+    expect(lease.metadata?.sandboxApiVersion).toBe("v1beta1");
+  });
+
+  it("falls back to v1alpha1 on a controller that predates the graduation", async () => {
+    const c = clients(["v1alpha1"]);
+    h.clients = c;
+
+    const lease = await acquire();
+
+    const created = c.custom.createNamespacedCustomObject.mock.calls[0]![0] as {
+      version: string;
+      body: { apiVersion: string };
+    };
+    expect(created.version).toBe("v1alpha1");
+    expect(created.body.apiVersion).toBe("agents.x-k8s.io/v1alpha1");
+    expect(lease.metadata?.sandboxApiVersion).toBe("v1alpha1");
+  });
+
+  it("stamps the resolved version into both ownerReferences, so cascade delete still matches", async () => {
+    const c = clients(["v1beta1"]);
+    h.clients = c;
+
+    await acquire();
+
+    const policy = c.networking.createNamespacedNetworkPolicy.mock.calls[0]![0] as {
+      body: { metadata: { ownerReferences: { apiVersion: string; kind: string }[] } };
+    };
+    expect(policy.body.metadata.ownerReferences[0]).toMatchObject({
+      apiVersion: "agents.x-k8s.io/v1beta1",
+      kind: "Sandbox",
+    });
+    expect(h.createPerRunSecret.mock.calls[0]![1]).toMatchObject({
+      ownerApiVersion: "agents.x-k8s.io/v1beta1",
+      ownerKind: "Sandbox",
+    });
+  });
+
+  it("refuses the lease before provisioning anything when the controller is not installed", async () => {
+    const c = clients([]);
+    c.apis.getAPIVersions.mockResolvedValue({ groups: [{ name: "batch", versions: [{ version: "v1" }] }] });
+    h.clients = c;
+
+    await expect(acquire()).rejects.toThrow(/agent-sandbox/);
+    // Failing this late would leave a tenant namespace, RBAC, quotas and network
+    // policies behind for a cluster that can never run a sandbox lease.
+    expect(h.ensureTenant).not.toHaveBeenCalled();
+    expect(c.custom.createNamespacedCustomObject).not.toHaveBeenCalled();
+  });
+
+  it("does not require the Sandbox CRD at all for the job backend", async () => {
+    const c = clients([]);
+    c.apis.getAPIVersions.mockResolvedValue({ groups: [] });
+    h.clients = {
+      ...c,
+      batch: {
+        createNamespacedJob: vi.fn().mockResolvedValue({ metadata: { uid: "job-uid" } }),
+        readNamespacedJobStatus: vi.fn().mockResolvedValue({ status: {} }),
+      },
+      core: { ...c.core, listNamespacedPod: vi.fn().mockResolvedValue({ items: [] }) },
+    };
+
+    const lease = await acquire({ inCluster: true, backend: "job" });
+
+    expect(c.apis.getAPIVersions).not.toHaveBeenCalled();
+    expect(lease.metadata?.sandboxApiVersion).toBeUndefined();
+    expect(lease.metadata?.backend).toBe("job");
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-api-version.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-api-version.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  SANDBOX_GROUP,
+  __clearSandboxApiVersionCache,
+  resolveSandboxApiVersion,
+} from "../../src/sandbox-api-version.js";
+
+/** A KubeClients stand-in whose discovery reports the given served versions. */
+function clientsServing(versions: string[], getAPIVersions = vi.fn()) {
+  getAPIVersions.mockResolvedValue({
+    groups: [
+      { name: "batch", versions: [{ version: "v1" }] },
+      { name: SANDBOX_GROUP, versions: versions.map((version) => ({ version })) },
+    ],
+  });
+  return { clients: { apis: { getAPIVersions } } as never, getAPIVersions };
+}
+
+/** A KubeClients stand-in whose discovery does not list the sandbox group at all. */
+function clientsWithoutGroup() {
+  return {
+    apis: {
+      getAPIVersions: vi.fn().mockResolvedValue({
+        groups: [{ name: "batch", versions: [{ version: "v1" }] }],
+      }),
+    },
+  } as never;
+}
+
+beforeEach(() => {
+  __clearSandboxApiVersionCache();
+});
+
+describe("resolveSandboxApiVersion", () => {
+  it("prefers v1beta1 when the cluster serves it (agent-sandbox >= v0.5.0)", async () => {
+    const { clients } = clientsServing(["v1alpha1", "v1beta1"]);
+    expect(await resolveSandboxApiVersion(clients, "https://a")).toBe("v1beta1");
+  });
+
+  it("falls back to v1alpha1 on controllers that predate the graduation", async () => {
+    const { clients } = clientsServing(["v1alpha1"]);
+    expect(await resolveSandboxApiVersion(clients, "https://a")).toBe("v1alpha1");
+  });
+
+  it("names the missing controller when the API group is absent", async () => {
+    await expect(
+      resolveSandboxApiVersion(clientsWithoutGroup(), "https://a"),
+    ).rejects.toThrow(/agent-sandbox/);
+    __clearSandboxApiVersionCache();
+    await expect(
+      resolveSandboxApiVersion(clientsWithoutGroup(), "https://a"),
+    ).rejects.toThrow(/backend/);
+  });
+
+  it("asks for an upgrade when the group serves only versions this plugin cannot address", async () => {
+    const { clients } = clientsServing(["v1"]);
+    await expect(resolveSandboxApiVersion(clients, "https://a")).rejects.toThrow(
+      /Upgrade the agent-sandbox controller/,
+    );
+  });
+
+  it("discovers once per API-server URL and serves later calls from the cache", async () => {
+    const { clients, getAPIVersions } = clientsServing(["v1beta1"]);
+    expect(await resolveSandboxApiVersion(clients, "https://a")).toBe("v1beta1");
+
+    // A client that would throw if it were consulted: the second call must not
+    // reach discovery at all.
+    const exploding = {
+      apis: {
+        getAPIVersions: vi.fn().mockRejectedValue(new Error("discovery must not run again")),
+      },
+    } as never;
+    expect(await resolveSandboxApiVersion(exploding, "https://a")).toBe("v1beta1");
+    expect(getAPIVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves each API-server URL independently", async () => {
+    const beta = clientsServing(["v1beta1"]);
+    const alpha = clientsServing(["v1alpha1"]);
+    expect(await resolveSandboxApiVersion(beta.clients, "https://a")).toBe("v1beta1");
+    expect(await resolveSandboxApiVersion(alpha.clients, "https://b")).toBe("v1alpha1");
+    expect(beta.getAPIVersions).toHaveBeenCalledTimes(1);
+    expect(alpha.getAPIVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one discovery request between concurrent first callers", async () => {
+    let release!: (value: unknown) => void;
+    const getAPIVersions = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+    const clients = { apis: { getAPIVersions } } as never;
+
+    const first = resolveSandboxApiVersion(clients, "https://a");
+    const second = resolveSandboxApiVersion(clients, "https://a");
+    release({ groups: [{ name: SANDBOX_GROUP, versions: [{ version: "v1beta1" }] }] });
+
+    expect(await first).toBe("v1beta1");
+    expect(await second).toBe("v1beta1");
+    expect(getAPIVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not poison the cache with a transient discovery failure", async () => {
+    const failing = {
+      apis: { getAPIVersions: vi.fn().mockRejectedValue(new Error("connection reset")) },
+    } as never;
+    await expect(resolveSandboxApiVersion(failing, "https://a")).rejects.toThrow(
+      /connection reset/,
+    );
+
+    // The retry must re-run discovery rather than replay the rejected promise.
+    const { clients } = clientsServing(["v1beta1"]);
+    expect(await resolveSandboxApiVersion(clients, "https://a")).toBe("v1beta1");
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { buildSandboxCrManifest } from "../../src/sandbox-cr-builder.js";
 
 const baseInput = {
+  apiVersion: "v1beta1" as const,
   namespace: "paperclip-acme",
   sandboxName: "pc-01h00000000000000000000000",
   adapterType: "claude_local",
@@ -17,10 +18,27 @@ const baseInput = {
 };
 
 describe("buildSandboxCrManifest", () => {
-  it("returns a Sandbox CR with the correct apiVersion and kind", () => {
+  it("stamps the resolved served version into apiVersion, with kind Sandbox", () => {
     const cr = buildSandboxCrManifest(baseInput);
-    expect(cr.apiVersion).toBe("agents.x-k8s.io/v1alpha1");
+    expect(cr.apiVersion).toBe("agents.x-k8s.io/v1beta1");
     expect(cr.kind).toBe("Sandbox");
+  });
+
+  // The same manifest has to be valid on a controller that predates the
+  // v1beta1 graduation: `spec.podTemplate` is required and identically shaped
+  // in both versions, and the builder sets neither the v1alpha1 `spec.replicas`
+  // nor the v1beta1 `spec.operatingMode` that replaced it.
+  it("addresses an older controller through v1alpha1 with a byte-identical spec", () => {
+    const beta = buildSandboxCrManifest(baseInput);
+    const alpha = buildSandboxCrManifest({ ...baseInput, apiVersion: "v1alpha1" });
+    expect(alpha.apiVersion).toBe("agents.x-k8s.io/v1alpha1");
+    expect(alpha.spec).toEqual(beta.spec);
+  });
+
+  it("sets neither replicas (v1alpha1) nor operatingMode (v1beta1), the one field the graduation changed", () => {
+    const spec = buildSandboxCrManifest(baseInput).spec as Record<string, unknown>;
+    expect(spec.replicas).toBeUndefined();
+    expect(spec.operatingMode).toBeUndefined();
   });
 
   it("sets metadata name and namespace correctly", () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-orchestrator.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-orchestrator.test.ts
@@ -4,12 +4,15 @@ import {
   deleteSandboxCr,
   getSandboxCrStatus,
   findPodForSandbox,
+  makeSandboxCrOrchestrator,
   SandboxCrTimeoutError,
   waitForSandboxReady,
 } from "../../src/sandbox-cr-orchestrator.js";
 
 const SANDBOX_GROUP = "agents.x-k8s.io";
-const SANDBOX_VERSION = "v1alpha1";
+// Every CR request carries the version the caller resolved from cluster
+// discovery; these tests pin the modern one and assert it reaches the API.
+const SANDBOX_VERSION = "v1beta1";
 const SANDBOX_PLURAL = "sandboxes";
 
 // Helpers to build mock CR objects with given phase
@@ -28,11 +31,11 @@ describe("createSandboxCr", () => {
     const create = vi.fn().mockResolvedValue({ metadata: { uid: "test-uid" } });
     const clients = { custom: { createNamespacedCustomObject: create } };
     const manifest = {
-      apiVersion: "agents.x-k8s.io/v1alpha1",
+      apiVersion: "agents.x-k8s.io/v1beta1",
       kind: "Sandbox",
       metadata: { name: "pc-abc", namespace: "paperclip-acme" },
     };
-    const result = await createSandboxCr(clients as never, "paperclip-acme", manifest);
+    const result = await createSandboxCr(clients as never, "paperclip-acme", manifest, SANDBOX_VERSION);
     expect(create).toHaveBeenCalledWith({
       group: SANDBOX_GROUP,
       version: SANDBOX_VERSION,
@@ -47,7 +50,7 @@ describe("createSandboxCr", () => {
     const create = vi.fn().mockResolvedValue({ metadata: {} });
     const clients = { custom: { createNamespacedCustomObject: create } };
     await expect(
-      createSandboxCr(clients as never, "ns", {}),
+      createSandboxCr(clients as never, "ns", {}, SANDBOX_VERSION),
     ).rejects.toThrow("Sandbox CR created without a UID");
   });
 });
@@ -56,7 +59,7 @@ describe("getSandboxCrStatus", () => {
   it("maps phase=Ready to SandboxStatus.phase=Running with active=1", async () => {
     const get = vi.fn().mockResolvedValue(makeCr("Ready"));
     const clients = { custom: { getNamespacedCustomObject: get } };
-    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc");
+    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(status.phase).toBe("Running");
     expect(status.active).toBe(1);
     expect(status.complete).toBe(false);
@@ -65,7 +68,7 @@ describe("getSandboxCrStatus", () => {
   it("maps phase=Pending to SandboxStatus.phase=Pending", async () => {
     const get = vi.fn().mockResolvedValue(makeCr("Pending"));
     const clients = { custom: { getNamespacedCustomObject: get } };
-    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc");
+    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(status.phase).toBe("Pending");
     expect(status.active).toBe(0);
   });
@@ -81,7 +84,7 @@ describe("getSandboxCrStatus", () => {
       },
     });
     const clients = { custom: { getNamespacedCustomObject: get } };
-    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc");
+    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(status.phase).toBe("Failed");
     expect(status.failed).toBe(1);
     expect(status.reason).toBe("ImagePullFailed");
@@ -90,7 +93,7 @@ describe("getSandboxCrStatus", () => {
   it("maps phase=Terminating to SandboxStatus.phase=Running with reason=Terminating", async () => {
     const get = vi.fn().mockResolvedValue(makeCr("Terminating"));
     const clients = { custom: { getNamespacedCustomObject: get } };
-    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc");
+    const status = await getSandboxCrStatus(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(status.phase).toBe("Running");
     expect(status.reason).toBe("Terminating");
   });
@@ -103,7 +106,7 @@ describe("findPodForSandbox", () => {
       custom: { getNamespacedCustomObject: get },
       core: { readNamespacedPod: vi.fn(), listNamespacedPod: vi.fn() },
     };
-    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc");
+    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(podName).toBe("pc-abc-pod-xyz");
     // Primary path succeeded: neither the exact-name GET nor the label list runs.
     expect(clients.core.readNamespacedPod).not.toHaveBeenCalled();
@@ -121,7 +124,7 @@ describe("findPodForSandbox", () => {
       custom: { getNamespacedCustomObject: get },
       core: { readNamespacedPod: read, listNamespacedPod: list },
     };
-    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc");
+    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(read).toHaveBeenCalledWith({ namespace: "ns", name: "pc-abc" });
     expect(podName).toBe("pc-abc");
     expect(list).not.toHaveBeenCalled();
@@ -142,7 +145,7 @@ describe("findPodForSandbox", () => {
       custom: { getNamespacedCustomObject: get },
       core: { readNamespacedPod: read, listNamespacedPod: list },
     };
-    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc");
+    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(list).toHaveBeenCalledWith(
       expect.objectContaining({ labelSelector: "agents.x-k8s.io/sandbox-name=pc-abc" }),
     );
@@ -164,7 +167,7 @@ describe("findPodForSandbox", () => {
       custom: { getNamespacedCustomObject: get },
       core: { readNamespacedPod: vi.fn().mockRejectedValue({ code: 404 }), listNamespacedPod: list },
     };
-    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc");
+    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(podName).toBeNull();
   });
 
@@ -176,7 +179,7 @@ describe("findPodForSandbox", () => {
       custom: { getNamespacedCustomObject: get },
       core: { readNamespacedPod: read, listNamespacedPod: list },
     };
-    await expect(findPodForSandbox(clients as never, "ns", "pc-abc")).rejects.toMatchObject({
+    await expect(findPodForSandbox(clients as never, "ns", "pc-abc", SANDBOX_VERSION)).rejects.toMatchObject({
       code: 403,
     });
     expect(list).not.toHaveBeenCalled();
@@ -189,7 +192,7 @@ describe("findPodForSandbox", () => {
       custom: { getNamespacedCustomObject: get },
       core: { readNamespacedPod: vi.fn().mockRejectedValue({ code: 404 }), listNamespacedPod: list },
     };
-    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc");
+    const podName = await findPodForSandbox(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(podName).toBeNull();
   });
 });
@@ -198,7 +201,7 @@ describe("deleteSandboxCr", () => {
   it("calls custom.deleteNamespacedCustomObject with Foreground propagation", async () => {
     const del = vi.fn().mockResolvedValue({});
     const clients = { custom: { deleteNamespacedCustomObject: del } };
-    await deleteSandboxCr(clients as never, "ns", "pc-abc");
+    await deleteSandboxCr(clients as never, "ns", "pc-abc", SANDBOX_VERSION);
     expect(del).toHaveBeenCalledWith(
       expect.objectContaining({
         group: SANDBOX_GROUP,
@@ -221,6 +224,7 @@ describe("waitForSandboxReady", () => {
       "ns",
       "pc-abc",
       { timeoutMs: 5000, pollMs: 10 },
+      SANDBOX_VERSION,
     );
     expect(status.phase).toBe("Running"); // Ready maps to Running
     expect(get).toHaveBeenCalledTimes(1);
@@ -238,6 +242,7 @@ describe("waitForSandboxReady", () => {
       "ns",
       "pc-abc",
       { timeoutMs: 5000, pollMs: 10 },
+      SANDBOX_VERSION,
     );
     expect(status.phase).toBe("Running");
     expect(get).toHaveBeenCalledTimes(3);
@@ -247,10 +252,13 @@ describe("waitForSandboxReady", () => {
     const get = vi.fn().mockResolvedValue(makeCr("Pending"));
     const clients = { custom: { getNamespacedCustomObject: get } };
     await expect(
-      waitForSandboxReady(clients as never, "ns", "pc-abc", {
-        timeoutMs: 50,
-        pollMs: 10,
-      }),
+      waitForSandboxReady(
+        clients as never,
+        "ns",
+        "pc-abc",
+        { timeoutMs: 50, pollMs: 10 },
+        SANDBOX_VERSION,
+      ),
     ).rejects.toBeInstanceOf(SandboxCrTimeoutError);
   });
 
@@ -261,10 +269,55 @@ describe("waitForSandboxReady", () => {
     });
     const clients = { custom: { getNamespacedCustomObject: get } };
     await expect(
-      waitForSandboxReady(clients as never, "ns", "pc-abc", {
-        timeoutMs: 5000,
-        pollMs: 10,
-      }),
+      waitForSandboxReady(
+        clients as never,
+        "ns",
+        "pc-abc",
+        { timeoutMs: 5000, pollMs: 10 },
+        SANDBOX_VERSION,
+      ),
     ).rejects.toThrow(/failed.*OOMKilled/i);
+  });
+});
+
+describe("makeSandboxCrOrchestrator", () => {
+  // The SandboxOrchestrator interface is version-agnostic by design (the job
+  // backend has no such notion), so the resolved version is bound into the
+  // orchestrator instead of travelling through every call signature.
+  it("binds the resolved version into every CR request it makes", async () => {
+    const create = vi.fn().mockResolvedValue({ metadata: { uid: "u" } });
+    const get = vi.fn().mockResolvedValue(makeCr("Ready", "pc-abc-pod"));
+    const del = vi.fn().mockResolvedValue({});
+    const clients = {
+      custom: {
+        createNamespacedCustomObject: create,
+        getNamespacedCustomObject: get,
+        deleteNamespacedCustomObject: del,
+      },
+      core: { readNamespacedPod: vi.fn(), listNamespacedPod: vi.fn() },
+    } as never;
+
+    const orchestrator = makeSandboxCrOrchestrator("v1beta1");
+    await orchestrator.claim(clients, "ns", { kind: "Sandbox" });
+    await orchestrator.getStatus(clients, "ns", "pc-abc");
+    await orchestrator.findPod(clients, "ns", "pc-abc");
+    await orchestrator.release(clients, "ns", "pc-abc");
+    await orchestrator.waitForCompletion(clients, "ns", "pc-abc", {
+      timeoutMs: 5000,
+      pollMs: 10,
+    });
+
+    for (const call of [...create.mock.calls, ...get.mock.calls, ...del.mock.calls]) {
+      expect(call[0]).toMatchObject({ group: SANDBOX_GROUP, version: "v1beta1" });
+    }
+  });
+
+  it("addresses an older controller through v1alpha1", async () => {
+    const del = vi.fn().mockResolvedValue({});
+    const clients = { custom: { deleteNamespacedCustomObject: del } } as never;
+    await makeSandboxCrOrchestrator("v1alpha1").release(clients, "ns", "pc-abc");
+    expect(del).toHaveBeenCalledWith(
+      expect.objectContaining({ version: "v1alpha1" }),
+    );
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute inside sandbox environments provided by sandbox-provider plugins; the first-party `kubernetes` plugin gives each company its own namespace and execs commands into a pod managed by the `kubernetes-sigs/agent-sandbox` controller
> - That controller graduated its API from `v1alpha1` to `v1beta1` in release v0.5.0 (2026-06-24; latest is v0.5.3). The v0.5.3 CRD serves both: `v1beta1` as the storage version and `v1alpha1` as `deprecated: true` behind a conversion webhook
> - The plugin hard-codes `agents.x-k8s.io/v1alpha1` in four places: `SANDBOX_VERSION` in `sandbox-cr-orchestrator.ts`, the `apiVersion` literal in `sandbox-cr-builder.ts`, and two `ownerReference.apiVersion` sites in `plugin.ts`. Every request it makes therefore addresses a deprecated version, and the day a controller stops serving it the provider stops working
> - Swapping one hard-coded version for the other is not the fix either: that would break every cluster still running a pre-v0.5.0 controller. So the plugin now discovers what the cluster serves and addresses that, preferring `v1beta1`
> - The plugin's ALPHA label was scoped to exactly this dependency ("built on agent-sandbox v1alpha1, expect breaking changes as that CRD evolves toward Beta"). The CRD reached Beta. The label describes something that is no longer true, so this pull request drops it and ships 0.2.0
> - The benefit is that Kubernetes environments keep working across the agent-sandbox graduation in both directions — new controllers and old ones, with no configuration — and operators stop seeing an alpha warning on the provider that has per-tenant namespace isolation, PSS-restricted pods, deny-all networking with FQDN egress, and the largest test suite of any sandbox provider in this repo

## Linked Issues or Issue Description

No existing public issue — described in-PR following the bug template.

**What happened?**

`packages/plugins/sandbox-providers/kubernetes` addresses the Sandbox CRD through a compile-time constant:

- `src/sandbox-cr-orchestrator.ts`: `const SANDBOX_VERSION = "v1alpha1"` — used by create, get, find-pod, delete and the readiness poll
- `src/sandbox-cr-builder.ts`: `apiVersion: "agents.x-k8s.io/v1alpha1"` on the manifest body
- `src/plugin.ts`: `agents.x-k8s.io/v1alpha1` on the run-scoped egress policy's `ownerReference` and on the per-run Secret's `ownerReference`

agent-sandbox v0.5.0 made `v1beta1` the storage version and marked `v1alpha1` deprecated. Deprecated versions are eventually unserved, and the conversion webhook that keeps `v1alpha1` working today sits in the path of every lease. Nothing in the plugin notices any of this.

Separately, the plugin declared two different versions of itself: `PLUGIN_VERSION = "0.1.0-alpha.1"` in `src/manifest.ts` versus `"version": "0.1.0"` in `package.json`. paperclip-server registers the plugin under the manifest value, so the installed package and the registered plugin disagreed about what was running.

**Expected behavior**

The provider addresses whichever Sandbox API version the cluster actually serves, keeps addressing a live lease's object through the version it was created with, and reports one version of itself.

## What Changed

- **New `src/sandbox-api-version.ts`**: `resolveSandboxApiVersion(clients, serverUrl)` reads discovery (`ApisApi.getAPIVersions`), finds the `agents.x-k8s.io` group and returns the first of `["v1beta1", "v1alpha1"]` the cluster serves. A missing group throws "install the kubernetes-sigs/agent-sandbox controller, or set `backend: \"job\"`"; a group serving neither asks for a controller upgrade. Resolution is cached per API-server URL for the worker's lifetime — the **promise** is cached, so concurrent first callers share one discovery request, and a rejected promise is evicted so a transient discovery failure cannot poison the cache into failing every subsequent lease.
- **`KubeClients` gains `apis: ApisApi`**, plus `apiServerUrl(kc)` as the cache key (served versions are a property of the API server, so two environments pointing at one cluster share a result).
- **The resolved version is threaded, not re-derived.** `BuildSandboxCrManifestInput` gains `apiVersion`; the orchestrator's exported functions take it explicitly and `makeSandboxCrOrchestrator(apiVersion)` binds it into the version-agnostic `SandboxOrchestrator` interface; `ResumeCheckInput`/`DestroyLeaseInput` carry it as part of the backend discriminant, so it is impossible to reach a CR call site with a `sandbox-cr` lease and no resolved version, and equally impossible to demand one for a `job` lease. `plugin.ts` branches on the resolved version rather than the backend string for the same reason. Both `ownerReference.apiVersion` sites name it too — an ownerReference is matched on apiVersion + kind + uid, so a stale version there breaks cascade delete.
- **The version is recorded on the lease** (`KubernetesLeaseMetadata.sandboxApiVersion`) and preferred over rediscovery on every later call. A worker that restarts mid-lease, or a cluster whose controller is upgraded mid-lease, still addresses the object through the version it was created with. Leases taken before the field existed fall back to discovery.
- **Resolution happens before any tenant resource is created.** A cluster without the controller now fails the lease with an actionable message instead of provisioning a namespace, ServiceAccount, RBAC, quotas and network policies for a lease that can never run. The `job` backend never triggers discovery at all — it addresses `batch/v1` and must not require the CRD to be present.
- **The manifest body is unchanged between versions, verified against the real CRD.** The graduation's one breaking spec change replaced `spec.replicas` with `spec.operatingMode` (enum Running|Suspended, default Running). This builder sets neither; it sets only `spec.podTemplate`, which is required and identically shaped in both versions. A test pins that: `alpha.spec` deep-equals `beta.spec`, and neither field is present.
- **De-alpha.** `PLUGIN_VERSION` and the `package.json` version are both `0.2.0`, with a test pinning them equal so they cannot drift again. `displayName: "Kubernetes Sandbox"`. Rewritten manifest description, `backend` enum description, `types.ts` doc comment, and README (title, maturity note, backend table, config table, resource listing). A test asserts no manifest surface carries alpha labelling.
- **The `job` backend is described honestly.** It was "stable fallback", which reads like parity. It is dispatch-only: the container entrypoint runs once and exits, so there is no exec channel, which means no multi-command adapter install and no native file sync. README, manifest and type docs now say that.
- Fixed a broken install link in the README and in the integration-test prerequisites: agent-sandbox releases publish `sandbox.yaml`, not `install.yaml` (the documented URL 404s).

## Verification

- `pnpm --dir packages/plugins/sandbox-providers/kubernetes test` — **204 passed, 22 of them new**. The 7 failures in `test/unit/file-sync.test.ts` are pre-existing on `master` in this environment and unrelated: those tests exercise `/proc/self/fd/<n>`, which does not exist on macOS (`realpath: /proc/self/fd/9: No such file or directory`). Verified against a clean checkout of `master`: identical 7 failures, 182 passed.
- `pnpm --dir packages/plugins/sandbox-providers/kubernetes typecheck` — passed.
- The claims about agent-sandbox were checked against the shipped artifact rather than the docs. `sandbox.yaml` from the v0.5.3 release declares `versions: [v1beta1 (served, storage), v1alpha1 (served, deprecated)]` with a `Webhook` conversion strategy (`agent-sandbox-webhook-service` in `agent-sandbox-system`, path `/convert`), `spec` keys `[operatingMode, podTemplate, service, shutdownPolicy, shutdownTime, volumeClaimTemplates]` for v1beta1 versus `[podTemplate, replicas, ...]` for v1alpha1, and `podTemplate` required in both. Readiness is reported through `status.conditions[type=Ready]` in both versions, which is what the plugin polls.
- Test-driven. The resolver's tests were written first and observed failing (`Cannot find module '../../src/sandbox-api-version.js'`), then the threading tests (`makeSandboxCrOrchestrator is not a function`, `expected 'agents.x-k8s.io/v1alpha1' to be 'agents.x-k8s.io/v1beta1'`), then the implementation. The "refuses the lease before provisioning anything" assertion was mutation-checked by moving the resolve call back below `ensureTenant` and confirming it fails.

## Notes for reviewers

This is one of three independent sibling pull requests against this plugin; #10263 (exec correctness: `cwd`, `signal`, `timeoutMs`) and #10264 (lease reuse) are the others. None is stacked on the others, so each can merge alone. They touch the README config table and `src/manifest.ts` in different places, and I will rebase this branch onto whichever lands first. This branch deliberately does not document #10263's `timeoutMs` or #10264's `reuseLease` in the README, since neither key exists here.

## Risks

- **Behavioral change on a cluster without the agent-sandbox controller**: `acquireLease` with `backend: "sandbox-cr"` now fails at discovery instead of failing later at CR creation. The failure is strictly earlier and strictly more informative (it names the fix), and it no longer strands a provisioned tenant namespace. A cluster that *does* have the controller sees no change in outcome, only in which API version the requests carry.
- **One extra API request per worker per cluster**: discovery runs once and is cached for the worker's lifetime, and never runs at all for the `job` backend or for a lease that already recorded its version. The cache holds the promise, so a burst of concurrent first leases still issues one request. The failure path evicts, so a cluster that was briefly unreachable during discovery recovers on the next lease instead of failing forever.
- **Live leases are safe across the upgrade.** A lease acquired by an older worker carries no `sandboxApiVersion`; the new code rediscovers rather than assuming, and agent-sandbox keeps `v1alpha1` served and convertible, so the CR is still reachable. A lease acquired after this change carries its version and keeps using it even if the controller is upgraded mid-lease.
- **`ownerReference.apiVersion` on existing objects is not rewritten** and does not need to be: those objects are owned by a Sandbox created through the version recorded in the same reference, and Kubernetes resolves the owner through the conversion webhook.
- **Version bump 0.1.0 → 0.2.0** changes the string paperclip-server registers the plugin under. This is the intended fix for the manifest/package drift, but any operator tooling that pinned the literal `0.1.0-alpha.1` will need updating.
- The `SandboxOrchestrator` interface is unchanged; `sandbox-cr-orchestrator.ts`'s exported functions gained a required trailing `apiVersion` argument and the previously exported `sandboxCrOrchestrator` singleton (which was bound to `v1alpha1` by construction) is replaced by `makeSandboxCrOrchestrator`. Both are internal to this package — `src/index.ts` exports only `manifest` and `plugin` — and every call site in the repo is updated. The compiler catches any missed one; there is no silent default that could keep addressing a deprecated version.
- The plugin's tests are not run by repo CI (`pnpm-workspace.yaml` deliberately excludes `packages/plugins/sandbox-providers/**`), so the local run recorded under Verification is the gate for this change.

## Model Used

Anthropic Claude, exact model ID `claude-opus-5[1m]` (Opus 5, 1M context), extended thinking, with tool use and code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
