### PR TITLE
fix(codex-local): default CODEX_PATH to the system Codex CLI for ACP runs

### DIFF
--- a/packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts
+++ b/packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { withCodexAppServerCodexPathDefault } from "./acp.js";
+
+const tempDirs: string[] = [];
+const originalPath = process.env.PATH;
+const originalCodexPath = process.env.CODEX_PATH;
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-path-default-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeExecutable(filePath: string, content: string | Buffer): Promise<void> {
+  await fs.writeFile(filePath, content, { mode: 0o755 });
+}
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  if (originalCodexPath === undefined) delete process.env.CODEX_PATH;
+  else process.env.CODEX_PATH = originalCodexPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("withCodexAppServerCodexPathDefault", () => {
+  it("keeps an explicit adapter-config CODEX_PATH", async () => {
+    const config = { env: { CODEX_PATH: "/custom/codex" } };
+    const result = await withCodexAppServerCodexPathDefault(config, {});
+    expect(result).toBe(config);
+  });
+
+  it("keeps config untouched when the host env already sets CODEX_PATH", async () => {
+    process.env.CODEX_PATH = "/host/codex";
+    const config = { agent: "codex" };
+    const result = await withCodexAppServerCodexPathDefault(config, {});
+    expect(result).toBe(config);
+  });
+
+  it("does not set CODEX_PATH for remote execution targets", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    await writeExecutable(path.join(dir, "codex"), "#!/usr/bin/env node\n");
+    process.env.PATH = dir;
+    const config = { agent: "codex" };
+    const result = await withCodexAppServerCodexPathDefault(config, {
+      executionTarget: { kind: "remote", transport: "sandbox", remoteCwd: "/remote/work" } as never,
+    });
+    expect(result).toBe(config);
+  });
+
+  it("resolves a node-script Codex CLI from PATH for local targets", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    const codex = path.join(dir, "codex");
+    await writeExecutable(codex, "#!/usr/bin/env node\nconsole.log('codex');\n");
+    process.env.PATH = dir;
+    const result = await withCodexAppServerCodexPathDefault({ agent: "codex" }, {});
+    expect((result.env as Record<string, string>).CODEX_PATH).toBe(codex);
+  });
+
+  it("skips shell wrapper shims and picks a later real Codex on PATH", async () => {
+    delete process.env.CODEX_PATH;
+    const shimDir = await makeTempDir();
+    const realDir = await makeTempDir();
+    // Terminal-multiplexer style shim: a bash wrapper that execs `codex`.
+    await writeExecutable(path.join(shimDir, "codex"), "#!/usr/bin/env bash\nexec codex \"$@\"\n");
+    const realCodex = path.join(realDir, "codex");
+    await writeExecutable(realCodex, "#!/usr/bin/env node\n");
+    process.env.PATH = `${shimDir}${path.delimiter}${realDir}`;
+    const result = await withCodexAppServerCodexPathDefault({ agent: "codex" }, {});
+    expect((result.env as Record<string, string>).CODEX_PATH).toBe(realCodex);
+  });
+
+  it("accepts symlinks and compiled binaries as Codex candidates", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    const target = path.join(dir, "codex.js");
+    await writeExecutable(target, "#!/usr/bin/env node\n");
+    const link = path.join(dir, "codex");
+    await fs.symlink(target, link);
+    process.env.PATH = dir;
+    const result = await withCodexAppServerCodexPathDefault({ agent: "codex" }, {});
+    expect((result.env as Record<string, string>).CODEX_PATH).toBe(link);
+  });
+
+  it("leaves config untouched when no Codex CLI is on PATH", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    process.env.PATH = dir;
+    const config = { agent: "codex" };
+    const result = await withCodexAppServerCodexPathDefault(config, {});
+    expect(result).toBe(config);
+  });
+});

--- a/packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts
+++ b/packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts
@@ -94,4 +94,24 @@ describe("withCodexAppServerCodexPathDefault", () => {
     const result = await withCodexAppServerCodexPathDefault(config, {});
     expect(result).toBe(config);
   });
+
+  it("skips non-executable files named codex", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    await fs.writeFile(path.join(dir, "codex"), "#!/usr/bin/env node\n", { mode: 0o644 });
+    process.env.PATH = dir;
+    const config = { agent: "codex" };
+    const result = await withCodexAppServerCodexPathDefault(config, {});
+    expect(result).toBe(config);
+  });
+
+  it("skips broken symlinks named codex", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    await fs.symlink(path.join(dir, "does-not-exist.js"), path.join(dir, "codex"));
+    process.env.PATH = dir;
+    const config = { agent: "codex" };
+    const result = await withCodexAppServerCodexPathDefault(config, {});
+    expect(result).toBe(config);
+  });
 });

--- a/packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts
+++ b/packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts
@@ -105,6 +105,18 @@ describe("withCodexAppServerCodexPathDefault", () => {
     expect(result).toBe(config);
   });
 
+  it("skips symlinks that target a shell wrapper", async () => {
+    delete process.env.CODEX_PATH;
+    const dir = await makeTempDir();
+    const wrapper = path.join(dir, "codex-wrapper.sh");
+    await writeExecutable(wrapper, "#!/usr/bin/env bash\nexec codex \"$@\"\n");
+    await fs.symlink(wrapper, path.join(dir, "codex"));
+    process.env.PATH = dir;
+    const config = { agent: "codex" };
+    const result = await withCodexAppServerCodexPathDefault(config, {});
+    expect(result).toBe(config);
+  });
+
   it("skips broken symlinks named codex", async () => {
     delete process.env.CODEX_PATH;
     const dir = await makeTempDir();

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -397,14 +397,35 @@ async function findAncestorBin(startDir: string, binName: string): Promise<strin
   }
 }
 
+const CODEX_PATH_CANDIDATE_NAMES =
+  process.platform === "win32"
+    ? ["codex.cmd", "codex.exe", "codex.bat", "codex"]
+    : ["codex"];
+
+/** Regular, executable file (follows symlinks; mode bits ignored on win32). */
+async function isExecutableFile(candidate: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(candidate);
+    if (!stat.isFile()) return false;
+    if (process.platform === "win32") return true;
+    return (stat.mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * True when a PATH candidate looks like a real Codex CLI entrypoint (a node/
  * bun script, a compiled binary, or a symlink to one) rather than a shell
  * wrapper. Terminal-multiplexer and launcher shims (e.g. cmux-cli-shims)
  * intercept interactive `codex` CLI calls and hang or swallow the
  * `codex app-server` stdio protocol, so they must not be picked as CODEX_PATH.
+ * On Windows the npm-installed entrypoint IS a .cmd/.bat shell shim, so the
+ * wrapper filter only applies to POSIX platforms.
  */
 async function isCodexAppServerCapableBinary(candidate: string): Promise<boolean> {
+  if (!(await isExecutableFile(candidate))) return false;
+  if (process.platform === "win32") return true;
   try {
     const stat = await fs.lstat(candidate);
     if (stat.isSymbolicLink()) return true;
@@ -428,9 +449,11 @@ async function findCodexAppServerBinaryOnPath(): Promise<string | null> {
   const pathValue = process.env.PATH ?? "";
   for (const segment of pathValue.split(path.delimiter)) {
     if (!segment) continue;
-    const candidate = path.join(segment, "codex");
-    if (!(await pathExists(candidate))) continue;
-    if (await isCodexAppServerCapableBinary(candidate)) return candidate;
+    for (const name of CODEX_PATH_CANDIDATE_NAMES) {
+      const candidate = path.join(segment, name);
+      if (!(await pathExists(candidate))) continue;
+      if (await isCodexAppServerCapableBinary(candidate)) return candidate;
+    }
   }
   return null;
 }

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -344,7 +344,7 @@ export function createCodexAcpExecutor(options: CodexAcpExecutorOptions = {}): C
     }
     const result = await currentExecutor({
       ...ctx,
-      config: buildCodexAcpConfig(ctx.config),
+      config: await withCodexAppServerCodexPathDefault(buildCodexAcpConfig(ctx.config), ctx),
     });
     return withCodexAuthRefreshFailureClassification(result);
   };
@@ -395,6 +395,73 @@ async function findAncestorBin(startDir: string, binName: string): Promise<strin
     if (parent === current) return null;
     current = parent;
   }
+}
+
+/**
+ * True when a PATH candidate looks like a real Codex CLI entrypoint (a node/
+ * bun script, a compiled binary, or a symlink to one) rather than a shell
+ * wrapper. Terminal-multiplexer and launcher shims (e.g. cmux-cli-shims)
+ * intercept interactive `codex` CLI calls and hang or swallow the
+ * `codex app-server` stdio protocol, so they must not be picked as CODEX_PATH.
+ */
+async function isCodexAppServerCapableBinary(candidate: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(candidate);
+    if (stat.isSymbolicLink()) return true;
+    const handle = await fs.open(candidate, "r");
+    try {
+      const buffer = Buffer.alloc(256);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+      const head = buffer.subarray(0, bytesRead).toString("utf8");
+      if (!head.startsWith("#!")) return true; // compiled binary
+      const shebang = head.split("\n", 1)[0] ?? "";
+      return /\b(node|bun|deno)\b/.test(shebang);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+async function findCodexAppServerBinaryOnPath(): Promise<string | null> {
+  const pathValue = process.env.PATH ?? "";
+  for (const segment of pathValue.split(path.delimiter)) {
+    if (!segment) continue;
+    const candidate = path.join(segment, "codex");
+    if (!(await pathExists(candidate))) continue;
+    if (await isCodexAppServerCapableBinary(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Default CODEX_PATH to the system Codex CLI for local ACP runs.
+ *
+ * codex-acp spawns its bundled Codex app-server unless CODEX_PATH points at a
+ * Codex CLI. The bundled version can lag behind the CODEX_HOME cache format
+ * written by a newer system Codex (e.g. model-catalog JSON schema changes),
+ * which makes ACP session init fail with an opaque "Internal error"
+ * (acpx_session_init_failed). Preferring the on-PATH Codex keeps the
+ * app-server version aligned with the tooling that maintains CODEX_HOME.
+ * An explicit CODEX_PATH (adapter config env or host env) always wins, and
+ * remote targets are left alone because a host path is meaningless there.
+ */
+async function withCodexAppServerCodexPathDefault(
+  config: Record<string, unknown>,
+  ctx: Partial<Pick<AdapterExecutionContext, "executionTarget" | "executionTransport">>,
+): Promise<Record<string, unknown>> {
+  const env = parseObject(config.env);
+  if (asString(env.CODEX_PATH, "").trim()) return config;
+  if (asString(process.env.CODEX_PATH, "").trim()) return config;
+  const target = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+  if (target?.kind === "remote") return config;
+  const codexPath = await findCodexAppServerBinaryOnPath();
+  if (!codexPath) return config;
+  return { ...config, env: { ...env, CODEX_PATH: codexPath } };
 }
 
 async function commandIsResolvable(

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -447,7 +447,7 @@ async function findCodexAppServerBinaryOnPath(): Promise<string | null> {
  * An explicit CODEX_PATH (adapter config env or host env) always wins, and
  * remote targets are left alone because a host path is meaningless there.
  */
-async function withCodexAppServerCodexPathDefault(
+export async function withCodexAppServerCodexPathDefault(
   config: Record<string, unknown>,
   ctx: Partial<Pick<AdapterExecutionContext, "executionTarget" | "executionTransport">>,
 ): Promise<Record<string, unknown>> {

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -426,10 +426,12 @@ async function isExecutableFile(candidate: string): Promise<boolean> {
 async function isCodexAppServerCapableBinary(candidate: string): Promise<boolean> {
   if (!(await isExecutableFile(candidate))) return false;
   if (process.platform === "win32") return true;
+  // Resolve symlinks so a symlinked shell wrapper is classified by its
+  // target, not accepted sight-unseen.
+  const resolved = await fs.realpath(candidate).catch(() => null);
+  if (!resolved) return false;
   try {
-    const stat = await fs.lstat(candidate);
-    if (stat.isSymbolicLink()) return true;
-    const handle = await fs.open(candidate, "r");
+    const handle = await fs.open(resolved, "r");
     try {
       const buffer = Buffer.alloc(256);
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `codex_local` adapter runs heartbeats through its ACP lane by default, spawning `codex-acp`, which starts a Codex `app-server` as its backend
> - `codex-acp` only uses a system Codex CLI when `CODEX_PATH` is set; otherwise it falls back to its **bundled** `@openai/codex` dependency
> - When the operator also uses a **newer** system Codex CLI, that CLI writes newer-format cache files (e.g. the `model-catalog-*.json` schema) into the shared `~/.codex` home; the older bundled Codex then fails to parse them and ACP `session/new` dies with an opaque `Internal error` → every heartbeat fails in ~1s with `acpx_session_init_failed`
> - This pull request defaults `CODEX_PATH` to the on-PATH Codex CLI for local ACP runs so the app-server version stays aligned with the tooling that maintains `CODEX_HOME`
> - The benefit is codex_local agents keep working on machines where the system Codex is newer than the one bundled inside `codex-acp`, instead of failing every heartbeat with an undiagnosable error

## Linked Issues or Issue Description

- Refs #9948 (surfaces/falls back on ACP session-init failure; this PR removes a common root cause of that failure)
- Refs #10088 (related: wrapper/shim executables breaking the ACP lane — this PR's candidate filtering deliberately skips shell wrapper shims)

Bug report (per template, no existing issue):

- **What happened**: All `codex_local` heartbeats fail after ~1 second with `Internal error (acpx_session_init_failed)`, exit code 1. The run log only shows `RequestError: Internal error` from the ACP JSON-RPC connection during `ensure_session`.
- **Expected**: The ACP lane initializes a session and the agent runs.
- **Reproduction**: Install a recent system Codex CLI (e.g. 0.145.0), let it populate `~/.codex` (model catalog cache), then run any `codex_local` agent through the ACP lane on a machine where `codex-acp`'s bundled Codex is older (e.g. 0.142.x). Reproduced minimally with: `CODEX_HOME=<managed-home> acpx --model gpt-5.6-luna codex exec "say ok"` → `failed to parse model_catalog_json ... missing field supports_reasoning_summaries`.
- **Root cause**: version skew between the bundled Codex that `codex-acp` launches and the cache format written by the newer system Codex into the shared Codex home.

## What Changed

- `packages/adapters/codex-local/src/server/acp.ts`
  - New `withCodexAppServerCodexPathDefault()`: for local ACP runs without an explicit `CODEX_PATH` (adapter config env or host env), resolves the `codex` CLI on `PATH` and injects it as `env.CODEX_PATH` before the acpx engine builds the child environment. Remote execution targets are skipped (a host path is meaningless there).
  - New candidate filter `isCodexAppServerCapableBinary()`: PATH candidates are accepted when they are symlinks, compiled binaries, or scripts with a `node`/`bun`/`deno` shebang — and rejected when they are shell wrapper scripts (e.g. terminal-multiplexer shims such as `cmux-cli-shims/codex`), which intercept interactive CLI invocations and hang/swallow the `codex app-server` stdio protocol.
- `packages/adapters/codex-local/src/server/acp-codex-path-default.test.ts` (new): 7 unit tests covering explicit-config precedence, host-env precedence, remote-target skip, node-script resolution, shell-shim skipping, symlink acceptance, and no-codex-on-PATH no-op.

## Verification

- `pnpm --filter @paperclipai/adapter-codex-local typecheck` → clean
- `vitest run src/server/acp-codex-path-default.test.ts src/server/acp.test.ts src/server/execute.acp-fallback.test.ts` → 32/32 pass
- End-to-end on a machine exhibiting the bug (system Codex 0.145.0, bundled 0.142.x):
  - Before: every heartbeat failed in ~1s with `acpx_session_init_failed`
  - After: invoked a heartbeat via `POST /api/agents/:id/heartbeat/invoke`; the run passed session init, executed tool calls, reported live token usage, and kept running normally
  - Direct acpx repro: `CODEX_PATH=/opt/homebrew/bin/codex acpx --model gpt-5.6-luna codex exec "reply with just: ok"` → `ok`; same command via a `cmux-cli-shims` wrapper hangs at `initialize` (hence the shell-shim filter)

## Risks

- **Behavioral shift**: local ACP runs now prefer the system Codex CLI over the bundled one. If a machine's system Codex is *older* than the bundled one, the ACP lane follows the system CLI instead — mitigated by the fact that an explicit `CODEX_PATH` (adapter env or host env) always wins, and the previous behavior is fully recoverable by setting `CODEX_PATH` explicitly or removing `codex` from PATH.
- **Session fingerprint**: the injected `env.CODEX_PATH` joins the adapter env that feeds the warm-session fingerprint, so the first run after upgrade starts a fresh ACP session instead of resuming a warm one. One-time effect.
- Low risk otherwise: no schema changes, no API changes, no changes to the CLI lane or remote targets.

## Model Used

- Kimi K3 (Moonshot AI, model ID `k3`, via `kimi-coding` provider) — high reasoning level, tool-use/code-execution agent (Pi coding agent harness). Diagnosis, patch, and tests were produced by the model with human direction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
