### PR TITLE
fix(heartbeat): claimQueuedRun race fix, process-lost retry backoff, host telemetry

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2408,7 +2408,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
 
     const retryRun = runs.find((row) => row.id !== runId);
-    expect(["queued", "running"]).toContain(retryRun?.status);
+    // reapOrphanedRuns() enqueues this retry with applyBackoff: true (RENA-51447 /
+    // RENA-55149), so it lands in scheduled_retry rather than being immediately
+    // claimable, unlike the graceful-shutdown restart path this assertion previously
+    // assumed.
+    expect(["queued", "running", "scheduled_retry"]).toContain(retryRun?.status);
 
     const issue = await db
       .select()

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1299,7 +1299,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       timeoutConfigured: false,
       timeoutFired: false,
     });
-    expect(["queued", "running"]).toContain(retryRun?.status);
+    expect(["queued", "running", "scheduled_retry"]).toContain(retryRun?.status);
     expect(retryRun?.retryOfRunId).toBe(runId);
     expect(retryRun?.processLossRetryCount).toBe(1);
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1644,4 +1644,109 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(run?.errorCode).toBeNull();
     expect(countExecuteCallsForRun(runId)).toBe(1);
   });
+
+  // RENA-51447 / RENA-55149: two open issues that share the same
+  // (companyId, originKind, originId, originFingerprint) tuple -- the common case is a
+  // routine that produces the same fingerprint on every dispatch -- can each be queued for
+  // claim at the same time. claimQueuedRun() stamps the issue's executionRunId only after
+  // marking the run "running", and that stamp is guarded by the partial unique index
+  // issues_open_routine_execution_uq. Previously the second claim's UPDATE threw an uncaught
+  // DrizzleQueryError (23505), leaving that run stuck at status="running" with no process ever
+  // spawned until the 5-minute orphan reaper mislabeled it "process_lost". It must instead be
+  // caught and resolved to a clean terminal state in the same claim call.
+  it("cancels the losing claim instead of throwing when two open issues collide on the same routine execution fingerprint", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ maxConcurrentRuns: 2 });
+    const originId = randomUUID();
+    const originFingerprint = "fp-1628";
+
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: issueAId,
+        companyId,
+        title: "Routine dispatch A",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        originKind: "routine_execution",
+        originId,
+        originFingerprint,
+      },
+      {
+        id: issueBId,
+        companyId,
+        title: "Routine dispatch B",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        originKind: "routine_execution",
+        originId,
+        originFingerprint,
+      },
+    ]);
+
+    const { runId: runAId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId: issueAId,
+      wakeReason: "issue_assigned",
+    });
+    const { runId: runBId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId: issueBId,
+      wakeReason: "issue_assigned",
+    });
+
+    await expect(heartbeat.resumeQueuedRuns()).resolves.not.toThrow();
+
+    await waitForCondition(async () => {
+      const runs = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      return runs.every((run) => run.status !== "queued");
+    });
+
+    const runs = await db
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+        processPid: heartbeatRuns.processPid,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.companyId, companyId));
+    const runById = new Map(runs.map((run) => [run.id, run]));
+    const runA = runById.get(runAId);
+    const runB = runById.get(runBId);
+
+    // Exactly one of the two claims won the execution lock; the other must be cancelled
+    // deterministically here rather than left "running" with no process (which is what
+    // forced a wait on the 5-minute orphan reaper before this fix).
+    const winner = runA?.status === "cancelled" ? runB : runA;
+    const loser = winner === runA ? runB : runA;
+
+    expect(["queued", "running", "succeeded"]).toContain(winner?.status);
+    expect(loser?.status).toBe("cancelled");
+    expect(loser?.errorCode).toBe("duplicate_execution_lock");
+    expect(loser?.status).not.toBe("running");
+
+    const wakeups = await db
+      .select({ status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakeups.every((wakeup) => wakeup.status !== "queued")).toBe(true);
+
+    // The loser's issue was never stamped -- it should stay unlocked regardless of how far
+    // the winner's own run has since progressed (it may already be "succeeded" and have
+    // released its own lock by the time this assertion runs).
+    const loserIssue = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, loser === runA ? issueAId : issueBId))
+      .then((rows) => rows[0] ?? null);
+    expect(loserIssue?.executionRunId).toBeNull();
+  });
 });

--- a/server/src/__tests__/host-telemetry.test.ts
+++ b/server/src/__tests__/host-telemetry.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// RENA-55149 / Greptile review on PR #10288: startHostResourceTelemetry() used to resolve
+// and create its log directory (fs.mkdirSync) outside of any error handling, so a
+// filesystem error there (e.g. read-only disk, permission denial) threw synchronously out
+// of the exported function. Since it's called unguarded during server startup
+// (server/src/index.ts), that failure could reject startServer entirely for what is meant
+// to be optional, best-effort diagnostics. It must instead log a warning and return a
+// no-op cleanup so telemetry setup failures never take down the server.
+
+const mockLogger = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn() }));
+vi.mock("../middleware/logger.js", () => ({ logger: mockLogger }));
+
+const mockResolveDefaultLogsDir = vi.hoisted(() => vi.fn());
+vi.mock("../home-paths.js", () => ({
+  resolveDefaultLogsDir: mockResolveDefaultLogsDir,
+}));
+
+describe("startHostResourceTelemetry", () => {
+  const tempRoots: string[] = [];
+
+  beforeEach(() => {
+    mockLogger.warn.mockClear();
+    mockLogger.error.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    for (const root of tempRoots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not throw and returns a no-op cleanup when the log directory cannot be created", async () => {
+    // Point the log dir at a path that already exists as a regular file. mkdirSync(...,
+    // { recursive: true }) throws EEXIST in that situation, exercising the real failure
+    // this defect covers without needing to mock node:fs internals.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-host-telemetry-"));
+    tempRoots.push(root);
+    const blockedDirPath = path.join(root, "blocked-log-dir");
+    fs.writeFileSync(blockedDirPath, "not a directory");
+    mockResolveDefaultLogsDir.mockReturnValue(blockedDirPath);
+
+    const { startHostResourceTelemetry } = await import("../services/host-telemetry.js");
+
+    let stop: (() => void) | undefined;
+    expect(() => {
+      stop = startHostResourceTelemetry();
+    }).not.toThrow();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.anything() }),
+      expect.stringContaining("host resource telemetry disabled"),
+    );
+
+    // Cleanup must be safely callable even though nothing was actually started.
+    expect(() => stop?.()).not.toThrow();
+
+    // The blocked path must remain untouched: no interval was ever scheduled.
+    expect(fs.readFileSync(blockedDirPath, "utf8")).toBe("not a directory");
+  });
+
+  it("samples immediately and on interval, and stops cleanly", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-host-telemetry-"));
+    tempRoots.push(root);
+    const logDir = path.join(root, "logs");
+    mockResolveDefaultLogsDir.mockReturnValue(logDir);
+
+    vi.useFakeTimers();
+
+    const { startHostResourceTelemetry } = await import("../services/host-telemetry.js");
+    const stop = startHostResourceTelemetry({ intervalMs: 30_000 });
+
+    const logFile = path.join(logDir, "host-telemetry.log");
+    const readLines = () =>
+      fs
+        .readFileSync(logFile, "utf8")
+        .split("\n")
+        .filter((line) => line.length > 0);
+
+    expect(readLines()).toHaveLength(1);
+
+    vi.advanceTimersByTime(30_000);
+    expect(readLines()).toHaveLength(2);
+
+    stop();
+    vi.advanceTimersByTime(60_000);
+    expect(readLines()).toHaveLength(2);
+  });
+});

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -330,6 +330,13 @@ vi.mock("../services/plugin-worker-manager.js", () => ({
   createPluginWorkerManager: vi.fn(() => ({ id: "plugin-worker-manager" })),
 }));
 
+// Without this mock, startHostResourceTelemetry() registers its own real setInterval
+// during startServer(), which clobbers the setInterval spy's captured callback in tests
+// below that rely on it being the routine-tick interval (RENA-55149).
+vi.mock("../services/host-telemetry.js", () => ({
+  startHostResourceTelemetry: vi.fn(() => () => {}),
+}));
+
 vi.mock("../startup-banner.js", () => ({
   printStartupBanner: vi.fn(),
 }));

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -922,6 +922,7 @@ export async function startServer(): Promise<StartedServer> {
   }>) | null = null;
   let heartbeatSchedulerStopped = false;
   let heartbeatSchedulerInterval: ReturnType<typeof setInterval> | null = null;
+  let stopHostResourceTelemetry: (() => void) | null = null;
   const heartbeatSchedulerInFlight = new Set<Promise<void>>();
   const trackHeartbeatSchedulerWork = (work: Promise<unknown>) => {
     let tracked: Promise<void>;
@@ -1352,7 +1353,12 @@ export async function startServer(): Promise<StartedServer> {
   }
 
   // Lightweight periodic CPU/RAM sampling for post-incident diagnostics (RENA-51447).
-  startHostResourceTelemetry();
+  // Optional/best-effort: never let a telemetry setup failure reject startServer.
+  try {
+    stopHostResourceTelemetry = startHostResourceTelemetry();
+  } catch (err) {
+    logger.warn({ err }, "failed to start host resource telemetry; continuing without it");
+  }
 
   // Wait for external adapters to finish loading before accepting requests.
   // Without this, adapter type validation (assertKnownAdapterType) would
@@ -1443,6 +1449,10 @@ export async function startServer(): Promise<StartedServer> {
       if (heartbeatSchedulerInterval) {
         clearInterval(heartbeatSchedulerInterval);
         heartbeatSchedulerInterval = null;
+      }
+      if (stopHostResourceTelemetry) {
+        stopHostResourceTelemetry();
+        stopHostResourceTelemetry = null;
       }
 
       const heartbeatShutdown = await coordinateHeartbeatSchedulerShutdown({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -77,6 +77,7 @@ import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
 import { maybePersistWorktreeRuntimePorts } from "./worktree-config.js";
 import { initTelemetry, getTelemetryClient } from "./telemetry.js";
+import { startHostResourceTelemetry } from "./services/host-telemetry.js";
 import { conflict } from "./errors.js";
 import { ensureDecisionSigningSecret } from "./services/decision-signing.js";
 import { createDecisionRetentionNotifyOriginAgent, createDecisionWakeOriginAgent } from "./services/decision-wakeup.js";
@@ -1349,7 +1350,10 @@ export async function startServer(): Promise<StartedServer> {
       });
     }, backupIntervalMs);
   }
-  
+
+  // Lightweight periodic CPU/RAM sampling for post-incident diagnostics (RENA-51447).
+  startHostResourceTelemetry();
+
   // Wait for external adapters to finish loading before accepting requests.
   // Without this, adapter type validation (assertKnownAdapterType) would
   // reject valid external adapter types during the startup loading window.

--- a/server/src/services/agent-start-lock.ts
+++ b/server/src/services/agent-start-lock.ts
@@ -1,7 +1,16 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { logger } from "../middleware/logger.js";
 
 const AGENT_START_LOCK_STALE_MS = 30_000;
 const startLocksByAgent = new Map<string, { promise: Promise<void>; startedAtMs: number }>();
+
+// Tracks agentIds whose withAgentStartLock() call is currently executing somewhere up the
+// current async call chain. A call that re-enters the lock for the same agent from within
+// its own execution (e.g. claimQueuedRun -> cancelRunInternal -> releaseIssueExecutionAndPromote
+// -> startNextQueuedRunForAgent for the same agent, see RENA-55149) is not a concurrent start
+// attempt -- it runs inline instead of waiting on the lock it is already holding, which would
+// otherwise stall for AGENT_START_LOCK_STALE_MS before the staleness fallback releases it.
+const activeAgentIds = new AsyncLocalStorage<ReadonlySet<string>>();
 
 async function waitForAgentStartLock(agentId: string, lock: { promise: Promise<void>; startedAtMs: number }) {
   const elapsedMs = Date.now() - lock.startedAtMs;
@@ -29,10 +38,16 @@ async function waitForAgentStartLock(agentId: string, lock: { promise: Promise<v
   }
 }
 
-export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>) {
+export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
+  if (activeAgentIds.getStore()?.has(agentId)) {
+    return fn();
+  }
+
   const previous = startLocksByAgent.get(agentId);
   const waitForPrevious = previous ? waitForAgentStartLock(agentId, previous) : Promise.resolve();
-  const run = waitForPrevious.then(fn);
+  const nextActive = new Set(activeAgentIds.getStore());
+  nextActive.add(agentId);
+  const run = waitForPrevious.then(() => activeAgentIds.run(nextActive, fn));
   const marker = run.then(
     () => undefined,
     () => undefined,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -377,6 +377,11 @@ export const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS = [
   2 * 60 * 60 * 1000,
 ] as const;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_JITTER_RATIO = 0.25;
+// Short backoff before a process-lost retry becomes claimable, so a burst of orphaned
+// runs (e.g. concurrency pressure from a large routine dispatch batch) doesn't immediately
+// re-collide with the same resource/concurrency pressure that caused the original loss.
+export const PROCESS_LOSS_RETRY_DELAYS_MS = [15 * 1000, 60 * 1000, 3 * 60 * 1000] as const;
+const PROCESS_LOSS_RETRY_JITTER_RATIO = 0.25;
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON = "transient_failure";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON = "transient_failure_retry";
 const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS = BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length;
@@ -1166,6 +1171,20 @@ export function applyRunScopedMentionedSkillKeys(
     ...existingPreference.desiredSkillEntries,
     ...normalizedSkillKeys,
   ]);
+}
+
+export function computeProcessLossRetryDelayMs(
+  attempt: number,
+  random: () => number = Math.random,
+) {
+  const index = Math.min(
+    Math.max(Math.floor(attempt) || 1, 1),
+    PROCESS_LOSS_RETRY_DELAYS_MS.length,
+  ) - 1;
+  const baseDelayMs = PROCESS_LOSS_RETRY_DELAYS_MS[index];
+  const sample = Math.min(1, Math.max(0, random()));
+  const jitterMultiplier = 1 + (((sample * 2) - 1) * PROCESS_LOSS_RETRY_JITTER_RATIO);
+  return Math.max(1_000, Math.round(baseDelayMs * jitterMultiplier));
 }
 
 export function computeBoundedTransientHeartbeatRetrySchedule(
@@ -9946,7 +9965,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
     now: Date,
+    options: { applyBackoff?: boolean } = {},
   ) {
+    // Backoff only applies to genuine process-loss reaping (orphaned/dead process detection),
+    // which is the resource-pressure scenario a burst of losses can re-collide on (RENA-51447).
+    // Graceful shutdown restarts are a deliberate, non-concurrent event, so they keep the prior
+    // immediate "queued" behavior instead of waiting out a backoff window.
+    const applyBackoff = options.applyBackoff ?? false;
     const existingRetry = await db
       .select()
       .from(heartbeatRuns)
@@ -9992,11 +10017,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : "process_lost";
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const processLossRetryAttempt = (run.processLossRetryCount ?? 0) + 1;
+    const processLossRetryDelayMs = applyBackoff
+      ? computeProcessLossRetryDelayMs(processLossRetryAttempt)
+      : 0;
+    const processLossRetryDueAt = new Date(now.getTime() + processLossRetryDelayMs);
     const retryContextSnapshot = withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason: "process_lost_retry",
       retryReason,
+      ...(applyBackoff
+        ? {
+          scheduledRetryAttempt: processLossRetryAttempt,
+          scheduledRetryAt: processLossRetryDueAt.toISOString(),
+        }
+        : {}),
     }, "normal_model");
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
@@ -10012,6 +10048,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           payload: withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
+            ...(applyBackoff
+              ? {
+                scheduledRetryAttempt: processLossRetryAttempt,
+                scheduledRetryAt: processLossRetryDueAt.toISOString(),
+              }
+              : {}),
           }, "normal_model"),
           status: "queued",
           requestedByActorType: "system",
@@ -10021,6 +10063,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .returning()
         .then((rows) => rows[0]);
 
+      // When backoff applies, land the retry in scheduled_retry (not queued) so it only
+      // becomes claimable once processLossRetryDueAt passes. promoteDueScheduledRetries()
+      // promotes it to "queued" when due, reusing the same backoff machinery as other bounded
+      // retries. This spreads out retries after a burst of process losses instead of
+      // re-claiming immediately, which reduces the chance of re-colliding with the same
+      // concurrency/resource pressure that caused the original loss (RENA-51447). Graceful
+      // shutdown restarts skip this and stay immediately "queued", as before.
       const retryRun = await tx
         .insert(heartbeatRuns)
         .values({
@@ -10028,13 +10077,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agentId: run.agentId,
           invocationSource: "automation",
           triggerDetail: "system",
-          status: "queued",
+          status: applyBackoff ? "scheduled_retry" : "queued",
           wakeupRequestId: wakeupRequest.id,
           contextSnapshot: retryContextSnapshot,
           responsibleUserId,
           sessionIdBefore: sessionBefore,
           retryOfRunId: run.id,
-          processLossRetryCount: (run.processLossRetryCount ?? 0) + 1,
+          processLossRetryCount: processLossRetryAttempt,
+          ...(applyBackoff
+            ? {
+              scheduledRetryAt: processLossRetryDueAt,
+              scheduledRetryAttempt: processLossRetryAttempt,
+              scheduledRetryReason: "process_lost_retry",
+            }
+            : {}),
           updatedAt: now,
         })
         .returning()
@@ -10064,27 +10120,45 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return retryRun;
     });
 
-    publishLiveEvent({
-      companyId: queued.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: queued.id,
-        agentId: queued.agentId,
-        invocationSource: queued.invocationSource,
-        triggerDetail: queued.triggerDetail,
-        wakeupRequestId: queued.wakeupRequestId,
-      },
-    });
+    if (applyBackoff) {
+      // Promotion to "queued" (and the corresponding heartbeat.run.queued live event) happens
+      // once promoteDueScheduledRetries() finds this row past scheduledRetryAt.
+      await appendRunEvent(queued, 1, {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: `Scheduled automatic retry ${processLossRetryAttempt} in ${processLossRetryDelayMs}ms `
+          + `(due ${processLossRetryDueAt.toISOString()}) after orphaned child process was confirmed dead`,
+        payload: {
+          retryOfRunId: run.id,
+          scheduledRetryAttempt: processLossRetryAttempt,
+          scheduledRetryAt: processLossRetryDueAt.toISOString(),
+          delayMs: processLossRetryDelayMs,
+        },
+      });
+    } else {
+      publishLiveEvent({
+        companyId: queued.companyId,
+        type: "heartbeat.run.queued",
+        payload: {
+          runId: queued.id,
+          agentId: queued.agentId,
+          invocationSource: queued.invocationSource,
+          triggerDetail: queued.triggerDetail,
+          wakeupRequestId: queued.wakeupRequestId,
+        },
+      });
 
-    await appendRunEvent(queued, 1, {
-      eventType: "lifecycle",
-      stream: "system",
-      level: "warn",
-      message: "Queued automatic retry after orphaned child process was confirmed dead",
-      payload: {
-        retryOfRunId: run.id,
-      },
-    });
+      await appendRunEvent(queued, 1, {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: "Queued automatic retry after orphaned child process was confirmed dead",
+        payload: {
+          retryOfRunId: run.id,
+        },
+      });
+    }
 
     return queued;
   }
@@ -13160,7 +13234,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const retryAgent = await getAgent(run.agentId);
       if (shouldRetry) {
         if (retryAgent) {
-          retriedRun = await enqueueProcessLossRetry(finalizedRun, retryAgent, now);
+          retriedRun = await enqueueProcessLossRetry(finalizedRun, retryAgent, now, { applyBackoff: true });
         }
       } else if (retryAgent) {
         const scheduled = await scheduleInteractionContinuationInfrastructureRetryIfEligible(finalizedRun, retryAgent);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -363,6 +363,33 @@ const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retr
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
 const TIMER_ACTIONABLE_ISSUE_STATUSES = ["todo", "in_progress"] as const;
+
+// Detects a violation of the partial unique index issues_open_routine_execution_uq
+// (companyId, originKind, originId, originFingerprint), which only allows one open issue
+// per fingerprint to hold an execution lock (executionRunId IS NOT NULL) at a time. See
+// RENA-51447/RENA-55149.
+//
+// db is drizzle over the `postgres` (postgres.js) driver, which throws a PostgresError
+// exposing `constraint_name` (not `constraint`, the node-postgres/`pg` field name), and
+// drizzle wraps that in a DrizzleQueryError with the real error on `.cause` rather than on
+// the thrown error itself. routines.ts's isOpenExecutionConflictError checks `error.constraint`
+// on the caught error directly, which matches neither shape with this driver -- so that
+// existing "working" collision handler cannot actually match a real 23505 from this driver
+// either. Checking both the error and its `.cause` for both field name variants here keeps
+// this resilient regardless of which layer surfaces which shape.
+function isOpenRoutineExecutionConflictError(error: unknown): boolean {
+  const candidates = [error, (error as { cause?: unknown } | null)?.cause];
+  return candidates.some((candidate) => (
+    !!candidate &&
+    typeof candidate === "object" &&
+    "code" in candidate &&
+    (candidate as { code?: string }).code === "23505" &&
+    (
+      (candidate as { constraint?: string }).constraint === "issues_open_routine_execution_uq" ||
+      (candidate as { constraint_name?: string }).constraint_name === "issues_open_routine_execution_uq"
+    )
+  ));
+}
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
@@ -12497,24 +12524,52 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
     if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
       const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, claimedIssueId),
-            eq(issues.companyId, claimed.companyId),
-            // Mention/context runs can touch an issue, but only the current assignee
-            // owns the issue execution lock shown as the active run.
-            eq(issues.assigneeAgentId, claimed.agentId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
+      try {
+        await db
+          .update(issues)
+          .set({
+            executionRunId: claimed.id,
+            executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
+            executionLockedAt: claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(
+            and(
+              eq(issues.id, claimedIssueId),
+              eq(issues.companyId, claimed.companyId),
+              // Mention/context runs can touch an issue, but only the current assignee
+              // owns the issue execution lock shown as the active run.
+              eq(issues.assigneeAgentId, claimed.agentId),
+              or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
+            ),
+          );
+      } catch (error) {
+        if (!isOpenRoutineExecutionConflictError(error)) throw error;
+
+        // issues_open_routine_execution_uq (companyId, originKind, originId, originFingerprint)
+        // only allows one *open* issue per fingerprint to hold an execution lock at a time.
+        // Two open issues sharing a fingerprint (most commonly a routine that produces the
+        // same fingerprint on every dispatch, see RENA-51428) can both reach this claim in
+        // the same window; the loser's UPDATE above hits the constraint. Previously that threw
+        // out of claimQueuedRun() uncaught, leaving the run stuck at status="running" with no
+        // process ever spawned until the 5-minute orphan reaper mislabeled it "process_lost"
+        // (RENA-51447). Resolve it here immediately instead: the run itself is fine, it just
+        // lost the race for the issue's execution slot, so cancel it deterministically with a
+        // clear, non-misleading errorCode and let the next queued run for this agent proceed.
+        logger.warn(
+          { runId: claimed.id, issueId: claimedIssueId, companyId: claimed.companyId },
+          "claimQueuedRun: issues_open_routine_execution_uq collision stamping executionRunId; cancelling run as duplicate_execution_lock",
         );
+        return await cancelRunInternal(
+          claimed.id,
+          "Cancelled because another run already holds the execution lock for this issue (duplicate dispatch)",
+          {
+            errorCode: "duplicate_execution_lock",
+            eventMessage: "Run lost the race for the issue execution lock (duplicate_execution_lock); cancelled instead of leaking to the orphan reaper",
+            eventPayload: { issueId: claimedIssueId },
+          },
+        );
+      }
     }
 
     return claimed;
@@ -17115,6 +17170,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         kind: "queued_recovery" as const,
         run: queuedRun,
       };
+    }).catch((error) => {
+      if (!isOpenRoutineExecutionConflictError(error)) throw error;
+
+      // A losing claimQueuedRun() (see RENA-51447/RENA-55149) can route here via
+      // cancelRunInternal -> releaseIssueExecutionAndPromote to promote a fresh recovery/next
+      // run onto the just-released issue. If a sibling issue with the same
+      // (companyId, originKind, originId, originFingerprint) is still open and holding the
+      // execution lock, that promotion UPDATE hits the same issues_open_routine_execution_uq
+      // constraint. There is nothing to roll back (the transaction already did that), so treat
+      // it as "nothing to promote right now" instead of letting it escape uncaught -- the next
+      // wakeup/resumeQueuedRuns pass will re-evaluate this issue once the sibling's lock clears.
+      logger.warn(
+        { err: error, runId: run.id, issueId: contextIssueId },
+        "releaseIssueExecutionAndPromote: issues_open_routine_execution_uq collision promoting next candidate; skipping promotion for now",
+      );
+      return null;
     });
 
     if (promotionResult?.kind === "blocked") {

--- a/server/src/services/host-telemetry.ts
+++ b/server/src/services/host-telemetry.ts
@@ -77,6 +77,6 @@ export function startHostResourceTelemetry(options: {
 
   tick();
   const interval = setInterval(tick, intervalMs);
-  interval.unref();
+  interval.unref?.();
   return () => clearInterval(interval);
 }

--- a/server/src/services/host-telemetry.ts
+++ b/server/src/services/host-telemetry.ts
@@ -64,7 +64,14 @@ export function startHostResourceTelemetry(options: {
   const intervalMs = options.intervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
   const maxFileBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
   const rotatedFilesKept = options.rotatedFilesKept ?? DEFAULT_ROTATED_FILES_KEPT;
-  const filePath = resolveTelemetryFilePath();
+
+  let filePath: string;
+  try {
+    filePath = resolveTelemetryFilePath();
+  } catch (err) {
+    logger.warn({ err }, "host resource telemetry disabled: failed to resolve/create log directory");
+    return () => {};
+  }
 
   const tick = () => {
     try {

--- a/server/src/services/host-telemetry.ts
+++ b/server/src/services/host-telemetry.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveDefaultLogsDir } from "../home-paths.js";
+import { logger } from "../middleware/logger.js";
+
+const DEFAULT_SAMPLE_INTERVAL_MS = 30_000;
+const DEFAULT_MAX_FILE_BYTES = 10 * 1024 * 1024;
+const DEFAULT_ROTATED_FILES_KEPT = 3;
+
+function resolveTelemetryFilePath(): string {
+  const logDir = resolveDefaultLogsDir();
+  fs.mkdirSync(logDir, { recursive: true });
+  return path.join(logDir, "host-telemetry.log");
+}
+
+function rotateIfNeeded(filePath: string, maxBytes: number, keep: number) {
+  let size = 0;
+  try {
+    size = fs.statSync(filePath).size;
+  } catch {
+    return;
+  }
+  if (size < maxBytes) return;
+
+  for (let index = keep - 1; index >= 1; index--) {
+    const from = `${filePath}.${index}`;
+    const to = `${filePath}.${index + 1}`;
+    if (fs.existsSync(from)) {
+      fs.renameSync(from, to);
+    }
+  }
+  fs.renameSync(filePath, `${filePath}.1`);
+}
+
+function sampleHostResources() {
+  const memoryUsage = process.memoryUsage();
+  const totalMemBytes = os.totalmem();
+  const freeMemBytes = os.freemem();
+  return {
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    loadAvg1m: os.loadavg()[0],
+    cpuCount: os.cpus().length,
+    systemMemUsedBytes: totalMemBytes - freeMemBytes,
+    systemMemTotalBytes: totalMemBytes,
+    processRssBytes: memoryUsage.rss,
+    processHeapUsedBytes: memoryUsage.heapUsed,
+    processHeapTotalBytes: memoryUsage.heapTotal,
+    uptimeSec: Math.round(process.uptime()),
+  };
+}
+
+/**
+ * Periodically appends a compact CPU/RAM sample line to a rotating host-telemetry
+ * log so that "process lost" / resource-pressure incidents (RENA-51447) have
+ * historical host-load context to correlate against, since none existed before.
+ */
+export function startHostResourceTelemetry(options: {
+  intervalMs?: number;
+  maxFileBytes?: number;
+  rotatedFilesKept?: number;
+} = {}) {
+  const intervalMs = options.intervalMs ?? DEFAULT_SAMPLE_INTERVAL_MS;
+  const maxFileBytes = options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const rotatedFilesKept = options.rotatedFilesKept ?? DEFAULT_ROTATED_FILES_KEPT;
+  const filePath = resolveTelemetryFilePath();
+
+  const tick = () => {
+    try {
+      rotateIfNeeded(filePath, maxFileBytes, rotatedFilesKept);
+      fs.appendFileSync(filePath, `${JSON.stringify(sampleHostResources())}\n`);
+    } catch (err) {
+      logger.warn({ err }, "host resource telemetry sample failed");
+    }
+  };
+
+  tick();
+  const interval = setInterval(tick, intervalMs);
+  interval.unref();
+  return () => clearInterval(interval);
+}

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1784,71 +1784,105 @@ export function routineService(
           return updated ?? createdRun;
         }
 
-        try {
-          createdIssue = await issueSvc.create(input.routine.companyId, {
-            projectId,
-            projectWorkspaceId,
-            goalId: input.routine.goalId,
-            parentId: input.routine.parentIssueId,
-            title,
-            description,
-            status: "todo",
-            priority: input.routine.priority,
-            assigneeAgentId,
-            createdByAgentId: input.source === "manual" ? input.actor?.agentId ?? null : null,
-            createdByUserId: manualRunnerUserId,
-            responsibleUserId,
-            trustExplicitResponsibleUserId: true,
-            originKind: issueOriginKind,
-            originId: issueOriginId,
-            originRunId: createdRun.id,
-            originFingerprint: dispatchFingerprint,
-            billingCode: issueBillingCode,
-            executionWorkspaceId: input.executionWorkspaceId ?? null,
-            executionWorkspacePreference: input.executionWorkspacePreference ?? null,
-            executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
-          });
-        } catch (error) {
-          const isOpenExecutionConflict =
-            !!error &&
-            typeof error === "object" &&
-            "code" in error &&
-            (error as { code?: string }).code === "23505" &&
-            "constraint" in error &&
-            (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
-          if (!isOpenExecutionConflict || input.routine.concurrencyPolicy === "always_enqueue") {
-            throw error;
-          }
+        const isOpenExecutionConflictError = (error: unknown) =>
+          !!error &&
+          typeof error === "object" &&
+          "code" in error &&
+          (error as { code?: string }).code === "23505" &&
+          "constraint" in error &&
+          (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
-            kind: issueOriginKind,
-            id: issueOriginId,
-          });
-          if (!existingIssue) throw error;
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
-          if (manualRunnerUserId) {
-            await touchIssueForUserInbox(txDb, {
-              companyId: input.routine.companyId,
-              issueId: existingIssue.id,
-              userId: manualRunnerUserId,
-              touchedAt: triggeredAt,
+        // issues_open_routine_execution_uq (companyId, originKind, originId, originFingerprint)
+        // only allows one *open* issue per fingerprint. For "always_enqueue" the caller wants a
+        // fresh issue on every dispatch regardless of what's still open, so a same-fingerprint
+        // collision here isn't a dedup signal to coalesce on -- it just means two dispatches
+        // produced an identical fingerprint while the earlier issue is still open. Salt the
+        // fingerprint and retry a bounded number of times instead of letting the unique-constraint
+        // violation escape as an unhandled DrizzleQueryError (RENA-51447).
+        const ALWAYS_ENQUEUE_CONFLICT_MAX_ATTEMPTS = 5;
+        let effectiveFingerprint = dispatchFingerprint;
+        for (let attempt = 1; attempt <= ALWAYS_ENQUEUE_CONFLICT_MAX_ATTEMPTS; attempt += 1) {
+          try {
+            createdIssue = await issueSvc.create(input.routine.companyId, {
+              projectId,
+              projectWorkspaceId,
+              goalId: input.routine.goalId,
+              parentId: input.routine.parentIssueId,
+              title,
+              description,
+              status: "todo",
+              priority: input.routine.priority,
+              assigneeAgentId,
+              createdByAgentId: input.source === "manual" ? input.actor?.agentId ?? null : null,
+              createdByUserId: manualRunnerUserId,
+              responsibleUserId,
+              trustExplicitResponsibleUserId: true,
+              originKind: issueOriginKind,
+              originId: issueOriginId,
+              originRunId: createdRun.id,
+              originFingerprint: effectiveFingerprint,
+              billingCode: issueBillingCode,
+              executionWorkspaceId: input.executionWorkspaceId ?? null,
+              executionWorkspacePreference: input.executionWorkspacePreference ?? null,
+              executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
             });
+            break;
+          } catch (error) {
+            if (!isOpenExecutionConflictError(error)) {
+              throw error;
+            }
+
+            if (input.routine.concurrencyPolicy === "always_enqueue") {
+              if (attempt >= ALWAYS_ENQUEUE_CONFLICT_MAX_ATTEMPTS) {
+                throw error;
+              }
+              logger.warn(
+                {
+                  routineId: input.routine.id,
+                  companyId: input.routine.companyId,
+                  assigneeAgentId,
+                  attempt,
+                },
+                "dispatchRoutineRun: issues_open_routine_execution_uq collision for always_enqueue policy; retrying with salted fingerprint",
+              );
+              effectiveFingerprint = `${dispatchFingerprint}:always_enqueue:${crypto.randomUUID()}`;
+              continue;
+            }
+
+            const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+              kind: issueOriginKind,
+              id: issueOriginId,
+            });
+            if (!existingIssue) throw error;
+            const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+            if (manualRunnerUserId) {
+              await touchIssueForUserInbox(txDb, {
+                companyId: input.routine.companyId,
+                issueId: existingIssue.id,
+                userId: manualRunnerUserId,
+                touchedAt: triggeredAt,
+              });
+            }
+            const updated = await finalizeRun(createdRun.id, {
+              status,
+              linkedIssueId: existingIssue.id,
+              coalescedIntoRunId: existingIssue.originRunId,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status,
+              issueId: existingIssue.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
           }
-          const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: existingIssue.id,
-            coalescedIntoRunId: existingIssue.originRunId,
-            completedAt: triggeredAt,
-          }, txDb);
-          await updateRoutineTouchedState({
-            routineId: input.routine.id,
-            triggerId: input.trigger?.id ?? null,
-            triggeredAt,
-            status,
-            issueId: existingIssue.id,
-            nextRunAt,
-          }, txDb);
-          return updated ?? createdRun;
+        }
+
+        if (!createdIssue) {
+          throw new Error("dispatchRoutineRun: issue creation loop exited without creating an issue or throwing");
         }
 
         // Keep the dispatch lock until the issue is linked to a queued heartbeat run.


### PR DESCRIPTION
## Thinking Path

RENA-51447 root-caused 62x "Codex Worker Fast" process-lost errors correlated with a 235-issue routine batch that produced 204x `issues_open_routine_execution_uq` unique-constraint collisions. Four mandatory work items (Aufträge) were scoped in RENA-51428/RENA-51447, tracked for implementation under this issue, RENA-55149:

1. **claimQueuedRun() race fix (Pflicht)** — the `issues.executionRunId` UPDATE inside `claimQueuedRun()` was unprotected. On a unique-constraint collision it threw an uncaught `DrizzleQueryError`, leaving the losing run stuck in `status="running"` with `process_pid IS NULL`, dependent on the 5-minute orphan reaper to notice. This PR was opened with Aufträge 3 and 4 already implemented but Auftrag 1 still missing; I picked up the branch and added it.
2. **always_enqueue routine-dispatch collision (verified live by CTO Gino, no action needed here)**.
3. **Process-lost retry backoff (Pflicht)** — already implemented before I started: `enqueueProcessLossRetry()` now applies a short jittered backoff (15s/60s/3m by attempt) via `scheduled_retry` status when triggered from `reapOrphanedRuns()`, instead of immediately re-claiming into the same resource pressure that caused the original loss.
4. **Host CPU/RAM telemetry (Pflicht)** — already implemented before I started: `services/host-telemetry.ts`, a ~30s rotating-log sampler giving future process-lost incidents historical host-load context.

Implementing Auftrag 1 required deciding *how* to resolve the loser of a collision. The chosen approach reuses the existing `cancelRunInternal` → `releaseIssueExecutionAndPromote` machinery (used elsewhere for stale/duplicate run cleanup) rather than inventing a new terminal-state path, so the loser reaches a clean `cancelled` state with `errorCode: "duplicate_execution_lock"` through the same code path other collision types already use.

A driver-shape gotcha needed handling: Drizzle wraps the real Postgres error in `DrizzleQueryError.cause`, and `postgres.js` (this project's driver) exposes the violated constraint as `constraint_name`, not `constraint` (the `node-postgres`/`pg` field name). Naive detection code checking only `constraint` — including the pre-existing `isOpenExecutionConflictError` in `routines.ts` — silently fails to recognize the collision on this driver. `isOpenRoutineExecutionConflictError()` in `heartbeat.ts` checks both field names.

Adding the collision-handling call chain (`claimQueuedRun` → `cancelRunInternal` → `releaseIssueExecutionAndPromote` → `startNextQueuedRunForAgent(agentId)`) exposed a real reentrancy hazard in `agent-start-lock.ts`'s non-reentrant per-agent mutex: the inline resolution path re-enters `withAgentStartLock` for the *same* agent whose lock the outer `startNextQueuedRunForAgent` call already holds, self-stalling for the lock's 30s staleness fallback on every collision. Fixed by making the lock reentrant via `AsyncLocalStorage`, tracking which agentIds are already active up the current async call chain so same-agent re-entry runs inline instead of waiting on itself.

## Linked Issues or Issue Description

No public GitHub issue exists for this change yet, so the underlying problem is described inline here, following the bug report template.

## What happened?

A background routine-execution scheduler ("heartbeat") claims queued runs by writing the claiming run's id onto the `issues.execution_run_id` column, guarded by a partial unique index (`issues_open_routine_execution_uq`) that allows only one open run per `(company_id, origin_kind, origin_id, origin_fingerprint)` tuple. When two claim attempts raced for the same tuple, the losing attempt's UPDATE threw an uncaught database error instead of being handled. That left the losing run stuck in a `running` status with no process ever actually started for it (`process_pid IS NULL`), and it stayed stuck until an unrelated 5-minute orphan-reaper pass eventually mislabeled it as a lost process. During a batch of 235 similar routine issues enqueued together, this produced roughly 204 of these collisions, which in turn manifested as 62 confusing "process lost" errors for a single worker type, with no direct link back to the real cause (a claim race, not an actual crashed process).

## Expected behavior

A losing claim attempt should be recognized as a collision immediately, reach a clean terminal state right away (not "running" with nothing behind it), and require no dependency on the periodic orphan reaper to notice and relabel it.

## Steps to reproduce

Enqueue two routine-triggered issues that share the same origin fingerprint (company, origin kind, origin id) so both attempt to claim an open execution slot concurrently. Before this change, the second `claimQueuedRun()` call throws an unhandled unique-constraint error instead of resolving the loser cleanly; the included regression test (`heartbeat-stale-queue-invalidation.test.ts`) reproduces this deterministically by invoking `claimQueuedRun()` twice for two open issues sharing one origin fingerprint.

## Paperclip version or commit

Branch `fix/rena-51447-codex-worker-fast-process-lost`, based on current `master`.

## Deployment mode

Self-hosted server deployment; affects the `server` package's background heartbeat/routine-execution scheduler only.

## What Changed

- **`server/src/services/heartbeat.ts`**
  - `claimQueuedRun()`: wrapped the `issues.executionRunId` UPDATE in try/catch. On an `issues_open_routine_execution_uq` collision, cancels the losing run inline via `cancelRunInternal(..., { errorCode: "duplicate_execution_lock" })` instead of letting the exception propagate.
  - `isOpenRoutineExecutionConflictError()`: new helper checking both `constraint` and `constraint_name` (postgres.js) error shapes, on both the error and `error.cause`.
  - `releaseIssueExecutionAndPromote()`: the promotion transaction can hit the same collision when promoting a `queued_recovery` candidate onto an issue another run just claimed; now caught and logged (skipping promotion for that pass) instead of throwing.
- **`server/src/services/agent-start-lock.ts`**: rewrote `withAgentStartLock` to be reentrant per agentId using `AsyncLocalStorage`, fixing the ~30s self-stall described above.
- **`server/src/services/host-telemetry.ts`**: guarded `interval.unref()` with `?.()`, matching the existing pattern in `external-objects.ts`/`plugin-worker-manager.ts` — fixes a `TypeError` under fake timers in tests (CI: `General tests (server (1/3))`).
- **Test fixes for pre-existing/newly-surfaced CI failures on this branch:**
  - `heartbeat-process-recovery.test.ts`: the orphan-reaper regression test's status assertion hadn't been updated for the `scheduled_retry` backoff state introduced by Auftrag 3's `applyBackoff` option (an already-analogous assertion elsewhere in the same file had been fixed; this one was missed). CI: `Verify serialized server suites (3/4)`.
  - `server-startup-feedback-export.test.ts`: added a mock for `host-telemetry.js`'s `startHostResourceTelemetry` — without it, the real (unmocked) implementation registers its own `setInterval` during `startServer()`, which clobbered a test's `setInterval` spy capture of the routine-tick callback, masked until the `.unref` crash above was fixed.
  - `heartbeat-stale-queue-invalidation.test.ts`: new regression test simulating two concurrent `claimQueuedRun()` calls for two open issues sharing the same `origin_fingerprint`, asserting (a) no uncaught exception, (b) the losing run reaches a clean terminal status immediately, (c) no dependency on `reapOrphanedRuns()`.

## Verification

Targeted `vitest` runs (no full-repo build needed; no shared types changed):

- `heartbeat-process-recovery.test.ts`, `heartbeat-stale-queue-invalidation.test.ts`, `server-startup-feedback-export.test.ts`: **139 passed, 2 skipped** (the 2 skips are pre-existing `it.skipIf(process.platform === "win32")` Linux-only tests, one of which is the fixed `scheduled_retry` assertion — could not execute it directly on this Windows dev machine; verified by analogy to an already-correct identical pattern elsewhere in the same file plus no regression in the file's other 98 tests).
- `heartbeat-issue-liveness-escalation.test.ts` (exercises `claimQueuedRun`/`startNextQueuedRunForAgent`): **23 passed**.
- `tsc --noEmit` on the server package: zero errors in any file touched by this PR (remaining errors elsewhere in the package, e.g. `plugin-host-services.ts`/`@paperclipai/plugin-sdk` module resolution, are pre-existing and unrelated to this change).

## Risks

- The reentrant-lock change to `agent-start-lock.ts` widens what `withAgentStartLock` permits (same-agent re-entry now runs inline instead of always serializing); this is intentionally scoped to same-async-chain re-entry only (via `AsyncLocalStorage`), so unrelated concurrent start attempts for the same agent from a *different* call chain still serialize as before.
- Auftrag 1's cancellation path reuses `cancelRunInternal`/`releaseIssueExecutionAndPromote`, which already run inside `db.transaction`; the added catch only swallows the one specific, identified constraint-violation shape (both `constraint` and `constraint_name` postgres.js field names) — any other DB error still propagates unchanged.
- **Known related but explicitly out-of-scope finding, not fixed in this PR**: `routines.ts`'s pre-existing `isOpenExecutionConflictError` has the same `constraint` vs. `constraint_name` driver-shape gap as the bug fixed here in `heartbeat.ts`, and is likely silently failing to detect collisions on the same driver. This is reported here as a finding for a follow-up PR rather than fixed in this one, to keep this change focused.
- Global concurrency cap policy (out of scope for this change) intentionally untouched.

## Model Used

Claude Opus 4.7

## Update 2026-08-06: Greptile follow-up fix

Greptile's review of the previous commit flagged a real (if narrow) defect: `startHostResourceTelemetry()` resolved and created its log directory (`fs.mkdirSync`) outside any error handling, so a filesystem error there (permission denial, read-only disk, etc.) threw synchronously out of the exported function. It's called unguarded during `startServer()` (`index.ts`), so that could have rejected server startup entirely for what's meant to be optional, best-effort diagnostics -- and the returned interval-cleanup callback was being discarded at the call site instead of being invoked on shutdown.

- **`server/src/services/host-telemetry.ts`**: wrapped the log-dir resolution/creation in try/catch inside `startHostResourceTelemetry()`; on failure it now logs a warning and returns a no-op cleanup instead of throwing.
- **`server/src/index.ts`**: also guards the call site with try/catch (defense in depth), and now captures the returned cleanup callback into `stopHostResourceTelemetry`, invoking it during graceful shutdown alongside the existing `heartbeatSchedulerInterval` clear.
- Added `server/src/__tests__/host-telemetry.test.ts` covering both the mkdir-failure path (no throw, warning logged, safe no-op cleanup, no interval scheduled) and normal immediate + interval sampling/cleanup behavior, using a real temp directory rather than mocking `node:fs` internals.

Verification: `npx vitest run src/__tests__/host-telemetry.test.ts` -- 2 passed. Re-ran the previously-verified suites (`heartbeat-process-recovery.test.ts`: 98 passed/2 skipped when run in isolation; `heartbeat-stale-queue-invalidation.test.ts` and `server-startup-feedback-export.test.ts`: all passing; `heartbeat-issue-liveness-escalation.test.ts`: 23 passed) -- no regressions from this change. `tsc --noEmit` on the server package: no new errors in any file touched (remaining errors are the same pre-existing, unrelated `plugin-host-services.ts`/`@paperclipai/plugin-sdk` module-resolution errors noted above).

## Checklist

- [x] I have searched GitHub for duplicate or related PRs and confirmed this is not a duplicate (found and built on this same PR, #10288, rather than opening a new one).
- [x] I have described the underlying issue in-PR following the bug report issue template (see "Linked Issues or Issue Description" above) since no public GitHub issue exists for it.
