### PR TITLE
fix(server): unwrap the plugin tool envelope in MCP gateway responses

### DIFF
--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -730,7 +730,7 @@ describeEmbeddedPostgres("tool gateway service", () => {
       parameters: { target: "tampered" },
     });
     expect(result.status).toBe("completed");
-    expect((result.result as { result?: { data?: { target?: string } } }).result?.data?.target).toBe("repo");
+    expect((result.result as { data?: { target?: string } }).data?.target).toBe("repo");
   });
 
   it("maps remote MCP elicitation to a durable issue interaction", async () => {

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -3907,6 +3907,92 @@ rl.on("line", (line) => {
     ]);
   });
 
+  it("returns spec-valid MCP results for plugin tools over the gateway protocol", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const results: Record<string, { content?: string; data?: unknown; error?: string }> = {
+      "demo-plugin:structured": { content: "structured ok", data: { ok: true } },
+      "demo-plugin:text_only": { content: "text only" },
+      "demo-plugin:failing": { error: "plugin refused the call" },
+    };
+    const dispatcher: PluginToolDispatcher = {
+      initialize: async () => {},
+      teardown: () => {},
+      listToolsForAgent: () => Object.keys(results).map((name) => ({
+        name,
+        displayName: name,
+        description: "Plugin tool fixture.",
+        parametersSchema: { type: "object" },
+        pluginId: "demo-plugin",
+      })),
+      getTool: () => null,
+      executeTool: async (tool) => ({
+        pluginId: "demo-plugin",
+        toolName: tool.split(":")[1]!,
+        result: results[tool]!,
+      }),
+      registerPluginTools: () => {},
+      unregisterPluginTools: () => {},
+      toolCount: () => Object.keys(results).length,
+      getRegistry: () => {
+        throw new Error("not used");
+      },
+    };
+
+    const gateway = createTestToolGatewayService(db, { pluginToolDispatcher: dispatcher });
+    const profile = await allowToolsForAgent(db, company.id, agent.id, Object.keys(results));
+    const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+
+    await expect(gateway.executeTool({
+      sessionToken: session.token,
+      tool: "demo-plugin:structured",
+      parameters: {},
+    })).resolves.toMatchObject({
+      status: "completed",
+      result: { content: "structured ok", data: { ok: true } },
+    });
+
+    const created = await gateway.createNamedGateway({
+      companyId: company.id,
+      body: { name: "Plugin MCP surface", profileId: profile.id },
+    });
+    const app = createGatewayRouteApp(db, gateway);
+    const endpoint = `/mcp/gateways/${created.gatewayPublicId}`;
+
+    const structured = await request(app)
+      .post(endpoint)
+      .set("authorization", `Bearer ${session.token}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "demo-plugin:structured", arguments: {} } })
+      .expect(200);
+    expect(structured.body.result).toEqual({
+      content: [{ type: "text", text: "structured ok" }],
+      structuredContent: { ok: true },
+      isError: false,
+    });
+
+    const textOnly = await request(app)
+      .post(endpoint)
+      .set("authorization", `Bearer ${session.token}`)
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "demo-plugin:text_only", arguments: {} } })
+      .expect(200);
+    expect(textOnly.body.result).toEqual({
+      content: [{ type: "text", text: "text only" }],
+      isError: false,
+    });
+    expect(textOnly.body.result).not.toHaveProperty("structuredContent");
+
+    const failing = await request(app)
+      .post(endpoint)
+      .set("authorization", `Bearer ${session.token}`)
+      .send({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "demo-plugin:failing", arguments: {} } })
+      .expect(200);
+    expect(failing.body.result).toEqual({
+      content: [{ type: "text", text: "plugin refused the call" }],
+      isError: true,
+    });
+  });
+
   it("rejects caller-supplied issue context outside the run company", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -3915,6 +3915,7 @@ rl.on("line", (line) => {
       "demo-plugin:structured": { content: "structured ok", data: { ok: true } },
       "demo-plugin:text_only": { content: "text only" },
       "demo-plugin:failing": { error: "plugin refused the call" },
+      "demo-plugin:empty_error": { error: "", content: "ignored on failure" },
     };
     const dispatcher: PluginToolDispatcher = {
       initialize: async () => {},
@@ -3989,6 +3990,16 @@ rl.on("line", (line) => {
       .expect(200);
     expect(failing.body.result).toEqual({
       content: [{ type: "text", text: "plugin refused the call" }],
+      isError: true,
+    });
+
+    const emptyError = await request(app)
+      .post(endpoint)
+      .set("authorization", `Bearer ${session.token}`)
+      .send({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "demo-plugin:empty_error", arguments: {} } })
+      .expect(200);
+    expect(emptyError.body.result).toEqual({
+      content: [{ type: "text", text: "ignored on failure" }],
       isError: true,
     });
   });

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -130,7 +130,7 @@ async function handleMcpGatewayProtocol(
         ? result.result as Record<string, unknown>
         : null;
       const toolError = typeof resultRecord?.error === "string" ? resultRecord.error : null;
-      const contentText = toolError
+      const contentText = toolError !== null && toolError.length > 0
         ? toolError
         : typeof resultRecord?.content === "string"
         ? resultRecord.content
@@ -145,7 +145,7 @@ async function handleMcpGatewayProtocol(
         result: {
           content: [{ type: "text", text: contentText }],
           ...(structuredContent === undefined ? {} : { structuredContent }),
-          isError: Boolean(toolError),
+          isError: toolError !== null,
         },
       });
       return;

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -129,16 +129,23 @@ async function handleMcpGatewayProtocol(
       const resultRecord = result.result && typeof result.result === "object" && !Array.isArray(result.result)
         ? result.result as Record<string, unknown>
         : null;
-      const contentText = typeof resultRecord?.content === "string"
+      const toolError = typeof resultRecord?.error === "string" ? resultRecord.error : null;
+      const contentText = toolError
+        ? toolError
+        : typeof resultRecord?.content === "string"
         ? resultRecord.content
         : JSON.stringify(resultRecord?.data ?? result.result ?? null);
+      const structuredContent =
+        resultRecord?.data && typeof resultRecord.data === "object" && !Array.isArray(resultRecord.data)
+          ? resultRecord.data as Record<string, unknown>
+          : undefined;
       res.json({
         jsonrpc: "2.0",
         id,
         result: {
           content: [{ type: "text", text: contentText }],
-          structuredContent: resultRecord?.data ?? null,
-          isError: false,
+          ...(structuredContent === undefined ? {} : { structuredContent }),
+          isError: Boolean(toolError),
         },
       });
       return;

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -5746,7 +5746,7 @@ export function createToolGatewayService(
           connectedMcpExecution
             ? connectedMcpExecution.result
             : tool.providerType === "paperclip_plugin"
-            ? await runWithTimeout(
+            ? (await runWithTimeout(
                 pluginToolDispatcher!.executeTool(
                   tool.name,
                   effectiveParameters,
@@ -5758,7 +5758,7 @@ export function createToolGatewayService(
                   },
                 ),
                 executionTimeoutMs,
-              )
+              )).result
             : await runWithTimeout(executeBuiltinTool(session, tool, effectiveParameters), executionTimeoutMs);
 
         const resultValidation = validateToolContent({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach governed capabilities through the tool gateway, which serves builtin tools, connected MCP servers, and plugin-contributed tools behind one policy layer
> - The gateway exposes those tools over a JSON-RPC MCP endpoint, so any spec-compliant MCP client can call them
> - Plugin tools are dispatched through `pluginToolDispatcher.executeTool`, which returns a routing envelope rather than a bare `ToolResult` like every other provider
> - That envelope is stored unnormalised, so the MCP response builder reads the wrong object and emits `structuredContent: null`, which is invalid MCP and makes clients reject every plugin tool call
> - This pull request unwraps the envelope at the dispatch site and makes the response builder emit spec-valid results
> - The benefit is that plugin tools become callable over MCP at all, and plugin error text reaches the agent instead of being replaced by a schema-validation failure

## Linked Issues or Issue Description

No existing issue covers this defect. Following `bug_report.yml`:

**What happened.** Every call to a plugin-contributed tool through a gateway's MCP endpoint fails client-side response validation. The failure is independent of the tool and of its arguments. Policy, dispatch, and the plugin handler all succeed; only the MCP serialization is wrong. The client rejects the response with:

```
MCP server "..." returned a malformed result that failed schema validation:
[{ "expected": "record", "code": "invalid_type", "path": ["structuredContent"],
   "message": "Invalid input: expected record, received null" }]
```

**Expected behavior.** The tool result is returned to the client, as it already is for builtin, `mcp_remote_http`, and `mcp_local_stdio` tools.

**Steps to reproduce.**

1. Install a plugin declaring a tool that returns `{content, data}`.
2. Give an agent access to it through a gateway whose profile permits the tool.
3. Call the tool over the gateway's MCP endpoint from any spec-compliant MCP client.

**Cause.** `pluginToolDispatcher.executeTool` returns `ToolExecutionResult`, which is `{pluginId, toolName, result: ToolResult}` (`server/src/services/plugin-tool-registry.ts:83`). Every other provider yields a bare `ToolResult`. The gateway stores whichever it got without normalising (`server/src/services/tool-gateway.ts:5748`), so for plugin tools `result.result` is the envelope, not the `ToolResult`. The MCP response builder then reads the bare shape (`server/src/routes/tool-gateway.ts:129-142`): `resultRecord.content` is `undefined`, so the content falls back to a JSON dump of the whole envelope, and `resultRecord?.data` is `undefined`, so `structuredContent` becomes `null`.

`structuredContent` is optional in MCP and must be an object when present, so `null` invalidates the entire response.

The same file already applies exactly this unwrap for local stdio tools at `server/src/services/tool-gateway.ts:4199`, `(await executeLocalStdioTool(...)).result`, which suggests the plugin branch was overlooked rather than intentionally different.

Two adjacent defects live in the same twelve-line response builder and are fixed here as well, because the first one alone does not make the endpoint spec-valid:

- `structuredContent: resultRecord?.data ?? null` still emits `null` for any tool that returns `content` without `data`, even after the envelope is unwrapped.
- `isError` is hardcoded `false`, so a `ToolResult` carrying `error` is reported as success and the plugin's own error text is dropped. The agent sees a schema-validation failure instead of the reason its call was rejected.

**Version.** Reproduced on `2026.724.0-canary.2` and `2026.726.0-canary.0`; both affected identically. Confirmed still present on `master` at `2568bdec`.

**Deployment mode.** Self-hosted.

**Why HTTP callers never saw this.** `/api/plugins/tools/execute` and `/api/tool-gateway/tools/call` return the envelope and let the caller unwrap it. Only the JSON-RPC route consumes the result positionally, so only it is broken.

**Related issues, not duplicates.** #6707, #4192 and #6818 all describe plugin tools never reaching a managed agent run in the first place. That is a delivery gap upstream of this one; reaching this defect currently requires working around it. They can land independently, but both are needed before plugin tools are usable end to end.

**Related pull requests, not duplicates.** #1355 and #4716 address that same delivery gap from the adapter side. #5702 is adjacent rather than related: its diff is dynamic tool registration across the plugin SDK, host services, dispatcher and registry, with no adapter or run-delivery changes. An earlier revision of this section grouped it with the other two, which was wrong. I checked each against this change: none of them touches `server/src/routes/tool-gateway.ts` or `server/src/services/tool-gateway.ts`, so none fixes the serialization defect, and this PR does not overlap their work. If any of them lands first it makes this one reachable in practice rather than conflicting with it.

## What Changed

- `server/src/services/tool-gateway.ts`: unwrap the dispatcher envelope at the plugin dispatch site so plugin results are shape-identical to builtin and connected-MCP results everywhere downstream, matching what the local stdio branch already does.
- `server/src/routes/tool-gateway.ts`: omit `structuredContent` when there is no structured object to report, instead of emitting `null`; map a `ToolResult` whose `error` field is present to `isError: true`, using the error text as content when it is non-empty.
- `server/src/__tests__/tool-gateway.test.ts`: add gateway-protocol coverage for plugin tools, which had none.
- `server/src/__tests__/tool-gateway-service.test.ts`: update one existing assertion that reached the echoed parameter through the envelope (`result.result.result.data.target`) to the unwrapped path (`result.result.data.target`). The test is about rejecting tampered parameters after board approval; its intent is unchanged and it still asserts the approved value won.
- No documentation changes. Nothing under `doc/` describes the MCP gateway response shape, so there is no page that goes stale: a repository search for `structuredContent` under `doc/` returns zero matches. No telemetry events are added, removed or modified, so the Telemetry Data Contract is unaffected.

## Verification

```bash
pnpm test
pnpm --filter @paperclipai/server typecheck
```

To run only the tests that cover this change:

```bash
pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-gateway.test.ts src/__tests__/tool-gateway-service.test.ts
```

One caveat on the wider suite, so it does not surprise a reviewer. `pnpm test` at the repo root reports four failures on this branch, none of them in the tool gateway:

- two in `heartbeat-workspace-branch-containment.test.ts`, comparing a recorded `/tmp/...` path against a resolved `/private/tmp/...` one. That is the macOS `/tmp` symlink, so it cannot occur on Linux CI;
- one in `workspace-runtime.test.ts`, adopting a live auto-port shared service;
- one in `issue-recovery-actions.test.ts`, which fails with `socket hang up` rather than an assertion.

The first three fail identically on `master` at `2568bdec` with none of this applied, so they are pre-existing on macOS rather than anything this branch introduces. The fourth is a dropped connection to the test database and looks like local flake. This change touches only `routes/tool-gateway.ts` and `services/tool-gateway.ts`.

The new test `returns spec-valid MCP results for plugin tools over the gateway protocol` covers three cases through the real MCP endpoint with a stubbed dispatcher:

- a tool returning `{content, data}` yields `structuredContent` equal to `data`, not the routing envelope;
- a tool returning only `content` yields a response with no `structuredContent` key at all;
- a tool returning `error` yields `isError: true` with the error text as content.

It also asserts at the service layer that `executeTool` resolves a bare `ToolResult` for a plugin tool.

Each of the three defects is covered independently, checked by reverting them one at a time:

| Reverted | Test fails on |
| --- | --- |
| the service unwrap only | `pluginId` and `toolName` leaking into the gateway result |
| the route response builder only | `structuredContent: null` on the tool that returns no `data` |
| `isError: Boolean(toolError)` only | `isError` reported `false` for a tool that returned `error` |

So no part of this change is unverified, and none of the three is carried by another's assertion.

`executePluginTool`, the non-gateway path used by `/api/plugins/tools/execute`, still returns the envelope and its existing coverage is unchanged.

One existing assertion in `tool-gateway-service.test.ts` changed, and it is the only place in the suite that observed the envelope through the gateway. It navigated `result.result.result.data.target` purely to read back an echoed parameter; the fix shortens that to `result.result.data.target`. Nothing about what the test proves has changed.

## Risks

Low, but not confined to plugin tools, and an earlier revision of this section said otherwise. The response builder in `server/src/routes/tool-gateway.ts` runs after the provider-agnostic `executeTool`, so the `structuredContent` and `isError` changes apply to builtin, `mcp_remote_http` and `mcp_local_stdio` results as well. That is intended, since `structuredContent: null` was invalid for those providers too, but the regression coverage added here exercises the plugin path only.

- The unwrap narrows what the gateway stores for `paperclip_plugin` tools from the envelope to its `result` field. Anything downstream that read `pluginId` or `toolName` off a gateway result would lose them, but the audit trail records tool identity separately via `toolAuditMetadata(tool)` and does not read them from the result.
- Omitting `structuredContent` rather than sending `null` is strictly closer to the MCP schema; clients treat absent and null-but-optional identically at best, and reject the latter at worst.
- The `isError` change makes failing calls report as failures, for every provider rather than only plugins. A client that was somehow relying on tool errors arriving as successful responses would see the change, but that path currently fails schema validation anyway. `isError` keys off the presence of `error` rather than its truthiness, so a result carrying an empty error string is still reported as a failure.
- No schema, migration, telemetry, or public API contract changes.

## Model Used

Claude Opus 5 (Anthropic), model ID `claude-opus-5`, 200K context, extended thinking enabled, with tool use and code execution. Used to trace the defect against the shipped source, port the fix from a runtime patch to repository source, and write the regression test. All changes were reviewed and verified by running the suite locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

