### PR TITLE
fix(adapter-utils): exclude test files from build output

### DIFF
--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -38,7 +38,7 @@
     "acpx"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/adapter-utils/tsconfig.build.json
+++ b/packages/adapter-utils/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**", "src/**/__fixtures__/**"]
+}


### PR DESCRIPTION
## Problem

The `@paperclipai/adapter-utils` build (`tsc` with `include: ["src"]` and no `exclude`) compiles every `*.test.ts` into `dist/*.test.js` (21 files). When vitest runs after a build, it discovers and re-runs the compiled `dist/` copies **in addition** to the `src/` originals. The `dist/` copies fail because they resolve sibling `.ts` sources by a relative path that only exists under `src/` (e.g. `sandbox-managed-runtime.test.js` → `ENOENT` on `dist/*.ts`), producing spurious **sandbox** test failures in the local build-then-test workflow. CI is unaffected because `dist/` is gitignored.

## Fix

- Add `packages/adapter-utils/tsconfig.build.json` that extends the base config and excludes `*.test.ts` / `*.spec.ts` / `__tests__` / `__fixtures__`.
- Point the package `build` script at it (`tsc -p tsconfig.build.json`).
- `tsconfig.json` is untouched, so `typecheck` still covers test files.

## Verification

- Clean rebuild yields **0** test files in `dist/` (was 21); `dist/index.js` and prod code intact.
- `typecheck` passes.
- Project test run with `dist/` present went from **3 failures → 1** (the remaining failure is an unrelated environment gate: `mcp-isolation.integration.test.ts` asserts the local Claude Code CLI is ≥ 2.1.207).

🤖 Generated with [Claude Code](https://claude.com/claude-code)