### PR TITLE
fix(server): reject done while first-class blockers remain open

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -919,4 +919,35 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       svc.count(companyId, { attention: "blocked", assigneeAgentId: "not-a-uuid" }),
     ).rejects.toThrow(/assigneeAgentId/i);
   });
+
+  it("reports unresolved first-class blockers on false-done issues so attention matches diagnostics", async () => {
+    const { companyId } = await createCompany("BFD");
+    const parentId = await insertIssue({
+      companyId,
+      identifier: "BFD-1",
+      title: "False done packaging",
+      status: "done",
+    });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "BFD-2",
+      title: "Capture gate still open",
+      status: "blocked",
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "done" })).find((issue) => issue.id === parentId);
+    const readiness = await svc.getDependencyReadiness(parentId);
+
+    expect(readiness).toMatchObject({
+      unresolvedBlockerCount: 1,
+      isDependencyReady: false,
+    });
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: readiness.unresolvedBlockerCount,
+      attentionBlockerCount: readiness.unresolvedBlockerCount,
+    });
+  });
 });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -90,7 +90,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
   async function insertIssue(input: {
     companyId: string;
     id?: string;
-    identifier: string;
+    identifier: string | null;
     title: string;
     status: string;
     parentId?: string | null;
@@ -949,6 +949,39 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       unresolvedBlockerCount: readiness.unresolvedBlockerCount,
       attentionBlockerCount: readiness.unresolvedBlockerCount,
       sampleBlockerIdentifier: "BFD-2",
+    });
+    expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe(blockerId);
+  });
+
+  it("does not expose a raw UUID when a false-done blocker has a null identifier", async () => {
+    const { companyId } = await createCompany("BFN");
+    const parentId = await insertIssue({
+      companyId,
+      identifier: "BFN-1",
+      title: "False done with null-identifier blocker",
+      status: "done",
+    });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: null,
+      title: "Capture gate without identifier",
+      status: "blocked",
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "done" })).find((issue) => issue.id === parentId);
+    const readiness = await svc.getDependencyReadiness(parentId);
+
+    expect(readiness).toMatchObject({
+      unresolvedBlockerCount: 1,
+      isDependencyReady: false,
+    });
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: readiness.unresolvedBlockerCount,
+      attentionBlockerCount: readiness.unresolvedBlockerCount,
+      sampleBlockerIdentifier: null,
     });
     expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe(blockerId);
   });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -948,6 +948,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       reason: "attention_required",
       unresolvedBlockerCount: readiness.unresolvedBlockerCount,
       attentionBlockerCount: readiness.unresolvedBlockerCount,
+      sampleBlockerIdentifier: "BFD-2",
     });
+    expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe(blockerId);
   });
 });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1552,6 +1552,58 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     });
   });
 
+  it("keeps recovery active when source reaches done while first-class blockers remain open", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    const blockerId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerId,
+      companyId,
+      title: "Still-open blocker",
+      status: "blocked",
+      priority: "high",
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: sourceIssueId,
+      type: "blocks",
+    });
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "stranded_assigned_issue",
+      fingerprint: "stranded:false-done-with-blockers",
+      evidence: { latestIssueStatus: "blocked" },
+      nextAction: "Keep packaging parked until capture gate clears.",
+      wakePolicy: { type: "manual" },
+    });
+    // Bypass service update to simulate the historical false-done bug path.
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, sourceIssueId));
+    const app = createApp();
+
+    const detail = await request(app).get(`/api/issues/${sourceIssueId}`).expect(200);
+
+    expect(detail.body).toMatchObject({
+      id: sourceIssueId,
+      status: "done",
+      activeRecoveryAction: { id: action.id, status: "active" },
+    });
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      id: action.id,
+      status: "active",
+      outcome: null,
+      resolvedAt: null,
+    });
+  });
+
   it("keeps active recovery visible when a plain comment does not create a live path", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3953,6 +3953,71 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 
+  it("rejects explicit done while first-class blockers remain open", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerId = randomUUID();
+    const dependentId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerId, companyId, title: "Open blocker", status: "blocked", priority: "medium" },
+      { id: dependentId, companyId, title: "Dependent", status: "in_progress", priority: "medium" },
+    ]);
+    await svc.update(dependentId, { blockedByIssueIds: [blockerId], status: "blocked" });
+
+    await expect(svc.update(dependentId, { status: "done" })).rejects.toThrow(
+      /blocked by unresolved blockers/i,
+    );
+    await expect(svc.getById(dependentId)).resolves.toMatchObject({
+      id: dependentId,
+      status: "blocked",
+    });
+  });
+
+  it("heals remain-done with open first-class blockers back to blocked on next update", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockerId = randomUUID();
+    const dependentId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerId, companyId, title: "Open blocker", status: "todo", priority: "medium" },
+      {
+        id: dependentId,
+        companyId,
+        title: "False done dependent",
+        status: "done",
+        priority: "medium",
+        completedAt: new Date("2026-07-27T09:00:00.000Z"),
+      },
+    ]);
+    // Simulate a pre-guard false-done with an open first-class edge.
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: dependentId,
+      type: "blocks",
+    });
+
+    const healed = await svc.update(dependentId, { title: "False done dependent (healed)" });
+    expect(healed).toMatchObject({
+      id: dependentId,
+      status: "blocked",
+      title: "False done dependent (healed)",
+    });
+    expect(healed?.completedAt).toBeNull();
+  });
+
   it("unblocks a source issue when a liveness escalation recovery issue is marked done", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2943,7 +2943,7 @@ export function issueRoutes(
     if (issue.status === "done" || issue.status === "cancelled") {
       // False terminal: done while first-class blockers remain open is not a valid
       // resolution. Keep recovery active so stranded work is not cancelled solely
-      // because status flipped to done under an open dependency (SFB-321 / SFB-305).
+      // because status flipped to done under an open dependency.
       if (issue.status === "done") {
         const readiness = await svc.getDependencyReadiness(issue.id);
         if (readiness.unresolvedBlockerCount > 0) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2941,6 +2941,15 @@ export function issueRoutes(
   }): Promise<string | null> {
     const { issue } = input;
     if (issue.status === "done" || issue.status === "cancelled") {
+      // False terminal: done while first-class blockers remain open is not a valid
+      // resolution. Keep recovery active so stranded work is not cancelled solely
+      // because status flipped to done under an open dependency (SFB-321 / SFB-305).
+      if (issue.status === "done") {
+        const readiness = await svc.getDependencyReadiness(issue.id);
+        if (readiness.unresolvedBlockerCount > 0) {
+          return null;
+        }
+      }
       return `Recovery action became stale because the source issue reached ${issue.status}.`;
     }
     if (input.blockedToTodoRecovery === true) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2164,11 +2164,39 @@ async function listIssueBlockerAttentionMap(
   companyId: string,
   issueRows: IssueBlockerAttentionInputNode[],
 ): Promise<Map<string, IssueBlockerAttention>> {
+  // Full attention graph (explicit blockers + open children) is still scoped to
+  // blocked roots. Non-blocked issues still need unresolved first-class blocker
+  // counts so false-done / other inconsistent states agree with diagnostics.
   const roots = issueRows.filter((row) => row.companyId === companyId && row.status === "blocked");
   const attentionMap = new Map<string, IssueBlockerAttention>();
   for (const row of issueRows) {
     if (row.status !== "blocked") {
       attentionMap.set(row.id, createIssueBlockerAttention());
+    }
+  }
+  const nonBlockedRoots = issueRows.filter(
+    (row) => row.companyId === companyId && row.status !== "blocked" && row.status !== "cancelled",
+  );
+  if (nonBlockedRoots.length > 0) {
+    const readinessMap = await listIssueDependencyReadinessMap(
+      dbOrTx,
+      companyId,
+      nonBlockedRoots.map((row) => row.id),
+    );
+    for (const row of nonBlockedRoots) {
+      const readiness = readinessMap.get(row.id);
+      const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
+      if (unresolvedBlockerCount <= 0) continue;
+      attentionMap.set(
+        row.id,
+        createIssueBlockerAttention({
+          state: "needs_attention",
+          reason: "attention_required",
+          unresolvedBlockerCount,
+          attentionBlockerCount: unresolvedBlockerCount,
+          sampleBlockerIdentifier: readiness?.unresolvedBlockerIssueIds[0] ?? null,
+        }),
+      );
     }
   }
   if (roots.length === 0) return attentionMap;
@@ -6511,6 +6539,23 @@ export function issueService(db: Db) {
         if (values.status === "cancelled") {
           values.cancelledAt = new Date();
         }
+        // Reject create-as-done / create-as-in_progress when first-class blockers
+        // are already open. Escape hatch is omitting the blocker edges (or later
+        // removing them with an audit trail), not a force-done flag.
+        if (
+          (values.status === "in_progress" || values.status === "done") &&
+          blockedByIssueIds !== undefined &&
+          blockedByIssueIds.length > 0
+        ) {
+          const unresolvedBlockerIssueIds = await listUnresolvedBlockerIssueIds(
+            tx,
+            companyId,
+            blockedByIssueIds,
+          );
+          if (unresolvedBlockerIssueIds.length > 0) {
+            throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+          }
+        }
         Object.assign(
           values,
           buildInitialIssueMonitorFields({
@@ -6623,14 +6668,32 @@ export function issueService(db: Db) {
       if (patch.status === "in_progress" && !nextAssigneeAgentId && !nextAssigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
-      if (patch.status === "in_progress") {
-        const unresolvedBlockerIssueIds = blockedByIssueIds !== undefined
-          ? await listUnresolvedBlockerIssueIds(dbOrTx, existing.companyId, blockedByIssueIds)
-          : (
-              await listIssueDependencyReadinessMap(dbOrTx, existing.companyId, [id])
-            ).get(id)?.unresolvedBlockerIssueIds ?? [];
-        if (unresolvedBlockerIssueIds.length > 0) {
-          throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+      // Reject in_progress / explicit done when first-class blockers are still open.
+      // Also heal a false "remain done" state (status already done, blockers still open)
+      // back to blocked so done cannot settle while dependencies remain unresolved.
+      // Escape hatch is intentional blocker-edge removal (blockedByIssueIds / relation
+      // delete with audit), not a force-done flag.
+      {
+        const requestedStatus = patch.status;
+        const nextStatus = requestedStatus ?? existing.status;
+        if (nextStatus === "in_progress" || nextStatus === "done") {
+          const unresolvedBlockerIssueIds = blockedByIssueIds !== undefined
+            ? await listUnresolvedBlockerIssueIds(dbOrTx, existing.companyId, blockedByIssueIds)
+            : (
+                await listIssueDependencyReadinessMap(dbOrTx, existing.companyId, [id])
+              ).get(id)?.unresolvedBlockerIssueIds ?? [];
+          if (unresolvedBlockerIssueIds.length > 0) {
+            if (nextStatus === "in_progress" || requestedStatus === "done") {
+              throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+            }
+            // remaining done with open first-class blockers → coerce to blocked
+            patch.status = "blocked";
+            patch.completedAt = null;
+            if (existing.status !== "blocked") {
+              patch.blockedTransitionAt = patch.updatedAt ?? new Date();
+              patch.blockedOwnerNotifiedAt = null;
+            }
+          }
         }
       }
       const shouldValidateNextAssignee =
@@ -6694,14 +6757,17 @@ export function issueService(db: Db) {
         });
       }
 
-      applyStatusSideEffects(issueData.status, patch);
-      if (issueData.status && issueData.status !== "done") {
+      // Use effective status so heal-to-blocked side effects (completedAt clear)
+      // still apply when the caller did not send status explicitly.
+      const effectiveStatus = (patch.status ?? issueData.status) as string | undefined;
+      applyStatusSideEffects(effectiveStatus, patch);
+      if (effectiveStatus && effectiveStatus !== "done") {
         patch.completedAt = null;
       }
-      if (issueData.status && issueData.status !== "cancelled") {
+      if (effectiveStatus && effectiveStatus !== "cancelled") {
         patch.cancelledAt = null;
       }
-      if (issueData.status && issueData.status !== "in_progress") {
+      if (effectiveStatus && effectiveStatus !== "in_progress") {
         patch.checkoutRunId = null;
         patch.executionRunId = null;
         patch.executionAgentNameKey = null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2183,10 +2183,28 @@ async function listIssueBlockerAttentionMap(
       companyId,
       nonBlockedRoots.map((row) => row.id),
     );
+    const sampleBlockerIds = [
+      ...new Set(
+        nonBlockedRoots
+          .map((row) => readinessMap.get(row.id)?.unresolvedBlockerIssueIds[0] ?? null)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    const sampleIdentifierById = new Map<string, string | null>();
+    if (sampleBlockerIds.length > 0) {
+      const sampleRows = await dbOrTx
+        .select({ id: issues.id, identifier: issues.identifier })
+        .from(issues)
+        .where(inArray(issues.id, sampleBlockerIds));
+      for (const sampleRow of sampleRows) {
+        sampleIdentifierById.set(sampleRow.id, sampleRow.identifier);
+      }
+    }
     for (const row of nonBlockedRoots) {
       const readiness = readinessMap.get(row.id);
       const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
       if (unresolvedBlockerCount <= 0) continue;
+      const sampleBlockerId = readiness?.unresolvedBlockerIssueIds[0] ?? null;
       attentionMap.set(
         row.id,
         createIssueBlockerAttention({
@@ -2194,7 +2212,9 @@ async function listIssueBlockerAttentionMap(
           reason: "attention_required",
           unresolvedBlockerCount,
           attentionBlockerCount: unresolvedBlockerCount,
-          sampleBlockerIdentifier: readiness?.unresolvedBlockerIssueIds[0] ?? null,
+          sampleBlockerIdentifier: sampleBlockerId
+            ? (sampleIdentifierById.get(sampleBlockerId) ?? sampleBlockerId)
+            : null,
         }),
       );
     }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2212,8 +2212,9 @@ async function listIssueBlockerAttentionMap(
           reason: "attention_required",
           unresolvedBlockerCount,
           attentionBlockerCount: unresolvedBlockerCount,
+          // Human-readable sample only. Never fall back to a raw UUID when identifier is null.
           sampleBlockerIdentifier: sampleBlockerId
-            ? (sampleIdentifierById.get(sampleBlockerId) ?? sampleBlockerId)
+            ? (sampleIdentifierById.get(sampleBlockerId) ?? null)
             : null,
         }),
       );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issue dependency edges (`blocks`) and recovery revalidation decide when work is terminal
> - An issue could settle as `done` while unresolved first-class blockers remained open
> - Recovery then treated that false terminal as a real resolution and cancelled stranded recovery
> - This pull request rejects and heals false-done terminals, keeps recovery active under open blockers, and aligns blocker attention counts with diagnostics
> - The benefit is dependency-honest terminal state and recovery that cannot cancel work solely because status flipped to done under an open edge

## Linked Issues or Issue Description

### Bug: issue can reach done while first-class blockers remain open

## What happened?

An issue with unresolved first-class `blocks` edges can settle as `done`. Recovery revalidation then treats that status as a valid terminal and cancels stranded recovery, even though dependency readiness still reports open blockers. `blockerAttention.unresolvedBlockerCount` can also disagree with diagnostics for the same issue when status is not `blocked`.

## Expected behavior

1. An issue with unresolved first-class blockers cannot transition to or remain `done` until blockers clear or the edge is intentionally removed.
2. `blockerAttention.unresolvedBlockerCount` agrees with dependency diagnostics for the same issue.
3. Recovery reconcile does not cancel a stranded recovery solely because status flipped to `done` while dependencies remain blocked.
4. Sample blocker identifiers stay human-readable.

## Steps to reproduce

1. Create issue A blocked by open issue B (`blocks` edge).
2. Force or allow A to become `done` while B is still open.
3. Observe A remains `done` with unresolved blockers.
4. Observe stranded recovery on A cancel with "source issue reached done".
5. Observe `blockerAttention.unresolvedBlockerCount` may be 0 while diagnostics report unresolved blockers.

## Paperclip version or commit

Branch `fix/done-with-open-first-class-blockers` at `b10deef4` (fork of paperclipai/paperclip master).

## Deployment mode

Self-hosted server

## What Changed

- Reject create/update transitions to `done` or `in_progress` when unresolved first-class blockers remain
- Heal already-false-done issues back to `blocked` on the next update while open blockers remain
- Project unresolved first-class blocker counts onto non-blocked issues so attention matches diagnostics
- Resolve sample blocker identifiers to human-readable issue identifiers (not raw UUIDs)
- Keep stranded recovery active when source reaches `done` under open first-class blockers
- Add regression tests for reject, heal, attention agreement, and recovery keep-active paths

## Verification

```bash
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/issue-blocker-attention.test.ts \
  src/__tests__/issue-recovery-actions.test.ts \
  src/__tests__/issues-service.test.ts \
  -t 'false-done|first-class blockers|rejects explicit done|heals remain-done'
```

Local result: targeted regression tests passed (5/5 selected).

## Risks

- Behavioral shift: explicit `done` / `in_progress` while open first-class blockers now returns unprocessable instead of accepting the write
- Healing path rewrites a remaining false-done to `blocked` on next update; operators who intentionally want done-with-open-edge must remove the edge first
- Non-blocked attention projection adds a readiness lookup for non-blocked list rows; scoped to non-cancelled statuses and only material when unresolved blockers exist

## Model Used

- Provider: xAI Grok via Hermes custom provider
- Model: grok-4.5
- Tool use and code execution enabled in Hermes local agent session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
