### PR TITLE
fix(plugins): run and repair the workspace-excluded sandbox-provider test suites

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       lockfile_regenerated: ${{ steps.regen_lockfile.outputs.regenerated }}
+      standalone_plugins_changed: ${{ steps.standalone_plugins.outputs.changed }}
 
     steps:
       - name: Checkout repository
@@ -67,6 +68,9 @@ jobs:
       - name: Test standalone package build concurrency
         run: node --test ./scripts/__tests__/build-standalone-concurrency.test.mjs
 
+      - name: Test standalone plugin suite runner
+        run: node --test ./scripts/__tests__/standalone-plugin-tests.test.mjs
+
       - name: Validate release package manifest
         run: node ./scripts/release-package-map.mjs check
 
@@ -75,6 +79,21 @@ jobs:
           mapfile -t changed_paths < <(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
           PAPERCLIP_RELEASE_BOOTSTRAP_BASE_SHA="${{ github.event.pull_request.base.sha }}" \
             node ./scripts/check-release-package-bootstrap.mjs "${changed_paths[@]}"
+
+      # The sandbox-provider plugins sit outside the pnpm workspace, so their
+      # suites are not part of any workspace test run and need their own lane.
+      # That lane installs each package standalone, which is too slow to spend
+      # on every PR, so gate it on the paths that can actually break it.
+      - name: Detect standalone plugin package changes
+        id: standalone_plugins
+        run: |
+          changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")"
+          standalone_pattern='^packages/plugins/sandbox-providers/|^packages/plugins/sdk/|^scripts/(test-standalone-plugin-packages|build-standalone-public-packages|link-plugin-dev-sdk)\.mjs$|^pnpm-workspace\.yaml$|^\.github/workflows/pr\.yml$'
+          if printf '%s\n' "$changed" | grep -Eq "$standalone_pattern"; then
+            echo "changed=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Validate dependency resolution when manifests change
         id: regen_lockfile
@@ -201,11 +220,49 @@ jobs:
             pnpm test:run:general -- --group '${{ matrix.group }}'
           fi
 
+  standalone_plugin_tests:
+    name: Standalone plugin suites
+    needs: [policy]
+    if: needs.policy.outputs.standalone_plugins_changed == '1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.15.4
+
+      - name: Restore regenerated PR lockfile (if policy uploaded one)
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: pr-lockfile
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # The workspace install is what makes the in-repo @paperclipai/plugin-sdk
+      # buildable; each plugin package still installs its own third-party deps
+      # standalone, exactly the way it is released.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run standalone plugin test suites
+        run: node ./scripts/test-standalone-plugin-packages.mjs
+
   verify:
     # Preserve the legacy required-check name while the underlying work runs in parallel.
     name: verify
     if: ${{ always() }}
-    needs: [typecheck_release_registry, general_tests, build]
+    needs: [typecheck_release_registry, general_tests, build, standalone_plugin_tests]
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -215,10 +272,15 @@ jobs:
           TYPECHECK_RELEASE_REGISTRY_RESULT: ${{ needs.typecheck_release_registry.result }}
           GENERAL_TESTS_RESULT: ${{ needs.general_tests.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          STANDALONE_PLUGIN_TESTS_RESULT: ${{ needs.standalone_plugin_tests.result }}
         run: |
           test "$TYPECHECK_RELEASE_REGISTRY_RESULT" = "success"
           test "$GENERAL_TESTS_RESULT" = "success"
           test "$BUILD_RESULT" = "success"
+          # The standalone plugin lane is path-gated, so "skipped" means this PR
+          # cannot have touched those packages. Any other non-success is a fail.
+          test "$STANDALONE_PLUGIN_TESTS_RESULT" = "success" \
+            || test "$STANDALONE_PLUGIN_TESTS_RESULT" = "skipped"
 
   build:
     name: Build

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/tsconfig.json
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/tsconfig.json
@@ -6,6 +6,5 @@
     "types": ["@cloudflare/workers-types"],
     "noEmit": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/plugins/sandbox-providers/cloudflare/package.json
+++ b/packages/plugins/sandbox-providers/cloudflare/package.json
@@ -43,9 +43,9 @@
   ],
   "scripts": {
     "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit -p tsconfig.build.json",
     "test": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && vitest run --config vitest.config.ts",
     "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"

--- a/packages/plugins/sandbox-providers/cloudflare/tsconfig.build.json
+++ b/packages/plugins/sandbox-providers/cloudflare/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/cloudflare/tsconfig.json
+++ b/packages/plugins/sandbox-providers/cloudflare/tsconfig.json
@@ -6,6 +6,5 @@
     "lib": ["ES2023"],
     "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/plugins/sandbox-providers/daytona/package.json
+++ b/packages/plugins/sandbox-providers/daytona/package.json
@@ -42,9 +42,9 @@
   ],
   "scripts": {
     "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit -p tsconfig.build.json",
     "test": "vitest run --config vitest.config.ts",
     "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"

--- a/packages/plugins/sandbox-providers/daytona/tsconfig.build.json
+++ b/packages/plugins/sandbox-providers/daytona/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/daytona/tsconfig.json
+++ b/packages/plugins/sandbox-providers/daytona/tsconfig.json
@@ -9,6 +9,5 @@
       "@paperclipai/plugin-sdk": ["../../sdk/dist/index.d.ts"]
     }
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/plugins/sandbox-providers/e2b/package.json
+++ b/packages/plugins/sandbox-providers/e2b/package.json
@@ -42,9 +42,9 @@
   ],
   "scripts": {
     "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit -p tsconfig.build.json",
     "test": "vitest run --config vitest.config.ts",
     "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"

--- a/packages/plugins/sandbox-providers/e2b/tsconfig.build.json
+++ b/packages/plugins/sandbox-providers/e2b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/e2b/tsconfig.json
+++ b/packages/plugins/sandbox-providers/e2b/tsconfig.json
@@ -6,6 +6,5 @@
     "lib": ["ES2023"],
     "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/plugins/sandbox-providers/exe-dev/package.json
+++ b/packages/plugins/sandbox-providers/exe-dev/package.json
@@ -42,9 +42,9 @@
   ],
   "scripts": {
     "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit -p tsconfig.build.json",
     "test": "vitest run --config vitest.config.ts",
     "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"

--- a/packages/plugins/sandbox-providers/exe-dev/tsconfig.build.json
+++ b/packages/plugins/sandbox-providers/exe-dev/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/exe-dev/tsconfig.json
+++ b/packages/plugins/sandbox-providers/exe-dev/tsconfig.json
@@ -6,6 +6,5 @@
     "lib": ["ES2023"],
     "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/plugins/sandbox-providers/modal/package.json
+++ b/packages/plugins/sandbox-providers/modal/package.json
@@ -42,9 +42,9 @@
   ],
   "scripts": {
     "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit -p tsconfig.build.json",
     "test": "vitest run --config vitest.config.ts",
     "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"

--- a/packages/plugins/sandbox-providers/modal/tsconfig.build.json
+++ b/packages/plugins/sandbox-providers/modal/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/modal/tsconfig.json
+++ b/packages/plugins/sandbox-providers/modal/tsconfig.json
@@ -6,6 +6,5 @@
     "lib": ["ES2023"],
     "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/plugins/sandbox-providers/novita/package.json
+++ b/packages/plugins/sandbox-providers/novita/package.json
@@ -43,9 +43,9 @@
   ],
   "scripts": {
     "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
-    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit -p tsconfig.build.json",
     "test": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && vitest run --config vitest.config.ts",
     "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"

--- a/packages/plugins/sandbox-providers/novita/tsconfig.build.json
+++ b/packages/plugins/sandbox-providers/novita/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/novita/tsconfig.json
+++ b/packages/plugins/sandbox-providers/novita/tsconfig.json
@@ -6,6 +6,5 @@
     "lib": ["ES2023"],
     "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/scripts/__tests__/standalone-plugin-tests.test.mjs
+++ b/scripts/__tests__/standalone-plugin-tests.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  collectSuiteProblems,
+  discoverStandalonePluginPackages,
+  parseVitestConfigPath,
+  summarizeReport,
+} from "../test-standalone-plugin-packages.mjs";
+
+const WORKSPACE_TEXT = [
+  "packages:",
+  "  - packages/*",
+  "  - packages/plugins/*",
+  '  - "!packages/plugins/sandbox-providers/**"',
+].join("\n");
+
+function makeRepo(packages) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "standalone-plugin-tests-"));
+  for (const [dir, manifest] of Object.entries(packages)) {
+    const packageDir = path.join(root, dir);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(path.join(packageDir, "package.json"), JSON.stringify(manifest));
+  }
+  return root;
+}
+
+function passingReport({ files = 2, testsPerFile = 3 } = {}) {
+  const testResults = Array.from({ length: files }, (_, index) => ({
+    name: `/repo/test/unit/file-${index}.test.ts`,
+    assertionResults: Array.from({ length: testsPerFile }, () => ({ status: "passed" })),
+  }));
+  return {
+    success: true,
+    numTotalTests: files * testsPerFile,
+    numFailedTests: 0,
+    testResults,
+  };
+}
+
+test("discovers every sandbox-provider package that the workspace excludes", () => {
+  const root = makeRepo({
+    "packages/plugins/sandbox-providers/kubernetes": {
+      name: "@paperclipai/plugin-kubernetes",
+      scripts: { test: "vitest run --config vitest.config.ts" },
+    },
+    "packages/plugins/sandbox-providers/modal": {
+      name: "@paperclipai/plugin-modal",
+      scripts: { test: "vitest run --config vitest.config.ts" },
+    },
+  });
+
+  try {
+    const { packages, skipped } = discoverStandalonePluginPackages({
+      repoRoot: root,
+      workspaceText: WORKSPACE_TEXT,
+    });
+
+    assert.deepEqual(
+      packages.map((pkg) => pkg.name),
+      ["@paperclipai/plugin-kubernetes", "@paperclipai/plugin-modal"],
+    );
+    assert.deepEqual(skipped, []);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("skips a provider that is back inside the workspace", () => {
+  const root = makeRepo({
+    "packages/plugins/sandbox-providers/kubernetes": {
+      name: "@paperclipai/plugin-kubernetes",
+      scripts: { test: "vitest run --config vitest.config.ts" },
+    },
+    "packages/plugins/sandbox-providers/modal": {
+      name: "@paperclipai/plugin-modal",
+      scripts: { test: "vitest run --config vitest.config.ts" },
+    },
+  });
+  const workspaceText = [
+    "packages:",
+    "  - packages/plugins/sandbox-providers/*",
+    '  - "!packages/plugins/sandbox-providers/kubernetes"',
+  ].join("\n");
+
+  try {
+    const { packages, skipped } = discoverStandalonePluginPackages({
+      repoRoot: root,
+      workspaceText,
+    });
+
+    assert.deepEqual(
+      packages.map((pkg) => pkg.name),
+      ["@paperclipai/plugin-kubernetes"],
+    );
+    assert.deepEqual(
+      skipped.map((entry) => entry.dir),
+      ["packages/plugins/sandbox-providers/modal"],
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("refuses to let an excluded package opt out of testing", () => {
+  const root = makeRepo({
+    "packages/plugins/sandbox-providers/kubernetes": {
+      name: "@paperclipai/plugin-kubernetes",
+      scripts: { build: "tsc" },
+    },
+  });
+
+  try {
+    assert.throws(
+      () => discoverStandalonePluginPackages({ repoRoot: root, workspaceText: WORKSPACE_TEXT }),
+      /has no "test" script/,
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("an empty provider tree fails instead of reading as a pass", () => {
+  const root = makeRepo({});
+
+  try {
+    assert.throws(
+      () => discoverStandalonePluginPackages({ repoRoot: root, workspaceText: WORKSPACE_TEXT }),
+      /must never read as a passing test lane/,
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("reads the vitest config path out of a package test script", () => {
+  assert.equal(
+    parseVitestConfigPath("pkg", "vitest run --config vitest.config.ts"),
+    "vitest.config.ts",
+  );
+  assert.equal(parseVitestConfigPath("pkg", "vitest run"), null);
+  assert.equal(
+    parseVitestConfigPath(
+      "pkg",
+      "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && vitest run --config vitest.config.ts",
+    ),
+    "vitest.config.ts",
+  );
+});
+
+test("a test script this runner cannot drive fails instead of going unrun", () => {
+  assert.throws(
+    () => parseVitestConfigPath("pkg", "jest --ci"),
+    /cannot drive/,
+  );
+});
+
+test("a green run with real tests reports no problems", () => {
+  assert.deepEqual(collectSuiteProblems({ exitCode: 0, report: passingReport() }), []);
+});
+
+test("a failing suite is a problem", () => {
+  const report = passingReport();
+  report.success = false;
+  report.numFailedTests = 1;
+
+  const problems = collectSuiteProblems({ exitCode: 1, report });
+
+  assert.ok(problems.some((problem) => problem.includes("exited with code 1")));
+  assert.ok(problems.some((problem) => problem.includes("failing run")));
+});
+
+test("a zero-test run fails even when vitest claims success", () => {
+  const problems = collectSuiteProblems({
+    exitCode: 0,
+    report: { success: true, numTotalTests: 0, numFailedTests: 0, testResults: [] },
+  });
+
+  assert.ok(problems.some((problem) => problem.includes("0 test files")));
+  assert.ok(problems.some((problem) => problem.includes("0 tests")));
+});
+
+test("a test file that collected nothing fails the suite", () => {
+  const report = passingReport();
+  report.testResults.push({
+    name: "/repo/test/unit/plugin.test.ts",
+    assertionResults: [],
+  });
+
+  const problems = collectSuiteProblems({ exitCode: 0, report });
+
+  assert.ok(problems.some((problem) => problem.includes("produced no tests")));
+  assert.ok(problems.some((problem) => problem.includes("plugin.test.ts")));
+});
+
+test("a missing JSON report fails the suite", () => {
+  const problems = collectSuiteProblems({ exitCode: 0, report: null });
+
+  assert.ok(problems.some((problem) => problem.includes("no vitest JSON report")));
+});
+
+test("summarizeReport tolerates a missing report", () => {
+  assert.deepEqual(summarizeReport(null), { files: 0, tests: 0, failed: 0 });
+  assert.deepEqual(summarizeReport(passingReport({ files: 3, testsPerFile: 4 })), {
+    files: 3,
+    tests: 12,
+    failed: 0,
+  });
+});

--- a/scripts/build-standalone-public-packages.mjs
+++ b/scripts/build-standalone-public-packages.mjs
@@ -17,7 +17,9 @@ const repoRoot = path.resolve(scriptDir, "..");
 const workspacePath = path.join(repoRoot, "pnpm-workspace.yaml");
 const releasePackageMapPath = path.join(repoRoot, "scripts", "release-package-map.mjs");
 
-function parseWorkspaceEntries(workspaceText) {
+// Exported so scripts/test-standalone-plugin-packages.mjs classifies packages
+// against pnpm-workspace.yaml exactly the way this builder does.
+export function parseWorkspaceEntries(workspaceText) {
   // Keep this aligned with the repo's block-sequence `packages:` format in
   // pnpm-workspace.yaml. If that file moves to a more complex YAML shape,
   // switch this parser to a real YAML parser instead of line matching.
@@ -61,7 +63,7 @@ function globToRegExp(pattern) {
   return new RegExp(`^${regex}$`);
 }
 
-function isWorkspacePackage(pkgDir, workspaceEntries) {
+export function isWorkspacePackage(pkgDir, workspaceEntries) {
   let included = false;
 
   for (const entry of workspaceEntries) {

--- a/scripts/test-standalone-plugin-packages.mjs
+++ b/scripts/test-standalone-plugin-packages.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+// Run the test suites of the plugin packages that pnpm-workspace.yaml keeps
+// OUT of the workspace (see the "!packages/plugins/sandbox-providers/**"
+// exclusion). Workspace members are covered by the root vitest projects list;
+// these packages are not in it, so without this runner their suites never
+// execute anywhere in CI.
+//
+// Each package is installed the same way `build-standalone-public-packages.mjs`
+// installs it for release (`pnpm install --ignore-workspace`, then the in-repo
+// @paperclipai/plugin-sdk linked in), so the suites run against the dependency
+// tree the published package actually ships with.
+//
+// A suite that runs zero tests is treated as a failure, not a pass: a missing
+// standalone install makes test files fail to import, which silently shrinks
+// the reported test count. See collectSuiteProblems below.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path, { dirname } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  isWorkspacePackage,
+  parseWorkspaceEntries,
+} from "./build-standalone-public-packages.mjs";
+import { linkSdkInto, readPluginsUnder } from "./link-plugin-dev-sdk.mjs";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+
+// The workspace exclusion this runner compensates for is scoped to the
+// sandbox-provider tree. Other excluded plugin packages (the orchestration
+// smoke example) declare `workspace:*` dependencies, which cannot resolve
+// under `--ignore-workspace`, so they are not standalone-installable.
+const PROVIDERS_DIR = "packages/plugins/sandbox-providers";
+
+function toRepoRelative(absoluteDir) {
+  return path.relative(repoRoot, absoluteDir).split(path.sep).join("/");
+}
+
+// The runner drives vitest directly instead of `pnpm run test` so it can add
+// the JSON reporter it needs to prove a suite really executed (pnpm defines its
+// own --reporter flag, so forwarding one through `pnpm run` is ambiguous).
+// Reading the config path out of the package's own test script keeps the two in
+// step, and an unrecognised script fails loudly rather than going unrun.
+export function parseVitestConfigPath(dir, testScript) {
+  const match = /(^|&&\s*)vitest\s+run(\s+--config\s+(\S+))?\s*$/.exec(testScript.trim());
+
+  if (!match) {
+    throw new Error(
+      `${dir} has a "test" script this runner cannot drive: ${testScript}\n` +
+      "Expected `vitest run [--config <file>]`. Update scripts/test-standalone-plugin-packages.mjs " +
+      "so the suite keeps running in CI.",
+    );
+  }
+
+  return match[3] ?? null;
+}
+
+// Discover every package under the sandbox-provider tree. Discovery is by
+// directory, not by a hand-maintained list, so a newly added provider is
+// covered the day it lands instead of quietly opting out of CI.
+export function discoverStandalonePluginPackages({
+  repoRoot: root,
+  workspaceText,
+  providersDir = PROVIDERS_DIR,
+}) {
+  const workspaceEntries = parseWorkspaceEntries(workspaceText);
+  const packages = [];
+  const skipped = [];
+
+  for (const packageDir of readPluginsUnder(path.join(root, providersDir)).sort()) {
+    const dir = path.relative(root, packageDir).split(path.sep).join("/");
+
+    // A provider that is (re-)added to the workspace is already covered by the
+    // root vitest projects list, so running it here would only duplicate work.
+    if (isWorkspacePackage(dir, workspaceEntries)) {
+      skipped.push({ dir, reason: "pnpm workspace member (covered by the root test run)" });
+      continue;
+    }
+
+    const manifest = JSON.parse(
+      readFileSync(path.join(packageDir, "package.json"), "utf8"),
+    );
+
+    if (!manifest.scripts?.test) {
+      throw new Error(
+        `${dir} is excluded from the pnpm workspace but has no "test" script, so nothing would ` +
+        "run it. Add a test script, or move the package back into the workspace.",
+      );
+    }
+
+    packages.push({
+      dir,
+      name: manifest.name,
+      vitestConfig: parseVitestConfigPath(dir, manifest.scripts.test),
+    });
+  }
+
+  if (packages.length === 0) {
+    throw new Error(
+      `No standalone plugin packages found under ${providersDir}. If that tree moved, update ` +
+      "this runner — an empty package list must never read as a passing test lane.",
+    );
+  }
+
+  return { packages, skipped };
+}
+
+export function summarizeReport(report) {
+  const files = Array.isArray(report?.testResults) ? report.testResults.length : 0;
+  const tests = Number.isFinite(report?.numTotalTests) ? report.numTotalTests : 0;
+  const failed = Number.isFinite(report?.numFailedTests) ? report.numFailedTests : 0;
+  return { files, tests, failed };
+}
+
+// Turn one package's run into a list of human-readable problems. Empty list ==
+// the suite genuinely passed. Kept pure so the zero-test guard itself is
+// covered by scripts/__tests__/standalone-plugin-tests.test.mjs.
+export function collectSuiteProblems({ exitCode, report }) {
+  const problems = [];
+
+  if (exitCode !== 0) {
+    problems.push(`test script exited with code ${exitCode}`);
+  }
+
+  if (!report) {
+    problems.push(
+      "no vitest JSON report was written, so the run cannot be proven to have executed any test",
+    );
+    return problems;
+  }
+
+  const { files, tests } = summarizeReport(report);
+
+  if (report.success !== true) {
+    problems.push("vitest reported a failing run");
+  }
+  if (files === 0) {
+    problems.push("vitest ran 0 test files");
+  }
+  if (tests === 0) {
+    problems.push("vitest ran 0 tests (a zero-test run is a failure, not a pass)");
+  }
+
+  // A test file that fails to import is reported with no assertions at all.
+  // Without this check a suite can silently shrink while still looking healthy.
+  const emptyFiles = (report.testResults ?? [])
+    .filter((result) => (result?.assertionResults?.length ?? 0) === 0)
+    .map((result) => result?.name ?? "<unknown file>");
+
+  if (emptyFiles.length > 0) {
+    problems.push(
+      `${emptyFiles.length} test file(s) produced no tests (import failure?): ${emptyFiles.join(", ")}`,
+    );
+  }
+
+  return problems;
+}
+
+function reportPathFor(name) {
+  const outputDir = path.join(os.tmpdir(), "paperclip-standalone-plugin-tests");
+  mkdirSync(outputDir, { recursive: true });
+  return path.join(outputDir, `${name.replace(/[^a-z0-9]+/gi, "-")}.json`);
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: "inherit",
+    env: { ...process.env, CI: "true" },
+  });
+
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+function testPackage(pkg) {
+  const packageDir = path.join(repoRoot, pkg.dir);
+  const nodeModulesDir = path.join(packageDir, "node_modules");
+  const packageLockfilePath = path.join(packageDir, "pnpm-lock.yaml");
+  const reportPath = reportPathFor(pkg.name);
+
+  console.log(`\n=== ${pkg.name} (${pkg.dir}) ===`);
+
+  if (existsSync(nodeModulesDir)) {
+    rmSync(nodeModulesDir, { force: true, recursive: true });
+  }
+  rmSync(reportPath, { force: true });
+
+  // Mirror the release-time standalone install. These packages intentionally
+  // ship no committed lockfile (their .gitignore forbids one), so there is
+  // usually nothing to freeze against.
+  const installArgs = existsSync(packageLockfilePath)
+    ? ["install", "--ignore-workspace", "--frozen-lockfile"]
+    : ["install", "--ignore-workspace", "--no-lockfile"];
+
+  const installExit = run("pnpm", installArgs, packageDir);
+  if (installExit !== 0) {
+    return { pkg, problems: [`standalone install exited with code ${installExit}`] };
+  }
+
+  // The fresh install wipes node_modules, so relink the in-repo plugin SDK the
+  // suites import (published installs get it from the registry instead).
+  linkSdkInto(packageDir);
+
+  const exitCode = run(
+    "pnpm",
+    [
+      "exec",
+      "vitest",
+      "run",
+      ...(pkg.vitestConfig ? ["--config", pkg.vitestConfig] : []),
+      "--reporter=default",
+      "--reporter=json",
+      `--outputFile.json=${reportPath}`,
+    ],
+    packageDir,
+  );
+
+  let report = null;
+  if (existsSync(reportPath)) {
+    try {
+      report = JSON.parse(readFileSync(reportPath, "utf8"));
+    } catch (error) {
+      console.error(`  Could not parse the vitest JSON report: ${error.message}`);
+    }
+  }
+
+  return { pkg, report, problems: collectSuiteProblems({ exitCode, report }) };
+}
+
+function main() {
+  const { packages, skipped } = discoverStandalonePluginPackages({
+    repoRoot,
+    workspaceText: readFileSync(path.join(repoRoot, "pnpm-workspace.yaml"), "utf8"),
+  });
+
+  for (const entry of skipped) {
+    console.log(`  i Skipping ${entry.dir}: ${entry.reason}`);
+  }
+  console.log(
+    `Running ${packages.length} standalone plugin suite(s): ${packages.map((p) => p.name).join(", ")}`,
+  );
+
+  // Every suite imports @paperclipai/plugin-sdk, which resolves to the in-repo
+  // build output. Build it once here so a stale dist cannot skew any suite.
+  execFileSync(
+    "pnpm",
+    ["--filter", "@paperclipai/plugin-sdk", "ensure-build-deps"],
+    { cwd: repoRoot, stdio: "inherit" },
+  );
+
+  const results = packages.map((pkg) => testPackage(pkg));
+
+  console.log("\nStandalone plugin suites:");
+  for (const { pkg, report, problems } of results) {
+    const { files, tests, failed } = summarizeReport(report);
+    console.log(
+      `  ${problems.length === 0 ? "PASS" : "FAIL"}  ${pkg.name}: ` +
+      `${tests} test(s) across ${files} file(s), ${failed} failed`,
+    );
+    for (const problem of problems) {
+      console.log(`        - ${problem}`);
+    }
+  }
+
+  const totalTests = results.reduce(
+    (sum, { report }) => sum + summarizeReport(report).tests,
+    0,
+  );
+  const failures = results.filter(({ problems }) => problems.length > 0);
+
+  console.log(`\nTotal: ${totalTests} test(s) across ${results.length} package(s)`);
+
+  if (failures.length > 0) {
+    console.error(
+      `\n  x ${failures.length} standalone plugin suite(s) failed: ` +
+      failures.map(({ pkg }) => pkg.name).join(", "),
+    );
+    process.exitCode = 1;
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  main();
+}

--- a/scripts/test-standalone-plugin-packages.mjs
+++ b/scripts/test-standalone-plugin-packages.mjs
@@ -37,10 +37,6 @@ const repoRoot = path.resolve(scriptDir, "..");
 // under `--ignore-workspace`, so they are not standalone-installable.
 const PROVIDERS_DIR = "packages/plugins/sandbox-providers";
 
-function toRepoRelative(absoluteDir) {
-  return path.relative(repoRoot, absoluteDir).split(path.sep).join("/");
-}
-
 // The runner drives vitest directly instead of `pnpm run test` so it can add
 // the JSON reporter it needs to prove a suite really executed (pnpm defines its
 // own --reporter flag, so forwarding one through `pnpm run` is ambiguous).

--- a/scripts/test-standalone-plugin-packages.mjs
+++ b/scripts/test-standalone-plugin-packages.mjs
@@ -277,7 +277,8 @@ function main() {
   console.log(`\nTotal: ${totalTests} test(s) across ${results.length} package(s)`);
 
   if (failures.length > 0) {
-    console.error(
+    // Same stream as the summary above so the two cannot interleave in CI logs.
+    console.log(
       `\n  x ${failures.length} standalone plugin suite(s) failed: ` +
       failures.map(({ pkg }) => pkg.name).join(", "),
     );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute inside sandbox environments provided by sandbox-provider plugins, and the first-party plugins for those providers live in `packages/plugins/sandbox-providers/`
> - `pnpm-workspace.yaml` deliberately keeps that tree out of the workspace (`- "!packages/plugins/sandbox-providers/**"`) so the providers' third-party deps never churn the root `pnpm-lock.yaml`. That is the right call and this PR keeps it
> - The side effect nobody wired up for: packages outside the workspace are also outside the root vitest projects list, so no CI job anywhere runs their tests. The seven providers ship 361 tests between them (per-tenant namespace isolation, RBAC, network policies, lease lifecycle, pod exec, file sync), and a green PR check has never said anything about a single one of them
> - The failure mode is worse than "untested", because these suites also fail quietly. A test file that cannot be imported contributes zero tests, so a suite can shrink to nothing while the summary still reads like a run that happened
> - This pull request adds a lane that installs each package standalone exactly the way the release build does, runs its suite, and fails when a suite fails **or** when a suite runs zero tests, zero files, or contains a file that collected nothing
> - Turning the lane on immediately proved the point: six of the seven suites do not load at all on `master` today, so the PR also fixes that
> - The benefit is that the four PRs currently open against the `kubernetes` provider, and every future one, get a check that actually exercises the code they change

## Linked Issues or Issue Description

No existing public issue — described in-PR following the bug template.

**What happened?**

1. No CI job runs the sandbox-provider suites. `pnpm test:run:general` and `pnpm test:run:serialized` both drive the root vitest projects, which resolve from the pnpm workspace; the providers are excluded from it, so their `test` scripts are only ever run by hand.
2. Because nothing ran them, they rotted. On `master`, six of the seven suites (`cloudflare`, `daytona`, `e2b`, `exe-dev`, `modal`, `novita`) fail to transform a single test file:

```
FAIL  src/plugin.test.ts [ src/plugin.test.ts ]
Error: Transform failed with 1 error:
[TSCONFIG_ERROR] Failed to load tsconfig for 'src/plugin.test.ts': Tsconfig not found
  Plugin: vite:oxc

 Test Files  1 failed (1)
      Tests  no tests
```

   Each provider's `tsconfig.json` carries `"exclude": ["src/**/*.test.ts"]` so `tsc` never emits test files into `dist/`. Vite 8's oxc transform (vitest 4, adopted for these packages in #7581) refuses to transform a file that the nearest tsconfig disowns, so every test file fails to load and vitest reports `Tests  no tests`. `kubernetes` is unaffected only because it is still on vitest 3.

**Expected behavior**

The suites run in CI, and a run that executes no tests is a failure rather than a quiet pass.

## What Changed

**The lane** — `scripts/test-standalone-plugin-packages.mjs`, run from a new path-gated `standalone_plugin_tests` job in `pr.yml`:

- Discovers packages by walking the provider tree (the same `readPluginsUnder` the SDK dev-linker uses) and classifies each against `pnpm-workspace.yaml` with the helpers `build-standalone-public-packages.mjs` already owns. A provider that is a workspace member is skipped with a reason; an excluded provider with no `test` script is an error; an empty tree is an error. A new provider is covered the day it lands, and none of them can quietly opt out.
- Installs each package the way `build-standalone-public-packages.mjs` installs it for release: wipe `node_modules`, `pnpm install --ignore-workspace` (`--frozen-lockfile` if the package ships a lockfile, `--no-lockfile` otherwise, since these packages deliberately commit none), then link the in-repo `@paperclipai/plugin-sdk`. Suites therefore run against the dependency tree the published package ships with, and the root lockfile is untouched.
- Drives `vitest run` directly with the config path read out of the package's own `test` script, rather than `pnpm run test`, because pnpm defines its own `--reporter` flag and forwarding one through `pnpm run` is ambiguous. A `test` script this runner cannot drive is a hard error, not a silent skip.
- **Zero-test guard.** Every suite is judged on its vitest JSON report, not just the exit code. A package fails if the run exits non-zero, if no report was written, if `success` is not `true`, if it ran 0 tests, if it ran 0 test files, or if any test file collected no tests at all — which is exactly how a failed import presents. The pure helpers behind that (`collectSuiteProblems`, `discoverStandalonePluginPackages`, `parseVitestConfigPath`) are covered by `scripts/__tests__/standalone-plugin-tests.test.mjs`, wired into the `policy` job next to the other `node --test` script checks, so the guard itself is verified on every PR.
- Cost: the `policy` job computes whether a PR touches the provider tree, the plugin SDK, this runner or the workflow, and the job only runs when it does. `verify` gains the lane in its `needs` and accepts `success` or `skipped`, so a red provider suite blocks the PR while unrelated PRs pay nothing.

**The fix the lane exposed** — for the six affected providers:

- `tsconfig.json` no longer excludes `src/**/*.test.ts`, so the transform can resolve compiler options for test files again.
- A new `tsconfig.build.json` (`extends: ./tsconfig.json`) carries the emit exclusion, and `build` / `typecheck` use `-p tsconfig.build.json`. `dist/` contents and the typecheck surface are byte-for-byte what they were.
- Same one-line exclusion drop in `cloudflare/bridge-template/tsconfig.json`, which is `noEmit` and only needs its tests inside the project.

## Verification

- The new lane on this PR (run 30176684438, job "Standalone plugin suites"): **361 tests across 7 packages, all green on the Linux runner** in 44 seconds of suite time.

```
Running 7 standalone plugin suite(s): ...
  PASS  @paperclipai/plugin-cloudflare-sandbox: 31 test(s) across 6 file(s), 0 failed
  PASS  @paperclipai/plugin-daytona: 57 test(s) across 1 file(s), 0 failed
  PASS  @paperclipai/plugin-e2b: 19 test(s) across 1 file(s), 0 failed
  PASS  @paperclipai/plugin-exe-dev: 33 test(s) across 1 file(s), 0 failed
  PASS  @paperclipai/plugin-kubernetes: 189 test(s) across 20 file(s), 0 failed
  PASS  @paperclipai/plugin-modal: 24 test(s) across 1 file(s), 0 failed
  PASS  @paperclipai/plugin-novita-sandbox: 8 test(s) across 1 file(s), 0 failed
Total: 361 test(s) across 7 package(s)
```

- **Zero-test guard proven red in CI, not just in unit tests.** A scratch branch rigged one package's vitest config to match no test files with `passWithNoTests: true`, so vitest exited 0 and printed `No test files found, exiting with code 0`. The job still failed:

```
  FAIL  @paperclipai/plugin-e2b: 0 test(s) across 0 file(s), 0 failed
        - vitest ran 0 test files
        - vitest ran 0 tests (a zero-test run is a failure, not a pass)
  x 1 standalone plugin suite(s) failed: @paperclipai/plugin-e2b
```

- **Failure path proven red in CI.** A scratch branch added an unresolvable import to `kubernetes/test/unit/pod-exec.test.ts`; the job failed with the file named. (Worth knowing: an *unused* named import is erased by the TS transform and breaks nothing, so the check has to be a real one.) Both scratch branches were run on a fork PR and are not part of this branch.
- `node --test scripts/__tests__/standalone-plugin-tests.test.mjs` — 12 passed, covering the zero-test, zero-file, empty-file, missing-report, discovery and test-script-shape cases. It runs in the `policy` job on every PR.
- `pnpm build` in each of the six changed packages: succeeds and emits no `*.test.js` into `dist/`. The `Canary Dry Run` job exercises the same `tsc -p tsconfig.build.json` path through `release.sh`.
- Locally on macOS the lane reports 9 environment-specific failures (7 in `kubernetes/test/unit/file-sync.test.ts`, which need `/proc/self/fd`, and 2 in `daytona`, which depend on GNU `tar` output). All 9 pass on the Linux CI runner; they are pre-existing on `master` and untouched here.

## Risks

- The lane is path-gated in the `policy` job, so a change that can break these suites from outside the gated paths (a `packages/shared` change reaching them through the SDK, or third-party drift, since these packages install unpinned by design) is not caught at PR time. The gate covers the provider tree, the plugin SDK, the runner and its two helper scripts, `pnpm-workspace.yaml` and `pr.yml`. Widening it to `packages/shared` would put a full standalone install on roughly one PR in six, which did not look like a good trade; a scheduled run on `master` would be the cheaper follow-up if drift shows up.
- `verify` now depends on the new job and accepts `success` or `skipped`. `skipped` is only reachable via the `if:` gate, so a cancelled or failed lane still fails `verify`. If the lane is ever made a required check in its own right, the path gate would have to go, because a skipped required check blocks a PR.
- The runner drives `vitest run` itself rather than `pnpm run test`, so a provider whose test script grows something the runner does not replicate (an env var, a second config) would have that part ignored. It only accepts a script of the shape `vitest run [--config <file>]` and throws otherwise, so the drift surfaces as a red lane rather than as silently reduced coverage.
- `tsconfig.json` in the six changed packages now covers test files while `build` and `typecheck` point at `tsconfig.build.json`. Emitted output and the typecheck surface are unchanged. The visible consequence is that `tsc --noEmit -p tsconfig.json` (an editor's default) now reports four pre-existing type errors in `e2b` and `novita` test files that were previously invisible because those files were in no project at all. Fixing them is a follow-up, deliberately not mixed into this PR.
- Each standalone install hits the registry (no lockfile to freeze against, by design). The lane adds roughly 90 seconds of install plus 44 seconds of suite time on the PRs where it runs.

## Model Used

Anthropic Claude, exact model ID `claude-opus-5[1m]` (Opus 5, 1M context), extended thinking, with tool use and code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
