### PR TITLE
fix(codex-local): stop rendering non-fatal advisories as errors

### DIFF
--- a/packages/adapters/codex-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/codex-local/src/ui/parse-stdout.test.ts
@@ -80,4 +80,40 @@ describe("parseCodexStdoutLine", () => {
       isError: true,
     }]);
   });
+
+  // Codex reports non-fatal advisories through the same `error` item type it
+  // uses for real failures. The model-metadata one is emitted at session start,
+  // before the first API call, so it lands as item_0 -- the very first line a
+  // reader sees on a run that then proceeds normally and succeeds.
+  it("demotes the model-metadata advisory to a neutral notice", () => {
+    const entries = parseCodexStdoutLine(JSON.stringify({
+      type: "item.completed",
+      item: {
+        id: "item_0",
+        type: "error",
+        message:
+          "Model metadata for `gpt-5.6-luna` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.",
+      },
+    }), "2026-04-08T12:00:04.000Z");
+
+    expect(entries).toEqual([{
+      kind: "system",
+      ts: "2026-04-08T12:00:04.000Z",
+      text:
+        "Model metadata for `gpt-5.6-luna` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.",
+    }]);
+  });
+
+  it("still surfaces genuine error items as stderr", () => {
+    const entries = parseCodexStdoutLine(JSON.stringify({
+      type: "item.completed",
+      item: { id: "item_4", type: "error", message: "stream disconnected before completion" },
+    }), "2026-04-08T12:00:05.000Z");
+
+    expect(entries).toEqual([{
+      kind: "stderr",
+      ts: "2026-04-08T12:00:05.000Z",
+      text: "stream disconnected before completion",
+    }]);
+  });
 });

--- a/packages/adapters/codex-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/codex-local/src/ui/parse-stdout.ts
@@ -165,6 +165,24 @@ function parseToolUseItem(
   }];
 }
 
+/**
+ * Codex `error` items that report a degraded-but-working condition rather than
+ * a failure. Kept deliberately narrow and anchored: an over-broad pattern here
+ * would silence real errors, which is far worse than showing an extra one.
+ */
+const NON_FATAL_ADVISORY_PATTERNS: RegExp[] = [
+  // Requested model is absent from the CLI's compiled metadata table. The turn
+  // proceeds on fallback metadata, so this warns that context-window and token
+  // accounting are approximate -- it does not mean the run failed.
+  /^model metadata for .+ not found\b/i,
+];
+
+function isNonFatalAdvisory(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) return false;
+  return NON_FATAL_ADVISORY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
 function parseCodexItem(
   item: Record<string, unknown>,
   ts: string,
@@ -209,6 +227,15 @@ function parseCodexItem(
 
   if (itemType === "error" && phase === "completed") {
     const text = errorText(item.message ?? item.error ?? item);
+    // Codex reports non-fatal advisories through the same `error` item type it
+    // uses for genuine failures, so routing every one to stderr makes a healthy
+    // run look broken. The model-metadata advisory is emitted at session start
+    // before the first API call, which puts it at item_0 -- the first line a
+    // reader sees on a run that then completes normally. Demote the known
+    // advisories to a neutral notice; anything unrecognised stays stderr.
+    if (isNonFatalAdvisory(text)) {
+      return [{ kind: "system", ts, text }];
+    }
     return [{ kind: "stderr", ts, text: text || "error" }];
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The codex_local adapter turns the Codex CLI's JSONL event stream into transcript entries via `parseCodexItem` in `packages/adapters/codex-local/src/ui/parse-stdout.ts`
> - Codex uses a single `item.type === "error"` shape for two very different things: genuine failures, and non-fatal advisories about a degraded-but-working condition
> - The parser maps all of them to `kind: "stderr"`, which the transcript renders with error styling
> - The model-metadata advisory is emitted client-side at session start, before the first API call, so it always lands as `item_0` — the first line of the transcript
> - The run then proceeds normally and completes successfully, but anyone reading it sees an error at the top and concludes the run failed
> - This pull request demotes known non-fatal advisories to a neutral system notice while leaving every unrecognised error item on stderr
> - The benefit is that a successful run stops looking like a broken one, without hiding information or suppressing real errors

## Linked Issues or Issue Description

No existing issue. Describing it inline per `bug_report.yml`:

**What happened**

A run whose transcript opens with an `error` item, and which then completes normally and is recorded as succeeded:

```json
{"type":"thread.started","thread_id":"019fa008-1a27-7882-82c5-27b30e380f93"}
{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Model metadata for `gpt-5.6-luna` not found. Defaulting to fallback metadata; this can degrade performance and cause issues."}}
{"type":"turn.started"}
{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"I'm using the Paperclip workflow now, then I'll inspect the assigned repo issue and implement the smallest bootstrap slice..."}}
```

**What I expected**

A successful run should not open with something styled as an error. The advisory is real information (fallback metadata means context-window and token accounting are approximate) but it is not a failure.

**Steps to reproduce**

No account or valid credentials needed — the advisory precedes authentication:

```
codex exec --json --skip-git-repo-check --model gpt-5.6-luna hi
# with any invalid OPENAI_API_KEY
```

Any model absent from the CLI's compiled metadata table reproduces it. Verified against `@openai/codex` 0.142.5 (emits it for `gpt-5.6-luna`) and 0.145.0 (does not, but still emits it for `gpt-5.6`, `gpt-5`, `o3`, `o4-mini`, `gpt-5-mini`, `gpt-5-nano`, `o3-mini`, `codex-mini-latest`, `gpt-5.3-codex-spark`).

**Impact**

Users reviewing their own runs conclude the product is broken while the run record says `succeeded` and the work products are present. It also costs operator time: the same transcript makes a healthy run look like an incident.

Related prior art, same family of problem (a non-failure signal being read as failure): #9751, #9905.

## What Changed

- Added a narrow, anchored `NON_FATAL_ADVISORY_PATTERNS` list and an `isNonFatalAdvisory` helper to `packages/adapters/codex-local/src/ui/parse-stdout.ts`
- `parseCodexItem` now returns `kind: "system"` for an `error` item matching a known advisory, and continues to return `kind: "stderr"` for everything else
- Added two tests: one asserting the model-metadata advisory becomes a neutral notice, one asserting an unrecognised `error` item is still stderr (this second test is what keeps the match narrow)

### What this means in the rendered transcript

`stderr` entries render via `TranscriptStderrGroup` with error styling, at the top of the run. `system` entries are batched by `RunTranscriptView` into `TranscriptSystemGroup`, which renders as a neutral blue-tinted row reading "1 system message" and is **collapsed by default** (`useState(false)`), expandable by click.

So the advisory moves from "error styling, always expanded, first thing you see" to "neutral row, one click away". It is de-emphasised rather than shown inline, which is the intended outcome for a per-run condition the reader usually cannot act on. It is deliberately not `shouldHideNiceModeStderr`-style suppression, because falling back to default model metadata does change context-window and token accounting and should stay retrievable.

## Verification

```
npx vitest run packages/adapters/codex-local/src/ui/parse-stdout.test.ts
# Test Files 1 passed (1) / Tests 5 passed (5)
```

Manual reproduction of the input this fixes, which needs no credentials because the advisory is emitted before the first API call:

```
codex exec --json --skip-git-repo-check --model gpt-5.6-luna hi   # any invalid key
```

Note: `packages/adapters/codex-local/src/server/acp.test.ts > keeps the host staged Codex home after a clean teardown so a compatible resume can reuse it` fails on this branch. It fails identically on a clean `master` checkout with these changes stashed, so it is pre-existing and unrelated.

## Risks

Low risk, and the risk is deliberately bounded in one direction.

The only behavioural change is the transcript `kind` for `error` items whose text matches `/^model metadata for .+ not found\b/i`. Nothing about run status, error classification, retries, or billing is touched — those never consulted this code path.

The failure mode worth guarding against is an over-broad pattern silencing a genuine error, which is why the regex is anchored to the start of the message, requires a non-empty model name, and lives in an explicit list rather than a substring check. The second test exists specifically to fail if that narrowness regresses.

The trade-off to be explicit about: because `system` entries are collapsed by default, a reader who *wants* the advisory now has to expand one row to see it. That is the point for a condition that is not actionable mid-run, but it is a real reduction in prominence and not merely a restyle. If reviewers would rather it stay inline and visible, the alternative is a new neutral `kind` (e.g. `notice`) in `TranscriptEntry` plus a matching block type, which is a wider change across `adapter-utils` and the transcript renderer, and I am happy to take it that way instead.

## Model Used

Claude Opus 5 (Anthropic), model id `claude-opus-5[1m]`, 1M context window, extended thinking enabled, with tool use and code execution. Used to investigate the root cause, write the tests, and author the change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
