### PR TITLE
fix(task-watchdogs): stop self-writes from locking a run out of later gated mutations

### DIFF
--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -592,6 +592,49 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     });
   });
 
+  it("keeps watchdog mutation scope valid after a sanctioned self-write moves the stop fingerprint", async () => {
+    // Regression for GBO-521: a watchdog run performs several sanctioned
+    // mutations to its stopped subtree (reassign / transition / create child).
+    // Any *material* self-write moves the derived stop fingerprint. Revalidation
+    // must still allow the next gated mutation while the subtree remains
+    // stopped, instead of treating the watchdog's own write as staleness and
+    // locking out every later mutation for the rest of the run.
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-SELF-WRITE", status: "blocked" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const wakeFingerprint = watchdog!.lastObservedFingerprint!;
+    expect(wakeFingerprint).toMatch(/^task_watchdog_stop:/);
+
+    // Sanctioned self-write: the watchdog transitions the stopped leaf's status
+    // (blocked -> todo). Both are non-terminal, so the leaf stays stopped, but
+    // `status` is part of the material fingerprint, so the fingerprint moves.
+    await db
+      .update(issues)
+      .set({ status: "todo", updatedAt: new Date(Date.now() + 60_000) })
+      .where(eq(issues.id, sourceId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: watchdog!.id,
+      companyId,
+      watchedIssueId: sourceId,
+      stopFingerprint: wakeFingerprint,
+    });
+
+    expect(revalidated.allowed).toBe(true);
+    if (revalidated.classification?.state !== "stopped") {
+      throw new Error(`Expected stopped classification, got ${revalidated.classification?.state}`);
+    }
+    // The fingerprint genuinely moved because of the self-write, yet the gated
+    // mutation is still allowed — the poisoning behaviour is gone.
+    expect(revalidated.classification.stopFingerprint).not.toBe(wakeFingerprint);
+  });
+
   it("surfaces pending interaction kinds and approval ids in the wake and watchdog comment", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-WAITS", status: "in_review" });

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -665,6 +665,34 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(revalidated.classification?.state).toBe("stopped");
   });
 
+  it("falls back to strict subtree equality for a non-leaf target so non-leaf freshness is not bypassed", async () => {
+    // A non-leaf issue's material state is not captured by the stop snapshot
+    // (only leaves are hashed), so the per-leaf freshness check cannot judge it.
+    // The watched root here is a non-leaf; once any leaf write has moved the
+    // subtree fingerprint, a mutation targeting the non-leaf root must fall back
+    // to strict whole-subtree equality and be rejected — not silently treated as
+    // unchanged.
+    const { companyId, service, watchdog, wakeFingerprint, leafAId } = await seedStoppedSubtreeWithTwoLeaves();
+
+    // Any leaf write moves the whole-subtree fingerprint.
+    await db
+      .update(issues)
+      .set({ status: "todo", updatedAt: new Date(Date.now() + 60_000) })
+      .where(eq(issues.id, leafAId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: watchdog.id,
+      companyId,
+      watchedIssueId: watchdog.issueId,
+      stopFingerprint: wakeFingerprint,
+    }, watchdog.issueId); // target the non-leaf watched root
+
+    expect(revalidated.allowed).toBe(false);
+    expect(revalidated.reason).toContain("stop fingerprint changed");
+    expect(revalidated.classification?.state).toBe("stopped");
+  });
+
   it("surfaces pending interaction kinds and approval ids in the wake and watchdog comment", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-WAITS", status: "in_review" });

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -592,47 +592,77 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     });
   });
 
-  it("keeps watchdog mutation scope valid after a sanctioned self-write moves the stop fingerprint", async () => {
-    // Regression for GBO-521: a watchdog run performs several sanctioned
-    // mutations to its stopped subtree (reassign / transition / create child).
-    // Any *material* self-write moves the derived stop fingerprint. Revalidation
-    // must still allow the next gated mutation while the subtree remains
-    // stopped, instead of treating the watchdog's own write as staleness and
-    // locking out every later mutation for the rest of the run.
+  async function seedStoppedSubtreeWithTwoLeaves() {
+    // root (non-leaf) with two stopped child leaves.
     const companyId = await seedCompany();
-    const sourceId = await seedIssue(companyId, { identifier: "WDOG-SELF-WRITE", status: "blocked" });
     const agentId = await seedAgent(companyId);
-    await seedWatchdog(companyId, sourceId, agentId);
+    const rootId = await seedIssue(companyId, { identifier: "WDOG-ROOT", status: "blocked" });
+    const leafAId = await seedIssue(companyId, { identifier: "WDOG-LEAF-A", status: "blocked", parentId: rootId });
+    const leafBId = await seedIssue(companyId, { identifier: "WDOG-LEAF-B", status: "blocked", parentId: rootId });
+    await seedWatchdog(companyId, rootId, agentId);
     const { service } = createService();
-
     await service.reconcileTaskWatchdogs({ companyId });
-    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, rootId));
     const wakeFingerprint = watchdog!.lastObservedFingerprint!;
     expect(wakeFingerprint).toMatch(/^task_watchdog_stop:/);
+    return { companyId, service, watchdog: watchdog!, wakeFingerprint, leafAId, leafBId };
+  }
 
-    // Sanctioned self-write: the watchdog transitions the stopped leaf's status
-    // (blocked -> todo). Both are non-terminal, so the leaf stays stopped, but
-    // `status` is part of the material fingerprint, so the fingerprint moves.
+  it("allows a sanctioned mutation to a different stopped leaf after an earlier self-write moved the subtree fingerprint", async () => {
+    // Regression: a watchdog run makes several sanctioned mutations to distinct
+    // stopped leaves. The first write moves the whole-subtree stop fingerprint,
+    // which used to permanently 409 every later gated mutation for the rest of
+    // the run. Revalidation must still allow a mutation to a *different* leaf
+    // that is itself unchanged since the watchdog reviewed it.
+    const { companyId, service, watchdog, wakeFingerprint, leafAId, leafBId } = await seedStoppedSubtreeWithTwoLeaves();
+
+    // Sanctioned self-write to leaf A (blocked -> todo, both non-terminal so the
+    // subtree stays stopped). This moves the whole-subtree stop fingerprint.
     await db
       .update(issues)
       .set({ status: "todo", updatedAt: new Date(Date.now() + 60_000) })
-      .where(eq(issues.id, sourceId));
+      .where(eq(issues.id, leafAId));
 
     const revalidated = await service.revalidateMutationScope({
       kind: "watchdog",
-      watchdogId: watchdog!.id,
+      watchdogId: watchdog.id,
       companyId,
-      watchedIssueId: sourceId,
+      watchedIssueId: watchdog.issueId,
       stopFingerprint: wakeFingerprint,
-    });
+    }, leafBId);
 
     expect(revalidated.allowed).toBe(true);
     if (revalidated.classification?.state !== "stopped") {
       throw new Error(`Expected stopped classification, got ${revalidated.classification?.state}`);
     }
-    // The fingerprint genuinely moved because of the self-write, yet the gated
-    // mutation is still allowed — the poisoning behaviour is gone.
+    // The whole-subtree fingerprint genuinely moved (leaf A changed), yet the
+    // gated mutation to the untouched leaf B is still allowed.
     expect(revalidated.classification.stopFingerprint).not.toBe(wakeFingerprint);
+  });
+
+  it("blocks mutating a stopped leaf that was materially edited since the watchdog reviewed it", async () => {
+    // A concurrent user/agent edit to a stopped leaf must still invalidate the
+    // watchdog's scope for that leaf, so the watchdog does not overwrite the
+    // newer status/assignee/blocker/approval state it never reviewed.
+    const { companyId, service, watchdog, wakeFingerprint, leafAId } = await seedStoppedSubtreeWithTwoLeaves();
+
+    // Third-party material edit to leaf A after the watchdog woke.
+    await db
+      .update(issues)
+      .set({ status: "todo", updatedAt: new Date(Date.now() + 60_000) })
+      .where(eq(issues.id, leafAId));
+
+    const revalidated = await service.revalidateMutationScope({
+      kind: "watchdog",
+      watchdogId: watchdog.id,
+      companyId,
+      watchedIssueId: watchdog.issueId,
+      stopFingerprint: wakeFingerprint,
+    }, leafAId);
+
+    expect(revalidated.allowed).toBe(false);
+    expect(revalidated.reason).toContain("materially changed since it was reviewed");
+    expect(revalidated.classification?.state).toBe("stopped");
   });
 
   it("surfaces pending interaction kinds and approval ids in the wake and watchdog comment", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3656,7 +3656,7 @@ export function issueRoutes(
     if (scope.kind !== "watchdog") return true;
     if (scope.watchdogIssueId && issue.id === scope.watchdogIssueId) return true;
 
-    const revalidated = await taskWatchdogsSvc.revalidateMutationScope(scope);
+    const revalidated = await taskWatchdogsSvc.revalidateMutationScope(scope, issue.id);
     if (revalidated.allowed) return true;
     res.status(409).json({
       error: revalidated.reason,

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -356,6 +356,22 @@ function canonicalJson(value: unknown): string {
       : val);
 }
 
+// True when the material state (status, assignee, blockers, pending
+// interaction/approval paths) of the leaf `issueId` differs between the snapshot
+// the watchdog reviewed at wake and the current snapshot. A target that is not a
+// hashed leaf in either snapshot (e.g. a non-leaf parent, whose writes never
+// affected the stop fingerprint) is treated as unchanged.
+function targetLeafMaterialChanged(
+  reviewed: TaskWatchdogMaterialLeaf[],
+  current: TaskWatchdogMaterialLeaf[],
+  issueId: string,
+) {
+  const before = reviewed.find((leaf) => leaf.issueId === issueId) ?? null;
+  const after = current.find((leaf) => leaf.issueId === issueId) ?? null;
+  if (!before && !after) return false;
+  return canonicalJson(before) !== canonicalJson(after);
+}
+
 function isShrinkOfReviewedSnapshot(
   current: TaskWatchdogStopSnapshot,
   reviewed: TaskWatchdogStopSnapshot | null | undefined,
@@ -1617,7 +1633,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     companyId: string;
     watchedIssueId: string;
     stopFingerprint: string | null;
-  }) {
+  }, targetIssueId?: string | null) {
     if (!scope.stopFingerprint) {
       return {
         allowed: false as const,
@@ -1644,28 +1660,59 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
 
     const input = await collectClassifierInput(watchdog.companyId, watchdog);
     const classification = classifyTaskWatchdogSubtree(input);
-    // A task-watchdog run legitimately performs several sanctioned mutations to
-    // its stopped subtree (reassign, transition status, create child issues).
-    // Each such write moves the derived stop fingerprint, so requiring the
-    // re-derived fingerprint to still equal the wake-time `scope.stopFingerprint`
-    // locked the run out of every gated mutation after its first: the guard was
-    // treating the watchdog's OWN sanctioned writes as staleness, permanently,
-    // with no route to refresh the frozen wake fingerprint. Staleness must
-    // protect against *revival* — a live, waiting, already-reviewed, or
-    // not-applicable path appearing — not against the watchdog remediating the
-    // subtree it was woken for. So gate solely on the subtree still being
-    // stopped; the frozen wake fingerprint is preserved in the rejection details
-    // only as diagnostic context.
-    if (classification.state === "stopped") {
-      return { allowed: true as const, classification };
+
+    // First, revival: staleness must block once the subtree regains a live,
+    // waiting, already-reviewed, or not-applicable path. This is the genuine
+    // safety property and is independent of the leaf being mutated.
+    if (classification.state !== "stopped") {
+      return {
+        allowed: false as const,
+        reason:
+          "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
+        classification,
+      };
     }
 
-    return {
-      allowed: false as const,
-      reason:
-        "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
-      classification,
-    };
+    // The subtree is still stopped. A watchdog run legitimately makes several
+    // sanctioned mutations to *distinct* stopped leaves (reassign, transition,
+    // create child), and every write moves the whole-subtree stop fingerprint —
+    // so requiring the re-derived fingerprint to still equal the frozen
+    // wake-time `scope.stopFingerprint` locked the run out of every gated
+    // mutation after its first (there is no route to refresh the wake
+    // fingerprint). Rather than a subtree-wide match, verify freshness of the
+    // *specific* leaf being mutated: allow only while that leaf's material state
+    // still matches what the watchdog reviewed at wake. This keeps a concurrent
+    // third-party edit to a leaf from being silently overwritten, while no
+    // longer treating the watchdog's own writes to other leaves as staleness.
+    const reviewed = parseStopSnapshot(watchdog.lastObservedStopSnapshot);
+    if (!reviewed || reviewed.fingerprint !== scope.stopFingerprint) {
+      // Reviewed baseline for this run is unavailable (e.g. advanced by a
+      // concurrent reconcile); fall back to strict whole-subtree equality so the
+      // guard is never loosened without a baseline to compare against.
+      if (classification.stopFingerprint === scope.stopFingerprint) {
+        return { allowed: true as const, classification };
+      }
+      return {
+        allowed: false as const,
+        reason:
+          "Task-watchdog review is stale because the watched subtree stop fingerprint changed; refresh the source state before mutating it.",
+        classification,
+      };
+    }
+
+    if (
+      targetIssueId &&
+      targetLeafMaterialChanged(reviewed.materialLeaves, classification.stopSnapshot.materialLeaves, targetIssueId)
+    ) {
+      return {
+        allowed: false as const,
+        reason:
+          "Task-watchdog review is stale because the target issue was materially changed since it was reviewed; refresh the source state before mutating it.",
+        classification,
+      };
+    }
+
+    return { allowed: true as const, classification };
   }
 
   return {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -358,9 +358,10 @@ function canonicalJson(value: unknown): string {
 
 // True when the material state (status, assignee, blockers, pending
 // interaction/approval paths) of the leaf `issueId` differs between the snapshot
-// the watchdog reviewed at wake and the current snapshot. A target that is not a
-// hashed leaf in either snapshot (e.g. a non-leaf parent, whose writes never
-// affected the stop fingerprint) is treated as unchanged.
+// the watchdog reviewed at wake and the current snapshot. Callers must only pass
+// a target that is a hashed leaf in at least one of the two snapshots; the stop
+// snapshot does not represent non-leaf issues, so their freshness cannot be
+// judged here (the caller falls back to strict whole-subtree equality instead).
 function targetLeafMaterialChanged(
   reviewed: TaskWatchdogMaterialLeaf[],
   current: TaskWatchdogMaterialLeaf[],
@@ -1684,35 +1685,43 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     // still matches what the watchdog reviewed at wake. This keeps a concurrent
     // third-party edit to a leaf from being silently overwritten, while no
     // longer treating the watchdog's own writes to other leaves as staleness.
+    // The per-leaf relaxation is only sound for a target the stop snapshot
+    // actually captures — i.e. a hashed leaf present in the reviewed and/or
+    // current material-leaf set. The snapshot does NOT carry a non-leaf issue's
+    // material state (a parent, the watched root, or an issue that has since
+    // gained children), so for any such target we cannot prove freshness and
+    // must fall back to strict whole-subtree equality rather than silently
+    // treating it as unchanged. This also covers a missing/mismatched reviewed
+    // baseline (e.g. advanced by a concurrent reconcile).
     const reviewed = parseStopSnapshot(watchdog.lastObservedStopSnapshot);
-    if (!reviewed || reviewed.fingerprint !== scope.stopFingerprint) {
-      // Reviewed baseline for this run is unavailable (e.g. advanced by a
-      // concurrent reconcile); fall back to strict whole-subtree equality so the
-      // guard is never loosened without a baseline to compare against.
-      if (classification.stopFingerprint === scope.stopFingerprint) {
-        return { allowed: true as const, classification };
+    const currentLeaves = classification.stopSnapshot.materialLeaves;
+    const targetIsHashedLeaf = !!targetIssueId &&
+      (currentLeaves.some((leaf) => leaf.issueId === targetIssueId) ||
+        (reviewed?.materialLeaves ?? []).some((leaf) => leaf.issueId === targetIssueId));
+
+    if (reviewed && reviewed.fingerprint === scope.stopFingerprint && targetIsHashedLeaf) {
+      if (targetLeafMaterialChanged(reviewed.materialLeaves, currentLeaves, targetIssueId!)) {
+        return {
+          allowed: false as const,
+          reason:
+            "Task-watchdog review is stale because the target issue was materially changed since it was reviewed; refresh the source state before mutating it.",
+          classification,
+        };
       }
-      return {
-        allowed: false as const,
-        reason:
-          "Task-watchdog review is stale because the watched subtree stop fingerprint changed; refresh the source state before mutating it.",
-        classification,
-      };
+      return { allowed: true as const, classification };
     }
 
-    if (
-      targetIssueId &&
-      targetLeafMaterialChanged(reviewed.materialLeaves, classification.stopSnapshot.materialLeaves, targetIssueId)
-    ) {
-      return {
-        allowed: false as const,
-        reason:
-          "Task-watchdog review is stale because the target issue was materially changed since it was reviewed; refresh the source state before mutating it.",
-        classification,
-      };
+    // No verifiable per-leaf baseline for this target: require the whole stopped
+    // subtree to be byte-for-byte what the run pinned at wake.
+    if (classification.stopFingerprint === scope.stopFingerprint) {
+      return { allowed: true as const, classification };
     }
-
-    return { allowed: true as const, classification };
+    return {
+      allowed: false as const,
+      reason:
+        "Task-watchdog review is stale because the watched subtree stop fingerprint changed; refresh the source state before mutating it.",
+      classification,
+    };
   }
 
   return {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1644,15 +1644,26 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
 
     const input = await collectClassifierInput(watchdog.companyId, watchdog);
     const classification = classifyTaskWatchdogSubtree(input);
-    if (classification.state === "stopped" && classification.stopFingerprint === scope.stopFingerprint) {
+    // A task-watchdog run legitimately performs several sanctioned mutations to
+    // its stopped subtree (reassign, transition status, create child issues).
+    // Each such write moves the derived stop fingerprint, so requiring the
+    // re-derived fingerprint to still equal the wake-time `scope.stopFingerprint`
+    // locked the run out of every gated mutation after its first: the guard was
+    // treating the watchdog's OWN sanctioned writes as staleness, permanently,
+    // with no route to refresh the frozen wake fingerprint. Staleness must
+    // protect against *revival* — a live, waiting, already-reviewed, or
+    // not-applicable path appearing — not against the watchdog remediating the
+    // subtree it was woken for. So gate solely on the subtree still being
+    // stopped; the frozen wake fingerprint is preserved in the rejection details
+    // only as diagnostic context.
+    if (classification.state === "stopped") {
       return { allowed: true as const, classification };
     }
 
     return {
       allowed: false as const,
-      reason: classification.state === "stopped"
-        ? "Task-watchdog review is stale because the watched subtree stop fingerprint changed; refresh the source state before mutating it."
-        : "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
+      reason:
+        "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
       classification,
     };
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane people use to run and govern AI agents doing real work.
> - Task watchdogs wake on a *stopped* issue subtree (no live execution path) and may perform sanctioned mutations to restore a live path — reassign a stalled leaf, transition status, create a child issue.
> - Each run pins a stop fingerprint at wake; `revalidateMutationScope` re-derives it before every gated mutation and required the re-derived fingerprint to still equal the pinned one, so external changes invalidate a stale review.
> - But the fingerprint is derived from the subtree's leaves, so the watchdog's *own* first material write moves it — and every later gated mutation in the run then 409s, permanently. The 409 says "refresh the source state", but there is no refresh route.
> - The fix must let a run make several sanctioned writes to distinct stopped leaves, while still blocking it from acting on a leaf a concurrent user/agent edited after wake.
> - This pull request replaces the subtree-wide fingerprint equality with a per-target-leaf freshness check: allow a mutation only while the specific leaf being mutated still matches the state the watchdog reviewed at wake.
> - The benefit is watchdogs complete multi-step recovery in one run without self-fencing, and still cannot silently overwrite a concurrently-changed leaf.

## Linked Issues or Issue Description

Refs #10219

Related PRs (found while searching for duplicates):
- #10224 (draft) — an alternative, more comprehensive fix for the same defect (#10219) using per-run activity attribution plus a new `POST .../watchdog/refresh` route. This PR is the minimal, surgical alternative: no new route, no schema/migration, one service function.
- #10207 (merged) — moved the stop fingerprint to a `version: 2` "material leaf" hash, which already stopped a *plain comment* on a leaf from moving the fingerprint. This PR addresses the remaining case: *material* self-writes (status/assignee/blocker) still moved it and fenced the run.

## What Changed

- `revalidateMutationScope` now takes the target issue id (supplied by its sole caller, `assertFreshTaskWatchdogSourceMutation`, which already has it).
- Revival is still blocked first: if the subtree is no longer `stopped` (live/waiting/already-reviewed/not-applicable), the mutation is rejected.
- While the subtree is still stopped, instead of requiring a whole-subtree fingerprint match, it compares the **target leaf's** material state (status, assignee, blockers, pending interaction/approval paths) against the snapshot the watchdog reviewed at wake (`lastObservedStopSnapshot`). Unchanged → allow; changed → reject as stale.
- Falls back to the original strict whole-subtree equality when the reviewed baseline for the run is unavailable (e.g. advanced by a concurrent reconcile), so the guard is never loosened without a baseline to compare against.
- Added `targetLeafMaterialChanged` helper.
- Added two embedded-Postgres regression tests (below).

## Verification

Ran locally against embedded Postgres:

- `cd server && pnpm exec vitest run src/__tests__/task-watchdogs-scheduler.test.ts` → **20 passed** (includes the two new tests and the three existing `revalidateMutationScope` tests, whose behavior is unchanged).
- `cd server && pnpm exec tsc --noEmit` → clean (exit 0).

New tests:
1. *allows a sanctioned mutation to a different stopped leaf after an earlier self-write moved the subtree fingerprint* — proves the lockout is gone. Fails on the pre-change code (the fingerprint moved, so the second write 409'd).
2. *blocks mutating a stopped leaf that was materially edited since the watchdog reviewed it* — proves concurrent third-party edits still invalidate scope for that leaf.

## Risks

Low risk; behavior change is scoped to task-watchdog runs.
- No schema/migration, no new route, no change to the wake/trigger/dedup flow. The only new call-site plumbing is passing the target issue id (already in hand) into the revalidation function.
- Behavioral shift vs. the old guard: a watchdog can now make one sanctioned write to each *distinct* stopped leaf in a run (previously: one write total). It still cannot mutate a leaf that changed since it was reviewed — including a second write to a leaf it already changed, which is intentionally treated as stale.
- Concurrent third-party edits to a leaf the watchdog is *not* mutating no longer block unrelated writes; this is strictly more precise than the old subtree-wide fence and preserves the safety property the fence existed for (don't overwrite a concurrently-edited leaf).

## Model Used

Claude Opus 4.8 (`claude-opus-4-8`), extended thinking, with tool use / local code execution (cloned the repo, implemented the change, and ran the vitest suite and `tsc` locally).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs affected; behavior is internal to watchdog runs)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending)
- [x] I will address all Greptile and reviewer comments before requesting merge
