### PR TITLE
fix(acpx-engine): bound pre-turn ACPX RPCs with a setup timeout

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -2089,13 +2089,51 @@ function usdCostAmount(cost: AcpRuntimeUsageCost | null | undefined): number | n
   return cost.amount;
 }
 
+// Pre-turn ACPX RPCs (session handshake, session config, status snapshot) run
+// BEFORE the per-turn abort/timeout guard (see `timeout`/`controller` below,
+// armed only once `runtime.startTurn` is about to be called). None of them
+// carry their own timeout, so a warm-handle reused against a child process
+// that died or wedged (no error, no response) hangs the `await` forever —
+// the run then sits at status="running" with no processPid recorded for
+// this run (a reused handle never re-fires `onSpawn`), until the platform's
+// periodic stale-run reaper reaps it with a generic "Process lost" message
+// after its multi-minute threshold. Bound every pre-turn RPC with this
+// wrapper so a dead/unresponsive child fails the run promptly and
+// diagnosably instead of relying on that external reaper.
+const ACPX_SESSION_SETUP_TIMEOUT_MS = 60_000;
+
+async function withAcpxSetupTimeout<T>(
+  label: string,
+  operation: Promise<T>,
+  timeoutMs = ACPX_SESSION_SETUP_TIMEOUT_MS,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `ACPX ${label} timed out after ${timeoutMs}ms with no response from the agent process ` +
+                `(it may be dead or unresponsive).`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function readRuntimeStatus(
   runtime: AcpRuntime,
   handle: AcpRuntimeHandle,
 ): Promise<AcpRuntimeStatus | null> {
   if (!runtime.getStatus) return null;
   try {
-    return (await runtime.getStatus({ handle })) ?? null;
+    return (await withAcpxSetupTimeout("status snapshot", runtime.getStatus({ handle }))) ?? null;
   } catch {
     return null;
   }
@@ -2614,14 +2652,17 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           // resume). A throwing handshake still reports its duration before the
           // resume-retry path below runs.
           handle = await measureStartupStep(ctx, now, "acp.handshake", () =>
-            runtime.ensureSession({
-              sessionKey: prepared.sessionKey,
-              agent: prepared.acpxAgent,
-              mode: prepared.mode,
-              cwd: prepared.cwd,
-              resumeSessionId,
-              sessionOptions: { env: prepared.env },
-            }),
+            withAcpxSetupTimeout(
+              "session handshake",
+              runtime.ensureSession({
+                sessionKey: prepared.sessionKey,
+                agent: prepared.acpxAgent,
+                mode: prepared.mode,
+                cwd: prepared.cwd,
+                resumeSessionId,
+                sessionOptions: { env: prepared.env },
+              }),
+            ),
           );
         } catch (err) {
           if (!resumeSessionId || !isResumeFailure(err)) throw err;
@@ -2632,13 +2673,16 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             `[paperclip] ACPX resume session "${resumeSessionId}" is unavailable; retrying with a fresh session.\n`,
           );
           handle = await measureStartupStep(ctx, now, "acp.handshake", () =>
-            runtime.ensureSession({
-              sessionKey: prepared.sessionKey,
-              agent: prepared.acpxAgent,
-              mode: prepared.mode,
-              cwd: prepared.cwd,
-              sessionOptions: { env: prepared.env },
-            }),
+            withAcpxSetupTimeout(
+              "session handshake",
+              runtime.ensureSession({
+                sessionKey: prepared.sessionKey,
+                agent: prepared.acpxAgent,
+                mode: prepared.mode,
+                cwd: prepared.cwd,
+                sessionOptions: { env: prepared.env },
+              }),
+            ),
           );
         }
       }
@@ -2682,12 +2726,15 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
     }
     const sessionHandle = handle;
     try {
-      await applySessionConfigOptions({
-        runtime,
-        handle: sessionHandle,
-        prepared,
-        onLog: ctx.onLog,
-      });
+      await withAcpxSetupTimeout(
+        "session configure",
+        applySessionConfigOptions({
+          runtime,
+          handle: sessionHandle,
+          prepared,
+          onLog: ctx.onLog,
+        }),
+      );
     } catch (err) {
       const { classified, message } = await emitAcpxFailure({
         ctx,


### PR DESCRIPTION
## Summary
- Fixes RENA-51448: "Codex Worker Fast" runs were being reaped as `process_lost` (processPid=NULL) ~5-20 min after start, matching the platform stale-run reaper threshold, not resource exhaustion.
- Root cause: `heartbeat.ts`'s `executeRun()` pre-spawn path (the issue's original hypothesis) is actually well-guarded (try/catch/finally with defensive `.catch()` throughout). The real cause is in `packages/adapter-utils/src/acpx-engine/execute.ts`: pre-turn ACPX RPCs (session handshake `runtime.ensureSession`, `applySessionConfigOptions`, and the status snapshot `runtime.getStatus` inside `readRuntimeStatus`) run *before* the per-turn abort/timeout guard is armed (that guard only wraps `runtime.startTurn`). None of these pre-turn calls had their own timeout, so a warm handle reused against a dead/wedged child process could hang one of these `await`s forever - no throw, no resolve. The run then sits at status="running" with no `processPid` recorded (a reused warm handle never re-fires `onSpawn`), until the external stale-run reaper reaps it with the generic "Process lost" fallback message.
- Fix: added `withAcpxSetupTimeout()` (60s bound) and wrapped all four pre-turn RPCs with it. Existing catch blocks around each call site already handle thrown errors correctly (`emitAcpxFailure` -> structured `AdapterExecutionResult`), so a timeout is now treated identically to any other handshake/config failure - no new error-handling logic needed.
- Deliberately did NOT reduce the concurrency limit, per the issue's explicit instruction (peak concurrency was 4 of 20 allowed; not a resource issue).

## Test plan
- [x] Manual code audit of `heartbeat.ts` executeRun() (line-by-line trace of every awaited call between `activeRunExecutions.add` and `onSpawn`) - confirmed no silent-early-return path exists there today.
- [x] Traced the actual "Codex Worker Fast" execution path (ACP engine via `acpx-engine/execute.ts`) and matched the fix location to the observed symptom pattern exactly (processPid=NULL, 5:20-5:40min lifetime, generic reaper message).
- [x] Standalone TypeScript syntax/structure check of the edited file (no errors introduced beyond pre-existing missing-`@types/node` noise; verified via ad-hoc `tsc --noEmit` since this worktree has no installed monorepo deps).
- [ ] Full `pnpm install` + package test suite (`execute.test.ts`, `spawn-smoke.test.ts`, `remote-spawn-smoke.test.ts`) - not run in this environment; recommend CI run this.
- [ ] Production verification: 48h with no new `process_lost` cases with `process_pid IS NULL` near the reaper threshold, per the issue's own success criterion.
