### PR TITLE
fix(kubernetes): clean up partial lease acquisition

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/src/lease-lifecycle.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/lease-lifecycle.ts
@@ -31,11 +31,14 @@ export function isKubeNotFoundError(err: unknown): boolean {
   return code === 404;
 }
 
-async function ignoreNotFound(promise: Promise<unknown>): Promise<void> {
+async function attemptDelete(
+  errors: unknown[],
+  operation: () => Promise<unknown>,
+): Promise<void> {
   try {
-    await promise;
+    await operation();
   } catch (err) {
-    if (!isKubeNotFoundError(err)) throw err;
+    if (!isKubeNotFoundError(err)) errors.push(err);
   }
 }
 
@@ -169,25 +172,40 @@ export async function destroyLeaseResources(
   clients: KubeClients,
   input: DestroyLeaseInput,
 ): Promise<void> {
+  const errors: unknown[] = [];
   if (input.backend === "sandbox-cr") {
-    await ignoreNotFound(deleteSandboxCr(clients, input.namespace, input.name));
+    await attemptDelete(
+      errors,
+      () => deleteSandboxCr(clients, input.namespace, input.name),
+    );
   } else {
-    await ignoreNotFound(deleteJob(clients, input.namespace, input.name));
+    await attemptDelete(
+      errors,
+      () => deleteJob(clients, input.namespace, input.name),
+    );
   }
-  if (input.podName) {
-    await ignoreNotFound(
-      clients.core.deleteNamespacedPod({
+  const podName = input.podName;
+  if (podName) {
+    await attemptDelete(
+      errors,
+      () => clients.core.deleteNamespacedPod({
         namespace: input.namespace,
-        name: input.podName,
+        name: podName,
       }),
     );
   }
-  if (input.secretName) {
-    await ignoreNotFound(
-      clients.core.deleteNamespacedSecret({
+  const secretName = input.secretName;
+  if (secretName) {
+    await attemptDelete(
+      errors,
+      () => clients.core.deleteNamespacedSecret({
         namespace: input.namespace,
-        name: input.secretName,
+        name: secretName,
       }),
     );
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Failed to delete one or more Kubernetes lease resources");
   }
 }

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -398,74 +398,91 @@ const plugin = definePlugin({
         });
 
     const { uid: ownerUid } = await orchestrator.claim(clients, namespace, manifest);
-    const scopedNetworkEgress = parseScopedNetworkEgressGrant(params.executionWorkspaceSettings);
-    const scopedNetworkPolicyName = await createScopedNetworkEgressPolicyOrReleaseWorkload(
-      {
-        clients,
-        namespace,
-        mode: config.egressMode,
-        runId: params.runId,
-        workloadName: jobName,
-        ownerReference: {
-          apiVersion: isSandboxCrBackend ? "agents.x-k8s.io/v1alpha1" : "batch/v1",
-          kind: isSandboxCrBackend ? "Sandbox" : "Job",
-          name: jobName,
-          uid: ownerUid,
-          controller: false,
-          blockOwnerDeletion: false,
+    try {
+      const scopedNetworkEgress = parseScopedNetworkEgressGrant(params.executionWorkspaceSettings);
+      const scopedNetworkPolicyName = await createScopedNetworkEgressPolicyOrReleaseWorkload(
+        {
+          clients,
+          namespace,
+          mode: config.egressMode,
+          runId: params.runId,
+          workloadName: jobName,
+          ownerReference: {
+            apiVersion: isSandboxCrBackend ? "agents.x-k8s.io/v1alpha1" : "batch/v1",
+            kind: isSandboxCrBackend ? "Sandbox" : "Job",
+            name: jobName,
+            uid: ownerUid,
+            controller: false,
+            blockOwnerDeletion: false,
+          },
+          grant: scopedNetworkEgress,
         },
-        grant: scopedNetworkEgress,
-      },
-      () => orchestrator.release(clients, namespace, jobName),
-    );
+        () => orchestrator.release(clients, namespace, jobName),
+      );
 
-    // defaultEnv (non-secret base, e.g. the inference base URL) is layered first;
-    // the process-env secrets named by envKeys override it.
-    const adapterEnv = buildAdapterEnv(adapterDefaults);
-    adapterEnv.PAPERCLIP_NETWORK_EGRESS_POLICY = "kubernetes-default-deny";
-    adapterEnv.PAPERCLIP_NETWORK_EGRESS_GRANT_PATH = NETWORK_EGRESS_GRANT_PATH;
-    adapterEnv.PAPERCLIP_NETWORK_EGRESS_ALLOW_FQDNS = scopedNetworkEgress.allowFqdns.join(",");
-    adapterEnv.PAPERCLIP_NETWORK_EGRESS_ALLOW_CIDRS = scopedNetworkEgress.allowCidrs.join(",");
-    const bootstrapToken = generateBootstrapToken();
+      // defaultEnv (non-secret base, e.g. the inference base URL) is layered first;
+      // the process-env secrets named by envKeys override it.
+      const adapterEnv = buildAdapterEnv(adapterDefaults);
+      adapterEnv.PAPERCLIP_NETWORK_EGRESS_POLICY = "kubernetes-default-deny";
+      adapterEnv.PAPERCLIP_NETWORK_EGRESS_GRANT_PATH = NETWORK_EGRESS_GRANT_PATH;
+      adapterEnv.PAPERCLIP_NETWORK_EGRESS_ALLOW_FQDNS = scopedNetworkEgress.allowFqdns.join(",");
+      adapterEnv.PAPERCLIP_NETWORK_EGRESS_ALLOW_CIDRS = scopedNetworkEgress.allowCidrs.join(",");
+      const bootstrapToken = generateBootstrapToken();
 
-    // Secret ownerRef: for job backend, the Job owns the Secret (cascade delete).
-    // For sandbox-cr backend, the Sandbox CR owns the Secret.
-    // NOTE: For sandbox-cr, if the Secret outlives the Sandbox due to a cluster
-    // quirk, the release() call will still clean it up via namespace GC or
-    // explicit delete in a future iteration.
-    await createPerRunSecret(clients, {
-      namespace,
-      secretName,
-      runId: params.runId,
-      ownerKind: isSandboxCrBackend ? "Sandbox" : "Job",
-      ownerApiVersion: isSandboxCrBackend ? "agents.x-k8s.io/v1alpha1" : "batch/v1",
-      ownerName: jobName,
-      ownerUid,
-      bootstrapToken,
-      adapterEnv,
-    });
+      // Secret ownerRef: for job backend, the Job owns the Secret (cascade delete).
+      // For sandbox-cr backend, the Sandbox CR owns the Secret.
+      await createPerRunSecret(clients, {
+        namespace,
+        secretName,
+        runId: params.runId,
+        ownerKind: isSandboxCrBackend ? "Sandbox" : "Job",
+        ownerApiVersion: isSandboxCrBackend ? "agents.x-k8s.io/v1alpha1" : "batch/v1",
+        ownerName: jobName,
+        ownerUid,
+        bootstrapToken,
+        adapterEnv,
+      });
 
-    const podName = await orchestrator.findPod(clients, namespace, jobName);
+      const podName = await orchestrator.findPod(clients, namespace, jobName);
 
-    const leaseMetadata: KubernetesLeaseMetadata = {
-      namespace,
-      jobName,
-      podName,
-      secretName,
-      phase: "Pending",
-      backend: config.backend,
-      scopedNetworkPolicyName,
-      scopedNetworkEgress,
-      // Native file sync streams over a pod exec; only the sandbox-cr backend
-      // exposes one. Flag the job backend so the server keeps the base64 fallback
-      // rather than routing its sync to a hook that would reject immediately.
-      nativeFileSyncUnsupported: config.backend !== "sandbox-cr",
-    };
+      const leaseMetadata: KubernetesLeaseMetadata = {
+        namespace,
+        jobName,
+        podName,
+        secretName,
+        phase: "Pending",
+        backend: config.backend,
+        scopedNetworkPolicyName,
+        scopedNetworkEgress,
+        // Native file sync streams over a pod exec; only the sandbox-cr backend
+        // exposes one. Flag the job backend so the server keeps the base64 fallback
+        // rather than routing its sync to a hook that would reject immediately.
+        nativeFileSyncUnsupported: config.backend !== "sandbox-cr",
+      };
 
-    return {
-      providerLeaseId: jobName,
-      metadata: leaseMetadata as unknown as Record<string, unknown>,
-    };
+      return {
+        providerLeaseId: jobName,
+        metadata: leaseMetadata as unknown as Record<string, unknown>,
+      };
+    } catch (acquireError) {
+      try {
+        // The host cannot release a lease that acquireLease never returned.
+        // Remove every claimed resource here so retries cannot consume quota or
+        // strand credentials after Secret creation or pod discovery fails.
+        await destroyLeaseResources(clients, {
+          namespace,
+          name: jobName,
+          backend: config.backend,
+          podName: null,
+          secretName,
+        });
+      } catch {
+        // Do not attach raw Kubernetes errors: create-Secret failures can carry
+        // request data and must never leak credential values through logs.
+        throw new Error("Kubernetes sandbox lease acquisition failed and cleanup was incomplete.");
+      }
+      throw acquireError;
+    }
   },
 
   async onEnvironmentResumeLease(

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/acquire-cleanup.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/acquire-cleanup.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({
+  clients: {},
+  ensureTenant: vi.fn(),
+  claim: vi.fn(),
+  findPod: vi.fn(),
+  release: vi.fn(),
+  createPolicy: vi.fn(),
+  createSecret: vi.fn(),
+  destroyResources: vi.fn(),
+}));
+
+vi.mock("../../src/kube-client.js", () => ({
+  createKubeConfig: vi.fn(() => ({})),
+  makeKubeClients: vi.fn(() => h.clients),
+}));
+
+vi.mock("../../src/tenant-orchestrator.js", () => ({
+  ensureTenant: h.ensureTenant,
+}));
+
+vi.mock("../../src/sandbox-cr-orchestrator.js", () => ({
+  SandboxCrTimeoutError: class SandboxCrTimeoutError extends Error {},
+  sandboxCrOrchestrator: {
+    claim: h.claim,
+    findPod: h.findPod,
+    release: h.release,
+  },
+}));
+
+vi.mock("../../src/job-orchestrator.js", () => ({
+  JobTimeoutError: class JobTimeoutError extends Error {},
+  jobOrchestrator: {
+    claim: h.claim,
+    findPod: h.findPod,
+    release: h.release,
+  },
+}));
+
+vi.mock("../../src/secret-manager.js", () => ({
+  createPerRunSecret: h.createSecret,
+}));
+
+vi.mock("../../src/scoped-network-egress.js", () => ({
+  NETWORK_EGRESS_GRANT_PATH: "/run/paperclip/network-egress.json",
+  appendNetworkEgressDenyHint: vi.fn((message: string) => message),
+  parseScopedNetworkEgressGrant: vi.fn(() => ({
+    allowFqdns: [],
+    allowCidrs: [],
+  })),
+  createScopedNetworkEgressPolicyOrReleaseWorkload: h.createPolicy,
+}));
+
+vi.mock("../../src/lease-lifecycle.js", () => ({
+  checkLeaseResumable: vi.fn(),
+  destroyLeaseResources: h.destroyResources,
+}));
+
+import plugin from "../../src/plugin.js";
+
+const acquireInput = {
+  driverKey: "kubernetes",
+  companyId: "company-1",
+  environmentId: "environment-1",
+  runId: "run-1",
+  config: {
+    inCluster: true,
+    backend: "sandbox-cr",
+    companySlug: "team-one",
+    egressMode: "cilium",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.clients = {};
+  h.ensureTenant.mockResolvedValue(undefined);
+  h.claim.mockResolvedValue({ uid: "sandbox-uid-1" });
+  h.createPolicy.mockResolvedValue("pc-run-egress");
+  h.createSecret.mockResolvedValue(undefined);
+  h.findPod.mockResolvedValue("pc-run-pod");
+  h.release.mockResolvedValue(undefined);
+  h.destroyResources.mockResolvedValue(undefined);
+});
+
+describe("onEnvironmentAcquireLease partial-failure cleanup", () => {
+  it("deletes the claimed workload and per-run Secret when pod discovery fails", async () => {
+    const readinessFailure = new Error("sandbox did not produce a pod");
+    h.findPod.mockRejectedValue(readinessFailure);
+
+    await expect(
+      plugin.definition.onEnvironmentAcquireLease!(acquireInput),
+    ).rejects.toBe(readinessFailure);
+
+    const workloadName = h.claim.mock.calls[0]?.[2]?.metadata?.name as string;
+    expect(workloadName).toMatch(/^pc-[a-z0-9]+$/);
+    expect(h.createSecret).toHaveBeenCalledWith(
+      h.clients,
+      expect.objectContaining({
+        namespace: "paperclip-team-one",
+        secretName: `${workloadName}-env`,
+        ownerName: workloadName,
+      }),
+    );
+    expect(h.destroyResources).toHaveBeenCalledWith(h.clients, {
+      namespace: "paperclip-team-one",
+      name: workloadName,
+      backend: "sandbox-cr",
+      podName: null,
+      secretName: `${workloadName}-env`,
+    });
+  });
+
+  it("deletes the claimed workload when Secret creation fails", async () => {
+    const secretFailure = new Error("secret create rejected");
+    h.createSecret.mockRejectedValue(secretFailure);
+
+    await expect(
+      plugin.definition.onEnvironmentAcquireLease!(acquireInput),
+    ).rejects.toBe(secretFailure);
+
+    const workloadName = h.claim.mock.calls[0]?.[2]?.metadata?.name as string;
+    expect(h.findPod).not.toHaveBeenCalled();
+    expect(h.destroyResources).toHaveBeenCalledWith(h.clients, {
+      namespace: "paperclip-team-one",
+      name: workloadName,
+      backend: "sandbox-cr",
+      podName: null,
+      secretName: `${workloadName}-env`,
+    });
+  });
+
+  it("does not expose Secret request details when acquisition and cleanup both fail", async () => {
+    h.createSecret.mockRejectedValue(new Error("request contained credential-marker"));
+    h.destroyResources.mockRejectedValue(new Error("delete failed"));
+
+    const result = plugin.definition.onEnvironmentAcquireLease!(acquireInput);
+    await expect(result).rejects.toThrow(
+      "Kubernetes sandbox lease acquisition failed and cleanup was incomplete.",
+    );
+    await expect(result).rejects.not.toThrow(/credential-marker/);
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/lease-lifecycle.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/lease-lifecycle.test.ts
@@ -345,4 +345,36 @@ describe("destroyLeaseResources", () => {
       }),
     ).rejects.toThrow("forbidden");
   });
+
+  it("attempts pod and Secret deletion when workload deletion fails", async () => {
+    const workloadFailure = Object.assign(new Error("workload delete forbidden"), { code: 403 });
+    const clients = {
+      custom: {
+        deleteNamespacedCustomObject: vi.fn().mockRejectedValue(workloadFailure),
+      },
+      batch: { deleteNamespacedJob: vi.fn() },
+      core: {
+        deleteNamespacedPod: vi.fn().mockResolvedValue({}),
+        deleteNamespacedSecret: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    await expect(
+      destroyLeaseResources(clients as never, {
+        namespace: "ns",
+        name: "pc-abc",
+        backend: "sandbox-cr",
+        podName: "pc-abc-pod",
+        secretName: "pc-abc-env",
+      }),
+    ).rejects.toBe(workloadFailure);
+    expect(clients.core.deleteNamespacedPod).toHaveBeenCalledWith({
+      namespace: "ns",
+      name: "pc-abc-pod",
+    });
+    expect(clients.core.deleteNamespacedSecret).toHaveBeenCalledWith({
+      namespace: "ns",
+      name: "pc-abc-env",
+    });
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Kubernetes sandbox provider claims a workload, creates a scoped egress policy and per-run Secret, and then waits for its Pod before returning a lease to the host
> - If any step after the workload claim fails, the host never receives a lease ID and therefore cannot invoke normal release or destroy handling
> - The claimed workload and Secret can remain in the tenant namespace, consuming quota and retaining credentials until an operator intervenes
> - Acquisition must therefore be transactional from the host's perspective: either return a usable lease or attempt to remove everything already claimed
> - Cleanup must also attempt independent resources even when an earlier Kubernetes delete fails
> - This pull request adds compensating acquisition cleanup and an all-resources-attempted destroy path

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched existing open and closed issues and pull requests; this is not a duplicate.
- [x] The bug reproduces on `master`.
- [x] The failure originates in Paperclip's Kubernetes sandbox provider.

### What happened?

The Kubernetes sandbox provider can successfully claim a Sandbox/Job and then fail while creating its per-run Secret or discovering the backing Pod. Because acquisition rejects before returning `providerLeaseId`, the Paperclip host has no lease it can release. The claimed workload and credential-bearing Secret can remain in the tenant namespace.

The existing destroy helper also stopped after the first non-404 Kubernetes delete error, so a workload-delete failure could prevent an independently deletable Secret from being attempted.

### Expected behavior

If any post-claim acquisition step fails, the provider should attempt deletion of every resource it knows about. A failure deleting one resource must not prevent attempts to delete the Pod or per-run Secret.

### Steps to reproduce

1. Configure the stock Kubernetes sandbox provider with either the `sandbox-cr` or `job` backend.
2. Allow the workload claim to succeed.
3. Make per-run Secret creation or Pod discovery reject.
4. Observe that acquisition returns no lease to the host.
5. Before this change, observe the claimed resource remaining; additionally, make workload deletion return a non-404 error and observe that Secret deletion is not attempted.

### Paperclip version or commit

`master` at `030dd9d15c6b27fd9776a0e9b972c745323caea5`.

### Deployment mode

Self-hosted server with the stock Kubernetes sandbox provider.

### Installation method

Built from source.

### Agent adapter(s) involved

Not adapter-specific (core Kubernetes sandbox-provider lifecycle).

### Database mode

Not database-related.

### Access context

Not applicable.

### Operating system

Linux Kubernetes workload; deterministic unit reproduction is platform-independent.

### Relevant logs or output

The acquisition error from Secret creation or Pod discovery is returned before a provider lease exists. No sensitive logs are included.

### Relevant config

No secret or instance-specific configuration is required. The regression uses an in-cluster provider with the `sandbox-cr` backend.

### Additional context

All examples, identifiers, and error strings in the tests are synthetic and contain no instance-local information.

### Privacy checklist

- [x] I reviewed this description and test output for PII, credentials, internal identifiers, and company names.

## What Changed

- Wrap every post-claim acquisition step in compensating cleanup.
- Reuse the provider's idempotent destroy path to remove the workload and explicitly remove the per-run Secret.
- Make destroy attempt workload, Pod, and Secret independently; rethrow the single original deletion error or aggregate multiple failures afterward.
- Preserve the original acquisition error when cleanup succeeds.
- Emit a generic error if cleanup also fails so Kubernetes Secret request details cannot be attached to the combined failure.
- Add regressions for Pod-discovery failure, Secret-creation failure, acquisition-plus-cleanup failure, and workload deletion that fails before Pod/Secret cleanup.

## Verification

- RED before implementation: the acquisition regressions observed zero destroy calls, and the lifecycle regression observed zero Pod/Secret delete calls after workload deletion failed.
- `vitest run --config vitest.config.ts test/unit/lease-lifecycle.test.ts test/unit/acquire-cleanup.test.ts` — 20 tests passed.
- `tsc --noEmit` in `packages/plugins/sandbox-providers/kubernetes` — passed.
- Previous Linux container run before the follow-up lifecycle regression: all 21 files and 192 tests passed; PR CI reruns the updated suite on Linux.
- Local macOS full package run: 186 passed and the same 7 `/proc/self/fd` file-sync tests failed because those tests require Linux procfs.
- `git diff --check` — passed.
- `gitleaks protect --staged --redact` — no leaks found.

## Risks

- Low and limited to failed acquisition or explicit lease destruction. Successful lease acquisition is unchanged.
- Deletes remain sequential to avoid unnecessary API pressure, but every applicable resource is attempted.
- 404 remains success. One non-404 failure is rethrown unchanged; multiple failures are returned as an `AggregateError`.
- No database, migration, public API, or plugin SDK changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 through the Codex agent environment, with extended reasoning, repository inspection, shell/tool use, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass; platform-specific full-suite results are documented above
- [x] I have added or updated tests where applicable
- [x] Documentation is not required because this changes failed-acquisition cleanup without changing configuration or user-facing behavior
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
