### PR TITLE
fix(sandbox): resolve object-shaped secret refs

### DIFF
--- a/server/src/__tests__/environment-routes.test.ts
+++ b/server/src/__tests__/environment-routes.test.ts
@@ -1172,6 +1172,8 @@ describe("environment routes", () => {
       type: "secret_ref" as const,
       secretId: "11111111-1111-1111-1111-111111111111",
       version: 4,
+      projectionClass: "class_3_static_lease" as const,
+      projectionAllowlistKey: "kubernetes.kubeconfig",
     };
     const environment = {
       ...createEnvironment(),

--- a/server/src/__tests__/environment-routes.test.ts
+++ b/server/src/__tests__/environment-routes.test.ts
@@ -1167,6 +1167,83 @@ describe("environment routes", () => {
     );
   });
 
+  it("preserves and binds selected object-shaped sandbox secret refs", async () => {
+    const apiKeyRef = {
+      type: "secret_ref" as const,
+      secretId: "11111111-1111-1111-1111-111111111111",
+      version: 4,
+    };
+    const environment = {
+      ...createEnvironment(),
+      id: "env-sandbox-secure-plugin",
+      name: "Secure Sandbox",
+      driver: "sandbox" as const,
+      config: {
+        provider: "secure-plugin",
+        template: "base",
+        apiKey: apiKeyRef,
+        reuseLease: false,
+      },
+    };
+    mockEnvironmentService.create.mockResolvedValue(environment);
+    mockValidatePluginSandboxProviderConfig.mockResolvedValue({
+      normalizedConfig: {
+        template: "base",
+        apiKey: apiKeyRef,
+        reuseLease: false,
+      },
+      pluginId: "plugin-secure",
+      pluginKey: "acme.secure-sandbox-provider",
+      driver: {
+        driverKey: "secure-plugin",
+        kind: "sandbox_provider",
+        displayName: "Secure Sandbox",
+        configSchema: {
+          type: "object",
+          properties: {
+            template: { type: "string" },
+            apiKey: { type: "string", format: "secret-ref" },
+            reuseLease: { type: "boolean" },
+          },
+        },
+      },
+    });
+    const pluginWorkerManager = {};
+    const app = createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    }, { pluginWorkerManager });
+
+    const res = await request(app)
+      .post("/api/companies/company-1/environments")
+      .send({
+        name: "Secure Sandbox",
+        driver: "sandbox",
+        config: {
+          provider: "secure-plugin",
+          template: "base",
+          apiKey: apiKeyRef,
+          reuseLease: false,
+        },
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockSecretService.create).not.toHaveBeenCalled();
+    expect(mockEnvironmentService.create).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({ apiKey: apiKeyRef }),
+    }));
+    expect(mockSecretService.syncSecretRefsForTarget).toHaveBeenCalledWith(
+      "company-1",
+      { targetType: "environment", targetId: environment.id },
+      [{
+        secretId: apiKeyRef.secretId,
+        configPath: "apiKey",
+        versionSelector: apiKeyRef.version,
+      }],
+    );
+  });
+
   it("uses the configured provider for schema-driven sandbox secret fields", async () => {
     process.env.PAPERCLIP_SECRETS_PROVIDER = "aws_secrets_manager";
     const environment = {
@@ -1812,7 +1889,11 @@ describe("environment routes", () => {
     mockValidatePluginSandboxProviderConfig.mockResolvedValue({
       normalizedConfig: {
         template: "base",
-        apiKey: "11111111-1111-1111-1111-111111111111",
+        apiKey: {
+          type: "secret_ref",
+          secretId: "11111111-1111-1111-1111-111111111111",
+          version: 3,
+        },
         timeoutMs: 300000,
         reuseLease: true,
       },
@@ -1855,7 +1936,11 @@ describe("environment routes", () => {
         config: {
           provider: "secure-plugin",
           template: "base",
-          apiKey: "11111111-1111-1111-1111-111111111111",
+          apiKey: {
+            type: "secret_ref",
+            secretId: "11111111-1111-1111-1111-111111111111",
+            version: 3,
+          },
           timeoutMs: 300000,
           reuseLease: true,
         },
@@ -1867,7 +1952,7 @@ describe("environment routes", () => {
     expect(mockSecretService.resolveSecretValueForEphemeralAccess).toHaveBeenCalledWith(
       "company-1",
       "11111111-1111-1111-1111-111111111111",
-      "latest",
+      3,
       {
         consumerType: "system",
         consumerId: "environment-probe-config",

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -709,7 +709,11 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     const providerConfig = {
       provider: "secure-plugin",
       template: "base",
-      apiKey: apiSecret.id,
+      apiKey: {
+        type: "secret_ref" as const,
+        secretId: apiSecret.id,
+        version: "latest" as const,
+      },
       timeoutMs: 1234,
       reuseLease: false,
     };
@@ -815,7 +819,11 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(acquired.lease.metadata).toMatchObject({
       provider: "secure-plugin",
       template: "base",
-      apiKey: apiSecret.id,
+      apiKey: {
+        type: "secret_ref",
+        secretId: apiSecret.id,
+        version: "latest",
+      },
       timeoutMs: 1234,
       sandboxId: "sandbox-1",
     });

--- a/server/src/services/environment-config.ts
+++ b/server/src/services/environment-config.ts
@@ -120,6 +120,19 @@ function getSandboxProvider(raw: Record<string, unknown>) {
   return typeof raw.provider === "string" && raw.provider.trim().length > 0 ? raw.provider.trim() : "fake";
 }
 
+function parseSandboxSecretRef(
+  value: unknown,
+): { secretId: string; versionSelector: SecretVersionSelector } | null {
+  if (typeof value === "string") {
+    const secretId = value.trim();
+    return isUuidSecretRef(secretId) ? { secretId, versionSelector: "latest" } : null;
+  }
+  const parsed = secretRefSchema.safeParse(value);
+  return parsed.success
+    ? { secretId: parsed.data.secretId, versionSelector: parsed.data.version }
+    : null;
+}
+
 function parseSandboxEnvironmentConfig(
   input: Record<string, unknown> | null | undefined,
 ) {
@@ -253,16 +266,15 @@ async function resolveConfigSecretRefsForRuntime(input: {
   let nextConfig = { ...input.config };
   for (const path of collectSecretRefPaths(input.schema)) {
     const current = readConfigValueAtPath(nextConfig, path);
-    if (typeof current !== "string") continue;
-    const trimmed = current.trim();
-    if (!isUuidSecretRef(trimmed)) continue;
+    const secretRef = parseSandboxSecretRef(current);
+    if (!secretRef) continue;
     if (!input.context.consumerId) {
       throw unprocessable("Runtime secret resolution requires an environment id");
     }
     nextConfig = writeConfigValueAtPath(
       nextConfig,
       path,
-      await secrets.resolveSecretValue(input.companyId, trimmed, "latest", {
+      await secrets.resolveSecretValue(input.companyId, secretRef.secretId, secretRef.versionSelector, {
         consumerType: "environment",
         consumerId: input.context.consumerId,
         actorType: "system",
@@ -292,24 +304,28 @@ async function resolveConfigSecretRefsForProbe(input: {
   let nextConfig = { ...input.config };
   for (const path of collectSecretRefPaths(input.schema)) {
     const current = readConfigValueAtPath(nextConfig, path);
-    if (typeof current !== "string") continue;
-    const trimmed = current.trim();
-    if (!isUuidSecretRef(trimmed)) continue;
+    const secretRef = parseSandboxSecretRef(current);
+    if (!secretRef) continue;
     // Unsaved draft probes do not have an environment record yet, so they
     // cannot rely on environment-bound secret resolution. Resolve directly for
     // this ephemeral board-only probe and never persist the plaintext value.
     nextConfig = writeConfigValueAtPath(
       nextConfig,
       path,
-      await secrets.resolveSecretValueForEphemeralAccess(input.companyId, trimmed, "latest", {
-        consumerType: "system",
-        consumerId: "environment-probe-config",
-        configPath: path,
-        actorType: input.accessContext?.actorType ?? "system",
-        actorId: input.accessContext?.actorId ?? null,
-        actorSource: input.accessContext?.actorSource,
-        heartbeatRunId: input.accessContext?.heartbeatRunId ?? null,
-      }),
+      await secrets.resolveSecretValueForEphemeralAccess(
+        input.companyId,
+        secretRef.secretId,
+        secretRef.versionSelector,
+        {
+          consumerType: "system",
+          consumerId: "environment-probe-config",
+          configPath: path,
+          actorType: input.accessContext?.actorType ?? "system",
+          actorId: input.accessContext?.actorId ?? null,
+          actorSource: input.accessContext?.actorSource,
+          heartbeatRunId: input.accessContext?.heartbeatRunId ?? null,
+        },
+      ),
     );
   }
   return nextConfig;
@@ -332,8 +348,13 @@ export async function collectEnvironmentSecretRefs(input: {
     const refs: Array<{ secretId: string; configPath: string; versionSelector?: SecretVersionSelector }> = [];
     for (const path of collectSecretRefPaths(schema)) {
       const current = readConfigValueAtPath(parsed.config as Record<string, unknown>, path);
-      if (typeof current === "string" && isUuidSecretRef(current.trim())) {
-        refs.push({ secretId: current.trim(), configPath: path, versionSelector: "latest" });
+      const secretRef = parseSandboxSecretRef(current);
+      if (secretRef) {
+        refs.push({
+          secretId: secretRef.secretId,
+          configPath: path,
+          versionSelector: secretRef.versionSelector,
+        });
       }
     }
     return refs;
@@ -623,7 +644,7 @@ export async function resolveEnvironmentDriverConfigForRuntime(
     } else {
       for (const path of collectSecretRefPaths(schema)) {
         const current = readConfigValueAtPath(parsed.config as Record<string, unknown>, path);
-        if (typeof current === "string" && isUuidSecretRef(current.trim())) {
+        if (parseSandboxSecretRef(current)) {
           throw unprocessable("Runtime secret resolution requires a companyId context");
         }
       }

--- a/server/src/services/environment-config.ts
+++ b/server/src/services/environment-config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import type { Db } from "@paperclipai/db";
+import { envBindingSecretRefSchema } from "@paperclipai/shared";
 import type {
   Environment,
   EnvironmentDriver,
@@ -127,9 +128,9 @@ function parseSandboxSecretRef(
     const secretId = value.trim();
     return isUuidSecretRef(secretId) ? { secretId, versionSelector: "latest" } : null;
   }
-  const parsed = secretRefSchema.safeParse(value);
+  const parsed = envBindingSecretRefSchema.safeParse(value);
   return parsed.success
-    ? { secretId: parsed.data.secretId, versionSelector: parsed.data.version }
+    ? { secretId: parsed.data.secretId, versionSelector: parsed.data.version ?? "latest" }
     : null;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Environment drivers let those agents execute through remote sandbox providers
> - Sandbox providers declare credential fields with JSON Schema `format: secret-ref`
> - The UI stores a selected secret as `{ type: "secret_ref", secretId, version }`
> - The sandbox host paths only recognized legacy bare UUID strings, so canonical references were not resolved for probes or execution and were not synchronized as bindings
> - This pull request gives probe, runtime, binding discovery, and context validation one parser for canonical and legacy references
> - The benefit is secure sandbox configuration without plaintext workarounds, while preserving version selection and backward compatibility

## Linked Issues or Issue Description

- Refs: #10105

The reported provider-validation failure is one symptom of canonical object-shaped references traversing sandbox configuration. Even after a provider accepts that shape during validation, the host currently passes it unresolved to draft probes and runtime hooks, does not discover it when synchronizing environment bindings, and misses it in the no-company safety check.

## What Changed

- Resolve canonical object-shaped sandbox secret references before draft probes and runtime provider calls.
- Preserve explicit numeric or `latest` secret version selectors.
- Discover object-shaped references when synchronizing environment secret bindings.
- Apply the company-context safety check to canonical and legacy reference shapes.
- Retain backward compatibility for persisted bare UUID references.
- Add route and runtime regression coverage.

## Verification

- `pnpm exec vitest run server/src/__tests__/environment-routes.test.ts server/src/__tests__/environment-runtime.test.ts` — 66 passed on current `master`.
- `pnpm -r typecheck` — passed across 31 workspace packages.
- `pnpm build` — passed.
- The regression tests first failed with zero ephemeral-resolution calls and an unresolved object reaching `environmentAcquireLease`; both pass after the fix.

## Risks

- Low compatibility risk: legacy UUID strings retain `latest` behavior; canonical references now honor their selected version.
- Secret resolution still flows through the existing company-scoped secret service and its access audit path.
- Plaintext secret values remain ephemeral provider inputs and are not added to persisted environment config or activity logs.

## Model Used

- OpenAI Codex based on GPT-5, with repository tools, code execution, and test-driven implementation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing issue or described the issue in-PR
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run applicable tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No user-facing documentation change is required for this compatibility bug fix
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge