### PR TITLE
test: cover create-time issue blocker links

### DIFF
--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -87,6 +87,41 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     return parent;
   }
 
+  it("persists create-time blocker links and returns them in the created issue", async () => {
+    const companyId = await seedCompany();
+    const blocker = await seedParent(companyId);
+    const app = createApp();
+
+    const created = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Blocked launch work",
+        status: "blocked",
+        blockedByIssueIds: [blocker.id],
+      })
+      .expect(201);
+
+    expect(created.body.blockedBy).toEqual([
+      expect.objectContaining({
+        id: blocker.id,
+        identifier: blocker.identifier,
+        title: blocker.title,
+      }),
+    ]);
+
+    const fetched = await request(app)
+      .get(`/api/issues/${created.body.id}`)
+      .expect(200);
+
+    expect(fetched.body.blockedBy).toEqual([
+      expect.objectContaining({
+        id: blocker.id,
+        identifier: blocker.identifier,
+        title: blocker.title,
+      }),
+    ]);
+  });
+
   it("replays the existing issue for the same company idempotency key", async () => {
     const companyId = await seedCompany();
     const parent = await seedParent(companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane people use to coordinate AI-agent work.
> - Issue dependencies are first-class board mechanics that must survive issue creation.
> - The service layer already persists `blockedByIssueIds` transactionally and decorates create responses after #8901.
> - The public create route did not have an end-to-end regression proving that contract.
> - Without route-level coverage, a validator or route mapping regression could again return success while silently dropping dependency data.
> - This pull request exercises the real HTTP and database path for create-time blockers.
> - The benefit is an executable contract that prevents successful creates from silently losing blocker links.

## Linked Issues or Issue Description

Refs #8901

Bug regression:
- What happened: an issue create request containing `blockedByIssueIds` could report success while its response omitted the requested blocker relation.
- Expected behavior: a successful create persists the blocker edge and returns it immediately; a subsequent read returns the same edge.
- Steps to verify: create a blocker, create a blocked issue with the blocker's ID, then inspect both the `201` response and a fresh issue read.
- Paperclip version/commit: regression coverage added on current `master`.
- Deployment mode: local trusted integration-test environment.

Related public work:
- #8901 implemented create-response relation summaries.
- #4099 covers blocker readback shape more broadly.

## What Changed

- Added an embedded-Postgres route regression that creates an issue with `blockedByIssueIds`.
- Asserted both the `201` create response and a subsequent `GET` contain the persisted blocker summary.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-create-deduplication-routes.test.ts` — 9/9 passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `pnpm test:run` — 2,823 passed, 1 skipped, 2 unrelated failures in `workspace-runtime.test.ts` caused by local auto-port adoption/collision behavior (`EADDRINUSE`).
- `bin/ci` is absent; the repository-documented gates above were used.

## Risks

Low risk. This changes test coverage only. The test uses the existing embedded-Postgres harness and does not alter production behavior.

> `ROADMAP.md` contains no matching blocker/create-contract work. This is regression coverage for an existing behavior, not a new core feature.

## Model Used

OpenAI Codex, GPT-5, with reasoning and repository-aware shell/code execution tools. The serving context-window size is managed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
