### PR TITLE
Fix recovery-owner issue write boundary

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -8,6 +8,7 @@ const companyId = "22222222-2222-4222-8222-222222222222";
 const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
+const stuckAgentId = "66666666-6666-4666-8666-666666666666";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 
 const mockIssueService = vi.hoisted(() => ({
@@ -247,6 +248,38 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
     executionPolicy: null,
     executionState: null,
     hiddenAt: null,
+    ...overrides,
+  };
+}
+
+function makeActiveRecoveryAction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: recoveryActionId,
+    companyId,
+    sourceIssueId: issueId,
+    recoveryIssueId: null,
+    kind: "stranded_assigned_issue",
+    status: "active",
+    ownerType: "agent",
+    ownerAgentId,
+    ownerUserId: null,
+    previousOwnerAgentId: stuckAgentId,
+    returnOwnerAgentId: stuckAgentId,
+    cause: "stranded_assigned_issue",
+    fingerprint: "source-scoped:test",
+    evidence: {},
+    nextAction: "Restore a live execution path.",
+    wakePolicy: null,
+    monitorPolicy: null,
+    attemptCount: 1,
+    maxAttempts: null,
+    timeoutAt: null,
+    lastAttemptAt: new Date("2026-05-13T18:00:00.000Z"),
+    outcome: null,
+    resolutionNote: null,
+    resolvedAt: null,
+    createdAt: new Date("2026-05-13T17:55:00.000Z"),
+    updatedAt: new Date("2026-05-13T18:00:00.000Z"),
     ...overrides,
   };
 }
@@ -814,6 +847,124 @@ describe("agent issue mutation checkout ownership", () => {
     const res = await request(await createApp(peerActor()))
       .post(`/api/issues/${issueId}/comments`)
       .send({ body: "I was not mentioned." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("allows the active recovery owner to comment when the source boundary denies", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: stuckAgentId }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Recovered and closing this out." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Recovered and closing this out.",
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("denies a stale recovery owner after terminal source revalidation", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "done", assigneeAgentId: stuckAgentId }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue
+      .mockResolvedValueOnce(makeActiveRecoveryAction())
+      .mockResolvedValue(null);
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Late recovery update." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueRecoveryActionService.resolveActiveForIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        companyId,
+        sourceIssueId: issueId,
+        actionId: recoveryActionId,
+        status: "cancelled",
+      }),
+    );
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("denies when terminal recovery cancellation loses an ownership race", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "done", assigneeAgentId: stuckAgentId }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue
+      .mockResolvedValueOnce(makeActiveRecoveryAction())
+      .mockResolvedValue(null);
+    mockIssueRecoveryActionService.resolveActiveForIssue.mockResolvedValue(null);
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Racing recovery update." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unrelated agent outside the recovery owner's comment boundary", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: stuckAgentId }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Unrelated update." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the recovery owner lookup cannot be revalidated", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: stuckAgentId }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockRejectedValue(
+      new Error("recovery lookup unavailable"),
+    );
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Recovery update." });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
@@ -1487,6 +1638,71 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status).toBe(200);
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows the active recovery owner to update a source issue assigned to the stuck agent", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: stuckAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: stuckAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Recovered source issue" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ title: "Recovered source issue" }),
+    );
+  });
+
+  it("keeps an unrelated agent outside the recovery owner's mutation boundary", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: stuckAgentId }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Unrelated mutation" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("does not extend the recovery owner override to issue deletion", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: stuckAgentId }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue(makeActiveRecoveryAction());
+
+    const res = await request(await createApp(ownerActor())).delete(`/api/issues/${issueId}`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.remove).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3461,15 +3461,7 @@ export function issueRoutes(
   async function assertAgentIssueCommentAllowed(
     req: Request,
     res: Response,
-    issue: {
-      id: string;
-      companyId: string;
-      projectId: string | null;
-      parentId: string | null;
-      status: string;
-      assigneeAgentId: string | null;
-      assigneeUserId: string | null;
-    },
+    issue: IssueRouteSnapshot,
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3494,6 +3486,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
     if (!boundaryDecision.allowed) {
+      if (await activeRecoveryOwnerAllowsAgentBoundaryOverride(req, issue)) return true;
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
     }
@@ -3543,18 +3536,42 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  async function activeRecoveryOwnerAllowsAgentBoundaryOverride(
+    req: Request,
+    issue: IssueRouteSnapshot,
+  ) {
+    if (req.actor.type !== "agent" || !req.actor.agentId) return false;
+
+    try {
+      const revalidatedRecoveryAction = await revalidateActiveSourceRecovery({
+        issue,
+        trigger: "read_projection",
+        actor: getActorInfo(req),
+      });
+      if (!revalidatedRecoveryAction) return false;
+
+      const currentRecoveryAction = await recoveryActionsSvc.getActiveForIssue(
+        issue.companyId,
+        issue.id,
+      );
+      return (
+        currentRecoveryAction?.id === revalidatedRecoveryAction.id &&
+        currentRecoveryAction.ownerAgentId === req.actor.agentId
+      );
+    } catch (err) {
+      logger.warn(
+        { err, issueId: issue.id, actorAgentId: req.actor.agentId },
+        "failed to evaluate recovery owner boundary override",
+      );
+      return false;
+    }
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: {
-      id: string;
-      companyId: string;
-      projectId: string | null;
-      parentId: string | null;
-      status: string;
-      assigneeAgentId: string | null;
-      assigneeUserId: string | null;
-    },
+    issue: IssueRouteSnapshot,
+    options: { allowRecoveryOwnerBoundaryOverride?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3587,6 +3604,12 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
+      if (
+        options.allowRecoveryOwnerBoundaryOverride === true &&
+        await activeRecoveryOwnerAllowsAgentBoundaryOverride(req, issue)
+      ) {
+        return true;
+      }
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
     }
@@ -5566,7 +5589,11 @@ export function issueRoutes(
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(
+      await assertAgentIssueMutationAllowed(req, res, existing, {
+        allowRecoveryOwnerBoundaryOverride: true,
+      })
+    )) return;
     const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id);
     if (
       !(await assertRecoveryActionAuthority(
@@ -7668,7 +7695,11 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(
+      await assertAgentIssueMutationAllowed(req, res, existing, {
+        allowRecoveryOwnerBoundaryOverride: true,
+      })
+    )) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue authorization normally limits an agent to its assigned or explicitly granted work.
> - Recovery actions temporarily name an agent responsible for restoring a source issue.
> - The normal boundary can still deny that exact recovery owner when the source issue is assigned elsewhere.
> - That prevents the recovery owner from recording progress or resolving the recovery it owns.
> - This pull request adds a narrow, fail-closed recovery-owner path for comments and two explicit mutations.
> - The benefit is that recovery work can be recorded without granting broad manager or destructive access.

## Linked Issues or Issue Description

Refs #8701.
Supersedes #10281.

Bug: an agent named as the exact owner of an active source-issue recovery action can be denied when it tries to comment, update the source issue, or resolve that recovery action. The denial persists even though the recovery assignment is the authority for that work.

Expected behavior: only the exact owner of the currently active recovery action may use the narrow recovery path. Unrelated agents, stale actions, lookup failures, and destructive routes must remain denied.

## What Changed

- Added a recovery-owner boundary check for source-issue comments.
- Added an explicit opt-in for the main issue update and recovery-resolution routes only.
- Revalidated recovery semantics and performed an authoritative second lookup before granting access.
- Kept deletion and all other mutation routes outside the override.
- Added positive and negative authorization regression coverage.

## Verification

- Focused recovery-owner route tests: 9 passed.
- Preserved local-runtime authorization suite: 70 passed.
- Preserved local-runtime server type check: passed.
- Structured autoreview: clean, with no actionable findings.
- Current-master workflow checks provide the authoritative full-suite result.

## Risks

- Low and intentionally bounded: the change affects authorization.
- The override is available only after normal access denies, only to the exact active recovery owner, and only on explicitly selected routes.
- Recovery lookup and semantic revalidation fail closed.
- Destructive issue deletion remains denied and is covered by a regression test.

## Model Used

- OpenAI GPT-5.6 family via Codex.
- Sol was used for structured review; tool use and code execution were enabled.
- The runtime did not surface a reliable context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
