### PR TITLE
fix(company-skills): approve managed_checkout project dirs for local skill import (LOOA-850)

### DIFF
--- a/server/src/__tests__/company-skill-import-boundary.test.ts
+++ b/server/src/__tests__/company-skill-import-boundary.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { companies, companySkills, createDb, projects, projectWorkspaces } from "@paperclipai/db";
 import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
 import { companySkillService } from "../services/company-skills.js";
+import { resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -82,5 +83,64 @@ describeEmbeddedPostgres("company skill local import boundary", () => {
       status: 422,
       details: { code: "skill_source_validation_failed" },
     });
+  });
+
+  // Regression for LOOA-850: a `managed_checkout` project (no registered workspace row) exposes
+  // only a server-derived `codebase.managedFolder`; before the fix that folder was never an
+  // approved root, so every managed_checkout project's in-place skill re-import was denied.
+  it("allows managed_checkout project managedFolder imports and rejects prefix-adjacent siblings", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    // Redirect the instance root at temp so the server-derived managedFolder is under our control.
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-managed-home-"));
+    cleanupDirs.add(home);
+    const previousHome = process.env.PAPERCLIP_HOME;
+    process.env.PAPERCLIP_HOME = home;
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Managed Co",
+        issuePrefix: `M${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+      // No projectWorkspaces row => origin "managed_checkout", primaryWorkspace null,
+      // managedFolder = resolveManagedProjectWorkspaceDir({ companyId, projectId }) (server-derived).
+      await db.insert(projects).values({ id: projectId, companyId, name: "Managed project" });
+
+      const managedFolder = resolveManagedProjectWorkspaceDir({ companyId, projectId });
+      const allowedSkill = path.join(managedFolder, ".agents", "skills", "managed-allowed");
+      await fs.mkdir(allowedSkill, { recursive: true });
+      await fs.writeFile(
+        path.join(allowedSkill, "SKILL.md"),
+        "---\nname: managed-allowed\ndescription: managed-allowed\n---\n# Managed Allowed\n",
+        "utf8",
+      );
+
+      // Prefix-adjacent sibling: its path is a string-prefix match of managedFolder but it is NOT
+      // inside the subtree. Confirms the boundary uses `${root}${sep}`-anchored matching, not a bare
+      // startsWith, so the added root cannot be widened by an adjacent directory name.
+      const prefixAdjacent = `${managedFolder}-evil`;
+      await fs.mkdir(prefixAdjacent, { recursive: true });
+      await fs.writeFile(
+        path.join(prefixAdjacent, "SKILL.md"),
+        "---\nname: managed-evil\ndescription: managed-evil\n---\n# Managed Evil\n",
+        "utf8",
+      );
+
+      const service = companySkillService(db);
+      await expect(service.importFromSource(companyId, allowedSkill)).resolves.toMatchObject({
+        imported: [expect.objectContaining({ slug: "managed-allowed" })],
+      });
+      await expect(service.importFromSource(companyId, prefixAdjacent)).rejects.toMatchObject({
+        status: 403,
+        details: { code: "skill_workspace_boundary_denied" },
+      });
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.PAPERCLIP_HOME;
+      } else {
+        process.env.PAPERCLIP_HOME = previousHome;
+      }
+    }
   });
 });

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2787,6 +2787,10 @@ export function companySkillService(db: Db) {
     const configuredRoots = [
       resolveManagedSkillsRoot(companyId),
       ...projectRows.flatMap((project) => project.workspaces.map((workspace) => workspace.cwd)),
+      // Include server-derived managed-checkout dirs for projects with no registered workspace cwd.
+      // Uses managedFolder (not effectiveLocalFolder) to stay server-controlled; user-registered
+      // localFolder paths are already covered by workspaces[].cwd above.
+      ...projectRows.map((project) => project.codebase.managedFolder),
     ].filter((root): root is string => typeof root === "string" && root.trim().length > 0);
     const approvedRoots = (await Promise.all(
       configuredRoots.map((root) => fs.realpath(path.resolve(root)).catch(() => null)),


### PR DESCRIPTION
## What
`assertLocalImportSourceAllowed` (server/src/services/company-skills.ts) built `configuredRoots` from only the managed skills root and **registered** `project_workspaces[].cwd`. Every `managed_checkout` project (`primaryWorkspace: null`, `workspaces: []`) had its server-derived `codebase.managedFolder` excluded, so in-place skill re-imports were denied with `skill_workspace_boundary_denied`.

This adds `project.codebase.managedFolder` to `configuredRoots`. `managedFolder = resolveManagedProjectWorkspaceDir({ companyId, projectId })` is fully server-derived from the instance root + sanitized ids — same trust class as the pre-existing `resolveManagedSkillsRoot`. It is `fs.realpath`-resolved and `${root}${sep}`-prefix matched exactly like every other root, so no traversal/escape is reintroduced.

## Why it's safe (Security sign-off on LOOA-850)
- **Server-derived, not attacker-derived.** `companyId` = request tenant scope; `projectId` from `projects.list(companyId)` (that company's rows only); `repoName` derived via `new URL(...)`. None comes from the import `source` argument.
- **Separator-safe.** `sanitizeFriendlyPathSegment` maps `[^a-zA-Z0-9._-]+ -> -`, so no segment can inject `/`/`\` or a new path level.
- **`..` traversal unreachable** — the only user-influenced segment (`repoName`) is normalized by `new URL(...)`.
- Prefers `managedFolder` over `effectiveLocalFolder` (the latter can fall through to a user-registered `localFolder`, already covered by `workspaces[].cwd`).

## Test
`company-skill-import-boundary.test.ts` adds a regression case: a `managed_checkout` project's `managedFolder/<skill>` import is **allowed**, and a **prefix-adjacent sibling** (`${managedFolder}-evil`) stays **denied** — confirming `${root}${sep}`-anchored matching (not bare `startsWith`). 2/2 pass; verified independently by CTO on the live tree.

## Impact
Generically repairs every `managed_checkout` project's in-place skill re-import (the ~16 Signal Aggregator siblings + Onboarding/Editorial/Growth State/Content Strategy/Talks/Gateway Chat). The per-skill managed-root mirror (LOOA-849 Option B, routine `6a2f6060`) becomes optional rather than required.

Refs: LOOA-850 (systemic fix), delegated from LOOA-849. Boundary hardening history: #9564 / #9620 / #9633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)