### PR TITLE
Platform fix: auto-assign creator on ownerless wake_assignee interactions

### DIFF
--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -34,6 +34,33 @@ function createSelectChain(rows: SelectRow[], onLock?: (mode: string) => void) {
   };
 }
 
+// `status` is a column on both `issues` and `issue_thread_interactions`, so the
+// create flow's selects can only be told apart by the table they read. Used for
+// the locked interaction re-read on the reuse paths.
+function createTableAwareSelectChain(
+  rowsByTable: Record<string, SelectRow[]>,
+  onLock?: (mode: string) => void,
+  onFrom?: (tableName: string) => void,
+) {
+  return {
+    from(table: unknown) {
+      const tableName = getTableName(table as never);
+      onFrom?.(tableName);
+      const rows = rowsByTable[tableName] ?? [];
+      const result: any = {
+        for(mode: string) {
+          onLock?.(mode);
+          return result;
+        },
+        then(callback: (r: SelectRow[]) => unknown) {
+          return Promise.resolve(callback(rows));
+        },
+      };
+      return { where: () => result };
+    },
+  };
+}
+
 function createFakeDb(args: {
   interactionRow: Record<string, unknown>;
   parentRows?: SelectRow[];
@@ -92,6 +119,10 @@ function createCreateFlowDb(args: {
   issueStatus?: string;
   failAssignment?: boolean;
   onInsert?: () => void;
+  // What the locked interaction re-read sees inside the reuse transaction. Set
+  // it apart from `existingInteractionRow` to model a concurrent resolution
+  // landing between the unlocked read and the transaction.
+  lockedInteractionRow?: SelectRow | null;
 }) {
   const touches: Array<Record<string, unknown>> = [];
   const events: string[] = [];
@@ -106,15 +137,25 @@ function createCreateFlowDb(args: {
       // The create path reads status and assignee together under one lock; the
       // idempotent-reuse path reads assignee columns on their own.
       if (columns && "status" in columns) {
-        events.push("select:issue");
-        return createSelectChain(
-          [{
-            status: args.issueStatus ?? "in_progress",
-            assigneeAgentId: null,
-            assigneeUserId: null,
-            ...(args.currentIssueRow ?? {}),
-          }],
+        // Both the create path's issue read and the reuse path's locked
+        // interaction re-read select `status`, so dispatch on the table.
+        const lockedInteraction = args.lockedInteractionRow !== undefined
+          ? args.lockedInteractionRow
+          : args.existingInteractionRow ?? null;
+        return createTableAwareSelectChain(
+          {
+            issues: [{
+              status: args.issueStatus ?? "in_progress",
+              assigneeAgentId: null,
+              assigneeUserId: null,
+              ...(args.currentIssueRow ?? {}),
+            }],
+            issue_thread_interactions: lockedInteraction ? [lockedInteraction] : [],
+          },
           (mode) => locks.push(mode),
+          (tableName) => events.push(
+            tableName === "issues" ? "select:issue" : "select:interaction",
+          ),
         );
       }
       if (wantsAssignee) {
@@ -489,7 +530,78 @@ describe("issueThreadInteractionService", { timeout: 30_000 }, () => {
     expect(db.insert).not.toHaveBeenCalled();
     expect(touches).toContainEqual(expect.objectContaining({ assigneeAgentId: "agent-1" }));
     expect(locks).toContain("update");
-    expect(events).toEqual(["tx:begin", "select:assignee", "update:assignee", "tx:end"]);
+    // The locked interaction re-read sits between the issue lock and the write:
+    // the caller's "still pending" came from an unlocked snapshot.
+    expect(events).toEqual([
+      "tx:begin",
+      "select:assignee",
+      "select:interaction",
+      "update:assignee",
+      "tx:end",
+    ]);
+  });
+
+  it("create does not adopt the issue when the reused interaction resolves before the repair", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    // The reuse paths decide "still pending" from an unlocked read. A concurrent
+    // resolution can land between that read and the repair transaction; adopting
+    // then would hand the issue to a creator whose one continuation is already
+    // spent — an ownership change that buys no wake path. Reported by review as a
+    // P1 on the first rebased head, so it is pinned by a test rather than a comment.
+    const pendingSnapshot = {
+      id: "interaction-existing",
+      companyId: "company-1",
+      issueId: "11111111-1111-4111-8111-111111111111",
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      requestedResolverPolicy: "anyone",
+      effectiveResolverPolicy: "anyone",
+      resolverPolicyProvenance: "inherited",
+      effectiveResolverPolicySource: "requested",
+      addresseeAgentId: null,
+      idempotencyKey: "run-1:suggest",
+      sourceCommentId: null,
+      sourceRunId: null,
+      title: null,
+      summary: null,
+      createdByAgentId: "agent-1",
+      createdByUserId: null,
+      resolvedByAgentId: null,
+      resolvedByUserId: null,
+      payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+      result: null,
+      resolvedAt: null,
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+    };
+
+    const { db, events, touches } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+      // The unlocked idempotency lookup still sees `pending` …
+      existingInteractionRow: pendingSnapshot,
+      // … while the locked re-read inside the transaction sees the resolution.
+      lockedInteractionRow: { ...pendingSnapshot, status: "accepted" },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    const created = await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "suggest_tasks",
+      idempotencyKey: "run-1:suggest",
+      continuationPolicy: "wake_assignee",
+      payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(created.id).toBe("interaction-existing");
+    expect(events).toContain("select:interaction");
+    expect(events).not.toContain("update:assignee");
+    expect(touches).toEqual([]);
   });
 
   it("create does not adopt the issue when reusing an already-resolved interaction", async () => {

--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -2,25 +2,32 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getTableName } from "drizzle-orm";
 
 const mockCreateChild = vi.fn();
+const mockUpdateIssue = vi.fn();
 
 vi.mock("./issues.js", () => ({
   issueService: () => ({
     createChild: mockCreateChild,
+    update: mockUpdateIssue,
   }),
 }));
 
 type SelectRow = Record<string, unknown>;
 
-function createSelectChain(rows: SelectRow[]) {
+function createSelectChain(rows: SelectRow[], onLock?: (mode: string) => void) {
+  const result: any = {
+    for(mode: string) {
+      onLock?.(mode);
+      return result;
+    },
+    then(callback: (rows: SelectRow[]) => unknown) {
+      return Promise.resolve(callback(rows));
+    },
+  };
   return {
     from() {
       return {
         where() {
-          return {
-            then(callback: (rows: SelectRow[]) => unknown) {
-              return Promise.resolve(callback(rows));
-            },
-          };
+          return result;
         },
       };
     },
@@ -79,10 +86,105 @@ function createFakeDb(args: {
   };
 }
 
-describe("issueThreadInteractionService", () => {
+function createCreateFlowDb(args: {
+  currentIssueRow: SelectRow | null;
+  existingInteractionRow?: SelectRow | null;
+  issueStatus?: string;
+  failAssignment?: boolean;
+  onInsert?: () => void;
+}) {
+  const touches: Array<Record<string, unknown>> = [];
+  const events: string[] = [];
+  const locks: string[] = [];
+
+  const db: any = {
+    select: vi.fn((columns?: Record<string, unknown>) => {
+      // The assignee probe is the only select that asks for the assignee columns;
+      // every other select in the create flow (idempotency / source lookups) gets
+      // an empty result, so this stays independent of call ordering.
+      const wantsAssignee = Boolean(columns && "assigneeAgentId" in columns);
+      // The create path reads status and assignee together under one lock; the
+      // idempotent-reuse path reads assignee columns on their own.
+      if (columns && "status" in columns) {
+        events.push("select:issue");
+        return createSelectChain(
+          [{
+            status: args.issueStatus ?? "in_progress",
+            assigneeAgentId: null,
+            assigneeUserId: null,
+            ...(args.currentIssueRow ?? {}),
+          }],
+          (mode) => locks.push(mode),
+        );
+      }
+      if (wantsAssignee) {
+        events.push("select:assignee");
+        return createSelectChain(
+          args.currentIssueRow ? [args.currentIssueRow] : [],
+          (mode) => locks.push(mode),
+        );
+      }
+      // A column-less select is the idempotency lookup.
+      return createSelectChain(args.existingInteractionRow ? [args.existingInteractionRow] : []);
+    }),
+    insert: vi.fn(() => ({
+      values(values: Record<string, unknown>) {
+        events.push("insert:interaction");
+        args.onInsert?.();
+        const row = {
+          id: "interaction-new",
+          createdAt: new Date("2026-04-20T10:00:00.000Z"),
+          updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+          resolvedByAgentId: null,
+          resolvedByUserId: null,
+          resolvedAt: null,
+          result: null,
+          ...values,
+        };
+        return {
+          returning: async () => [row],
+        };
+      },
+    })),
+    update: vi.fn(() => ({
+      set(values: Record<string, unknown>) {
+        return {
+          where() {
+            touches.push(values);
+            if ("assigneeAgentId" in values) {
+              events.push("update:assignee");
+              if (args.failAssignment) return Promise.reject(new Error("assignment failed"));
+            }
+            // Drizzle's update builder is awaitable *and* exposes `.returning()`;
+            // the adopt path awaits it directly, the supersede path chains.
+            const result: any = Promise.resolve(undefined);
+            result.returning = async () => [];
+            return result;
+          },
+        };
+      },
+    })),
+    transaction: async (callback: (tx: any) => Promise<void>) => {
+      events.push("tx:begin");
+      try {
+        return await callback(db);
+      } finally {
+        events.push("tx:end");
+      }
+    },
+  };
+
+  return { db, touches, events, locks };
+}
+
+// Every test re-imports the service module (`vi.resetModules()` below), so the
+// first one to run pays the full module-graph import cost and sits close to the
+// 5s default on a cold cache.
+describe("issueThreadInteractionService", { timeout: 30_000 }, () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockUpdateIssue.mockResolvedValue({ id: "issue-1", assigneeAgentId: "agent-1" });
   });
 
   it.each([
@@ -159,9 +261,15 @@ describe("issueThreadInteractionService", () => {
     };
 
     const db: any = {
-      select: vi.fn(() => createSelectChain([existingRow])),
+      // The issue already has an assignee, so reuse keeps its wake target and this
+      // test stays focused on the idempotency behaviour itself.
+      select: vi.fn((columns?: Record<string, unknown>) =>
+        columns && "assigneeAgentId" in columns
+          ? createSelectChain([{ assigneeAgentId: "agent-1", assigneeUserId: null }])
+          : createSelectChain([existingRow])),
       insert: vi.fn(),
       update: vi.fn(),
+      transaction: async (callback: (tx: any) => Promise<void>) => callback(db),
     };
 
     const svc = issueThreadInteractionService(db as never);
@@ -186,6 +294,358 @@ describe("issueThreadInteractionService", () => {
     expect(created.id).toBe("interaction-1");
     expect(created.idempotencyKey).toBe("run-1:suggest");
     expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("create auto-assigns the creating agent when a wake_assignee interaction targets an ownerless issue", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const { db, events, locks, touches } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    const created = await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Pick one scope",
+          selectionMode: "single",
+          required: true,
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(touches).toContainEqual(expect.objectContaining({ assigneeAgentId: "agent-1" }));
+    expect(created.kind).toBe("ask_user_questions");
+    // The issue row is read exactly once, under an exclusive lock. FOR SHARE here
+    // would let two agents racing to create an interaction on the same ownerless
+    // issue both hold it and then deadlock upgrading to write the assignee.
+    expect(locks).toEqual(["update"]);
+    // The adoption must happen inside the same transaction as the insert, so the
+    // interaction and the wake target it depends on both land or neither does.
+    expect(events).toEqual(["tx:begin", "select:issue", "insert:interaction", "update:assignee", "tx:end"]);
+  });
+
+  it("create leaves a user-assigned issue alone for a wake_assignee interaction", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const { db, events } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: "user-1" },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Pick one scope",
+          selectionMode: "single",
+          required: true,
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      agentId: "agent-1",
+    });
+
+    // A user assignee is already a live waiting path (this is a pending *user*
+    // decision), and an issue may only carry one assignee — adopting here would
+    // take the issue away from its human owner.
+    expect(events).not.toContain("update:assignee");
+  });
+
+  it("create fails rather than persisting an interaction whose auto-assign failed", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const { db, events } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+      failAssignment: true,
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+
+    // The assignment shares the insert's transaction: swallowing the failure here
+    // would persist an interaction behind exactly the dead wake path this guards
+    // against, so both must roll back and let the caller retry cleanly.
+    await expect(svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Pick one scope",
+          selectionMode: "single",
+          required: true,
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      agentId: "agent-1",
+    })).rejects.toThrow("assignment failed");
+
+    expect(events).toContain("update:assignee");
+  });
+
+  it("create does not override an existing assignee for a wake_assignee interaction", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const { db, events } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: "agent-2", assigneeUserId: null },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Pick one scope",
+          selectionMode: "single",
+          required: true,
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(events).not.toContain("update:assignee");
+  });
+
+  it("create re-establishes the wake target when reusing an idempotent interaction on an ownerless issue", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    // Rows created before this guard existed — or whose issue lost its assignee
+    // since — must not be handed back on retry still pointing at a dead wake path.
+    const { db, events, locks, touches } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+      existingInteractionRow: {
+        id: "interaction-existing",
+        companyId: "company-1",
+        issueId: "11111111-1111-4111-8111-111111111111",
+        kind: "suggest_tasks",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        requestedResolverPolicy: "anyone",
+        effectiveResolverPolicy: "anyone",
+        resolverPolicyProvenance: "inherited",
+        effectiveResolverPolicySource: "requested",
+        addresseeAgentId: null,
+        idempotencyKey: "run-1:suggest",
+        sourceCommentId: null,
+        sourceRunId: null,
+        title: null,
+        summary: null,
+        createdByAgentId: "agent-1",
+        createdByUserId: null,
+        resolvedByAgentId: null,
+        resolvedByUserId: null,
+        payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+        result: null,
+        resolvedAt: null,
+        createdAt: new Date("2026-04-20T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+      },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    const created = await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "suggest_tasks",
+      idempotencyKey: "run-1:suggest",
+      continuationPolicy: "wake_assignee",
+      payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(created.id).toBe("interaction-existing");
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(touches).toContainEqual(expect.objectContaining({ assigneeAgentId: "agent-1" }));
+    expect(locks).toContain("update");
+    expect(events).toEqual(["tx:begin", "select:assignee", "update:assignee", "tx:end"]);
+  });
+
+  it("create does not adopt the issue when reusing an already-resolved interaction", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    // A resolved interaction has spent its one continuation and can never wake
+    // anyone again, so repairing its wake target would change ownership of an
+    // ownerless issue without buying anything.
+    const { db, events } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+      existingInteractionRow: {
+        id: "interaction-existing",
+        companyId: "company-1",
+        issueId: "11111111-1111-4111-8111-111111111111",
+        kind: "suggest_tasks",
+        status: "accepted",
+        continuationPolicy: "wake_assignee",
+        requestedResolverPolicy: "anyone",
+        effectiveResolverPolicy: "anyone",
+        resolverPolicyProvenance: "inherited",
+        effectiveResolverPolicySource: "requested",
+        addresseeAgentId: null,
+        idempotencyKey: "run-1:suggest",
+        sourceCommentId: null,
+        sourceRunId: null,
+        title: null,
+        summary: null,
+        createdByAgentId: "agent-1",
+        createdByUserId: null,
+        resolvedByAgentId: null,
+        resolvedByUserId: "local-board",
+        payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+        result: { version: 1, outcome: "accepted", createdTasks: [] },
+        resolvedAt: new Date("2026-04-20T11:00:00.000Z"),
+        createdAt: new Date("2026-04-20T10:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T11:00:00.000Z"),
+      },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    const created = await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "suggest_tasks",
+      idempotencyKey: "run-1:suggest",
+      continuationPolicy: "wake_assignee",
+      payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(created.id).toBe("interaction-existing");
+    expect(events).not.toContain("update:assignee");
+  });
+
+  it("create re-establishes the wake target when it loses the idempotency insert race", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    // The loser of a concurrent create does not go through the pre-insert
+    // idempotency lookup — it reaches the existing row through the unique-violation
+    // catch instead. That branch hands the row back just like the pre-check does,
+    // so it has to re-establish the wake target too. Otherwise whichever caller
+    // loses the race silently receives an interaction with a dead wake path.
+    const winnerRow = {
+      id: "interaction-existing",
+      companyId: "company-1",
+      issueId: "11111111-1111-4111-8111-111111111111",
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      requestedResolverPolicy: "anyone",
+      effectiveResolverPolicy: "anyone",
+      resolverPolicyProvenance: "inherited",
+      effectiveResolverPolicySource: "requested",
+      addresseeAgentId: null,
+      idempotencyKey: "run-1:suggest",
+      sourceCommentId: null,
+      sourceRunId: null,
+      title: null,
+      summary: null,
+      createdByAgentId: "agent-1",
+      createdByUserId: null,
+      resolvedByAgentId: null,
+      resolvedByUserId: null,
+      payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+      result: null,
+      resolvedAt: null,
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+    };
+
+    // The pre-insert lookup must miss (that is what makes this the race path);
+    // the winner's row only becomes visible once our insert has hit the unique
+    // index, so the fixture starts empty and is filled by `onInsert`.
+    const dbArgs: Parameters<typeof createCreateFlowDb>[0] = {
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+      existingInteractionRow: null,
+      onInsert: () => {
+        dbArgs.existingInteractionRow = winnerRow;
+        throw Object.assign(new Error("duplicate key value violates unique constraint"), {
+          code: "23505",
+          constraint: "issue_thread_interactions_company_issue_idempotency_uq",
+        });
+      },
+    };
+    const { db, events, touches } = createCreateFlowDb(dbArgs);
+
+    const svc = issueThreadInteractionService(db as never);
+    const created = await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "suggest_tasks",
+      idempotencyKey: "run-1:suggest",
+      continuationPolicy: "wake_assignee",
+      payload: { version: 1, tasks: [{ clientKey: "task-1", title: "One" }] },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(created.id).toBe("interaction-existing");
+    expect(events).toContain("insert:interaction");
+    expect(touches).toContainEqual(expect.objectContaining({ assigneeAgentId: "agent-1" }));
+  });
+
+  it("create does not auto-assign for request_confirmation's default none continuation policy", async () => {
+    const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+
+    const { db, events, locks, touches } = createCreateFlowDb({
+      currentIssueRow: { assigneeAgentId: null, assigneeUserId: null },
+    });
+
+    const svc = issueThreadInteractionService(db as never);
+    await svc.create({
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "none",
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        allowDeclineReason: true,
+      },
+    }, {
+      agentId: "agent-1",
+    });
+
+    expect(events).not.toContain("update:assignee");
+    // An interaction that cannot strand a wake path never writes the assignee;
+    // it still takes the terminal-issue gate's exclusive lock, which the create
+    // path holds unconditionally.
+    expect(events).toEqual(["tx:begin", "select:issue", "insert:interaction", "tx:end"]);
+    expect(locks).toEqual(["update"]);
+    expect(touches).not.toContainEqual(expect.objectContaining({ assigneeAgentId: "agent-1" }));
   });
 
   it("answerQuestions normalizes duplicate option ids and persists answered results", async () => {

--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -529,9 +529,14 @@ describe("issueThreadInteractionService", { timeout: 30_000 }, () => {
     expect(created.id).toBe("interaction-existing");
     expect(db.insert).not.toHaveBeenCalled();
     expect(touches).toContainEqual(expect.objectContaining({ assigneeAgentId: "agent-1" }));
-    expect(locks).toContain("update");
-    // The locked interaction re-read sits between the issue lock and the write:
-    // the caller's "still pending" came from an unlocked snapshot.
+    // Exactly one row lock: the issue. The interaction is re-read WITHOUT a lock
+    // on purpose — every resolution path writes the issue row before committing,
+    // so the issue lock already serializes this repair against all of them, while
+    // locking the interaction too would invert the order against paths that take
+    // the interaction first (`submitItemVerdicts`) and deadlock on the same issue.
+    expect(locks).toEqual(["update"]);
+    // The re-read still happens, and still sits between the issue lock and the
+    // write: the caller's "still pending" came from a snapshot taken earlier.
     expect(events).toEqual([
       "tx:begin",
       "select:assignee",

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1573,20 +1573,28 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
 
     if (!current || current.assigneeAgentId || current.assigneeUserId) return;
 
-    // Re-read the interaction under lock before writing. The reuse paths decided
-    // "still pending" from an unlocked snapshot, and a concurrent resolution can
-    // land between that read and here. Adopting then would hand the issue to a
+    // Re-read the interaction before writing. The reuse paths decided "still
+    // pending" from a snapshot taken outside this transaction, and a concurrent
+    // resolution can land in between. Adopting then would hand the issue to a
     // creator whose one continuation has already been spent — an ownership change
     // that buys no wake path, which is the opposite of this guard's purpose.
-    // Lock order stays issue -> interaction, matching the resolution paths.
+    //
+    // Deliberately NOT `FOR UPDATE`. Every resolution path in this file writes the
+    // issue row before it commits (`touchIssue`, or `issueService.update` on the
+    // hand-back branch), so the issue lock this transaction already holds is what
+    // serializes us against all of them: a resolution either committed before we
+    // took that lock — and this read sees it — or it blocks behind us and commits
+    // after. Locking the interaction as well would buy nothing and would invert
+    // the lock order against paths that take the interaction first and only then
+    // write the issue (`submitItemVerdicts`), turning a benign read into a real
+    // deadlock cycle on the same issue.
     if (args.requireStillPendingInteractionId) {
-      const lockedInteraction = await tx
+      const currentInteraction = await tx
         .select({ status: issueThreadInteractions.status })
         .from(issueThreadInteractions)
         .where(eq(issueThreadInteractions.id, args.requireStillPendingInteractionId))
-        .for("update")
         .then((rows) => rows[0] ?? null);
-      if (!lockedInteraction || lockedInteraction.status !== "pending") return;
+      if (!currentInteraction || currentInteraction.status !== "pending") return;
     }
 
     await adoptWakeTargetCreator(tx, args.issueId, args.creatorAgentId);

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -587,6 +587,10 @@ function interactionTerminalError(row: { status: string; result?: unknown }) {
   );
 }
 
+function isWakeAssigneeContinuationPolicy(continuationPolicy: string): boolean {
+  return continuationPolicy === "wake_assignee" || continuationPolicy === "wake_assignee_on_accept";
+}
+
 function shouldReturnAcceptedConfirmationToCreatorAgent(args: {
   issue: IssueResolutionContext;
   current: IssueThreadInteractionRow;
@@ -1499,6 +1503,105 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     return hydrateInteraction(current);
   }
 
+  /**
+   * A `wake_assignee` / `wake_assignee_on_accept` interaction only has a live
+   * continuation path if the issue carries an `assigneeAgentId` by the time it
+   * resolves — `queueResolvedInteractionContinuationWakeup` drops the wakeup
+   * otherwise, which leaves the interaction pending behind a permanently dead
+   * wake path until the slow ownerless sweep happens to notice.
+   *
+   * Adopt the creating agent as assignee when the issue is genuinely ownerless so
+   * that path always exists. Issues that already carry an `assigneeUserId` are
+   * deliberately left alone: a user assignee is itself a live waiting path
+   * (`ask_user_questions` on a user-owned issue is a pending *user* decision), and
+   * the issue schema permits only one assignee, so adopting here would silently
+   * take the issue away from its human owner.
+   *
+   * Callers must already hold a write lock on the issue row, and must have
+   * confirmed from that locked read that the issue carries neither an
+   * `assigneeAgentId` nor an `assigneeUserId`.
+   *
+   * Deliberately a single narrow UPDATE rather than `issueService.update()`. This
+   * runs inside the interaction-insert transaction while holding the issue row
+   * lock, and the full update path reads and writes further tables — which
+   * inverts lock order against heartbeat-run cleanup (whose `heartbeat_runs`
+   * delete cascades into `issues`) and deadlocks under concurrency. Keeping the
+   * transaction's footprint to `issues` plus the interaction row avoids the
+   * cycle. The WHERE guard makes the write a no-op if anything claimed the issue
+   * between the locked read and here.
+   */
+  async function adoptWakeTargetCreator(tx: Db, issueId: string, creatorAgentId: string) {
+    await tx
+      .update(issues)
+      .set({ assigneeAgentId: creatorAgentId, updatedAt: new Date() })
+      .where(and(
+        eq(issues.id, issueId),
+        isNull(issues.assigneeAgentId),
+        isNull(issues.assigneeUserId),
+      ));
+  }
+
+  /**
+   * Locked read + adopt, for callers that do not already hold the issue row.
+   */
+  async function ensureWakeAssigneeContinuationHasLiveTarget(
+    tx: Db,
+    args: {
+      issueId: string;
+      continuationPolicy: string;
+      creatorAgentId: string | null;
+    },
+  ) {
+    if (!args.creatorAgentId) return;
+    if (!isWakeAssigneeContinuationPolicy(args.continuationPolicy)) return;
+
+    // Lock the row so two agents racing on the same ownerless issue cannot both
+    // observe a null assignee and have the second adopt it out from under the first.
+    const current = await tx
+      .select({
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+      })
+      .from(issues)
+      .where(eq(issues.id, args.issueId))
+      .for("update")
+      .then((rows) => rows[0] ?? null);
+
+    if (!current || current.assigneeAgentId || current.assigneeUserId) return;
+
+    await adoptWakeTargetCreator(tx, args.issueId, args.creatorAgentId);
+  }
+
+  /**
+   * Same invariant as above, applied when `create` returns an *existing* row for
+   * an idempotent retry instead of inserting one. Those rows can predate this
+   * guard, or can have lost their assignee since, so reuse has to re-establish the
+   * wake target rather than assume the insert path already did — otherwise a retry
+   * quietly hands back an interaction that will never wake anyone.
+   *
+   * Only pending rows are repaired. An interaction that already resolved — accepted,
+   * rejected, answered, cancelled or expired — has spent its one continuation and
+   * can never wake anyone again, so adopting the issue for its historical creator
+   * would change ownership without buying a wake path.
+   */
+  async function ensureReusedInteractionHasLiveWakeTarget(
+    existing: IssueThreadInteractionRow,
+    actor: InteractionActor,
+  ) {
+    if (existing.status !== "pending") return;
+    const creatorAgentId = existing.createdByAgentId ?? actor.agentId ?? null;
+    if (!creatorAgentId) return;
+    if (!isWakeAssigneeContinuationPolicy(existing.continuationPolicy)) return;
+
+    await db.transaction(async (tx) => {
+      await ensureWakeAssigneeContinuationHasLiveTarget(tx as unknown as Db, {
+        issueId: existing.issueId,
+        continuationPolicy: existing.continuationPolicy,
+        creatorAgentId,
+      });
+    });
+  }
+
   async function assertIssueWorkspaceFinalizedForAccept(args: {
     db: Pick<Db, "select">;
     issue: { id: string; companyId: string };
@@ -2322,6 +2425,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
               idempotencyKey: normalizedData.idempotencyKey,
             });
           }
+          await ensureReusedInteractionHasLiveWakeTarget(existing, actor);
           return hydrateInteraction(existing);
         }
       }
@@ -2358,6 +2462,11 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         || data.kind === "request_checkbox_confirmation"
         || data.kind === "request_item_verdicts";
 
+      // Only agent-created interactions with a waking continuation policy can
+      // strand a wake path, so only those need the issue row locked for write.
+      const needsWakeTargetGuard =
+        Boolean(actor.agentId) && isWakeAssigneeContinuationPolicy(data.continuationPolicy);
+
       let created: IssueThreadInteractionRow;
       let superseded: IssueThreadInteractionRow[] = [];
       try {
@@ -2366,9 +2475,20 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         // transitions and against concurrent confirmations on the same issue.
         // Idempotent reuse above stays allowed so retries of a pre-close
         // create keep returning the (by now expired) original.
+        //
+        // The same locked read also serves the wake-target probe below: the
+        // terminal-status check and the assignee probe read one row under one
+        // lock, and because that lock is already FOR UPDATE the guard never has
+        // to upgrade it. Two agents racing to create an interaction on the same
+        // ownerless issue therefore serialize instead of both observing a null
+        // assignee (or deadlocking on a shared-to-exclusive upgrade).
         const result = await db.transaction(async (tx) => {
           const [issueRow] = await tx
-            .select({ status: issues.status })
+            .select({
+              status: issues.status,
+              assigneeAgentId: issues.assigneeAgentId,
+              assigneeUserId: issues.assigneeUserId,
+            })
             .from(issues)
             .where(and(eq(issues.id, issue.id), eq(issues.companyId, issue.companyId)))
             .for("update");
@@ -2411,6 +2531,22 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
               payload: data.payload,
             })
             .returning();
+
+          // Adopt the creating agent as assignee when a waking interaction is
+          // created on a genuinely ownerless issue, so the continuation wakeup
+          // has a live target by the time the interaction resolves. Same
+          // transaction as the insert: an interaction that outlives a failed
+          // assignment is exactly the dead wake path this guards against.
+          // This runs before the supersede early-return below, so kinds that
+          // never supersede siblings still get their wake target.
+          if (
+            needsWakeTargetGuard
+            && actor.agentId
+            && !issueRow.assigneeAgentId
+            && !issueRow.assigneeUserId
+          ) {
+            await adoptWakeTargetCreator(tx as unknown as Db, issue.id, actor.agentId);
+          }
 
           // An agent replacing its own still-pending card supersedes the older
           // one so the thread never accumulates stale sibling cards. This covers
@@ -2477,6 +2613,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
             idempotencyKey: normalizedData.idempotencyKey,
           });
         }
+        await ensureReusedInteractionHasLiveWakeTarget(existing, actor);
         return hydrateInteraction(existing);
       }
 

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1550,6 +1550,10 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       issueId: string;
       continuationPolicy: string;
       creatorAgentId: string | null;
+      // Set on the reuse paths, where the interaction's status was read outside
+      // this transaction and can be stale by now. Left unset on the insert path,
+      // whose interaction is inserted by this very transaction.
+      requireStillPendingInteractionId?: string;
     },
   ) {
     if (!args.creatorAgentId) return;
@@ -1568,6 +1572,22 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       .then((rows) => rows[0] ?? null);
 
     if (!current || current.assigneeAgentId || current.assigneeUserId) return;
+
+    // Re-read the interaction under lock before writing. The reuse paths decided
+    // "still pending" from an unlocked snapshot, and a concurrent resolution can
+    // land between that read and here. Adopting then would hand the issue to a
+    // creator whose one continuation has already been spent — an ownership change
+    // that buys no wake path, which is the opposite of this guard's purpose.
+    // Lock order stays issue -> interaction, matching the resolution paths.
+    if (args.requireStillPendingInteractionId) {
+      const lockedInteraction = await tx
+        .select({ status: issueThreadInteractions.status })
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, args.requireStillPendingInteractionId))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (!lockedInteraction || lockedInteraction.status !== "pending") return;
+    }
 
     await adoptWakeTargetCreator(tx, args.issueId, args.creatorAgentId);
   }
@@ -1598,6 +1618,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         issueId: existing.issueId,
         continuationPolicy: existing.continuationPolicy,
         creatorAgentId,
+        requireStillPendingInteractionId: existing.id,
       });
     });
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issue-thread interactions (`suggest_tasks`, `ask_user_questions`, `request_confirmation`) are how an agent pauses work and hands a decision back to a human or the board; a `continuationPolicy` of `wake_assignee` is the promise that the agent gets woken again once that decision lands
> - That promise is only kept if the issue carries an `assigneeAgentId` at resolution time — `queueResolvedInteractionContinuationWakeup` (`server/src/routes/issues.ts:2086`) drops the wakeup outright when the issue has no agent assignee
> - Nothing on the creation path enforces that invariant, so an agent can create a `wake_assignee` interaction on an ownerless issue and get a silently dead wake path: the interaction sits `pending` forever, looking alive on the board while nothing will ever wake anyone
> - The only backstop is a slow periodic ownerless sweep, which is exactly the safety net that already failed in practice — one such issue sat unrecovered for 21 days
> - This pull request closes the hole at the source: when a `wake_assignee`/`wake_assignee_on_accept` interaction is created on a genuinely ownerless issue, the creating agent is adopted as `assigneeAgentId`, so the wake target always exists by the time the interaction resolves
> - The benefit is that a resolved interaction can no longer strand an issue behind a permanently dead continuation path, for any company using these interaction kinds

## Linked Issues or Issue Description

No existing public GitHub issue — describing the bug in-PR per the bug report template.

**What happened?**
An agent creates an issue-thread interaction with `continuationPolicy: wake_assignee` (the schema default for `suggest_tasks` and `ask_user_questions`, see `packages/shared/src/validators/issue.ts`) on an issue that has no assignee. When a human later answers the interaction, no continuation wakeup is queued: `queueResolvedInteractionContinuationWakeup` returns early at the `if (!input.issue.assigneeAgentId || ...) return;` guard. The interaction is marked resolved, but no agent is ever woken. The issue looks like it is waiting on a live decision path when in fact nothing will ever pick it back up. In one observed case the issue sat unrecovered for 21 days until an ops sweep noticed it.

**Expected behavior**
Answering a `wake_assignee` interaction should always resume work — either by waking an agent, or by the interaction never having been created against a dead wake path in the first place.

**Steps to reproduce**
1. Create an issue and leave it unassigned (no `assigneeAgentId`, no `assigneeUserId`).
2. As an agent, `POST /api/issues/{issueId}/interactions` with `kind: "ask_user_questions"` (or `suggest_tasks`), leaving `continuationPolicy` at its `wake_assignee` default.
3. Answer the interaction as a user.
4. Observe: the interaction resolves, but no heartbeat wakeup is queued and no agent resumes. The issue is stranded.

**Paperclip version or commit**
Reproduces on `master`; this branch is rebased onto `d1573244b`.

**Deployment mode / Database mode**
Self-hosted server, Postgres. Not deployment-specific.

**Agent adapter(s) involved**
Not adapter-specific (core bug) — the guard is in the server's interaction/wake path.

## What Changed

- `server/src/services/issue-thread-interactions.ts`: `create()` now adopts the creating agent as `assigneeAgentId` when a `wake_assignee`/`wake_assignee_on_accept` interaction targets an issue carrying neither an `assigneeAgentId` nor an `assigneeUserId`.
- The probe runs inside the **same transaction** as the interaction insert, after it, so the interaction and the wake target it depends on either both commit or neither does. A failed insert cannot leave behind a stray assignment, and a failed assignment cannot leave behind an interaction sitting on a dead wake path — the caller can retry cleanly against unchanged state.
- The probe takes a `FOR UPDATE` row lock on the issue, so two agents racing to create an interaction on the same ownerless issue cannot both observe a null assignee and have the second adopt the issue out from under the first.
- **The adoption is a single narrow `UPDATE`, deliberately not `issueService.update()`.** This matters: it runs inside the insert transaction while holding the issue row lock, and the full update path reads and writes further tables, so the transaction's real lock footprint was far wider than the one row it appeared to touch. That inverted lock order against heartbeat-run cleanup — `delete from heartbeat_runs` cascades into `UPDATE issues SET execution_run_id = NULL` — and deadlocked (`40P01`) reproducibly in CI's serialized server suites. Keeping the transaction to `issues` plus the inserted interaction row removes the cycle. The trade-off is that an auto-adoption no longer emits the full update path's side effects; for a system safety net writing one column on an issue nobody owns, that is the intended call, and it is called out here rather than buried.
- **The earlier conditional lock is gone, and that is a simplification, not a regression.** An earlier revision of this pull request raised the terminal-issue gate's row lock from `FOR SHARE` to `FOR UPDATE` only when the wake guard could fire, to avoid two creators deadlocking on a shared-to-exclusive upgrade. Current `master` takes that lock as `FOR UPDATE` unconditionally, so the whole conditional disappeared on rebase: the guard now writes under a lock the transaction already holds and can never upgrade one. The deadlock this bullet used to describe is structurally impossible rather than avoided by hand.
- **One locked read serves both gates.** The terminal-status check and the wake-target probe read the same row, so they share a single `SELECT`; nothing re-reads or re-locks the issue while the transaction is open.
- The insert's idempotency-conflict handler re-selects the existing row *outside* the transaction, so it is unaffected by the rollback a unique violation triggers.
- **The adoption runs before `master`'s supersede early-return.** `create()` now supersedes an agent's own older pending sibling card in the same transaction, and returns early for every kind that does not qualify. Placing the adoption after that return would silently skip it for exactly the kinds that never supersede, so the guard sits ahead of it and every waking kind gets its wake target.
- Added `isWakeAssigneeContinuationPolicy()` helper covering both `wake_assignee` and `wake_assignee_on_accept`.
- Both idempotent-reuse paths in `create()` (the up-front lookup and the unique-violation handler) re-establish the wake target before returning the existing row, so "create returned a pending `wake_assignee` interaction" implies a live wake target regardless of which path produced it. This matters for rows created before this guard existed and for issues that lost their assignee after the interaction was created.
- **The reuse repair re-reads the interaction under lock.** Both reuse paths decide "still pending" from a row read *outside* the repair transaction. A concurrent resolution landing between that read and the transaction would leave the repair adopting the issue for a creator whose one continuation is already spent — an ownership change on an ownerless issue that buys no wake path, i.e. the opposite of this guard's purpose. The transaction therefore re-reads the interaction and skips the adoption unless it is still pending. The re-read is deliberately **not** `FOR UPDATE`: a first attempt did lock it, and review correctly flagged that as a lock-order inversion against `submitItemVerdicts`, which locks the interaction first and only then writes the issue through `touchIssue` — two requests on the same issue could then hold one row each and Postgres would abort one. The lock was never needed. **Every** resolution path in this file writes the issue row before it commits (`touchIssue`, or `issueService.update` on the hand-back branch), so the issue-row lock this transaction already holds is what serializes the repair against all of them: a resolution either committed before that lock was taken — and the re-read observes it — or it blocks behind this transaction and commits after. A test pins the exact lock set for the repair path, so restoring the lock turns it red instead of silently reintroducing the cycle. The insert path passes no id and takes no extra read: its interaction is inserted by the very transaction that adopts. Raised as a **P1 by review on the first rebased head** and pinned by a regression test. A second P1 on the follow-up head raised the lock-order point above; both are fixed and both are pinned.
- **Only *pending* rows are repaired on reuse.** An interaction that already resolved — accepted, rejected, answered, cancelled or expired — has spent its one continuation and can never wake anyone again, so adopting the issue for its historical creator would mutate ownership without buying a wake path.
- `server/src/services/issue-thread-interactions.test.ts`: 9 new cases (see Verification), plus fake-db support for transactions, row locks, assignment writes and table-aware select dispatch (`issues` and `issue_thread_interactions` both carry a `status` column, so the two locked reads can only be told apart by table).

### Why issues with an `assigneeUserId` are deliberately left alone

A raised review point was that an issue with an `assigneeUserId` but no `assigneeAgentId` also fails the wake guard, and so should also get the creator adopted. This PR intentionally does not do that:

- An issue may only ever carry one assignee — `issueService.update()` throws `"Issue can only have one assignee"` when both fields would be set (`server/src/services/issues.ts:6620`). Adopting the creator would therefore require *removing* the human owner.
- A user assignee is already modelled as a live waiting path, not a dead one: `server/src/services/issues.ts:2425` treats `assigneeUserId` as `covered: true, stalled: false`, and `issues.ts:3417` classifies `ask_user_questions` on a user-assigned issue as a pending **user** decision (`pending_user_decision`) with the user as owner.

So for user-assigned issues the absent agent wakeup is the intended shape, and adopting the issue away from its human owner would be a real behavioral regression. The narrow "no assignee at all" condition is the deliberate scope. This is asserted by a test.

## Verification

Rebased onto `master` (`d1573244b`). Three commits, each reviewable on its own: the rebased guard, and two review-raised P1 fixes on top. The previous head had gone `CONFLICTING` against 323 commits of drift; the conflicts were resolved by hand, not re-applied mechanically (see the two rebase notes under What Changed).

**Unit and integration suites** — `vitest run src/services/issue-thread-interactions.test.ts` from `server/`: **22 passed**, which includes the 13 pre-existing cases, so the conflict resolution is verified in both directions. `vitest run src/services/issue-thread-interaction-resolution.test.ts src/__tests__/issue-thread-interactions-service.test.ts`: **71 passed**.

**Paired base control.** The local dependency tree is older than `master`, and an unpaired run is not readable: the first attempt failed 20/20 on a missing workspace package, and a control run on the base commit failed identically. Every result quoted here was produced after the base commit ran **13/13 green** under the same linking, so a failure on this branch means this branch.

**Mutation probes — the nine new cases are proven to bind, not merely to pass.** Each mechanism was disabled in turn and the suite re-run:

| Mechanism disabled | Result |
| --- | --- |
| Adoption on the insert path | 2 failed |
| Wake-target repair on the pre-insert idempotent-reuse path | 1 failed |
| Wake-target repair on the unique-violation (race-loser) path | **20 passed — uncovered** |
| Pending re-check on the reuse path (first P1 fix) | 1 failed |
| Restoring `FOR UPDATE` on that re-read (the deadlock the second P1 named) | 1 failed |

The third row was a real gap in this pull request, found by the probe rather than by review. The eighth case (`create re-establishes the wake target when it loses the idempotency insert race`) was added to close it, and the same probe now turns it red. Losing the insert race is precisely the concurrency the guard exists for, so an unverified branch there was worth closing.

The nine cases cover:

- auto-assigns the creating agent on a genuinely ownerless issue, **and** asserts the issue row is read exactly once under an exclusive lock and the adoption happens inside the insert's transaction
- leaves a user-assigned issue alone
- create fails (and rolls back) rather than persisting an interaction whose auto-assign failed
- does not override an existing agent assignee
- re-establishes the wake target when an idempotent retry reuses a *pending* interaction on an ownerless issue
- does **not** adopt the issue when the reused interaction has already resolved
- does **not** adopt the issue when the reused interaction resolves *between* the unlocked read and the repair transaction (the P1 case)
- re-establishes the wake target when the create loses the idempotency insert race
- does not trigger for a non-`wake_assignee` continuation policy (`request_confirmation`'s default `none`), and asserts that path never writes the issue row

**Typecheck** — `tsc --noEmit -p tsconfig.json` from `server/`, run on this branch and on the base commit under identical linking: **1253 errors on each, and the two error sets are identical** (`comm -13` between the sorted outputs is empty). This branch introduces no new type error. The shared errors come from unbuilt workspace packages and a `zod` major-version difference in the local store; they are not reproduced by CI, whose Typecheck job resolves those packages properly.

## Risks

Low-to-moderate, and reversible (server-side logic only, no migration).

- **Behavioral shift:** an agent that deliberately creates a `wake_assignee` interaction on an ownerless issue will now find itself assigned to that issue. This is the intended trade — a wrong-but-live owner is recoverable in one reassignment, a dead wake path is not — but it is a visible change for any flow that relies on issues staying ownerless. Flows that want to keep an issue ownerless can pass an explicit non-waking `continuationPolicy`.
- **Scope is deliberately narrow:** only issues with *no* assignee at all are touched; any existing agent or user assignee is preserved (asserted by tests).
- **Concurrency:** handled via the `FOR UPDATE` row lock; the lock is held only for the assignee probe plus the single update.
- **Failure mode:** if the assignment fails, the whole create rolls back and the caller gets an error against unchanged state. This is a deliberate trade over swallowing the failure: a persisted interaction whose assignment silently failed would reintroduce exactly the dead wake path this PR fixes, whereas a rolled-back create is safely retriable.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5`, 1M context window, extended thinking enabled, run under Claude Code with tool use and code execution (tests and typecheck run locally against this branch).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — searched open and closed PRs for `wake_assignee` and for creator/assignee auto-assignment. No PR implements this fix. Related but distinct, all on the *recovery/suppression* side rather than the creation path: #5060 (wake assignee on interaction-resolved coalescing), #4854 (skip stranded-issue recovery when a pending wake interaction exists), #7260 / #8721 (skip recovery for issues with open waiting interactions), #7312 (creator-withdraw path for interactions).
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details — **not met:** the branch name carries an instance-local ticket id. Renaming the branch would close this PR, so it is left as-is; happy to re-open under a clean branch name if maintainers prefer.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no user-facing docs affected; rationale is documented in source comments on the new helper.
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — 28 pass / 1 skipping on `0c6aca6d4`; the one remaining red check is Greptile, see below
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — **no open findings**, but the score is 4/5 and the check reports `Confidence 4/5 — below your required 5/5`. Its own output states this "reflects your team's confidence threshold, not a review failure". Three P1s were raised across the rebased heads and all three are fixed; the reviewer closed the last one itself ("Correction noted and the finding is closed on my end"). Left unchecked because the numeric threshold is not met, rather than abandoning the box.
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)




