### PR TITLE
fix(server): wake the requester on any interaction rejection that carries a reason

### DIFF
--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -1449,7 +1449,7 @@ describe.sequential("issue thread interaction routes", () => {
     );
   });
 
-  it("does not emit a continuation wake when request confirmations are rejected", async () => {
+  it("wakes the assignee when a rejected request confirmation carries a reason, even under wake_assignee_on_accept", async () => {
     mockInteractionService.rejectInteraction.mockResolvedValueOnce({
       id: "interaction-3",
       companyId: "company-1",
@@ -1478,6 +1478,45 @@ describe.sequential("issue thread interaction routes", () => {
     const res = await request(app)
       .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-3/reject")
       .send({ reason: "Needs changes" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        payload: expect.objectContaining({ rejectionReason: "Needs changes" }),
+        contextSnapshot: expect.objectContaining({ rejectionReason: "Needs changes" }),
+      }),
+    );
+  });
+
+  it("does not wake the assignee for a reason-less rejection under wake_assignee_on_accept", async () => {
+    mockInteractionService.rejectInteraction.mockResolvedValueOnce({
+      id: "interaction-3b",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "request_confirmation",
+      status: "rejected",
+      continuationPolicy: "wake_assignee_on_accept",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: "run-3b",
+      payload: {
+        version: 1,
+        prompt: "Apply this plan?",
+      },
+      result: {
+        version: 1,
+        outcome: "rejected",
+      },
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:05:00.000Z",
+      resolvedAt: "2026-04-20T12:05:00.000Z",
+    });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-3b/reject")
+      .send({});
 
     expect(res.status).toBe(200);
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
@@ -1522,6 +1561,47 @@ describe.sequential("issue thread interaction routes", () => {
         contextSnapshot: expect.objectContaining({
           reviewPathLost: true,
           reviewPathInstruction: expect.stringContaining("Restore a reviewer"),
+        }),
+      }),
+    );
+  });
+
+  it("wakes the assignee when a rejected request confirmation carries a reason, even under continuationPolicy none", async () => {
+    mockInteractionService.rejectInteraction.mockResolvedValueOnce({
+      id: "interaction-3c",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "request_confirmation",
+      status: "rejected",
+      continuationPolicy: "none",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: "run-3c",
+      payload: {
+        version: 1,
+        prompt: "Approve v4?",
+      },
+      result: {
+        version: 1,
+        outcome: "rejected",
+        reason: "Diagnose the looping problem and present a plan before continuing.",
+      },
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:05:00.000Z",
+      resolvedAt: "2026-04-20T12:05:00.000Z",
+    });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-3c/reject")
+      .send({ reason: "Diagnose the looping problem and present a plan before continuing." });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          rejectionReason: "Diagnose the looping problem and present a plan before continuing.",
         }),
       }),
     );
@@ -1580,7 +1660,7 @@ describe.sequential("issue thread interaction routes", () => {
     );
   });
 
-  it("does not emit an accept-only continuation wake for rejected suggested tasks", async () => {
+  it("wakes the assignee for a rejected suggested-tasks interaction that carries a reason", async () => {
     mockInteractionService.rejectInteraction.mockResolvedValueOnce({
       id: "interaction-5",
       companyId: "company-1",
@@ -1610,7 +1690,12 @@ describe.sequential("issue thread interaction routes", () => {
       .send({ reason: "Not now" });
 
     expect(res.status).toBe(200);
-    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        payload: expect.objectContaining({ rejectionReason: "Not now" }),
+      }),
+    );
   });
 
   it("allows agent-authored interaction creation and stamps the active run id", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1986,13 +1986,20 @@ async function queueResolvedInteractionContinuationWakeup(input: {
         );
         return false;
       }));
+  const interactionResult = readConfirmationResultForWake(input.interaction.result);
+  // A rejection that carries a reason is a message, not silence — the requester needs
+  // it regardless of continuationPolicy. Policies like "none" or "wake_assignee_on_accept"
+  // exist to control noise on the accept path; they were never meant to suppress feedback
+  // the requester is actively waiting to hear. Without this, a reasoned decline silently
+  // vanishes (paperclipai/paperclip#8617, #6800).
+  const isRejectionWithReason = input.interaction.status === "rejected" && !!interactionResult?.reason;
   const continuationPolicyAllowsWake =
     input.interaction.continuationPolicy === "wake_assignee"
     || (
       input.interaction.continuationPolicy === "wake_assignee_on_accept"
       && input.interaction.status === "accepted"
     );
-  if (!continuationPolicyAllowsWake && !reviewPathLost) return;
+  if (!continuationPolicyAllowsWake && !reviewPathLost && !isRejectionWithReason) return;
   if (input.interaction.status === "expired" && !reviewPathLost) return;
   const reviewPathContext = reviewPathLost
     ? {
@@ -2005,7 +2012,6 @@ async function queueResolvedInteractionContinuationWakeup(input: {
   const forceFreshSession = input.forceFreshSession === true;
   const workspaceRefreshReason = readNonEmptyString(input.workspaceRefreshReason);
   const planTarget = readPlanConfirmationTargetForIssue(input.interaction.payload, input.issue.id);
-  const interactionResult = readConfirmationResultForWake(input.interaction.result);
   const checkboxSelection = readCheckboxSelectionForWake(input.interaction);
   const toolAction = readToolActionContinuationContext(input.interaction);
   const newlyResolvedItemIds = input.newlyResolvedItemIds?.filter((value) => value.length > 0) ?? [];
@@ -2042,6 +2048,10 @@ async function queueResolvedInteractionContinuationWakeup(input: {
       ...(toolAction ? { toolAction } : {}),
       ...(itemVerdicts ? { itemVerdicts, newlyResolvedItemIds } : {}),
       ...(reviewPathContext ?? {}),
+      // Surfaced at the top level (in addition to any kind-specific structure above)
+      // so the woken agent sees the actual feedback without a follow-up fetch — the
+      // entire point of overriding a silent continuationPolicy for this case.
+      ...(isRejectionWithReason ? { rejectionReason: interactionResult!.reason } : {}),
       mutation: "interaction",
     },
     idempotencyKey: input.idempotencyKey ?? `interaction:${input.interaction.id}:${input.interaction.status}`,
@@ -2060,6 +2070,7 @@ async function queueResolvedInteractionContinuationWakeup(input: {
       ...(toolAction ? { toolAction } : {}),
       ...(itemVerdicts ? { itemVerdicts, newlyResolvedItemIds } : {}),
       ...(reviewPathContext ?? {}),
+      ...(isRejectionWithReason ? { rejectionReason: interactionResult!.reason } : {}),
       wakeReason: "issue_commented",
       source: input.source,
       ...(forceFreshSession ? { forceFreshSession: true } : {}),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issue-thread interactions (`request_confirmation`, `suggest_tasks`, etc.) let a human respond to an agent's request; `continuationPolicy` controls whether resolving one wakes the requesting agent
> - `continuationPolicy` is meant to control noise on the *accept* path — e.g. `wake_assignee_on_accept` so a routine "looks good" doesn't burn a wake, or `none` when the requester genuinely doesn't need to resume
> - But the same gate also silently swallowed *rejections that carried a written reason* — the one outcome the requester most needs to hear, since a reject is new information while an accept is usually just "proceed as planned"
> - I hit this live, twice, on the same production issue: an agent created a `request_confirmation` with `continuationPolicy: "none"`, the operator rejected it with a substantive question ("why did we deviate from spec, and the loop still isn't clean — diagnose and propose a plan"), and it sat resolved-but-unread for hours until a human noticed and manually relayed it
> - This pull request makes a rejection-with-reason wake the assignee regardless of the configured continuationPolicy, and surfaces the reason directly in the wake payload so the assignee doesn't need a follow-up fetch to see it
> - The benefit: reasoned feedback can no longer disappear into a stranded interaction — continuationPolicy still controls the accept path exactly as before, but is no longer able to suppress an operator's actual words

## Linked Issues or Issue Description

Fixes: #8617
Refs: #6800

Both describe adjacent symptoms of the same underlying gap (an operator's response to an interaction/approval failing to reach the requester). This PR closes the general case for issue-thread interactions: any `reject` (or task-rejection) result whose `reason`/`rejectionReason` field is non-empty now wakes the assignee, independent of `continuationPolicy`.

## What Changed

- `queueResolvedInteractionContinuationWakeup` (`server/src/routes/issues.ts`): computes `interactionResult` up front and adds `isRejectionWithReason` (status `rejected` + non-empty `reason`/`rejectionReason`, via the existing `readConfirmationResultForWake` helper). The wake gate now fires when the configured policy allows it *or* when this is a reasoned rejection.
- Both the wake `payload` and `contextSnapshot` gain a `rejectionReason` field whenever `isRejectionWithReason` is true, so the woken agent sees the actual feedback text without an extra round-trip — mirroring how tool-action rejections already surface `declineReason`.
- Reason-less rejections are untouched: a bare "rejected, no comment" still respects the configured policy and stays silent under `none` / `wake_assignee_on_accept`. This only overrides silence when there is something to say.
- Updated two existing tests that encoded the previous (buggy) behavior — both rejected an interaction *with* a reason under `wake_assignee_on_accept` and asserted no wake; flipped to assert the wake now fires with the reason visible in the payload.
- Added: a reason-less-rejection negative case (still silent, guards against over-firing), and the exact `continuationPolicy: "none"` + reasoned-rejection case that reproduced the production incident.

## Verification

- `cd server && pnpm vitest run src/__tests__/issue-thread-interaction-routes.test.ts` → 20/20 pass.
- Revert-check: with the `issues.ts` change reverted (tests kept), the three "carries a reason" tests fail — `expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(...)` on a call that never happened. Restored and re-ran green.
- `cd server && pnpm tsc --noEmit` → clean.

## Risks

- Low, and intentionally narrow: the override condition requires both `status === "rejected"` and a non-empty reason string — an already-existing, validated field on the interaction result. No new inputs, no schema change.
- Behavior change is additive only (adds wake occasions, never removes one) and confined to the rejection-with-reason case; all previously-passing accept-path and reason-less-reject-path assertions in the same test file continue to pass unmodified.
- The `rejectionReason` field is new and additive on the wake payload/contextSnapshot shape — existing consumers that don't know about it are unaffected.

## Model Used

- Anthropic Claude — Fable 5 (`claude-fable-5`), extended thinking, agentic tool use via Claude Code (CLI). Diagnosis from a live production incident, fix, and tests all model-authored under human direction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none applicable — inline comments cover the new branch)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending first CI run on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending first review pass)
- [x] I will address all Greptile and reviewer comments before requesting merge
