### PR TITLE
fix(recovery): skip resolved-dependency backstop candidates with non-invokable assignees

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -630,6 +630,36 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(wakes.some((wake) => ["queued", "claimed", "completed"].includes(wake.status))).toBe(true);
   });
 
+  it.each(["paused", "terminated", "pending_approval"] as const)(
+    "skips resolved-dependency backstop candidates whose assignee is %s",
+    async (assigneeStatus) => {
+      await enableAutoRecovery();
+      const { companyId, agentId, blockedIssueId } =
+        await seedResolvedDependencyBackstopFixture({ workspaceState: "none" });
+      // Flip the assignee into a directly non-invokable state. The backstop
+      // must drop the candidate at the SQL layer — otherwise it enqueues a
+      // wake that always fails with 409 and loops on every heartbeat.
+      await db.update(agents).set({ status: assigneeStatus }).where(eq(agents.id, agentId));
+
+      const result = await heartbeatService(db).reconcileIssueGraphLiveness();
+
+      expect(result.dependencyWakeBackstopChecked).toBe(0);
+      expect(result.dependencyWakesHealed).toBe(0);
+      expect(result.dependencyWakeIssueIds).not.toContain(blockedIssueId);
+
+      const wakes = await db
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.reason, "issue_blockers_resolved"),
+          ),
+        );
+      expect(wakes).toHaveLength(0);
+    },
+  );
+
   it("waits for workspace finalize before healing a resolved blocked dependent", async () => {
     await enableAutoRecovery();
     const { companyId, agentId, blockedIssueId, blockerIssueId, executionWorkspaceId } =

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -53,7 +53,7 @@ import {
   buildIssueBlockersResolvedWakeStateKey,
   findExistingIssueBlockersResolvedWakeForReadyState,
 } from "../issue-dependency-wakeups.js";
-import { evaluateAgentInvokabilityFromDb } from "../agent-invokability.js";
+import { DIRECT_NON_INVOKABLE_STATUSES, evaluateAgentInvokabilityFromDb } from "../agent-invokability.js";
 import { isHeartbeatWakeOnDemandEnabled } from "../heartbeat-policy.js";
 import { getRunLogStore } from "../run-log-store.js";
 import {
@@ -6303,6 +6303,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         eq(issues.status, "blocked"),
         visibleIssueCondition(),
         sql`${issues.assigneeAgentId} is not null`,
+        // Skip candidates whose assignee is directly non-invokable (paused,
+        // terminated, pending_approval). Without this filter the backstop
+        // repeatedly enqueues wakes that always fail with 409, producing a
+        // steady stream of `wake_target_not_invokable` warnings for the same
+        // issue every heartbeat until an operator intervenes. Matches the
+        // atomic guard in the heartbeat's `agents.status -> running` update.
+        // Org-chain invalidity is not covered here for cost reasons; the
+        // enqueue path still filters those cases via
+        // `evaluateAgentInvokabilityFromDb`.
+        notInArray(agents.status, [...DIRECT_NON_INVOKABLE_STATUSES]),
       ];
       if (opts?.companyId) filters.push(eq(issues.companyId, opts.companyId));
       if (afterIssueId) filters.push(gt(issues.id, afterIssueId));
@@ -6324,6 +6334,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           })
           .from(issueRelations)
           .innerJoin(issues, eq(issueRelations.relatedIssueId, issues.id))
+          .innerJoin(agents, eq(agents.id, issues.assigneeAgentId))
           .where(and(...filters))
           .orderBy(asc(issues.id))
           .limit(RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT);
@@ -6338,6 +6349,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           totalCount: sql<number>`count(*) over()::int`,
         })
         .from(issues)
+        .innerJoin(agents, eq(agents.id, issues.assigneeAgentId))
         .where(and(...filters))
         .orderBy(asc(issues.id))
         .limit(RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery service runs an "issue graph liveness" reconciliation each heartbeat; part of that sweep, `reconcileResolvedDependencyWakeBackstop`, wakes assignees of blocked issues once their blockers have completed
> - When the assignee is directly non-invokable (paused, terminated, pending_approval) the wake is guaranteed to be rejected with `wake_target_not_invokable` (409). Because the sweep does not consult the assignee's status, the same issue re-enters the candidate set every tick and produces a steady stream of warnings until an operator intervenes
> - The rest of the codebase already tracks this precise notion — `services/agent-invokability.ts` exports `DIRECT_NON_INVOKABLE_STATUSES` and the heartbeat's `agents.status -> running` update uses it as an atomic guard — so the backstop was the only place still ignoring it
> - This pull request adds `notInArray(agents.status, [...DIRECT_NON_INVOKABLE_STATUSES])` to the backstop's candidate query and `innerJoin`s the `agents` table in both branches (with and without `blockerIssueId`) so the filter applies uniformly
> - The benefit is that a single paused/terminated assignee no longer produces a warning per heartbeat, and no code path outside the backstop changes — org-chain invalidity is still evaluated per-candidate at the enqueue path

## Linked Issues or Issue Description

No public GitHub issue exists for this. Describing it inline following the bug report template per the "No issue exists" path.

#### What happened?

In production we observed ~2874 `wake_target_not_invokable` warnings over 24h coming from `services/recovery/service.ts` — every one of them traced back to a single blocked issue whose assignee had been switched to `paused` days earlier. `reconcileResolvedDependencyWakeBackstop` re-selected the issue on every heartbeat, called `enqueueWakeup`, the wake was rejected by the runtime's invokability guard, the issue stayed blocked, and the loop repeated.

#### Expected behavior

The backstop should not enqueue wakes it knows cannot be delivered. `DIRECT_NON_INVOKABLE_STATUSES` (paused, terminated, pending_approval) is the exact set the heartbeat's own pause-durability guard already uses when it atomically flips an agent to `running`; the backstop should honor the same set.

#### Steps to reproduce

1. Seed a company with one agent (status `paused`, `terminated`, or `pending_approval`) and one blocked issue assigned to it, with a `blocks` relation from a `done` blocker.
2. Enable `enableIssueGraphLivenessAutoRecovery`.
3. Call `heartbeatService(db).reconcileIssueGraphLiveness()`.
4. **Before this PR:** `dependencyWakeBackstopChecked === 1`, a wake row is inserted into `agent_wakeup_requests` with `reason = "issue_blockers_resolved"`, and the wake is subsequently rejected. Running the sweep repeatedly produces a new warning each time.
5. **After this PR:** `dependencyWakeBackstopChecked === 0`, no wake row is inserted, no warning is emitted.

#### Paperclip version or commit

Reproduced on `master` at the branch base (`2568bde`). The added regression test in `heartbeat-issue-liveness-escalation.test.ts` covers all three non-invokable statuses.

#### Deployment mode

Docker (self-hosted server). The same code path executes under any deployment mode, since `services/recovery/service.ts` is server-side and the sweep runs each heartbeat regardless of runtime.

## What Changed

- `server/src/services/recovery/service.ts` — import `DIRECT_NON_INVOKABLE_STATUSES` from `../agent-invokability.js`; in `reconcileResolvedDependencyWakeBackstop.queryCandidates`, add `notInArray(agents.status, [...DIRECT_NON_INVOKABLE_STATUSES])` to `filters` and `innerJoin(agents, eq(agents.id, issues.assigneeAgentId))` in both branches (blockerIssueId-scoped and unscoped).
- `server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts` — add an `it.each(["paused", "terminated", "pending_approval"])` case reusing the existing `seedResolvedDependencyBackstopFixture`. Flips the assignee into the non-invokable status and asserts `dependencyWakeBackstopChecked === 0`, `dependencyWakesHealed === 0`, and no `issue_blockers_resolved` wake row is created.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — passes with no new errors.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-issue-liveness-escalation.test.ts` — 25 passed (22 pre-existing + 3 new, one per non-invokable status).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/instance-settings-routes.test.ts src/__tests__/server-startup-feedback-export.test.ts src/__tests__/heartbeat-dependency-scheduling.test.ts` — 37 passed. Sanity check for the two other files that import `reconcileResolvedDependencyWakeBackstop` / `reconcileIssueGraphLiveness` plus the dependency-scheduling suite that exercises the surrounding wake logic.

Runtime evidence from the production trace that motivated the fix: at the moment of the sweep the assignee row had `status = 'paused'`, `updated_at` >72h old; without the filter the same `issue_id` appeared in `agent_wakeup_requests` once per heartbeat with `status = 'skipped'` and `error = 'wake_target_not_invokable'`. After applying the same filter as a container-level hotfix, the warning volume dropped to 0 in a 1-hour window.

## Risks

- Adds an `innerJoin(agents)` to the hot path of the backstop. Cost is comparable to the existing `notInArray` and `visibleIssueCondition` filters that already run on the same query; the join key is the `agents.id` primary key. There is no index change.
- Behavior narrows only: an issue whose assignee is `active`/`idle`/`running` is unaffected. The only issues that now get skipped are those that were guaranteed to fail their wake anyway; operators still see them as `blocked` in the UI, exactly as before.
- Org-chain invalidity (e.g. reporting-chain issues that render an otherwise-invokable agent non-invokable) is intentionally not covered here — that check requires per-candidate evaluation and remains in `evaluateAgentInvokabilityFromDb` at the enqueue path, so no regression there.

## Model Used

- Anthropic Claude Opus 4.7 (`claude-opus-4-7`, 200k context window), extended-thinking mode with tool use. Diff, tests, and PR body drafted by the model; human-reviewed before push.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

