### PR TITLE
fix(pi-local): use maintained pi coding agent package

### DIFF
--- a/docker/agent-runtime/Dockerfile.pi
+++ b/docker/agent-runtime/Dockerfile.pi
@@ -4,9 +4,9 @@ FROM paperclipai/agent-runtime-base:${BASE_TAG}
 
 USER root
 # pi is the multi-provider Pi coding-agent router. Verified npm package:
-# @mariozechner/pi-coding-agent (binary 'pi' → dist/cli.js). Same package
+# @earendil-works/pi-coding-agent (binary 'pi' → dist/cli.js). Same package
 # is used by SANDBOX_INSTALL_COMMAND in pi-local/src/index.ts.
-RUN npm install -g @mariozechner/pi-coding-agent@latest \
+RUN npm install -g @earendil-works/pi-coding-agent@latest \
     && { chown -R 1000:1000 /usr/lib/node_modules || true; }
 
 USER 1000:1000

--- a/docker/agent-runtime/README.md
+++ b/docker/agent-runtime/README.md
@@ -6,7 +6,7 @@ Container images for running coding-agent harnesses in sandboxed environments (f
 
 - **`agent-runtime-base`**: Foundation. Ubuntu 22.04 + Node 22 + git + tini + non-root user (uid 1000) + the agent shim.
 - **`agent-runtime-opencode`**: Extends base with `opencode-ai` globally installed.
-- **`agent-runtime-pi`**: Extends base with `@mariozechner/pi-coding-agent`.
+- **`agent-runtime-pi`**: Extends base with `@earendil-works/pi-coding-agent`.
 - **`agent-runtime-codex`**: Extends base with `@openai/codex`.
 - **`agent-runtime-gemini`**: Extends base with `@google/gemini-cli` plus headless auth-mode settings.
 - **`agent-runtime-claude`**: Extends base with `@anthropic-ai/claude-code` (symlinked as `claude-code`).

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -301,6 +301,7 @@ describe("server adapter registry", () => {
     const expectedCodexInstall = `if ! command -v 'codex' >/dev/null 2>&1; then ${buildSandboxNpmInstallCommand("@openai/codex")}; fi`;
     const expectedGeminiInstall = `if ! command -v 'gemini' >/dev/null 2>&1; then ${buildSandboxNpmInstallCommand("@google/gemini-cli")}; fi`;
     const expectedOpenCodeInstall = `if ! command -v 'opencode' >/dev/null 2>&1; then ${buildSandboxNpmInstallCommand("opencode-ai")}; fi`;
+    const expectedPiInstall = `if ! command -v 'pi' >/dev/null 2>&1; then ${buildSandboxNpmInstallCommand("@earendil-works/pi-coding-agent")}; fi`;
 
     expect(findActiveServerAdapter("claude_local")?.getRuntimeCommandSpec?.({})).toEqual({
       command: "claude",
@@ -321,6 +322,11 @@ describe("server adapter registry", () => {
       command: "opencode",
       detectCommand: "opencode",
       installCommand: expectedOpenCodeInstall,
+    });
+    expect(findActiveServerAdapter("pi_local")?.getRuntimeCommandSpec?.({})).toEqual({
+      command: "pi",
+      detectCommand: "pi",
+      installCommand: expectedPiInstall,
     });
   });
 

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -417,7 +417,7 @@ const piLocalAdapter: ServerAdapterModule = {
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: true,
   getRuntimeCommandSpec: (config) =>
-    buildNpmRuntimeCommandSpec(config, "pi", "@mariozechner/pi-coding-agent"),
+    buildNpmRuntimeCommandSpec(config, "pi", "@earendil-works/pi-coding-agent"),
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `pi_local` adapter can bootstrap the Pi CLI in sandboxes, and Paperclip also publishes a Pi agent-runtime image
> - Both install paths must point at the actively maintained npm package so Pi agents remain installable and current
> - `@mariozechner/pi-coding-agent` is deprecated on npm with an author message directing users to `@earendil-works/pi-coding-agent`
> - The replacement package preserves the `pi` binary contract used by Paperclip
> - This pull request switches the remaining runtime, image, and documentation references to the maintained package and adds regression coverage for the sandbox install command
> - The benefit is that Paperclip no longer directs fresh Pi installations through a deprecated package

## Linked Issues or Issue Description

No public issue currently tracks this package deprecation. Related: #5976 previously selected `@earendil-works/pi-coding-agent` for an older container-image path, but that PR was closed and the current runtime paths still referenced the deprecated scope.

**What happened?**

The `pi_local` sandbox bootstrap and Pi agent-runtime image install `@mariozechner/pi-coding-agent`, which npm now marks deprecated with the author message: `please use @earendil-works/pi-coding-agent instead going forward`.

**Expected behavior**

Fresh Pi runtime installations should use the maintained `@earendil-works/pi-coding-agent` package while preserving the `pi` CLI entry point.

**Steps to reproduce**

1. Inspect the `pi_local` runtime command spec or build `docker/agent-runtime/Dockerfile.pi` from current `master`.
2. Observe that the generated/install command targets `@mariozechner/pi-coding-agent`.
3. Query that package on npm and observe its deprecation message.

**Paperclip version or commit:** `2568bdecc4577c60d76d58a45c5eaf3dc58f7e13`

**Deployment mode:** Local dev and Docker

## What Changed

- Switched the `pi_local` sandbox runtime bootstrap to `@earendil-works/pi-coding-agent`.
- Switched the Pi agent-runtime image and its documentation to the maintained package scope.
- Extended the adapter registry test to lock the Pi sandbox install command to the maintained package.

## Verification

- `pnpm exec vitest run server/src/__tests__/adapter-registry.test.ts` — 14/14 tests passed.
- `pnpm -r typecheck` — passed across all workspace packages.
- `pnpm test:run` — all 287 server test files passed (2,936 passed, 1 skipped); the UI run exposed three existing timezone-sensitive assertions under this host's `Asia/Hong_Kong` timezone.
- `TZ=UTC pnpm exec vitest run --project @paperclipai/ui` — all 379 UI test files passed (3,099 tests), matching GitHub Actions' UTC environment.
- `pnpm build` — passed across all workspace packages.
- `npx --yes @earendil-works/pi-coding-agent@latest --version` — `0.82.1`.
- Built the `base` and `pi` runtime images locally for `linux/arm64`, then ran `docker run --rm ghcr.io/paperclipai/agent-runtime-pi:dev pi --version` — `0.82.1`. The repository bake file targets `linux/amd64`; this ARM host lacks amd64 binfmt, so the local smoke build used the native architecture while CI retains the canonical target.

## Risks

Low risk. The replacement package is the package named by the deprecated package's author, and it preserves the `pi` binary (`dist/cli.js`) expected by both runtime paths. The Docker image continues to install `@latest`, so normal upstream release movement remains unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex `gpt-5.6-sol` — agentic multi-step reasoning with repository, shell, Docker, npm, and GitHub tool use. The provider does not expose a separate reasoning-effort setting or context-window size in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
