### PR TITLE
Support forced GitHub external-object refresh

### DIFF
--- a/server/src/__tests__/external-object-routes.test.ts
+++ b/server/src/__tests__/external-object-routes.test.ts
@@ -277,17 +277,29 @@ describe("external object routes", () => {
     expect(mockExternalObjectsService.refreshIssueObjects).not.toHaveBeenCalled();
   });
 
+  it("requires manual refresh force to be a boolean", async () => {
+    const app = await createApp(ownerActor());
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/external-objects/refresh`)
+      .send({ force: "true" });
+
+    expect(res.status).toBe(400);
+    expect(mockExternalObjectsService.refreshIssueObjects).not.toHaveBeenCalled();
+  });
+
   it("allows the checked-out agent to request manual refresh", async () => {
     const app = await createApp(ownerActor());
 
     const res = await request(app)
       .post(`/api/issues/${issueId}/external-objects/refresh`)
-      .send({});
+      .send({ force: true });
 
     expect(res.status).toBe(200);
     expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId);
     expect(mockExternalObjectsService.refreshIssueObjects).toHaveBeenCalledWith(issueId, expect.objectContaining({
       companyId,
+      force: true,
       actor: expect.objectContaining({ actorType: "agent", actorId: ownerAgentId }),
     }));
   });

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -328,11 +328,6 @@ describe("GitHub external object provider", () => {
       }),
       { ok: false, liveness: "unreachable", errorCode: "github_rate_limited" },
     ],
-    [
-      "not-found",
-      new Response("", { status: 404, headers: { etag: '"missing"' } }),
-      { ok: true, snapshot: expect.objectContaining({ displayKey: "GitHub Pull Request", iconKey: "github", statusKey: "not_found", statusIconKey: "archive", statusCategory: "archived", statusTone: "muted" }) },
-    ],
   ])("maps %s responses to provider-safe results", async (_name, githubResponse, expected) => {
     const provider = createGitHubExternalObjectProvider({} as any, {
       fetch: async () => githubResponse,
@@ -347,6 +342,25 @@ describe("GitHub external object provider", () => {
 
     expect(result).toEqual(expect.objectContaining(expected));
     expect(JSON.stringify(result)).not.toContain("http");
+  });
+
+  it.each([
+    ["anonymous", false, "auth_required", "github_auth_required"],
+    ["authenticated", true, "unreachable", "github_not_found_unverified"],
+  ])("treats a %s GitHub 404 as an unverified failure", async (_name, hasToken, liveness, errorCode) => {
+    const provider = createGitHubExternalObjectProvider({} as any, {
+      fetch: async () => new Response("", { status: 404, headers: { etag: '"missing"' } }),
+      tokenProvider: hasToken ? async () => "ghp_secret" : null,
+    });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toMatchObject({ ok: false, liveness, errorCode });
+    expect(JSON.stringify(result)).not.toContain("ghp_secret");
   });
 });
 
@@ -527,6 +541,75 @@ describeEmbeddedPostgres("externalObjectService", () => {
 
     expect(refreshed).toHaveLength(1);
     expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("bypasses refresh backoff only when forced through an issue refresh", async () => {
+    const { companyId, issueId } = await createIssue();
+    const resolve = vi.fn(async () => ({
+      ok: true as const,
+      snapshot: {
+        statusCategory: "open" as const,
+        statusTone: "info" as const,
+        statusKey: "open",
+        statusLabel: "Open",
+        ttlSeconds: 300,
+      },
+    }));
+    const resolver: ExternalObjectResolver = {
+      providerKey: "url",
+      objectType: "link",
+      resolve,
+    };
+    const svc = externalObjectService(db, { resolvers: [resolver], github: false });
+    await svc.syncIssue(issueId);
+    const object = await db.select().from(externalObjects).then((rows) => rows[0]!);
+    await db
+      .update(externalObjects)
+      .set({ nextRefreshAt: new Date(Date.now() + 60_000) })
+      .where(eq(externalObjects.id, object.id));
+
+    const skipped = await svc.refreshIssueObjects(issueId, { companyId });
+    const explicitlySkipped = await svc.refreshIssueObjects(issueId, { companyId, force: false });
+
+    expect(skipped).toMatchObject([{ refreshed: false, reason: "backoff" }]);
+    expect(explicitlySkipped).toMatchObject([{ refreshed: false, reason: "backoff" }]);
+    expect(resolve).not.toHaveBeenCalled();
+
+    const forced = await svc.refreshIssueObjects(issueId, { companyId, force: true });
+
+    expect(forced).toMatchObject([{ refreshed: true, reason: "resolved" }]);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains confirmed GitHub state when an anonymous 404 cannot verify visibility", async () => {
+    const { companyId, issueId } = await createIssue();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        state: "open",
+        draft: false,
+        merged: false,
+        title: "Visible PR",
+      })))
+      .mockResolvedValueOnce(new Response("", { status: 404 }));
+    const svc = externalObjectService(db, {
+      github: { fetch, tokenProvider: null },
+    });
+    await svc.syncIssue(issueId);
+    const object = await db.select().from(externalObjects).then((rows) => rows[0]!);
+
+    await svc.refreshObject(object.id, { companyId, force: true });
+    const failed = await svc.refreshObject(object.id, { companyId, force: true });
+    const updated = await db.select().from(externalObjects).then((rows) => rows[0]!);
+
+    expect(failed).toMatchObject({ refreshed: true, reason: "auth_required" });
+    expect(updated).toMatchObject({
+      statusKey: "open",
+      statusLabel: "Open",
+      isTerminal: false,
+      liveness: "auth_required",
+      lastErrorCode: "github_auth_required",
+    });
   });
 
   it("removes comment mentions when a synced comment is hard-deleted", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -204,6 +204,7 @@ const updateIssueRouteSchema = updateIssueSchema.extend({
 });
 const refreshExternalObjectsSchema = z.object({
   objectIds: z.array(z.string().uuid()).max(50).optional(),
+  force: z.boolean().optional(),
 }).strict();
 const inboxArchiveBodySchema = z.object({
   userId: z.string().trim().min(1).optional(),
@@ -5801,6 +5802,7 @@ export function issueRoutes(
     const results = await externalObjectsSvc.refreshIssueObjects(issue.id, {
       companyId: issue.companyId,
       objectIds: req.body.objectIds,
+      force: req.body.force,
       actor,
     });
     await logActivity(db, {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -527,6 +527,7 @@ const externalObjectSummariesBodySchema = z.object({
 
 const refreshExternalObjectsBodySchema = z.object({
   objectIds: z.array(z.string().uuid()).max(50).optional(),
+  force: z.boolean().optional(),
 }).strict();
 
 const environmentCustomImageCompanyQuerySchema = z.object({

--- a/server/src/services/external-objects.ts
+++ b/server/src/services/external-objects.ts
@@ -889,6 +889,7 @@ export function externalObjectService(
   async function refreshIssueObjects(issueId: string, input: {
     companyId: string;
     objectIds?: string[];
+    force?: boolean;
     actor?: Pick<LogActivityInput, "actorType" | "actorId" | "agentId" | "runId">;
   }) {
     if (!(await isEnabled())) return [];
@@ -898,7 +899,11 @@ export function externalObjectService(
       .filter((id) => !input.objectIds || input.objectIds.includes(id));
     const results = [];
     for (const objectId of objectIds) {
-      results.push(await refreshObject(objectId, { companyId: input.companyId, actor: input.actor }));
+      results.push(await refreshObject(objectId, {
+        companyId: input.companyId,
+        force: input.force,
+        actor: input.actor,
+      }));
     }
     return results;
   }

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -165,29 +165,6 @@ function failureFromGitHubResponse(response: Response): ExternalObjectResolveRes
   return null;
 }
 
-function notFoundSnapshot(identity: GitHubObjectIdentity, etag: string | null): ExternalObjectResolverSnapshot {
-  return {
-    displayKey: displayKeyFor(identity),
-    iconKey: "github",
-    displayTitle: displayTitleFor(identity),
-    statusKey: "not_found",
-    statusLabel: "Not found",
-    statusIconKey: "archive",
-    statusCategory: "archived",
-    statusTone: "muted",
-    isTerminal: true,
-    etag,
-    ttlSeconds: GITHUB_OBJECT_TTL_SECONDS,
-    data: {
-      provider: "github",
-      owner: identity.owner,
-      repo: identity.repo,
-      number: identity.number,
-      notFound: true,
-    },
-  };
-}
-
 function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string, unknown>, etag: string | null): ExternalObjectResolverSnapshot {
   const title = asString(body.title);
   const state = asString(body.state) ?? "unknown";
@@ -402,7 +379,15 @@ export function createGitHubExternalObjectProvider(
 
         const etag = response.headers.get("etag");
         if (response.status === 404) {
-          return { ok: true, snapshot: notFoundSnapshot(identity, etag) };
+          return {
+            ok: false,
+            liveness: token ? "unreachable" : "auth_required",
+            errorCode: token ? "github_not_found_unverified" : "github_auth_required",
+            errorMessage: token
+              ? "GitHub could not verify whether this object exists or is accessible."
+              : "GitHub authentication is required to verify whether this object exists.",
+            retryAfterSeconds: retryAfterSeconds(response),
+          };
         }
 
         const failure = failureFromGitHubResponse(response);

--- a/ui/src/api/externalObjects.ts
+++ b/ui/src/api/externalObjects.ts
@@ -11,7 +11,7 @@ export const externalObjectsApi = {
       `/companies/${companyId}/issues/external-object-summaries`,
       { issueIds },
     ),
-  refreshIssueObjects: (issueId: string, data?: { objectIds?: string[] }) =>
+  refreshIssueObjects: (issueId: string, data?: { objectIds?: string[]; force?: boolean }) =>
     api.post<{ refreshed: unknown[] }>(`/issues/${issueId}/external-objects/refresh`, data ?? {}),
   getProjectSummary: (projectId: string) =>
     api.get<ExternalObjectSummary>(`/projects/${projectId}/external-object-summary`),


### PR DESCRIPTION
## Summary
- add a strict optional `force` flag to issue External Object refresh requests and propagate it through the service so callers can bypass TTL backoff
- treat GitHub 404 responses as visibility-unverified failures instead of terminal Not Found state, preserving the last confirmed status
- update the OpenAPI and UI client contracts and cover the behavior with focused route and service tests

## Verification
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/external-object-routes.test.ts src/__tests__/external-objects-service.test.ts` — 34 passed
- `pnpm --filter @paperclipai/server typecheck` — passed
- `pnpm --filter @paperclipai/ui typecheck` — passed
- `git diff --check upstream/master...HEAD` — passed
- independent correctness review — passed with no blockers

## Test plan
- [ ] Confirm refresh without `force` still returns backoff for an object whose next refresh is not due
- [ ] Confirm refresh with `force: true` contacts the resolver despite active backoff
- [ ] Confirm anonymous GitHub 404 returns `auth_required` without replacing prior state
- [ ] Confirm authenticated GitHub 404 returns `unreachable` without creating terminal Not Found state
