### PR TITLE
feat(adapter-opencode): surface OpenRouter models in the config dropdown

### DIFF
--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,4 +1,35 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { runChildProcess } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async (_runId: string, command: string, args: string[]) => {
+    if (command === "__paperclip_missing_opencode_command__") {
+      throw new Error("Failed to start command");
+    }
+    if (args.includes("models")) {
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      };
+    }
+    throw new Error("Unexpected command");
+  }),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    runChildProcess,
+  };
+});
+
 import {
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
@@ -6,16 +37,128 @@ import {
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
 
+function setMockOpenCodeDiscovery(stdout: string) {
+  runChildProcess.mockImplementation(async (_runId: string, command: string, args: string[]) => {
+    if (command === "__paperclip_missing_opencode_command__") {
+      throw new Error("Failed to start command");
+    }
+    if (args.includes("models")) {
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout,
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      };
+    }
+    throw new Error("Unexpected command");
+  });
+}
+
+function mockOpenRouterResponse(payload: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    statusText: "",
+    json: vi.fn(async () => payload),
+  } as unknown as Response;
+}
+
 describe("openCode models", () => {
+  const originalAllowlist = process.env.PAPERCLIP_OPENROUTER_MODEL_ALLOWLIST;
+  const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+
+  beforeEach(() => {
+    setMockOpenCodeDiscovery("");
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.PAPERCLIP_OPENROUTER_MODEL_ALLOWLIST;
+  });
+
   afterEach(() => {
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
     delete process.env.OPENCODE_ALLOW_ALL_MODELS;
+    if (originalAllowlist === undefined) {
+      delete process.env.PAPERCLIP_OPENROUTER_MODEL_ALLOWLIST;
+    } else {
+      process.env.PAPERCLIP_OPENROUTER_MODEL_ALLOWLIST = originalAllowlist;
+    }
+    if (originalOpenRouterApiKey === undefined) {
+      delete process.env.OPENROUTER_API_KEY;
+    } else {
+      process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+    }
+    vi.restoreAllMocks();
+    runChildProcess.mockReset();
     resetOpenCodeModelsCacheForTests();
   });
 
   it("returns an empty list when discovery command is unavailable", async () => {
     process.env.PAPERCLIP_OPENCODE_COMMAND = "__paperclip_missing_opencode_command__";
     await expect(listOpenCodeModels()).resolves.toEqual([]);
+  });
+
+  it("merges discovered models with curated OpenRouter models", async () => {
+    setMockOpenCodeDiscovery("openrouter/openai/gpt-5\nopenai/gpt-4o\n");
+    process.env.OPENROUTER_API_KEY = "or-test-key";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockOpenRouterResponse({
+        data: [
+          { id: "openai/gpt-5", name: "OpenAI GPT-5" },
+          { id: "deepseek/deepseek-chat", name: "DeepSeek Chat" },
+        ],
+      }),
+    );
+
+    await expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "openai/gpt-4o", label: "openai/gpt-4o" },
+      { id: "openrouter/deepseek/deepseek-chat", label: "DeepSeek Chat" },
+      { id: "openrouter/openai/gpt-5", label: "OpenAI GPT-5" },
+    ]);
+  });
+
+  it("falls back to discovery models when OpenRouter fetch fails", async () => {
+    setMockOpenCodeDiscovery("openai/gpt-4o\n");
+    process.env.OPENROUTER_API_KEY = "or-test-key";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("OpenRouter request failed"));
+
+    await expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "openai/gpt-4o", label: "openai/gpt-4o" },
+    ]);
+  });
+
+  it("skips OpenRouter discovery when the key is missing", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    setMockOpenCodeDiscovery("openai/gpt-4o\n");
+
+    await expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "openai/gpt-4o", label: "openai/gpt-4o" },
+    ]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("respects the OpenRouter model cache TTL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockOpenRouterResponse({
+        data: [{ id: "openai/gpt-5", name: "OpenAI GPT-5" }],
+      }),
+    );
+    setMockOpenCodeDiscovery("");
+    process.env.OPENROUTER_API_KEY = "or-test-key";
+
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    await expect(listOpenCodeModels()).resolves.toEqual([{ id: "openrouter/openai/gpt-5", label: "OpenAI GPT-5" }]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await expect(listOpenCodeModels()).resolves.toEqual([{ id: "openrouter/openai/gpt-5", label: "OpenAI GPT-5" }]);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(60_001);
+    await expect(listOpenCodeModels()).resolves.toEqual([{ id: "openrouter/openai/gpt-5", label: "OpenAI GPT-5" }]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it("rejects when model is missing", async () => {
@@ -54,7 +197,10 @@ describe("openCode models", () => {
         env: { OPENCODE_ALLOW_ALL_MODELS: "true" },
       }),
     ).resolves.toEqual([
-      { id: "anthropic/tensorix/deepseek/deepseek-chat-v3.1", label: "anthropic/tensorix/deepseek/deepseek-chat-v3.1" },
+      {
+        id: "anthropic/tensorix/deepseek/deepseek-chat-v3.1",
+        label: "anthropic/tensorix/deepseek/deepseek-chat-v3.1",
+      },
     ]);
   });
 
@@ -63,7 +209,9 @@ describe("openCode models", () => {
     process.env.OPENCODE_ALLOW_ALL_MODELS = "1";
     await expect(
       ensureOpenCodeModelConfiguredAndAvailable({ model: "anthropic/gateway/some-model" }),
-    ).resolves.toEqual([{ id: "anthropic/gateway/some-model", label: "anthropic/gateway/some-model" }]);
+    ).resolves.toEqual([
+      { id: "anthropic/gateway/some-model", label: "anthropic/gateway/some-model" },
+    ]);
   });
 
   it("still enforces provider/model format when OPENCODE_ALLOW_ALL_MODELS is set", async () => {

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -10,11 +10,21 @@ import { isValidOpenCodeModelId } from "../index.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const OPENROUTER_MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models";
+const OPENROUTER_MODELS_TIMEOUT_MS = 5_000;
+const OPENROUTER_MODELS_CACHE_TTL_MS = 60_000;
+const OPENROUTER_ALLOWLIST_DEFAULT: readonly string[] = [
+  "openai/",
+  "anthropic/",
+  "qwen/",
+  "deepseek/",
+  "google/",
+];
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =
     typeof process.env.PAPERCLIP_OPENCODE_COMMAND === "string" &&
-    process.env.PAPERCLIP_OPENCODE_COMMAND.trim().length > 0
+      process.env.PAPERCLIP_OPENCODE_COMMAND.trim().length > 0
       ? process.env.PAPERCLIP_OPENCODE_COMMAND.trim()
       : "opencode";
   return asString(input, envOverride);
@@ -23,6 +33,12 @@ function resolveOpenCodeCommand(input: unknown): string {
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
+
+let openRouterModelsCache: {
+  keyFingerprint: string;
+  expiresAt: number;
+  models: AdapterModel[];
+} | null = null;
 
 export function requireOpenCodeModelId(input: unknown): string {
   const model = asString(input, "").trim();
@@ -92,6 +108,146 @@ function isVolatileEnvKey(key: string): boolean {
 
 function hashValue(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function fingerprint(apiKey: string): string {
+  const digest = createHash("sha256").update(apiKey).digest("base64url").slice(0, 16);
+  return `${apiKey.length}:${digest}`;
+}
+
+function resolveOpenRouterApiKey(): string | null {
+  const apiKey = process.env.OPENROUTER_API_KEY?.trim();
+  return apiKey && apiKey.length > 0 ? apiKey : null;
+}
+
+function parseOpenRouterAllowlist(): string[] {
+  const raw = process.env.PAPERCLIP_OPENROUTER_MODEL_ALLOWLIST?.trim();
+  if (!raw) return [...OPENROUTER_ALLOWLIST_DEFAULT];
+
+  if (raw === "*") return ["*"];
+
+  const entries = raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      if (entry === "*") return "*";
+      return entry.endsWith("/") ? entry : `${entry}/`;
+    });
+
+  if (entries.length === 0) return [...OPENROUTER_ALLOWLIST_DEFAULT];
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const entry of entries) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    deduped.push(entry);
+  }
+  return deduped;
+}
+
+function normalizeOpenRouterModelId(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  return trimmed.startsWith("openrouter/") ? trimmed.slice("openrouter/".length) : trimmed;
+}
+
+function hasOpenRouterModelAllowlistMatch(modelId: string, allowlist: string[]): boolean {
+  const lowerId = modelId.toLowerCase();
+  if (allowlist.includes("*")) return true;
+  return allowlist.some((entry) => {
+    const normalized = entry.endsWith("/") ? entry : `${entry}/`;
+    return lowerId.startsWith(normalized);
+  });
+}
+
+function filterAndPrefixOpenRouterModels(input: AdapterModel[]): AdapterModel[] {
+  const allowlist = parseOpenRouterAllowlist();
+  const filtered: AdapterModel[] = [];
+
+  for (const model of input) {
+    const rawId = normalizeOpenRouterModelId(model.id);
+    if (!rawId) continue;
+    if (!hasOpenRouterModelAllowlistMatch(rawId, allowlist)) continue;
+    filtered.push({ id: `openrouter/${rawId}`, label: model.label || rawId });
+  }
+
+  return dedupeModels(filtered);
+}
+
+function pruneExpiredOpenRouterModelsCache(now: number) {
+  if (!openRouterModelsCache) return;
+  if (openRouterModelsCache.expiresAt > now) return;
+  openRouterModelsCache = null;
+}
+
+async function fetchOpenRouterModels(apiKey: string): Promise<AdapterModel[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPENROUTER_MODELS_TIMEOUT_MS);
+  try {
+    const response = await fetch(OPENROUTER_MODELS_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) return [];
+
+    const payload = (await response.json()) as { data?: unknown };
+    const data = Array.isArray(payload.data) ? payload.data : [];
+    const parsed: AdapterModel[] = [];
+    for (const item of data) {
+      if (typeof item !== "object" || item === null) continue;
+      const record = item as { id?: unknown; name?: unknown };
+      if (typeof record.id !== "string" || record.id.trim().length === 0) continue;
+      const normalized = normalizeOpenRouterModelId(record.id);
+      if (!normalized) continue;
+      const label =
+        typeof record.name === "string" && record.name.trim().length > 0 ? record.name.trim() : normalized;
+      parsed.push({ id: normalized, label });
+    }
+    return dedupeModels(parsed);
+  } catch (error) {
+    console.warn("[paperclip] OpenRouter model discovery failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function discoverOpenRouterModelsCached(): Promise<AdapterModel[]> {
+  const apiKey = resolveOpenRouterApiKey();
+  if (!apiKey) return [];
+
+  const now = Date.now();
+  const keyFingerprint = fingerprint(apiKey);
+  pruneExpiredOpenRouterModelsCache(now);
+  if (openRouterModelsCache && openRouterModelsCache.keyFingerprint === keyFingerprint) {
+    return openRouterModelsCache.models;
+  }
+
+  const fetched = await fetchOpenRouterModels(apiKey);
+  if (fetched.length > 0) {
+    openRouterModelsCache = {
+      keyFingerprint,
+      expiresAt: now + OPENROUTER_MODELS_CACHE_TTL_MS,
+      models: fetched,
+    };
+    return fetched;
+  }
+
+  if (
+    openRouterModelsCache &&
+    openRouterModelsCache.keyFingerprint === keyFingerprint &&
+    openRouterModelsCache.models.length > 0
+  ) {
+    return openRouterModelsCache.models;
+  }
+
+  return [];
 }
 
 function discoveryCacheKey(command: string, cwd: string, env: Record<string, string>) {
@@ -220,13 +376,18 @@ export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
 }
 
 export async function listOpenCodeModels(): Promise<AdapterModel[]> {
-  try {
-    return await discoverOpenCodeModelsCached();
-  } catch {
-    return [];
-  }
+  const [discovered, openRouterRaw] = await Promise.all([
+    discoverOpenCodeModelsCached().catch(() => []),
+    discoverOpenRouterModelsCached().catch(() => []),
+  ]);
+  const openRouterModels = filterAndPrefixOpenRouterModels(openRouterRaw);
+  // OpenRouter entries first so their curated catalog labels win over the raw
+  // `openrouter/<id>` labels that `opencode models` echoes for the same ids
+  // (dedupeModels keeps the first occurrence of each id).
+  return sortModels(dedupeModels([...openRouterModels, ...discovered]));
 }
 
 export function resetOpenCodeModelsCacheForTests() {
   discoveryCache.clear();
+  openRouterModelsCache = null;
 }

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -156,6 +156,34 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     await prepared.cleanup();
   });
 
+  it("falls back to a process-level OPENROUTER_API_KEY when the run env sets an empty value", async () => {
+    // A blank run-env key must not mask a valid process-level key: model
+    // discovery reads process.env, so skipping injection here would leave
+    // OpenRouter models selectable but unrunnable.
+    process.env.OPENROUTER_API_KEY = "or-process-key";
+    const configHome = await makeConfigHome({ permission: { read: "allow" } });
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome, OPENROUTER_API_KEY: "" },
+      config: {},
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+    ) as { provider?: Record<string, { npm: string; name: string; options: { baseURL: string; apiKey: string } }> };
+    expect(runtimeConfig.provider?.openrouter).toMatchObject({
+      npm: "@ai-sdk/openai-compatible",
+      name: "OpenRouter",
+      options: {
+        baseURL: "https://openrouter.ai/api/v1",
+        apiKey: "or-process-key",
+      },
+    });
+    expect(prepared.notes).toContain(
+      "Injected default OpenRouter provider from OPENROUTER_API_KEY into the runtime OpenCode config.",
+    );
+    await prepared.cleanup();
+  });
+
   it("does not clobber a custom OpenRouter provider while injecting missing OpenRouter defaults", async () => {
     const configHome = await makeConfigHome({ permission: { read: "allow" } });
     const providers = {

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -230,6 +230,36 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     await prepared.cleanup();
   });
 
+  it("fills a blank apiKey on a custom OpenRouter provider with the resolved key", async () => {
+    // A custom openrouter provider that declares an empty/whitespace apiKey must
+    // not mask the resolved OPENROUTER_API_KEY: a bare presence check would keep
+    // the blank value, leaving models discoverable but unauthenticated at runtime.
+    const configHome = await makeConfigHome({ permission: { read: "allow" } });
+    const providers = {
+      openrouter: {
+        options: {
+          baseURL: "https://gateway.example/api/v1",
+          apiKey: "   ",
+        },
+      },
+    };
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: {
+        XDG_CONFIG_HOME: configHome,
+        OPENROUTER_API_KEY: "or-test-key",
+        PAPERCLIP_OPENCODE_PROVIDERS: JSON.stringify(providers),
+      },
+      config: {},
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+    ) as { provider?: { openrouter?: { options?: { baseURL: string; apiKey?: string } } } };
+    expect(runtimeConfig.provider?.openrouter?.options?.baseURL).toBe("https://gateway.example/api/v1");
+    expect(runtimeConfig.provider?.openrouter?.options?.apiKey).toBe("or-test-key");
+    await prepared.cleanup();
+  });
+
   it("expands {env:VAR} placeholders in custom providers using the run/process env (bakes the literal vk)", async () => {
     const configHome = await makeConfigHome({ permission: { read: "allow" } });
     const providers = {

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
 
 const cleanupPaths = new Set<string>();
+const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 
 afterEach(async () => {
   await Promise.all(
@@ -13,6 +14,18 @@ afterEach(async () => {
       cleanupPaths.delete(filepath);
     }),
   );
+});
+
+beforeEach(() => {
+  delete process.env.OPENROUTER_API_KEY;
+});
+
+afterEach(async () => {
+  if (originalOpenRouterApiKey === undefined) {
+    delete process.env.OPENROUTER_API_KEY;
+  } else {
+    process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+  }
 });
 
 async function makeConfigHome(initialConfig?: Record<string, unknown>) {
@@ -117,6 +130,76 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     } finally {
       delete process.env.PAPERCLIP_OPENCODE_PROVIDERS;
     }
+  });
+
+  it("injects a default OpenRouter provider when OPENROUTER_API_KEY is present", async () => {
+    const configHome = await makeConfigHome({ permission: { read: "allow" } });
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome, OPENROUTER_API_KEY: "or-test-key" },
+      config: {},
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+    ) as { provider?: Record<string, { npm: string; name: string; options: { baseURL: string; apiKey: string } }> };
+    expect(runtimeConfig.provider?.openrouter).toMatchObject({
+      npm: "@ai-sdk/openai-compatible",
+      name: "OpenRouter",
+      options: {
+        baseURL: "https://openrouter.ai/api/v1",
+        apiKey: "or-test-key",
+      },
+    });
+    expect(prepared.notes).toContain(
+      "Injected default OpenRouter provider from OPENROUTER_API_KEY into the runtime OpenCode config.",
+    );
+    await prepared.cleanup();
+  });
+
+  it("does not clobber a custom OpenRouter provider while injecting missing OpenRouter defaults", async () => {
+    const configHome = await makeConfigHome({ permission: { read: "allow" } });
+    const providers = {
+      openrouter: {
+        npm: "@some/vendor-sdk",
+        name: "Enterprise Gateway",
+        options: {
+          baseURL: "https://gateway.example/api/v1",
+        },
+        models: { "example/model-a": { name: "Model A" } },
+      },
+    };
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: {
+        XDG_CONFIG_HOME: configHome,
+        OPENROUTER_API_KEY: "or-test-key",
+        PAPERCLIP_OPENCODE_PROVIDERS: JSON.stringify(providers),
+      },
+      config: { model: "openrouter/example/model-a" },
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"), "utf8"),
+    ) as {
+      provider?: {
+        openrouter?: {
+          npm: string;
+          name: string;
+          options?: { baseURL: string; apiKey?: string };
+          models?: Record<string, unknown>;
+        };
+      };
+    };
+    expect(runtimeConfig.provider?.openrouter?.npm).toBe("@some/vendor-sdk");
+    expect(runtimeConfig.provider?.openrouter?.name).toBe("Enterprise Gateway");
+    expect(runtimeConfig.provider?.openrouter?.options?.baseURL).toBe("https://gateway.example/api/v1");
+    expect(runtimeConfig.provider?.openrouter?.options?.apiKey).toBe("or-test-key");
+    expect(runtimeConfig.provider?.openrouter?.models).toEqual({
+      "example/model-a": { name: "Model A" },
+    });
+    expect(prepared.notes).toContain(
+      "Injected default OpenRouter provider from OPENROUTER_API_KEY into the runtime OpenCode config.",
+    );
+    await prepared.cleanup();
   });
 
   it("expands {env:VAR} placeholders in custom providers using the run/process env (bakes the literal vk)", async () => {

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -9,6 +9,11 @@ type PreparedOpenCodeRuntimeConfig = {
   cleanup: () => Promise<void>;
 };
 
+const OPENROUTER_DEFAULT_PROVIDER_ID = "openrouter";
+const OPENROUTER_DEFAULT_PROVIDER_NAME = "OpenRouter";
+const OPENROUTER_DEFAULT_PROVIDER_BASE_URL = "https://openrouter.ai/api/v1";
+const OPENROUTER_DEFAULT_PROVIDER_NPM = "@ai-sdk/openai-compatible";
+
 function resolveXdgConfigHome(env: Record<string, string>): string {
   return (
     (typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()) ||
@@ -82,6 +87,47 @@ function parseProviderConfig(
     );
   }
   return Object.keys(providers).length > 0 ? providers : null;
+}
+
+function ensureOpenRouterProviderInConfig(
+  providers: Record<string, unknown>,
+  openRouterApiKey: string,
+): { providers: Record<string, unknown>; changed: boolean } {
+  const hasOpenRouterProvider = isPlainObject(providers[OPENROUTER_DEFAULT_PROVIDER_ID]);
+  const provider = hasOpenRouterProvider
+    ? { ...(providers[OPENROUTER_DEFAULT_PROVIDER_ID] as Record<string, unknown>) }
+    : {};
+  let changed = !hasOpenRouterProvider;
+
+  if (!("npm" in provider)) {
+    provider.npm = OPENROUTER_DEFAULT_PROVIDER_NPM;
+    changed = true;
+  }
+  if (!("name" in provider)) {
+    provider.name = OPENROUTER_DEFAULT_PROVIDER_NAME;
+    changed = true;
+  }
+
+  const providerOptions = isPlainObject(provider.options)
+    ? { ...(provider.options as Record<string, unknown>) }
+    : {};
+  if (!("baseURL" in providerOptions)) {
+    providerOptions.baseURL = OPENROUTER_DEFAULT_PROVIDER_BASE_URL;
+    changed = true;
+  }
+  if (!("apiKey" in providerOptions)) {
+    providerOptions.apiKey = openRouterApiKey;
+    changed = true;
+  }
+  provider.options = providerOptions;
+
+  return {
+    providers: {
+      ...providers,
+      [OPENROUTER_DEFAULT_PROVIDER_ID]: provider,
+    },
+    changed,
+  };
 }
 
 function parseConfiguredModelRef(raw: unknown): { provider: string; model: string } | null {
@@ -177,6 +223,20 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     notes.push(
       `Injected ${Object.keys(gatewayProviders).length} custom OpenCode provider(s) from PAPERCLIP_OPENCODE_PROVIDERS: ${Object.keys(gatewayProviders).join(", ")}.`,
     );
+  }
+
+  const openRouterApiKey = input.env.OPENROUTER_API_KEY?.trim() ?? process.env.OPENROUTER_API_KEY?.trim();
+  if (openRouterApiKey) {
+    const { providers: providersWithOpenRouter, changed } = ensureOpenRouterProviderInConfig(
+      nextProvider,
+      openRouterApiKey,
+    );
+    nextProvider = providersWithOpenRouter;
+    if (changed) {
+      notes.push(
+        "Injected default OpenRouter provider from OPENROUTER_API_KEY into the runtime OpenCode config.",
+      );
+    }
   }
 
   // Register the configured model on its provider's models map. OpenCode resolves

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -225,7 +225,13 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     );
   }
 
-  const openRouterApiKey = input.env.OPENROUTER_API_KEY?.trim() ?? process.env.OPENROUTER_API_KEY?.trim();
+  // Prefer the run-env key, but treat a blank/whitespace value as absent so a
+  // valid process-level key still wins. Using `??` here would let an empty
+  // `OPENROUTER_API_KEY=""` in the run env mask a real process key, skipping
+  // provider injection even though model discovery (which reads process.env)
+  // still surfaces OpenRouter models — leaving them selectable but unrunnable.
+  const openRouterApiKey =
+    input.env.OPENROUTER_API_KEY?.trim() || process.env.OPENROUTER_API_KEY?.trim() || undefined;
   if (openRouterApiKey) {
     const { providers: providersWithOpenRouter, changed } = ensureOpenRouterProviderInConfig(
       nextProvider,

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -115,7 +115,14 @@ function ensureOpenRouterProviderInConfig(
     providerOptions.baseURL = OPENROUTER_DEFAULT_PROVIDER_BASE_URL;
     changed = true;
   }
-  if (!("apiKey" in providerOptions)) {
+  // Treat a blank/whitespace (or non-string) existing apiKey as absent so the
+  // resolved OPENROUTER_API_KEY still wins. A mere presence check would keep an
+  // explicit `apiKey: ""` from PAPERCLIP_OPENCODE_PROVIDERS, leaving OpenRouter
+  // models discoverable (discovery reads process.env) but unrunnable — the same
+  // "selectable but unauthenticated" failure the run-env key resolution guards
+  // against above.
+  const existingApiKey = providerOptions.apiKey;
+  if (typeof existingApiKey !== "string" || existingApiKey.trim().length === 0) {
     providerOptions.apiKey = openRouterApiKey;
     changed = true;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents pick their model from a dropdown in agent config, populated per-adapter by `listAdapterModels()` → each adapter's live provider catalog merged over a static fallback list
> - An OpenRouter API key can be configured, but **no adapter ever fetches `openrouter.ai/api/v1/models`**, so OpenRouter models never appear as options — you can only reach OpenRouter by hand-typing an id and wiring `PAPERCLIP_OPENCODE_PROVIDERS` yourself
> - `opencode_local` is the natural host: its model-id space is already `provider/model`, so an `openrouter/<model>` id is directly runnable via the existing provider routing
> - This pull request adds an OpenRouter catalog fetch (allowlisted, cached) to `opencode_local`'s `listOpenCodeModels`, and injects a default OpenRouter provider into the runtime config when `OPENROUTER_API_KEY` is present, so the model is both selectable and executable
> - The benefit is that OpenRouter models finally show up in the agent-config dropdown and run without per-agent manual provider wiring

## Linked Issues or Issue Description

No public GitHub issue. This is an adapter feature; the underlying gap is described inline following the feature-request template:

**Problem or motivation**
An OpenRouter API key can be configured, but no adapter ever fetches `https://openrouter.ai/api/v1/models`, so OpenRouter models never populate the agent-config dropdown. Today OpenRouter is reachable only by hand-typing a model id and manually configuring `PAPERCLIP_OPENCODE_PROVIDERS`; `OPENROUTER_API_KEY` was wired only for billing attribution and k8s passthrough.

**Proposed solution**
In `opencode_local`, merge an allowlisted, cached OpenRouter catalog fetch into `listOpenCodeModels` so the models are selectable, and inject a default OpenRouter provider into the runtime config when `OPENROUTER_API_KEY` is present so the selected model is executable.

**Alternatives considered**
Adding OpenRouter discovery to a different adapter (rejected — `opencode_local`'s model-id space is already `provider/model`, so `openrouter/<id>` is directly runnable via existing routing); or leaving manual `PAPERCLIP_OPENCODE_PROVIDERS` wiring as the only path (rejected — it never surfaces models in the dropdown).

**Roadmap alignment**
Additive adapter capability; does not duplicate planned core work (checked ROADMAP.md).

## What Changed

- **`models.ts` — catalog discovery.** `listOpenCodeModels` now merges the existing `opencode models` output with an OpenRouter catalog fetch. The fetch is gated on `OPENROUTER_API_KEY`, has a 5s timeout and a 60s cache (keyed by a non-reversible key fingerprint), and returns `[]` (falling back to CLI-only discovery) on any error or non-2xx. Results are filtered by a curated provider allowlist (default `openai/ anthropic/ qwen/ deepseek/ google/`, overridable via `PAPERCLIP_OPENROUTER_MODEL_ALLOWLIST`, `*` = allow all) and prefixed `openrouter/<id>` so they are directly runnable.
- **`runtime-config.ts` — executability.** When `OPENROUTER_API_KEY` is present, `prepareOpenCodeRuntimeConfig` injects a default `openrouter` provider (`@ai-sdk/openai-compatible`, `baseURL https://openrouter.ai/api/v1`, apiKey) into the runtime OpenCode config, filling only missing fields so a custom/enterprise OpenRouter provider is never clobbered.
- **`runtime-config.ts` — empty-run-env-key fallback (review fix).** Key resolution now uses `input.env.OPENROUTER_API_KEY?.trim() || process.env...?.trim() || undefined` instead of `??`. Previously a blank `OPENROUTER_API_KEY=""` in the run env trimmed to a defined empty string, so `??` never fell back to a valid process-level key — provider injection was skipped even though model discovery (which reads `process.env`) still surfaced OpenRouter models, leaving them selectable but unrunnable. A blank/whitespace run-env value is now treated as absent.
- **Tests** for merge/label precedence, key-missing skip, fetch-failure fallback, cache TTL, default-provider injection, custom-provider preservation, and the new empty-run-env-key → process-key fallback case.

## Verification

- `pnpm -C packages/adapters/opencode-local exec tsc --noEmit` — clean.
- `pnpm -C packages/adapters/opencode-local exec vitest run` — **43 tests pass (7 files)**, including the new empty-run-env-key fallback case.
- Confirmed the new fallback test is meaningful: it fails against the previous `??` form (provider not injected) and passes with the `||` fix.
- Fixed one dedup-ordering defect surfaced by the suite: when the same id arrives from both the `opencode models` CLI (label = raw id) and the OpenRouter catalog (curated name), OpenRouter entries are merged first so the human-readable label wins.

## Risks

- **Deployment gating:** discovery reads `OPENROUTER_API_KEY` from the **server process env** (same model as `claude_local` reading `ANTHROPIC_API_KEY`). If the key is only stored as a per-environment secret and not present in the server process, the dropdown will not populate — a config/rollout step, not a code change.
- **Network:** adds one outbound `GET openrouter.ai/api/v1/models` per 60s cache window when a key is set; failures degrade silently to CLI-only discovery, so a slow/down OpenRouter cannot break the dropdown.
- **Scope:** purely additive to `opencode_local`; no change to other adapters or to the CLI discovery path when no key is set.

## Model Used

Claude (Anthropic), model id `claude-opus-4-8` (Opus 4.8), extended thinking + tool use, run as the Paperclip CTO agent. Recovered, verified, and addressed the Greptile P1 on an implementation drafted by a teammate coding agent whose run crashed before committing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (branch describes the change; forked from origin/master for this recovery)
- [x] I have run tests locally and they pass (opencode-local: tsc clean + 43 vitest tests)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (n/a — no docs reference this path)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending re-review of the P1 fix)
- [x] I will address all Greptile and reviewer comments before requesting merge
