### PR TITLE
fix(db): add indexes for heartbeat run history

### DIFF
--- a/packages/db/src/heartbeat-run-history-indexes.test.ts
+++ b/packages/db/src/heartbeat-run-history-indexes.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const companyHistoryMigrationPath = fileURLToPath(
+  new URL("./migrations/0141_heartbeat_runs_company_created_at_index.sql", import.meta.url),
+);
+const agentHistoryMigrationPath = fileURLToPath(new URL("./migrations/0196_heartbeat_run_history_indexes.sql", import.meta.url));
+
+describe("heartbeat run history indexes", () => {
+  it("keeps company_id and created_at aligned for recent company history", () => {
+    const migration = readFileSync(companyHistoryMigrationPath, "utf8");
+
+    expect(migration).toContain(
+      'CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_created_at_desc_idx"\n' +
+        '  ON "heartbeat_runs" USING btree ("company_id", "created_at" DESC)',
+    );
+  });
+
+  it("keeps equality keys first for recent agent history", () => {
+    const migration = readFileSync(agentHistoryMigrationPath, "utf8");
+
+    expect(migration).toContain(
+      'CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_agent_created_at_desc_idx"\n' +
+        '  ON "heartbeat_runs" USING btree ("company_id", "agent_id", "created_at" DESC)',
+    );
+  });
+});

--- a/packages/db/src/migrations/0196_heartbeat_run_history_indexes.sql
+++ b/packages/db/src/migrations/0196_heartbeat_run_history_indexes.sql
@@ -1,0 +1,3 @@
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: Drizzle migrations run transactionally, so CONCURRENTLY is unavailable; this covers recent heartbeat history when filtered by agent.
+CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_agent_created_at_desc_idx"
+  ON "heartbeat_runs" USING btree ("company_id", "agent_id", "created_at" DESC);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1359,6 +1359,13 @@
       "when": 1785170000001,
       "tag": "0195_built_in_agent_unique_marker",
       "breakpoints": true
+    },
+    {
+      "idx": 196,
+      "version": "7",
+      "when": 1785242400000,
+      "tag": "0196_heartbeat_run_history_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -69,6 +69,11 @@ export const heartbeatRuns = pgTable(
       table.responsibleUserId,
       table.createdAt,
     ),
+    companyAgentCreatedAtDescIdx: index("heartbeat_runs_company_agent_created_at_desc_idx").on(
+      table.companyId,
+      table.agentId,
+      table.createdAt.desc(),
+    ),
     companyLivenessIdx: index("heartbeat_runs_company_liveness_idx").on(
       table.companyId,
       table.livenessState,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat runs are the durable execution history that powers agent detail pages, dashboards, and operator visibility.
> - The company heartbeat-run history endpoint reads recent runs ordered by `created_at DESC` and may also filter by agent.
> - Current master already includes the company-wide `(company_id, created_at DESC)` path.
> - The remaining gap is the agent-filtered recent-history path, which should seek by company and agent before reading newest runs.
> - This pull request adds a durable agent-history index and a regression test that guards both company and agent history index shapes.
> - The benefit is a bounded index-backed path for the common history queries without changing the API response shape.

## Linked Issues or Issue Description

Refs #958

## What Changed

- Added `heartbeat_runs_company_agent_created_at_desc_idx` on `(company_id, agent_id, created_at DESC)` for agent-filtered recent history.
- Added migration `0195_heartbeat_run_history_indexes.sql` and wired the index into the Drizzle schema and migration journal.
- Added a focused regression test that guards the existing company history index and the new agent history index key order.

## Verification

- `pnpm --filter @paperclipai/db exec vitest run src/heartbeat-run-history-indexes.test.ts`
- `pnpm --filter @paperclipai/db check:migrations`
- `pnpm --filter @paperclipai/db typecheck`
- Applied the final durable indexes to a live embedded PostgreSQL instance with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` for operational verification.
- Removed the earlier emergency-only created-at-leading live indexes with `DROP INDEX CONCURRENTLY IF EXISTS` after the durable index set was present.
- Verified the company-wide recent-history query uses `Index Scan using heartbeat_runs_company_created_at_desc_idx` and returns 200 rows in about 1 ms.
- Verified the agent-filtered recent-history query uses `Index Scan using heartbeat_runs_company_agent_created_at_desc_idx` and returns 200 rows in about 1 ms.
- Verified live endpoint `GET /api/companies/{companyId}/heartbeat-runs?limit=200` returned 200 rows with HTTP 200 in 0.413s after the Greptile fix.
- Verified assignment paths after the final live index set: `GET /api/agents/me/inbox-lite` returned HTTP 200 in 0.039s, and assigned-issues fallback returned HTTP 200 in 0.015s.

## Risks

- Migration creates an index on `heartbeat_runs`, which can be large. The migration includes explicit safety rationale because the repo migration runner is transactional; operators handling large production tables can apply the same index concurrently before or during rollout.
- The index adds write overhead to heartbeat run insertion, but it targets the hot read path for agent-filtered recent history.
- No API response shape or route behavior changes are intended.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, `gpt-5.5`, high reasoning effort, local shell and GitHub CLI tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge