### PR TITLE
fix: route unblock requests to reporting-line managers

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1476,6 +1476,67 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(run?.errorCode).toBeNull();
   });
 
+  it("runs a named manager unblock wake on a report-owned issue without first-class blockers", async () => {
+    const { companyId, agentId: managerAgentId } = await seedCompanyAndAgent({ agentName: "ManagerAgent" });
+    const reportAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: reportAgentId,
+      companyId,
+      name: "ReportAgent",
+      role: "engineer",
+      status: "active",
+      reportsTo: managerAgentId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: blockedIssueId,
+      companyId,
+      title: "Blocked report-owned task without issue relation",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: reportAgentId,
+      unblockDescriptor: {
+        owner: { agentId: managerAgentId },
+        action: "Choose the recovery path",
+      },
+      blockedTransitionAt: new Date(),
+    });
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId: managerAgentId,
+      issueId: blockedIssueId,
+      wakeReason: "issue_unblock_requested",
+      invocationSource: "automation",
+      contextExtras: { source: "issue.blocked" },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+
   it("runs a named manager unblock wake on a report-owned issue with unresolved blockers", async () => {
     const { companyId, agentId: managerAgentId } = await seedCompanyAndAgent({ agentName: "ManagerAgent" });
     const reportAgentId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -12,6 +12,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueRelations,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
@@ -1473,6 +1474,145 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       .then((rows) => rows[0] ?? null);
     expect(run?.status).toBe("succeeded");
     expect(run?.errorCode).toBeNull();
+  });
+
+  it("runs a named manager unblock wake on a report-owned issue with unresolved blockers", async () => {
+    const { companyId, agentId: managerAgentId } = await seedCompanyAndAgent({ agentName: "ManagerAgent" });
+    const reportAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: reportAgentId,
+      companyId,
+      name: "ReportAgent",
+      role: "engineer",
+      status: "active",
+      reportsTo: managerAgentId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Live blocker",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: reportAgentId,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked report-owned task",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: reportAgentId,
+        unblockDescriptor: {
+          owner: { agentId: managerAgentId },
+          action: "Choose the recovery path",
+        },
+        blockedTransitionAt: new Date(),
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId: managerAgentId,
+      issueId: blockedIssueId,
+      wakeReason: "issue_unblock_requested",
+      invocationSource: "automation",
+      contextExtras: { source: "issue.blocked" },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+
+  it("rejects a spoofed manager unblock wake when the persisted owner does not match", async () => {
+    const { companyId, agentId: managerAgentId } = await seedCompanyAndAgent({ agentName: "ManagerAgent" });
+    const reportAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: reportAgentId,
+      companyId,
+      name: "ReportAgent",
+      role: "engineer",
+      status: "active",
+      reportsTo: managerAgentId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Blocked task with a different unblock owner",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: reportAgentId,
+      unblockDescriptor: {
+        owner: { agentId: reportAgentId },
+        action: "Resolve the blocker",
+      },
+      blockedTransitionAt: new Date(),
+    });
+
+    const { runId } = await seedQueuedRun({
+      companyId,
+      agentId: managerAgentId,
+      issueId,
+      wakeReason: "issue_unblock_requested",
+      invocationSource: "automation",
+      contextExtras: { source: "issue.blocked" },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("issue_assignee_changed");
+    expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
   it("baseline: runs queued runs when the issue is in_progress with the same assignee", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -9,7 +9,9 @@ const companyId = "22222222-2222-4222-8222-222222222222";
 const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
+const topManagerAgentId = "66666666-6666-4666-8666-666666666666";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
+const missingManagerAgentId = "88888888-8888-4888-8888-888888888888";
 
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
@@ -269,7 +271,9 @@ function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
   return {
     id,
     companyId,
+    name: `Agent ${id}`,
     role: "engineer",
+    status: "active",
     reportsTo: null,
     permissions: { canCreateAgents: false },
     ...overrides,
@@ -280,6 +284,7 @@ function createRunContextDb(
   contextSnapshot: Record<string, unknown> = {},
   runAgentOrRows: string | Record<string, unknown>[] = ownerAgentId,
   runId: string = ownerRunId,
+  agentOrgRows?: Record<string, unknown>[],
 ) {
   const runRows = Array.isArray(runAgentOrRows)
     ? runAgentOrRows
@@ -298,7 +303,10 @@ function createRunContextDb(
     if (keys.includes("entityId")) return [];
     if (keys.includes("contextSnapshot")) return runRows;
     if (keys.includes("agentCompanyId")) return runRows;
-    return [{ id: runAgentId, companyId: runAgentCompanyId, permissions: {}, role: "engineer", reportsTo: null }];
+    if (keys.includes("name") && keys.includes("status") && keys.includes("reportsTo")) {
+      return agentOrgRows ?? [makeAgent(runAgentId, { companyId: runAgentCompanyId })];
+    }
+    return [makeAgent(runAgentId, { companyId: runAgentCompanyId })];
   };
   const buildQuery = (selection: Record<string, unknown>) => {
     const rows = rowsForSelection(selection);
@@ -1642,6 +1650,152 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agents may only name themselves as an unblock owner");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent to name its reporting-line manager as unblock owner", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "in_progress" }),
+      ...patch,
+    }));
+    const db = createRunContextDb({}, ownerAgentId, ownerRunId, [
+      makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+      makeAgent(peerAgentId),
+    ]);
+
+    const res = await request(await createApp(ownerActor(), db)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path for the delegated finding",
+      },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+        unblockDescriptor: {
+          owner: { agentId: peerAgentId },
+          action: "Choose the remediation path for the delegated finding",
+        },
+      }),
+    );
+  });
+
+  it("allows an agent to name an ancestor in its reporting line as unblock owner", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "in_progress" }),
+      ...patch,
+    }));
+    const db = createRunContextDb({}, ownerAgentId, ownerRunId, [
+      makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+      makeAgent(peerAgentId, { reportsTo: topManagerAgentId }),
+      makeAgent(topManagerAgentId),
+    ]);
+
+    const res = await request(await createApp(ownerActor(), db)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: topManagerAgentId },
+        action: "Resolve a dependency outside the worker's scope",
+      },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        unblockDescriptor: expect.objectContaining({ owner: { agentId: topManagerAgentId } }),
+      }),
+    );
+  });
+
+  it("rejects an agent naming an unrelated same-company agent as unblock owner", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    const db = createRunContextDb({}, ownerAgentId, ownerRunId, [
+      makeAgent(ownerAgentId),
+      makeAgent(peerAgentId),
+    ]);
+
+    const res = await request(await createApp(ownerActor(), db)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Review the blocker",
+      },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe(
+      "Agents may only name themselves or a reporting-line manager as an unblock owner",
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "cyclic",
+      rows: [
+        makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+        makeAgent(peerAgentId, { reportsTo: ownerAgentId }),
+      ],
+      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+    },
+    {
+      label: "terminated",
+      rows: [
+        makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+        makeAgent(peerAgentId, { status: "terminated" }),
+      ],
+      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+    },
+    {
+      label: "paused",
+      rows: [
+        makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+        makeAgent(peerAgentId, { status: "paused" }),
+      ],
+      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+    },
+    {
+      label: "pending-approval",
+      rows: [
+        makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+        makeAgent(peerAgentId, { status: "pending_approval" }),
+      ],
+      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+    },
+    {
+      label: "missing-ancestor",
+      rows: [
+        makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
+        makeAgent(peerAgentId, { reportsTo: missingManagerAgentId }),
+      ],
+      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+    },
+    {
+      label: "not-in-company-roster",
+      rows: [makeAgent(ownerAgentId, { reportsTo: peerAgentId })],
+      error: "Unblock owner agent must belong to the issue company",
+    },
+  ])("rejects a $label reporting-line unblock owner before mutation", async ({ rows, error }) => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    const db = createRunContextDb({}, ownerAgentId, ownerRunId, rows);
+
+    const res = await request(await createApp(ownerActor(), db)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Review the blocker",
+      },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toBe(error);
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1736,6 +1736,40 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("keeps self-owned unblock descriptors valid when the actor's reporting chain is unhealthy", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "in_progress" }),
+      ...patch,
+    }));
+    const db = createRunContextDb(
+      {},
+      ownerAgentId,
+      ownerRunId,
+      [makeAgent(ownerAgentId, { reportsTo: missingManagerAgentId })],
+    );
+
+    const res = await request(await createApp(ownerActor(), db)).patch(`/api/issues/${issueId}`).send({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: ownerAgentId },
+        action: "Investigate the blocker",
+      },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "blocked",
+        unblockDescriptor: {
+          owner: { agentId: ownerAgentId },
+          action: "Investigate the blocker",
+        },
+      }),
+    );
+  });
+
   it.each([
     {
       label: "cyclic",
@@ -1743,7 +1777,8 @@ describe("agent issue mutation checkout ownership", () => {
         makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
         makeAgent(peerAgentId, { reportsTo: ownerAgentId }),
       ],
-      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+      status: 403,
+      error: "Agents may only name themselves or a reporting-line manager as an unblock owner",
     },
     {
       label: "terminated",
@@ -1751,7 +1786,8 @@ describe("agent issue mutation checkout ownership", () => {
         makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
         makeAgent(peerAgentId, { status: "terminated" }),
       ],
-      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+      status: 403,
+      error: "Agents may only name themselves or a reporting-line manager as an unblock owner",
     },
     {
       label: "paused",
@@ -1759,7 +1795,8 @@ describe("agent issue mutation checkout ownership", () => {
         makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
         makeAgent(peerAgentId, { status: "paused" }),
       ],
-      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+      status: 403,
+      error: "Agents may only name themselves or a reporting-line manager as an unblock owner",
     },
     {
       label: "pending-approval",
@@ -1767,7 +1804,8 @@ describe("agent issue mutation checkout ownership", () => {
         makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
         makeAgent(peerAgentId, { status: "pending_approval" }),
       ],
-      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+      status: 403,
+      error: "Agents may only name themselves or a reporting-line manager as an unblock owner",
     },
     {
       label: "missing-ancestor",
@@ -1775,14 +1813,16 @@ describe("agent issue mutation checkout ownership", () => {
         makeAgent(ownerAgentId, { reportsTo: peerAgentId }),
         makeAgent(peerAgentId, { reportsTo: missingManagerAgentId }),
       ],
-      error: "Unblock owner agent must be invokable with a healthy reporting chain",
+      status: 403,
+      error: "Agents may only name themselves or a reporting-line manager as an unblock owner",
     },
     {
       label: "not-in-company-roster",
       rows: [makeAgent(ownerAgentId, { reportsTo: peerAgentId })],
+      status: 422,
       error: "Unblock owner agent must belong to the issue company",
     },
-  ])("rejects a $label reporting-line unblock owner before mutation", async ({ rows, error }) => {
+  ])("rejects a $label reporting-line unblock owner before mutation", async ({ rows, status, error }) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
     const db = createRunContextDb({}, ownerAgentId, ownerRunId, rows);
 
@@ -1794,7 +1834,7 @@ describe("agent issue mutation checkout ownership", () => {
       },
     });
 
-    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.status, JSON.stringify(res.body)).toBe(status);
     expect(res.body.error).toBe(error);
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9381,10 +9381,6 @@ export function issueRoutes(
         if (!target) {
           throw unprocessable("Unblock owner agent must belong to the issue company");
         }
-        const targetEligibility = getAgentWorkEligibility({ agent: target, agents: companyAgents });
-        if (!targetEligibility.invokable) {
-          throw unprocessable("Unblock owner agent must be invokable with a healthy reporting chain");
-        }
         if (req.actor.type === "agent" && req.actor.agentId !== owner.agentId) {
           const targetIsReportingLineManager = req.actor.agentId
             ? isInvokableReportingLineManager(companyAgents, owner.agentId, req.actor.agentId)

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -66,6 +66,7 @@ import {
   updateDocumentAnnotationThreadSchema,
   upsertIssueDocumentSchema,
   updateIssueSchema,
+  getAgentWorkEligibility,
   isClosedIsolatedExecutionWorkspace,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
@@ -1712,6 +1713,30 @@ function buildExecutionStageWakeContext(input: {
     lastDecisionOutcome: input.state.lastDecisionOutcome,
     allowedActions: input.allowedActions,
   };
+}
+
+type ReportingLineAgent = {
+  id: string;
+  companyId: string;
+  name: string;
+  status: string;
+  reportsTo: string | null;
+};
+
+function isInvokableReportingLineManager(
+  companyAgents: ReportingLineAgent[],
+  managerAgentId: string,
+  reportAgentId: string,
+) {
+  const report = companyAgents.find((agent) => agent.id === reportAgentId);
+  const manager = companyAgents.find((agent) => agent.id === managerAgentId);
+  if (!report || !manager) return false;
+  const reportEligibility = getAgentWorkEligibility({ agent: report, agents: companyAgents });
+  const managerEligibility = getAgentWorkEligibility({ agent: manager, agents: companyAgents });
+  if (!reportEligibility.invokable || !managerEligibility.invokable) return false;
+  return reportEligibility.orgChainHealth.fullChain.some(
+    (entry) => entry.relation === "ancestor" && entry.id === managerAgentId,
+  );
 }
 
 function summarizeIssueRelationForActivity(relation: {
@@ -9342,13 +9367,31 @@ export function issueRoutes(
         throw forbidden("Agents may only name themselves as an unblock owner");
       }
       if (owner !== "board" && "agentId" in owner) {
-        const target = await db.select({ id: agents.id }).from(agents).where(and(
-          eq(agents.id, owner.agentId),
-          eq(agents.companyId, existing.companyId),
-        )).limit(1).then((rows) => rows[0] ?? null);
-        if (!target) throw unprocessable("Unblock owner agent must belong to the issue company");
+        const companyAgents = await db
+          .select({
+            id: agents.id,
+            companyId: agents.companyId,
+            name: agents.name,
+            status: agents.status,
+            reportsTo: agents.reportsTo,
+          })
+          .from(agents)
+          .where(eq(agents.companyId, existing.companyId));
+        const target = companyAgents.find((agent) => agent.id === owner.agentId);
+        if (!target) {
+          throw unprocessable("Unblock owner agent must belong to the issue company");
+        }
+        const targetEligibility = getAgentWorkEligibility({ agent: target, agents: companyAgents });
+        if (!targetEligibility.invokable) {
+          throw unprocessable("Unblock owner agent must be invokable with a healthy reporting chain");
+        }
         if (req.actor.type === "agent" && req.actor.agentId !== owner.agentId) {
-          throw forbidden("Agents may only name themselves as an unblock owner");
+          const targetIsReportingLineManager = req.actor.agentId
+            ? isInvokableReportingLineManager(companyAgents, owner.agentId, req.actor.agentId)
+            : false;
+          if (!targetIsReportingLineManager) {
+            throw forbidden("Agents may only name themselves or a reporting-line manager as an unblock owner");
+          }
         }
       } else if (owner !== "board" && "userId" in owner) {
         const member = await db.select({ id: companyMemberships.id }).from(companyMemberships).where(and(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4157,6 +4157,17 @@ function allowsIssueInteractionWake(
   return Boolean(deriveCommentId(contextSnapshot, null));
 }
 
+function allowsIssueUnblockRequestWake(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+  issue: { status: string; unblockDescriptor: unknown },
+  agentId: string,
+) {
+  if (readNonEmptyString(contextSnapshot?.wakeReason) !== "issue_unblock_requested") return false;
+  if (issue.status !== "blocked") return false;
+  const owner = parseObject(parseObject(issue.unblockDescriptor).owner);
+  return readNonEmptyString(owner.agentId) === agentId;
+}
+
 async function listUnresolvedBlockerSummaries(
   dbOrTx: Pick<Db, "select">,
   companyId: string,
@@ -12544,7 +12555,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const dependencyReadiness = await issuesSvc.listDependencyReadiness(run.companyId, [issueId]);
       const readiness = dependencyReadiness.get(issueId);
       const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
-      if (unresolvedBlockerCount > 0 && !allowsIssueInteractionWake(context)) {
+      const unblockRequestIssue = unresolvedBlockerCount > 0 &&
+        readNonEmptyString(context.wakeReason) === "issue_unblock_requested"
+        ? await db
+          .select({ status: issues.status, unblockDescriptor: issues.unblockDescriptor })
+          .from(issues)
+          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+          .then((rows) => rows[0] ?? null)
+        : null;
+      const unblockRequestWake = unblockRequestIssue
+        ? allowsIssueUnblockRequestWake(context, unblockRequestIssue, run.agentId)
+        : false;
+      if (unresolvedBlockerCount > 0 && !allowsIssueInteractionWake(context) && !unblockRequestWake) {
         await cancelQueuedRunForBlockedDependencies(run, issueId, readiness?.unresolvedBlockerIssueIds ?? []);
         logger.info({ runId: run.id, issueId, unresolvedBlockerCount }, "claimQueuedRun: cancelled blocked queued run");
         return null;
@@ -12716,6 +12738,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
+        unblockDescriptor: issues.unblockDescriptor,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -12731,7 +12754,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     const wakeCommentId = deriveCommentId(context, null);
-    const isInteractionWake = allowsIssueInteractionWake(context);
+    const isInteractionWake =
+      allowsIssueInteractionWake(context) ||
+      allowsIssueUnblockRequestWake(context, issue, run.agentId);
     const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
     const wakeReason = readNonEmptyString(context.wakeReason);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
@@ -17854,6 +17879,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             executionWorkspacePreference: issues.executionWorkspacePreference,
             executionWorkspaceSettings: issues.executionWorkspaceSettings,
             assigneeAgentId: issues.assigneeAgentId,
+            unblockDescriptor: issues.unblockDescriptor,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
             createdAt: issues.createdAt,
@@ -18124,7 +18150,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const blockedInteractionWake =
           dependencyReadiness &&
           !dependencyReadiness.isDependencyReady &&
-          allowsIssueInteractionWake(enrichedContextSnapshot);
+          (
+            allowsIssueInteractionWake(enrichedContextSnapshot) ||
+            allowsIssueUnblockRequestWake(enrichedContextSnapshot, issue, agentId)
+          );
 
         if (blockedInteractionWake) {
           enrichedContextSnapshot.dependencyBlockedInteraction = true;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane people use to coordinate AI agents and recover blocked work.
> - Structured `unblockDescriptor` ownership makes a blocked transition durable and wakeable.
> - The existing agent-authored path only permits self-ownership, so a delegated worker cannot route a blocker to its reporting-line manager.
> - Allowing arbitrary agents would weaken authorization and permit unrelated wakeups.
> - Paperclip already stores same-company `reportsTo` ancestry and work-eligibility rules.
> - A manager-targeted unblock wake must also survive stale-assignee and unresolved-dependency checks without reassigning the child.
> - This pull request authorizes only healthy, invokable reporting-line managers and revalidates the persisted descriptor at wake time.
> - The benefit is event-driven manager/orchestrator recovery without board intervention, external polling, or arbitrary cross-agent routing.

## Linked Issues or Issue Description

- Closes #10361
- Builds on #10112

## What Changed

- Added a cycle-safe reporting-chain check using a narrow same-company agent query and existing work-eligibility evaluation.
- Allows agent-authored unblock descriptors to name direct or transitive reporting-line managers.
- Preserves the existing self-owned descriptor path even when the acting agent’s ancestry is unhealthy.
- Continues to reject unrelated agents, missing/cross-company IDs, and unhealthy manager targets before mutation.
- Treats `issue_unblock_requested` as an intentional non-assignee interaction wake only when the issue is blocked and the persisted descriptor names the wake agent.
- Allows that verified wake through unresolved dependency checks without changing issue assignment or blocked status.
- Added positive direct/ancestor/self-owner cases and negative unrelated, cyclic, terminated, paused, pending, missing-ancestor, missing-roster, and spoofed-wake regressions.
- Added real-heartbeat coverage proving the named manager runs on a report-owned issue both with only a structured unblock descriptor and with unresolved first-class blockers.

## Verification

- `pnpm exec vitest run` for route authorization, routable delivery, and stale-queue validation: **110 tests passed**.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/server build` passed.
- Independent review identified and the follow-up fixed the self-owner regression before this update.
- Production-equivalent backport suite additionally passed structured-blocker, lifecycle, low-trust, Hermes-adapter, typecheck, and full-build gates.

## Risks

- Manager authorization loads only same-company IDs, status, name, and `reportsTo`; it does not hydrate spend or unrelated roster state.
- Manager targets must be invokable with a healthy ancestry; self-owned and board-authored ownership retain their existing behavior.
- The non-assignee/dependency bypass is fail-closed: the wake reason, blocked issue status, and persisted descriptor owner must all match.
- No ownership transfer occurs. The manager/orchestrator receives a recovery wake in the blocked issue context and decides the next action.
- No database migration is introduced by this PR; it extends the structured-blocker capability from #10112.

> ROADMAP.md was checked. This extends the existing enforced-outcomes and structured-blocker mechanics rather than adding a new orchestration subsystem.

## Model Used

- OpenAI Codex, GPT-5.6 (`gpt-5.6-sol`), with repository tool use, code execution, database-backed tests, and independent delegated code review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
