### PR TITLE
fix(heartbeat): reap detached runs after critical output silence

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -27,6 +27,7 @@ import {
   executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
+  heartbeatRunWatchdogDecisions,
   issueComments,
   issueDocuments,
   issuePlanDecompositions,
@@ -1194,6 +1195,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processPid: child.pid ?? null,
       includeIssue: false,
     });
+    // Fresh output keeps the detached run below the critical-silence reaper threshold.
+    await db
+      .update(heartbeatRuns)
+      .set({ lastOutputAt: new Date() })
+      .where(eq(heartbeatRuns.id, runId));
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reapOrphanedRuns();
@@ -1210,6 +1216,95 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(agentWakeupRequests.id, wakeupRequestId))
       .then((rows) => rows[0] ?? null);
     expect(wakeup?.status).toBe("claimed");
+  });
+
+  it("reaps a detached local run once output silence crosses the critical threshold", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    expect(mockTerminateLocalService).toHaveBeenCalledWith(
+      expect.objectContaining({ pid: child.pid, processGroupId: null }),
+      undefined,
+    );
+    expect(await waitForPidExit(child.pid!)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+    expect(run?.error).toContain("critical output silence");
+    expect(run?.error).toContain(String(child.pid));
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    const reapEvent = events.find((event) =>
+      typeof event.message === "string" && event.message.includes("critical output silence"),
+    );
+    expect(reapEvent?.payload).toMatchObject({
+      detachedProcessReaped: true,
+      processPid: child.pid,
+    });
+  });
+
+  it("does not reap a detached local run before the critical silence threshold", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({ lastOutputAt: new Date() })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+    expect(isPidAlive(child.pid)).toBe(true);
+  });
+
+  it("does not reap a critically silent detached run while the watchdog is snoozed", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { companyId, runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+    await db.insert(heartbeatRunWatchdogDecisions).values({
+      companyId,
+      runId,
+      decision: "snooze",
+      snoozedUntil: new Date(Date.now() + 60 * 60 * 1000),
+      reason: "operator is investigating",
+      createdByUserId: "board-user",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(0);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+    expect(isPidAlive(child.pid)).toBe(true);
   });
 
   it("skips generic timer wakes without invoking an adapter when no assigned work is actionable", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1307,6 +1307,116 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(isPidAlive(child.pid)).toBe(true);
   });
 
+  it("finalizes a critically silent detached run without signaling a recycled pid", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+    // The recorded spawn time predates the live process by hours: the pid was
+    // recycled by an unrelated process after the original child exited.
+    await db
+      .update(heartbeatRuns)
+      .set({ processStartedAt: new Date(Date.now() - 6 * 60 * 60 * 1000) })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    expect(mockTerminateLocalService).not.toHaveBeenCalled();
+    expect(isPidAlive(child.pid)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+    expect(run?.error).toContain("recycled");
+    expect(run?.error).toContain(String(child.pid));
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    const recycleEvent = events.find((event) =>
+      typeof event.message === "string" && event.message.includes("recycled"),
+    );
+    expect(recycleEvent?.payload).toMatchObject({
+      detachedPidRecycled: true,
+      processPid: child.pid,
+    });
+  });
+
+  it("does not signal the recorded process group when it is led by the recycled pid's new owner", async () => {
+    // detached: true makes the child its own process-group leader, so the
+    // recorded processGroupId equals the recycled pid and the whole group
+    // belongs to the stranger process.
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+      detached: true,
+    });
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      processGroupId: child.pid ?? null,
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({ processStartedAt: new Date(Date.now() - 6 * 60 * 60 * 1000) })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    expect(mockTerminateLocalService).not.toHaveBeenCalled();
+    expect(isPidAlive(child.pid)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+    expect(run?.error).toContain("recycled");
+  });
+
+  it("reaps a critically silent detached run when the live process start matches the recorded spawn time", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+    });
+    // Recorded spawn time matches the live process start (identity confirmed);
+    // lastOutputAt keeps the run critically silent (silence tracks lastOutputAt
+    // before processStartedAt).
+    await db
+      .update(heartbeatRuns)
+      .set({
+        processStartedAt: new Date(),
+        lastOutputAt: new Date(Date.now() - 6 * 60 * 60 * 1000),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    expect(mockTerminateLocalService).toHaveBeenCalledWith(
+      expect.objectContaining({ pid: child.pid, processGroupId: null }),
+      undefined,
+    );
+    expect(await waitForPidExit(child.pid!)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+    expect(run?.error).toContain("critical output silence");
+  });
+
   it("skips generic timer wakes without invoking an adapter when no assigned work is actionable", async () => {
     const { companyId, agentId } = await seedIdleTimerAgentFixture();
     const heartbeat = heartbeatService(db);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -48,6 +48,7 @@ import {
   executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
+  heartbeatRunWatchdogDecisions,
   issueApprovals,
   issueComments,
   issuePlanDecompositions,
@@ -337,6 +338,10 @@ export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
   ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
+} from "./recovery/service.js";
+import {
+  ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
+  silenceAgeMsForRun,
 } from "./recovery/service.js";
 export const ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS = 60 * 1000;
 export const ACTIVE_RUN_LOG_RUNTIME_STATUS_REFRESH_INTERVAL_MS = 5 * 1000;
@@ -5187,6 +5192,16 @@ function buildProcessLossMessage(run: {
   return "Process lost -- server may have restarted";
 }
 
+function buildDetachedProcessReapMessage(run: {
+  processPid: number | null;
+  processGroupId: number | null;
+}) {
+  const target = run.processGroupId
+    ? `process group ${run.processGroupId}`
+    : `child pid ${run.processPid ?? "unknown"}`;
+  return `Detached child process reaped after critical output silence -- ${target} was terminated (SIGTERM, then SIGKILL)`;
+}
+
 function readHotRestartAdoptionMetadata(resultJson: Record<string, unknown> | null | undefined) {
   const result = parseObject(resultJson);
   const hotRestart = parseObject(result.hotRestart);
@@ -8385,6 +8400,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return updated;
   }
 
+  // Mirrors recovery/service.ts latestActiveOutputQuietUntilDecision: an active
+  // snooze/continue watchdog decision means an operator deliberately let this run
+  // keep going, so the detached-process reaper must leave it alone.
+  async function hasActiveOutputQuietDecision(companyId: string, runId: string, now = new Date()) {
+    const [row] = await db
+      .select({ id: heartbeatRunWatchdogDecisions.id })
+      .from(heartbeatRunWatchdogDecisions)
+      .where(
+        and(
+          eq(heartbeatRunWatchdogDecisions.companyId, companyId),
+          eq(heartbeatRunWatchdogDecisions.runId, runId),
+          inArray(heartbeatRunWatchdogDecisions.decision, ["snooze", "continue"]),
+          gt(heartbeatRunWatchdogDecisions.snoozedUntil, now),
+        ),
+      )
+      .limit(1);
+    return row != null;
+  }
+
   async function patchRunIssueCommentStatus(
     runId: string,
     patch: Partial<Pick<typeof heartbeatRuns.$inferInsert, "issueCommentStatus" | "issueCommentSatisfiedByCommentId" | "issueCommentRetryQueuedAt">>,
@@ -11487,6 +11521,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ) {
         continue;
       }
+      let detachedReapSilenceMs: number | null = null;
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -11506,11 +11541,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             });
           }
         }
-        continue;
+        // The in-memory handle is gone, so this process can no longer be cancelled
+        // through the harness. While the child still produces output it may recover
+        // (see clearDetachedRunWarning / hot-restart adoption), but once output
+        // silence crosses the critical threshold — with no operator snooze — the
+        // orphan is reaped (SIGTERM, then SIGKILL) and the run is failed through the
+        // normal process-loss path instead of waiting for a manual operator kill.
+        const detachedSilenceMs = silenceAgeMsForRun(run, now);
+        const criticallySilent =
+          detachedSilenceMs !== null && detachedSilenceMs >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS;
+        if (!criticallySilent || (await hasActiveOutputQuietDecision(run.companyId, run.id, now))) {
+          continue;
+        }
+        detachedReapSilenceMs = detachedSilenceMs;
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
       }
+      const detachedReap = detachedReapSilenceMs !== null;
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      if (!detachedReap && processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,
@@ -11531,7 +11583,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         (tracksLocalChild && (!!run.processPid || !!run.processGroupId)) ||
         monitorDispatchLostWithoutFutureWake
       );
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const baseMessage = detachedReap
+        ? buildDetachedProcessReapMessage(run)
+        : buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
       const unmanagedBackgroundTaskEvidence = descendantOnlyCleanup
         ? {
           kind: "orphaned_process_group_cleanup",
@@ -11607,6 +11661,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
+          ...(detachedReap
+            ? { detachedProcessReaped: true, detachedSilenceMs: detachedReapSilenceMs }
+            : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
         },
       });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -157,7 +157,7 @@ import {
 import { buildPlanReviewContext } from "./plan-review-context.js";
 import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { workspaceOperationService, type WorkspaceOperationRecorder } from "./workspace-operations.js";
-import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
+import { isProcessGroupAlive, readProcessGroupId, terminateLocalService } from "./local-service-supervisor.js";
 import {
   HEARTBEAT_RUN_SCRATCH_MARKER,
   buildHeartbeatRunScratchEnv,
@@ -5152,6 +5152,37 @@ function isProcessAlive(pid: number | null | undefined) {
   }
 }
 
+const DETACHED_REAP_PID_START_TOLERANCE_MS = 60_000;
+
+// The detached-run reaper acts on a >=4h output-silence window, which is also
+// ample time for the OS to recycle the recorded pid after the original child
+// exits. isProcessAlive (kill(pid, 0)) is only an existence check, so a
+// newer, unrelated process that inherited the pid looks "alive" and would be
+// signaled. Before escalating to SIGTERM/SIGKILL, compare the live process's
+// start time (`ps -o lstart=`) with the spawn time persisted via onSpawn: a
+// materially newer start means the pid was recycled and must never be
+// signaled. Returns true only when recycling is positively identified; when
+// the start time cannot be determined (no recorded spawn time, ps
+// unsupported/failed, unparsable output) the caller proceeds, matching every
+// other terminateHeartbeatRunProcess call site.
+async function isRecordedPidRecycledByNewerProcess(input: {
+  pid: number;
+  processStartedAt: Date | null | undefined;
+}) {
+  const recordedStartMs = input.processStartedAt?.getTime();
+  if (typeof recordedStartMs !== "number" || Number.isNaN(recordedStartMs)) return false;
+  if (process.platform === "win32") return false;
+  let liveStartMs: number;
+  try {
+    const { stdout } = await execFile("ps", ["-o", "lstart=", "-p", String(input.pid)]);
+    liveStartMs = Date.parse(stdout.trim());
+  } catch {
+    return false;
+  }
+  if (Number.isNaN(liveStartMs)) return false;
+  return liveStartMs > recordedStartMs + DETACHED_REAP_PID_START_TOLERANCE_MS;
+}
+
 async function terminateHeartbeatRunProcess(input: {
   pid: number | null | undefined;
   processGroupId: number | null | undefined;
@@ -5179,9 +5210,12 @@ async function terminateHeartbeatRunProcess(input: {
 function buildProcessLossMessage(run: {
   processPid: number | null;
   processGroupId: number | null;
-}, options?: { descendantOnly?: boolean }) {
+}, options?: { descendantOnly?: boolean; pidRecycled?: boolean }) {
   if (options?.descendantOnly && run.processGroupId) {
     return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
+  }
+  if (options?.pidRecycled && run.processPid) {
+    return `Process lost -- recorded child pid ${run.processPid} was recycled by an unrelated process after the original child exited; the recycled process was left untouched`;
   }
   if (run.processPid) {
     return `Process lost -- child pid ${run.processPid} is no longer running`;
@@ -11522,6 +11556,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         continue;
       }
       let detachedReapSilenceMs: number | null = null;
+      let detachedPidRecycled = false;
+      let detachedProcessGroupRecycled = false;
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -11553,16 +11589,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (!criticallySilent || (await hasActiveOutputQuietDecision(run.companyId, run.id, now))) {
           continue;
         }
-        detachedReapSilenceMs = detachedSilenceMs;
-        await terminateHeartbeatRunProcess({
-          pid: run.processPid,
-          processGroupId: run.processGroupId,
-        });
+        // The silence window also gives the OS ample time to recycle the
+        // recorded pid after the original child exits: never signal a pid
+        // whose live start time is materially newer than the recorded spawn
+        // time — that is a different process that inherited the pid. When the
+        // recorded process group is led by that same recycled pid, the whole
+        // group belongs to the stranger (a group id is its leader's pid and
+        // cannot be recycled while any member holds it), so the descendant
+        // cleanup below is suppressed too; a surviving group not led by the
+        // recycled pid is still held by our own descendants and is cleaned up.
+        const recordedPid = run.processPid;
+        if (typeof recordedPid === "number") {
+          detachedPidRecycled = await isRecordedPidRecycledByNewerProcess({
+            pid: recordedPid,
+            processStartedAt: run.processStartedAt,
+          });
+          if (detachedPidRecycled && processGroupAlive && run.processGroupId) {
+            const recycledOwnerGroupId = await readProcessGroupId(recordedPid);
+            detachedProcessGroupRecycled =
+              recycledOwnerGroupId !== null && recycledOwnerGroupId === run.processGroupId;
+          }
+        }
+        if (!detachedPidRecycled) {
+          detachedReapSilenceMs = detachedSilenceMs;
+          await terminateHeartbeatRunProcess({
+            pid: run.processPid,
+            processGroupId: run.processGroupId,
+          });
+        }
       }
       const detachedReap = detachedReapSilenceMs !== null;
 
       let descendantOnlyCleanup = false;
-      if (!detachedReap && processGroupAlive) {
+      if (!detachedReap && !detachedProcessGroupRecycled && processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,
@@ -11585,7 +11644,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
       const baseMessage = detachedReap
         ? buildDetachedProcessReapMessage(run)
-        : buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+        : buildProcessLossMessage(run, {
+            ...(descendantOnlyCleanup ? { descendantOnly: true } : {}),
+            ...(detachedPidRecycled ? { pidRecycled: true } : {}),
+          });
       const unmanagedBackgroundTaskEvidence = descendantOnlyCleanup
         ? {
           kind: "orphaned_process_group_cleanup",
@@ -11664,6 +11726,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ...(detachedReap
             ? { detachedProcessReaped: true, detachedSilenceMs: detachedReapSilenceMs }
             : {}),
+          ...(detachedPidRecycled ? { detachedPidRecycled: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
         },
       });

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -285,7 +285,7 @@ export async function findAdoptableLocalService(input: {
   return record;
 }
 
-async function readProcessGroupId(pid: number) {
+export async function readProcessGroupId(pid: number) {
   if (process.platform === "win32") return null;
   try {
     const { stdout } = await execFileAsync("ps", ["-o", "pgid=", "-p", String(pid)]);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -82,6 +82,20 @@ export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 export const DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS = 60 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
+
+type RunOutputSilenceRun = Pick<
+  typeof heartbeatRuns.$inferSelect,
+  "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt"
+>;
+
+export function silenceStartedAtForRun(run: RunOutputSilenceRun) {
+  return run.lastOutputAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt ?? null;
+}
+
+export function silenceAgeMsForRun(run: RunOutputSilenceRun, now = new Date()) {
+  const startedAt = silenceStartedAtForRun(run);
+  return startedAt ? Math.max(0, now.getTime() - startedAt.getTime()) : null;
+}
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
@@ -1221,15 +1235,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Object.values(RECOVERY_ORIGIN_KINDS).includes(
       issue.originKind as typeof RECOVERY_ORIGIN_KINDS[keyof typeof RECOVERY_ORIGIN_KINDS],
     );
-  }
-
-  function silenceStartedAtForRun(run: Pick<typeof heartbeatRuns.$inferSelect, "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">) {
-    return run.lastOutputAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt ?? null;
-  }
-
-  function silenceAgeMsForRun(run: Pick<typeof heartbeatRuns.$inferSelect, "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">, now = new Date()) {
-    const startedAt = silenceStartedAtForRun(run);
-    return startedAt ? Math.max(0, now.getTime() - startedAt.getTime()) : null;
   }
 
   async function latestActiveOutputQuietUntilDecision(companyId: string, runId: string, now = new Date()) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat supervisor spawns local adapter child processes (claude_local, codex_local, opencode_local, …) and tracks them in-memory plus via persisted `processPid`/`processGroupId`
> - When the in-memory handle is lost while the child pid is still alive, `reapOrphanedRuns()` marks the run `process_detached` — and then `continue`s, forever; no kill is ever scheduled no matter how long the run stays silent
> - A hung provider stream (e.g. a stalled LLM SSE stream) therefore wedges a run in `running` state indefinitely: it holds its issue checkout/execution lock, and recovery requires a manual `kill` on the exec host
> - This pull request adds a reaper path for exactly that case: detached + output-silent past the critical threshold + no active operator snooze ⇒ terminate the recorded pid/process group (SIGTERM, then SIGKILL after the grace window) and fail the run through the existing process-loss finalization path
> - The benefit is that orphaned adapter processes are reaped automatically within one reaper sweep of crossing the critical silence threshold, while detached runs that still produce output, recover activity, get hot-restart-adopted, or were deliberately snoozed/continued by an operator are never killed

## Linked Issues or Issue Description

- Refs #6406 — same root cause (`process_detached` runs hang forever). This PR implements the R1 proposal with two extra safety gates on top of the basic silent-terminate: (a) termination is gated on the run's *output silence* crossing `ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS` (4h) rather than a short grace, so a live-but-detached child that is still streaming output is never killed; (b) an active operator `snooze`/`continue` watchdog decision suppresses the reap.
- Related prior attempts (all appear stale): #8539 (reaps in the stale-lock sweep instead of the orphan reaper), #6273 (kills 5 min after detach regardless of output), #4605, #6232.

## What Changed

- `server/src/services/heartbeat.ts`
  - `reapOrphanedRuns()`: after marking/confirming `process_detached` with a live pid, compute the run's output-silence age (`silenceAgeMsForRun`); if it is past the critical threshold and `hasActiveOutputQuietDecision()` is false, call `terminateHeartbeatRunProcess()` (existing SIGTERM → grace → SIGKILL escalation) and fall through to the shared process-loss finalization path (status `failed`, `errorCode: "process_lost"`, single `enqueueProcessLossRetry`, wakeup failure, environment-lease release, issue checkout release).
  - New `hasActiveOutputQuietDecision()` query — mirrors `latestActiveOutputQuietUntilDecision` in recovery/service.ts so an operator snooze/continue suppresses the reap.
  - New `buildDetachedProcessReapMessage()` and a `detachedProcessReaped`/`detachedSilenceMs` payload on the finalization run event for observability.
  - New `isRecordedPidRecycledByNewerProcess()` gate — before signaling, the live process's start time (`ps -o lstart=`) is compared with the `processStartedAt` persisted at spawn; a materially newer start (>60s) proves the pid was recycled by an unrelated process, so no signal is sent and the run is finalized as `process_lost` with a `detachedPidRecycled` event flag. The descendant-group cleanup is likewise suppressed when the recorded group is currently led by the recycled pid (group ids cannot be recycled while any member holds them, so a surviving group not led by the recycled pid is still held by our own descendants). Suppression requires positive identification; indeterminate cases keep the historical behavior of every other `terminateHeartbeatRunProcess` call site.
  - The pid-dead and descendant-only-cleanup branches are unchanged.
- `server/src/services/recovery/service.ts`
  - Hoisted `silenceStartedAtForRun`/`silenceAgeMsForRun` to module scope and exported them (single source of truth for "what counts as output silence"); no behavior change.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`
  - New: reaps a detached run once output silence crosses the critical threshold (asserts SIGTERM escalation via `terminateLocalService`, real child exit, `process_lost` failure, reap event payload).
  - New: does not reap a detached run before the critical silence threshold.
  - New: does not reap a critically silent detached run while the watchdog is snoozed.
  - New: finalizes a critically silent detached run without signaling a recycled pid (recorded spawn time hours older than the live process start; asserts `terminateLocalService` never called, stranger process still alive, `detachedPidRecycled` payload).
  - New: does not signal the recorded process group when it is led by the recycled pid's new owner (detached stranger = group leader).
  - New: reaps normally when the live process start matches the recorded spawn time (identity confirmed).
  - Updated: "keeps a local run active when the recorded pid is still alive" now seeds fresh `lastOutputAt` — the old version of this test asserted the exact hang-forever behavior #6406 reports (ancient `startedAt`, no output, still kept alive); with the fix that scenario is reaped by design, so the test now covers the "alive **and** producing output" case it was named for.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- `vitest run --project @paperclipai/server src/__tests__/heartbeat-process-recovery.test.ts` — 94/94 pass (including the 3 new tests; the reap test spawns a real `node -e setInterval` child and asserts it is actually terminated).
- `vitest run --project @paperclipai/server src/__tests__/recovery-classifiers.test.ts src/__tests__/recovery-observability.test.ts` — 17/17 pass.
- Reviewer spot-check: seed a `running` run with a live pid, `errorCode = 'process_detached'`, `lastOutputAt` 5h in the past; call `reapOrphanedRuns()`; expect the run failed with "Detached child process reaped after critical output silence" and the pid dead.

## Risks

- Behavioral shift by design: a detached run whose output has been silent ≥4h (with no operator snooze) is now killed and failed instead of being left running forever. That is the intended fix for #6406, but operators who relied on multi-day silent detached runs eventually resuming will see them failed (with one automatic retry) instead.
- Retry semantics: reaped runs go through the standard single `process_lost` retry, same as a pid-dead orphan — worst case one duplicate heartbeat attempt, bounded by the existing `processLossRetryCount < 1` guard.
- `terminateHeartbeatRunProcess` targets the recorded `processGroupId` when present (SIGTERM to the group, then SIGKILL) — same primitive already used for cancellation and descendant-only cleanup. Pid/pgid-reuse risk on the new 4h-silence path is gated by the start-time identity check above (suppression only on positive identification; indeterminate cases keep existing behavior).
- Low migration risk: no schema changes, no config changes; the critical threshold constant is the one the stale-run watchdog already pages on.

## Model Used

- Moonshot AI Kimi K3 (exact model ID `moonshotai/kimi-k3` via OpenRouter), agentic tool-use mode (shell, file editing, test execution), orchestrated by a Paperclip DevOps agent heartbeat.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (#6406, #8539, #6273, #4605, #6232)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no doc changes needed — recovery behavior only; runbook-facing behavior is described in the run event payload and error message)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
