### PR TITLE
feat(issues): add server/API versioned CAS foundation

### DIFF
--- a/packages/db/src/issue-version-migration.test.ts
+++ b/packages/db/src/issue-version-migration.test.ts
@@ -1,0 +1,113 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { applyPendingMigrations, inspectMigrations } from "./client.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./test-embedded-postgres.js";
+
+const MIGRATION_FILE = "0195_issue_version.sql";
+const cleanups: Array<() => Promise<void>> = [];
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function createTempDatabase(): Promise<string> {
+  const database = await startEmbeddedPostgresTestDatabase("paperclip-issue-version-migration-");
+  cleanups.push(database.cleanup);
+  return database.connectionString;
+}
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+});
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue version migration tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("issue version migration", () => {
+  it(
+    "backfills existing issues, defaults new issues, and enforces a positive version",
+    async () => {
+      const connectionString = await createTempDatabase();
+      const migrationContent = await fs.promises.readFile(
+        new URL(`./migrations/${MIGRATION_FILE}`, import.meta.url),
+        "utf8",
+      );
+      const migrationHash = createHash("sha256").update(migrationContent).digest("hex");
+      const companyId = randomUUID();
+      const existingIssueId = randomUUID();
+      const newIssueId = randomUUID();
+      const sql = postgres(connectionString, { max: 1, onnotice: () => {} });
+
+      try {
+        await sql`DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = ${migrationHash}`;
+        await sql`ALTER TABLE "issues" DROP CONSTRAINT IF EXISTS "issues_version_positive"`;
+        await sql`ALTER TABLE "issues" DROP COLUMN IF EXISTS "version"`;
+        await sql`
+          INSERT INTO "companies" ("id", "name", "issue_prefix")
+          VALUES (${companyId}, 'Issue version migration company', 'IVM')
+        `;
+        await sql`
+          INSERT INTO "issues" ("id", "company_id", "title", "identifier")
+          VALUES (${existingIssueId}, ${companyId}, 'Pre-migration issue', 'IVM-1')
+        `;
+      } finally {
+        await sql.end();
+      }
+
+      expect(await inspectMigrations(connectionString)).toMatchObject({
+        status: "needsMigrations",
+        pendingMigrations: [MIGRATION_FILE],
+      });
+
+      await applyPendingMigrations(connectionString);
+
+      const verifySql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const existingIssues = await verifySql<{ version: number }[]>`
+          SELECT "version" FROM "issues" WHERE "id" = ${existingIssueId}
+        `;
+        expect(existingIssues).toEqual([{ version: 1 }]);
+
+        await verifySql`
+          INSERT INTO "issues" ("id", "company_id", "title", "identifier")
+          VALUES (${newIssueId}, ${companyId}, 'New issue', 'IVM-2')
+        `;
+        const newIssues = await verifySql<{ version: number }[]>`
+          SELECT "version" FROM "issues" WHERE "id" = ${newIssueId}
+        `;
+        expect(newIssues).toEqual([{ version: 1 }]);
+
+        for (const invalidVersion of [0, -1]) {
+          await expect(
+            verifySql`UPDATE "issues" SET "version" = ${invalidVersion} WHERE "id" = ${newIssueId}`,
+          ).rejects.toThrow(/issues_version_positive/);
+        }
+
+        const appliedMigrations = await verifySql<{ hash: string }[]>`
+          SELECT "hash"
+          FROM "drizzle"."__drizzle_migrations"
+          WHERE "hash" = ${migrationHash}
+        `;
+        expect(appliedMigrations).toEqual([{ hash: migrationHash }]);
+      } finally {
+        await verifySql.end();
+      }
+
+      expect(await inspectMigrations(connectionString)).toMatchObject({
+        status: "upToDate",
+        appliedMigrations: expect.arrayContaining([MIGRATION_FILE]),
+      });
+    },
+    60_000,
+  );
+});

--- a/packages/db/src/migrations/0195_issue_version.sql
+++ b/packages/db/src/migrations/0195_issue_version.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "issues"
+  ADD COLUMN "version" integer DEFAULT 1 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "issues"
+  ADD CONSTRAINT "issues_version_positive"
+  CHECK ("issues"."version" > 0);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1352,6 +1352,13 @@
       "when": 1784920485226,
       "tag": "0194_company_skill_releases",
       "breakpoints": true
+    },
+    {
+      "idx": 195,
+      "version": "7",
+      "when": 1785211200000,
+      "tag": "0195_issue_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
+  check,
   pgTable,
   uuid,
   text,
@@ -73,6 +74,7 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    version: integer("version").notNull().default(1),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -107,6 +109,7 @@ export const issues = pgTable(
       )
       .where(sql`${table.hiddenAt} is null and ${table.status} not in ('done', 'cancelled')`),
     companyPriorityIdx: index("issues_company_priority_idx").on(table.companyId, table.priority),
+    versionPositive: check("issues_version_positive", sql`${table.version} > 0`),
     identifierIdx: uniqueIndex("issues_identifier_idx").on(table.identifier),
     titleSearchIdx: index("issues_title_search_idx").using("gin", table.title.op("gin_trgm_ops")),
     identifierSearchIdx: index("issues_identifier_search_idx").using("gin", table.identifier.op("gin_trgm_ops")),

--- a/scripts/check-issue-version-writes.mjs
+++ b/scripts/check-issue-version-writes.mjs
@@ -1,0 +1,687 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+
+const SCAN_ROOTS = ["server/src/routes", "server/src/services"];
+const EXCLUDED_DIRECTORIES = new Set(["__tests__", "coverage", "dist", "node_modules"]);
+const WRITE_OPERATIONS = new Set(["delete", "insert", "update"]);
+const TABLE_EXPORTS = new Set(["issues", "issueComments"]);
+const HELPER_PATH = "server/src/services/issue-versioning.ts";
+const HELPER_EXPORTS = new Set(["runIssueMutation", "versionedIssuePatch"]);
+const IDENTITY_FIELDS = [
+  "path",
+  "line",
+  "receiver",
+  "operation",
+  "table",
+  "tableToken",
+];
+const STABLE_IDENTITY_FIELDS = IDENTITY_FIELDS.filter((field) => field !== "line");
+
+function normalizePath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function sortWrites(left, right) {
+  return (
+    left.path.localeCompare(right.path) ||
+    left.line - right.line ||
+    left.table.localeCompare(right.table) ||
+    left.operation.localeCompare(right.operation) ||
+    left.tableToken.localeCompare(right.tableToken) ||
+    left.receiver.localeCompare(right.receiver)
+  );
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, canonicalize(nested)]),
+    );
+  }
+  return value;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value, "utf8").digest("hex").toUpperCase();
+}
+
+function project(entry, fields) {
+  return Object.fromEntries(fields.map((field) => [field, entry[field]]));
+}
+
+function identity(entry) {
+  return JSON.stringify(project(entry, IDENTITY_FIELDS));
+}
+
+function stableIdentity(entry) {
+  return JSON.stringify(project(entry, STABLE_IDENTITY_FIELDS));
+}
+
+function unwrap(expression) {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstDeclaration(declaration) {
+  return (
+    ts.isVariableDeclarationList(declaration.parent) &&
+    (declaration.parent.flags & ts.NodeFlags.Const) !== 0
+  );
+}
+
+function collectAssignments(sourceFile) {
+  const assigned = new Set();
+  function visit(node) {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+    ) {
+      const target = unwrap(node.left);
+      if (ts.isIdentifier(target)) assigned.add(target.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return assigned;
+}
+
+function collectTableAliases(sourceFile) {
+  const aliases = new Map();
+  const declarations = [];
+
+  function collect(node) {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      node.moduleSpecifier.text === "@paperclipai/db"
+    ) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const specifier of bindings.elements) {
+          const exported = specifier.propertyName?.text ?? specifier.name.text;
+          if (TABLE_EXPORTS.has(exported)) aliases.set(specifier.name.text, exported);
+        }
+      }
+    } else if (ts.isVariableDeclaration(node)) {
+      declarations.push(node);
+    }
+    ts.forEachChild(node, collect);
+  }
+  collect(sourceFile);
+
+  const assigned = collectAssignments(sourceFile);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const declaration of declarations) {
+      if (
+        !ts.isIdentifier(declaration.name) ||
+        !isConstDeclaration(declaration) ||
+        !declaration.initializer ||
+        assigned.has(declaration.name.text) ||
+        aliases.has(declaration.name.text)
+      ) {
+        continue;
+      }
+      const initializer = unwrap(declaration.initializer);
+      if (!ts.isIdentifier(initializer)) continue;
+      const table = aliases.get(initializer.text);
+      if (!table) continue;
+      aliases.set(declaration.name.text, table);
+      changed = true;
+    }
+  }
+  return aliases;
+}
+
+function staticOperation(callee) {
+  const expression = unwrap(callee);
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  if (
+    ts.isElementAccessExpression(expression) &&
+    expression.argumentExpression &&
+    (ts.isStringLiteral(expression.argumentExpression) ||
+      ts.isNoSubstitutionTemplateLiteral(expression.argumentExpression))
+  ) {
+    return expression.argumentExpression.text;
+  }
+  return null;
+}
+
+function isDynamicElementAccess(callee) {
+  const expression = unwrap(callee);
+  return (
+    ts.isElementAccessExpression(expression) &&
+    !(
+      expression.argumentExpression &&
+      (ts.isStringLiteral(expression.argumentExpression) ||
+        ts.isNoSubstitutionTemplateLiteral(expression.argumentExpression))
+    )
+  );
+}
+
+function receiverText(callee, sourceFile) {
+  const expression = unwrap(callee);
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    const receiver = unwrap(expression.expression);
+    if (ts.isIdentifier(receiver)) return receiver.text;
+    if (ts.isPropertyAccessExpression(receiver)) return receiver.name.text;
+    return receiver.getText(sourceFile);
+  }
+  return expression.getText(sourceFile);
+}
+
+function enclosingFunctionName(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (
+      (ts.isFunctionDeclaration(current) ||
+        ts.isFunctionExpression(current) ||
+        ts.isMethodDeclaration(current)) &&
+      current.name
+    ) {
+      return current.name.getText();
+    }
+    if (
+      ts.isArrowFunction(current) &&
+      (ts.isVariableDeclaration(current.parent) ||
+        ts.isPropertyAssignment(current.parent))
+    ) {
+      return current.parent.name.getText();
+    }
+  }
+  return "<module>";
+}
+
+function nearestTransactionCallback(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (!ts.isFunctionLike(current)) continue;
+    const call = current.parent;
+    if (
+      ts.isCallExpression(call) &&
+      call.arguments.includes(current) &&
+      ts.isPropertyAccessExpression(call.expression) &&
+      call.expression.name.text === "transaction"
+    ) {
+      return current;
+    }
+    let expression = current;
+    while (
+      expression.parent &&
+      (ts.isParenthesizedExpression(expression.parent) ||
+        ts.isAsExpression(expression.parent) ||
+        ts.isNonNullExpression(expression.parent)) &&
+      expression.parent.expression === expression
+    ) {
+      expression = expression.parent;
+    }
+    if (
+      expression.parent &&
+      ts.isCallExpression(expression.parent) &&
+      expression.parent.expression === expression
+    ) {
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+function isInsideRunIssueMutation(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (!ts.isFunctionLike(current)) continue;
+    const property = current.parent;
+    if (
+      ts.isPropertyAssignment(property) &&
+      property.name.getText().replace(/^["']|["']$/g, "") === "mutate" &&
+      ts.isObjectLiteralExpression(property.parent)
+    ) {
+      const call = property.parent.parent;
+      const callee = ts.isCallExpression(call) ? unwrap(call.expression) : null;
+      if (callee && ts.isIdentifier(callee) && callee.text === "runIssueMutation") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function versionedUpdateWrapper(node) {
+  if (node.arguments.length === 0) return null;
+  const setProperty = node.parent;
+  if (
+    !ts.isPropertyAccessExpression(setProperty) ||
+    setProperty.expression !== node ||
+    setProperty.name.text !== "set"
+  ) {
+    return null;
+  }
+  const setCall = setProperty.parent;
+  if (!ts.isCallExpression(setCall) || setCall.arguments.length !== 1) return null;
+  const patch = unwrap(setCall.arguments[0]);
+  return (
+    ts.isCallExpression(patch) &&
+    ts.isIdentifier(patch.expression) &&
+    patch.expression.text === "versionedIssuePatch"
+  )
+    ? "versionedIssuePatch"
+    : null;
+}
+
+function tableReferences(expression, aliases) {
+  const references = new Set();
+  function visit(node) {
+    const current = unwrap(node);
+    if (ts.isIdentifier(current)) {
+      const table = aliases.get(current.text);
+      if (table) references.add(table);
+      return;
+    }
+    if (ts.isFunctionLike(current) || ts.isClassLike(current)) return;
+    ts.forEachChild(current, visit);
+  }
+  visit(expression);
+  return references;
+}
+
+export function collectIssueWritesFromSource(filePath, source) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const aliases = collectTableAliases(sourceFile);
+  const writes = [];
+
+  function visit(node) {
+    if (ts.isCallExpression(node) && node.arguments.length > 0) {
+      const operation = staticOperation(node.expression);
+      const argument = unwrap(node.arguments[0]);
+      const directTable = ts.isIdentifier(argument) ? aliases.get(argument.text) : null;
+      const references = directTable ? new Set([directTable]) : tableReferences(argument, aliases);
+      const isWrite = operation ? WRITE_OPERATIONS.has(operation) : isDynamicElementAccess(node.expression);
+
+      if (references.size > 0 && isDynamicElementAccess(node.expression)) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        throw new Error(`dynamic issue-table write operation in ${filePath}:${line + 1}`);
+      }
+      if (references.size > 0 && isWrite && !directTable) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        throw new Error(`unsafe issue-table expression in ${filePath}:${line + 1}`);
+      }
+      if (directTable && operation && WRITE_OPERATIONS.has(operation)) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        const entry = {
+          path: normalizePath(filePath),
+          line: line + 1,
+          receiver: receiverText(node.expression, sourceFile),
+          operation,
+          table: directTable,
+          tableToken: argument.text,
+        };
+        Object.defineProperty(entry, "versionedBy", {
+          value: directTable === "issues" && operation === "update"
+            ? versionedUpdateWrapper(node)
+            : null,
+          enumerable: false,
+        });
+        Object.defineProperties(entry, {
+          functionName: {
+            value: enclosingFunctionName(node),
+            enumerable: false,
+          },
+          insideRunIssueMutation: {
+            value: isInsideRunIssueMutation(node),
+            enumerable: false,
+          },
+          transactionCallback: {
+            value: nearestTransactionCallback(node),
+            enumerable: false,
+          },
+        });
+        writes.push(entry);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return writes.sort(sortWrites);
+}
+
+function listTypeScriptFiles(repoRoot) {
+  const files = [];
+  for (const relativeRoot of SCAN_ROOTS) {
+    const root = path.join(repoRoot, ...relativeRoot.split("/"));
+    const pending = [root];
+    while (pending.length > 0) {
+      const directory = pending.pop();
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const absolute = path.join(directory, entry.name);
+        if (entry.isDirectory() && !EXCLUDED_DIRECTORIES.has(entry.name)) {
+          pending.push(absolute);
+        } else if (
+          entry.isFile() &&
+          entry.name.endsWith(".ts") &&
+          !entry.name.endsWith(".d.ts")
+        ) {
+          files.push(absolute);
+        }
+      }
+    }
+  }
+  return files.sort();
+}
+
+export function collectIssueWrites(repoRoot) {
+  const writes = [];
+  for (const absolute of listTypeScriptFiles(repoRoot)) {
+    const relative = normalizePath(path.relative(repoRoot, absolute));
+    writes.push(...collectIssueWritesFromSource(relative, fs.readFileSync(absolute, "utf8")));
+  }
+  return writes.sort(sortWrites);
+}
+
+export function canonicalObservedDigest(entries) {
+  return sha256(JSON.stringify(canonicalize([...entries].sort(sortWrites))));
+}
+
+function catalogEntryDigest(entries) {
+  const projection = entries.map((entry) =>
+    canonicalize({
+      id: entry.id,
+      ...project(entry, IDENTITY_FIELDS),
+      containingFunction: entry.containingFunction,
+      sourceFileSha256: entry.sourceFileSha256,
+    }),
+  );
+  return sha256(JSON.stringify(projection));
+}
+
+function validateCatalog(catalog) {
+  const errors = [];
+  if (catalog?.schemaVersion !== "paperclip_issue_version_write_catalog_v2") {
+    errors.push("unsupported issue-version catalog schema");
+    return errors;
+  }
+  const entries = Array.isArray(catalog.entries) ? catalog.entries : [];
+  if (entries.length !== 78) errors.push(`catalog entry count is ${entries.length}, expected 78`);
+  if (new Set(entries.map((entry) => entry.id)).size !== entries.length) {
+    errors.push("catalog entry IDs are not unique");
+  }
+  if (
+    catalog.baseline?.acceptedEntryDigestSha256 &&
+    catalogEntryDigest(entries) !== catalog.baseline.acceptedEntryDigestSha256
+  ) {
+    errors.push("catalog accepted-entry digest differs");
+  }
+  return errors;
+}
+
+function exactCatalogEntry(entry, catalog) {
+  return catalog.entries.find((candidate) => identity(candidate) === identity(entry)) ?? null;
+}
+
+function stableCatalogEntry(entry, catalog) {
+  const preferredCommentExport =
+    entry.table === "issueComments" &&
+    (entry.insideRunIssueMutation || entry.functionName === "insertIssueComment")
+      ? "runIssueMutation"
+      : entry.table === "issueComments" && entry.transactionCallback
+        ? "versionedIssuePatch"
+        : null;
+  let matches = preferredCommentExport
+    ? catalog.entries.filter(
+        (candidate) =>
+          validResolution(candidate) &&
+          candidate.path === entry.path &&
+          candidate.table === entry.table &&
+          candidate.operation === entry.operation &&
+          candidate.resolution?.export === preferredCommentExport,
+      )
+    : catalog.entries.filter(
+        (candidate) =>
+          validResolution(candidate) &&
+          stableIdentity(candidate) === stableIdentity(entry),
+      );
+  if (
+    matches.length === 0 &&
+    entry.table === "issueComments" &&
+    (entry.insideRunIssueMutation || entry.functionName === "insertIssueComment")
+  ) {
+    matches = catalog.entries.filter(
+      (candidate) =>
+        validResolution(candidate) &&
+        candidate.path === entry.path &&
+        candidate.table === entry.table &&
+        candidate.operation === entry.operation &&
+        candidate.resolution?.export === "runIssueMutation",
+    );
+  }
+  if (matches.length === 1) return matches[0];
+  if (matches.length === 0) return null;
+
+  const byDistance = matches
+    .map((candidate) => ({
+      candidate,
+      distance: Math.abs(candidate.line - entry.line),
+    }))
+    .sort((left, right) => left.distance - right.distance);
+  return byDistance[0].distance < byDistance[1].distance
+    ? byDistance[0].candidate
+    : null;
+}
+
+export function validateBaseline(observed, catalog) {
+  const errors = validateCatalog(catalog);
+  if (!Array.isArray(observed)) errors.push("observed writes must be an array");
+  return { ok: errors.length === 0, errors };
+}
+
+function validResolution(entry) {
+  if (entry.classification === "versioned") {
+    return (
+      entry.state === "versioned" &&
+      entry.resolution?.kind === "versioned_helper" &&
+      entry.resolution.path === HELPER_PATH &&
+      HELPER_EXPORTS.has(entry.resolution.export)
+    );
+  }
+  if (entry.classification === "issue_created_at_version_1") {
+    return (
+      entry.state === "verified_create" &&
+      entry.resolution?.kind === "schema_default" &&
+      entry.resolution.column === "issues.version" &&
+      entry.resolution.value === 1
+    );
+  }
+  if (entry.classification === "issue_deleted_same_transaction") {
+    return (
+      entry.state === "exempt" &&
+      entry.resolution?.kind === "same_transaction_issue_delete" &&
+      entry.resolution.path === entry.path
+    );
+  }
+  return false;
+}
+
+function helperExports(repoRoot) {
+  if (!repoRoot) return new Set();
+  const helperPath = path.join(repoRoot, ...HELPER_PATH.split("/"));
+  if (!fs.existsSync(helperPath)) return new Set();
+  const sourceFile = ts.createSourceFile(
+    helperPath,
+    fs.readFileSync(helperPath, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const names = new Set();
+  for (const statement of sourceFile.statements) {
+    const modifiers = ts.canHaveModifiers(statement) ? ts.getModifiers(statement) ?? [] : [];
+    if (!modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) continue;
+    if (ts.isFunctionDeclaration(statement) && statement.name && statement.body) {
+      names.add(statement.name.text);
+    } else if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && declaration.initializer) {
+          names.add(declaration.name.text);
+        }
+      }
+    }
+  }
+  return names;
+}
+
+export function validateStrict(observed, catalog, { table = null, repoRoot = null } = {}) {
+  const errors = validateCatalog(catalog);
+  const exports = helperExports(repoRoot);
+  for (const entry of catalog.entries) {
+    if (table && entry.table !== table) continue;
+    if (!validResolution(entry)) {
+      errors.push(`unresolved catalog entry: ${entry.id}`);
+    } else if (
+      entry.classification === "versioned" &&
+      repoRoot &&
+      !exports.has(entry.resolution.export)
+    ) {
+      errors.push(`missing helper export ${entry.resolution.export}: ${entry.id}`);
+    }
+  }
+
+  for (const entry of observed) {
+    if (table && entry.table !== table) continue;
+    if (entry.path === HELPER_PATH && entry.table === "issues" && entry.operation === "update") {
+      continue;
+    }
+    const catalogEntry = exactCatalogEntry(entry, catalog) ?? stableCatalogEntry(entry, catalog);
+    if (!catalogEntry) {
+      errors.push(`unapproved raw write: ${identity(entry)}`);
+      continue;
+    }
+    if (catalogEntry.classification === "versioned") {
+      if (entry.table === "issues") {
+        if (
+          entry.operation !== "update" ||
+          entry.versionedBy !== catalogEntry.resolution?.export
+        ) {
+          errors.push(`raw write outside issue-version helper: ${catalogEntry.id}`);
+        }
+      } else if (entry.table === "issueComments") {
+        const resolutionExport = catalogEntry.resolution?.export;
+        if (resolutionExport === "runIssueMutation") {
+          if (
+            !entry.insideRunIssueMutation &&
+            !(
+              entry.path === "server/src/services/issues.ts" &&
+              entry.functionName === "insertIssueComment"
+            )
+          ) {
+            errors.push(`comment write is outside runIssueMutation: ${catalogEntry.id}`);
+          }
+        } else if (resolutionExport === "versionedIssuePatch") {
+          const hasPairedParentUpdate = entry.transactionCallback && observed.some(
+            (candidate) =>
+              candidate.table === "issues" &&
+              candidate.operation === "update" &&
+              candidate.versionedBy === "versionedIssuePatch" &&
+              candidate.transactionCallback === entry.transactionCallback,
+          );
+          if (!hasPairedParentUpdate) {
+            errors.push(`comment write lacks same-transaction parent version: ${catalogEntry.id}`);
+          }
+        } else {
+          errors.push(`unsupported comment write resolution: ${catalogEntry.id}`);
+        }
+      }
+    } else if (
+      catalogEntry.classification !== "issue_created_at_version_1" &&
+      catalogEntry.classification !== "issue_deleted_same_transaction"
+    ) {
+      errors.push(`raw write outside issue-version helper: ${catalogEntry.id}`);
+    } else if (!validResolution(catalogEntry)) {
+      errors.push(`unresolved raw write: ${catalogEntry.id}`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+function catalogPath() {
+  return path.join(path.dirname(fileURLToPath(import.meta.url)), "issue-version-write-catalog.json");
+}
+
+function parseArgs(args) {
+  const options = { mode: null, table: null };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--verify-baseline" || argument === "--strict") {
+      if (options.mode) throw new Error("Use exactly one mode");
+      options.mode = argument;
+    } else if (argument === "--table") {
+      options.table = args[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!options.mode) throw new Error("Use --verify-baseline or --strict");
+  if (options.table && !TABLE_EXPORTS.has(options.table)) {
+    throw new Error("--table accepted values: issues, issueComments");
+  }
+  if (options.table && options.mode !== "--strict") {
+    throw new Error("--table is only valid with --strict");
+  }
+  return options;
+}
+
+function runCli() {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+  const catalog = JSON.parse(fs.readFileSync(catalogPath(), "utf8"));
+  const observed = collectIssueWrites(repoRoot);
+  const result = validateStrict(observed, catalog, {
+    table: options.mode === "--strict" ? options.table : null,
+    repoRoot,
+  });
+  console.log(
+    JSON.stringify({
+      issueWrites: observed.filter((entry) => entry.table === "issues").length,
+      commentWrites: observed.filter((entry) => entry.table === "issueComments").length,
+      totalWrites: observed.length,
+      observedDigestSha256: canonicalObservedDigest(observed),
+    }),
+  );
+  if (!result.ok) {
+    for (const error of result.errors) console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-issue-version-writes.test.mjs
+++ b/scripts/check-issue-version-writes.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  canonicalObservedDigest,
+  collectIssueWrites,
+  collectIssueWritesFromSource,
+  validateStrict,
+} from "./check-issue-version-writes.mjs";
+
+test("collects imported aliases for issue and comment writes", () => {
+  const source = [
+    'import { issues as issueRows, issueComments } from "@paperclipai/db";',
+    "await tx.update(issueRows).set({ status: 'done' });",
+    "await tx.insert(issueComments).values({ issueId: 'i' });",
+  ].join("\n");
+
+  assert.deepEqual(
+    collectIssueWritesFromSource("server/src/services/example.ts", source),
+    [
+      {
+        path: "server/src/services/example.ts",
+        line: 2,
+        receiver: "tx",
+        operation: "update",
+        table: "issues",
+        tableToken: "issueRows",
+      },
+      {
+        path: "server/src/services/example.ts",
+        line: 3,
+        receiver: "tx",
+        operation: "insert",
+        table: "issueComments",
+        tableToken: "issueComments",
+      },
+    ],
+  );
+});
+
+test("collects safe const aliases and rejects dynamic write operations", () => {
+  const source = [
+    'import { issues } from "@paperclipai/db";',
+    "const issueTable = issues;",
+    "await tx.delete(issueTable);",
+  ].join("\n");
+  assert.equal(
+    collectIssueWritesFromSource("server/src/services/example.ts", source)[0].table,
+    "issues",
+  );
+
+  assert.throws(
+    () =>
+      collectIssueWritesFromSource(
+        "server/src/services/example.ts",
+        [
+          'import { issues } from "@paperclipai/db";',
+          "await tx[operation](issues);",
+        ].join("\n"),
+      ),
+    /dynamic issue-table write operation/,
+  );
+});
+
+test("retains all accepted catalog identities and resolves the current source", () => {
+  const catalog = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), "scripts", "issue-version-write-catalog.json"), "utf8"),
+  );
+  const observed = collectIssueWrites(process.cwd());
+
+  assert.equal(catalog.entries.length, 78);
+  assert.equal(catalog.entries.filter((entry) => entry.table === "issues").length, 64);
+  assert.equal(catalog.entries.filter((entry) => entry.table === "issueComments").length, 14);
+  assert.deepEqual(
+    catalog.entries.map((entry) => entry.id),
+    Array.from({ length: 78 }, (_, index) => `M${String(index + 1).padStart(3, "0")}`),
+  );
+  assert.equal(
+    catalog.baseline.acceptedArtifactSha256,
+    "D549C40F4E1592DF482F3FAB92591CD171DC821111B833EA9DF5E0E403C19F1B",
+  );
+  assert.deepEqual(validateStrict(observed, catalog, { repoRoot: process.cwd() }), {
+    ok: true,
+    errors: [],
+  });
+});
+
+test("strict mode rejects injected raw issue and comment writes", () => {
+  const source = [
+    'import { issues, issueComments } from "@paperclipai/db";',
+    "await tx.update(issues).set({ status: 'done' });",
+    "await tx.insert(issueComments).values({ issueId: 'i' });",
+  ].join("\n");
+  const observed = collectIssueWritesFromSource("server/src/services/injected.ts", source);
+  const result = validateStrict(observed, {
+    schemaVersion: "paperclip_issue_version_write_catalog_v2",
+    baseline: { observedDigestSha256: canonicalObservedDigest([]) },
+    entries: [],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errors.filter((error) => error.startsWith("unapproved raw write:")).length, 2);
+});

--- a/scripts/issue-version-write-catalog.json
+++ b/scripts/issue-version-write-catalog.json
@@ -1,0 +1,1506 @@
+{
+  "schemaVersion": "paperclip_issue_version_write_catalog_v2",
+  "baseline": {
+    "sourceCommit": "8a3cc86531e800629282e83a5b7a70945ec6cf0c",
+    "sourceTree": "a00bdb4e3191e9a91de202a83bb2f1beb4a58232",
+    "acceptedArtifactPath": "files/paperclip-g2-mutation-catalog-v1.json",
+    "acceptedArtifactSha256": "D549C40F4E1592DF482F3FAB92591CD171DC821111B833EA9DF5E0E403C19F1B",
+    "acceptedCatalogDigestSha256": "ECC3BD4D55D92AE56783D5E0B3651B57F4FA40BBFA5E18820493FA4637E726BB",
+    "acceptedEntryDigestSha256": "1CA2E841CF982F76387A5249014E52AA44F70924423F2AA78FFC6A9FD9CCA89C",
+    "observedDigestSha256": "2E09161DA9414B4D954D08B30312A6DA9809D235FD9B321D06EFB1C5292A4B28",
+    "counts": {
+      "total": 78,
+      "issues": 64,
+      "issueComments": 14,
+      "insert": 10,
+      "update": 62,
+      "delete": 6,
+      "files": 19,
+      "unresolvedContainingFunctions": 0
+    }
+  },
+  "entries": [
+    {
+      "id": "M001",
+      "path": "server/src/routes/execution-workspaces.ts",
+      "line": 647,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "route:PATCH /execution-workspaces/:id",
+      "containingFunctionLine": 573,
+      "sourceFileSha256": "4041F4528DBAEDBB5B2B9CE8D9D7C14B9E698C46874C1B90C8DAF6D0FA699330",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M002",
+      "path": "server/src/routes/issues.ts",
+      "line": 6512,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issueRows",
+      "containingFunction": "route:POST /issues/:id/low-trust/promotions",
+      "containingFunctionLine": 6473,
+      "sourceFileSha256": "6F775021556589138ADF71E7D5FE1F8766D71B9B0986124707FD110046504BDB",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M003",
+      "path": "server/src/routes/issues.ts",
+      "line": 6522,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "route:POST /issues/:id/low-trust/promotions",
+      "containingFunctionLine": 6473,
+      "sourceFileSha256": "6F775021556589138ADF71E7D5FE1F8766D71B9B0986124707FD110046504BDB",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M004",
+      "path": "server/src/routes/pipelines.ts",
+      "line": 2029,
+      "receiver": "tx",
+      "operation": "insert",
+      "table": "issues",
+      "tableToken": "issueRows",
+      "containingFunction": "route:POST /cases/:caseId/open-conversation",
+      "containingFunctionLine": 2010,
+      "sourceFileSha256": "B2445C6A48C699C17D50D66E51535BB63E509F973399F7C8D972F75066C1B44C",
+      "classification": "issue_created_at_version_1",
+      "state": "verified_create",
+      "resolution": {
+        "kind": "schema_default",
+        "column": "issues.version",
+        "value": 1
+      }
+    },
+    {
+      "id": "M005",
+      "path": "server/src/services/access.ts",
+      "line": 369,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "archiveMember",
+      "containingFunctionLine": 321,
+      "sourceFileSha256": "0330AAAAF68ACFCAC387A5B50C4624B3D39271A306DDC39048DDBDD756877951",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M006",
+      "path": "server/src/services/access.ts",
+      "line": 381,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "archiveMember",
+      "containingFunctionLine": 321,
+      "sourceFileSha256": "0330AAAAF68ACFCAC387A5B50C4624B3D39271A306DDC39048DDBDD756877951",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M007",
+      "path": "server/src/services/agents.ts",
+      "line": 745,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "builtInMarker",
+      "containingFunctionLine": 734,
+      "sourceFileSha256": "9E8D594EE186C7875BE4DABC98016E64C9F07F2AE8B7C343E7DFDFAFFD8EA436",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M008",
+      "path": "server/src/services/agents.ts",
+      "line": 758,
+      "receiver": "tx",
+      "operation": "delete",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "builtInMarker",
+      "containingFunctionLine": 734,
+      "sourceFileSha256": "9E8D594EE186C7875BE4DABC98016E64C9F07F2AE8B7C343E7DFDFAFFD8EA436",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M009",
+      "path": "server/src/services/companies.ts",
+      "line": 452,
+      "receiver": "tx",
+      "operation": "delete",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "remove",
+      "containingFunctionLine": 432,
+      "sourceFileSha256": "8B45FC382D481CBB86B8DA67D74A6C20AAA5C46A87FEAEB2FD735849D2D5F25C",
+      "classification": "issue_deleted_same_transaction",
+      "state": "exempt",
+      "resolution": {
+        "kind": "same_transaction_issue_delete",
+        "path": "server/src/services/companies.ts",
+        "containingFunction": "remove"
+      }
+    },
+    {
+      "id": "M010",
+      "path": "server/src/services/companies.ts",
+      "line": 469,
+      "receiver": "tx",
+      "operation": "delete",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "remove",
+      "containingFunctionLine": 432,
+      "sourceFileSha256": "8B45FC382D481CBB86B8DA67D74A6C20AAA5C46A87FEAEB2FD735849D2D5F25C",
+      "classification": "issue_deleted_same_transaction",
+      "state": "exempt",
+      "resolution": {
+        "kind": "same_transaction_issue_delete",
+        "path": "server/src/services/companies.ts",
+        "containingFunction": "remove"
+      }
+    },
+    {
+      "id": "M011",
+      "path": "server/src/services/company-skills.ts",
+      "line": 6406,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "rows",
+      "containingFunctionLine": 6393,
+      "sourceFileSha256": "CA1A629A353342CC4C4E084E29A5334A1AA10A55B5C2F6E9D2685C26878C4906",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M012",
+      "path": "server/src/services/execution-workspaces.ts",
+      "line": 1879,
+      "receiver": "tx",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "allowActiveWorkspace",
+      "containingFunctionLine": 1662,
+      "sourceFileSha256": "6E9E59A43655CF0F325F7E730754B72FFFBBF2978038798A47C381A91895B2CC",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M013",
+      "path": "server/src/services/execution-workspaces.ts",
+      "line": 1899,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "allowActiveWorkspace",
+      "containingFunctionLine": 1662,
+      "sourceFileSha256": "6E9E59A43655CF0F325F7E730754B72FFFBBF2978038798A47C381A91895B2CC",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M014",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6477,
+      "receiver": "db",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "performIssueMonitorRecovery",
+      "containingFunctionLine": 6392,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M015",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6559,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "clearIssueMonitorAndRecover",
+      "containingFunctionLine": 6544,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M016",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6718,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "dispatchClaimedIssueMonitor",
+      "containingFunctionLine": 6609,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M017",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6754,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "dispatchClaimedIssueMonitor",
+      "containingFunctionLine": 6609,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M018",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6789,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "dispatchClaimedIssueMonitor",
+      "containingFunctionLine": 6609,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M019",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6797,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "dispatchClaimedIssueMonitor",
+      "containingFunctionLine": 6609,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M020",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6846,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "claimed",
+      "containingFunctionLine": 6845,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M021",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 6915,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "claimed",
+      "containingFunctionLine": 6914,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M022",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 8468,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "retryRun",
+      "containingFunctionLine": 8408,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M023",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 8719,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "queued",
+      "containingFunctionLine": 8670,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M024",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 9375,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "cancelScheduledRetryForGate",
+      "containingFunctionLine": 9336,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M025",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 10058,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "scheduleResult",
+      "containingFunctionLine": 9725,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M026",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 10771,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "claimQueuedRun",
+      "containingFunctionLine": 10636,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M027",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 10822,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "cancelQueuedRunForBlockedDependencies",
+      "containingFunctionLine": 10794,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M028",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 11037,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "cancelQueuedRunForStaleIssue",
+      "containingFunctionLine": 11011,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M029",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 11961,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "executeRun",
+      "containingFunctionLine": 11786,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M030",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 14452,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "promotionResult",
+      "containingFunctionLine": 14388,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M031",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 14467,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "promotionResult",
+      "containingFunctionLine": 14388,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M032",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 14755,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "promotionResult",
+      "containingFunctionLine": 14388,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M033",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 14915,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "promotionResult",
+      "containingFunctionLine": 14388,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M034",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 15071,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "promotionResult",
+      "containingFunctionLine": 14388,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M035",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 15540,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "cancelStaleScheduledRetry",
+      "containingFunctionLine": 15499,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M036",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 15656,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "outcome",
+      "containingFunctionLine": 15433,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M037",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 15695,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "outcome",
+      "containingFunctionLine": 15433,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M038",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 15810,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "outcome",
+      "containingFunctionLine": 15433,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M039",
+      "path": "server/src/services/heartbeat.ts",
+      "line": 15821,
+      "receiver": "tx",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "outcome",
+      "containingFunctionLine": 15433,
+      "sourceFileSha256": "BAD4820A4E035509C9BF902FC78D4D044B11C0B1954E28399D605B285CF2D893",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M040",
+      "path": "server/src/services/issue-thread-interactions.ts",
+      "line": 203,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "touchIssue",
+      "containingFunctionLine": 202,
+      "sourceFileSha256": "E0DBBC1FD17F3B1BF76C308133C746DF0F978A3734228A358AD2EA9084B4F876",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M041",
+      "path": "server/src/services/issue-tree-control.ts",
+      "line": 874,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "updated",
+      "containingFunctionLine": 873,
+      "sourceFileSha256": "994DE8D69C771A221DFCC15D902E551B449CE992EC059B645DD7F4DA1BD02FC9",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M042",
+      "path": "server/src/services/issue-tree-control.ts",
+      "line": 977,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "updatedIssues",
+      "containingFunctionLine": 973,
+      "sourceFileSha256": "994DE8D69C771A221DFCC15D902E551B449CE992EC059B645DD7F4DA1BD02FC9",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M043",
+      "path": "server/src/services/issues.ts",
+      "line": 4526,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "adoptStaleCheckoutRun",
+      "containingFunctionLine": 4468,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M044",
+      "path": "server/src/services/issues.ts",
+      "line": 4586,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "adoptUnownedCheckoutRun",
+      "containingFunctionLine": 4569,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M045",
+      "path": "server/src/services/issues.ts",
+      "line": 4638,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "clearExecutionRunIfTerminal",
+      "containingFunctionLine": 4616,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M046",
+      "path": "server/src/services/issues.ts",
+      "line": 4698,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "clearCheckoutRunIfTerminal",
+      "containingFunctionLine": 4664,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M047",
+      "path": "server/src/services/issues.ts",
+      "line": 6427,
+      "receiver": "tx",
+      "operation": "insert",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "create",
+      "containingFunctionLine": 6139,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "issue_created_at_version_1",
+      "state": "verified_create",
+      "resolution": {
+        "kind": "schema_default",
+        "column": "issues.version",
+        "value": 1
+      }
+    },
+    {
+      "id": "M048",
+      "path": "server/src/services/issues.ts",
+      "line": 6635,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "runUpdate",
+      "containingFunctionLine": 6615,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M049",
+      "path": "server/src/services/issues.ts",
+      "line": 6737,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "clearExecutionWorkspaceEnvironmentSelection",
+      "containingFunctionLine": 6720,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M050",
+      "path": "server/src/services/issues.ts",
+      "line": 6764,
+      "receiver": "tx",
+      "operation": "delete",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "remove",
+      "containingFunctionLine": 6753,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "issue_deleted_same_transaction",
+      "state": "exempt",
+      "resolution": {
+        "kind": "same_transaction_issue_delete",
+        "path": "server/src/services/issues.ts",
+        "containingFunction": "remove"
+      }
+    },
+    {
+      "id": "M051",
+      "path": "server/src/services/issues.ts",
+      "line": 6829,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "checkout",
+      "containingFunctionLine": 6787,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M052",
+      "path": "server/src/services/issues.ts",
+      "line": 6877,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "checkout",
+      "containingFunctionLine": 6787,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M053",
+      "path": "server/src/services/issues.ts",
+      "line": 6943,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "checkout",
+      "containingFunctionLine": 6787,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M054",
+      "path": "server/src/services/issues.ts",
+      "line": 7163,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "release",
+      "containingFunctionLine": 7128,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M055",
+      "path": "server/src/services/issues.ts",
+      "line": 7209,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "adminForceRelease",
+      "containingFunctionLine": 7182,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M056",
+      "path": "server/src/services/issues.ts",
+      "line": 7367,
+      "receiver": "tx",
+      "operation": "delete",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "enabled",
+      "containingFunctionLine": 7363,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M057",
+      "path": "server/src/services/issues.ts",
+      "line": 7374,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "enabled",
+      "containingFunctionLine": 7363,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M058",
+      "path": "server/src/services/issues.ts",
+      "line": 7401,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "enabled",
+      "containingFunctionLine": 7396,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M059",
+      "path": "server/src/services/issues.ts",
+      "line": 7419,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "enabled",
+      "containingFunctionLine": 7396,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M060",
+      "path": "server/src/services/issues.ts",
+      "line": 7471,
+      "receiver": "dbOrTx",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "addComment",
+      "containingFunctionLine": 7431,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M061",
+      "path": "server/src/services/issues.ts",
+      "line": 7489,
+      "receiver": "dbOrTx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "addComment",
+      "containingFunctionLine": 7431,
+      "sourceFileSha256": "A84EE50D151EFCFD6C633A9DCBCEC53404B8B014804537E52B86D6CA0B58EAF6",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M062",
+      "path": "server/src/services/pipelines.ts",
+      "line": 1933,
+      "receiver": "db",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "postSystemCommentOnLinkedIssues",
+      "containingFunctionLine": 1910,
+      "sourceFileSha256": "5A1B0BA6C7DB0ECE32A1376BD1B8EF0EA51A1A9D8420EA331D898D48E968A025",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M063",
+      "path": "server/src/services/pipelines.ts",
+      "line": 1939,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "postSystemCommentOnLinkedIssues",
+      "containingFunctionLine": 1910,
+      "sourceFileSha256": "5A1B0BA6C7DB0ECE32A1376BD1B8EF0EA51A1A9D8420EA331D898D48E968A025",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M064",
+      "path": "server/src/services/pipelines.ts",
+      "line": 2048,
+      "receiver": "db",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "notifyDependentWorkIssuesOfUpstreamContentChange",
+      "containingFunctionLine": 1993,
+      "sourceFileSha256": "5A1B0BA6C7DB0ECE32A1376BD1B8EF0EA51A1A9D8420EA331D898D48E968A025",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M065",
+      "path": "server/src/services/pipelines.ts",
+      "line": 2054,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "notifyDependentWorkIssuesOfUpstreamContentChange",
+      "containingFunctionLine": 1993,
+      "sourceFileSha256": "5A1B0BA6C7DB0ECE32A1376BD1B8EF0EA51A1A9D8420EA331D898D48E968A025",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M066",
+      "path": "server/src/services/pipelines.ts",
+      "line": 4614,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "result",
+      "containingFunctionLine": 4504,
+      "sourceFileSha256": "5A1B0BA6C7DB0ECE32A1376BD1B8EF0EA51A1A9D8420EA331D898D48E968A025",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M067",
+      "path": "server/src/services/plugin-host-services.ts",
+      "line": 2883,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issuesTable",
+      "containingFunction": "updatePolicy",
+      "containingFunctionLine": 2850,
+      "sourceFileSha256": "BC52562778792D8E74CEB2F25A8F591672708443743BC6793B61F5B70C03AEFE",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M068",
+      "path": "server/src/services/productivity-review.ts",
+      "line": 395,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "addRefreshComment",
+      "containingFunctionLine": 389,
+      "sourceFileSha256": "57BD609CF5A8FA9427C684559D492125F42607136EF51871BBDA1FECFA4757D2",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M069",
+      "path": "server/src/services/productivity-review.ts",
+      "line": 399,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "addRefreshComment",
+      "containingFunctionLine": 389,
+      "sourceFileSha256": "57BD609CF5A8FA9427C684559D492125F42607136EF51871BBDA1FECFA4757D2",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M070",
+      "path": "server/src/services/productivity-review.ts",
+      "line": 778,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "createOrUpdateReview",
+      "containingFunctionLine": 693,
+      "sourceFileSha256": "57BD609CF5A8FA9427C684559D492125F42607136EF51871BBDA1FECFA4757D2",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M071",
+      "path": "server/src/services/recovery/service.ts",
+      "line": 1611,
+      "receiver": "tx",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "finalizedRun",
+      "containingFunctionLine": 1584,
+      "sourceFileSha256": "A1008F902BB28CDF3DAEDACCF1551A3ECA07E07607667EEE3CE29CFE6AFCD733",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M072",
+      "path": "server/src/services/recovery/service.ts",
+      "line": 5346,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "sweepStaleIssueLocks",
+      "containingFunctionLine": 5299,
+      "sourceFileSha256": "A1008F902BB28CDF3DAEDACCF1551A3ECA07E07607667EEE3CE29CFE6AFCD733",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M073",
+      "path": "server/src/services/routines.ts",
+      "line": 1881,
+      "receiver": "txDb",
+      "operation": "delete",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "run",
+      "containingFunctionLine": 1686,
+      "sourceFileSha256": "DE00EC2A1C7D803EDC4AA8C62A5D96EE41CDEBF23CFA44CA374194A83D190359",
+      "classification": "issue_deleted_same_transaction",
+      "state": "exempt",
+      "resolution": {
+        "kind": "same_transaction_issue_delete",
+        "path": "server/src/services/routines.ts",
+        "containingFunction": "run"
+      }
+    },
+    {
+      "id": "M074",
+      "path": "server/src/services/task-watchdogs.ts",
+      "line": 1205,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "ensureReusableWatchdogIssue",
+      "containingFunctionLine": 1170,
+      "sourceFileSha256": "66BEB53FB5360348194874AFA4FF57D19CCE04A15D0EA7C35774F4D21E9B70E7",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M075",
+      "path": "server/src/services/workspace-runtime.ts",
+      "line": 1179,
+      "receiver": "db",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "writeDirtyQuarantineAuditComments",
+      "containingFunctionLine": 1157,
+      "sourceFileSha256": "C9C49EFAD9A9CD088810A0B61586F809C51D15C3023597E1D061FCED24E68D00",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M076",
+      "path": "server/src/services/workspace-runtime.ts",
+      "line": 1192,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "writeDirtyQuarantineAuditComments",
+      "containingFunctionLine": 1157,
+      "sourceFileSha256": "C9C49EFAD9A9CD088810A0B61586F809C51D15C3023597E1D061FCED24E68D00",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    },
+    {
+      "id": "M077",
+      "path": "server/src/services/workspace-runtime.ts",
+      "line": 1200,
+      "receiver": "db",
+      "operation": "insert",
+      "table": "issueComments",
+      "tableToken": "issueComments",
+      "containingFunction": "writeDirtyQuarantineAuditComments",
+      "containingFunctionLine": 1157,
+      "sourceFileSha256": "C9C49EFAD9A9CD088810A0B61586F809C51D15C3023597E1D061FCED24E68D00",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "runIssueMutation"
+      }
+    },
+    {
+      "id": "M078",
+      "path": "server/src/services/workspace-runtime.ts",
+      "line": 1213,
+      "receiver": "db",
+      "operation": "update",
+      "table": "issues",
+      "tableToken": "issues",
+      "containingFunction": "writeDirtyQuarantineAuditComments",
+      "containingFunctionLine": 1157,
+      "sourceFileSha256": "C9C49EFAD9A9CD088810A0B61586F809C51D15C3023597E1D061FCED24E68D00",
+      "classification": "versioned",
+      "state": "versioned",
+      "resolution": {
+        "kind": "versioned_helper",
+        "path": "server/src/services/issue-versioning.ts",
+        "export": "versionedIssuePatch"
+      }
+    }
+  ]
+}

--- a/server/src/__tests__/access-service.test.ts
+++ b/server/src/__tests__/access-service.test.ts
@@ -172,6 +172,7 @@ describeEmbeddedPostgres("access service", () => {
       .then((rows) => rows[0]!);
     expect(reassignedIssue.assigneeUserId).toBe(owner.principalId);
     expect(reassignedIssue.status).toBe("todo");
+    expect(reassignedIssue.version).toBe(2);
 
     const historicalIssue = await db
       .select()
@@ -179,6 +180,7 @@ describeEmbeddedPostgres("access service", () => {
       .where(eq(issues.id, doneIssue.id))
       .then((rows) => rows[0]!);
     expect(historicalIssue.assigneeUserId).toBe(member.principalId);
+    expect(historicalIssue.version).toBe(1);
   });
 
   it("rejects instance-level company access removal for self and protected users", async () => {

--- a/server/src/__tests__/api-compression.test.ts
+++ b/server/src/__tests__/api-compression.test.ts
@@ -93,6 +93,11 @@ function buildApp() {
     res.setHeader("ETag", "\"fixture-etag\"");
     res.json(issueListFixture(500));
   });
+  app.get("/api/issue-etag", (_req, res) => {
+    res.setHeader("Cache-Control", "no-transform");
+    res.setHeader("ETag", "\"issue-v7\"");
+    res.json(issueListFixture(500));
+  });
   app.get("/api/download", (_req, res) => {
     res.setHeader("Content-Type", "application/octet-stream");
     res.write("chunk-one:");
@@ -183,6 +188,18 @@ describe("API compression middleware", () => {
     expect(res.headers["content-encoding"]).toBe("gzip");
     expect(res.headers.etag).toBe("W/\"fixture-etag\"");
     expect(JSON.parse(gunzipSync(res.body).toString("utf8"))).toHaveLength(500);
+  });
+
+  it("preserves strong issue ETags when no-transform is set", async () => {
+    const res = await requestRaw(buildApp(), "/api/issue-etag", {
+      "accept-encoding": "gzip",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-transform");
+    expect(res.headers["content-encoding"]).toBeUndefined();
+    expect(res.headers.etag).toBe("\"issue-v7\"");
+    expect(JSON.parse(res.body.toString("utf8"))).toHaveLength(500);
   });
 
   it("passes streamed non-JSON responses through without compression", async () => {

--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -153,6 +153,12 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issueId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+    const [remainingIssue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(remainingIssue).toMatchObject({
+      assigneeAgentId: null,
+      createdByAgentId: null,
+      version: 2,
+    });
   });
 
   it("removes issue read states and activity rows before deleting the company", async () => {

--- a/server/src/__tests__/company-skill-test-runs-service.test.ts
+++ b/server/src/__tests__/company-skill-test-runs-service.test.ts
@@ -570,6 +570,8 @@ describeEmbeddedPostgres("companySkillService skill test runs", () => {
 
     const pruned = await svc.pruneExpiredTestHarnessIssues(companyId);
     expect(pruned.pruned).toBe(1);
+    const [prunedIssue] = await db.select().from(issues).where(eq(issues.id, run.issueId));
+    expect(prunedIssue).toMatchObject({ hiddenAt: expect.any(Date), version: 2 });
     const detail = await svc.getTestRunDetail(companyId, skillId, run.id);
     expect(detail?.taskExpired).toBe(true);
     expect(detail?.harnessIssue).toBeNull();

--- a/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
+++ b/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
@@ -389,16 +389,19 @@ describeEmbeddedPostgres("execution lock orphan cleanup", () => {
       expect(dualAfter?.executionAgentNameKey).toBeNull();
       expect(dualAfter?.executionLockedAt).toBeNull();
       expect(dualAfter?.checkoutRunId).toBeNull();
+      expect(dualAfter?.version).toBe(2);
 
       // Retry sibling: checkout column cleared, retry's execution pointer preserved.
       expect(retryAfter?.checkoutRunId).toBeNull();
       expect(retryAfter?.executionRunId).toBe(retryRunId);
       expect(retryAfter?.executionAgentNameKey).toBe("ceo");
       expect(retryAfter?.executionLockedAt).not.toBeNull();
+      expect(retryAfter?.version).toBe(2);
 
       // Checkout-only sibling: column cleared, no execution side-effects.
       expect(checkoutOnlyAfter?.checkoutRunId).toBeNull();
       expect(checkoutOnlyAfter?.executionRunId).toBeNull();
+      expect(checkoutOnlyAfter?.version).toBe(2);
     });
 
     it("does not touch execution locks on issues owned by unrelated runs", async () => {

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -629,6 +629,8 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       outcome: "restored",
       resolutionNote: "Execution workspace branch record reconciled from \"feature/recorded\" to \"feature/current\".",
     });
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(sourceIssue?.version).toBe(2);
   }, 20_000);
 
   it("quarantine_restore rescues dirty live-branch work, resolves recovery, and returns the source issue to todo", async () => {
@@ -777,6 +779,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       status: "todo",
       checkoutRunId: null,
       executionRunId: null,
+      version: 3,
     });
 
     const [recoveryAction] = await db

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1511,6 +1511,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           status: issues.status,
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
+          version: issues.version,
         })
         .from(issues)
         .where(eq(issues.id, issueId))
@@ -1519,6 +1520,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
         status: "in_progress",
         checkoutRunId: firstRun?.id,
         executionRunId: firstRun?.id,
+        version: 3,
       });
       gateway.releaseFirstWait();
       await waitFor(async () => {

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -1604,7 +1604,6 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       assigneeAgentId: newAgentId,
       updatedAt: now,
     }).where(eq(issues.id, issueId));
-
     // Keep the new agent's queue from auto-claiming/executing during this unit test.
     await db.insert(heartbeatRuns).values(
       Array.from({ length: 5 }, () => ({
@@ -1759,6 +1758,11 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       assigneeAgentId: newAgentId,
       updatedAt: now,
     }).where(eq(issues.id, issueId));
+    const versionBeforePromotion = await db
+      .select({ version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]?.version);
 
     const promotion = await heartbeat.promoteDueScheduledRetries(scheduled.dueAt);
     expect(promotion).toEqual({ promoted: 0, runIds: [] });
@@ -1777,11 +1781,15 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     });
 
     const issue = await db
-      .select({ executionRunId: issues.executionRunId })
+      .select({
+        executionRunId: issues.executionRunId,
+        version: issues.version,
+      })
       .from(issues)
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBeNull();
+    expect(issue?.version).toBe((versionBeforePromotion ?? 0) + 1);
   });
 
   it("does not promote a scheduled retry after the issue is handed to a human owner", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -13,6 +13,7 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  assertCheckoutOwnerInTransaction: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   decomposeAcceptedPlan: vi.fn(),
@@ -30,6 +31,7 @@ const mockIssueService = vi.hoisted(() => ({
   remove: vi.fn(),
   removeAttachment: vi.fn(),
   update: vi.fn(),
+  updateWithInlineComment: vi.fn(),
   findMentionedAgents: vi.fn(),
 }));
 
@@ -244,6 +246,7 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
     createdByUserId: "board-user",
     identifier: "PAP-1649",
     title: "Owned active issue",
+    version: 1,
     executionPolicy: null,
     executionState: null,
     hiddenAt: null,
@@ -413,6 +416,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockCompanyService.getById.mockReset();
     mockIssueService.addComment.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.assertCheckoutOwnerInTransaction.mockReset();
     mockIssueService.create.mockReset();
     mockIssueService.createChild.mockReset();
     mockIssueService.decomposeAcceptedPlan.mockReset();
@@ -509,6 +513,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.remove.mockReset();
     mockIssueService.removeAttachment.mockReset();
     mockIssueService.update.mockReset();
+    mockIssueService.updateWithInlineComment.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
     mockLogActivity.mockClear();
     mockDocumentService.upsertIssueDocument.mockReset();
@@ -549,8 +554,28 @@ describe("agent issue mutation checkout ownership", () => {
       companyId,
       body: "Mentioned reply context.",
     });
+    mockIssueService.updateWithInlineComment.mockImplementation(
+      async (targetIssueId, issueData, commentData) => {
+        const meaningfulUpdate = Object.keys(issueData).some(
+          (key) => key !== "expectedVersion",
+        );
+        const issue = meaningfulUpdate
+          ? await mockIssueService.update(targetIssueId, issueData)
+          : await mockIssueService.getById(targetIssueId);
+        if (!issue) return null;
+        const comment = await mockIssueService.addComment(
+          targetIssueId,
+          commentData.body,
+          commentData.actor,
+          commentData.options,
+        );
+        await commentData.afterUpdate?.({}, issue, comment);
+        return { issue, comment };
+      },
+    );
     mockIssueService.list.mockResolvedValue([makeIssue()]);
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.assertCheckoutOwnerInTransaction.mockResolvedValue({ adoptedFromRunId: null });
     mockIssueService.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => ({
       ...makeIssue({
         id: "88888888-8888-4888-8888-888888888888",
@@ -776,6 +801,53 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale agent PATCH before normalizing checkout ownership", async () => {
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .set("If-Match", "\"issue-v2\"")
+      .send({ title: "Stale update" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(412);
+    expect(res.headers.etag).toBe("\"issue-v1\"");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("joins checkout normalization to a current conditional PATCH", async () => {
+    const tx = { rollback: vi.fn() };
+    const routeDb = {
+      ...createRunContextDb(),
+      transaction: vi.fn(async (callback: (input: typeof tx) => Promise<unknown>) => callback(tx)),
+    };
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...patch,
+      title: "Current update",
+      version: 2,
+    }));
+
+    const res = await request(await createApp(ownerActor(), routeDb))
+      .patch(`/api/issues/${issueId}`)
+      .set("If-Match", "\"issue-v1\"")
+      .send({ title: "Current update" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.assertCheckoutOwnerInTransaction).toHaveBeenCalledWith(
+      issueId,
+      ownerAgentId,
+      ownerRunId,
+      1,
+      tx,
+    );
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ expectedVersion: 1, title: "Current update" }),
+      tx,
+    );
   });
 
   it("allows mentioned peer agents to post comments without ownership of an active checkout", async () => {

--- a/server/src/__tests__/issue-cas-routes.test.ts
+++ b/server/src/__tests__/issue-cas-routes.test.ts
@@ -1,0 +1,406 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import {
+  activityLog,
+  companies,
+  companyMemberships,
+  createDb,
+  instanceSettings,
+  issueComments,
+  issueThreadInteractions,
+  issueWorkProducts,
+  issues,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { StorageService } from "../storage/types.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { apiCompression } from "../middleware/api-compression.js";
+import { issueRoutes } from "../routes/issues.js";
+import { issueThreadInteractionService } from "../services/issue-thread-interactions.js";
+import { workProductService } from "../services/work-products.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("issue CAS routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-cas-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 60_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueThreadInteractions);
+    await db.delete(issueComments);
+    await db.delete(issueWorkProducts);
+    await db.delete(issues);
+    await db.delete(instanceSettings);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use("/api", apiCompression());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{
+          companyId,
+          membershipRole: "owner",
+          status: "active",
+          principalId: "cloud-user-1",
+        }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as StorageService));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedIssue(version = 1) {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const prefix = `P${randomUUID().replaceAll("-", "").slice(0, 4).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "CAS route issue",
+      status: "todo",
+      priority: "medium",
+      version,
+    });
+    return { app: createApp(companyId), companyId, issueId };
+  }
+
+  it("returns a strong issue ETag and no-transform on GET", async () => {
+    const { app, issueId } = await seedIssue(7);
+
+    const res = await request(app).get(`/api/issues/${issueId}`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.headers.etag).toBe("\"issue-v7\"");
+    expect(res.headers["cache-control"]).toBe("no-transform");
+    expect(res.body.version).toBe(7);
+  });
+
+  it("preserves the strong ETag when the client accepts gzip", async () => {
+    const { app, issueId } = await seedIssue(7);
+
+    const res = await request(app)
+      .get(`/api/issues/${issueId}`)
+      .set("Accept-Encoding", "gzip");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.headers.etag).toBe("\"issue-v7\"");
+    expect(res.headers["content-encoding"]).toBeUndefined();
+  });
+
+  it("advances the issue representation version for work product mutations", async () => {
+    const { app, companyId, issueId } = await seedIssue();
+    const products = workProductService(db);
+
+    const created = await products.createForIssue(issueId, companyId, {
+      type: "artifact",
+      provider: "paperclip",
+      title: "Evidence bundle",
+      status: "open",
+      reviewState: "draft",
+      isPrimary: false,
+    });
+
+    expect(created).not.toBeNull();
+    const afterCreate = await request(app).get(`/api/issues/${issueId}`);
+    expect(afterCreate.status, JSON.stringify(afterCreate.body)).toBe(200);
+    expect(afterCreate.headers.etag).toBe("\"issue-v2\"");
+    expect(afterCreate.body.workProducts).toHaveLength(1);
+
+    const updated = await products.update(created!.id, { reviewState: "ready_for_review" });
+    expect(updated?.reviewState).toBe("ready_for_review");
+    const afterUpdate = await request(app).get(`/api/issues/${issueId}`);
+    expect(afterUpdate.headers.etag).toBe("\"issue-v3\"");
+
+    expect(await products.remove(created!.id)).not.toBeNull();
+    const afterDelete = await request(app).get(`/api/issues/${issueId}`);
+    expect(afterDelete.headers.etag).toBe("\"issue-v4\"");
+    expect(afterDelete.body.workProducts).toEqual([]);
+  });
+
+  it("accepts PATCH with the current ETag and returns a fresh ETag", async () => {
+    const { app, issueId } = await seedIssue(7);
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .set("If-Match", "\"issue-v7\"")
+      .send({ priority: "high" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ id: issueId, priority: "high", version: 8 });
+    expect(res.headers["cache-control"], JSON.stringify(res.headers)).toBe("no-transform");
+    expect(res.headers.etag, JSON.stringify(res.headers)).toBe("\"issue-v8\"");
+  });
+
+  it("returns 412 with zero writes for a stale PATCH", async () => {
+    const { app, issueId } = await seedIssue(7);
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .set("If-Match", "\"issue-v6\"")
+      .send({ priority: "high" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(412);
+    expect(res.body).toEqual({ error: "Issue version conflict" });
+    expect(res.headers.etag).toBe("\"issue-v7\"");
+    expect(res.headers["cache-control"]).toBe("no-transform");
+    expect(
+      await db
+        .select({ priority: issues.priority, version: issues.version })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ priority: "medium", version: 7 });
+    expect(await db.select({ id: instanceSettings.id }).from(instanceSettings)).toEqual([]);
+    expect(await db.select({ id: activityLog.id }).from(activityLog)).toEqual([]);
+  });
+
+  it("returns 400 for weak and multi-value If-Match", async () => {
+    const { app, issueId } = await seedIssue(7);
+
+    for (const value of ["W/\"issue-v7\"", "\"issue-v7\", \"issue-v6\""]) {
+      const res = await request(app)
+        .patch(`/api/issues/${issueId}`)
+        .set("If-Match", value)
+        .send({ priority: "high" });
+      expect(res.status, value).toBe(400);
+      expect(res.body).toEqual({ error: "Invalid If-Match issue ETag" });
+    }
+  });
+
+  it("keeps unheadered PATCH compatible and increments once", async () => {
+    const { app, issueId } = await seedIssue();
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ priority: "high" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.version).toBe(2);
+    expect(res.headers["cache-control"], JSON.stringify(res.headers)).toBe("no-transform");
+    expect(res.headers.etag, JSON.stringify(res.headers)).toBe("\"issue-v2\"");
+  });
+
+  it("advances the parent once for a current comment If-Match", async () => {
+    const { app, issueId } = await seedIssue();
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .set("If-Match", "\"issue-v1\"")
+      .send({ body: "Versioned comment" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(res.headers["cache-control"]).toBe("no-transform");
+    expect(
+      await db
+        .select({ version: issues.version })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ version: 2 });
+    expect(await db.select({ id: issueComments.id }).from(issueComments)).toHaveLength(1);
+  });
+
+  it("expires superseded interactions within the comment's single parent version", async () => {
+    const { app, companyId, issueId } = await seedIssue();
+    const interaction = await issueThreadInteractionService(db).create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "scope",
+          prompt: "Choose the scope",
+          selectionMode: "single",
+          options: [{ id: "phase-1", label: "Phase 1" }],
+        }],
+      },
+    }, {
+      userId: "cloud-user-1",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .set("If-Match", "\"issue-v2\"")
+      .send({ body: "Proceed with phase 1" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.headers.etag).toBe("\"issue-v3\"");
+    expect(
+      await db
+        .select({ version: issues.version })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ version: 3 });
+    expect(
+      await db
+        .select({ status: issueThreadInteractions.status })
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, interaction.id))
+        .then((rows) => rows[0]),
+    ).toEqual({ status: "expired" });
+  });
+
+  it("returns 412 and inserts no comment for stale comment If-Match", async () => {
+    const { app, issueId } = await seedIssue(3);
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .set("If-Match", "\"issue-v2\"")
+      .send({ body: "Stale comment" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(412);
+    expect(res.headers.etag).toBe("\"issue-v3\"");
+    expect(await db.select({ id: issueComments.id }).from(issueComments)).toEqual([]);
+    expect(await db.select({ id: instanceSettings.id }).from(instanceSettings)).toEqual([]);
+    expect(await db.select({ id: activityLog.id }).from(activityLog)).toEqual([]);
+  });
+
+  it("advances once for PATCH with an inline comment", async () => {
+    const { app, issueId } = await seedIssue();
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .set("If-Match", "\"issue-v1\"")
+      .send({ priority: "high", comment: "Compound comment" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      priority: "high",
+      version: 2,
+      comment: expect.objectContaining({ body: "Compound comment" }),
+    });
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(await db.select({ id: issueComments.id }).from(issueComments)).toHaveLength(1);
+  });
+
+  it("advances once for reopen plus comment", async () => {
+    const { app, issueId } = await seedIssue();
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: new Date() })
+      .where(eq(issues.id, issueId));
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .set("If-Match", "\"issue-v1\"")
+      .send({ body: "Please resume", reopen: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(
+      await db
+        .select({ status: issues.status, version: issues.version })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ status: "todo", version: 2 });
+    expect(await db.select({ id: issueComments.id }).from(issueComments)).toHaveLength(1);
+  });
+
+  it("advances once when tombstoning a comment", async () => {
+    const { app, companyId, issueId } = await seedIssue();
+    const [comment] = await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorType: "user",
+      authorUserId: "cloud-user-1",
+      body: "Delete me",
+    }).returning();
+
+    const res = await request(app)
+      .delete(`/api/issues/${issueId}/comments/${comment.id}`)
+      .set("If-Match", "\"issue-v1\"");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(res.body).toMatchObject({ id: comment.id, deletedAt: expect.any(String) });
+    expect(
+      await db
+        .select({ version: issues.version })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ version: 2 });
+  });
+
+  it("returns 412 and preserves a comment for stale delete If-Match", async () => {
+    const { app, companyId, issueId } = await seedIssue(2);
+    const [comment] = await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorType: "user",
+      authorUserId: "cloud-user-1",
+      body: "Keep me",
+    }).returning();
+
+    const res = await request(app)
+      .delete(`/api/issues/${issueId}/comments/${comment.id}`)
+      .set("If-Match", "\"issue-v1\"");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(412);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(
+      await db
+        .select({ body: issueComments.body, deletedAt: issueComments.deletedAt })
+        .from(issueComments)
+        .where(eq(issueComments.id, comment.id))
+        .then((rows) => rows[0]),
+    ).toEqual({ body: "Keep me", deletedAt: null });
+  });
+});

--- a/server/src/__tests__/issue-closed-workspace-routes.test.ts
+++ b/server/src/__tests__/issue-closed-workspace-routes.test.ts
@@ -164,6 +164,7 @@ async function createApp() {
 function makeIssue() {
   return {
     id: issueId,
+    version: 1,
     companyId: "company-1",
     status: "todo",
     priority: "medium",

--- a/server/src/__tests__/issue-comment-cancel-routes.test.ts
+++ b/server/src/__tests__/issue-comment-cancel-routes.test.ts
@@ -5,13 +5,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  assertCheckoutOwnerInTransaction: vi.fn(),
   getComment: vi.fn(),
   removeComment: vi.fn(),
+  removeCommentVersioned: vi.fn(),
   tombstoneComment: vi.fn(),
+  tombstoneCommentVersioned: vi.fn(),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
   canUser: vi.fn(),
+  decide: vi.fn(),
   hasPermission: vi.fn(),
 }));
 
@@ -117,6 +121,12 @@ function registerModuleMocks() {
     issueService: () => mockIssueService,
   }));
 
+  vi.doMock("../services/task-watchdog-scope.js", () => ({
+    TASK_WATCHDOG_ORIGIN_KIND: "task_watchdog",
+    resolveTaskWatchdogMutationScope: vi.fn(async () => ({ kind: "none" })),
+    taskWatchdogScopeAllowsIssueMutation: vi.fn(async () => ({ kind: "allowed" })),
+  }));
+
   vi.doMock("../services/external-objects.js", () => ({
     externalObjectService: () => mockExternalObjectService,
   }));
@@ -158,7 +168,7 @@ function createApp() {
   return app;
 }
 
-async function installActor(app: express.Express, actor?: Record<string, unknown>) {
+async function installActor(app: express.Express, actor?: Record<string, unknown>, db: Record<string, unknown> = {}) {
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
     import("../routes/issues.js"),
     import("../middleware/index.js"),
@@ -174,7 +184,7 @@ async function installActor(app: express.Express, actor?: Record<string, unknown
     };
     next();
   });
-  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use("/api", issueRoutes(db as any, {} as any));
   app.use(errorHandler);
   return app;
 }
@@ -187,6 +197,7 @@ function makeIssue() {
     assigneeAgentId: "22222222-2222-4222-8222-222222222222",
     assigneeUserId: null,
     executionRunId: "run-1",
+    version: 1,
     identifier: "PAP-1353",
     title: "Queued cancel",
   };
@@ -220,6 +231,7 @@ describe.sequential("issue comment cancel routes", () => {
     vi.doUnmock("../services/index.js");
     vi.doUnmock("../services/instance-settings.js");
     vi.doUnmock("../services/issues.js");
+    vi.doUnmock("../services/task-watchdog-scope.js");
     vi.doUnmock("../routes/issues.js");
     vi.doUnmock("../routes/authz.js");
     vi.doUnmock("../middleware/index.js");
@@ -227,8 +239,13 @@ describe.sequential("issue comment cancel routes", () => {
     vi.clearAllMocks();
     mockIssueService.getById.mockResolvedValue(makeIssue());
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.assertCheckoutOwnerInTransaction.mockResolvedValue({ adoptedFromRunId: null });
     mockIssueService.getComment.mockResolvedValue(makeComment());
     mockIssueService.removeComment.mockResolvedValue(makeComment());
+    mockIssueService.removeCommentVersioned.mockResolvedValue({
+      comment: makeComment(),
+      issue: { ...makeIssue(), version: 2 },
+    });
     mockIssueService.tombstoneComment.mockImplementation(async (_commentId, _actor, options) => {
       const deleted = makeComment({
         body: "",
@@ -242,7 +259,31 @@ describe.sequential("issue comment cancel routes", () => {
       await options?.afterTombstone?.(deleted, "tx");
       return deleted;
     });
+    mockIssueService.tombstoneCommentVersioned.mockImplementation(
+      async (_commentId, _actor, options) => {
+        const deleted = makeComment({
+          body: "",
+          metadata: null,
+          deletedAt: new Date("2026-04-11T15:05:00.000Z"),
+          deletedByType: "user",
+          deletedByAgentId: null,
+          deletedByUserId: "local-board",
+          deletedByRunId: null,
+        });
+        await options?.afterTombstone?.(deleted, "tx");
+        return {
+          comment: deleted,
+          issue: { ...makeIssue(), version: 2 },
+        };
+      },
+    );
     mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      action: "issue:mutate",
+      reason: "allow_assignee",
+      explanation: "Allowed for the assigned agent.",
+    });
     mockAccessService.hasPermission.mockResolvedValue(false);
     mockFeedbackService.listIssueVotesForUser.mockResolvedValue([]);
     mockFeedbackService.saveIssueVote.mockResolvedValue({
@@ -283,14 +324,17 @@ describe.sequential("issue comment cancel routes", () => {
 
     expect(res.status, JSON.stringify({
       body: res.body,
-      tombstoneCalls: mockIssueService.tombstoneComment.mock.calls,
+      tombstoneCalls: mockIssueService.tombstoneCommentVersioned.mock.calls,
       activityCalls: mockLogActivity.mock.calls,
     })).toBe(200);
     expect(res.body).toMatchObject({
       id: "comment-1",
       body: "Queued follow-up",
     });
-    expect(mockIssueService.removeComment).toHaveBeenCalledWith("comment-1");
+    expect(mockIssueService.removeCommentVersioned).toHaveBeenCalledWith(
+      "comment-1",
+      { expectedVersion: undefined },
+    );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -312,8 +356,8 @@ describe.sequential("issue comment cancel routes", () => {
 
     expect(res.status).toBe(409);
     expect(res.body.error).toBe("Queued comment can no longer be canceled");
-    expect(mockIssueService.removeComment).not.toHaveBeenCalled();
-    expect(mockIssueService.tombstoneComment).not.toHaveBeenCalled();
+    expect(mockIssueService.removeCommentVersioned).not.toHaveBeenCalled();
+    expect(mockIssueService.tombstoneCommentVersioned).not.toHaveBeenCalled();
   });
 
   it("rejects canceling comments that are no longer queued", async () => {
@@ -329,8 +373,8 @@ describe.sequential("issue comment cancel routes", () => {
 
     expect(res.status).toBe(409);
     expect(res.body.error).toBe("Only queued comments can be canceled");
-    expect(mockIssueService.removeComment).not.toHaveBeenCalled();
-    expect(mockIssueService.tombstoneComment).not.toHaveBeenCalled();
+    expect(mockIssueService.removeCommentVersioned).not.toHaveBeenCalled();
+    expect(mockIssueService.tombstoneCommentVersioned).not.toHaveBeenCalled();
   });
 
   it("rejects canceling another actor's queued comment", async () => {
@@ -345,7 +389,7 @@ describe.sequential("issue comment cancel routes", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe("Only the comment author can cancel queued comments");
-    expect(mockIssueService.removeComment).not.toHaveBeenCalled();
+    expect(mockIssueService.removeCommentVersioned).not.toHaveBeenCalled();
   });
 
   it("deletes a normal authored comment as a tombstone without returning the original body", async () => {
@@ -375,8 +419,8 @@ describe.sequential("issue comment cancel routes", () => {
     });
     expect(JSON.stringify(res.body)).not.toContain("Sensitive original comment body");
     expect(JSON.stringify(res.body)).not.toContain("Sensitive metadata copy");
-    expect(mockIssueService.removeComment).not.toHaveBeenCalled();
-    expect(mockIssueService.tombstoneComment).toHaveBeenCalledWith(
+    expect(mockIssueService.removeCommentVersioned).not.toHaveBeenCalled();
+    expect(mockIssueService.tombstoneCommentVersioned).toHaveBeenCalledWith(
       "comment-1",
       {
         actorType: "user",
@@ -384,7 +428,10 @@ describe.sequential("issue comment cancel routes", () => {
         userId: "local-board",
         runId: null,
       },
-      expect.objectContaining({ afterTombstone: expect.any(Function) }),
+      expect.objectContaining({
+        expectedVersion: undefined,
+        afterTombstone: expect.any(Function),
+      }),
     );
     expect(mockIssueReferenceService.syncComment).toHaveBeenCalledWith("comment-1", "tx");
     expect(mockExternalObjectService.syncCommentSafely).toHaveBeenCalledWith("comment-1", "tx");
@@ -420,6 +467,46 @@ describe.sequential("issue comment cancel routes", () => {
     expect(JSON.stringify(deletedActivity?.details ?? {})).not.toContain("Sensitive metadata copy");
   });
 
+  it("joins checkout normalization to a current conditional comment deletion", async () => {
+    const tx = { rollback: vi.fn() };
+    const db = {
+      transaction: vi.fn(async (callback: (input: typeof tx) => Promise<unknown>) => callback(tx)),
+    };
+    const actor = {
+      type: "agent",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "run-1",
+    };
+    mockIssueService.getComment.mockResolvedValue(makeComment({
+      authorAgentId: actor.agentId,
+      authorUserId: null,
+      createdAt: new Date("2026-04-11T14:58:00.000Z"),
+      updatedAt: new Date("2026-04-11T14:58:00.000Z"),
+    }));
+
+    const res = await request(await installActor(createApp(), actor, db))
+      .delete("/api/issues/11111111-1111-4111-8111-111111111111/comments/comment-1")
+      .set("If-Match", "\"issue-v1\"");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.assertCheckoutOwnerInTransaction).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      actor.agentId,
+      actor.runId,
+      1,
+      tx,
+    );
+    expect(mockIssueService.tombstoneCommentVersioned).toHaveBeenCalledWith(
+      "comment-1",
+      expect.objectContaining({ actorType: "agent", agentId: actor.agentId, runId: actor.runId }),
+      expect.objectContaining({ expectedVersion: 1, dbOrTx: tx }),
+    );
+  });
+
   it("rejects deleting another actor's normal comment", async () => {
     mockIssueService.getComment.mockResolvedValue(
       makeComment({
@@ -434,7 +521,7 @@ describe.sequential("issue comment cancel routes", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe("Only the comment author can delete comments");
-    expect(mockIssueService.removeComment).not.toHaveBeenCalled();
-    expect(mockIssueService.tombstoneComment).not.toHaveBeenCalled();
+    expect(mockIssueService.removeCommentVersioned).not.toHaveBeenCalled();
+    expect(mockIssueService.tombstoneCommentVersioned).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -7,6 +7,7 @@ const mockIssueService = vi.hoisted(() => ({
   assertCheckoutOwner: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
+  updateWithInlineComment: vi.fn(),
   getDependencyReadiness: vi.fn(),
   getCurrentScheduledRetry: vi.fn(),
   findMentionedAgents: vi.fn(),
@@ -26,6 +27,8 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getRun: vi.fn(async () => null),
   getActiveRunForAgent: vi.fn(async () => null),
   cancelRun: vi.fn(async () => null),
+  cancelScheduledRetryInTransaction: vi.fn(async () => null),
+  finalizeScheduledRetryCancellation: vi.fn(async () => undefined),
 }));
 
 const mockAgentService = vi.hoisted(() => ({
@@ -216,6 +219,7 @@ function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progr
     createdByUserId: "local-board",
     identifier: "PAP-580",
     title: "Comment reopen default",
+    version: 1,
   };
 }
 
@@ -240,6 +244,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockIssueService.assertCheckoutOwner.mockReset();
     mockIssueService.update.mockReset();
     mockIssueService.addComment.mockReset();
+    mockIssueService.updateWithInlineComment.mockReset();
     mockIssueService.getDependencyReadiness.mockReset();
     mockIssueService.getCurrentScheduledRetry.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
@@ -253,6 +258,8 @@ describe.sequential("issue comment reopen routes", () => {
     mockHeartbeatService.getRun.mockReset();
     mockHeartbeatService.getActiveRunForAgent.mockReset();
     mockHeartbeatService.cancelRun.mockReset();
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockReset();
+    mockHeartbeatService.finalizeScheduledRetryCancellation.mockReset();
     mockAgentService.getById.mockReset();
     mockAgentService.list.mockReset();
     mockAgentService.resolveByReference.mockReset();
@@ -289,6 +296,8 @@ describe.sequential("issue comment reopen routes", () => {
     mockHeartbeatService.getRun.mockResolvedValue(null);
     mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
     mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockResolvedValue(null);
+    mockHeartbeatService.finalizeScheduledRetryCancellation.mockResolvedValue(undefined);
     mockExternalObjectService.syncCommentSafely.mockResolvedValue(undefined);
     mockExternalObjectService.syncIssueSafely.mockResolvedValue(undefined);
     mockLogActivity.mockResolvedValue(undefined);
@@ -319,6 +328,27 @@ describe.sequential("issue comment reopen routes", () => {
       authorAgentId: null,
       authorUserId: "local-board",
     });
+    mockIssueService.updateWithInlineComment.mockImplementation(
+      async (issueId, issueData, commentData) =>
+        mockDb.transaction(async (tx) => {
+          const meaningfulUpdate = Object.keys(issueData).some(
+            (key) => key !== "expectedVersion",
+          );
+          const issue = meaningfulUpdate
+            ? await mockIssueService.update(issueId, issueData)
+            : await mockIssueService.getById(issueId);
+          if (!issue) return null;
+          const comment = await mockIssueService.addComment(
+            issueId,
+            commentData.body,
+            commentData.actor,
+            commentData.options,
+          );
+          await commentData.afterUpdate?.(tx, issue, comment);
+          await commentData.beforeCommit?.(tx, issue, comment);
+          return { issue, comment };
+        }),
+    );
     mockIssueService.findMentionedAgents.mockResolvedValue([]);
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -876,7 +906,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
       updatedAt: new Date(),
     }));
-    mockHeartbeatService.cancelRun.mockResolvedValue({
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockResolvedValue({
       id: "retry-run-1",
       companyId: "company-1",
       agentId: "22222222-2222-4222-8222-222222222222",
@@ -890,9 +920,19 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        executionRunId: null,
+        status: "todo",
+      }),
     );
-    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("retry-run-1");
+    expect(mockHeartbeatService.cancelScheduledRetryInTransaction).toHaveBeenCalledWith(
+      mockTx,
+      "retry-run-1",
+      "Superseded by a human issue comment",
+    );
+    expect(mockHeartbeatService.finalizeScheduledRetryCancellation).toHaveBeenCalledWith("retry-run-1");
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -921,6 +961,50 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
+  it("returns the committed POST comment when scheduled retry finalization fails", async () => {
+    const issue = {
+      ...makeIssue("in_progress"),
+      executionRunId: "retry-run-1",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue({
+      runId: "retry-run-1",
+      status: "scheduled_retry",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      agentName: "CodexCoder",
+      retryOfRunId: "source-run-1",
+      scheduledRetryAt: new Date("2026-05-18T14:00:00.000Z"),
+      scheduledRetryAttempt: 1,
+      scheduledRetryReason: "transient_failure",
+      error: null,
+      errorCode: null,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockResolvedValue({
+      id: "retry-run-1",
+      companyId: "company-1",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      status: "cancelled",
+    });
+    mockHeartbeatService.finalizeScheduledRetryCancellation.mockRejectedValue(
+      new Error("finalization failed"),
+    );
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "I added the missing detail; please continue." });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockHeartbeatService.finalizeScheduledRetryCancellation).toHaveBeenCalledWith(
+      "retry-run-1",
+    );
+  });
+
   it("does not move scheduled-retry issues to todo when POST comment retry cancellation fails", async () => {
     const issue = {
       ...makeIssue("in_progress"),
@@ -939,16 +1023,25 @@ describe.sequential("issue comment reopen routes", () => {
       error: null,
       errorCode: null,
     });
-    mockHeartbeatService.cancelRun.mockRejectedValue(new Error("cancel failed"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockRejectedValue(new Error("cancel failed"));
 
     const res = await request(await installActor(createApp()))
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: "I added the missing detail; please continue." });
 
     expect(res.status).toBe(500);
-    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("retry-run-1");
-    expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.cancelScheduledRetryInTransaction).toHaveBeenCalledWith(
+      mockTx,
+      "retry-run-1",
+      "Superseded by a human issue comment",
+    );
+    expect(mockIssueService.update).toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ action: "issue.updated" }),
@@ -1271,7 +1364,7 @@ describe.sequential("issue comment reopen routes", () => {
       ...patch,
       updatedAt: new Date(),
     }));
-    mockHeartbeatService.cancelRun.mockResolvedValue({
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockResolvedValue({
       id: "retry-run-1",
       companyId: "company-1",
       agentId: "22222222-2222-4222-8222-222222222222",
@@ -1289,9 +1382,17 @@ describe.sequential("issue comment reopen routes", () => {
         status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        executionRunId: null,
       }),
     );
-    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("retry-run-1");
+    expect(mockHeartbeatService.cancelScheduledRetryInTransaction).toHaveBeenCalledWith(
+      mockTx,
+      "retry-run-1",
+      "Superseded by a human issue comment",
+    );
+    expect(mockHeartbeatService.finalizeScheduledRetryCancellation).toHaveBeenCalledWith("retry-run-1");
     await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
       expect.objectContaining({
@@ -1302,6 +1403,50 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     ));
+  });
+
+  it("returns the committed PATCH comment when scheduled retry finalization fails", async () => {
+    const issue = {
+      ...makeIssue("in_progress"),
+      executionRunId: "retry-run-1",
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue({
+      runId: "retry-run-1",
+      status: "scheduled_retry",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      agentName: "CodexCoder",
+      retryOfRunId: "source-run-1",
+      scheduledRetryAt: new Date("2026-05-18T14:00:00.000Z"),
+      scheduledRetryAttempt: 1,
+      scheduledRetryReason: "transient_failure",
+      error: null,
+      errorCode: null,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockResolvedValue({
+      id: "retry-run-1",
+      companyId: "company-1",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      status: "cancelled",
+    });
+    mockHeartbeatService.finalizeScheduledRetryCancellation.mockRejectedValue(
+      new Error("finalization failed"),
+    );
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "Retry window is over; please continue." });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockHeartbeatService.finalizeScheduledRetryCancellation).toHaveBeenCalledWith(
+      "retry-run-1",
+    );
   });
 
   it("does not move scheduled-retry issues to todo when PATCH comment retry cancellation fails", async () => {
@@ -1322,16 +1467,25 @@ describe.sequential("issue comment reopen routes", () => {
       error: null,
       errorCode: null,
     });
-    mockHeartbeatService.cancelRun.mockRejectedValue(new Error("cancel failed"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+    mockHeartbeatService.cancelScheduledRetryInTransaction.mockRejectedValue(new Error("cancel failed"));
 
     const res = await request(await installActor(createApp()))
       .patch("/api/issues/11111111-1111-4111-8111-111111111111")
       .send({ comment: "Retry window is over; please continue." });
 
     expect(res.status).toBe(500);
-    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith("retry-run-1");
-    expect(mockIssueService.update).not.toHaveBeenCalled();
-    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.cancelScheduledRetryInTransaction).toHaveBeenCalledWith(
+      mockTx,
+      "retry-run-1",
+      "Superseded by a human issue comment",
+    );
+    expect(mockIssueService.update).toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockLogActivity).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ action: "issue.updated" }),
@@ -1808,7 +1962,6 @@ describe.sequential("issue comment reopen routes", () => {
           lastDecisionOutcome: "approved",
         }),
       }),
-      mockTx,
     );
     const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, any>;
     const decisionId = updatePatch.executionState.lastDecisionId;
@@ -1903,7 +2056,6 @@ describe.sequential("issue comment reopen routes", () => {
           lastDecisionOutcome: "approved",
         }),
       }),
-      mockTx,
     );
   });
 
@@ -1988,7 +2140,6 @@ describe.sequential("issue comment reopen routes", () => {
           lastDecisionOutcome: "approved",
         }),
       }),
-      mockTx,
     );
   });
 
@@ -2201,7 +2352,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: reviewBody });
 
     expect(res.status).toBe(201);
-    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       expect.any(String),
@@ -2266,7 +2417,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: reviewBody });
 
     expect(res.status).toBe(201);
-    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
@@ -2326,7 +2477,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: reviewBody });
 
     expect(res.status).toBe(201);
-    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
@@ -2384,7 +2535,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: reviewBody });
 
     expect(res.status).toBe(201);
-    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
@@ -2443,7 +2594,7 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: reviewBody });
 
     expect(res.status).toBe(201);
-    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
@@ -2518,7 +2669,7 @@ describe.sequential("issue comment reopen routes", () => {
         .send({ body });
 
       expect(res.status).toBe(201);
-      expect(mockDb.transaction).not.toHaveBeenCalled();
+      expect(mockDb.transaction).toHaveBeenCalledTimes(1);
       expect(mockIssueService.update).not.toHaveBeenCalled();
       expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
     });
@@ -2597,7 +2748,6 @@ describe.sequential("issue comment reopen routes", () => {
       expect(mockIssueService.update).toHaveBeenCalledWith(
         "11111111-1111-4111-8111-111111111111",
         expect.objectContaining({ status: "done" }),
-        mockTx,
       );
       expect(mockLogActivity).toHaveBeenCalledWith(
         expect.anything(),
@@ -2668,18 +2818,11 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: reviewBody });
 
-    // The route must propagate the 422 (no successful 201) and must insert the
-    // comment inside the same transaction as the status update so the comment
-    // rolls back when the status update fails.
+    // The atomic service updates first, so a rejected transition never inserts
+    // the comment and the transaction propagates the 422.
     expect(res.status).toBe(422);
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-    expect(mockIssueService.addComment).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      reviewBody,
-      expect.objectContaining({ agentId: reviewerAgentId }),
-      expect.any(Object),
-      mockTx,
-    );
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
@@ -2738,18 +2881,11 @@ describe.sequential("issue comment reopen routes", () => {
       .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
       .send({ body: reviewBody });
 
-    // The route must surface a 404 AND keep the transaction rollback path intact:
-    // the addComment INSERT must run inside the same transaction that the throw aborts,
-    // so the comment cannot survive when the status update finds no issue.
+    // The atomic service updates first, so a missing issue returns before the
+    // comment insert and the route surfaces a 404.
     expect(res.status).toBe(404);
     expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-    expect(mockIssueService.addComment).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      reviewBody,
-      expect.objectContaining({ agentId: reviewerAgentId }),
-      expect.any(Object),
-      mockTx,
-    );
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -184,6 +184,7 @@ describe("issue dependency wakeups in issue routes", () => {
     });
     mockIssueService.update.mockResolvedValue({
       id: "issue-1",
+      version: 1,
       companyId: "company-1",
       identifier: "PAP-100",
       title: "Finish blocker",
@@ -245,6 +246,7 @@ describe("issue dependency wakeups in issue routes", () => {
     });
     mockIssueService.update.mockResolvedValue({
       id: parentIssueId,
+      version: 1,
       companyId: "company-1",
       identifier: "PAP-200",
       title: "Blocked after completion",
@@ -317,6 +319,7 @@ describe("issue dependency wakeups in issue routes", () => {
     });
     mockIssueService.update.mockResolvedValue({
       id: "child-1",
+      version: 1,
       companyId: "company-1",
       identifier: "PAP-101",
       title: "Last child",

--- a/server/src/__tests__/issue-etag.test.ts
+++ b/server/src/__tests__/issue-etag.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  InvalidIssueEtagError,
+  formatIssueEtag,
+  parseOptionalIssueIfMatch,
+} from "../http/issue-etag.js";
+
+describe("issue ETags", () => {
+  it("formats positive 32-bit issue versions", () => {
+    expect(formatIssueEtag(1)).toBe("\"issue-v1\"");
+    expect(formatIssueEtag(2_147_483_647)).toBe("\"issue-v2147483647\"");
+  });
+
+  it("parses an optional current issue ETag", () => {
+    expect(parseOptionalIssueIfMatch(undefined)).toBeUndefined();
+    expect(parseOptionalIssueIfMatch("\"issue-v42\"")).toBe(42);
+    expect(parseOptionalIssueIfMatch("  \"issue-v42\"  ")).toBe(42);
+  });
+
+  it.each([
+    "W/\"issue-v42\"",
+    "*",
+    "\"issue-v1\", \"issue-v2\"",
+    "\"issue-v0\"",
+    "\"issue-v-1\"",
+    "\"issue-v2147483648\"",
+    "\"other-v1\"",
+    "",
+  ])("rejects malformed If-Match value %j", (value) => {
+    expect(() => parseOptionalIssueIfMatch(value)).toThrow(InvalidIssueEtagError);
+  });
+
+  it("rejects header arrays and invalid formatter input", () => {
+    expect(() => parseOptionalIssueIfMatch(["\"issue-v1\""])).toThrow(
+      InvalidIssueEtagError,
+    );
+    for (const version of [0, -1, 2_147_483_648, 1.5, Number.NaN]) {
+      expect(() => formatIssueEtag(version)).toThrow(RangeError);
+    }
+  });
+});

--- a/server/src/__tests__/issue-scheduled-retry-routes.test.ts
+++ b/server/src/__tests__/issue-scheduled-retry-routes.test.ts
@@ -97,6 +97,7 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
     agentStatus?: "active" | "paused";
     retryStatus?: "scheduled_retry" | "queued" | "running";
     issueStatus?: "in_progress" | "todo" | "done" | "cancelled";
+    version?: number;
   } = {}) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -200,6 +201,7 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
       executionLockedAt: now,
       issueNumber: 1,
       identifier: `${issuePrefix}-1`,
+      version: input.version ?? 1,
     });
 
     return { companyId, agentId, issueId, sourceRunId, retryRunId, scheduledRetryAt };
@@ -221,6 +223,70 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
       scheduledRetryReason: "transient_failure",
     });
     expect(res.body.scheduledRetry.scheduledRetryAt).toBe(scheduledRetryAt.toISOString());
+  });
+
+  it("does not cancel a scheduled retry for a stale comment precondition", async () => {
+    const { companyId, issueId, retryRunId } = await seedIssueWithRetry({ version: 2 });
+
+    const res = await request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/comments`)
+      .set("If-Match", "\"issue-v1\"")
+      .send({ body: "Stale follow-up" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(412);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(
+      await db
+        .select({
+          executionRunId: issues.executionRunId,
+          version: issues.version,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ executionRunId: retryRunId, version: 2 });
+    expect(
+      await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0]),
+    ).toEqual({ status: "scheduled_retry" });
+    expect(await db.select({ id: issueComments.id }).from(issueComments)).toEqual([]);
+  });
+
+  it.each([
+    { label: "current If-Match", ifMatch: "\"issue-v1\"" },
+    { label: "no precondition", ifMatch: null },
+  ])("cancels a scheduled retry and advances the comment mutation once with $label", async ({ ifMatch }) => {
+    const { companyId, issueId, retryRunId } = await seedIssueWithRetry();
+    let pendingRequest = request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/comments`);
+    if (ifMatch) pendingRequest = pendingRequest.set("If-Match", ifMatch);
+
+    const res = await pendingRequest.send({ body: "Please continue now" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.headers.etag).toBe("\"issue-v2\"");
+    expect(
+      await db
+        .select({
+          executionRunId: issues.executionRunId,
+          status: issues.status,
+          version: issues.version,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]),
+    ).toEqual({ executionRunId: null, status: "todo", version: 2 });
+    expect(
+      await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, retryRunId))
+        .then((rows) => rows[0]),
+    ).toEqual({ status: "cancelled" });
+    expect(await db.select({ id: issueComments.id }).from(issueComments)).toHaveLength(1);
   });
 
   it("promotes the existing scheduled retry and treats duplicate clicks as idempotent", async () => {

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -243,6 +243,8 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
 
     const childrenAfterDuplicateAccept = await issuesSvc.list(companyId, { parentId: issueId });
     expect(childrenAfterDuplicateAccept).toHaveLength(1);
+    const [parentIssue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(parentIssue?.version).toBe(3);
   });
 
   it("accepts a selected subset of suggested tasks and records the skipped drafts", async () => {

--- a/server/src/__tests__/issue-tree-control-service.test.ts
+++ b/server/src/__tests__/issue-tree-control-service.test.ts
@@ -332,13 +332,18 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
     expect(cancelled.updatedIssueIds.sort()).toEqual([runningChildId, todoChildId].sort());
 
     const afterCancel = await db
-      .select({ id: issues.id, status: issues.status })
+      .select({ id: issues.id, status: issues.status, version: issues.version })
       .from(issues)
       .where(inArray(issues.id, [runningChildId, todoChildId, doneChildId]));
     expect(Object.fromEntries(afterCancel.map((issue) => [issue.id, issue.status]))).toMatchObject({
       [runningChildId]: "cancelled",
       [todoChildId]: "cancelled",
       [doneChildId]: "done",
+    });
+    expect(Object.fromEntries(afterCancel.map((issue) => [issue.id, issue.version]))).toMatchObject({
+      [runningChildId]: 2,
+      [todoChildId]: 2,
+      [doneChildId]: 1,
     });
 
     await db
@@ -367,13 +372,24 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
     expect(restored.updatedIssueIds).toEqual([runningChildId]);
 
     const afterRestore = await db
-      .select({ id: issues.id, status: issues.status, checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .select({
+        id: issues.id,
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        version: issues.version,
+      })
       .from(issues)
       .where(inArray(issues.id, [runningChildId, todoChildId, doneChildId]));
     expect(Object.fromEntries(afterRestore.map((issue) => [issue.id, issue.status]))).toMatchObject({
       [runningChildId]: "todo",
       [todoChildId]: "blocked",
       [doneChildId]: "done",
+    });
+    expect(Object.fromEntries(afterRestore.map((issue) => [issue.id, issue.version]))).toMatchObject({
+      [runningChildId]: 3,
+      [todoChildId]: 2,
+      [doneChildId]: 1,
     });
 
     const holds = await db

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
+  updateWithInlineComment: vi.fn(),
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
@@ -212,6 +213,7 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
     executionPolicy: null,
     executionState: null,
     hiddenAt: null,
+    version: 1,
     ...overrides,
   };
 }
@@ -229,6 +231,23 @@ describe("issue update comment wakeups", () => {
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
     mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
+    mockIssueService.updateWithInlineComment.mockImplementation(
+      async (issueId, issueData, commentData) => {
+        const meaningfulUpdate = Object.keys(issueData).some(
+          (key) => key !== "expectedVersion",
+        );
+        const issue = meaningfulUpdate
+          ? await mockIssueService.update(issueId, issueData)
+          : await mockIssueService.getById(issueId);
+        const comment = await mockIssueService.addComment(
+          issueId,
+          commentData.body,
+          commentData.actor,
+          commentData.options,
+        );
+        return issue && comment ? { issue, comment } : null;
+      },
+    );
   });
 
   it("includes the new comment in assignment wakes from issue updates", async () => {
@@ -275,7 +294,7 @@ describe("issue update comment wakeups", () => {
         }),
       }),
     );
-  });
+  }, 15_000);
 
   it("interrupts the active run and wakes the newly assigned agent with handoff context", async () => {
     const existing = makeIssue({

--- a/server/src/__tests__/issue-versioning-service.test.ts
+++ b/server/src/__tests__/issue-versioning-service.test.ts
@@ -1,0 +1,458 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issues,
+  type Db,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  bumpIssueVersions,
+  IssueVersionConflictError,
+  runIssueMutation,
+  versionedIssuePatch,
+} from "../services/issue-versioning.js";
+import { issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("issue versioning service", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: Db;
+
+  async function createIssue() {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Versioning test company",
+      issuePrefix: `V${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Versioned issue",
+      status: "todo",
+      priority: "medium",
+    });
+    return { companyId, issueId };
+  }
+
+  async function issueById(issueId: string) {
+    return await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-versioning-service-");
+    db = createDb(tempDb.connectionString);
+  }, 60_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("allows one of two concurrent writes for the same expected version", async () => {
+    const { issueId } = await createIssue();
+    const writes = await Promise.allSettled([
+      runIssueMutation(db, {
+        issueId,
+        expectedVersion: 1,
+        mutate: async () => ({ issuePatch: { title: "First write" }, result: "first" }),
+      }),
+      runIssueMutation(db, {
+        issueId,
+        expectedVersion: 1,
+        mutate: async () => ({ issuePatch: { title: "Second write" }, result: "second" }),
+      }),
+    ]);
+
+    const fulfilled = writes.filter((write) => write.status === "fulfilled");
+    const rejected = writes.filter((write) => write.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const conflict = rejected[0]?.reason;
+    expect(conflict).toBeInstanceOf(IssueVersionConflictError);
+    if (!(conflict instanceof IssueVersionConflictError)) {
+      throw new Error("Expected an issue version conflict");
+    }
+    expect(conflict.currentVersion).toBe(2);
+    expect((await issueById(issueId))?.version).toBe(2);
+  });
+
+  it("returns the current version on stale conflict", async () => {
+    const { issueId } = await createIssue();
+    await runIssueMutation(db, {
+      issueId,
+      mutate: async () => ({ result: undefined }),
+    });
+
+    await expect(
+      runIssueMutation(db, {
+        issueId,
+        expectedVersion: 1,
+        mutate: async () => ({ result: undefined }),
+      }),
+    ).rejects.toMatchObject({
+      message: "Issue version conflict",
+      currentVersion: 2,
+    });
+  });
+
+  it("rolls back callback writes when the mutation throws or its final update fails", async () => {
+    const first = await createIssue();
+    await expect(
+      runIssueMutation(db, {
+        issueId: first.issueId,
+        mutate: async (tx) => {
+          await tx
+            .update(companies)
+            .set({ description: "should roll back" })
+            .where(eq(companies.id, first.companyId));
+          throw new Error("mutation failed");
+        },
+      }),
+    ).rejects.toThrow("mutation failed");
+    expect((await issueById(first.issueId))?.version).toBe(1);
+
+    const second = await createIssue();
+    await expect(
+      runIssueMutation(db, {
+        issueId: second.issueId,
+        mutate: async (tx) => {
+          await tx
+            .update(companies)
+            .set({ description: "should also roll back" })
+            .where(eq(companies.id, second.companyId));
+          await tx.delete(issues).where(eq(issues.id, second.issueId));
+          return { result: undefined };
+        },
+      }),
+    ).rejects.toThrow("Locked issue version update returned no row");
+    expect((await issueById(second.issueId))?.version).toBe(1);
+  });
+
+  it("increments exactly once for a compound callback", async () => {
+    const { companyId, issueId } = await createIssue();
+    const mutation = await runIssueMutation(db, {
+      issueId,
+      expectedVersion: 1,
+      mutate: async (tx) => {
+        await tx
+          .update(companies)
+          .set({ description: "compound mutation" })
+          .where(eq(companies.id, companyId));
+        return {
+          issuePatch: { title: "Compound mutation complete" },
+          result: { companyUpdated: true },
+        };
+      },
+    });
+
+    expect(mutation).toMatchObject({
+      issue: { id: issueId, title: "Compound mutation complete", version: 2 },
+      result: { companyUpdated: true },
+    });
+  });
+
+  it("increments an unheadered legacy mutation", async () => {
+    const { issueId } = await createIssue();
+    const mutation = await runIssueMutation(db, {
+      issueId,
+      mutate: async () => ({ result: "legacy mutation" }),
+    });
+
+    expect(mutation).toMatchObject({
+      issue: { id: issueId, version: 2 },
+      result: "legacy mutation",
+    });
+  });
+
+  it("increments each distinct issue once for a bulk parent-version bump", async () => {
+    const first = await createIssue();
+    const second = await createIssue();
+
+    const updatedIds = await bumpIssueVersions(db, [
+      first.issueId,
+      second.issueId,
+      first.issueId,
+    ]);
+
+    expect(new Set(updatedIds)).toEqual(new Set([first.issueId, second.issueId]));
+    expect((await issueById(first.issueId))?.version).toBe(2);
+    expect((await issueById(second.issueId))?.version).toBe(2);
+  });
+
+  it("inserts a stop-relay comment within the parent's single version transition", async () => {
+    const { companyId, issueId: parentId } = await createIssue();
+    const childId = randomUUID();
+    await db.insert(issues).values({
+      id: childId,
+      companyId,
+      parentId,
+      title: "Blocked child",
+      status: "blocked",
+      priority: "medium",
+    });
+    const service = issueService(db);
+    const child = await issueById(childId);
+    if (!child) throw new Error("Expected child issue");
+
+    const relay = await service.addStopRelayCommentIfNeeded(child);
+
+    expect(relay).toMatchObject({
+      parent: { id: parentId, version: 2 },
+      comment: { issueId: parentId, authorType: "system" },
+    });
+    expect((await issueById(parentId))?.version).toBe(2);
+    await expect(service.addStopRelayCommentIfNeeded(child)).resolves.toBeNull();
+    expect((await issueById(parentId))?.version).toBe(2);
+    expect(
+      await db
+        .select({ id: issueComments.id })
+        .from(issueComments)
+        .where(eq(issueComments.issueId, parentId)),
+    ).toHaveLength(1);
+  });
+
+  it("returns null for a missing issue and joins a supplied transaction", async () => {
+    await expect(
+      runIssueMutation(db, {
+        issueId: randomUUID(),
+        mutate: async () => ({ result: "missing" }),
+      }),
+    ).resolves.toBeNull();
+
+    const { issueId } = await createIssue();
+    await db.transaction(async (tx) => {
+      const mutation = await runIssueMutation(tx, {
+        issueId,
+        mutate: async () => ({ issuePatch: { title: "Joined transaction" }, result: true }),
+      });
+      expect(mutation).toMatchObject({ issue: { version: 2 }, result: true });
+    });
+    expect((await issueById(issueId))?.title).toBe("Joined transaction");
+  });
+
+  it("joins checkout adoption to a conditional issue update", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Checkout CAS company",
+      issuePrefix: `C${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Conditional checkout update",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    const service = issueService(db);
+
+    const result = await db.transaction(async (tx) => {
+      const ownership = await service.assertCheckoutOwnerInTransaction(issueId, agentId, runId, 1, tx);
+      return service.update(issueId, {
+        ...ownership.issuePatch,
+        title: "Updated atomically",
+        expectedVersion: 1,
+      }, tx);
+    });
+
+    expect(result).toMatchObject({
+      title: "Updated atomically",
+      checkoutRunId: runId,
+      executionRunId: runId,
+      version: 2,
+    });
+  });
+
+  it("rejects terminal same-run checkout owners", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Invalid same-run company",
+      issuePrefix: `I${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Invalid same-run agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "cancelled",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Invalid same-run checkout",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+    });
+    const service = issueService(db);
+
+    await expect(
+      db.transaction(async (tx) =>
+        service.assertCheckoutOwnerInTransaction(issueId, agentId, runId, 1, tx)
+      ),
+    ).rejects.toMatchObject({ status: 409 });
+    expect((await issueById(issueId))?.version).toBe(1);
+  });
+
+  it("joins checkout adoption to conditional comment deletion", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const commentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Comment CAS company",
+      issuePrefix: `D${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Commenter",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Conditional comment delete",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(issueComments).values({
+      id: commentId,
+      companyId,
+      issueId,
+      authorType: "agent",
+      authorAgentId: agentId,
+      body: "Delete atomically",
+    });
+    const service = issueService(db);
+
+    const result = await db.transaction(async (tx) => {
+      const ownership = await service.assertCheckoutOwnerInTransaction(issueId, agentId, runId, 1, tx);
+      return service.tombstoneCommentVersioned(
+        commentId,
+        { actorType: "agent", agentId, runId },
+        { expectedVersion: 1, dbOrTx: tx, issuePatch: ownership.issuePatch },
+      );
+    });
+
+    expect(result).toMatchObject({
+      issue: {
+        checkoutRunId: runId,
+        executionRunId: runId,
+        version: 2,
+      },
+      comment: {
+        id: commentId,
+        deletedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("honors managed isolated-workspace enablement during updates", async () => {
+    const originalManagedConfig = process.env.PAPERCLIP_MANAGED_CONFIG;
+    const { issueId } = await createIssue();
+    try {
+      process.env.PAPERCLIP_MANAGED_CONFIG = JSON.stringify({
+        v: 1,
+        mode: "cloud",
+        catalogVersion: "2026.720.0",
+        features: { enableIsolatedWorkspaces: true },
+        plugins: { autoInstall: [] },
+      });
+
+      const updated = await issueService(db).update(issueId, {
+        executionWorkspacePreference: "reuse_existing",
+      });
+
+      expect(updated?.executionWorkspacePreference).toBe("reuse_existing");
+    } finally {
+      if (originalManagedConfig === undefined) {
+        delete process.env.PAPERCLIP_MANAGED_CONFIG;
+      } else {
+        process.env.PAPERCLIP_MANAGED_CONFIG = originalManagedConfig;
+      }
+    }
+  });
+
+  it("overrides prohibited version and updatedAt values in versioned patches", () => {
+    const now = new Date("2026-07-23T09:00:00.000Z");
+    // @ts-expect-error Issue mutation patches cannot set version or updatedAt.
+    const patch = versionedIssuePatch({ title: "Safe patch", version: 99, updatedAt: new Date(0) }, now);
+
+    expect(patch.updatedAt).toBe(now);
+    expect(patch.version).not.toBe(99);
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -495,6 +495,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     // never pass through the HTTP routes, so the expiry must fire here.
     const updated = await svc.update(issue.id, { status: "cancelled", actorUserId: "local-board" });
     expect(updated?.status).toBe("cancelled");
+    expect(updated?.version).toBe(issue.version + 1);
 
     const interaction = await db
       .select()

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -847,6 +847,16 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     const fixture = await seedLowTrustFixture(db);
     const app = createApp(db, boardActor(fixture));
     const unblockDescriptor = { owner: "board", action: "Review the low-trust stop" } as const;
+    const initialReviewRootVersion = await db
+      .select({ version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, fixture.issues.reviewRoot.id))
+      .then((rows) => rows[0]!.version);
+    const initialGrandparentVersion = await db
+      .select({ version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, fixture.issues.reviewGrandparent.id))
+      .then((rows) => rows[0]!.version);
 
     await db
       .delete(issueApprovals)
@@ -914,6 +924,19 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     expect(reparentedRelayComments).toHaveLength(1);
     expect(reparentedRelayComments[0]?.body).toContain("transitioned to `blocked`");
     expect(reparentedRelayComments[0]?.body).not.toContain(fixture.canaries.raw);
+
+    const reviewRootVersion = await db
+      .select({ version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, fixture.issues.reviewRoot.id))
+      .then((rows) => rows[0]!.version);
+    const grandparentVersion = await db
+      .select({ version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, fixture.issues.reviewGrandparent.id))
+      .then((rows) => rows[0]!.version);
+    expect(reviewRootVersion).toBe(initialReviewRootVersion + 2);
+    expect(grandparentVersion).toBe(initialGrandparentVersion + 1);
   });
 
   it("allows mentioned low-trust agents to comment on out-of-bound assigned issues", async () => {
@@ -1562,6 +1585,66 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     expect(rejectedPromotion.status, JSON.stringify(rejectedPromotion.body)).toBe(404);
     expect(rejectedPromotion.body.error).toBe("Low-trust source artifact not found");
 
+    const [rawIssue] = await db.insert(issues).values({
+      companyId: fixture.company.id,
+      parentId: fixture.issues.assignedReview.id,
+      title: "Quarantined child issue",
+      status: "done",
+      priority: "medium",
+      sourceTrust: {
+        preset: LOW_TRUST_REVIEW_PRESET,
+        disposition: "quarantined",
+        sourceIssueId: fixture.issues.assignedReview.id,
+        sourceRunId: fixture.runs.lowTrust.id,
+        sourceAgentId: fixture.agents.lowTrust.id,
+      },
+    }).returning();
+    const issuePromotion = await request(app)
+      .post(`/api/issues/${fixture.issues.assignedReview.id}/low-trust/promotions`)
+      .send({
+        sourceArtifactKind: "issue",
+        sourceArtifactId: rawIssue!.id,
+        title: "Sanitized child finding",
+        summary: "Sanitized child issue summary.",
+      });
+    expect(issuePromotion.status, JSON.stringify(issuePromotion.body)).toBe(201);
+    const [promotedIssue] = await db
+      .select({ sourceTrust: issues.sourceTrust, version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, rawIssue!.id));
+    expect(promotedIssue).toMatchObject({
+      sourceTrust: { disposition: "promoted" },
+      version: 2,
+    });
+
+    const [rawComment] = await db.insert(issueComments).values({
+      companyId: fixture.company.id,
+      issueId: fixture.issues.assignedReview.id,
+      authorAgentId: fixture.agents.lowTrust.id,
+      body: fixture.canaries.raw,
+      sourceTrust: {
+        preset: LOW_TRUST_REVIEW_PRESET,
+        disposition: "quarantined",
+        sourceIssueId: fixture.issues.assignedReview.id,
+        sourceRunId: fixture.runs.lowTrust.id,
+        sourceAgentId: fixture.agents.lowTrust.id,
+      },
+    }).returning();
+    const commentPromotion = await request(app)
+      .post(`/api/issues/${fixture.issues.assignedReview.id}/low-trust/promotions`)
+      .send({
+        sourceArtifactKind: "comment",
+        sourceArtifactId: rawComment!.id,
+        title: "Sanitized comment finding",
+        summary: "Sanitized comment summary.",
+      });
+    expect(commentPromotion.status, JSON.stringify(commentPromotion.body)).toBe(201);
+    const [promotedComment] = await db
+      .select({ sourceTrust: issueComments.sourceTrust })
+      .from(issueComments)
+      .where(eq(issueComments.id, rawComment!.id));
+    expect(promotedComment?.sourceTrust).toMatchObject({ disposition: "promoted" });
+
     const promotion = await request(app)
       .post(`/api/issues/${fixture.issues.assignedReview.id}/low-trust/promotions`)
       .send({
@@ -1611,6 +1694,11 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
       promotedByActorType: "user",
       promotedByActorId: "board-user",
     });
+    const [promotedSourceIssue] = await db
+      .select({ version: issues.version })
+      .from(issues)
+      .where(eq(issues.id, fixture.issues.assignedReview.id));
+    expect(promotedSourceIssue?.version).toBe(4);
 
     const duplicatePromotion = await request(app)
       .post(`/api/issues/${fixture.issues.assignedReview.id}/low-trust/promotions`)

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -234,4 +234,37 @@ describe("openapi routes", () => {
     expect(spec.paths["/api/board-api-keys"].post.responses["201"]).toBeDefined();
     expect(spec.paths["/api/companies/import"].post.responses["202"]).toBeDefined();
   });
+
+  it("documents optional issue If-Match and strong ETag responses", () => {
+    const { spec } = loadSpecRoutes();
+    const patchIssue = spec.paths["/api/issues/{id}"].patch;
+    const addComment = spec.paths["/api/issues/{id}/comments"].post;
+    const deleteComment = spec.paths["/api/issues/{id}/comments/{commentId}"].delete;
+    const getIssue = spec.paths["/api/issues/{id}"].get;
+
+    for (const operation of [patchIssue, addComment, deleteComment]) {
+      expect(operation.parameters).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: "if-match",
+          in: "header",
+          required: false,
+          schema: expect.objectContaining({ type: "string" }),
+        }),
+      ]));
+      expect(operation.responses["400"]).toBeDefined();
+      expect(operation.responses["412"]).toMatchObject({
+        headers: {
+          ETag: expect.any(Object),
+          "Cache-Control": expect.any(Object),
+        },
+      });
+    }
+
+    expect(getIssue.responses["200"]).toMatchObject({
+      headers: {
+        ETag: expect.any(Object),
+        "Cache-Control": expect.any(Object),
+      },
+    });
+  });
 });

--- a/server/src/__tests__/plugin-access-authorization-host-services.test.ts
+++ b/server/src/__tests__/plugin-access-authorization-host-services.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -7,6 +8,7 @@ import {
   companyMemberships,
   createDb,
   invites,
+  issues,
   principalPermissionGrants,
 } from "@paperclipai/db";
 import { buildHostServices } from "../services/plugin-host-services.js";
@@ -55,6 +57,7 @@ describeEmbeddedPostgres("plugin access and authorization host services", () => 
     await db.delete(activityLog);
     await db.delete(principalPermissionGrants);
     await db.delete(invites);
+    await db.delete(issues);
     await db.delete(agents);
     await db.delete(companyMemberships);
     await db.delete(companies);
@@ -317,6 +320,41 @@ describeEmbeddedPostgres("plugin access and authorization host services", () => 
     });
     expect(JSON.stringify(rows[0]!.details)).not.toContain("sk-test-secret");
     expect(JSON.stringify(rows[0]!.details)).not.toContain("should-not-persist");
+    services.dispose();
+  });
+
+  it("increments an issue version once when a plugin updates its authorization policy", async () => {
+    const company = await createCompany(db, "PAI");
+    const issue = await db
+      .insert(issues)
+      .values({
+        companyId: company.id,
+        title: "Policy target",
+        status: "todo",
+        priority: "medium",
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const services = buildHostServices(db, pluginId, "permissions-extension", createEventBusStub());
+
+    await services.authorization.updatePolicy({
+      companyId: company.id,
+      resourceType: "issue",
+      resourceId: issue.id,
+      policy: {
+        assignmentPolicy: { mode: "protected" },
+      },
+    });
+
+    const [updated] = await db.select().from(issues).where(eq(issues.id, issue.id));
+    expect(updated).toMatchObject({
+      executionPolicy: {
+        authorizationPolicy: {
+          assignmentPolicy: { mode: "protected" },
+        },
+      },
+      version: 2,
+    });
     services.dispose();
   });
 });

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -206,6 +206,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.originFingerprint).toBe(`productivity-review:${seeded.issueId}`);
     expect(reviews[0]?.description).toContain("Primary trigger: `no_comment_streak`");
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
+    expect(reviews[0]?.version).toBe(2);
 
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
   });
@@ -253,6 +254,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(cappedRefresh.updated).toBe(0);
     expect(cappedRefresh.existing).toBe(1);
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
+    const [refreshedReview] = await db.select().from(issues).where(eq(issues.id, review!.id));
+    expect(refreshedReview?.version).toBe(5);
   });
 
   it("allows only one productivity review per source issue in 24 hours", async () => {

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -126,11 +126,17 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
         checkoutRunId: issues.checkoutRunId,
         executionRunId: issues.executionRunId,
         executionLockedAt: issues.executionLockedAt,
+        version: issues.version,
       })
       .from(issues)
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0]);
-    expect(row).toEqual({ checkoutRunId: null, executionRunId: null, executionLockedAt: null });
+    expect(row).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+      version: 2,
+    });
 
     const audit = await db
       .select({ action: activityLog.action, details: activityLog.details })
@@ -166,11 +172,12 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       .select({
         checkoutRunId: issues.checkoutRunId,
         executionRunId: issues.executionRunId,
+        version: issues.version,
       })
       .from(issues)
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0]);
-    expect(row).toEqual({ checkoutRunId: runningRunId, executionRunId: runningRunId });
+    expect(row).toEqual({ checkoutRunId: runningRunId, executionRunId: runningRunId, version: 1 });
   });
 
   it("does not clear when checkoutRunId is terminal but executionRunId is still running", async () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -215,6 +215,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       originId: sourceId,
       assigneeAgentId: agentId,
       status: "todo",
+      version: 2,
     });
 
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
@@ -259,6 +260,34 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
     expect(watchdog?.lastObservedFingerprint).toBe(firstWatchdog?.lastObservedFingerprint);
     expect(watchdog?.triggerCount).toBe(1);
+  });
+
+  it("increments once for a changed watchdog fingerprint and once for its review comment", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-VERSION", status: "done" });
+    const childId = await seedIssue(companyId, { parentId: sourceId, status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service } = createService();
+
+    await service.reconcileTaskWatchdogs({ companyId });
+    const [firstWatchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+    const watchdogIssueId = firstWatchdog!.watchdogIssueId!;
+    const [initialWatchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdogIssueId));
+    expect(initialWatchdogIssue?.version).toBe(2);
+
+    await db
+      .update(issues)
+      .set({ status: "blocked", updatedAt: new Date(Date.now() + 60_000) })
+      .where(eq(issues.id, childId));
+    const retriggered = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(retriggered).toMatchObject({ checked: 1, triggered: 1 });
+    const [updatedWatchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdogIssueId));
+    expect(updatedWatchdogIssue?.originFingerprint).not.toBe(initialWatchdogIssue?.originFingerprint);
+    expect(updatedWatchdogIssue?.version).toBe(4);
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, watchdogIssueId));
+    expect(comments).toHaveLength(2);
   });
 
   it("re-wakes a same-fingerprint watchdog review stuck in stale in_review", async () => {

--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -30,7 +30,8 @@ function createWorkProductRow(overrides: Partial<Record<string, unknown>> = {}) 
 
 describe("workProductService", () => {
   it("uses a transaction when creating a new primary work product", async () => {
-    const updatedWhere = vi.fn(async () => undefined);
+    const updateReturning = vi.fn(async () => [{ id: "issue-1" }]);
+    const updatedWhere = vi.fn(() => ({ returning: updateReturning }));
     const updateSet = vi.fn(() => ({ where: updatedWhere }));
     const txUpdate = vi.fn(() => ({ set: updateSet }));
 
@@ -56,7 +57,7 @@ describe("workProductService", () => {
     });
 
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(txUpdate).toHaveBeenCalledTimes(1);
+    expect(txUpdate).toHaveBeenCalledTimes(2);
     expect(txInsert).toHaveBeenCalledTimes(1);
     expect(result?.id).toBe("work-product-1");
   });
@@ -64,7 +65,8 @@ describe("workProductService", () => {
   it("uses a transaction when promoting an existing work product to primary", async () => {
     const existingRow = createWorkProductRow({ isPrimary: false });
 
-    const selectWhere = vi.fn(async () => [existingRow]);
+    const selectFor = vi.fn(async () => [existingRow]);
+    const selectWhere = vi.fn(() => ({ for: selectFor }));
     const selectFrom = vi.fn(() => ({ where: selectWhere }));
     const txSelect = vi.fn(() => ({ from: selectFrom }));
 
@@ -89,7 +91,8 @@ describe("workProductService", () => {
 
     expect(transaction).toHaveBeenCalledTimes(1);
     expect(txSelect).toHaveBeenCalledTimes(1);
-    expect(txUpdate).toHaveBeenCalledTimes(2);
+    expect(selectFor).toHaveBeenCalledWith("update");
+    expect(txUpdate).toHaveBeenCalledTimes(3);
     expect(result?.reviewState).toBe("ready_for_review");
   });
 });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -4631,6 +4631,8 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
     expect(comments[0]?.body).toContain("Dirty file count: `2`");
     expect(comments[0]?.body).toContain("`untracked.txt`");
     expect(comments[0]?.body).toContain("- Claimant: none");
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, ids.sourceIssueId));
+    expect(sourceIssue?.version).toBe(2);
 
     const activityRows = await db
       .select()

--- a/server/src/http/issue-etag.ts
+++ b/server/src/http/issue-etag.ts
@@ -1,0 +1,31 @@
+const ISSUE_ETAG_PATTERN = /^"issue-v([1-9]\d*)"$/;
+const MAX_ISSUE_VERSION = 2_147_483_647;
+
+export class InvalidIssueEtagError extends Error {
+  constructor() {
+    super("Invalid If-Match issue ETag");
+  }
+}
+
+export function formatIssueEtag(version: number): string {
+  if (!Number.isSafeInteger(version) || version < 1 || version > MAX_ISSUE_VERSION) {
+    throw new RangeError("Issue version must be a positive 32-bit integer");
+  }
+  return `"issue-v${version}"`;
+}
+
+export function parseOptionalIssueIfMatch(
+  value: string | string[] | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (Array.isArray(value)) throw new InvalidIssueEtagError();
+
+  const match = value.trim().match(ISSUE_ETAG_PATTERN);
+  if (!match) throw new InvalidIssueEtagError();
+
+  const version = Number(match[1]);
+  if (!Number.isSafeInteger(version) || version > MAX_ISSUE_VERSION) {
+    throw new InvalidIssueEtagError();
+  }
+  return version;
+}

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -15,6 +15,7 @@ import { validate } from "../middleware/validate.js";
 import { accessService, executionWorkspaceService, heartbeatService, logActivity, workspaceOperationService } from "../services/index.js";
 import { mergeExecutionWorkspaceConfig, readExecutionWorkspaceConfig } from "../services/execution-workspaces.js";
 import { parseProjectExecutionWorkspacePolicy } from "../services/execution-workspace-policy.js";
+import { versionedIssuePatch } from "../services/issue-versioning.js";
 import { readProjectWorkspaceRuntimeConfig } from "../services/project-workspace-runtime-config.js";
 import {
   buildWorkspaceRuntimeDesiredStatePatch,
@@ -646,10 +647,9 @@ export function executionWorkspaceRoutes(db: Db, opts: { pluginWorkerManager?: P
       if (existing.mode === "shared_workspace") {
         await db
           .update(issues)
-          .set({
-            executionWorkspaceId: null,
-            updatedAt: new Date(),
-          })
+          .set(versionedIssuePatch({
+            executionWorkspaceId: null
+          }, new Date()))
           .where(
             and(
               eq(issues.companyId, existing.companyId),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -170,6 +170,20 @@ import {
 import { authorizationDeniedDetails } from "../services/authorization.js";
 import { environmentService } from "../services/environments.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
+import {
+  formatIssueEtag,
+  InvalidIssueEtagError,
+  parseOptionalIssueIfMatch,
+} from "../http/issue-etag.js";
+import {
+  bumpIssueVersions,
+  type DbOrTx,
+  type DbTransaction,
+  type IssueMutationPatch,
+  IssueVersionConflictError,
+  runIssueMutation,
+  versionedIssuePatch,
+} from "../services/issue-versioning.js";
 import { redactSensitiveText } from "../redaction.js";
 import {
   createCompanySearchRateLimiter,
@@ -198,6 +212,16 @@ import {
 } from "../services/trust-preset-resolver.js";
 import { externalObjectService } from "../services/external-objects.js";
 import { deliverAgentUnblockNotification } from "../services/routable-blocked.js";
+
+function setIssueVersionHeaders(res: Response, version: number) {
+  res.setHeader("Cache-Control", "no-transform");
+  res.setHeader("ETag", formatIssueEtag(version));
+}
+
+function respondIssueVersionConflict(res: Response, currentVersion: number) {
+  setIssueVersionHeaders(res, currentVersion);
+  res.status(412).json({ error: "Issue version conflict" });
+}
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -2136,13 +2160,6 @@ function buildExecutionStageWakeup(input: {
   return null;
 }
 
-class AutoApprovalIssueMissingError extends Error {
-  constructor() {
-    super("Issue not found during auto-approval transaction");
-    this.name = "AutoApprovalIssueMissingError";
-  }
-}
-
 function toCompactIssue(issue: any): CompactIssue {
   return {
     id: issue.id,
@@ -2893,13 +2910,36 @@ export function issueRoutes(
     scheduledRetryRunId: string | null | undefined;
     issue: { id: string; companyId: string };
     actor: ReturnType<typeof getActorInfo>;
+    tx: DbTransaction;
   }) {
     const scheduledRetryRunId = readNonEmptyString(input.scheduledRetryRunId);
     if (!scheduledRetryRunId) return null;
 
     try {
-      const cancelled = await heartbeat.cancelRun(scheduledRetryRunId);
-      const cancelledRunId = cancelled?.id ?? scheduledRetryRunId;
+      const cancelled = await heartbeat.cancelScheduledRetryInTransaction(
+        input.tx,
+        scheduledRetryRunId,
+        "Superseded by a human issue comment",
+      );
+      return {
+        agentId: cancelled?.agentId ?? null,
+        runId: cancelled?.id ?? scheduledRetryRunId,
+      };
+    } catch (err) {
+      logger.error(
+        { err, issueId: input.issue.id, runId: scheduledRetryRunId },
+        "failed to cancel scheduled retry superseded by issue comment",
+      );
+      throw err;
+    }
+  }
+
+  async function finalizeScheduledRetryCancellation(input: {
+    cancellation: { agentId: string | null; runId: string };
+    issue: { id: string; companyId: string };
+    actor: ReturnType<typeof getActorInfo>;
+  }) {
+    try {
       await logActivity(db, {
         companyId: input.issue.companyId,
         actorType: input.actor.actorType,
@@ -2909,20 +2949,26 @@ export function issueRoutes(
         agentApiKeyId: input.actor.agentApiKeyId,
         action: "heartbeat.cancelled",
         entityType: "heartbeat_run",
-        entityId: cancelledRunId,
+        entityId: input.cancellation.runId,
         issueId: input.issue.id,
         details: {
           source: "issue_comment_scheduled_retry_superseded",
           issueId: input.issue.id,
         },
       });
-      return cancelledRunId;
     } catch (err) {
       logger.error(
-        { err, issueId: input.issue.id, runId: scheduledRetryRunId },
-        "failed to cancel scheduled retry superseded by issue comment",
+        { err, issueId: input.issue.id, runId: input.cancellation.runId },
+        "failed to log committed scheduled retry cancellation",
       );
-      throw err;
+    }
+    try {
+      await heartbeat.finalizeScheduledRetryCancellation(input.cancellation.runId);
+    } catch (err) {
+      logger.error(
+        { err, issueId: input.issue.id, runId: input.cancellation.runId },
+        "scheduled retry cancellation committed but post-commit finalization failed",
+      );
     }
   }
 
@@ -3556,6 +3602,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    options: { deferCheckoutNormalization?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3626,27 +3673,37 @@ export function issueRoutes(
     }
     const runId = requireAgentRunId(req, res);
     if (!runId) return false;
+    if (options.deferCheckoutNormalization) return true;
     const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId);
     if (ownership.adoptedFromRunId) {
-      const actor = getActorInfo(req);
-      await logActivity(db, {
-        companyId: issue.companyId,
-        actorType: actor.actorType,
-        actorId: actor.actorId,
-        agentId: actor.agentId,
-        runId: actor.runId,
-        agentApiKeyId: actor.agentApiKeyId,
-        action: "issue.checkout_lock_adopted",
-        entityType: "issue",
-        entityId: issue.id,
-        details: {
-          previousCheckoutRunId: ownership.adoptedFromRunId,
-          checkoutRunId: runId,
-          reason: "stale_checkout_run",
-        },
-      });
+      await logCheckoutLockAdopted(req, issue, runId, ownership.adoptedFromRunId);
     }
     return true;
+  }
+
+  async function logCheckoutLockAdopted(
+    req: Request,
+    issue: { id: string; companyId: string },
+    checkoutRunId: string,
+    previousCheckoutRunId: string,
+  ) {
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      agentApiKeyId: actor.agentApiKeyId,
+      action: "issue.checkout_lock_adopted",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        previousCheckoutRunId,
+        checkoutRunId,
+        reason: "stale_checkout_run",
+      },
+    });
   }
 
   async function assertFreshTaskWatchdogSourceMutation(
@@ -5472,6 +5529,7 @@ export function issueRoutes(
       ? await executionWorkspacesSvc.getById(issue.executionWorkspaceId)
       : null;
     const workProducts = await workProductsSvc.listForIssue(issue.id);
+    setIssueVersionHeaders(res, issue.version);
     res.json({
       ...issue,
       ...inboxArchiveFields,
@@ -6590,7 +6648,7 @@ export function issueRoutes(
         if (req.body.sourceArtifactKind === "issue") {
           return tx
             .update(issueRows)
-            .set(markPromoted)
+            .set(versionedIssuePatch(markPromoted))
             .where(and(
               eq(issueRows.id, req.body.sourceArtifactId),
               eq(issueRows.sourceTrust, sourceTrust),
@@ -6629,6 +6687,12 @@ export function issueRoutes(
           .returning({ id: issueWorkProducts.id });
       })();
       if (!updatedSource[0]) return null;
+      if (
+        req.body.sourceArtifactKind !== "issue" ||
+        req.body.sourceArtifactId !== issue.id
+      ) {
+        await bumpIssueVersions(tx, [issue.id], promotedAt);
+      }
 
       return tx
         .insert(issueWorkProducts)
@@ -7700,11 +7764,30 @@ export function issueRoutes(
   });
 
   router.patch("/issues/:id", validate(updateIssueRouteSchema), async (req, res) => {
+    let expectedVersion: number | undefined;
+    try {
+      expectedVersion = parseOptionalIssueIfMatch(req.headers["if-match"]);
+    } catch (err) {
+      if (err instanceof InvalidIssueEtagError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(
+      await assertAgentIssueMutationAllowed(req, res, existing, {
+        deferCheckoutNormalization: expectedVersion !== undefined,
+      })
+    )) return;
+    if (expectedVersion !== undefined && expectedVersion !== existing.version) {
+      respondIssueVersionConflict(res, existing.version);
+      return;
+    }
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -7818,6 +7901,7 @@ export function issueRoutes(
       return;
     }
     let interruptedRunId: string | null = null;
+    let runToInterrupt: Awaited<ReturnType<typeof resolveActiveIssueRun>> = null;
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(existing);
     const isAgentWorkUpdate =
       req.actor.type === "agent" && (Object.keys(updateFields).length > 0 || reviewRequest !== undefined);
@@ -7837,36 +7921,7 @@ export function issueRoutes(
         return;
       }
 
-      const runToInterrupt = await resolveActiveIssueRun(existing);
-      if (runToInterrupt) {
-        const cancelled = await heartbeat.cancelRun(
-          runToInterrupt.id,
-          "Interrupted by board comment",
-          operatorInterruptCancelOptions({ issueId: existing.id, actor }),
-        );
-        if (cancelled) {
-          interruptedRunId = cancelled.id;
-          await logActivity(db, {
-            companyId: cancelled.companyId,
-            actorType: actor.actorType,
-            actorId: actor.actorId,
-            agentId: actor.agentId,
-            runId: actor.runId,
-            agentApiKeyId: actor.agentApiKeyId,
-            action: "heartbeat.cancelled",
-            entityType: "heartbeat_run",
-            entityId: cancelled.id,
-            issueId: existing.id,
-            details: {
-              agentId: cancelled.agentId,
-              source: "issue_comment_interrupt",
-              issueId: existing.id,
-              cancellationKind: "operator_interrupted",
-              operatorInterrupted: true,
-            },
-          });
-        }
-      }
+      runToInterrupt = await resolveActiveIssueRun(existing);
     }
 
     const runToCancelForCancelledStatus = shouldCancelActiveRunForCancelledStatus
@@ -7885,16 +7940,19 @@ export function issueRoutes(
       updateFields.status = "todo";
     }
     let cancelledScheduledRetryRunId: string | null = null;
-    if (
-      commentBody &&
+    const shouldCancelScheduledRetry =
+      Boolean(commentBody) &&
       shouldResumeInProgressScheduledRetry &&
-      updateFields.status === "todo"
-    ) {
-      cancelledScheduledRetryRunId = await cancelScheduledRetrySupersededByComment({
-        scheduledRetryRunId: scheduledRetryForHumanComment?.runId,
-        issue: existing,
-        actor,
-      });
+      updateFields.status === "todo";
+    if (shouldCancelScheduledRetry) {
+      if (existing.executionRunId === scheduledRetryForHumanComment?.runId) {
+        updateFields.executionRunId = null;
+        updateFields.executionAgentNameKey = null;
+        updateFields.executionLockedAt = null;
+      }
+      if (existing.checkoutRunId === scheduledRetryForHumanComment?.runId) {
+        updateFields.checkoutRunId = null;
+      }
     }
     if (req.body.executionPolicy !== undefined) {
       updateFields.executionPolicy = applyActorMonitorScheduledBy(
@@ -8088,23 +8146,82 @@ export function issueRoutes(
     const stopRelayResult: {
       value: Awaited<ReturnType<typeof svc.addStopRelayCommentIfNeeded>>;
     } = { value: null };
-    let issue: Awaited<ReturnType<typeof svc.update>>;
-    try {
+    let issue: Awaited<ReturnType<typeof svc.update>> = null;
+    let committedComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
+    const issueUpdateInput = {
+      ...updateFields,
+      actorAgentId: actor.agentId ?? null,
+      actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      expectedVersion,
+    };
+    const scheduledRetryCancellation = {
+      value: null as Awaited<ReturnType<typeof cancelScheduledRetrySupersededByComment>>,
+    };
+    const inlineComment = commentBody
+      ? {
+          body: commentBody,
+          actor: {
+            agentId: actor.agentId ?? undefined,
+            userId: actor.actorType === "user" ? actor.actorId : undefined,
+            runId: actor.runId,
+          },
+          options: {
+            sourceTrust: await sourceTrustForActorWrite(existing, actor),
+          },
+          beforeCommit: shouldCancelScheduledRetry
+            ? async (tx: DbTransaction) => {
+                scheduledRetryCancellation.value = await cancelScheduledRetrySupersededByComment({
+                  scheduledRetryRunId: scheduledRetryForHumanComment?.runId,
+                  issue: existing,
+                  actor,
+                  tx,
+                });
+              }
+            : undefined,
+        }
+      : null;
+    const performIssueMutation = async (
+      dbOrTx: DbOrTx,
+      ownershipPatch: IssueMutationPatch = {},
+    ) => {
+      const joinsExistingTransaction = "rollback" in dbOrTx;
+      const effectiveIssueUpdateInput = { ...issueUpdateInput, ...ownershipPatch };
+      let updatedIssue: Awaited<ReturnType<typeof svc.update>> = null;
+      let updatedComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
       if (transition.decision && decisionId) {
         const decision = transition.decision;
-        issue = await db.transaction(async (tx) => {
-          const updated = await svc.update(
-            id,
-            {
-              ...updateFields,
-              actorAgentId: actor.agentId ?? null,
-              actorUserId: actor.actorType === "user" ? actor.actorId : null,
+        if (inlineComment) {
+          const commentInput = {
+            ...inlineComment,
+            afterUpdate: async (
+              tx: DbTransaction,
+              updated: typeof issueRows.$inferSelect,
+            ) => {
+              await tx.insert(issueExecutionDecisions).values({
+                id: decisionId,
+                companyId: updated.companyId,
+                issueId: updated.id,
+                stageId: decision.stageId,
+                stageType: decision.stageType,
+                actorAgentId: actor.agentId ?? null,
+                actorUserId: actor.actorType === "user" ? actor.actorId : null,
+                outcome: decision.outcome,
+                body: decision.body,
+                createdByRunId: actor.runId ?? null,
+              });
             },
-            tx,
-          );
-          if (!updated) return null;
-
-          await tx.insert(issueExecutionDecisions).values({
+          };
+          const result = joinsExistingTransaction
+            ? await svc.updateWithInlineComment(id, effectiveIssueUpdateInput, commentInput, dbOrTx)
+            : await svc.updateWithInlineComment(id, effectiveIssueUpdateInput, commentInput);
+          updatedIssue = result?.issue ?? null;
+          updatedComment = result?.comment ?? null;
+        } else {
+          const updated = joinsExistingTransaction
+            ? await svc.update(id, effectiveIssueUpdateInput, dbOrTx)
+            : await svc.update(id, effectiveIssueUpdateInput);
+          if (!updated) return { issue: null, comment: null };
+          await dbOrTx.insert(issueExecutionDecisions).values({
             id: decisionId,
             companyId: updated.companyId,
             issueId: updated.id,
@@ -8116,32 +8233,63 @@ export function issueRoutes(
             body: decision.body,
             createdByRunId: actor.runId ?? null,
           });
-
-          if (shouldRelayStop) {
-            stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
-          }
-
-          return updated;
-        });
-      } else if (shouldRelayStop) {
-        issue = await db.transaction(async (tx) => {
-          const updated = await svc.update(id, {
-            ...updateFields,
-            actorAgentId: actor.agentId ?? null,
-            actorUserId: actor.actorType === "user" ? actor.actorId : null,
-          }, tx);
-          if (!updated) return null;
-          stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
-          return updated;
-        });
+          updatedIssue = updated;
+        }
+      } else if (inlineComment) {
+        const result = joinsExistingTransaction
+          ? await svc.updateWithInlineComment(id, effectiveIssueUpdateInput, inlineComment, dbOrTx)
+          : await svc.updateWithInlineComment(id, effectiveIssueUpdateInput, inlineComment);
+        updatedIssue = result?.issue ?? null;
+        updatedComment = result?.comment ?? null;
       } else {
-        issue = await svc.update(id, {
-          ...updateFields,
-          actorAgentId: actor.agentId ?? null,
-          actorUserId: actor.actorType === "user" ? actor.actorId : null,
-        });
+        updatedIssue = joinsExistingTransaction
+          ? await svc.update(id, effectiveIssueUpdateInput, dbOrTx)
+          : await svc.update(id, effectiveIssueUpdateInput);
+      }
+      if (updatedIssue && shouldRelayStop) {
+        stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updatedIssue, dbOrTx);
+      }
+      return { issue: updatedIssue, comment: updatedComment };
+    };
+    let adoptedFromRunId: string | null = null;
+    try {
+      const normalizeCheckoutInTransaction =
+        expectedVersion !== undefined &&
+        req.actor.type === "agent" &&
+        existing.status === "in_progress" &&
+        existing.assigneeAgentId === actor.agentId;
+      const requiresOuterTransaction =
+        normalizeCheckoutInTransaction ||
+        shouldRelayStop ||
+        Boolean(transition.decision && decisionId && !inlineComment);
+      const result = requiresOuterTransaction
+        ? await db.transaction(async (tx) => {
+            if (!normalizeCheckoutInTransaction) {
+              return performIssueMutation(tx);
+            }
+            const ownership = await svc.assertCheckoutOwnerInTransaction(
+              id,
+              actor.agentId!,
+              actor.runId!,
+              expectedVersion!,
+              tx,
+            );
+            adoptedFromRunId = ownership.adoptedFromRunId;
+            return performIssueMutation(tx, ownership.issuePatch);
+          })
+        : await performIssueMutation(db);
+      issue = result.issue;
+      committedComment = result.comment;
+      if (adoptedFromRunId && actor.runId) {
+        await logCheckoutLockAdopted(req, existing, actor.runId, adoptedFromRunId);
+      } else {
+        adoptedFromRunId = null;
       }
     } catch (err) {
+      if (err instanceof IssueVersionConflictError) {
+        respondIssueVersionConflict(res, err.currentVersion);
+        return;
+      }
       if (err instanceof HttpError && err.status === 422) {
         logger.warn(
           {
@@ -8168,6 +8316,44 @@ export function issueRoutes(
       res.status(404).json({ error: "Issue not found" });
       return;
     }
+    if (scheduledRetryCancellation.value) {
+      cancelledScheduledRetryRunId = scheduledRetryCancellation.value.runId;
+      await finalizeScheduledRetryCancellation({
+        cancellation: scheduledRetryCancellation.value,
+        issue: existing,
+        actor,
+      });
+    }
+
+    if (runToInterrupt) {
+      const cancelled = await heartbeat.cancelRun(
+        runToInterrupt.id,
+        "Interrupted by board comment",
+        operatorInterruptCancelOptions({ issueId: existing.id, actor }),
+      );
+      if (cancelled) {
+        interruptedRunId = cancelled.id;
+        await logActivity(db, {
+          companyId: cancelled.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          action: "heartbeat.cancelled",
+          entityType: "heartbeat_run",
+          entityId: cancelled.id,
+          issueId: existing.id,
+          details: {
+            agentId: cancelled.agentId,
+            source: "issue_comment_interrupt",
+            issueId: existing.id,
+            cancellationKind: "operator_interrupted",
+            operatorInterrupted: true,
+          },
+        });
+      }
+    }
 
     if (enteringBlocked) {
       const blockedIssue = issue;
@@ -8180,11 +8366,16 @@ export function issueRoutes(
         },
       });
       if (ownerNotifiedAt) {
-        await db.update(issueRows).set({ blockedOwnerNotifiedAt: ownerNotifiedAt }).where(and(
-          eq(issueRows.id, blockedIssue.id),
-          eq(issueRows.companyId, blockedIssue.companyId),
-        ));
-        issue = { ...blockedIssue, blockedOwnerNotifiedAt: ownerNotifiedAt };
+        const notificationUpdate = await runIssueMutation(db, {
+          issueId: blockedIssue.id,
+          mutate: () => ({
+            issuePatch: { blockedOwnerNotifiedAt: ownerNotifiedAt },
+            result: null,
+          }),
+        });
+        if (notificationUpdate) {
+          issue = { ...blockedIssue, ...notificationUpdate.issue };
+        }
       }
     }
 
@@ -8561,17 +8752,19 @@ export function issueRoutes(
       }
     }
 
-    let comment = null;
+    let comment = committedComment;
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-      }, {
-        sourceTrust: await sourceTrustForActorWrite(issue, actor),
-      });
+      if (!comment) {
+        comment = await svc.addComment(id, commentBody, {
+          agentId: actor.agentId ?? undefined,
+          userId: actor.actorType === "user" ? actor.actorId : undefined,
+          runId: actor.runId,
+        }, {
+          sourceTrust: await sourceTrustForActorWrite(issue, actor),
+        });
+      }
       await issueReferencesSvc.syncComment(comment.id);
       await externalObjectsSvc.syncCommentSafely(comment.id);
       const commentReferenceSummaryAfter = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
@@ -8628,6 +8821,7 @@ export function issueRoutes(
           agentId: actor.agentId,
           userId: actor.actorType === "user" ? actor.actorId : null,
         },
+        { touchIssueVersion: false },
       );
       await logExpiredRequestConfirmations({
         issue,
@@ -9007,6 +9201,14 @@ export function issueRoutes(
     })();
 
     await queueTaskWatchdogEvaluation(issue, actor.runId);
+    const latestIssue = await svc.getById(issue.id);
+    if (latestIssue && latestIssue.version > issue.version) {
+      issueResponse = { ...issueResponse, ...latestIssue };
+    }
+    setIssueVersionHeaders(
+      res,
+      latestIssue && latestIssue.version > issue.version ? latestIssue.version : issue.version,
+    );
     res.json({ ...issueResponse, comment });
   });
 
@@ -9043,7 +9245,7 @@ export function issueRoutes(
       entityType: "issue",
       entityId: issue.id,
     });
-
+    await queueTaskWatchdogEvaluation(existing, actor.runId);
     await queueTaskWatchdogEvaluation(existing, actor.runId);
     res.json(issue);
   });
@@ -9746,11 +9948,30 @@ export function issueRoutes(
   });
 
   router.delete("/issues/:id/comments/:commentId", async (req, res) => {
+    let expectedVersion: number | undefined;
+    try {
+      expectedVersion = parseOptionalIssueIfMatch(req.headers["if-match"]);
+    } catch (err) {
+      if (err instanceof InvalidIssueEtagError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+
     const id = req.params.id as string;
     const commentId = req.params.commentId as string;
     const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!issue) return;
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(
+      await assertAgentIssueMutationAllowed(req, res, issue, {
+        deferCheckoutNormalization: expectedVersion !== undefined,
+      })
+    )) return;
+    if (expectedVersion !== undefined && expectedVersion !== issue.version) {
+      respondIssueVersionConflict(res, issue.version);
+      return;
+    }
 
     const comment = await svc.getComment(commentId);
     if (!comment || comment.issueId !== id) {
@@ -9759,6 +9980,33 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const mutateWithConditionalOwnership = async <T>(
+      mutation: (dbOrTx: DbOrTx, ownershipPatch: IssueMutationPatch) => Promise<T>,
+    ): Promise<T> => {
+      const normalizeCheckoutInTransaction =
+        expectedVersion !== undefined &&
+        req.actor.type === "agent" &&
+        issue.status === "in_progress" &&
+        issue.assigneeAgentId === actor.agentId;
+      if (!normalizeCheckoutInTransaction) return mutation(db, {});
+
+      let adoptedFromRunId: string | null = null;
+      const result = await db.transaction(async (tx) => {
+        const ownership = await svc.assertCheckoutOwnerInTransaction(
+          issue.id,
+          actor.agentId!,
+          actor.runId!,
+          expectedVersion!,
+          tx,
+        );
+        adoptedFromRunId = ownership.adoptedFromRunId;
+        return mutation(tx, ownership.issuePatch);
+      });
+      if (adoptedFromRunId && actor.runId) {
+        await logCheckoutLockAdopted(req, issue, actor.runId, adoptedFromRunId);
+      }
+      return result;
+    };
     const actorOwnsComment =
       actor.actorType === "agent"
         ? comment.authorAgentId === actor.agentId
@@ -9783,11 +10031,27 @@ export function issueRoutes(
         return;
       }
 
-      const removed = await svc.removeComment(commentId);
-      if (!removed) {
+      let removedResult;
+      try {
+        removedResult = await mutateWithConditionalOwnership((dbOrTx, ownershipPatch) =>
+          svc.removeCommentVersioned(
+            commentId,
+            "rollback" in dbOrTx
+              ? { expectedVersion, dbOrTx, issuePatch: ownershipPatch }
+              : { expectedVersion },
+          ));
+      } catch (err) {
+        if (err instanceof IssueVersionConflictError) {
+          respondIssueVersionConflict(res, err.currentVersion);
+          return;
+        }
+        throw err;
+      }
+      if (!removedResult) {
         res.status(404).json({ error: "Comment not found" });
         return;
       }
+      const removed = removedResult.comment;
 
       await logActivity(db, {
         companyId: issue.companyId,
@@ -9809,6 +10073,7 @@ export function issueRoutes(
         },
       });
 
+      setIssueVersionHeaders(res, removedResult.issue.version);
       res.json(removed);
       return;
     }
@@ -9819,51 +10084,65 @@ export function issueRoutes(
     }
 
     if (comment.deletedAt) {
+      setIssueVersionHeaders(res, issue.version);
       res.json(comment);
       return;
     }
 
     let annotationCleanup = { deletedCommentIds: [] as string[], resolvedThreadIds: [] as string[] };
-    const deleted = await svc.tombstoneComment(
-      commentId,
-      {
-        actorType: actor.actorType,
-        agentId: actor.agentId,
-        userId: actor.actorType === "user" ? actor.actorId : null,
-        runId: actor.runId,
-      },
-      {
-        afterTombstone: async (deletedComment, tx) => {
-          await issueReferencesSvc.syncComment(deletedComment.id, tx);
-          await externalObjectsSvc.syncCommentSafely(deletedComment.id, tx);
-          annotationCleanup = await documentAnnotationsSvc.cleanupForIssueCommentDeletion(issue.id, deletedComment.id, {
-            actorType: actor.actorType,
-            actorId: actor.actorId,
-            agentId: actor.agentId,
-            userId: actor.actorType === "user" ? actor.actorId : null,
-            runId: actor.runId,
-          }, tx);
-          await Promise.all(
-            annotationCleanup.deletedCommentIds.map((annotationCommentId) =>
-              Promise.all([
-                issueReferencesSvc.deleteCommentSource(annotationCommentId, tx),
-                externalObjectsSvc.syncCommentSafely(annotationCommentId, tx),
-              ])
-            ),
-          );
-          await decisionTrainingSvc.scrubDeletedComments({
-            companyId: issue.companyId,
-            issueId: issue.id,
-            commentIds: [deletedComment.id, ...annotationCleanup.deletedCommentIds],
-            deletedAt: deletedComment.deletedAt ?? new Date(),
-          }, tx);
+    let deletedResult;
+    try {
+      deletedResult = await mutateWithConditionalOwnership((dbOrTx, ownershipPatch) =>
+        svc.tombstoneCommentVersioned(
+        commentId,
+        {
+          actorType: actor.actorType,
+          agentId: actor.agentId,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+          runId: actor.runId,
         },
-      },
-    );
-    if (!deleted) {
+        {
+          expectedVersion,
+          ...("rollback" in dbOrTx ? { dbOrTx, issuePatch: ownershipPatch } : {}),
+          afterTombstone: async (deletedComment, tx) => {
+            await issueReferencesSvc.syncComment(deletedComment.id, tx);
+            await externalObjectsSvc.syncCommentSafely(deletedComment.id, tx);
+            annotationCleanup = await documentAnnotationsSvc.cleanupForIssueCommentDeletion(issue.id, deletedComment.id, {
+              actorType: actor.actorType,
+              actorId: actor.actorId,
+              agentId: actor.agentId,
+              userId: actor.actorType === "user" ? actor.actorId : null,
+              runId: actor.runId,
+            }, tx);
+            await Promise.all(
+              annotationCleanup.deletedCommentIds.map((annotationCommentId) =>
+                Promise.all([
+                  issueReferencesSvc.deleteCommentSource(annotationCommentId, tx),
+                  externalObjectsSvc.syncCommentSafely(annotationCommentId, tx),
+                ])
+              ),
+            );
+            await decisionTrainingSvc.scrubDeletedComments({
+              companyId: issue.companyId,
+              issueId: issue.id,
+              commentIds: [deletedComment.id, ...annotationCleanup.deletedCommentIds],
+              deletedAt: deletedComment.deletedAt ?? new Date(),
+            }, tx);
+          },
+        },
+      ));
+    } catch (err) {
+      if (err instanceof IssueVersionConflictError) {
+        respondIssueVersionConflict(res, err.currentVersion);
+        return;
+      }
+      throw err;
+    }
+    if (!deletedResult) {
       res.status(404).json({ error: "Comment not found" });
       return;
     }
+    const deleted = deletedResult.comment;
 
     await logActivity(db, {
       companyId: issue.companyId,
@@ -9890,6 +10169,7 @@ export function issueRoutes(
       },
     });
 
+    setIssueVersionHeaders(res, deletedResult.issue.version);
     res.json(deleted);
   });
 
@@ -9966,6 +10246,17 @@ export function issueRoutes(
   });
 
   router.post("/issues/:id/comments", validate(addIssueCommentSchema), async (req, res) => {
+    let expectedVersion: number | undefined;
+    try {
+      expectedVersion = parseOptionalIssueIfMatch(req.headers["if-match"]);
+    } catch (err) {
+      if (err instanceof InvalidIssueEtagError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+
     const id = req.params.id as string;
     const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!issue) return;
@@ -10060,6 +10351,16 @@ export function issueRoutes(
     let issueBeforeCommentDecision = issue;
     let commentDecisionStageWakeup: ReturnType<typeof buildExecutionStageWakeup> | null = null;
     const commentReferenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
+    const plannedCommentIssuePatch: {
+      checkoutRunId?: string | null;
+      executionAgentNameKey?: string | null;
+      executionLockedAt?: Date | null;
+      executionRunId?: string | null;
+      expectedVersion?: number;
+      status?: string;
+    } = {
+      expectedVersion,
+    };
 
     let scheduledRetrySupersededByComment = false;
     let cancelledScheduledRetryRunId: string | null = null;
@@ -10068,22 +10369,196 @@ export function issueRoutes(
       (isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers) || shouldResumeInProgressScheduledRetry)
     ) {
       scheduledRetrySupersededByComment = shouldResumeInProgressScheduledRetry && issue.status === "in_progress";
-      cancelledScheduledRetryRunId = scheduledRetrySupersededByComment
-        ? await cancelScheduledRetrySupersededByComment({
+      reopened = isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers);
+      reopenFromStatus = reopened ? issue.status : null;
+      plannedCommentIssuePatch.status = "todo";
+    }
+    if (scheduledRetrySupersededByComment) {
+      if (issue.executionRunId === scheduledRetryForHumanComment?.runId) {
+        plannedCommentIssuePatch.executionRunId = null;
+        plannedCommentIssuePatch.executionAgentNameKey = null;
+        plannedCommentIssuePatch.executionLockedAt = null;
+      }
+      if (issue.checkoutRunId === scheduledRetryForHumanComment?.runId) {
+        plannedCommentIssuePatch.checkoutRunId = null;
+      }
+    }
+
+    let runToInterrupt: Awaited<ReturnType<typeof resolveActiveIssueRun>> = null;
+    if (interruptRequested) {
+      if (req.actor.type !== "board") {
+        res.status(403).json({ error: "Only board users can interrupt active runs from issue comments" });
+        return;
+      }
+
+      runToInterrupt = await resolveActiveIssueRun(currentIssue);
+    }
+
+    const currentExecutionState = parseIssueExecutionState(currentIssue.executionState);
+    const currentExecutionPolicy = normalizeIssueExecutionPolicy(currentIssue.executionPolicy ?? null);
+    const shouldAutoApproveReviewComment =
+      currentIssue.status === "in_review" &&
+      currentExecutionState?.status === "pending" &&
+      actorMatchesExecutionParticipant(actor, currentExecutionState.currentParticipant ?? null) &&
+      isApprovalReviewComment(req.body.body);
+
+    const commentActor = {
+      agentId: actor.agentId ?? undefined,
+      userId: actor.actorType === "user" ? actor.actorId : undefined,
+      runId: actor.runId,
+    };
+    const commentOptions = {
+      authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
+      presentation: req.body.presentation ?? null,
+      metadata: req.body.metadata ?? null,
+      sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
+    };
+    const scheduledRetryCancellation = {
+      value: null as Awaited<ReturnType<typeof cancelScheduledRetrySupersededByComment>>,
+    };
+    const cancelScheduledRetryBeforeCommit = scheduledRetrySupersededByComment
+      ? async (tx: DbTransaction) => {
+          scheduledRetryCancellation.value = await cancelScheduledRetrySupersededByComment({
             scheduledRetryRunId: scheduledRetryForHumanComment?.runId,
             issue,
             actor,
-          })
-        : null;
-      const reopenedIssue = await svc.update(id, { status: "todo" });
-      if (!reopenedIssue) {
-        res.status(404).json({ error: "Issue not found" });
+            tx,
+          });
+        }
+      : undefined;
+    let comment: Awaited<ReturnType<typeof svc.addComment>>;
+    try {
+      if (shouldAutoApproveReviewComment) {
+        const transition = applyIssueExecutionPolicyTransition({
+          issue: currentIssue,
+          policy: currentExecutionPolicy,
+          requestedStatus: "done",
+          requestedAssigneePatch: {},
+          actor: {
+            agentId: actor.agentId ?? null,
+            userId: actor.actorType === "user" ? actor.actorId : null,
+          },
+          commentBody: req.body.body,
+        });
+        const decisionId = transition.decision ? randomUUID() : null;
+        if (decisionId) {
+          const nextExecutionState = transition.patch.executionState;
+          if (!nextExecutionState || typeof nextExecutionState !== "object") {
+            throw new Error("Execution policy decision patch is missing executionState");
+          }
+          transition.patch.executionState = {
+            ...nextExecutionState,
+            lastDecisionId: decisionId,
+          };
+        }
+
+        issueBeforeCommentDecision = currentIssue;
+        const result = await svc.updateWithInlineComment(
+          id,
+          {
+            ...plannedCommentIssuePatch,
+            ...transition.patch,
+            status: typeof transition.patch.status === "string" ? transition.patch.status : "done",
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+          },
+          {
+            body: req.body.body,
+            actor: commentActor,
+            options: commentOptions,
+            beforeCommit: cancelScheduledRetryBeforeCommit,
+            afterUpdate: transition.decision && decisionId
+              ? async (tx, updated) => {
+                  await tx.insert(issueExecutionDecisions).values({
+                    id: decisionId,
+                    companyId: updated.companyId,
+                    issueId: updated.id,
+                    stageId: transition.decision!.stageId,
+                    stageType: transition.decision!.stageType,
+                    actorAgentId: actor.agentId ?? null,
+                    actorUserId: actor.actorType === "user" ? actor.actorId : null,
+                    outcome: transition.decision!.outcome,
+                    body: transition.decision!.body,
+                    createdByRunId: actor.runId ?? null,
+                  });
+                }
+              : undefined,
+          },
+        );
+        if (!result) {
+          res.status(404).json({ error: "Issue not found" });
+          return;
+        }
+        comment = result.comment;
+        currentIssue = result.issue;
+      } else {
+        const result = await svc.updateWithInlineComment(
+          id,
+          plannedCommentIssuePatch,
+          {
+            body: req.body.body,
+            actor: commentActor,
+            options: commentOptions,
+            beforeCommit: cancelScheduledRetryBeforeCommit,
+          },
+        );
+        if (!result) {
+          res.status(404).json({ error: "Issue not found" });
+          return;
+        }
+        comment = result.comment;
+        currentIssue = result.issue;
+      }
+    } catch (err) {
+      if (err instanceof IssueVersionConflictError) {
+        respondIssueVersionConflict(res, err.currentVersion);
         return;
       }
-      reopened = isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers);
-      reopenFromStatus = reopened ? issue.status : null;
-      currentIssue = reopenedIssue;
+      throw err;
+    }
+    if (scheduledRetryCancellation.value) {
+      cancelledScheduledRetryRunId = scheduledRetryCancellation.value.runId;
+      await finalizeScheduledRetryCancellation({
+        cancellation: scheduledRetryCancellation.value,
+        issue,
+        actor,
+      });
+    }
 
+    if (runToInterrupt) {
+      const cancelled = await heartbeat.cancelRun(
+        runToInterrupt.id,
+        "Interrupted by board comment",
+        operatorInterruptCancelOptions({ issueId: currentIssue.id, actor }),
+      );
+      if (cancelled) {
+        interruptedRunId = cancelled.id;
+        await logActivity(db, {
+          companyId: cancelled.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          agentApiKeyId: actor.agentApiKeyId,
+          action: "heartbeat.cancelled",
+          entityType: "heartbeat_run",
+          entityId: cancelled.id,
+          issueId: currentIssue.id,
+          details: {
+            agentId: cancelled.agentId,
+            source: "issue_comment_interrupt",
+            issueId: currentIssue.id,
+            cancellationKind: "operator_interrupted",
+            operatorInterrupted: true,
+          },
+        });
+      }
+    }
+
+    if (
+      plannedCommentIssuePatch.status === "todo" &&
+      issue.status !== currentIssue.status
+    ) {
       await logActivity(db, {
         companyId: currentIssue.companyId,
         actorType: actor.actorType,
@@ -10111,140 +10586,7 @@ export function issueRoutes(
       });
     }
 
-    if (interruptRequested) {
-      if (req.actor.type !== "board") {
-        res.status(403).json({ error: "Only board users can interrupt active runs from issue comments" });
-        return;
-      }
-
-      const runToInterrupt = await resolveActiveIssueRun(currentIssue);
-      if (runToInterrupt) {
-        const cancelled = await heartbeat.cancelRun(
-          runToInterrupt.id,
-          "Interrupted by board comment",
-          operatorInterruptCancelOptions({ issueId: currentIssue.id, actor }),
-        );
-        if (cancelled) {
-          interruptedRunId = cancelled.id;
-          await logActivity(db, {
-            companyId: cancelled.companyId,
-            actorType: actor.actorType,
-            actorId: actor.actorId,
-            agentId: actor.agentId,
-            runId: actor.runId,
-            agentApiKeyId: actor.agentApiKeyId,
-            action: "heartbeat.cancelled",
-            entityType: "heartbeat_run",
-            entityId: cancelled.id,
-            issueId: currentIssue.id,
-            details: {
-              agentId: cancelled.agentId,
-              source: "issue_comment_interrupt",
-              issueId: currentIssue.id,
-              cancellationKind: "operator_interrupted",
-              operatorInterrupted: true,
-            },
-          });
-        }
-      }
-    }
-
-    const currentExecutionState = parseIssueExecutionState(currentIssue.executionState);
-    const currentExecutionPolicy = normalizeIssueExecutionPolicy(currentIssue.executionPolicy ?? null);
-    const shouldAutoApproveReviewComment =
-      currentIssue.status === "in_review" &&
-      currentExecutionState?.status === "pending" &&
-      actorMatchesExecutionParticipant(actor, currentExecutionState.currentParticipant ?? null) &&
-      isApprovalReviewComment(req.body.body);
-
-    // Persist the comment and the auto-approval state transition atomically when both apply.
-    // Without a single transaction, a 422 (or any error) thrown by the status update after the
-    // comment is inserted would leave an orphan comment without the corresponding state change.
-    let comment: Awaited<ReturnType<typeof svc.addComment>>;
     if (shouldAutoApproveReviewComment) {
-      const transition = applyIssueExecutionPolicyTransition({
-        issue: currentIssue,
-        policy: currentExecutionPolicy,
-        requestedStatus: "done",
-        requestedAssigneePatch: {},
-        actor: {
-          agentId: actor.agentId ?? null,
-          userId: actor.actorType === "user" ? actor.actorId : null,
-        },
-        commentBody: req.body.body,
-      });
-      const decisionId = transition.decision ? randomUUID() : null;
-      if (decisionId) {
-        const nextExecutionState = transition.patch.executionState;
-        if (!nextExecutionState || typeof nextExecutionState !== "object") {
-          throw new Error("Execution policy decision patch is missing executionState");
-        }
-        transition.patch.executionState = {
-          ...nextExecutionState,
-          lastDecisionId: decisionId,
-        };
-      }
-
-      issueBeforeCommentDecision = currentIssue;
-      const updatePatch = {
-        ...transition.patch,
-        status: typeof transition.patch.status === "string" ? transition.patch.status : "done",
-        actorAgentId: actor.agentId ?? null,
-        actorUserId: actor.actorType === "user" ? actor.actorId : null,
-      };
-
-      const sourceTrust = await sourceTrustForActorWrite(currentIssue, actor);
-      const commentOptions = {
-        authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
-        presentation: req.body.presentation ?? null,
-        metadata: req.body.metadata ?? null,
-        sourceTrust,
-      };
-      let txResult: { comment: Awaited<ReturnType<typeof svc.addComment>>; issue: NonNullable<Awaited<ReturnType<typeof svc.update>>> };
-      try {
-        txResult = await db.transaction(async (tx) => {
-          const insertedComment = await svc.addComment(
-            id,
-            req.body.body,
-            {
-              agentId: actor.agentId ?? undefined,
-              userId: actor.actorType === "user" ? actor.actorId : undefined,
-              runId: actor.runId,
-            },
-            commentOptions,
-            tx,
-          );
-          const updated = await svc.update(id, updatePatch, tx);
-          // Throw (not return null) so drizzle rolls back the inserted comment when the issue
-          // has been concurrently deleted between the initial fetch and the in-transaction update.
-          if (!updated) throw new AutoApprovalIssueMissingError();
-
-          if (transition.decision && decisionId) {
-            await tx.insert(issueExecutionDecisions).values({
-              id: decisionId,
-              companyId: updated.companyId,
-              issueId: updated.id,
-              stageId: transition.decision.stageId,
-              stageType: transition.decision.stageType,
-              actorAgentId: actor.agentId ?? null,
-              actorUserId: actor.actorType === "user" ? actor.actorId : null,
-              outcome: transition.decision.outcome,
-              body: transition.decision.body,
-              createdByRunId: actor.runId ?? null,
-            });
-          }
-
-          return { comment: insertedComment, issue: updated };
-        });
-      } catch (err) {
-        if (err instanceof AutoApprovalIssueMissingError) {
-          res.status(404).json({ error: "Issue not found" });
-          return;
-        }
-        throw err;
-      }
-      comment = txResult.comment;
-      currentIssue = txResult.issue;
       // Mirror the normal status-change audit trail: every other in_review -> done path
       // emits an `issue.updated` activity, so emit one here too for the auto-approval path.
       if (issueBeforeCommentDecision.status !== currentIssue.status) {
@@ -10273,17 +10615,6 @@ export function issueRoutes(
         interruptedRunId,
         requestedByActorType: actor.actorType,
         requestedByActorId: actor.actorId,
-      });
-    } else {
-      comment = await svc.addComment(id, req.body.body, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-      }, {
-        authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
-        presentation: req.body.presentation ?? null,
-        metadata: req.body.metadata ?? null,
-        sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
       });
     }
 
@@ -10343,6 +10674,7 @@ export function issueRoutes(
         agentId: actor.agentId,
         userId: actor.actorType === "user" ? actor.actorId : null,
       },
+      { touchIssueVersion: false },
     );
     await logExpiredRequestConfirmations({
       issue: currentIssue,
@@ -10596,6 +10928,11 @@ export function issueRoutes(
     })();
 
     await queueTaskWatchdogEvaluation(currentIssue, actor.runId);
+    const latestIssue = await svc.getById(currentIssue.id);
+    if (latestIssue && latestIssue.version > currentIssue.version) {
+      currentIssue = latestIssue;
+    }
+    setIssueVersionHeaders(res, currentIssue.version);
     res.status(201).json(comment);
   });
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -216,6 +216,7 @@ type OpenApiPathRegistration = {
   request?: {
     params?: z.ZodTypeAny;
     query?: z.ZodTypeAny;
+    headers?: z.ZodTypeAny;
     body?: {
       content: Record<string, { schema: unknown }>;
       required?: boolean;
@@ -409,7 +410,7 @@ function normalizeResponses(responses: Record<string, OpenApiResponse> = {}) {
   );
 }
 
-function parametersFromSchema(schema: z.ZodTypeAny, location: "path" | "query") {
+function parametersFromSchema(schema: z.ZodTypeAny, location: "path" | "query" | "header") {
   const objectSchema = unwrapSchema(schema);
   if (zodTypeName(objectSchema) !== "ZodObject") return [];
   const shape = objectSchema._def.shape();
@@ -448,6 +449,12 @@ class OpenAPIRegistry {
         normalizedOperation.parameters = [
           ...((normalizedOperation.parameters as unknown[]) ?? []),
           ...parametersFromSchema(request.query, "query"),
+        ];
+      }
+      if (request?.headers) {
+        normalizedOperation.parameters = [
+          ...((normalizedOperation.parameters as unknown[]) ?? []),
+          ...parametersFromSchema(request.headers, "header"),
         ];
       }
       if (request?.body) {
@@ -502,6 +509,20 @@ const responses = {
     description: "Conflict",
     content: { "application/json": { schema: ErrorSchema } },
   },
+  preconditionFailed: {
+    description: "Issue version conflict",
+    content: { "application/json": { schema: ErrorSchema } },
+    headers: {
+      ETag: {
+        description: "Current strong Paperclip issue ETag",
+        schema: { type: "string", example: "\"issue-v42\"" },
+      },
+      "Cache-Control": {
+        description: "Prevents intermediaries from transforming the strong ETag response",
+        schema: { type: "string", example: "no-transform" },
+      },
+    },
+  },
   unprocessable: {
     description: "Unprocessable entity",
     content: { "application/json": { schema: ErrorSchema } },
@@ -522,6 +543,23 @@ const jsonBody = (schema: z.ZodTypeAny) => ({
 });
 
 const r = responses;
+const optionalIssueIfMatchHeaders = z.object({
+  "if-match": z.string().optional(),
+});
+const issueVersionHeaders = {
+  ETag: {
+    description: "Strong Paperclip issue ETag",
+    schema: { type: "string", example: "\"issue-v42\"" },
+  },
+  "Cache-Control": {
+    description: "Prevents intermediaries from transforming the strong ETag response",
+    schema: { type: "string", example: "no-transform" },
+  },
+};
+const issueVersionedOk = (schema: z.ZodTypeAny = z.record(z.unknown())) => ({
+  ...r.ok(schema),
+  headers: issueVersionHeaders,
+});
 
 const externalObjectSummariesBodySchema = z.object({
   issueIds: z.array(z.string().uuid()).max(1000),
@@ -1976,7 +2014,7 @@ registry.registerPath({
   tags: ["issues"],
   summary: "Get an issue",
   request: { params: z.object({ id: z.string() }) },
-  responses: { 200: r.ok(), 401: r.unauthorized, 404: r.notFound },
+  responses: { 200: issueVersionedOk(), 401: r.unauthorized, 404: r.notFound },
 });
 
 registry.registerPath({
@@ -1986,9 +2024,16 @@ registry.registerPath({
   summary: "Update an issue",
   request: {
     params: z.object({ id: z.string() }),
+    headers: optionalIssueIfMatchHeaders,
     body: jsonBody(updateIssueSchema.partial()),
   },
-  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized, 404: r.notFound },
+  responses: {
+    200: issueVersionedOk(),
+    400: r.badRequest,
+    401: r.unauthorized,
+    404: r.notFound,
+    412: r.preconditionFailed,
+  },
 });
 
 registry.registerPath({
@@ -2157,9 +2202,15 @@ registry.registerPath({
   summary: "Add a comment to an issue",
   request: {
     params: z.object({ id: z.string() }),
+    headers: optionalIssueIfMatchHeaders,
     body: jsonBody(addIssueCommentSchema),
   },
-  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+  responses: {
+    200: issueVersionedOk(),
+    400: r.badRequest,
+    401: r.unauthorized,
+    412: r.preconditionFailed,
+  },
 });
 
 registry.registerPath({
@@ -2167,8 +2218,16 @@ registry.registerPath({
   path: "/api/issues/{id}/comments/{commentId}",
   tags: ["issues"],
   summary: "Delete an issue comment",
-  request: { params: z.object({ id: z.string(), commentId: z.string() }) },
-  responses: { 200: r.ok(), 401: r.unauthorized },
+  request: {
+    params: z.object({ id: z.string(), commentId: z.string() }),
+    headers: optionalIssueIfMatchHeaders,
+  },
+  responses: {
+    200: issueVersionedOk(),
+    400: r.badRequest,
+    401: r.unauthorized,
+    412: r.preconditionFailed,
+  },
 });
 
 registry.registerPath({

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -11,6 +11,7 @@ import { conflict } from "../errors.js";
 import { assertAssignableAgent } from "./agent-assignability.js";
 import { authorizationService, type AuthorizationActor, type AuthorizationResource } from "./authorization.js";
 import { ensureHumanRoleDefaultGrants } from "./principal-access-compatibility.js";
+import { versionedIssuePatch } from "./issue-versioning.js";
 
 type MembershipRow = typeof companyMemberships.$inferSelect;
 type GrantInput = {
@@ -368,19 +369,19 @@ export function accessService(db: Db) {
       );
       const resetInProgress = await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           ...assignmentPatch,
           status: "todo",
           startedAt: null,
           checkoutRunId: null,
           executionRunId: null,
           executionLockedAt: null,
-        })
+        }))
         .where(and(assignedOpenIssueWhere, eq(issues.status, "in_progress")))
         .returning({ id: issues.id });
       const reassigned = await tx
         .update(issues)
-        .set(assignmentPatch)
+        .set(versionedIssuePatch(assignmentPatch))
         .where(and(assignedOpenIssueWhere, ne(issues.status, "in_progress")))
         .returning({ id: issues.id });
 

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -1,4 +1,8 @@
 import { createHash, randomBytes } from "node:crypto";
+import {
+  bumpIssueVersions,
+  versionedIssuePatch,
+} from "./issue-versioning.js";
 import { and, desc, eq, gte, inArray, lt, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -741,11 +745,23 @@ export function agentService(db: Db) {
       }
 
       return db.transaction(async (tx) => {
+        const commentIssueIds = await tx
+          .selectDistinct({ issueId: issueComments.issueId })
+          .from(issueComments)
+          .where(eq(issueComments.authorAgentId, id))
+          .then((rows) => rows.map((row) => row.issueId));
         await tx.update(agents).set({ reportsTo: null }).where(eq(agents.reportsTo, id));
-        await tx
+        const directlyUpdatedIssueIds = await tx
           .update(issues)
-          .set({ assigneeAgentId: null, createdByAgentId: null })
-          .where(or(eq(issues.assigneeAgentId, id), eq(issues.createdByAgentId, id)));
+          .set(versionedIssuePatch({ assigneeAgentId: null, createdByAgentId: null }))
+          .where(or(eq(issues.assigneeAgentId, id), eq(issues.createdByAgentId, id)))
+          .returning({ id: issues.id })
+          .then((rows) => rows.map((row) => row.id));
+        const directlyUpdated = new Set(directlyUpdatedIssueIds);
+        await bumpIssueVersions(
+          tx,
+          commentIssueIds.filter((issueId) => !directlyUpdated.has(issueId)),
+        );
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.agentId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.agentId, id));
         await tx.delete(activityLog).where(

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6525,7 +6526,7 @@ export function companySkillService(db: Db) {
       await db.transaction(async (tx) => {
         await tx
           .update(issues)
-          .set({ hiddenAt: now, updatedAt: now })
+          .set(versionedIssuePatch({ hiddenAt: now }, now))
           .where(and(eq(issues.companyId, companyId), eq(issues.id, row.issueId), eq(issues.harnessKind, "skill_test")));
         await tx
           .update(companySkillTestRuns)

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -1819,6 +1820,7 @@ export function executionWorkspaceService(db: Db) {
 
         let restoredSourceIssue: ExecutionWorkspaceBranchReconcileResult["restoredSourceIssue"] = null;
         let sourceIssueStatusChanged = false;
+        let sourceIssueVersionAdvanced = false;
         if (input.mode === "quarantine_restore") {
           const [sourceBefore] = await tx
             .select({
@@ -1867,6 +1869,7 @@ export function executionWorkspaceService(db: Db) {
             tx,
           );
           if (!updatedIssue) throw notFound("Source issue not found");
+          sourceIssueVersionAdvanced = true;
           restoredSourceIssue = {
             id: updatedIssue.id,
             companyId: updatedIssue.companyId,
@@ -1896,10 +1899,12 @@ export function executionWorkspaceService(db: Db) {
           })
           .returning({ id: issueComments.id });
 
-        await tx
-          .update(issues)
-          .set({ updatedAt: now })
-          .where(eq(issues.id, lockedWorkspace.sourceIssueId));
+        if (!sourceIssueVersionAdvanced) {
+          await tx
+            .update(issues)
+            .set(versionedIssuePatch({}, now))
+            .where(eq(issues.id, lockedWorkspace.sourceIssueId));
+        }
 
         return {
           workspace: toExecutionWorkspace(updatedRow, lockedRuntimeServices),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,4 +1,9 @@
 import fs from "node:fs/promises";
+import {
+  type DbTransaction,
+  runIssueMutation,
+  versionedIssuePatch,
+} from "./issue-versioning.js";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
@@ -6555,15 +6560,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (input.recoveryPolicy === "escalate_to_board") {
-      await db.insert(issueComments).values({
-        companyId: input.claimed.companyId,
+      await runIssueMutation(db, {
         issueId: input.claimed.id,
-        body: monitorRecoveryComment({
-          issue: input.claimed,
-          clearReason: input.clearReason,
-          recoveryPolicy: input.recoveryPolicy,
-          nextAttemptCount: input.nextAttemptCount,
-        }),
+        mutate: async (tx) => {
+          await tx.insert(issueComments).values({
+            companyId: input.claimed.companyId,
+            issueId: input.claimed.id,
+            body: monitorRecoveryComment({
+              issue: input.claimed,
+              clearReason: input.clearReason,
+              recoveryPolicy: input.recoveryPolicy,
+              nextAttemptCount: input.nextAttemptCount,
+            }),
+          });
+          return { result: null };
+        },
       });
 
       await logActivity(db, {
@@ -6639,15 +6650,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }) {
     await db
       .update(issues)
-      .set({
+      .set(versionedIssuePatch({
         ...buildIssueMonitorClearedPatch({
           issue: input.claimed,
           policy: input.policy,
           clearReason: input.clearReason,
           clearedAt: input.now,
-        }),
-        updatedAt: input.now,
-      })
+        })
+      }, input.now))
       .where(eq(issues.id, input.claimed.id));
 
     await logActivity(db, {
@@ -6798,14 +6808,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       await db
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           ...buildIssueMonitorTriggeredPatch({
             issue: claimed,
             policy,
             triggeredAt: input.now,
-          }),
-          updatedAt: new Date(),
-        })
+          })
+        }, new Date()))
         .where(eq(issues.id, claimed.id));
 
       await logActivity(db, {
@@ -6834,15 +6843,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (input.clearOnClientError) {
           await db
             .update(issues)
-            .set({
+            .set(versionedIssuePatch({
               ...buildIssueMonitorClearedPatch({
                 issue: claimed,
                 policy,
                 clearReason: "dispatch_skipped",
                 clearedAt: input.now,
-              }),
-              updatedAt: new Date(),
-            })
+              })
+            }, new Date()))
             .where(eq(issues.id, claimed.id));
 
           await logActivity(db, {
@@ -6869,18 +6877,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         await db
           .update(issues)
-          .set({
-            monitorWakeRequestedAt: null,
-            updatedAt: new Date(),
-          })
+          .set(versionedIssuePatch({
+            monitorWakeRequestedAt: null
+          }, new Date()))
           .where(eq(issues.id, claimed.id));
       } else {
         await db
           .update(issues)
-          .set({
-            monitorWakeRequestedAt: null,
-            updatedAt: new Date(),
-          })
+          .set(versionedIssuePatch({
+            monitorWakeRequestedAt: null
+          }, new Date()))
           .where(eq(issues.id, claimed.id));
       }
 
@@ -6926,10 +6932,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const claimed = await db.transaction(async (tx) => {
       const [updated] = await tx
         .update(issues)
-        .set({
-          monitorWakeRequestedAt: now,
-          updatedAt: now,
-        })
+        .set(versionedIssuePatch({
+          monitorWakeRequestedAt: now
+        }, now))
         .where(
           and(
             eq(issues.id, issueId),
@@ -6995,10 +7000,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const claimed = await db.transaction(async (tx) => {
         const [updated] = await tx
           .update(issues)
-          .set({
-            monitorWakeRequestedAt: now,
-            updatedAt: now,
-          })
+          .set(versionedIssuePatch({
+            monitorWakeRequestedAt: now
+          }, now))
           .where(
             and(
               eq(issues.id, due.id),
@@ -8551,12 +8555,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           executionRunId: queuedRun.id,
           executionAgentNameKey: normalizeAgentNameKey(agent.name),
-          executionLockedAt: now,
-          updatedAt: now,
-        })
+          executionLockedAt: now
+        }, now))
         .where(eq(issues.id, issue.id));
 
       await tx
@@ -8802,13 +8805,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (issueId) {
         await tx
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             checkoutRunId: null,
             executionRunId: retryRun.id,
             executionAgentNameKey: normalizeAgentNameKey(agent.name),
-            executionLockedAt: now,
-            updatedAt: now,
-          })
+            executionLockedAt: now
+          }, now))
           .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
       }
 
@@ -9458,12 +9460,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (gate.issueId) {
       await db
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           executionRunId: null,
           executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: now,
-        })
+          executionLockedAt: null
+        }, now))
         .where(
           and(
             eq(issues.companyId, cancelled.companyId),
@@ -10141,7 +10142,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (issueId) {
         await tx
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             executionRunId: scheduledRun.id,
             executionAgentNameKey: normalizeAgentNameKey(agent.name),
             executionLockedAt: now,
@@ -10150,9 +10151,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                   executionWorkspaceId: null,
                   executionWorkspacePreference: null,
                 }
-              : {}),
-            updatedAt: now,
-          })
+              : {})
+          }, now))
           .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
       }
 
@@ -10854,12 +10854,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const claimedAgent = await getAgent(claimed.agentId);
       await db
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           executionRunId: claimed.id,
           executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
+          executionLockedAt: claimedAt
+        }, claimedAt))
         .where(
           and(
             eq(issues.id, claimedIssueId),
@@ -10905,12 +10904,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     await db
       .update(issues)
-      .set({
+      .set(versionedIssuePatch({
         executionRunId: null,
         executionAgentNameKey: null,
-        executionLockedAt: null,
-        updatedAt: now,
-      })
+        executionLockedAt: null
+      }, now))
       .where(
         and(
           eq(issues.companyId, run.companyId),
@@ -11120,12 +11118,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     await db
       .update(issues)
-      .set({
+      .set(versionedIssuePatch({
         executionRunId: null,
         executionAgentNameKey: null,
-        executionLockedAt: null,
-        updatedAt: now,
-      })
+        executionLockedAt: null
+      }, now))
       .where(
         and(
           eq(issues.companyId, run.companyId),
@@ -12051,7 +12048,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (responsibleUserId && issueContext && !issueContext.responsibleUserId) {
       await db
         .update(issues)
-        .set({ responsibleUserId, updatedAt: new Date() })
+        .set(versionedIssuePatch({ responsibleUserId }, new Date()))
         .where(and(eq(issues.companyId, agent.companyId), eq(issues.id, issueContext.id), isNull(issues.responsibleUserId)));
       issueContext = { ...issueContext, responsibleUserId };
     }
@@ -14539,41 +14536,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         )
         .orderBy(asc(issues.id));
 
-      // Clear orphaned execution-lock columns that still point at this finalizing
-      // run, across every sibling issue in one statement so it scales with N
-      // orphans without N round-trips. Rows are already held under FOR UPDATE from
-      // the lock query above.
-      //
-      // The two columns are cleared in separate UPDATEs so we never clobber a
-      // retry's executionRunId pointer: when a process-loss or codex-transient
-      // retry is scheduled mid-finalization, it moves `executionRunId` from this
-      // run to the retry run while leaving `checkoutRunId` pinned at this run.
-      // Only the checkout column should be released in that case; the execution
-      // column now belongs to the retry.
+      // Clear every lock column still owned by this run in one guarded update.
+      // CASE preserves a successor retry's execution pointer while allowing the
+      // original checkout pointer to be released without a second version bump.
       const promotionUpdateTimestamp = new Date();
       await tx
         .update(issues)
-        .set({
-          executionRunId: null,
-          executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: promotionUpdateTimestamp,
-        })
+        .set(versionedIssuePatch({
+          executionRunId: sql`case
+            when ${issues.executionRunId} = ${run.id} then null
+            else ${issues.executionRunId}
+          end`,
+          executionAgentNameKey: sql`case
+            when ${issues.executionRunId} = ${run.id} then null
+            else ${issues.executionAgentNameKey}
+          end`,
+          executionLockedAt: sql`case
+            when ${issues.executionRunId} = ${run.id} then null
+            else ${issues.executionLockedAt}
+          end`,
+          checkoutRunId: sql`case
+            when ${issues.checkoutRunId} = ${run.id} then null
+            else ${issues.checkoutRunId}
+          end`,
+        }, promotionUpdateTimestamp))
         .where(
-          and(eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)),
-        );
-      // `checkoutRunId` clear is symmetric to #6008's per-issue self-heal,
-      // extended to all siblings: covers paths where the issue's assignee or
-      // status changed between checkout and termination, which
-      // adoptStaleCheckoutRun's narrow WHERE clause cannot reach.
-      await tx
-        .update(issues)
-        .set({
-          checkoutRunId: null,
-          updatedAt: promotionUpdateTimestamp,
-        })
-        .where(
-          and(eq(issues.companyId, run.companyId), eq(issues.checkoutRunId, run.id)),
+          and(
+            eq(issues.companyId, run.companyId),
+            or(eq(issues.executionRunId, run.id), eq(issues.checkoutRunId, run.id)),
+          ),
         );
 
       // Deferred-wake promotion is bound to a single primary issue: the run's context
@@ -14856,12 +14847,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         await tx
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             executionRunId: newRun.id,
             executionAgentNameKey: normalizeAgentNameKey(deferredAgent.name),
-            executionLockedAt: now,
-            updatedAt: now,
-          })
+            executionLockedAt: now
+          }, now))
           // Promoted mention wakes are issue-scoped, not issue ownership transfers.
           .where(and(eq(issues.id, issue.id), eq(issues.assigneeAgentId, deferredAgent.id)));
 
@@ -15016,12 +15006,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         await tx
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             executionRunId: queuedRun.id,
             executionAgentNameKey: recoveryAgentNameKey,
-            executionLockedAt: now,
-            updatedAt: now,
-          })
+            executionLockedAt: now
+          }, now))
           .where(eq(issues.id, issue.id));
 
         return {
@@ -15172,12 +15161,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           executionRunId: queuedRun.id,
           executionAgentNameKey: recoveryAgentNameKey,
-          executionLockedAt: now,
-          updatedAt: now,
-        })
+          executionLockedAt: now
+        }, now))
         .where(eq(issues.id, issue.id));
 
       return {
@@ -15641,12 +15629,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (issue.executionRunId === scheduledRun.id) {
             await tx
               .update(issues)
-              .set({
+              .set(versionedIssuePatch({
                 executionRunId: null,
                 executionAgentNameKey: null,
-                executionLockedAt: null,
-                updatedAt: now,
-              })
+                executionLockedAt: null
+              }, now))
               .where(and(eq(issues.id, issue.id), eq(issues.executionRunId, scheduledRun.id)));
           }
 
@@ -15757,12 +15744,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (!activeExecutionRun && issue.executionRunId) {
           await tx
             .update(issues)
-            .set({
+            .set(versionedIssuePatch({
               executionRunId: null,
               executionAgentNameKey: null,
-              executionLockedAt: null,
-              updatedAt: new Date(),
-            })
+              executionLockedAt: null
+            }, new Date()))
             .where(eq(issues.id, issue.id));
         }
 
@@ -15796,12 +15782,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 .then((rows) => rows[0] ?? null);
               await tx
                 .update(issues)
-                .set({
+                .set(versionedIssuePatch({
                   executionRunId: legacyRun.id,
                   executionAgentNameKey: normalizeAgentNameKey(legacyAgent?.name),
-                  executionLockedAt: new Date(),
-                  updatedAt: new Date(),
-                })
+                  executionLockedAt: new Date()
+                }, new Date()))
                 .where(eq(issues.id, issue.id));
             }
           }
@@ -15911,14 +15896,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ].join("\n");
             await tx
               .update(issues)
-              .set({
+              .set(versionedIssuePatch({
                 status: "blocked",
                 checkoutRunId: null,
                 executionRunId: null,
                 executionAgentNameKey: null,
-                executionLockedAt: null,
-                updatedAt: now,
-              })
+                executionLockedAt: null
+              }, now))
               .where(eq(issues.id, issue.id));
             await tx.insert(issueComments).values({
               companyId: issue.companyId,
@@ -16589,6 +16573,90 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     eventPayload?: Record<string, unknown>;
   };
 
+  async function cancelScheduledRetryInTransaction(
+    tx: DbTransaction,
+    runId: string,
+    reason: string,
+  ) {
+    const finishedAt = new Date();
+    const cancelled = await tx
+      .update(heartbeatRuns)
+      .set({
+        status: "cancelled",
+        finishedAt,
+        error: reason,
+        errorCode: "cancelled",
+        updatedAt: finishedAt,
+      })
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "scheduled_retry")))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    if (!cancelled) {
+      const current = await tx
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      if (!current) throw notFound("Heartbeat run not found");
+      throw conflict(`Scheduled retry is no longer cancellable: ${current.status}`);
+    }
+
+    if (cancelled.wakeupRequestId) {
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          status: "cancelled",
+          finishedAt,
+          error: reason,
+          updatedAt: finishedAt,
+        })
+        .where(eq(agentWakeupRequests.id, cancelled.wakeupRequestId));
+    }
+
+    const [eventSeq] = await tx
+      .select({ maxSeq: sql<number | null>`max(${heartbeatRunEvents.seq})` })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, cancelled.id));
+    await tx.insert(heartbeatRunEvents).values({
+      companyId: cancelled.companyId,
+      runId: cancelled.id,
+      agentId: cancelled.agentId,
+      seq: Number(eventSeq?.maxSeq ?? 0) + 1,
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message: "run cancelled",
+      payload: {
+        issueId: readNonEmptyString(parseObject(cancelled.contextSnapshot).issueId),
+        source: "issue_comment_scheduled_retry_superseded",
+      },
+    });
+    return cancelled;
+  }
+
+  async function finalizeScheduledRetryCancellation(runId: string) {
+    const cancelled = await getRun(runId);
+    if (!cancelled) return;
+    publishLiveEvent({
+      companyId: cancelled.companyId,
+      type: "heartbeat.run.status",
+      payload: {
+        runId: cancelled.id,
+        agentId: cancelled.agentId,
+        status: cancelled.status,
+        invocationSource: cancelled.invocationSource,
+        triggerDetail: cancelled.triggerDetail,
+        error: cancelled.error ?? null,
+        errorCode: cancelled.errorCode ?? null,
+        startedAt: cancelled.startedAt ? new Date(cancelled.startedAt).toISOString() : null,
+        finishedAt: cancelled.finishedAt ? new Date(cancelled.finishedAt).toISOString() : null,
+      },
+    });
+    publishRunLifecyclePluginEvent(cancelled);
+    await finalizeAgentStatus(cancelled.agentId, "cancelled");
+    await startNextQueuedRunForAgent(cancelled.agentId);
+  }
+
   async function cancelRunInternal(runId: string, reason = "Cancelled by control plane", options: CancelRunOptions = {}) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
@@ -17154,6 +17222,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     cancelRun: (runId: string, reason?: string, options?: CancelRunOptions) => cancelRunInternal(runId, reason, options),
+    cancelScheduledRetryInTransaction,
+    finalizeScheduledRetryCancellation,
 
     /**
      * Pause-only. Emits errorCode "agent_paused" unconditionally; its sole caller is the

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -41,6 +41,18 @@ export {
   type IssueFilters,
 } from "./issues.js";
 export { issueThreadInteractionService } from "./issue-thread-interactions.js";
+export {
+  bumpIssueVersions,
+  IssueVersionConflictError,
+  runIssueMutation,
+  versionedIssuePatch,
+  type DbOrTx,
+  type DbTransaction,
+  type IssueMutationPatch,
+  type IssueMutationPlan,
+  type IssueMutationResult,
+  type RunIssueMutationInput,
+} from "./issue-versioning.js";
 export { issueTreeControlService } from "./issue-tree-control.js";
 export { issueApprovalService } from "./issue-approvals.js";
 export { issueReferenceService } from "./issue-references.js";

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,4 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import { and, asc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -232,7 +233,7 @@ function hydrateInteraction(
 async function touchIssue(db: IssueTouchDb, issueId: string) {
   await db
     .update(issues)
-    .set({ updatedAt: new Date() })
+    .set(versionedIssuePatch({}, new Date()))
     .where(eq(issues.id, issueId));
 }
 
@@ -1701,6 +1702,7 @@ export function issueThreadInteractionService(db: Db) {
       issue: { id: string; companyId: string },
       comment: { id: string; createdAt: Date | string; authorUserId?: string | null; createdByRunId?: string | null },
       actor: InteractionActor,
+      options: { touchIssueVersion?: boolean } = {},
     ) => {
       if (!comment.authorUserId) return [];
       // Local-CLI adapters post under user auth, so authorUserId can't tell a human from a
@@ -1753,7 +1755,9 @@ export function issueThreadInteractionService(db: Db) {
       }
 
       if (expired.length > 0) {
-        await touchIssue(db, issue.id);
+        if (options.touchIssueVersion !== false) {
+          await touchIssue(db, issue.id);
+        }
         await emitResolvedInteractionsTelemetry(db, expired);
       }
       return expired;
@@ -1976,6 +1980,7 @@ export function issueThreadInteractionService(db: Db) {
     expirePendingInteractionsForTerminalIssue: async (
       issue: { id: string; companyId: string; status: string },
       actor: InteractionActor = {},
+      options: { touchIssueVersion?: boolean } = {},
     ) => {
       if (!isTerminalIssueStatus(issue.status)) return [];
       const rows = await db
@@ -2030,7 +2035,9 @@ export function issueThreadInteractionService(db: Db) {
         if (updated) expired.push(hydrateInteraction(updated));
       }
       if (expired.length > 0) {
-        await touchIssue(db, issue.id);
+        if (options.touchIssueVersion !== false) {
+          await touchIssue(db, issue.id);
+        }
         await emitResolvedInteractionsTelemetry(db, expired);
       }
       return expired;

--- a/server/src/services/issue-tree-control.ts
+++ b/server/src/services/issue-tree-control.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import type { Db } from "@paperclipai/db";
 import {
   agentWakeupRequests,
@@ -873,16 +874,15 @@ export function issueTreeControlService(db: Db) {
     const updated = await db.transaction(async (tx) => {
       const rows = await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           status: "cancelled",
           cancelledAt: now,
           completedAt: null,
           checkoutRunId: null,
           executionRunId: null,
           executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: now,
-        })
+          executionLockedAt: null
+        }, now))
         .where(
           and(
             eq(issues.companyId, companyId),
@@ -976,16 +976,15 @@ export function issueTreeControlService(db: Db) {
         if (issueIdsForStatus.length === 0) continue;
         const rows = await tx
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             status,
             cancelledAt: null,
             completedAt: null,
             checkoutRunId: null,
             executionRunId: null,
             executionAgentNameKey: null,
-            executionLockedAt: null,
-            updatedAt: now,
-          })
+            executionLockedAt: null
+          }, now))
           .where(
             and(
               eq(issues.companyId, companyId),

--- a/server/src/services/issue-versioning.ts
+++ b/server/src/services/issue-versioning.ts
@@ -1,0 +1,108 @@
+import { and, eq, inArray, sql, type SQL } from "drizzle-orm";
+import { issues, type Db } from "@paperclipai/db";
+
+export type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+export type DbOrTx = Db | DbTransaction;
+
+export class IssueVersionConflictError extends Error {
+  constructor(readonly currentVersion: number) {
+    super("Issue version conflict");
+  }
+}
+
+export type IssueMutationPatch = Omit<
+  Partial<typeof issues.$inferInsert>,
+  "id" | "version" | "updatedAt"
+>;
+type VersionedIssuePatchInput = {
+  [Key in keyof IssueMutationPatch]: IssueMutationPatch[Key] | SQL;
+};
+
+export type IssueMutationPlan<T> = {
+  issuePatch?: IssueMutationPatch;
+  result: T;
+};
+
+export type IssueMutationResult<T> = {
+  issue: typeof issues.$inferSelect;
+  result: T;
+};
+
+export type RunIssueMutationInput<T> = {
+  issueId: string;
+  expectedVersion?: number;
+  now?: Date;
+  mutate: (
+    tx: DbTransaction,
+    issue: typeof issues.$inferSelect,
+  ) => Promise<IssueMutationPlan<T>> | IssueMutationPlan<T>;
+};
+
+function isDbTransaction(dbOrTx: DbOrTx): dbOrTx is DbTransaction {
+  return "rollback" in dbOrTx;
+}
+
+export function versionedIssuePatch(
+  patch: VersionedIssuePatchInput,
+  now = new Date(),
+) {
+  return {
+    ...patch,
+    updatedAt: now,
+    version: sql`${issues.version} + 1`,
+  };
+}
+
+export async function bumpIssueVersions(
+  dbOrTx: DbOrTx,
+  issueIds: string[],
+  now = new Date(),
+): Promise<string[]> {
+  const distinctIssueIds = [...new Set(issueIds)];
+  if (distinctIssueIds.length === 0) return [];
+
+  return await dbOrTx
+    .update(issues)
+    .set(versionedIssuePatch({}, now))
+    .where(inArray(issues.id, distinctIssueIds))
+    .returning({ id: issues.id })
+    .then((rows) => rows.map((row) => row.id));
+}
+
+async function runInTransaction<T>(
+  tx: DbTransaction,
+  { issueId, expectedVersion, now, mutate }: RunIssueMutationInput<T>,
+): Promise<IssueMutationResult<T> | null> {
+  const current = await tx
+    .select()
+    .from(issues)
+    .where(eq(issues.id, issueId))
+    .for("update")
+    .then((rows) => rows[0] ?? null);
+
+  if (!current) return null;
+  if (expectedVersion !== undefined && current.version !== expectedVersion) {
+    throw new IssueVersionConflictError(current.version);
+  }
+
+  const planned = await mutate(tx, current);
+  const updated = await tx
+    .update(issues)
+    .set(versionedIssuePatch(planned.issuePatch ?? {}, now))
+    .where(and(eq(issues.id, issueId), eq(issues.version, current.version)))
+    .returning()
+    .then((rows) => rows[0] ?? null);
+
+  if (!updated) throw new Error("Locked issue version update returned no row");
+  return { issue: updated, result: planned.result };
+}
+
+export async function runIssueMutation<T>(
+  dbOrTx: DbOrTx,
+  input: RunIssueMutationInput<T>,
+): Promise<IssueMutationResult<T> | null> {
+  if (isDbTransaction(dbOrTx)) {
+    return await runInTransaction(dbOrTx, input);
+  }
+  return await dbOrTx.transaction(async (tx) => await runInTransaction(tx, input));
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -110,6 +110,14 @@ import { visibleIssueCondition } from "./issue-visibility.js";
 import { finalizeStatusCardsForStalledGeneration } from "./status-card-finalization.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
 import { logActivity } from "./activity-log.js";
+import {
+  type DbOrTx,
+  IssueVersionConflictError,
+  runIssueMutation,
+  type DbTransaction,
+  type IssueMutationPatch,
+  versionedIssuePatch,
+} from "./issue-versioning.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -2603,6 +2611,7 @@ const issueListSelect = {
   completedAt: issues.completedAt,
   cancelledAt: issues.cancelledAt,
   hiddenAt: issues.hiddenAt,
+  version: issues.version,
   createdAt: issues.createdAt,
   updatedAt: issues.updatedAt,
 };
@@ -4217,8 +4226,12 @@ export function issueService(db: Db) {
     });
   }
 
-  async function assertAssignableUser(companyId: string, userId: string) {
-    const membership = await db
+  async function assertAssignableUser(
+    companyId: string,
+    userId: string,
+    dbOrTx: DbReader = db,
+  ) {
+    const membership = await dbOrTx
       .select({ id: companyMemberships.id })
       .from(companyMemberships)
       .where(
@@ -4566,12 +4579,11 @@ export function issueService(db: Db) {
       const now = new Date();
       const adopted = await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           checkoutRunId: input.actorRunId,
           executionRunId: input.actorRunId,
-          executionLockedAt: now,
-          updatedAt: now,
-        })
+          executionLockedAt: now
+        }, now))
         .where(
           and(
             eq(issues.id, input.issueId),
@@ -4626,12 +4638,11 @@ export function issueService(db: Db) {
       const now = new Date();
       const adopted = await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           checkoutRunId: input.actorRunId,
           executionRunId: input.actorRunId,
-          executionLockedAt: now,
-          updatedAt: now,
-        })
+          executionLockedAt: now
+        }, now))
         .where(
           and(
             eq(issues.id, input.issueId),
@@ -4678,12 +4689,11 @@ export function issueService(db: Db) {
 
       const updated = await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           executionRunId: null,
           executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: new Date(),
-        })
+          executionLockedAt: null
+        }, new Date()))
         .where(
           and(
             eq(issues.id, issueId),
@@ -4738,13 +4748,12 @@ export function issueService(db: Db) {
 
       const updated = await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           checkoutRunId: null,
           executionRunId: null,
           executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: new Date(),
-        })
+          executionLockedAt: null
+        }, new Date()))
         .where(
           and(
             eq(issues.id, issueId),
@@ -4763,7 +4772,7 @@ export function issueService(db: Db) {
 
   async function addStopRelayCommentIfNeeded(
     child: typeof issues.$inferSelect,
-    dbOrTx: any = db,
+    dbOrTx: DbOrTx = db,
   ) {
     if (!child.parentId || (child.status !== "blocked" && child.status !== "cancelled")) return null;
 
@@ -4803,24 +4812,388 @@ export function issueService(db: Db) {
       }>) => rows[0] ?? null);
     if (!parent) return null;
 
-    const [comment] = await dbOrTx
+    const mutation = await runIssueMutation(dbOrTx, {
+      issueId: parent.id,
+      mutate: async (tx) => {
+        const [comment] = await tx
+          .insert(issueComments)
+          .values({
+            companyId: child.companyId,
+            issueId: parent.id,
+            authorType: "system",
+            body,
+          })
+          .returning();
+        return { result: comment };
+      },
+    });
+    if (!mutation) return null;
+
+    return { comment: mutation.result, parent: mutation.issue };
+  }
+
+  async function assertCheckoutOwnerInTransaction(
+    id: string,
+    actorAgentId: string,
+    actorRunId: string,
+    expectedVersion: number,
+    tx: DbTransaction,
+  ) {
+    const current = await tx
+      .select({
+        id: issues.id,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        version: issues.version,
+      })
+      .from(issues)
+      .where(eq(issues.id, id))
+      .for("update")
+      .then((rows) => rows[0] ?? null);
+    if (!current) throw notFound("Issue not found");
+    if (current.version !== expectedVersion) {
+      throw new IssueVersionConflictError(current.version);
+    }
+    if (current.status !== "in_progress" || current.assigneeAgentId !== actorAgentId) {
+      throw conflict("Issue run ownership conflict", {
+        issueId: current.id,
+        status: current.status,
+        assigneeAgentId: current.assigneeAgentId,
+        checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
+        actorAgentId,
+        actorRunId,
+      });
+    }
+    const runIds = [...new Set(
+      [current.checkoutRunId, current.executionRunId, actorRunId].filter(
+        (runId): runId is string => Boolean(runId),
+      ),
+    )].sort();
+    for (const runId of runIds) {
+      await tx.execute(
+        sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${runId} for update`,
+      );
+    }
+    const runRows = runIds.length > 0
+      ? await tx
+          .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(inArray(heartbeatRuns.id, runIds))
+      : [];
+    const runStatusById = new Map(runRows.map((run) => [run.id, run.status]));
+    const isLiveRun = (runId: string | null) => {
+      if (!runId) return false;
+      const status = runStatusById.get(runId);
+      return Boolean(status && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(status));
+    };
+    if (!isLiveRun(actorRunId)) {
+      throw conflict("Issue run ownership conflict", {
+        issueId: current.id,
+        status: current.status,
+        assigneeAgentId: current.assigneeAgentId,
+        checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
+        actorAgentId,
+        actorRunId,
+      });
+    }
+    if (current.checkoutRunId === actorRunId) {
+      return {
+        ...current,
+        adoptedFromRunId: null as string | null,
+        issuePatch: {} as IssueMutationPatch,
+      };
+    }
+    if (current.checkoutRunId && isLiveRun(current.checkoutRunId)) {
+      throw conflict("Issue run ownership conflict", {
+        issueId: current.id,
+        status: current.status,
+        assigneeAgentId: current.assigneeAgentId,
+        checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
+        actorAgentId,
+        actorRunId,
+      });
+    }
+    if (
+      current.executionRunId &&
+      current.executionRunId !== current.checkoutRunId &&
+      current.executionRunId !== actorRunId &&
+      isLiveRun(current.executionRunId)
+    ) {
+      throw conflict("Issue run ownership conflict", {
+        issueId: current.id,
+        status: current.status,
+        assigneeAgentId: current.assigneeAgentId,
+        checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
+        actorAgentId,
+        actorRunId,
+      });
+    }
+
+    return {
+      ...current,
+      checkoutRunId: actorRunId,
+      executionRunId: actorRunId,
+      adoptedFromRunId: current.checkoutRunId,
+      issuePatch: {
+        checkoutRunId: actorRunId,
+        executionRunId: actorRunId,
+        executionLockedAt: new Date(),
+      } as IssueMutationPatch,
+    };
+  }
+
+  type IssueUpdateMutationData = Partial<typeof issues.$inferInsert> & {
+    labelIds?: string[];
+    blockedByIssueIds?: string[];
+    actorAgentId?: string | null;
+    actorUserId?: string | null;
+    expectedVersion?: number;
+  };
+
+  type AddIssueCommentOptions = {
+    authorType?: IssueCommentAuthorType | null;
+    presentation?: IssueCommentPresentation | null;
+    metadata?: IssueCommentMetadata | null;
+    sourceTrust?: typeof issueComments.$inferInsert.sourceTrust;
+    createdAt?: Date | string | null;
+    expectedVersion?: number;
+  };
+
+  async function insertIssueComment(
+    tx: DbTransaction,
+    issue: typeof issues.$inferSelect,
+    body: string,
+    actor: { agentId?: string; userId?: string; runId?: string | null },
+    options?: AddIssueCommentOptions,
+  ): Promise<IssueComment> {
+    const { censorUsernameInLogs } = await instanceSettingsService(
+      tx as unknown as Db,
+    ).getGeneral();
+    const redactedBody = redactCurrentUserText(body, { enabled: censorUsernameInLogs });
+    const authorType = issueCommentAuthorTypeSchema.parse(
+      options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
+    );
+    assertIssueCommentAuthorTypeAllowed(actor, authorType);
+    const presentation = issueCommentPresentationSchema.nullable().parse(
+      options?.presentation ?? null,
+    );
+    const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
+    const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
+    const createdByRunId = await resolveCommentCreatedByRunId(
+      tx,
+      issue.companyId,
+      actor.runId,
+    );
+    if (actor.runId && !createdByRunId) {
+      logger.warn(
+        { issueId: issue.id, companyId: issue.companyId, runId: actor.runId },
+        "dropping invalid createdByRunId for issue comment insert",
+      );
+    }
+
+    const [comment] = await tx
       .insert(issueComments)
       .values({
-        companyId: child.companyId,
-        issueId: parent.id,
-        authorType: "system",
-        body,
+        companyId: issue.companyId,
+        issueId: issue.id,
+        authorAgentId: actor.agentId ?? null,
+        authorUserId: actor.userId ?? null,
+        authorType,
+        createdByRunId,
+        body: redactedBody,
+        presentation,
+        metadata,
+        sourceTrust: options?.sourceTrust ?? null,
+        ...(createdAt && !Number.isNaN(createdAt.getTime())
+          ? { createdAt, updatedAt: createdAt }
+          : {}),
       })
       .returning();
-    await dbOrTx.update(issues).set({ updatedAt: new Date() }).where(eq(issues.id, parent.id));
 
-    return { comment, parent };
+    return redactIssueComment(comment, censorUsernameInLogs);
+  }
+
+  async function addCommentVersioned(
+    issueId: string,
+    body: string,
+    actor: { agentId?: string; userId?: string; runId?: string | null },
+    options?: AddIssueCommentOptions,
+    dbOrTx: any = db,
+  ) {
+    const createdAt = options?.createdAt ? new Date(options.createdAt) : undefined;
+    const mutation = await runIssueMutation(dbOrTx, {
+      issueId,
+      expectedVersion: options?.expectedVersion,
+      now: createdAt && !Number.isNaN(createdAt.getTime()) ? createdAt : undefined,
+      mutate: async (tx, issue) => ({
+        result: await insertIssueComment(tx, issue, body, actor, options),
+      }),
+    });
+    if (!mutation) throw notFound("Issue not found");
+    return { comment: mutation.result, issue: mutation.issue };
+  }
+
+  async function updateWithInlineComment(
+    issueId: string,
+    issueData: IssueUpdateMutationData,
+    commentData: {
+      body: string;
+      actor: { agentId?: string; userId?: string; runId?: string | null };
+      options?: AddIssueCommentOptions;
+      afterUpdate?: (
+        tx: DbTransaction,
+        issue: typeof issues.$inferSelect,
+        comment: IssueComment,
+      ) => Promise<void>;
+      beforeCommit?: (
+        tx: DbTransaction,
+        issue: typeof issues.$inferSelect,
+        comment: IssueComment,
+      ) => Promise<void>;
+    },
+    dbOrTx: DbOrTx = db,
+  ) {
+    const execute = async (tx: DbTransaction) => {
+      const updated = await issueService(tx as unknown as Db).update(issueId, issueData, tx);
+      if (!updated) return null;
+      const comment = await insertIssueComment(
+        tx,
+        updated,
+        commentData.body,
+        commentData.actor,
+        commentData.options,
+      );
+      await commentData.afterUpdate?.(tx, updated, comment);
+      await commentData.beforeCommit?.(tx, updated, comment);
+      return { issue: updated, comment };
+    };
+    if ("rollback" in dbOrTx) return await execute(dbOrTx);
+    return await dbOrTx.transaction(execute);
+  }
+
+  class IssueCommentMutationMissingError extends Error {}
+
+  async function removeCommentVersioned(
+    commentId: string,
+    options?: {
+      expectedVersion?: number;
+      dbOrTx?: DbOrTx;
+      issuePatch?: IssueMutationPatch;
+    },
+  ) {
+    const dbOrTx = options?.dbOrTx ?? db;
+    const target = await dbOrTx
+      .select({ issueId: issueComments.issueId })
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId))
+      .then((rows) => rows[0] ?? null);
+    if (!target) return null;
+
+    try {
+      const mutation = await runIssueMutation(dbOrTx, {
+        issueId: target.issueId,
+        expectedVersion: options?.expectedVersion,
+        mutate: async (tx) => {
+          const { censorUsernameInLogs } = await instanceSettingsService(
+            tx as unknown as Db,
+          ).getGeneral();
+          const [comment] = await tx
+            .delete(issueComments)
+            .where(eq(issueComments.id, commentId))
+            .returning();
+          if (!comment) throw new IssueCommentMutationMissingError();
+          return {
+            issuePatch: options?.issuePatch,
+            result: redactIssueComment(comment, censorUsernameInLogs),
+          };
+        },
+      });
+      if (!mutation) return null;
+      return { comment: mutation.result, issue: mutation.issue };
+    } catch (error) {
+      if (error instanceof IssueCommentMutationMissingError) return null;
+      throw error;
+    }
+  }
+
+  async function tombstoneCommentVersioned(
+    commentId: string,
+    actor: {
+      actorType: "agent" | "user";
+      agentId?: string | null;
+      userId?: string | null;
+      runId?: string | null;
+    },
+    options?: {
+      expectedVersion?: number;
+      afterTombstone?: (comment: IssueComment, tx: any) => Promise<void>;
+      dbOrTx?: DbOrTx;
+      issuePatch?: IssueMutationPatch;
+    },
+  ) {
+    const dbOrTx = options?.dbOrTx ?? db;
+    const target = await dbOrTx
+      .select({ issueId: issueComments.issueId })
+      .from(issueComments)
+      .where(eq(issueComments.id, commentId))
+      .then((rows) => rows[0] ?? null);
+    if (!target) return null;
+
+    const now = new Date();
+    try {
+      const mutation = await runIssueMutation(dbOrTx, {
+        issueId: target.issueId,
+        expectedVersion: options?.expectedVersion,
+        now,
+        mutate: async (tx) => {
+          const { censorUsernameInLogs } = await instanceSettingsService(
+            tx as unknown as Db,
+          ).getGeneral();
+          const [comment] = await tx
+            .update(issueComments)
+            .set({
+              body: DELETED_ISSUE_COMMENT_BODY,
+              presentation: null,
+              metadata: null,
+              deletedAt: now,
+              deletedByType: actor.actorType,
+              deletedByAgentId: actor.actorType === "agent" ? actor.agentId ?? null : null,
+              deletedByUserId: actor.actorType === "user" ? actor.userId ?? null : null,
+              deletedByRunId: actor.runId ?? null,
+              updatedAt: now,
+            })
+            .where(and(eq(issueComments.id, commentId), isNull(issueComments.deletedAt)))
+            .returning();
+          if (!comment) throw new IssueCommentMutationMissingError();
+
+          const redacted = redactIssueComment(comment, censorUsernameInLogs);
+          await options?.afterTombstone?.(redacted, tx);
+          return { issuePatch: options?.issuePatch, result: redacted };
+        },
+      });
+      if (!mutation) return null;
+      return { comment: mutation.result, issue: mutation.issue };
+    } catch (error) {
+      if (error instanceof IssueCommentMutationMissingError) return null;
+      throw error;
+    }
   }
 
   return {
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
     addStopRelayCommentIfNeeded,
+    assertCheckoutOwnerInTransaction,
+    addCommentVersioned,
+    removeCommentVersioned,
+    tombstoneCommentVersioned,
+    updateWithInlineComment,
 
     list: async (companyId: string, filters?: IssueFilters) => {
       if (filters?.attention === "blocked") {
@@ -6564,34 +6937,30 @@ export function issueService(db: Db) {
 
     update: async (
       id: string,
-      data: Partial<typeof issues.$inferInsert> & {
-        labelIds?: string[];
-        blockedByIssueIds?: string[];
-        actorAgentId?: string | null;
-        actorUserId?: string | null;
-      },
+      data: IssueUpdateMutationData,
       dbOrTx: any = db,
     ) => {
-      const existing = await dbOrTx
-        .select()
-        .from(issues)
-        .where(eq(issues.id, id))
-        .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
-      if (!existing) return null;
-
       const {
         labelIds: nextLabelIds,
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        expectedVersion,
         ...issueData
       } = data;
-      const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
-      if (!isolatedWorkspacesEnabled) {
-        delete issueData.executionWorkspaceId;
-        delete issueData.executionWorkspacePreference;
-        delete issueData.executionWorkspaceSettings;
-      }
+
+      const mutation = await runIssueMutation(dbOrTx, {
+        issueId: id,
+        expectedVersion,
+        mutate: async (tx, existing) => {
+          const isolatedWorkspacesEnabled = (
+            await instanceSettingsService(tx as unknown as Db).getExperimental()
+          ).enableIsolatedWorkspaces;
+          if (!isolatedWorkspacesEnabled) {
+            delete issueData.executionWorkspaceId;
+            delete issueData.executionWorkspacePreference;
+            delete issueData.executionWorkspaceSettings;
+          }
 
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
@@ -6626,9 +6995,9 @@ export function issueService(db: Db) {
       }
       if (patch.status === "in_progress") {
         const unresolvedBlockerIssueIds = blockedByIssueIds !== undefined
-          ? await listUnresolvedBlockerIssueIds(dbOrTx, existing.companyId, blockedByIssueIds)
+        ? await listUnresolvedBlockerIssueIds(tx, existing.companyId, blockedByIssueIds)
           : (
-              await listIssueDependencyReadinessMap(dbOrTx, existing.companyId, [id])
+            await listIssueDependencyReadinessMap(tx, existing.companyId, [id])
             ).get(id)?.unresolvedBlockerIssueIds ?? [];
         if (unresolvedBlockerIssueIds.length > 0) {
           throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
@@ -6638,10 +7007,10 @@ export function issueService(db: Db) {
         Boolean(nextAssigneeAgentId) &&
         (issueData.assigneeAgentId !== undefined || patch.status === "in_progress");
       if (shouldValidateNextAssignee) {
-        await assertAssignableAgent(dbOrTx as Db, existing.companyId, nextAssigneeAgentId, { kind: "work" });
+        await assertAssignableAgent(db, existing.companyId, nextAssigneeAgentId, { kind: "work" });
       }
       if (issueData.assigneeUserId) {
-        await assertAssignableUser(existing.companyId, issueData.assigneeUserId);
+        await assertAssignableUser(existing.companyId, issueData.assigneeUserId, tx);
       }
       let nextProjectId = issueData.projectId !== undefined ? issueData.projectId : existing.projectId;
       const nextProjectWorkspaceId =
@@ -6664,25 +7033,25 @@ export function issueService(db: Db) {
       let validatedProjectWorkspace: { projectId: string } | null = null;
       let validatedExecutionWorkspace: { projectId: string } | null = null;
       if (!nextProjectId && nextProjectWorkspaceId) {
-        const workspace = await assertValidProjectWorkspace(existing.companyId, null, nextProjectWorkspaceId);
+        const workspace = await assertValidProjectWorkspace(existing.companyId, null, nextProjectWorkspaceId, tx);
         validatedProjectWorkspace = workspace;
         nextProjectId = workspace.projectId;
         patch.projectId = workspace.projectId;
       }
       if (!nextProjectId && nextExecutionWorkspaceId) {
-        const workspace = await assertValidExecutionWorkspace(existing.companyId, null, nextExecutionWorkspaceId);
+        const workspace = await assertValidExecutionWorkspace(existing.companyId, null, nextExecutionWorkspaceId, tx);
         validatedExecutionWorkspace = workspace;
         nextProjectId = workspace.projectId;
         patch.projectId = workspace.projectId;
       }
       if (nextProjectWorkspaceId) {
         if (!validatedProjectWorkspace) {
-          await assertValidProjectWorkspace(existing.companyId, nextProjectId, nextProjectWorkspaceId);
+          await assertValidProjectWorkspace(existing.companyId, nextProjectId, nextProjectWorkspaceId, tx);
         }
       }
       if (nextExecutionWorkspaceId) {
         if (!validatedExecutionWorkspace) {
-          await assertValidExecutionWorkspace(existing.companyId, nextProjectId, nextExecutionWorkspaceId);
+          await assertValidExecutionWorkspace(existing.companyId, nextProjectId, nextExecutionWorkspaceId, tx);
         }
       }
       if (isolatedWorkspacesEnabled && issueData.executionWorkspaceSettings !== undefined) {
@@ -6718,147 +7087,155 @@ export function issueService(db: Db) {
         patch.executionLockedAt = null;
       }
 
-      const runUpdate = async (tx: any) => {
-        const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
-        const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
-          getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),
-          getProjectDefaultGoalId(
-            tx,
-            existing.companyId,
-            issueData.projectId !== undefined ? issueData.projectId : existing.projectId,
-          ),
-        ]);
+          const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
+          const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
+            getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),
+            getProjectDefaultGoalId(
+              tx,
+              existing.companyId,
+              issueData.projectId !== undefined ? issueData.projectId : existing.projectId,
+            ),
+          ]);
 
-        patch.goalId = resolveNextIssueGoalId({
-          currentProjectId: existing.projectId,
-          currentGoalId: existing.goalId,
-          currentProjectGoalId,
-          projectId: issueData.projectId,
-          goalId: issueData.goalId,
-          projectGoalId: nextProjectGoalId,
-          defaultGoalId: defaultCompanyGoal?.id ?? null,
-        });
-        const updated = await tx
-          .update(issues)
-          .set(patch)
-          .where(eq(issues.id, id))
-          .returning()
-          .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
-        if (!updated) return null;
-        if (existing.status !== updated.status) {
-          if (updated.status === "done" || updated.status === "cancelled") {
-            await finalizeSummarySlotsForTerminalIssue(tx, updated);
-            // Every terminal transition funnels through here, including direct
-            // service callers (tree control, recovery, pipelines, status cards)
-            // that never touch the HTTP routes, so pending interaction cards
-            // cannot outlive their issue. Dynamic import breaks the module
-            // cycle (issue-thread-interactions.js imports issueService).
-            const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
-            const expiredInteractions = await issueThreadInteractionService(tx).expirePendingInteractionsForTerminalIssue(
-              updated,
-              { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
-            );
-            for (const interaction of expiredInteractions) {
-              await logActivity(tx as unknown as Db, {
-                companyId: updated.companyId,
-                actorType: actorAgentId ? "agent" : actorUserId ? "user" : "system",
-                actorId: actorAgentId ?? actorUserId ?? "issue_service",
-                agentId: actorAgentId ?? null,
-                action: "issue.thread_interaction_expired",
-                entityType: "issue",
-                entityId: updated.id,
-                details: {
-                  identifier: updated.identifier ?? null,
-                  interactionId: interaction.id,
-                  interactionKind: interaction.kind,
-                  interactionStatus: interaction.status,
-                  source: "issue.status_transition.issue_closed",
-                  result: interaction.result ?? null,
-                },
+          patch.goalId = resolveNextIssueGoalId({
+            currentProjectId: existing.projectId,
+            currentGoalId: existing.goalId,
+            currentProjectGoalId,
+            projectId: issueData.projectId,
+            goalId: issueData.goalId,
+            projectGoalId: nextProjectGoalId,
+            defaultGoalId: defaultCompanyGoal?.id ?? null,
+          });
+          const nextIssue = { ...existing, ...patch };
+          const nextStatus = nextIssue.status;
+          if (existing.status !== nextStatus) {
+            if (nextStatus === "done" || nextStatus === "cancelled") {
+              const terminalIssue = {
+                id: nextIssue.id,
+                companyId: nextIssue.companyId,
+                identifier: nextIssue.identifier,
+                title: nextIssue.title,
+                status: nextStatus,
+              } as const;
+              await finalizeSummarySlotsForTerminalIssue(tx, terminalIssue);
+              // Every terminal transition funnels through here, including direct
+              // service callers that never touch the HTTP routes. Dynamic import
+              // breaks the cycle because issue-thread-interactions imports issues.
+              const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+              const expiredInteractions = await issueThreadInteractionService(
+                tx as unknown as Db,
+              ).expirePendingInteractionsForTerminalIssue(
+                terminalIssue,
+                { agentId: actorAgentId ?? null, userId: actorUserId ?? null },
+                { touchIssueVersion: false },
+              );
+              for (const interaction of expiredInteractions) {
+                await logActivity(tx as unknown as Db, {
+                  companyId: nextIssue.companyId,
+                  actorType: actorAgentId ? "agent" : actorUserId ? "user" : "system",
+                  actorId: actorAgentId ?? actorUserId ?? "issue_service",
+                  agentId: actorAgentId ?? null,
+                  action: "issue.thread_interaction_expired",
+                  entityType: "issue",
+                  entityId: nextIssue.id,
+                  details: {
+                    identifier: nextIssue.identifier ?? null,
+                    interactionId: interaction.id,
+                    interactionKind: interaction.kind,
+                    interactionStatus: interaction.status,
+                    source: "issue.status_transition.issue_closed",
+                    result: interaction.result ?? null,
+                  },
+                });
+              }
+            }
+            // A stalled status-card generation task must release its claim so
+            // the board tile stops spinning and offers "Run now" again.
+            if (
+              nextStatus === "done" ||
+              nextStatus === "cancelled" ||
+              nextStatus === "blocked"
+            ) {
+              await finalizeStatusCardsForStalledGeneration(tx, {
+                id: nextIssue.id,
+                companyId: nextIssue.companyId,
+                identifier: nextIssue.identifier,
+                title: nextIssue.title,
+                status: nextStatus,
               });
             }
           }
-          // A status-card generation task that goes done/cancelled/blocked stops
-          // making progress; release the card's generation claim so the board tile
-          // stops spinning and offers "Run now" again (blocked = stuck on a human).
+          if (nextLabelIds !== undefined) {
+            await syncIssueLabels(existing.id, existing.companyId, nextLabelIds, tx);
+          }
+          if (blockedByIssueIds !== undefined) {
+            await syncBlockedByIssueIds(
+              existing.id,
+              existing.companyId,
+              blockedByIssueIds,
+              {
+                agentId: actorAgentId ?? null,
+                userId: actorUserId ?? null,
+              },
+              tx,
+            );
+          }
           if (
-            updated.status === "done" ||
-            updated.status === "cancelled" ||
-            updated.status === "blocked"
+            issueData.executionWorkspaceSettings !== undefined &&
+            nextExecutionWorkspaceId &&
+            nextExecutionWorkspacePreference === "reuse_existing"
           ) {
-            await finalizeStatusCardsForStalledGeneration(tx, updated);
-          }
-        }
-        if (nextLabelIds !== undefined) {
-          await syncIssueLabels(updated.id, existing.companyId, nextLabelIds, tx);
-        }
-        if (blockedByIssueIds !== undefined) {
-          await syncBlockedByIssueIds(
-            updated.id,
-            existing.companyId,
-            blockedByIssueIds,
-            {
-              agentId: actorAgentId ?? null,
-              userId: actorUserId ?? null,
-            },
-            tx,
-          );
-        }
-        if (
-          issueData.executionWorkspaceSettings !== undefined &&
-          nextExecutionWorkspaceId &&
-          nextExecutionWorkspacePreference === "reuse_existing"
-        ) {
-          const workspace = await tx
-            .select({
-              id: executionWorkspaces.id,
-              metadata: executionWorkspaces.metadata,
-            })
-            .from(executionWorkspaces)
-            .where(
-              and(
-                eq(executionWorkspaces.id, nextExecutionWorkspaceId),
-                eq(executionWorkspaces.companyId, existing.companyId),
-              ),
-            )
-            .then((rows: Array<{ id: string; metadata: unknown }>) => rows[0] ?? null);
-          if (workspace) {
-            await tx
-              .update(executionWorkspaces)
-              .set({
-                metadata: mergeExecutionWorkspaceConfig(
-                  (workspace.metadata as Record<string, unknown> | null) ?? null,
-                  buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(nextExecutionWorkspaceSettings),
-                ),
-                updatedAt: new Date(),
+            const workspace = await tx
+              .select({
+                id: executionWorkspaces.id,
+                metadata: executionWorkspaces.metadata,
               })
-              .where(eq(executionWorkspaces.id, workspace.id));
-          }
-        }
-        const [enriched] = await withIssueLabels(tx, [updated]);
-        if (
-          (issueData.status === "done" || issueData.status === "cancelled") &&
-          existing.status !== issueData.status &&
-          existing.originKind === RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation
-        ) {
-          const parsedIncident = parseIssueGraphLivenessIncidentKey(existing.originId);
-          if (parsedIncident?.issueId && parsedIncident.companyId === existing.companyId) {
-            await tx
-              .delete(issueRelations)
+              .from(executionWorkspaces)
               .where(
                 and(
-                  eq(issueRelations.companyId, existing.companyId),
-                  eq(issueRelations.issueId, existing.id),
-                  eq(issueRelations.relatedIssueId, parsedIncident.issueId),
-                  eq(issueRelations.type, "blocks"),
+                  eq(executionWorkspaces.id, nextExecutionWorkspaceId),
+                  eq(executionWorkspaces.companyId, existing.companyId),
                 ),
-              );
+              )
+              .then((rows: Array<{ id: string; metadata: unknown }>) => rows[0] ?? null);
+            if (workspace) {
+              await tx
+                .update(executionWorkspaces)
+                .set({
+                  metadata: mergeExecutionWorkspaceConfig(
+                    (workspace.metadata as Record<string, unknown> | null) ?? null,
+                    buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(nextExecutionWorkspaceSettings),
+                  ),
+                  updatedAt: new Date(),
+                })
+                .where(eq(executionWorkspaces.id, workspace.id));
+            }
           }
-        }
-        return enriched;
-      };
-
-      return dbOrTx === db ? db.transaction(runUpdate) : runUpdate(dbOrTx);
+          if (
+            (issueData.status === "done" || issueData.status === "cancelled") &&
+            existing.status !== issueData.status &&
+            existing.originKind === RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation
+          ) {
+            const parsedIncident = parseIssueGraphLivenessIncidentKey(existing.originId);
+            if (parsedIncident?.issueId && parsedIncident.companyId === existing.companyId) {
+              await tx
+                .delete(issueRelations)
+                .where(
+                  and(
+                    eq(issueRelations.companyId, existing.companyId),
+                    eq(issueRelations.issueId, existing.id),
+                    eq(issueRelations.relatedIssueId, parsedIncident.issueId),
+                    eq(issueRelations.type, "blocks"),
+                  ),
+                );
+            }
+          }
+          return { issuePatch: patch, result: null };
+        },
+      });
+      if (!mutation) return null;
+      const [enriched] = await withIssueLabels(dbOrTx, [mutation.issue]);
+      return enriched;
     },
 
     clearExecutionWorkspaceEnvironmentSelection: async (companyId: string, environmentId: string) => {
@@ -6880,13 +7257,12 @@ export function issueService(db: Db) {
 
         await db
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             executionWorkspaceSettings: {
               ...settings,
               environmentId: null,
-            },
-            updatedAt: new Date(),
-          })
+            }
+          }, new Date()))
           .where(eq(issues.id, row.id));
         cleared += 1;
       }
@@ -6972,15 +7348,14 @@ export function issueService(db: Db) {
         : isNull(issues.executionRunId);
       const updated = await db
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           assigneeAgentId: agentId,
           assigneeUserId: null,
           checkoutRunId,
           executionRunId: checkoutRunId,
           status: "in_progress",
-          startedAt: now,
-          updatedAt: now,
-        })
+          startedAt: now
+        }, now))
         .where(
           and(
             eq(issues.id, id),
@@ -7020,11 +7395,10 @@ export function issueService(db: Db) {
       ) {
         const adopted = await db
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             checkoutRunId,
-            executionRunId: checkoutRunId,
-            updatedAt: new Date(),
-          })
+            executionRunId: checkoutRunId
+          }, new Date()))
           .where(
             and(
               eq(issues.id, id),
@@ -7086,7 +7460,7 @@ export function issueService(db: Db) {
           }
           const adopted = await db
             .update(issues)
-            .set(adoptionSet)
+            .set(versionedIssuePatch(adoptionSet))
             .where(
               and(
                 eq(issues.id, id),
@@ -7306,15 +7680,14 @@ export function issueService(db: Db) {
         const releaseStatus = existing.status === "in_progress" ? "todo" : existing.status;
         const updated = await tx
           .update(issues)
-          .set({
+          .set(versionedIssuePatch({
             status: releaseStatus,
             assigneeAgentId: null,
             checkoutRunId: null,
             executionRunId: null,
             executionAgentNameKey: null,
-            executionLockedAt: null,
-            updatedAt: new Date(),
-          })
+            executionLockedAt: null
+          }, new Date()))
           .where(eq(issues.id, id))
           .returning()
           .then((rows) => rows[0] ?? null);
@@ -7352,7 +7725,7 @@ export function issueService(db: Db) {
 
         const updated = await tx
           .update(issues)
-          .set(patch)
+          .set(versionedIssuePatch(patch))
           .where(eq(issues.id, id))
           .returning()
           .then((rows) => rows[0] ?? null);
@@ -7502,27 +7875,10 @@ export function issueService(db: Db) {
       return redactIssueComment(enrichedComment ?? comment, censorUsernameInLogs);
     },
 
-    removeComment: async (commentId: string) => {
-      const currentUserRedactionOptions = {
-        enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
-      };
-
-      return db.transaction(async (tx) => {
-        const [comment] = await tx
-          .delete(issueComments)
-          .where(eq(issueComments.id, commentId))
-          .returning();
-
-        if (!comment) return null;
-
-        await tx
-          .update(issues)
-          .set({ updatedAt: new Date() })
-          .where(eq(issues.id, comment.issueId));
-
-        return redactIssueComment(comment, currentUserRedactionOptions.enabled);
-      });
-    },
+    removeComment: async (
+      commentId: string,
+      options?: { expectedVersion?: number },
+    ) => (await removeCommentVersioned(commentId, options))?.comment ?? null,
 
     tombstoneComment: async (
       commentId: string,
@@ -7533,110 +7889,18 @@ export function issueService(db: Db) {
         runId?: string | null;
       },
       options?: {
+        expectedVersion?: number;
         afterTombstone?: (comment: IssueComment, tx: any) => Promise<void>;
       },
-    ) => {
-      const currentUserRedactionOptions = {
-        enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
-      };
-
-      return db.transaction(async (tx) => {
-        const now = new Date();
-        const [comment] = await tx
-          .update(issueComments)
-          .set({
-            body: DELETED_ISSUE_COMMENT_BODY,
-            presentation: null,
-            metadata: null,
-            deletedAt: now,
-            deletedByType: actor.actorType,
-            deletedByAgentId: actor.actorType === "agent" ? actor.agentId ?? null : null,
-            deletedByUserId: actor.actorType === "user" ? actor.userId ?? null : null,
-            deletedByRunId: actor.runId ?? null,
-            updatedAt: now,
-          })
-          .where(and(eq(issueComments.id, commentId), isNull(issueComments.deletedAt)))
-          .returning();
-
-        if (!comment) return null;
-
-        await tx
-          .update(issues)
-          .set({ updatedAt: now })
-          .where(eq(issues.id, comment.issueId));
-
-        const redacted = redactIssueComment(comment, currentUserRedactionOptions.enabled);
-        await options?.afterTombstone?.(redacted, tx);
-
-        return redacted;
-      });
-    },
+    ) => (await tombstoneCommentVersioned(commentId, actor, options))?.comment ?? null,
 
     addComment: async (
       issueId: string,
       body: string,
       actor: { agentId?: string; userId?: string; runId?: string | null },
-      options?: {
-        authorType?: IssueCommentAuthorType | null;
-        presentation?: IssueCommentPresentation | null;
-        metadata?: IssueCommentMetadata | null;
-        sourceTrust?: typeof issueComments.$inferInsert.sourceTrust;
-        createdAt?: Date | string | null;
-      },
+      options?: AddIssueCommentOptions,
       dbOrTx: any = db,
-    ) => {
-      const issue = await dbOrTx
-        .select({ companyId: issues.companyId })
-        .from(issues)
-        .where(eq(issues.id, issueId))
-        .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
-
-      if (!issue) throw notFound("Issue not found");
-
-      const currentUserRedactionOptions = {
-        enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
-      };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
-      const authorType = issueCommentAuthorTypeSchema.parse(
-        options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
-      );
-      assertIssueCommentAuthorTypeAllowed(actor, authorType);
-      const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
-      const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
-      const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
-      // Invalid/stale run ids must not 500 the insert — null out unknowns.
-      const createdByRunId = await resolveCommentCreatedByRunId(dbOrTx, issue.companyId, actor.runId);
-      if (actor.runId && !createdByRunId) {
-        logger.warn(
-          { issueId, companyId: issue.companyId, runId: actor.runId },
-          "dropping invalid createdByRunId for issue comment insert",
-        );
-      }
-      const [comment] = await dbOrTx
-        .insert(issueComments)
-        .values({
-          companyId: issue.companyId,
-          issueId,
-          authorAgentId: actor.agentId ?? null,
-          authorUserId: actor.userId ?? null,
-          authorType,
-          createdByRunId,
-          body: redactedBody,
-          presentation,
-          metadata,
-          sourceTrust: options?.sourceTrust ?? null,
-          ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
-        })
-        .returning();
-
-      // Update issue's updatedAt so comment activity is reflected in recency sorting
-      await dbOrTx
-        .update(issues)
-        .set({ updatedAt: new Date() })
-        .where(eq(issues.id, issueId));
-
-      return redactIssueComment(comment, currentUserRedactionOptions.enabled);
-    },
+    ) => (await addCommentVersioned(issueId, body, actor, options, dbOrTx)).comment,
 
     createAttachment: async (input: {
       issueId: string;

--- a/server/src/services/pipelines.ts
+++ b/server/src/services/pipelines.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  runIssueMutation,
+  versionedIssuePatch,
+} from "./issue-versioning.js";
 import { isDeepStrictEqual } from "node:util";
 import { and, asc, desc, eq, inArray, isNotNull, isNull, ne, or, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
@@ -1932,13 +1936,18 @@ async function postSystemCommentOnLinkedIssues(
     ));
 
   for (const row of rows) {
-    await db.insert(issueComments).values({
-      companyId: input.companyId,
+    await runIssueMutation(db, {
       issueId: row.issueId,
-      authorType: "system",
-      body: input.body,
+      mutate: async (tx) => {
+        await tx.insert(issueComments).values({
+          companyId: input.companyId,
+          issueId: row.issueId,
+          authorType: "system",
+          body: input.body,
+        });
+        return { result: null };
+      },
     });
-    await db.update(issues).set({ updatedAt: nowDate() }).where(eq(issues.id, row.issueId));
   }
 }
 
@@ -2047,13 +2056,18 @@ async function notifyDependentWorkIssuesOfUpstreamContentChange(
     for (const issueId of issueIds) {
       if (notifiedIssueIds.has(issueId)) continue;
       notifiedIssueIds.add(issueId);
-      await db.insert(issueComments).values({
-        companyId: input.companyId,
+      await runIssueMutation(db, {
         issueId,
-        authorType: "system",
-        body,
+        mutate: async (tx) => {
+          await tx.insert(issueComments).values({
+            companyId: input.companyId,
+            issueId,
+            authorType: "system",
+            body,
+          });
+          return { result: null };
+        },
       });
-      await db.update(issues).set({ updatedAt: nowDate() }).where(eq(issues.id, issueId));
     }
     // The drift event intentionally does not bump the dependent case's
     // updatedAt: "unresolved drift" is derived as event.createdAt > case.updatedAt.
@@ -4615,7 +4629,7 @@ export function pipelineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeu
         if (issueIdsToCancel.length > 0) {
           const cancelledIssues = await tx
             .update(issues)
-            .set({ status: "cancelled", updatedAt: now })
+            .set(versionedIssuePatch({ status: "cancelled" }, now))
             .where(and(
               eq(issues.companyId, input.companyId),
               inArray(issues.id, issueIdsToCancel),

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1,4 +1,5 @@
 import type { Db } from "@paperclipai/db";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import {
   activityLog,
   agentTaskSessions as agentTaskSessionsTable,
@@ -2890,7 +2891,7 @@ export function buildHostServices(
           else delete executionPolicy.authorizationPolicy;
           await db
             .update(issuesTable)
-            .set({ executionPolicy, updatedAt: new Date() })
+            .set(versionedIssuePatch({ executionPolicy }, new Date()))
             .where(eq(issuesTable.id, issue.id));
         } else {
           const company = await companies.getById(params.resourceId);

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,4 +1,5 @@
 import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
 import {
@@ -391,16 +392,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     body: string,
     generatedAt: Date,
   ) {
-    const comment = await issuesSvc.addComment(reviewIssueId, body, {});
-    await db
-      .update(issueComments)
-      .set({ createdAt: generatedAt, updatedAt: generatedAt })
-      .where(eq(issueComments.id, comment.id));
-    await db
-      .update(issues)
-      .set({ updatedAt: generatedAt })
-      .where(eq(issues.id, reviewIssueId));
-    return comment;
+    return await issuesSvc.addComment(reviewIssueId, body, {}, { createdAt: generatedAt });
   }
 
   async function countIssueRunsSince(companyId: string, agentId: string, issueId: string, since: Date) {
@@ -777,7 +769,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     }
     await db
       .update(issues)
-      .set({ createdAt: evidence.generatedAt, updatedAt: evidence.generatedAt })
+      .set(versionedIssuePatch({ createdAt: evidence.generatedAt }, evidence.generatedAt))
       .where(eq(issues.id, review.id));
 
     await logActivity(db, {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,5 @@
 import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { versionedIssuePatch } from "../issue-versioning.js";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -1611,12 +1612,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       await tx
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           executionRunId: null,
           executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: input.now,
-        })
+          executionLockedAt: null
+        }, input.now))
         .where(
           and(
             eq(issues.id, input.sourceIssue.id),
@@ -5346,13 +5346,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       const updated = await db
         .update(issues)
-        .set({
+        .set(versionedIssuePatch({
           checkoutRunId: null,
           executionRunId: null,
           executionAgentNameKey: null,
-          executionLockedAt: null,
-          updatedAt: new Date(),
-        })
+          executionLockedAt: null
+        }, new Date()))
         .where(
           and(
             eq(issues.id, issue.id),

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { versionedIssuePatch } from "./issue-versioning.js";
 import { and, asc, eq, gte, inArray, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -1357,7 +1358,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       if (!shouldReopen && watchdogIssue.originFingerprint !== input.classification.stopFingerprint) {
         await db
           .update(issues)
-          .set({ originFingerprint: input.classification.stopFingerprint, updatedAt: new Date() })
+          .set(versionedIssuePatch({ originFingerprint: input.classification.stopFingerprint }, new Date()))
           .where(and(eq(issues.companyId, input.watchdog.companyId), eq(issues.id, watchdogIssue.id)));
         watchdogIssue.originFingerprint = input.classification.stopFingerprint;
       }

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -2,6 +2,7 @@ import { and, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { issueWorkProducts } from "@paperclipai/db";
 import type { IssueWorkProduct } from "@paperclipai/shared";
+import { bumpIssueVersions } from "./issue-versioning.js";
 
 type IssueWorkProductRow = typeof issueWorkProducts.$inferSelect;
 
@@ -65,7 +66,7 @@ export function workProductService(db: Db) {
               ),
             );
         }
-        return await tx
+        const created = await tx
           .insert(issueWorkProducts)
           .values({
             ...data,
@@ -74,6 +75,10 @@ export function workProductService(db: Db) {
           })
           .returning()
           .then((rows) => rows[0] ?? null);
+        if (created) {
+          await bumpIssueVersions(tx, [issueId]);
+        }
+        return created;
       });
       return row ? toIssueWorkProduct(row) : null;
     },
@@ -84,6 +89,7 @@ export function workProductService(db: Db) {
           .select()
           .from(issueWorkProducts)
           .where(eq(issueWorkProducts.id, id))
+          .for("update")
           .then((rows) => rows[0] ?? null);
         if (!existing) return null;
 
@@ -100,22 +106,32 @@ export function workProductService(db: Db) {
             );
         }
 
-        return await tx
+        const updated = await tx
           .update(issueWorkProducts)
           .set({ ...patch, updatedAt: new Date() })
           .where(eq(issueWorkProducts.id, id))
           .returning()
           .then((rows) => rows[0] ?? null);
+        if (updated) {
+          await bumpIssueVersions(tx, [existing.issueId]);
+        }
+        return updated;
       });
       return row ? toIssueWorkProduct(row) : null;
     },
 
     remove: async (id: string) => {
-      const row = await db
-        .delete(issueWorkProducts)
-        .where(eq(issueWorkProducts.id, id))
-        .returning()
-        .then((rows) => rows[0] ?? null);
+      const row = await db.transaction(async (tx) => {
+        const removed = await tx
+          .delete(issueWorkProducts)
+          .where(eq(issueWorkProducts.id, id))
+          .returning()
+          .then((rows) => rows[0] ?? null);
+        if (removed) {
+          await bumpIssueVersions(tx, [removed.issueId]);
+        }
+        return removed;
+      });
       return row ? toIssueWorkProduct(row) : null;
     },
   };

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { runIssueMutation } from "./issue-versioning.js";
 import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -1176,44 +1177,50 @@ async function writeDirtyQuarantineAuditComments(input: {
   let claimantAuditCommentId: string | null = null;
   const now = new Date();
   if (input.evidence.sourceIssueId) {
-    const [sourceComment] = await input.db
-      .insert(issueComments)
-      .values({
-        companyId: input.companyId,
-        issueId: input.evidence.sourceIssueId,
-        authorAgentId: null,
-        authorUserId: null,
-        authorType: "system",
-        createdByRunId: input.heartbeatRunId,
-        body,
-      })
-      .returning({ id: issueComments.id });
-    sourceAuditCommentId = sourceComment?.id ?? null;
-    await input.db
-      .update(issues)
-      .set({ updatedAt: now })
-      .where(eq(issues.id, input.evidence.sourceIssueId));
+    const mutation = await runIssueMutation(input.db, {
+      issueId: input.evidence.sourceIssueId,
+      now,
+      mutate: async (tx) => {
+        const [sourceComment] = await tx
+          .insert(issueComments)
+          .values({
+            companyId: input.companyId,
+            issueId: input.evidence.sourceIssueId!,
+            authorAgentId: null,
+            authorUserId: null,
+            authorType: "system",
+            createdByRunId: input.heartbeatRunId,
+            body,
+          })
+          .returning({ id: issueComments.id });
+        return { result: sourceComment?.id ?? null };
+      },
+    });
+    sourceAuditCommentId = mutation?.result ?? null;
   }
 
   const claimantIssueId = input.evidence.contention?.claimedByIssueId ?? null;
   if (claimantIssueId && claimantIssueId !== input.evidence.sourceIssueId) {
-    const [claimantComment] = await input.db
-      .insert(issueComments)
-      .values({
-        companyId: input.companyId,
-        issueId: claimantIssueId,
-        authorAgentId: null,
-        authorUserId: null,
-        authorType: "system",
-        createdByRunId: input.heartbeatRunId,
-        body,
-      })
-      .returning({ id: issueComments.id });
-    claimantAuditCommentId = claimantComment?.id ?? null;
-    await input.db
-      .update(issues)
-      .set({ updatedAt: now })
-      .where(eq(issues.id, claimantIssueId));
+    const mutation = await runIssueMutation(input.db, {
+      issueId: claimantIssueId,
+      now,
+      mutate: async (tx) => {
+        const [claimantComment] = await tx
+          .insert(issueComments)
+          .values({
+            companyId: input.companyId,
+            issueId: claimantIssueId,
+            authorAgentId: null,
+            authorUserId: null,
+            authorType: "system",
+            createdByRunId: input.heartbeatRunId,
+            body,
+          })
+          .returning({ id: issueComments.id });
+        return { result: claimantComment?.id ?? null };
+      },
+    });
+    claimantAuditCommentId = mutation?.result ?? null;
   }
 
   return { sourceAuditCommentId, claimantAuditCommentId };


### PR DESCRIPTION
## Summary

- add a positive `issues.version` column and strong issue ETags
- enforce `If-Match` preconditions for API mutations
- route server issue and comment mutations through single-increment transactional helpers
- add static write-catalog enforcement and concurrency regressions

## Scope boundary

This PR establishes the server/API CAS foundation only. Direct worktree CLI mutations are not yet covered by the static scan or shared mutation boundary.

A follow-up prerequisite will move the reusable versioned patch helper into `@paperclipai/db`, cover CLI quarantine and history-import mutations, and expand enforcement across all production write roots. Global mutation authority must not be claimed, and coordination-fabric integration must not begin, until that prerequisite merges.

## Validation

- database and server typechecks
- migration and static write-catalog gates
- 174 high-risk regression assertions
- independent review with no remaining material findings