### PR TITLE
fix(adapter-utils): classify provider quota refusals in the ACPX engine

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1373,6 +1373,72 @@ describe("shared ACPX engine runtime behavior", () => {
   });
 });
 
+describe("ACPX engine provider quota classification", () => {
+  // Verbatim terminal message from a Claude session-limit refusal. Reported as a
+  // plain `acpx_turn_failed` it disarms the server's wait-for-reset recovery,
+  // which then re-wakes the agent straight into the same exhausted quota.
+  const SESSION_LIMIT_MESSAGE =
+    "Internal error: You've hit your session limit · resets 8am (Europe/Moscow)";
+
+  async function runFailingTurn(errorMessage: string) {
+    const execute = createAcpxEngineExecutor({
+      now: () => new Date("2026-07-27T00:30:00.000Z").getTime(),
+      createRuntime: () =>
+        ({
+          ensureSession: async () => ({
+            backendSessionId: "backend-session",
+            agentSessionId: "agent-session",
+            runtimeSessionName: "runtime-session",
+          }),
+          startTurn: () => ({
+            events: (async function* () {
+              yield { type: "done", stopReason: "error" };
+            })(),
+            result: Promise.resolve({
+              status: "failed",
+              stopReason: "error",
+              error: { message: errorMessage },
+            }),
+            cancel: async () => {},
+          }),
+          setConfigOption: async () => {},
+          close: async () => {},
+        }) as never,
+    });
+
+    return await execute({
+      runId: "run-quota",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "claude" },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+      onEvent: async () => {},
+    } as never);
+  }
+
+  it("reports a session-limit refusal as provider quota with the advertised reset", async () => {
+    const result = await runFailingTurn(SESSION_LIMIT_MESSAGE);
+
+    expect(result.errorCode).toBe("provider_quota");
+    expect(result.errorFamily).toBe("provider_quota");
+    // 8am Europe/Moscow on the day of the refusal.
+    expect(result.retryNotBefore).toBe("2026-07-27T05:00:00.000Z");
+    const resultJson = result.resultJson as Record<string, unknown>;
+    expect(resultJson.errorFamily).toBe("provider_quota");
+    expect(resultJson.providerQuotaRetryNotBefore).toBe("2026-07-27T05:00:00.000Z");
+  });
+
+  it("leaves unrelated turn failures on the generic turn-failed code", async () => {
+    const result = await runFailingTurn("connection reset by peer");
+
+    expect(result.errorCode).toBe("acpx_turn_failed");
+    expect(result.errorFamily ?? null).toBeNull();
+    expect(result.retryNotBefore ?? null).toBeNull();
+  });
+});
+
 describe("findAncestorBin", () => {
   async function writeFakeBin(dir: string, name: string) {
     const binDir = path.join(dir, "node_modules", ".bin");

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -58,6 +58,7 @@ import {
   type PaperclipSkillEntry,
 } from "@paperclipai/adapter-utils/server-utils";
 import { shellQuote } from "@paperclipai/adapter-utils/ssh";
+import { classifyProviderQuotaFailure } from "@paperclipai/adapter-utils/provider-quota";
 import {
   createAcpRuntime,
   createAgentRegistry,
@@ -2230,6 +2231,16 @@ function classifyError(
     ...(stackPreview ? { stackPreview } : {}),
     ...(phase ? { phase } : {}),
   };
+  // Quota exhaustion arrives as an ordinary thrown turn error. Classify it
+  // before the phase codes so it keeps its dedicated wait-for-reset recovery
+  // instead of collapsing into `acpx_turn_failed`.
+  const quota = classifyProviderQuotaFailure(message);
+  if (quota) {
+    return {
+      errorCode: quota.errorCode,
+      errorMeta: { category: "provider_quota", ...baseMeta },
+    };
+  }
   const lower = message.toLowerCase();
   const authLike = lower.includes("auth") || lower.includes("login") || lower.includes("credential");
   if (authLike) {
@@ -2896,6 +2907,12 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         ? formatAdapterExecutionTimeoutErrorMessage(prepared.timeoutResolution)
         : resultErrorMessage(terminal);
       const terminalStopReason = terminal.status === "failed" ? terminal.error.message : terminal.stopReason;
+      // A quota refusal is not a generic turn failure: reporting it as one hides
+      // it from the server's provider-quota wait path, which then re-wakes the
+      // agent against an exhausted quota instead of waiting for the reset.
+      const quota = terminal.status === "failed" && !timedOut
+        ? classifyProviderQuotaFailure(errorMessage, new Date(now()))
+        : null;
       await emitAcpxLog(ctx, {
         type: terminal.status === "completed" ? "acpx.result" : "acpx.error",
         summary: terminal.status,
@@ -2909,7 +2926,12 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         signal: timedOut ? "SIGTERM" : null,
         timedOut,
         errorMessage,
-        errorCode: terminal.status === "failed" ? "acpx_turn_failed" : timedOut ? "acpx_timeout" : null,
+        errorCode: quota
+          ? quota.errorCode
+          : terminal.status === "failed" ? "acpx_turn_failed" : timedOut ? "acpx_timeout" : null,
+        ...(quota
+          ? { errorFamily: quota.errorFamily, retryNotBefore: quota.retryNotBefore }
+          : {}),
         sessionId: sessionHandle.backendSessionId ?? sessionHandle.runtimeSessionName,
         sessionParams: buildSessionParams({ prepared, handle: sessionHandle }),
         sessionDisplayId: sessionHandle.agentSessionId ?? sessionHandle.backendSessionId ?? sessionHandle.runtimeSessionName,
@@ -2925,6 +2947,14 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           requestedModel: prepared.requestedModel || null,
           requestedThinkingEffort: prepared.requestedThinkingEffort || null,
           fastMode: prepared.fastMode,
+          ...(quota ? { errorFamily: quota.errorFamily } : {}),
+          ...(quota?.retryNotBefore
+            ? {
+                retryNotBefore: quota.retryNotBefore,
+                transientRetryNotBefore: quota.retryNotBefore,
+                providerQuotaRetryNotBefore: quota.retryNotBefore,
+              }
+            : {}),
           ...(turnUsage.usageDetail ? { usage: turnUsage.usageDetail } : {}),
           ...(turnUsage.cumulativeCostUsd != null
             ? { cumulativeCostUsd: turnUsage.cumulativeCostUsd }
@@ -2962,17 +2992,31 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
       });
       await cleanupRemoteBridges(prepared);
       flushChildStderr(childStderrState);
+      const thrownQuota = timedOut ? null : classifyProviderQuotaFailure(message, new Date(now()));
       return {
         exitCode: 1,
         signal: timedOut ? "SIGTERM" : null,
         timedOut,
         errorMessage: message,
         errorCode: timedOut ? "acpx_timeout" : classified.errorCode,
+        ...(thrownQuota
+          ? { errorFamily: thrownQuota.errorFamily, retryNotBefore: thrownQuota.retryNotBefore }
+          : {}),
         errorMeta: classified.errorMeta,
         ...billingFields,
         model: prepared.requestedModel || null,
         clearSession: clearSession || timedOut,
-        resultJson: { phase: "turn" },
+        resultJson: {
+          phase: "turn",
+          ...(thrownQuota ? { errorFamily: thrownQuota.errorFamily } : {}),
+          ...(thrownQuota?.retryNotBefore
+            ? {
+                retryNotBefore: thrownQuota.retryNotBefore,
+                transientRetryNotBefore: thrownQuota.retryNotBefore,
+                providerQuotaRetryNotBefore: thrownQuota.retryNotBefore,
+              }
+            : {}),
+        },
         summary: message,
       };
     }

--- a/packages/adapter-utils/src/provider-quota.test.ts
+++ b/packages/adapter-utils/src/provider-quota.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyProviderQuotaFailure,
+  isProviderQuotaMessage,
+  parseProviderQuotaRetryNotBefore,
+} from "./provider-quota.js";
+
+// Verbatim terminal message from a Claude session-limit refusal surfaced through
+// the ACP protocol path, where no adapter stdout exists to classify against.
+const SESSION_LIMIT_MESSAGE =
+  "Internal error: You've hit your session limit · resets 8am (Europe/Moscow)";
+
+describe("isProviderQuotaMessage", () => {
+  it("matches a session limit refusal", () => {
+    expect(isProviderQuotaMessage(SESSION_LIMIT_MESSAGE)).toBe(true);
+  });
+
+  it("matches the typographic apostrophe variant", () => {
+    expect(isProviderQuotaMessage("You’ve hit your session limit")).toBe(true);
+  });
+
+  it("matches usage-limit phrasings", () => {
+    expect(isProviderQuotaMessage("Claude usage limit reached")).toBe(true);
+    expect(isProviderQuotaMessage("weekly limit reached")).toBe(true);
+    expect(isProviderQuotaMessage("ServiceQuotaExceededException")).toBe(true);
+  });
+
+  it("does not match unrelated turn failures", () => {
+    expect(isProviderQuotaMessage("ACP_TURN_FAILED: connection reset by peer")).toBe(false);
+    expect(isProviderQuotaMessage("tool use limit exceeded for this turn")).toBe(false);
+    expect(isProviderQuotaMessage(null)).toBe(false);
+    expect(isProviderQuotaMessage("")).toBe(false);
+  });
+});
+
+describe("parseProviderQuotaRetryNotBefore", () => {
+  it("resolves the advertised reset in the zone named by the message", () => {
+    // 2026-07-27T00:30Z is 03:30 in Europe/Moscow (UTC+3), so 8am resets the same day.
+    const now = new Date("2026-07-27T00:30:00.000Z");
+    const retryAt = parseProviderQuotaRetryNotBefore(SESSION_LIMIT_MESSAGE, now);
+    expect(retryAt?.toISOString()).toBe("2026-07-27T05:00:00.000Z");
+  });
+
+  it("rolls to the next day when the reset hour already passed", () => {
+    // 09:00 Moscow is past 8am, so the next reset is tomorrow.
+    const now = new Date("2026-07-27T06:00:00.000Z");
+    const retryAt = parseProviderQuotaRetryNotBefore(SESSION_LIMIT_MESSAGE, now);
+    expect(retryAt?.toISOString()).toBe("2026-07-28T05:00:00.000Z");
+  });
+
+  it("returns null when the message advertises no reset time", () => {
+    expect(parseProviderQuotaRetryNotBefore("You've hit your session limit")).toBeNull();
+  });
+});
+
+describe("classifyProviderQuotaFailure", () => {
+  it("classifies a session limit refusal as provider quota with a reset instant", () => {
+    const now = new Date("2026-07-27T00:30:00.000Z");
+    expect(classifyProviderQuotaFailure(SESSION_LIMIT_MESSAGE, now)).toEqual({
+      errorCode: "provider_quota",
+      errorFamily: "provider_quota",
+      retryNotBefore: "2026-07-27T05:00:00.000Z",
+    });
+  });
+
+  it("classifies a quota refusal without a reset hint", () => {
+    expect(classifyProviderQuotaFailure("out of extra usage")).toEqual({
+      errorCode: "provider_quota",
+      errorFamily: "provider_quota",
+      retryNotBefore: null,
+    });
+  });
+
+  it("leaves other failures unclassified", () => {
+    expect(classifyProviderQuotaFailure("ACP_TURN_FAILED: connection reset by peer")).toBeNull();
+  });
+});

--- a/packages/adapter-utils/src/provider-quota.ts
+++ b/packages/adapter-utils/src/provider-quota.ts
@@ -1,0 +1,158 @@
+/**
+ * Provider quota detection shared by every adapter execution path.
+ *
+ * Quota exhaustion is not a normal turn failure: the server has a dedicated
+ * recovery path for it (wait for the reset instead of re-assigning the issue and
+ * re-waking the agent). That path is keyed on `errorCode: "provider_quota"` /
+ * `errorFamily: "provider_quota"`, so any execution path that reports a quota
+ * refusal as a generic failure silently disarms it.
+ *
+ * The CLI adapters (`claude-local`, `codex-local`) each carry their own copy of
+ * this matching. This module holds the message-level core so protocol-based
+ * execution paths — which never see adapter stdout — can classify the same way.
+ */
+
+const PROVIDER_QUOTA_MESSAGE_RE =
+  /(?:you(?:'|’)ve\s+hit\s+your\s+(?:session|usage)\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|usage\s+limit\s+(?:reached|exceeded)|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|quota\s+(?:limit\s+)?exceeded|servicequotaexceededexception)/i;
+
+const PROVIDER_QUOTA_RESET_RE =
+  /(?:you(?:'|’)ve\s+hit\s+your\s+(?:session|usage)\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+(?:reached|exceeded)|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!·]|\n|$)/i;
+
+const CLOCK_TIME_RE = /^(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?/i;
+
+/** Whether a provider refusal message reports exhausted quota. */
+export function isProviderQuotaMessage(text: string | null | undefined): boolean {
+  if (!text) return false;
+  return PROVIDER_QUOTA_MESSAGE_RE.test(text);
+}
+
+/**
+ * Resolve the next occurrence of `hour:minute` in an IANA time zone. The reset
+ * hint carries a zone name ("resets 8am (Europe/Moscow)"), so the wall clock has
+ * to be interpreted there rather than in the host's local zone.
+ */
+function nextClockTimeInTimeZone(input: {
+  now: Date;
+  hour: number;
+  minute: number;
+  timeZoneHint: string;
+}): Date | null {
+  const { now, hour, minute, timeZoneHint } = input;
+  const timeZone = timeZoneHint.trim();
+  if (!timeZone) return null;
+  let formatter: Intl.DateTimeFormat;
+  try {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return null;
+  }
+
+  // Offsets change across DST boundaries, so converge instead of assuming one.
+  const zoneOffsetMs = (at: Date): number | null => {
+    const parts = formatter.formatToParts(at);
+    const read = (type: string) => {
+      const value = parts.find((part) => part.type === type)?.value;
+      return value ? Number.parseInt(value, 10) : Number.NaN;
+    };
+    const asUtc = Date.UTC(read("year"), read("month") - 1, read("day"), read("hour"), read("minute"), read("second"));
+    if (Number.isNaN(asUtc)) return null;
+    return asUtc - at.getTime();
+  };
+
+  const buildAt = (dayOffset: number): Date | null => {
+    const offsetNow = zoneOffsetMs(now);
+    if (offsetNow === null) return null;
+    const zoneNow = new Date(now.getTime() + offsetNow);
+    let candidate = new Date(
+      Date.UTC(
+        zoneNow.getUTCFullYear(),
+        zoneNow.getUTCMonth(),
+        zoneNow.getUTCDate() + dayOffset,
+        hour,
+        minute,
+        0,
+        0,
+      ) - offsetNow,
+    );
+    for (let i = 0; i < 3; i += 1) {
+      const offsetCandidate = zoneOffsetMs(candidate);
+      if (offsetCandidate === null) return null;
+      const adjustment = offsetNow - offsetCandidate;
+      if (adjustment === 0) break;
+      candidate = new Date(candidate.getTime() + adjustment);
+    }
+    return candidate;
+  };
+
+  const sameDay = buildAt(0);
+  if (!sameDay) return null;
+  if (sameDay.getTime() > now.getTime()) return sameDay;
+  return buildAt(1);
+}
+
+function parseResetClockTime(clockText: string, now: Date, timeZoneHint?: string | null): Date | null {
+  const match = clockText.trim().replace(/\s+/g, " ").match(CLOCK_TIME_RE);
+  if (!match) return null;
+
+  const hour12 = Number.parseInt(match[1] ?? "", 10);
+  const minute = Number.parseInt(match[2] ?? "0", 10);
+  if (!Number.isInteger(hour12) || hour12 < 1 || hour12 > 12) return null;
+  if (!Number.isInteger(minute) || minute < 0 || minute > 59) return null;
+
+  let hour24 = hour12 % 12;
+  if ((match[3] ?? "").toLowerCase() === "p") hour24 += 12;
+
+  if (timeZoneHint) {
+    const explicitRetryAt = nextClockTimeInTimeZone({ now, hour: hour24, minute, timeZoneHint });
+    if (explicitRetryAt) return explicitRetryAt;
+  }
+
+  const retryAt = new Date(now);
+  retryAt.setHours(hour24, minute, 0, 0);
+  if (retryAt.getTime() <= now.getTime()) retryAt.setDate(retryAt.getDate() + 1);
+  return retryAt;
+}
+
+/** Reset instant advertised by a quota refusal, when it states one. */
+export function parseProviderQuotaRetryNotBefore(
+  text: string | null | undefined,
+  now = new Date(),
+): Date | null {
+  if (!text) return null;
+  const match = text.match(PROVIDER_QUOTA_RESET_RE);
+  if (!match) return null;
+  return parseResetClockTime(match[1] ?? "", now, match[2]);
+}
+
+export interface ProviderQuotaClassification {
+  errorCode: "provider_quota";
+  errorFamily: "provider_quota";
+  /** ISO instant when the quota resets, or `null` when the message omits it. */
+  retryNotBefore: string | null;
+}
+
+/**
+ * Classify a failure message as provider quota exhaustion. Returns `null` for
+ * every other failure so callers keep their existing classification.
+ */
+export function classifyProviderQuotaFailure(
+  text: string | null | undefined,
+  now = new Date(),
+): ProviderQuotaClassification | null {
+  if (!isProviderQuotaMessage(text)) return null;
+  const retryAt = parseProviderQuotaRetryNotBefore(text, now);
+  return {
+    errorCode: "provider_quota",
+    errorFamily: "provider_quota",
+    retryNotBefore: retryAt ? retryAt.toISOString() : null,
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Runs execute through adapters; the shared ACPX engine in `packages/adapter-utils` drives every ACP-protocol adapter, while `claude-local` / `codex-local` also have a CLI path that parses adapter stdout
> - Provider quota exhaustion has dedicated server handling: `errorCode`/`errorFamily` `provider_quota` routes a run into a wait-for-reset recovery instead of escalating the issue as a lost execution path
> - Only the CLI path ever sets it. The ACPX engine reports every terminal failure as `acpx_turn_failed` with no `errorFamily`, so a quota refusal arriving over the protocol looks like a generic crash
> - The consequence is a self-reinforcing loop: the issue is escalated and re-assigned, the agent is re-woken into the same exhausted quota, and the new run dies in seconds — each failure spending budget while producing nothing
> - This pull request adds a message-level provider-quota detector to `adapter-utils` and applies it on both ACPX engine failure paths, so protocol adapters classify quota the same way the CLI adapters already do
> - The benefit is that quota exhaustion parks the run until the advertised reset instead of fanning out escalations and burning the remaining quota on instant retries

## Linked Issues or Issue Description

No public issue exists, so the bug is described here following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened.** An agent running through the ACPX engine hit a Claude session limit. The adapter surfaced the terminal error `Internal error: You've hit your session limit · resets 8am (Europe/Moscow)`. The run was recorded with `error_code = acpx_turn_failed` and no `errorFamily`. Because neither marker says `provider_quota`, the server did not park the run until the reset: it treated the issue as having lost its execution path, escalated it, and re-woke the agent — which immediately failed the same way.

**Expected behavior.** A quota refusal reaching the engine should be reported as `errorCode: "provider_quota"` / `errorFamily: "provider_quota"`, with `retryNotBefore` taken from the reset time the message advertises, so the existing wait-for-reset recovery engages.

**Steps to reproduce.**
1. Run any ACP-protocol adapter through the shared ACPX engine until the provider refuses the turn for quota reasons (or stub the runtime so the turn resolves `{ status: "failed", error: { message: "Internal error: You've hit your session limit · resets 8am (Europe/Moscow)" } }`).
2. Inspect the returned `AdapterExecutionResult`.
3. Before this change: `errorCode: "acpx_turn_failed"`, `errorFamily` absent, `retryNotBefore` absent. After: `provider_quota` on both, with the parsed reset instant.

**Version.** `master` at `2568bdecc`.

**Measured impact on one instance.** Over a 36-hour window, 879 runs died on a provider session limit; every one carried `errorFamily = <none>` and `error_code = acpx_turn_failed`, so the quota wait path never engaged once. Failing runs averaged ~24s against ~649s for successful runs, i.e. the retry storm itself consumed the quota.

Related work, none of which touches the ACPX engine path:
- Refs #9288 — classifies quota in the `claude-local` CLI adapter and the recovery service
- Refs #10203 — classifies provider credit exhaustion in the recovery service
- Refs #9863 — regression coverage for the session-limit string in `claude-local` parsing

## What Changed

- Added `packages/adapter-utils/src/provider-quota.ts`: message-level quota detection (`isProviderQuotaMessage`), reset-time parsing including the IANA zone hint the message carries (`parseProviderQuotaRetryNotBefore`), and a combined `classifyProviderQuotaFailure` returning `errorCode` / `errorFamily` / `retryNotBefore`.
- ACPX engine, terminal-failure path: a `failed` turn result whose message reads as quota exhaustion now returns `provider_quota` instead of `acpx_turn_failed`, plus `errorFamily` and `retryNotBefore`; `resultJson` also carries `errorFamily`, `retryNotBefore`, `transientRetryNotBefore` and `providerQuotaRetryNotBefore` for the server-side readers.
- ACPX engine, thrown-error path: `classifyError` recognises quota before the phase codes, and the catch-branch result carries the same family and retry instant.
- Tests: unit coverage for the detector (`provider-quota.test.ts`) and engine-level coverage in `acpx-engine/execute.test.ts` for both the quota case and an unrelated failure that must stay `acpx_turn_failed`.

Timeouts are deliberately excluded — a timed-out turn keeps `acpx_timeout` even if the partial message mentions quota.

## Verification

```
npx vitest run packages/adapter-utils/src/provider-quota.test.ts
# 10 passed

npx vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts
# 82 passed
```

Red-before/green-after on the engine test, with only `execute.ts` reverted:

```
# execute.ts at master, new tests present
× reports a session-limit refusal as provider quota with the advertised reset
  → expected 'acpx_turn_failed' to be 'provider_quota'
# with the fix
✓ 2 passed
```

Full `packages/adapter-utils` suite on my machine: 310 passed, 11 failed. The 11 failures reproduce identically on unmodified `master` in the same checkout (`local-process-sandbox` — bubblewrap, Linux-only; `spawn-smoke`; `remote-spawn-smoke`; `workspace-restore-merge`; `mcp-isolation.integration`) and are macOS/environment-bound, not related to this change. I could not run a clean repo-wide `pnpm typecheck` locally (my checkout resolves a different `acpx` build and fails on pre-existing unrelated type errors in `acpx-engine`), so I am leaving the CI checkboxes unchecked for the reviewer's gates to answer.

## Risks

Low, and bounded by the matcher. The detector only fires on explicit quota phrasing; every other failure keeps its current classification, which the second engine test pins. The behavioral shift is intended: an affected run now reports `provider_quota` and, when the message advertises a reset, `retryNotBefore`, so the server parks it instead of escalating. No schema, migration, or public API change; the new module is additive.

The reset parser trusts the zone name in the provider message and falls back to host-local time when the zone is absent or unparseable; a wrong zone can only shift the wait window, not break the classification. The CLI adapters keep their own copies of this matching — folding them onto the shared detector is a mechanical follow-up I left out to keep this diff reviewable.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution (repo checkout, test runs against a local worktree).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no docs describe engine error classification; the new module is documented in-file
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not yet run at open time
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not yet run at open time
- [x] I will address all Greptile and reviewer comments before requesting merge
