### PR TITLE
fix(mcp-http): perform the MCP initialize handshake on the Streamable HTTP transport

### DIFF
--- a/server/src/__tests__/mcp-http.test.ts
+++ b/server/src/__tests__/mcp-http.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from "vitest";
-import { MCP_HTTP_ACCEPT, mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "../services/mcp-http.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  closeMcpHttpSession,
+  MCP_HTTP_ACCEPT,
+  mcpHttpRequestHeaders,
+  openMcpHttpSession,
+  parseMcpHttpResponseBody,
+  withMcpSessionHeader,
+} from "../services/mcp-http.js";
+
+function jsonResponse(
+  payload: unknown,
+  opts: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  return new Response(JSON.stringify(payload), {
+    status: opts.status ?? 200,
+    headers: {
+      "content-type": "application/json",
+      ...(opts.headers ?? {}),
+    },
+  });
+}
 
 describe("mcpHttpRequestHeaders", () => {
   it("advertises both JSON and SSE on every request", () => {
@@ -46,5 +66,217 @@ describe("parseMcpHttpResponseBody", () => {
 
   it("throws when an SSE stream carries no data events", () => {
     expect(() => parseMcpHttpResponseBody("event: ping\n\n", "text/event-stream")).toThrow();
+  });
+});
+
+describe("openMcpHttpSession", () => {
+  it("returns the session id and sends notifications/initialized when the server advertises one", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { method?: string };
+      if (body.method === "initialize") {
+        expect(init?.redirect).toBe("manual");
+        return jsonResponse(
+          {
+            jsonrpc: "2.0",
+            id: "paperclip-mcp-initialize",
+            result: { protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "sess", version: "1" } },
+          },
+          { headers: { "mcp-session-id": "sess-abc" } },
+        );
+      }
+      if (body.method === "notifications/initialized") {
+        expect(init?.redirect).toBe("manual");
+        return new Response(null, { status: 202 });
+      }
+      throw new Error(`unexpected method ${body.method}`);
+    });
+
+    const session = await openMcpHttpSession({
+      endpoint: "https://mcp.example/mcp",
+      headers: { Authorization: "Bearer x" },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(session).toEqual({ sessionId: "sess-abc", protocolVersion: "2025-03-26" });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const initBody = JSON.parse(String(fetchImpl.mock.calls[0]![1]?.body));
+    expect(initBody).toMatchObject({
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "paperclip", version: "0.3.1" },
+      },
+    });
+    const notifyInit = fetchImpl.mock.calls[1]![1];
+    expect(JSON.parse(String(notifyInit?.body))).toMatchObject({
+      method: "notifications/initialized",
+      params: {},
+    });
+    expect(notifyInit?.body).not.toContain('"id"');
+    expect(notifyInit?.headers).toEqual(
+      expect.objectContaining({
+        "mcp-session-id": "sess-abc",
+        "mcp-protocol-version": "2025-03-26",
+        accept: "application/json, text/event-stream",
+      }),
+    );
+  });
+
+  it("returns null sessionId and skips notifications/initialized when no session header is present", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "paperclip-mcp-initialize",
+        result: { protocolVersion: "2025-03-26", capabilities: {} },
+      }),
+    );
+
+    const session = await openMcpHttpSession({
+      endpoint: "https://mcp.example/mcp",
+      headers: {},
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(session).toEqual({ sessionId: null, protocolVersion: "2025-03-26" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]![1]?.body)).method).toBe("initialize");
+  });
+
+  it("fail-soft: HTTP 500 on initialize returns null session without throwing", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: "boom" }, { status: 500 }));
+
+    await expect(
+      openMcpHttpSession({
+        endpoint: "https://mcp.example/mcp",
+        headers: {},
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toEqual({ sessionId: null, protocolVersion: null });
+  });
+
+  it("fail-soft: 3xx redirect on initialize returns null session without following", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.example/steal" },
+      }),
+    );
+
+    await expect(
+      openMcpHttpSession({
+        endpoint: "https://mcp.example/mcp",
+        headers: { Authorization: "Bearer secret" },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toEqual({ sessionId: null, protocolVersion: null });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]![1]).toEqual(expect.objectContaining({ redirect: "manual" }));
+  });
+
+  it("fail-soft: network errors on initialize return null session without throwing", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await expect(
+      openMcpHttpSession({
+        endpoint: "https://mcp.example/mcp",
+        headers: {},
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toEqual({ sessionId: null, protocolVersion: null });
+  });
+
+  it("parses an SSE-framed initialize response via parseMcpHttpResponseBody", async () => {
+    const payload = {
+      jsonrpc: "2.0",
+      id: "paperclip-mcp-initialize",
+      result: { protocolVersion: "2025-03-26", capabilities: {} },
+    };
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(`event: message\ndata: ${JSON.stringify(payload)}\n\n`, {
+          status: 200,
+          headers: {
+            "content-type": "text/event-stream",
+            "mcp-session-id": "sse-sess",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+    const session = await openMcpHttpSession({
+      endpoint: "https://mcp.example/mcp",
+      headers: {},
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(session).toEqual({ sessionId: "sse-sess", protocolVersion: "2025-03-26" });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("closeMcpHttpSession", () => {
+  it("DELETEs with mcp-session-id and never throws", async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    await expect(
+      closeMcpHttpSession({
+        endpoint: "https://mcp.example/mcp",
+        headers: { Authorization: "Bearer x" },
+        sessionId: "sess-abc",
+        protocolVersion: "2025-03-26",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://mcp.example/mcp",
+      expect.objectContaining({
+        method: "DELETE",
+        redirect: "manual",
+        headers: expect.objectContaining({
+          "mcp-session-id": "sess-abc",
+          "mcp-protocol-version": "2025-03-26",
+        }),
+      }),
+    );
+  });
+
+  it("swallows network failures", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    await expect(
+      closeMcpHttpSession({
+        endpoint: "https://mcp.example/mcp",
+        headers: {},
+        sessionId: "sess-abc",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("withMcpSessionHeader", () => {
+  it("returns a copy without a session key when sessionId is null", () => {
+    const original = { Authorization: "Bearer x" };
+    const next = withMcpSessionHeader(original, null);
+    expect(next).toEqual({ Authorization: "Bearer x" });
+    expect(next).not.toHaveProperty("mcp-session-id");
+    expect(next).not.toBe(original);
+    original.Authorization = "mutated";
+    expect(next.Authorization).toBe("Bearer x");
+  });
+
+  it("adds mcp-session-id and optional protocol version without mutating the original", () => {
+    const original = { Authorization: "Bearer x" };
+    const next = withMcpSessionHeader(original, "abc", "2025-03-26");
+    expect(next).toEqual({
+      Authorization: "Bearer x",
+      "mcp-session-id": "abc",
+      "mcp-protocol-version": "2025-03-26",
+    });
+    expect(original).toEqual({ Authorization: "Bearer x" });
+    expect(next).not.toBe(original);
   });
 });

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -69,17 +69,20 @@ async function createCompany(db: ReturnType<typeof createDb>) {
 // also decode SSE-framed responses, so test doubles must supply both.
 function mcpHttpResponse(
   payload: unknown,
-  opts: { contentType?: string; body?: string } = {},
+  opts: { contentType?: string; body?: string; headers?: Record<string, string>; status?: number; ok?: boolean } = {},
 ): Response {
   const contentType = opts.contentType ?? "application/json";
   const body = opts.body ?? JSON.stringify(payload);
-  return {
-    ok: true,
-    status: 200,
-    headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null) },
-    text: async () => body,
-    json: async () => payload,
-  } as unknown as Response;
+  const status = opts.status ?? 200;
+  // Prefer a real Response/Headers so production code can use headers.get()
+  // without special-casing test doubles.
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": contentType,
+      ...(opts.headers ?? {}),
+    },
+  });
 }
 
 // Build an SSE-framed (`event: message\ndata: {…}`) MCP Streamable HTTP
@@ -93,7 +96,7 @@ function mcpSseResponse(payload: unknown): Response {
 }
 
 function mockToolsList(tools: unknown[]) {
-  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
     mcpHttpResponse({ jsonrpc: "2.0", id: "paperclip-catalog-refresh", result: { tools } }),
   );
 }
@@ -932,7 +935,8 @@ describeEmbeddedPostgres("tool access service", () => {
       .update(toolCatalogEntries)
       .set({ status: "active", reviewedAt: new Date(), quarantineReason: null, quarantinedAt: null })
       .where(eq(toolCatalogEntries.toolName, "send_email"));
-    fetchMock.mockResolvedValueOnce(mcpHttpResponse({
+    // initialize + tools/list both need the changed catalog payload (fresh body each call)
+    const changedCatalog = {
       jsonrpc: "2.0",
       id: "paperclip-catalog-refresh",
       result: {
@@ -945,7 +949,8 @@ describeEmbeddedPostgres("tool access service", () => {
           },
         ],
       },
-    }));
+    };
+    fetchMock.mockImplementation(async () => mcpHttpResponse(changedCatalog));
 
     const secondRefresh = await service.refreshCatalog(connection.id);
 
@@ -972,17 +977,15 @@ describeEmbeddedPostgres("tool access service", () => {
       const headers = (init?.headers ?? {}) as Record<string, string>;
       const accept = headers.accept ?? headers.Accept ?? "";
       if (!accept.includes("application/json") || !accept.includes("text/event-stream")) {
-        return {
-          ok: false,
-          status: 406,
-          headers: { get: () => null },
-          text: async () => JSON.stringify({
-            jsonrpc: "2.0",
-            error: { code: -32000, message: "Not Acceptable: Client must accept both application/json and text/event-stream" },
-            id: null,
-          }),
-        } as unknown as Response;
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Not Acceptable: Client must accept both application/json and text/event-stream" },
+          id: null,
+        }), { status: 406, headers: { "content-type": "application/json" } });
       }
+      // Session-less servers must not receive a session header.
+      expect(headers["mcp-session-id"]).toBeUndefined();
+      expect(headers["Mcp-Session-Id"]).toBeUndefined();
       return mcpSseResponse({
         jsonrpc: "2.0",
         id: "paperclip-catalog-refresh",
@@ -1015,6 +1018,126 @@ describeEmbeddedPostgres("tool access service", () => {
     // The same probe backs the periodic health sweep, so it must also pass.
     const health = await service.checkHealth(connection.id);
     expect(health.connection.healthStatus).toBe("ok");
+  });
+
+  it("forwards Mcp-Session-Id on tools/list after a session-keeping initialize handshake", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const sessionId = `catalog-sess-${randomUUID()}`;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { method?: string } : null;
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      if (init?.method === "DELETE") {
+        expect(headers["mcp-session-id"]).toBe(sessionId);
+        return new Response(null, { status: 200 });
+      }
+      if (body?.method === "initialize") {
+        return mcpHttpResponse(
+          {
+            jsonrpc: "2.0",
+            id: "paperclip-mcp-initialize",
+            result: { protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "sess", version: "1" } },
+          },
+          { headers: { "mcp-session-id": sessionId } },
+        );
+      }
+      if (body?.method === "notifications/initialized") {
+        expect(headers["mcp-session-id"]).toBe(sessionId);
+        expect(headers["mcp-protocol-version"]).toBe("2025-03-26");
+        return new Response(null, { status: 202 });
+      }
+      if (body?.method === "tools/list") {
+        expect(headers["mcp-session-id"]).toBe(sessionId);
+        expect(headers["mcp-protocol-version"]).toBe("2025-03-26");
+        return mcpHttpResponse({
+          jsonrpc: "2.0",
+          id: "paperclip-catalog-refresh",
+          result: { tools: [{ name: "kv_get", description: "Read.", annotations: { readOnlyHint: true } }] },
+        });
+      }
+      throw new Error(`unexpected method ${body?.method ?? init?.method}`);
+    });
+
+    const connection = await service.createConnection(company.id, {
+      name: "Session-keeping fixture",
+      transport: "mcp_remote",
+      config: { url: "https://session.example/mcp" },
+      enabled: true,
+      status: "active",
+    });
+    const refresh = await service.refreshCatalog(connection.id, { actorType: "user", actorId: "board" });
+
+    expect(refresh.discoveredCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalled();
+    const methods = fetchMock.mock.calls.map(([, init]) => {
+      if (init?.method === "DELETE") return "DELETE";
+      return JSON.parse(String(init?.body)).method;
+    });
+    expect(methods).toEqual(["initialize", "notifications/initialized", "tools/list", "DELETE"]);
+  });
+
+  it("fail-soft: catalog refresh succeeds when initialize returns HTTP 500", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { method?: string } : null;
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      if (body?.method === "initialize") {
+        return mcpHttpResponse({ error: "boom" }, { status: 500 });
+      }
+      if (body?.method === "tools/list") {
+        expect(headers["mcp-session-id"]).toBeUndefined();
+        return mcpHttpResponse({
+          jsonrpc: "2.0",
+          id: "paperclip-catalog-refresh",
+          result: { tools: [{ name: "kv_get", description: "Read.", annotations: { readOnlyHint: true } }] },
+        });
+      }
+      throw new Error(`unexpected method ${body?.method}`);
+    });
+
+    const connection = await service.createConnection(company.id, {
+      name: "Fail-soft 500 fixture",
+      transport: "mcp_remote",
+      config: { url: "https://failsoft500.example/mcp" },
+      enabled: true,
+      status: "active",
+    });
+    const refresh = await service.refreshCatalog(connection.id, { actorType: "user", actorId: "board" });
+    expect(refresh.discoveredCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("fail-soft: catalog refresh succeeds when initialize hits a network error", async () => {
+    const company = await createCompany(db);
+    const service = toolAccessService(db);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { method?: string } : null;
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      if (body?.method === "initialize") {
+        throw new TypeError("fetch failed");
+      }
+      if (body?.method === "tools/list") {
+        expect(headers["mcp-session-id"]).toBeUndefined();
+        return mcpHttpResponse({
+          jsonrpc: "2.0",
+          id: "paperclip-catalog-refresh",
+          result: { tools: [{ name: "kv_get", description: "Read.", annotations: { readOnlyHint: true } }] },
+        });
+      }
+      throw new Error(`unexpected method ${body?.method}`);
+    });
+
+    const connection = await service.createConnection(company.id, {
+      name: "Fail-soft network fixture",
+      transport: "mcp_remote",
+      config: { url: "https://failsoftnet.example/mcp" },
+      enabled: true,
+      status: "active",
+    });
+    const refresh = await service.refreshCatalog(connection.id, { actorType: "user", actorId: "board" });
+    expect(refresh.discoveredCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   it("registers an approved local stdio template and exposes its runtime slot", async () => {
@@ -1344,11 +1467,13 @@ describeEmbeddedPostgres("tool access service", () => {
       priority: 100,
       selectors: { connectionId: connection.id },
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(mcpHttpResponse({
-      jsonrpc: "2.0",
-      id: "paperclip-tool-test",
-      result: { content: [{ type: "text", text: "sent" }] },
-    }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      mcpHttpResponse({
+        jsonrpc: "2.0",
+        id: "paperclip-tool-test",
+        result: { content: [{ type: "text", text: "sent" }] },
+      }),
+    );
     const app = createRouteApp(
       db,
       boardSessionActor(company.id, "operator", userId),
@@ -1364,7 +1489,8 @@ describeEmbeddedPostgres("tool access service", () => {
       decision: "allowed",
       result: { data: expect.objectContaining({ isError: false, transport: "mcp_http" }) },
     });
-    expect(fetchMock).toHaveBeenCalledOnce();
+    // initialize handshake + tools/call
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     const [invocation] = await db.select().from(toolInvocations).where(eq(toolInvocations.companyId, company.id));
     expect(invocation).toMatchObject({
       actorType: "user",
@@ -1525,11 +1651,13 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(waiting.body.result).toBeUndefined();
 
     // 3. Approving from the review queue is what runs the parked test call.
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(mcpHttpResponse({
-      jsonrpc: "2.0",
-      id: "paperclip-tool-test",
-      result: { content: [{ type: "text", text: "sent" }] },
-    }));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      mcpHttpResponse({
+        jsonrpc: "2.0",
+        id: "paperclip-tool-test",
+        result: { content: [{ type: "text", text: "sent" }] },
+      }),
+    );
     await gateway.approveActionRequest({ companyId: company.id, actionRequestId, actor: { userId } });
     expect(fetchMock).toHaveBeenCalled();
 
@@ -1568,11 +1696,13 @@ describeEmbeddedPostgres("tool access service", () => {
       .send(body)
       .expect(200);
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(mcpHttpResponse({
-      jsonrpc: "2.0",
-      id: "paperclip-tool-test",
-      result: { content: [{ type: "text", text: "sent" }] },
-    }));
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      mcpHttpResponse({
+        jsonrpc: "2.0",
+        id: "paperclip-tool-test",
+        result: { content: [{ type: "text", text: "sent" }] },
+      }),
+    );
     await gateway.approveActionRequest({
       companyId: company.id,
       actionRequestId: first.body.actionRequestId as string,
@@ -3041,7 +3171,7 @@ describeEmbeddedPostgres("tool access service", () => {
       .query({ state, code: "oauth-code" });
 
     expect(callbackRes.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(callbackRes.body.connection).toMatchObject({
       id: connectRes.body.connectionId,
       status: "active",
@@ -3073,7 +3203,7 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(redirectCallbackRes.headers.location).toBe(
       `/${company.issuePrefix}/apps/${redirectConnectRes.body.connectionId}/setup?oauth=connected`,
     );
-    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock).toHaveBeenCalledTimes(10);
     await expect(db.select().from(toolOauthStates)).resolves.toHaveLength(0);
     await expect(db.select().from(companySecretBindings)).resolves.toHaveLength(6);
     const [connection] = await db.select().from(toolConnections).where(eq(toolConnections.id, connectRes.body.connectionId));
@@ -3386,7 +3516,7 @@ describeEmbeddedPostgres("tool access service", () => {
 
     const health = await service.checkHealth(connection.id, { actorType: "system", actorId: "health-check" });
     expect(health.connection.healthStatus).toBe("ok");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     const [updated] = await db.select().from(toolConnections).where(eq(toolConnections.id, connection.id));
     expect(updated.credentialSecretRefs).toEqual([
       expect.objectContaining({ configPath: "oauth.access_token", label: "OAuth access token" }),
@@ -4512,7 +4642,7 @@ describeEmbeddedPostgres("tool access service", () => {
       credentialValues: { "credentials.authorization": "zap-secret" },
     }, { actorType: "user", actorId: "board" });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(fetchMock).toHaveBeenCalledWith(
       "https://mcp.zapier.com/api/mcp",
       expect.objectContaining({
@@ -4602,7 +4732,7 @@ describeEmbeddedPostgres("tool access service", () => {
       ]),
     );
 
-    fetchMock.mockResolvedValueOnce(mcpHttpResponse({
+    const rereviewCatalog = {
       jsonrpc: "2.0",
       id: "paperclip-catalog-refresh",
       result: {
@@ -4627,7 +4757,8 @@ describeEmbeddedPostgres("tool access service", () => {
           },
         ],
       },
-    }));
+    };
+    fetchMock.mockImplementation(async () => mcpHttpResponse(rereviewCatalog));
     const rereview = await service.refreshCatalog(connect.connectionId, { actorType: "user", actorId: "board" });
     expect(rereview.quarantinedCount).toBe(2);
     expect(rereview.catalog).toEqual(

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -416,6 +416,7 @@ function createGatewayRouteApp(
 }
 
 type FakeMcpRequest = {
+  method: string;
   headers: IncomingMessage["headers"];
   body: Record<string, unknown> | null;
 };
@@ -432,7 +433,13 @@ async function startFakeRemoteMcpServer(handler: (request: FakeMcpRequest) => Pr
   body?: unknown;
   rawBody?: string;
   delayMs?: number;
-}) {
+}, opts: {
+  /** When set, initialize replies with this mcp-session-id (session-keeping server). */
+  sessionId?: string | null;
+  /** When false, initialize is forwarded to `handler` like any other method. Default true. */
+  autoInitialize?: boolean;
+} = {}) {
+  const autoInitialize = opts.autoInitialize !== false;
   const requests: FakeMcpRequest[] = [];
   const server = createServer(async (req, res) => {
     const chunks: Buffer[] = [];
@@ -445,8 +452,44 @@ async function startFakeRemoteMcpServer(handler: (request: FakeMcpRequest) => Pr
       } catch {
         body = null;
       }
-      const requestRecord = { headers: req.headers, body };
+      const requestRecord: FakeMcpRequest = {
+        method: req.method ?? "GET",
+        headers: req.headers,
+        body,
+      };
       requests.push(requestRecord);
+
+      // Default: answer initialize locally so existing tools/call handlers keep
+      // asserting only on the tool request. Session-less unless sessionId is set.
+      if (autoInitialize && body?.method === "initialize") {
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        if (opts.sessionId) {
+          res.setHeader("mcp-session-id", opts.sessionId);
+        }
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id ?? "test",
+          result: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            serverInfo: { name: "fake-remote-mcp", version: "0.0.0" },
+          },
+        }));
+        return;
+      }
+      if (autoInitialize && body?.method === "notifications/initialized") {
+        res.statusCode = 202;
+        res.end();
+        return;
+      }
+      // Session teardown is best-effort DELETE; acknowledge without involving the tool handler.
+      if (req.method === "DELETE") {
+        res.statusCode = 200;
+        res.end();
+        return;
+      }
+
       const response = await handler(requestRecord);
       if (response.delayMs) {
         await new Promise((resolve) => setTimeout(resolve, response.delayMs));
@@ -1510,16 +1553,21 @@ rl.on("line", (line) => {
           },
         },
       });
-      expect(fake.requests).toHaveLength(1);
+      // initialize (+ optional notifications/initialized) then tools/call
+      const toolCall = fake.requests.find((request) => request.body?.method === "tools/call");
+      expect(toolCall).toBeTruthy();
+      // Session-less servers must not receive a session header on tools/call.
+      expect(toolCall!.headers["mcp-session-id"]).toBeUndefined();
       // Streamable HTTP requires advertising both JSON and SSE on the call (PAP-11096).
-      expect(fake.requests[0]!.headers.accept).toBe("application/json, text/event-stream");
-      expect(fake.requests[0]!.body).toMatchObject({
+      expect(toolCall!.headers.accept).toBe("application/json, text/event-stream");
+      expect(toolCall!.body).toMatchObject({
         method: "tools/call",
         params: {
           name: "kv_set",
           arguments: { key: "alpha", value: "one" },
         },
       });
+      expect(fake.requests.some((request) => request.body?.method === "initialize")).toBe(true);
 
       const [invocation] = await db.select().from(toolInvocations);
       expect(invocation).toMatchObject({
@@ -1607,6 +1655,159 @@ rl.on("line", (line) => {
       });
       expect(persisted).not.toContain(credentialValue);
     } finally {
+      await fake.close();
+    }
+  });
+
+  it("forwards Mcp-Session-Id on tools/call after a session-keeping initialize handshake", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const sessionId = `sess-${randomUUID()}`;
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => {
+      expect(fakeRequest.headers["mcp-session-id"]).toBe(sessionId);
+      return {
+        body: {
+          jsonrpc: "2.0",
+          id: fakeRequest.body?.id,
+          result: { content: [{ type: "text", text: "session-ok" }] },
+        },
+      };
+    }, { sessionId });
+    try {
+      await createRemoteMcpTool(db, company.id, {
+        applicationKey: "session-demo",
+        toolName: "kv_get",
+        title: "Get KV",
+        riskLevel: "read",
+        url: fake.url,
+      });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.providerType === "mcp_remote_http");
+      expect(connectedTool).toBeTruthy();
+
+      const result = await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha" },
+      });
+      expect(result).toMatchObject({
+        status: "completed",
+        result: { content: "session-ok" },
+      });
+      expect(fake.requests.map((request) => request.body?.method ?? request.method)).toEqual([
+        "initialize",
+        "notifications/initialized",
+        "tools/call",
+        "DELETE",
+      ]);
+      expect(fake.requests[2]!.headers["mcp-session-id"]).toBe(sessionId);
+      expect(fake.requests[2]!.headers["mcp-protocol-version"]).toBe("2025-03-26");
+      expect(fake.requests[3]!.headers["mcp-session-id"]).toBe(sessionId);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("fail-soft: tools/call succeeds when initialize returns HTTP 500", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => {
+      if (fakeRequest.body?.method === "initialize") {
+        return { status: 500, body: { error: "initialize unsupported" } };
+      }
+      return {
+        body: {
+          jsonrpc: "2.0",
+          id: fakeRequest.body?.id,
+          result: { content: [{ type: "text", text: "ok-after-init-500" }] },
+        },
+      };
+    }, { autoInitialize: false });
+    try {
+      await createRemoteMcpTool(db, company.id, {
+        applicationKey: "failsoft-500",
+        toolName: "kv_get",
+        title: "Get KV",
+        riskLevel: "read",
+        url: fake.url,
+      });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.providerType === "mcp_remote_http");
+      expect(connectedTool).toBeTruthy();
+
+      const result = await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha" },
+      });
+      expect(result).toMatchObject({
+        status: "completed",
+        result: { content: "ok-after-init-500" },
+      });
+      const toolCall = fake.requests.find((request) => request.body?.method === "tools/call");
+      expect(toolCall).toBeTruthy();
+      expect(toolCall!.headers["mcp-session-id"]).toBeUndefined();
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("fail-soft: tools/call succeeds when initialize hits a network error", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => ({
+      body: {
+        jsonrpc: "2.0",
+        id: fakeRequest.body?.id,
+        result: { content: [{ type: "text", text: "ok-after-init-network" }] },
+      },
+    }));
+    const realFetch = globalThis.fetch;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { method?: string } : null;
+      if (body?.method === "initialize") {
+        throw new TypeError("fetch failed");
+      }
+      return realFetch(input as RequestInfo, init);
+    });
+    try {
+      await createRemoteMcpTool(db, company.id, {
+        applicationKey: "failsoft-net",
+        toolName: "kv_get",
+        title: "Get KV",
+        riskLevel: "read",
+        url: fake.url,
+      });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.providerType === "mcp_remote_http");
+      expect(connectedTool).toBeTruthy();
+
+      const result = await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha" },
+      });
+      expect(result).toMatchObject({
+        status: "completed",
+        result: { content: "ok-after-init-network" },
+      });
+      const toolCall = fake.requests.find((request) => request.body?.method === "tools/call");
+      expect(toolCall).toBeTruthy();
+      expect(toolCall!.headers["mcp-session-id"]).toBeUndefined();
+    } finally {
+      fetchSpy.mockRestore();
       await fake.close();
     }
   });
@@ -2701,7 +2902,9 @@ rl.on("line", (line) => {
             request: {
               endpoint: fake.url,
               mcpMethod: "tools/call",
-              dispatched: true,
+              // Timeout aborts the in-flight tools/call fetch before it returns,
+              // so dispatched stays false (set only after fetch resolves).
+              dispatched: scenario.reasonCode !== "tool_timeout",
             },
           },
         });

--- a/server/src/services/mcp-http.ts
+++ b/server/src/services/mcp-http.ts
@@ -10,9 +10,32 @@
 // SSE stream (`event: message\ndata: {…}`) instead of a bare JSON body. So any
 // code path that POSTs JSON-RPC to a remote `/mcp` endpoint must (a) send the
 // Accept header and (b) be able to read an SSE-framed response.
+//
+// Spec-compliant servers that keep a session also require an initialize
+// handshake before tools/list or tools/call. The server may return an
+// `mcp-session-id` response header; subsequent requests must echo it. The
+// local stdio path in tool-gateway.ts already does initialize +
+// notifications/initialized — openMcpHttpSession mirrors that for HTTP.
+// Handshake failures are fail-soft: many real-world servers ignore sessions
+// and already work without initialize, so a broken handshake must not block
+// the subsequent tools/list or tools/call.
 
 /** The Accept header value required by the MCP Streamable HTTP transport. */
 export const MCP_HTTP_ACCEPT = "application/json, text/event-stream";
+
+/** Session mechanics (mcp-session-id) arrived with the 2025-03-26 revision. */
+const DEFAULT_MCP_PROTOCOL_VERSION = "2025-03-26";
+const DEFAULT_CLIENT_NAME = "paperclip";
+const DEFAULT_CLIENT_VERSION = "0.3.1";
+/** Initialize responses are small; refuse oversized bodies fail-soft. */
+const MAX_INITIALIZE_RESPONSE_BYTES = 64 * 1024;
+
+export interface McpHttpSession {
+  /** Value of the mcp-session-id header, or null when the server is session-less. */
+  sessionId: string | null;
+  /** Protocol version negotiated by the server (sent on later requests). */
+  protocolVersion: string | null;
+}
 
 /**
  * Default headers for an MCP Streamable HTTP JSON-RPC POST. Caller-supplied
@@ -25,6 +48,20 @@ export function mcpHttpRequestHeaders(extra?: Record<string, string>): Record<st
     ...extra,
     accept: MCP_HTTP_ACCEPT,
   };
+}
+
+/**
+ * Attach session / negotiated protocol headers when present. Does not mutate input.
+ */
+export function withMcpSessionHeader(
+  headers: Record<string, string>,
+  sessionId: string | null,
+  protocolVersion?: string | null,
+): Record<string, string> {
+  const next = { ...headers };
+  if (sessionId) next["mcp-session-id"] = sessionId;
+  if (protocolVersion) next["mcp-protocol-version"] = protocolVersion;
+  return next;
 }
 
 function looksLikeJsonRpcMessage(value: unknown): boolean {
@@ -81,4 +118,183 @@ export function parseMcpHttpResponseBody(bodyText: string, contentType: string |
   if (sawData) return firstParsed;
   if (lastError) throw lastError;
   throw new SyntaxError("MCP SSE response contained no data events");
+}
+
+async function discardResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort; never let cleanup fail the handshake.
+  }
+}
+
+/**
+ * Read a response body up to `maxBytes`. Oversized or unreadable bodies return
+ * null after discarding leftover bytes (fail-soft for initialize).
+ */
+async function readBoundedResponseText(response: Response, maxBytes: number): Promise<string | null> {
+  try {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength !== null) {
+      const length = Number(contentLength);
+      if (Number.isFinite(length) && length > maxBytes) {
+        await discardResponseBody(response);
+        return null;
+      }
+    }
+    if (!response.body) {
+      const text = await response.text();
+      if (Buffer.byteLength(text, "utf8") > maxBytes) return null;
+      return text;
+    }
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // ignore
+        }
+        return null;
+      }
+      chunks.push(value);
+    }
+    const merged = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(merged);
+  } catch {
+    await discardResponseBody(response);
+    return null;
+  }
+}
+
+/**
+ * Open an MCP Streamable HTTP session via the initialize handshake.
+ *
+ * Fail-soft: any HTTP error, redirect, network failure, or unparseable body
+ * returns `{ sessionId: null, protocolVersion: null }` instead of throwing, so
+ * session-less / non-compliant servers keep working exactly as before.
+ *
+ * Both handshake requests use `redirect: "manual"` so a remote 3xx cannot bypass
+ * the caller's endpoint allowlist or leak credential headers cross-origin.
+ */
+export async function openMcpHttpSession(input: {
+  endpoint: string;
+  headers: Record<string, string>;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  clientName?: string;
+  clientVersion?: string;
+}): Promise<McpHttpSession> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const clientName = input.clientName ?? DEFAULT_CLIENT_NAME;
+  const clientVersion = input.clientVersion ?? DEFAULT_CLIENT_VERSION;
+
+  try {
+    const response = await fetchImpl(input.endpoint, {
+      method: "POST",
+      redirect: "manual",
+      headers: mcpHttpRequestHeaders(input.headers),
+      signal: input.signal,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "paperclip-mcp-initialize",
+        method: "initialize",
+        params: {
+          protocolVersion: DEFAULT_MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: clientName, version: clientVersion },
+        },
+      }),
+    });
+
+    // 3xx (and any non-2xx): do not follow; treat as session-less.
+    if (!response.ok || (response.status >= 300 && response.status < 400)) {
+      await discardResponseBody(response);
+      return { sessionId: null, protocolVersion: null };
+    }
+
+    const sessionId = response.headers.get("mcp-session-id") || null;
+    let protocolVersion: string | null = null;
+    const bodyText = await readBoundedResponseText(response, MAX_INITIALIZE_RESPONSE_BYTES);
+    if (bodyText) {
+      try {
+        const payload = parseMcpHttpResponseBody(bodyText, response.headers.get("content-type"));
+        if (typeof payload === "object" && payload !== null) {
+          const result = (payload as { result?: unknown }).result;
+          if (typeof result === "object" && result !== null) {
+            const version = (result as { protocolVersion?: unknown }).protocolVersion;
+            if (typeof version === "string") protocolVersion = version;
+          }
+        }
+      } catch {
+        // Body parse failure is still fail-soft for the overall handshake, but
+        // keep any session id the server already advertised on the response.
+      }
+    }
+
+    if (sessionId) {
+      // notifications/initialized is a notification (no `id`). Servers may
+      // answer with 202 and an empty body — discard the response body.
+      try {
+        const notifyResponse = await fetchImpl(input.endpoint, {
+          method: "POST",
+          redirect: "manual",
+          headers: mcpHttpRequestHeaders(
+            withMcpSessionHeader(input.headers, sessionId, protocolVersion),
+          ),
+          signal: input.signal,
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "notifications/initialized",
+            params: {},
+          }),
+        });
+        await discardResponseBody(notifyResponse);
+      } catch {
+        // Notification delivery is best-effort; the session id is still usable.
+      }
+    }
+
+    return { sessionId, protocolVersion };
+  } catch {
+    return { sessionId: null, protocolVersion: null };
+  }
+}
+
+/**
+ * Best-effort session teardown. Spec-compliant servers accept DELETE with
+ * mcp-session-id. Never throws; never waits on a response body.
+ */
+export async function closeMcpHttpSession(input: {
+  endpoint: string;
+  headers: Record<string, string>;
+  sessionId: string;
+  protocolVersion?: string | null;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<void> {
+  try {
+    const response = await (input.fetchImpl ?? fetch)(input.endpoint, {
+      method: "DELETE",
+      redirect: "manual",
+      headers: mcpHttpRequestHeaders(
+        withMcpSessionHeader(input.headers, input.sessionId, input.protocolVersion),
+      ),
+      signal: input.signal,
+    });
+    await discardResponseBody(response);
+  } catch {
+    // Best-effort only.
+  }
 }

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -110,7 +110,13 @@ import type {
 import { CLASS3_STATIC_LEASE_ALLOWLIST, credentialConfigPath, getAvailableConnectionMethod, getConnectableAppDefinition, isToolConnectionAttentionHealth, recommendedDefaultsForApp } from "@paperclipai/shared";
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
-import { mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
+import {
+  closeMcpHttpSession,
+  mcpHttpRequestHeaders,
+  openMcpHttpSession,
+  parseMcpHttpResponseBody,
+  withMcpSessionHeader,
+} from "./mcp-http.js";
 import { assertPublicRemoteHttpEndpoint, parseRemoteHttpEndpoint } from "./remote-http-endpoint-guard.js";
 import { secretService } from "./secrets.js";
 import { toolAccessPolicyService } from "./tool-access-policy.js";
@@ -2774,56 +2780,74 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   async function remoteTools(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {
     const headers = await resolveCredentialHeaders(connection);
     const endpoint = await assertRemoteEndpointAllowed(connection.config);
-    const response = await fetch(endpoint, {
-      method: "POST",
-      // MCP Streamable HTTP requires advertising that we accept both a JSON body
-      // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
-      headers: mcpHttpRequestHeaders(headers),
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: "paperclip-catalog-refresh",
-        method: "tools/list",
-        params: {},
-      }),
-    });
-    if (!response.ok) {
-      const authenticate = response.headers.get("www-authenticate") ?? "";
-      if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
-        const endpoints = await discoverOAuthEndpoints(connection, authenticate);
-        if (endpoints) {
-          const nextConfig = {
-            ...connection.config,
-            oauth: {
-              ...oauthConfig(connection),
-              provider: endpoints.provider,
-              authorizationUrl: endpoints.authorizationUrl,
-              tokenUrl: endpoints.tokenUrl,
-              metadataUrl: endpoints.metadataUrl ?? null,
-              scopes: endpoints.scopes,
-              grantType: endpoints.grantType ?? "authorization_code",
-              discoveredAt: new Date().toISOString(),
-            },
-          };
-          await db
-            .update(toolConnections)
-            .set({ config: nextConfig, transportConfig: nextConfig, updatedAt: new Date() })
-            .where(eq(toolConnections.id, connection.id));
+    // Spec-compliant session-keeping servers reject tools/list without an
+    // initialize handshake + mcp-session-id. Fail-soft when the server is
+    // session-less (see openMcpHttpSession).
+    const mcpSession = await openMcpHttpSession({ endpoint, headers });
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        redirect: "manual",
+        // MCP Streamable HTTP requires advertising that we accept both a JSON body
+        // and an SSE stream; spec-compliant servers 406 without it (see mcp-http.ts).
+        headers: mcpHttpRequestHeaders(
+          withMcpSessionHeader(headers, mcpSession.sessionId, mcpSession.protocolVersion),
+        ),
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "paperclip-catalog-refresh",
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      if (!response.ok) {
+        const authenticate = response.headers.get("www-authenticate") ?? "";
+        if (response.status === 401 && /bearer|oauth|authorization/i.test(authenticate)) {
+          const endpoints = await discoverOAuthEndpoints(connection, authenticate);
+          if (endpoints) {
+            const nextConfig = {
+              ...connection.config,
+              oauth: {
+                ...oauthConfig(connection),
+                provider: endpoints.provider,
+                authorizationUrl: endpoints.authorizationUrl,
+                tokenUrl: endpoints.tokenUrl,
+                metadataUrl: endpoints.metadataUrl ?? null,
+                scopes: endpoints.scopes,
+                grantType: endpoints.grantType ?? "authorization_code",
+                discoveredAt: new Date().toISOString(),
+              },
+            };
+            await db
+              .update(toolConnections)
+              .set({ config: nextConfig, transportConfig: nextConfig, updatedAt: new Date() })
+              .where(eq(toolConnections.id, connection.id));
+          }
+          throw new HttpError(502, "This app needs you to sign in.", {
+            code: "oauth_challenge",
+            status: response.status,
+            setupUrl: connectionSetupUrl(connection),
+            reconnectUrl: connectionReconnectUrl(connection),
+            oauthSupported: Boolean(endpoints),
+          });
         }
-        throw new HttpError(502, "This app needs you to sign in.", {
-          code: "oauth_challenge",
-          status: response.status,
-          setupUrl: connectionSetupUrl(connection),
-          reconnectUrl: connectionReconnectUrl(connection),
-          oauthSupported: Boolean(endpoints),
+        throw new HttpError(502, "Remote app returned an error", { status: response.status });
+      }
+      const payload = parseMcpHttpResponseBody(await response.text(), response.headers.get("content-type"));
+      const result = asRecord(asRecord(payload).result);
+      const payloadTools = asRecord(payload).tools;
+      const tools: unknown[] = Array.isArray(result.tools) ? result.tools : Array.isArray(payloadTools) ? payloadTools : [];
+      return tools.map((tool) => normalizeToolDescriptor(tool)).filter((tool): tool is McpToolDescriptor => Boolean(tool));
+    } finally {
+      if (mcpSession.sessionId) {
+        await closeMcpHttpSession({
+          endpoint,
+          headers,
+          sessionId: mcpSession.sessionId,
+          protocolVersion: mcpSession.protocolVersion,
         });
       }
-      throw new HttpError(502, "Remote app returned an error", { status: response.status });
     }
-    const payload = parseMcpHttpResponseBody(await response.text(), response.headers.get("content-type"));
-    const result = asRecord(asRecord(payload).result);
-    const payloadTools = asRecord(payload).tools;
-    const tools: unknown[] = Array.isArray(result.tools) ? result.tools : Array.isArray(payloadTools) ? payloadTools : [];
-    return tools.map((tool) => normalizeToolDescriptor(tool)).filter((tool): tool is McpToolDescriptor => Boolean(tool));
   }
 
   async function localTools(connection: typeof toolConnections.$inferSelect): Promise<McpToolDescriptor[]> {

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -53,7 +53,13 @@ import type {
 import type { AgentToolDescriptor, PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import { logActivity, type LogActivityInput } from "./activity-log.js";
 import { secretService } from "./secrets.js";
-import { mcpHttpRequestHeaders, parseMcpHttpResponseBody } from "./mcp-http.js";
+import {
+  closeMcpHttpSession,
+  mcpHttpRequestHeaders,
+  openMcpHttpSession,
+  parseMcpHttpResponseBody,
+  withMcpSessionHeader,
+} from "./mcp-http.js";
 import { assertPublicRemoteHttpEndpoint, parseRemoteHttpEndpoint } from "./remote-http-endpoint-guard.js";
 import { toolAccessPolicyService } from "./tool-access-policy.js";
 import { issueThreadInteractionService } from "./issue-thread-interactions.js";
@@ -242,7 +248,7 @@ type RemoteHttpExecutionAudit = {
     mcpMethod: "tools/call";
     requestId: string;
     upstreamToolName: string;
-    dispatched: true;
+    dispatched: boolean;
   };
   response?: {
     httpStatus: number;
@@ -2242,7 +2248,15 @@ export function createToolGatewayService(
       const normalized = headerName(name);
       if (normalized) credentialHeaders[normalized] = value;
     }
-    const reservedHeaders = new Set(["accept", "content-type", "content-length", "host", "connection"]);
+    const reservedHeaders = new Set([
+      "accept",
+      "content-type",
+      "content-length",
+      "host",
+      "connection",
+      "mcp-session-id",
+      "mcp-protocol-version",
+    ]);
     const managedCredentialHeaders = new Set(Object.keys(credentialHeaders));
     const headers: Record<string, string> = {};
     const summary: HeaderPolicySummary = {
@@ -3028,19 +3042,35 @@ export function createToolGatewayService(
         mcpMethod: "tools/call",
         requestId,
         upstreamToolName: entry.toolName,
-        dispatched: true,
+        // Set true only after the tools/call fetch returns — handshake may
+        // consume the whole timeout budget without ever dispatching the call.
+        dispatched: false,
       },
     };
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), ms);
     timer.unref?.();
+    let mcpSessionId: string | null = null;
+    let mcpProtocolVersion: string | null = null;
     try {
+      // Spec-compliant session-keeping servers reject tools/call without an
+      // initialize handshake + mcp-session-id. Share the call timeout signal so
+      // the handshake is bounded by the same budget (see openMcpHttpSession).
+      const mcpSession = await openMcpHttpSession({
+        endpoint,
+        headers,
+        signal: controller.signal,
+      });
+      mcpSessionId = mcpSession.sessionId;
+      mcpProtocolVersion = mcpSession.protocolVersion;
       const response = await fetch(endpoint, {
         method: "POST",
         redirect: "manual",
         // MCP Streamable HTTP requires the Accept header advertising both a JSON
         // body and an SSE stream; spec-compliant servers 406 without it.
-        headers: mcpHttpRequestHeaders(headers),
+        headers: mcpHttpRequestHeaders(
+          withMcpSessionHeader(headers, mcpSession.sessionId, mcpSession.protocolVersion),
+        ),
         signal: controller.signal,
         body: JSON.stringify({
           jsonrpc: "2.0",
@@ -3052,6 +3082,7 @@ export function createToolGatewayService(
           },
         }),
       });
+      execution.request.dispatched = true;
       const body = await readBoundedRemoteResponse(response);
       execution.response = {
         httpStatus: response.status,
@@ -3131,6 +3162,15 @@ export function createToolGatewayService(
       });
     } finally {
       clearTimeout(timer);
+      if (mcpSessionId) {
+        // Do not share the (possibly aborted) call signal — teardown is best-effort.
+        await closeMcpHttpSession({
+          endpoint,
+          headers,
+          sessionId: mcpSessionId,
+          protocolVersion: mcpProtocolVersion,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
fix(mcp-http): perform the MCP initialize handshake on the Streamable HTTP transport

## Problem

The server talks to remote MCP endpoints over Streamable HTTP but never performs the
initialize handshake. Both call sites POST `tools/list` / `tools/call` directly, with no
`initialize` request and no `Mcp-Session-Id` header:

- `server/src/services/tool-access.ts` → `remoteTools()` (catalog refresh + health check)
- `server/src/services/tool-gateway.ts` → remote HTTP tool execution

Spec-compliant servers that maintain a session reject those requests outright:

```
HTTP 400
{"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Bad Request: Missing session ID"}}
```

The connection then reports `healthStatus: "error"` with a generic *"Remote app returned an
error"*, which gives no hint that a handshake is missing.

## Why this looks like an oversight rather than a design choice

The **stdio** path in this same repository already does the handshake correctly —
`tool-gateway.ts`, local stdio execution:

```ts
await request("initialize", {
  protocolVersion: "2024-11-05",
  capabilities: {},
  clientInfo: { name: "paperclip-tool-gateway", version: "0.3.1" },
});
child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} })}\n`);
return await request("tools/call", { ... });
```

The HTTP transport simply does not mirror it. The header comment in `mcp-http.ts` already
cites the Streamable HTTP spec for the `Accept` header and SSE framing, so the transport was
clearly written with the spec in hand — the session step was just missed.

## Change

Adds three helpers to `server/src/services/mcp-http.ts` and uses them at both call sites:

- `openMcpHttpSession()` — POSTs `initialize`, reads the `mcp-session-id` response header,
  sends `notifications/initialized` when a session was issued, returns
  `{ sessionId, protocolVersion }`.
- `withMcpSessionHeader()` — attaches `mcp-session-id` (and `mcp-protocol-version`) to
  subsequent requests. Does not mutate its input.
- `closeMcpHttpSession()` — best-effort `DELETE` teardown so long-lived servers do not
  accumulate abandoned sessions.

### Design notes

**Fail-soft by default.** Any HTTP error, redirect, network failure or unparseable body from
`initialize` returns `{ sessionId: null }` instead of throwing. Servers that ignore sessions —
including non-compliant ones that reject `initialize` outright — keep working exactly as
before. This was a hard requirement: the change must not regress anyone currently running
against a session-less server.

**`redirect: "manual"` on both handshake requests.** The remote endpoint is validated once,
before the request. Following a redirect chosen by the remote server would bypass that
validation entirely and could leak credential headers to the redirect target (headers other
than `Authorization` are not stripped by the runtime on cross-origin redirects). A 3xx is
treated as a failed handshake. This mirrors the existing `redirect: "manual"` on the tool
call two lines below.

**Bounded body read.** The `initialize` response is read with a 64 KB cap and the body is
drained on every early return, matching the bounded-read guard the tool-call path already has.

**Protocol version `2025-03-26`** — session mechanics arrived in that revision, and this
repository's own gateway advertises the same version (`routes/tool-gateway.ts`).

**No session cache.** One handshake per operation. Stateless, immune to expiry, and cheap
relative to the tool call itself.

## Tests

`server/src/__tests__/mcp-http.test.ts` — 17 tests covering: session issued / not issued,
`notifications/initialized` sent only when a session exists, `initialize` returning HTTP 500,
`initialize` throwing a network error, SSE-framed `initialize` responses, header attachment
and non-mutation, and teardown.

Integration coverage added to `tool-access-service.test.ts` and `tool-gateway.test.ts`:
catalog refresh and tool call both succeed when `initialize` fails (fail-soft), and the
session header is present on the follow-up request when a session was issued — and absent
when it was not.

## Verification

Verified against a live session-keeping MCP server (a Google Workspace MCP deployment):
before the change the connection health check returned 502; after it, `tools/list` succeeds
and tool calls execute normally.