### PR TITLE
feat(issues): add scoped manager assignment handoff

### DIFF
--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -6,6 +6,8 @@ const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
 
 const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockFindExistingManagerHandoffWake = vi.hoisted(() => vi.fn(async () => null as any));
+const mockGetAgentById = vi.hoisted(() => vi.fn(async (_id: string) => null as any));
 const mockIssueService = vi.hoisted(() => ({
   create: vi.fn(),
   createChild: vi.fn(),
@@ -17,21 +19,39 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   findMentionedAgents: vi.fn(async () => []),
+  update: vi.fn(),
+}));
+
+vi.mock("../services/issue-manager-handoff.js", () => ({
+  ISSUE_MANAGER_HANDOFF_WAKE_REASON: "issue_manager_handoff",
+  buildIssueManagerHandoffWakeIdempotencyKey: ({ initiatingRunId, issueId }: {
+    initiatingRunId: string;
+    issueId: string;
+  }) => `issue-manager-handoff:${initiatingRunId}:${issueId}`,
+  findExistingIssueManagerHandoffWake: mockFindExistingManagerHandoffWake,
+}));
+
+vi.mock("../services/task-watchdog-scope.js", () => ({
+  TASK_WATCHDOG_ORIGIN_KIND: "task_watchdog",
+  resolveTaskWatchdogMutationScope: vi.fn(async () => ({ kind: "none" })),
+  taskWatchdogScopeAllowsIssueMutation: vi.fn(async () => ({ kind: "invalid", detail: "not in scope" })),
 }));
 
 vi.mock("../services/index.js", () => ({
   accessService: () => ({
     canUser: vi.fn(async () => true),
     decide: vi.fn(async (input: { action?: string }) => ({
-      allowed: true,
+      allowed: input.action !== "issue:mutate",
       action: input.action,
-      reason: "allow_explicit_grant",
-      explanation: "Allowed by test grant.",
+      reason: input.action === "issue:mutate" ? "deny_outside_issue_boundary" : "allow_explicit_grant",
+      explanation: input.action === "issue:mutate"
+        ? "Issue is outside this actor's authorization boundary."
+        : "Allowed by test grant.",
     })),
     hasPermission: vi.fn(async () => true),
   }),
   agentService: () => ({
-    getById: vi.fn(async () => null),
+    getById: mockGetAgentById,
     resolveByReference: vi.fn(async (_companyId: string, reference: string) => ({
       ambiguous: false,
       agent: {
@@ -114,7 +134,13 @@ vi.mock("../services/index.js", () => ({
   }),
 }));
 
-async function createApp() {
+async function createApp(actor: Record<string, unknown> = {
+  type: "board",
+  userId: "local-board",
+  companyIds: ["company-1"],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+}) {
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -122,13 +148,7 @@ async function createApp() {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", issueRoutes({} as any, {} as any));
@@ -245,7 +265,7 @@ describe("assigned backlog creation contract", () => {
         }),
       }),
     );
-  });
+  }, 15_000);
 
   it("does not let a parent-blocking assigned child become an unwoken backlog leaf by default", async () => {
     const res = await request(await createApp())
@@ -336,6 +356,260 @@ describe("assigned backlog creation contract", () => {
         }),
       }),
     );
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+});
+
+describe("manager assignment handoff", () => {
+  const managerId = "11111111-1111-4111-8111-111111111111";
+  const runId = "33333333-3333-4333-8333-333333333333";
+  const issueId = "44444444-4444-4444-8444-444444444444";
+  const managerActor = {
+    type: "agent",
+    agentId: managerId,
+    companyId: "company-1",
+    source: "agent_key",
+    runId,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      id: issueId,
+      title: "Existing delegated lane",
+      status: "backlog",
+      assigneeAgentId,
+    }));
+    mockIssueService.update.mockResolvedValue(makeIssue({
+      id: issueId,
+      title: "Existing delegated lane",
+      status: "todo",
+      assigneeAgentId,
+    }));
+    mockGetAgentById.mockImplementation(async (id: string) => id === managerId
+      ? {
+          id: managerId,
+          companyId: "company-1",
+          reportsTo: null,
+          status: "active",
+          orgChainHealth: { status: "healthy" },
+        }
+      : {
+          id: assigneeAgentId,
+          companyId: "company-1",
+          reportsTo: managerId,
+          status: "idle",
+          orgChainHealth: { status: "healthy" },
+        });
+  });
+
+  it("activates an existing backlog issue for a healthy direct report and requests a run-bound wake", async () => {
+    const wakeupRunId = "55555555-5555-4555-8555-555555555555";
+    const wakeRequestId = "66666666-6666-4666-8666-666666666666";
+    mockWakeup.mockResolvedValue({ id: wakeupRunId, wakeupRequestId: wakeRequestId } as any);
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({
+      status: "todo",
+      actorAgentId: managerId,
+      expectedStatus: "backlog",
+      expectedAssigneeAgentId: assigneeAgentId,
+    }));
+    expect(mockWakeup).toHaveBeenCalledWith(assigneeAgentId, expect.objectContaining({
+      source: "assignment",
+      reason: "issue_manager_handoff",
+      idempotencyKey: `issue-manager-handoff:${runId}:${issueId}`,
+      payload: expect.objectContaining({ issueId, managerAgentId: managerId, initiatingRunId: runId }),
+    }));
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "issue.manager_handoff_requested",
+      entityId: issueId,
+      runId,
+      details: expect.objectContaining({
+        managerAgentId: managerId,
+        targetAgentId: assigneeAgentId,
+        targetIssueId: issueId,
+      }),
+    }));
+    expect(res.body).toMatchObject({
+      issue: { id: issueId, status: "todo", assigneeAgentId },
+      handoff: {
+        initiatingRunId: runId,
+        managerAgentId: managerId,
+        targetAgentId: assigneeAgentId,
+        wakeRequestId,
+        wakeupRunId,
+      },
+    });
+  });
+
+  it("fails closed when the issue changes between authorization and backlog activation", async () => {
+    mockIssueService.update.mockResolvedValue(null);
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({
+      expectedStatus: "backlog",
+      expectedAssigneeAgentId: assigneeAgentId,
+    }));
+    expect(mockWakeup).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.manager_handoff_requested" }),
+    );
+  });
+
+  it("keeps arbitrary non-direct-report issue mutation forbidden", async () => {
+    mockGetAgentById.mockImplementation(async (id: string) => id === managerId
+      ? { id: managerId, companyId: "company-1", reportsTo: null, orgChainHealth: { status: "healthy" } }
+      : { id: assigneeAgentId, companyId: "company-1", reportsTo: "another-manager", orgChainHealth: { status: "healthy" } });
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for an unhealthy org chain", async () => {
+    mockGetAgentById.mockImplementation(async (id: string) => id === managerId
+      ? { id: managerId, companyId: "company-1", reportsTo: null, status: "active", orgChainHealth: { status: "healthy" } }
+      : { id: assigneeAgentId, companyId: "company-1", reportsTo: managerId, status: "idle", orgChainHealth: { status: "invalid_org_chain" } });
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a terminated direct report even when the stored org chain is otherwise healthy", async () => {
+    mockGetAgentById.mockImplementation(async (id: string) => id === managerId
+      ? { id: managerId, companyId: "company-1", reportsTo: null, status: "active", orgChainHealth: { status: "healthy" } }
+      : { id: assigneeAgentId, companyId: "company-1", reportsTo: managerId, status: "terminated", orgChainHealth: { status: "healthy" } });
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it.each(["pending_approval", "paused"])(
+    "fails closed when the direct report is %s and therefore cannot accept a wake",
+    async (status) => {
+      mockGetAgentById.mockImplementation(async (id: string) => id === managerId
+        ? { id: managerId, companyId: "company-1", reportsTo: null, status: "active", orgChainHealth: { status: "healthy" } }
+        : { id: assigneeAgentId, companyId: "company-1", reportsTo: managerId, status, orgChainHealth: { status: "healthy" } });
+
+      const res = await request(await createApp(managerActor))
+        .post(`/api/issues/${issueId}/manager-handoff`)
+        .send({});
+
+      expect(res.status).toBe(403);
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+      expect(mockWakeup).not.toHaveBeenCalled();
+    },
+  );
+
+  it("requires a run-bound agent key", async () => {
+    const res = await request(await createApp({ ...managerActor, runId: undefined }))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("preserves the original generic PATCH denial for a subordinate's issue", async () => {
+    const res = await request(await createApp(managerActor))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(403);
+    expect(String(res.body?.error ?? res.text)).toMatch(/authorization boundary/i);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("replays the same run-bound handoff without a second mutation or wake", async () => {
+    mockFindExistingManagerHandoffWake.mockResolvedValue({
+      id: "66666666-6666-4666-8666-666666666666",
+      status: "queued",
+      runId: "55555555-5555-4555-8555-555555555555",
+    });
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.handoff).toMatchObject({
+      initiatingRunId: runId,
+      managerAgentId: managerId,
+      targetAgentId: assigneeAgentId,
+      wakeRequestId: "66666666-6666-4666-8666-666666666666",
+      wakeupRunId: "55555555-5555-4555-8555-555555555555",
+      idempotentReplay: true,
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when idempotency readback is unavailable", async () => {
+    mockFindExistingManagerHandoffWake.mockRejectedValue(new Error("readback unavailable"));
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(500);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the assigned agent belongs to another company", async () => {
+    mockGetAgentById.mockImplementation(async (id: string) => id === managerId
+      ? { id: managerId, companyId: "company-1", reportsTo: null, orgChainHealth: { status: "healthy" } }
+      : { id: assigneeAgentId, companyId: "company-2", reportsTo: managerId, orgChainHealth: { status: "healthy" } });
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not widen mutations beyond backlog and todo", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      id: issueId,
+      title: "Already running lane",
+      status: "in_progress",
+      assigneeAgentId,
+    }));
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockWakeup).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -447,6 +447,30 @@ describe("manager assignment handoff", () => {
     });
   });
 
+  it("requests a wake for an existing todo issue without mutating it", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      id: issueId,
+      title: "Ready delegated lane",
+      status: "todo",
+      assigneeAgentId,
+    }));
+    const wakeupRunId = "55555555-5555-4555-8555-555555555555";
+    const wakeRequestId = "66666666-6666-4666-8666-666666666666";
+    mockWakeup.mockResolvedValue({ id: wakeupRunId, wakeupRequestId: wakeRequestId } as any);
+
+    const res = await request(await createApp(managerActor))
+      .post(`/api/issues/${issueId}/manager-handoff`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockWakeup).toHaveBeenCalledWith(assigneeAgentId, expect.objectContaining({
+      reason: "issue_manager_handoff",
+      payload: expect.objectContaining({ mutation: "assignment_wake" }),
+    }));
+    expect(res.body.issue).toMatchObject({ id: issueId, status: "todo", assigneeAgentId });
+  });
+
   it("fails closed when the issue changes between authorization and backlog activation", async () => {
     mockIssueService.update.mockResolvedValue(null);
 

--- a/server/src/__tests__/issue-wake-diagnostics-routes.test.ts
+++ b/server/src/__tests__/issue-wake-diagnostics-routes.test.ts
@@ -267,6 +267,47 @@ describeEmbeddedPostgres("issue wake diagnostics route", () => {
     expect(serialized).not.toContain("\"error\"");
   });
 
+  it("preserves manager handoff reason and run ids for diagnostic readback", async () => {
+    const company = await seedCompany(db);
+    const agent = await seedAgent(db, company.id);
+    const project = await seedProject(db, company.id, "Core");
+    const issue = await seedIssue(db, {
+      companyId: company.id,
+      projectId: project.id,
+      title: "Manager handoff target",
+      status: "todo",
+      assigneeAgentId: agent.id,
+    });
+    const wakeRunId = randomUUID();
+
+    await db.insert(agentWakeupRequests).values({
+      companyId: company.id,
+      agentId: agent.id,
+      source: "assignment",
+      reason: "issue_manager_handoff",
+      status: "completed",
+      payload: { issueId: issue.id },
+      runId: wakeRunId,
+      requestedAt: new Date(Date.now() - 10_000),
+      claimedAt: new Date(Date.now() - 9_000),
+      finishedAt: new Date(Date.now() - 1_000),
+    });
+
+    const res = await request(createApp(db, boardActor(company)))
+      .get(`/api/issues/${issue.id}/diagnostics/wakes`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.diagnosis).toContain("completed for issue_manager_handoff");
+    expect(res.body.events).toContainEqual(expect.objectContaining({
+      kind: "wake_request",
+      agentId: agent.id,
+      runId: wakeRunId,
+      source: "assignment",
+      reason: "issue_manager_handoff",
+      status: "completed",
+    }));
+  });
+
   it("returns null diagnosis for an unblocked issue with no wake history", async () => {
     const company = await seedCompany(db);
     const project = await seedProject(db, company.id, "Core");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -987,6 +987,7 @@ const ISSUE_WAKE_DIAGNOSTIC_KNOWN_SOURCES = new Set([
 
 const ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS = new Set([
   "issue_assigned",
+  ISSUE_MANAGER_HANDOFF_WAKE_REASON,
   "issue_blockers_resolved",
   "issue_commented",
   "issue_comment_mentioned",
@@ -9115,12 +9116,14 @@ export function issueRoutes(
       return;
     }
 
-    const activatedIssue = await svc.update(issue.id, {
-      status: "todo",
-      actorAgentId: managerAgentId,
-      expectedStatus: issue.status,
-      expectedAssigneeAgentId: issue.assigneeAgentId,
-    });
+    const activatedIssue = issue.status === "backlog"
+      ? await svc.update(issue.id, {
+          status: "todo",
+          actorAgentId: managerAgentId,
+          expectedStatus: "backlog",
+          expectedAssigneeAgentId: issue.assigneeAgentId,
+        })
+      : issue;
     if (!activatedIssue) {
       res.status(409).json({ error: "Issue status or assignee changed during manager handoff" });
       return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -66,6 +66,7 @@ import {
   updateIssueSchema,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
+  isAgentStatusInvokable,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
   type CompactIssue,
@@ -155,6 +156,11 @@ import {
   buildIssueBlockersResolvedWakeIdempotencyKey,
   findExistingIssueBlockersResolvedWake,
 } from "../services/issue-dependency-wakeups.js";
+import {
+  ISSUE_MANAGER_HANDOFF_WAKE_REASON,
+  buildIssueManagerHandoffWakeIdempotencyKey,
+  findExistingIssueManagerHandoffWake,
+} from "../services/issue-manager-handoff.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 import { executionWorkspaceService as executionWorkspaceServiceDirect } from "../services/execution-workspaces.js";
 import { decisionTrainingService } from "../services/decision-training.js";
@@ -9046,6 +9052,140 @@ export function issueRoutes(
 
     await queueTaskWatchdogEvaluation(existing, actor.runId);
     res.json(issue);
+  });
+
+  router.post("/issues/:id/manager-handoff", async (req, res) => {
+    const id = req.params.id as string;
+    if (req.actor.type !== "agent" || req.actor.source !== "agent_key" || !req.actor.agentId) {
+      res.status(403).json({ error: "Agent manager authentication required" });
+      return;
+    }
+    const initiatingRunId = requireAgentRunId(req, res);
+    if (!initiatingRunId) return;
+
+    const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
+    if (!issue) return;
+    if (issue.status !== "backlog" && issue.status !== "todo") {
+      res.status(409).json({ error: "Manager handoff only supports backlog or todo issues" });
+      return;
+    }
+    if (!issue.assigneeAgentId || issue.assigneeUserId) {
+      res.status(403).json({ error: "Manager handoff requires an existing agent assignee" });
+      return;
+    }
+
+    const managerAgentId = req.actor.agentId;
+    const [manager, targetAgent] = await Promise.all([
+      agentsSvc.getById(managerAgentId),
+      agentsSvc.getById(issue.assigneeAgentId),
+    ]);
+    const healthyDirectReport =
+      manager?.companyId === issue.companyId &&
+      targetAgent?.companyId === issue.companyId &&
+      isAgentStatusInvokable(manager.status) &&
+      isAgentStatusInvokable(targetAgent.status) &&
+      manager.orgChainHealth?.status === "healthy" &&
+      targetAgent.orgChainHealth?.status === "healthy" &&
+      targetAgent.reportsTo === managerAgentId;
+    if (!healthyDirectReport) {
+      res.status(403).json({ error: "Manager handoff is limited to healthy direct reports in the same company" });
+      return;
+    }
+
+    const idempotencyKey = buildIssueManagerHandoffWakeIdempotencyKey({ initiatingRunId, issueId: issue.id });
+    const existingWake = await findExistingIssueManagerHandoffWake(db, {
+      companyId: issue.companyId,
+      targetAgentId: issue.assigneeAgentId,
+      idempotencyKey,
+    });
+    if (existingWake) {
+      res.json({
+        issue,
+        handoff: {
+          initiatingRunId,
+          managerAgentId,
+          targetAgentId: issue.assigneeAgentId,
+          targetIssueId: issue.id,
+          idempotencyKey,
+          wakeRequestId: existingWake.id,
+          wakeupRunId: existingWake.runId,
+          idempotentReplay: true,
+        },
+      });
+      return;
+    }
+
+    const activatedIssue = await svc.update(issue.id, {
+      status: "todo",
+      actorAgentId: managerAgentId,
+      expectedStatus: issue.status,
+      expectedAssigneeAgentId: issue.assigneeAgentId,
+    });
+    if (!activatedIssue) {
+      res.status(409).json({ error: "Issue status or assignee changed during manager handoff" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    const wakeRun = await heartbeat.wakeup(issue.assigneeAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: ISSUE_MANAGER_HANDOFF_WAKE_REASON,
+      idempotencyKey,
+      payload: {
+        issueId: issue.id,
+        mutation: issue.status === "backlog" ? "backlog_to_todo" : "assignment_wake",
+        managerAgentId,
+        initiatingRunId,
+      },
+      requestedByActorType: actor.actorType,
+      requestedByActorId: actor.actorId,
+      contextSnapshot: {
+        issueId: issue.id,
+        taskId: issue.id,
+        source: "issue.manager_handoff",
+        wakeReason: ISSUE_MANAGER_HANDOFF_WAKE_REASON,
+        managerAgentId,
+        initiatingRunId,
+      },
+    });
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: initiatingRunId,
+      agentApiKeyId: actor.agentApiKeyId,
+      action: "issue.manager_handoff_requested",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        managerAgentId,
+        targetAgentId: issue.assigneeAgentId,
+        targetIssueId: issue.id,
+        initiatingRunId,
+        previousStatus: issue.status,
+        resultingStatus: activatedIssue.status,
+        idempotencyKey,
+        wakeRequestId: wakeRun?.wakeupRequestId ?? null,
+        wakeupRunId: wakeRun?.id ?? null,
+      },
+    });
+
+    res.json({
+      issue: activatedIssue,
+      handoff: {
+        initiatingRunId,
+        managerAgentId,
+        targetAgentId: issue.assigneeAgentId,
+        targetIssueId: issue.id,
+        idempotencyKey,
+        wakeRequestId: wakeRun?.wakeupRequestId ?? null,
+        wakeupRunId: wakeRun?.id ?? null,
+        idempotentReplay: false,
+      },
+    });
   });
 
   router.post("/issues/:id/checkout", validate(checkoutIssueSchema), async (req, res) => {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2001,6 +2001,17 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "post",
+  path: "/api/issues/{id}/manager-handoff",
+  tags: ["issues"],
+  summary: "Request a scoped manager assignment handoff",
+  description:
+    "Allows a run-bound manager agent to activate or wake one existing backlog/todo issue assigned to a healthy direct report without widening generic issue mutation or checkout authority.",
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: r.ok(), 401: r.unauthorized, 403: r.forbidden, 404: r.notFound, 409: r.conflict },
+});
+
+registry.registerPath({
   method: "get",
   path: "/api/issues/{id}/heartbeat-context",
   tags: ["issues"],

--- a/server/src/services/issue-manager-handoff.ts
+++ b/server/src/services/issue-manager-handoff.ts
@@ -1,0 +1,43 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agentWakeupRequests } from "@paperclipai/db";
+
+export const ISSUE_MANAGER_HANDOFF_WAKE_REASON = "issue_manager_handoff";
+
+const IDEMPOTENT_MANAGER_HANDOFF_WAKE_STATUSES = [
+  "queued",
+  "deferred_issue_execution",
+  "claimed",
+  "completed",
+  "coalesced",
+] as const;
+
+export function buildIssueManagerHandoffWakeIdempotencyKey(input: {
+  initiatingRunId: string;
+  issueId: string;
+}) {
+  return ["issue-manager-handoff", input.initiatingRunId, input.issueId].join(":");
+}
+
+export async function findExistingIssueManagerHandoffWake(
+  db: Db,
+  input: { companyId: string; targetAgentId: string; idempotencyKey: string },
+) {
+  return db
+    .select({
+      id: agentWakeupRequests.id,
+      status: agentWakeupRequests.status,
+      runId: agentWakeupRequests.runId,
+    })
+    .from(agentWakeupRequests)
+    .where(
+      and(
+        eq(agentWakeupRequests.companyId, input.companyId),
+        eq(agentWakeupRequests.agentId, input.targetAgentId),
+        eq(agentWakeupRequests.idempotencyKey, input.idempotencyKey),
+        inArray(agentWakeupRequests.status, [...IDEMPOTENT_MANAGER_HANDOFF_WAKE_STATUSES]),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6569,6 +6569,8 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        expectedStatus?: typeof issues.$inferSelect.status;
+        expectedAssigneeAgentId?: string;
       },
       dbOrTx: any = db,
     ) => {
@@ -6584,6 +6586,8 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        expectedStatus,
+        expectedAssigneeAgentId,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -6738,10 +6742,17 @@ export function issueService(db: Db) {
           projectGoalId: nextProjectGoalId,
           defaultGoalId: defaultCompanyGoal?.id ?? null,
         });
+        const updateConditions = [eq(issues.id, id)];
+        if (expectedStatus !== undefined) {
+          updateConditions.push(eq(issues.status, expectedStatus));
+        }
+        if (expectedAssigneeAgentId !== undefined) {
+          updateConditions.push(eq(issues.assigneeAgentId, expectedAssigneeAgentId));
+        }
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(eq(issues.id, id))
+          .where(and(...updateConditions))
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -511,6 +511,7 @@ If `plan` already exists, fetch the current document first and send its latest `
 | My compact inbox                      | `GET /api/agents/me/inbox-lite`                                                                                                 |
 | My assignments                        | `GET /api/companies/:companyId/issues?assigneeAgentId=:id&status=todo,in_progress,in_review,blocked`                            |
 | Checkout task                         | `POST /api/issues/:issueId/checkout`                                                                                            |
+| Activate direct report's assigned task | `POST /api/issues/:issueId/manager-handoff`                                                                                     |
 | Get task + ancestors                  | `GET /api/issues/:issueId`                                                                                                      |
 | Compact heartbeat context             | `GET /api/issues/:issueId/heartbeat-context`                                                                                    |
 | Update task                           | `PATCH /api/issues/:issueId` (optional `comment` field)                                                                         |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -191,6 +191,43 @@ The response also includes `blockedBy` and `blocks` arrays showing first-class d
 
 Blocker wake semantics are strict: `issue_blockers_resolved` only fires when every blocker reaches `done`. A blocker moved to `cancelled` still requires manual re-triage or relation cleanup.
 
+### Manager Assignment Handoff (`POST /api/issues/:issueId/manager-handoff`)
+
+Use this narrow endpoint when a run-bound manager agent needs to activate one existing task that is already assigned to a healthy direct report. It is not checkout and it does not transfer ownership. An assigned `backlog` task is atomically moved to `todo`; an assigned `todo` task keeps its status. In both cases Paperclip requests an issue-bound assignment wake for the existing assignee.
+
+```json
+POST /api/issues/issue-99/manager-handoff
+{}
+```
+
+```json
+{
+  "issue": {
+    "id": "issue-99",
+    "status": "todo",
+    "assigneeAgentId": "agent-42"
+  },
+  "handoff": {
+    "initiatingRunId": "run-7",
+    "managerAgentId": "manager-1",
+    "targetAgentId": "agent-42",
+    "targetIssueId": "issue-99",
+    "idempotencyKey": "issue-manager-handoff:run-7:issue-99",
+    "wakeRequestId": "wake-8",
+    "wakeupRunId": "run-8",
+    "idempotentReplay": false
+  }
+}
+```
+
+Authorization is fail-closed:
+
+- The caller must use a run-bound agent key; board sessions and unbound agent keys are rejected.
+- Manager, target agent, and issue must belong to the same company, both agents must have healthy org chains and invokable lifecycle states, and the target agent must report directly to the manager.
+- The issue must already have exactly that agent assignee and be in `backlog` or `todo`.
+- The generic issue `PATCH` and checkout routes keep their existing authorization boundaries; this endpoint accepts no arbitrary issue mutations and never checks out as the target agent.
+- Retries from the same initiating run and issue reuse the existing wake request. The response and activity audit identify the initiating run, manager, target agent, target issue, and wake/run ids for readback.
+
 ### Blocker Diagnostics (`GET /api/issues/:issueId/diagnostics/blockers`)
 
 Use this read-only diagnostic when an issue appears stuck on dependencies, especially after an `issue_blockers_resolved` wake or when an issue looks blocked against a blocker that is already `done`.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents for work.
> - Managers need to move an already assigned backlog/todo issue into execution without impersonating the assignee.
> - Existing agent authorization correctly rejects foreign checkout and broad issue mutation, but that also leaves safe manager-driven assignment wakes without a narrow path.
> - The new path must preserve company boundaries, direct reporting-line checks, run attribution, idempotency, and existing checkout ownership.
> - This pull request adds a dedicated manager handoff endpoint rather than weakening generic PATCH or checkout authorization.
> - The benefit is auditable delegation with an idempotent wake while unrelated issue mutations remain fail-closed.

## Linked Issues or Issue Description

No public GitHub issue exists for this change.

A manager/CEO agent cannot currently activate an existing backlog/todo issue assigned to a direct report: foreign checkout is intentionally rejected, while generic issue PATCH is outside the manager actor boundary. The missing capability is a narrow, company-scoped manager handoff that validates a healthy direct reporting line, preserves the existing assignee, atomically moves backlog to todo when needed, records the initiating run, and requests exactly one idempotent assignment wake. Draft PR #10272 is related but uses a broader grant-based PATCH path; this change keeps generic PATCH and foreign checkout unchanged.

## What Changed

- Add a dedicated manager-handoff service and `POST /api/issues/:id/manager-handoff` route.
- Require same-company manager authority, a healthy direct report, an existing agent assignee, backlog/todo source status, and run-scoped audit attribution.
- Keep generic issue PATCH and foreign checkout authorization unchanged.
- Make repeated handoff requests idempotent and expose wake/audit diagnostics for readback.
- Document the endpoint and add positive and fail-closed route coverage.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts server/src/__tests__/issue-wake-diagnostics-routes.test.ts` — 25/25 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.
- Changed-file credential-pattern scan — passed with zero findings.
- Review should confirm manager, company, reporting-line, assignee, status, run-id, idempotency, and negative authorization cases in the focused tests.

## Risks

- A faulty reporting-line or company-scope check could allow unauthorized delegation. The route fails closed and has explicit negative coverage for cross-company, unhealthy/non-direct reporting lines, missing assignees, unsupported statuses, missing run attribution, and generic mutation/checkout boundaries.
- Repeated wake requests could create duplicate work. The handoff is idempotent and diagnostics expose the initiating run and target issue/agent for readback.
- No database migration, deployment, production mutation, or broad grant change is included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, `gpt-5.6-sol`, with repository tool use, isolated git worktree execution, focused tests, type checking, diff validation, and evidence-first readback.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending branch publication and PR creation
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending PR review
- [x] I will address all Greptile and reviewer comments before requesting merge
