### PR TITLE
feat(claude-local): offer Claude Opus 5 and Sonnet 5 in the model list

### DIFF
--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -7,6 +7,8 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @anthropic-ai/claude-code
 
 export const models = [
   { id: "claude-opus-4-8", label: "Claude Opus 4.8" },
+  { id: "claude-opus-5", label: "Claude Opus 5" },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5" },
   { id: "claude-fable-5", label: "Claude Fable 5" },
   { id: "claude-mythos-5", label: "Claude Mythos 5" },
   { id: "claude-opus-4-7", label: "Claude Opus 4.7" },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run on adapters; `claude_local` drives the Claude Code CLI, and its exported `models` array is the fallback list the model picker offers when dynamic discovery is unavailable
> - Claude Opus 5 and Claude Sonnet 5 ship in current Claude Code releases, but neither id is in that array
> - Operators on a Claude subscription have no `ANTHROPIC_API_KEY`, so `listAdapterModels("claude_local")` always falls back to the static array — for them these models simply do not exist in the UI
> - The gap is not cosmetic: on the CLI release we run, the `opus` / `sonnet` aliases still resolve to 4.8 / 4.6, so the explicit ids are the only way to reach these models at all
> - This pull request adds both ids to the fallback list, placed so the current default option does not change
> - The benefit is discoverability for subscription-based operators, with no behavioral change for anyone else

## Linked Issues or Issue Description

No existing issue covers this, so per option (B) the problem is described here following the feature-request shape.

**Problem.** `packages/adapters/claude-local/src/index.ts` exports a static `models` array, used as the fallback whenever the Anthropic `/v1/models` lookup cannot run (no API key — the normal case on a Claude subscription). The array offers Opus 4.8/4.7/4.6, Fable 5, Mythos 5, Sonnet 4.6/4.5 and Haiku 4.5, but not Opus 5 or Sonnet 5.

**Effect.** The model field in agent configuration is a creatable combobox, so an operator *can* type any id by hand — but the current models are not offered. Discoverability is zero, and a typo surfaces only later, as a model-unavailable failure at run time.

**Requested behavior.** Offer both current models in the fallback list, exactly as Fable 5 and Mythos 5 are already offered.

Related for reviewer context, not duplicates: #10243 (unavailable Bedrock aliases in model profiles) and #8171 (stale default model in `hermes_local`) both concern other adapters and neither adds these ids to `claude_local`.

## What Changed

- `packages/adapters/claude-local/src/index.ts`: added `claude-opus-5` and `claude-sonnet-5` to the exported `models` array, directly after `claude-opus-4-8` and before `claude-fable-5`.

Two added lines; no logic changes.

## Verification

- `npx vitest run server/src/__tests__/adapter-models.test.ts` → **17/17 pass**. This includes `returns claude fallback models including the latest Opus alias when no Anthropic key is available`, which asserts `models[0]?.id === "claude-opus-4-8"`. Placement after 4.8 keeps that assertion true — putting the new ids first fails it, which is exactly why they are not at the top.
- Both ids confirmed working against Claude Code 2.1.196: `claude -p "ok" --model claude-opus-5` and the same with `--model claude-sonnet-5` both return a normal response. On that release `--model opus` reports `claude-opus-4-8` and `--model sonnet` reports `claude-sonnet-4-6`, which is the evidence that the aliases do not reach these models.
- Branch is based on current `master` (`2568bdec`) and contains nothing else.

## Risks

Low risk.

- No migration, no schema change, no API surface change; the diff is data-only.
- The default option is deliberately preserved: `models[0]` stays `claude-opus-4-8`, matching the intent recorded in `adapter-models.test.ts` ("Newer flagship models are offered, but Opus 4.8 stays the default (first) option").
- Worst case: an operator selects a new id on an older CLI that does not know it, and the run fails with the CLI's own model-unavailable error — identical to the existing behavior for the Fable 5 / Mythos 5 entries.
- If maintainers prefer different ordering (alphabetical, or newest-first with the test assertion updated), I am happy to adjust.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, adaptive thinking, with tool use and local command execution. Used for the change, the local test run, and this description.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [x] My branch name describes the change (`contrib/add-claude-opus-5-sonnet-5`) and contains no internal ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — no new test: the change is data-only and `adapter-models.test.ts` already covers list contents and default ordering. Happy to add explicit assertions for the two new ids if you want them.
- [x] I have updated relevant documentation to reflect my changes — found none that enumerates adapter model ids; please point me at it if it exists.
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
