### PR TITLE
test(issues): guard the blockerAttention early-warning against cancelled-child noise

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -298,6 +298,50 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention?.sampleBlockerIdentifier).not.toBe("PBD-4");
   });
 
+  it("flags a blocked issue that has no blocker edges at all", async () => {
+    const { companyId, agentId } = await createCompany("PBE");
+    const issueId = await insertIssue({
+      companyId,
+      identifier: "PBE-1",
+      title: "Blocked in prose only",
+      status: "blocked",
+      assigneeAgentId: agentId,
+      description: "Waiting on the vendor, no first-class blocker recorded.",
+    });
+
+    const issue = (await svc.list(companyId, { status: "blocked" })).find((row) => row.id === issueId);
+
+    expect(issue?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 0,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+    });
+  });
+
+  it("keeps a blocked parent attention-needed when its only child was cancelled", async () => {
+    const { companyId, agentId } = await createCompany("PBF");
+    const parentId = await insertIssue({ companyId, identifier: "PBF-1", title: "Parent", status: "blocked" });
+    await insertIssue({
+      companyId,
+      identifier: "PBF-2",
+      title: "Cancelled child",
+      status: "cancelled",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 0,
+    });
+  });
+
   it("covers recursive blocker chains when the downstream leaf has active work", async () => {
     const { companyId, agentId } = await createCompany("PBR");
     const parentId = await insertIssue({ companyId, identifier: "PBR-1", title: "Parent", status: "blocked" });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents in companies where no human watches the board continuously.
> - `blockerAttention` is the early-warning system for blocked issues: it distinguishes a blocked issue that has a live path from one that is blocked in prose only, with no first-class blocker and therefore no wake path.
> - The graph it walks is `explicit blockedBy edges ∪ non-terminal direct children`.
> - #7577 correctly made cancelled direct children terminal, because a cancelled child is neither a dependency nor a source of liveness — before that fix a cancelled child pinned its parent to `needs_attention` forever, since a cancelled issue never becomes `done`.
> - Two contract branches around that behaviour had no assertion in the suite, so nothing pins the signal's two ends: the pure early-warning case (blocked, zero edges) and the cancelled-child edge count in isolation.
> - This PR adds those two guards. It is test-only; no behaviour changes.

## Linked Issues or Issue Description

Refs #7578 (the cancelled-child defect fixed by #7577).

**Issue this addresses:** the regression test added in #7577 asserts the parent is `covered`, but that parent also has two live explicit blockers holding the state up. If the cancelled-child filter regressed, the counts would change while the *state* could still look plausible in other shapes, and the case the feature exists for — a blocked issue with **no** blocker edges at all — has no assertion anywhere in the file. `unresolvedBlockerCount: 0` appears in no test today.

Related PRs found while searching (neither overlaps; both touch blocker relations, not `blockerAttention` classification): #8251 (blocker summaries for legacy child blockers), #10316 (reject `done` while first-class blockers remain open).

## What Changed

Two tests in `server/src/__tests__/issue-blocker-attention.test.ts`:

- **`flags a blocked issue that has no blocker edges at all`** — a blocked, agent-assigned issue with no relations and no children must report `needs_attention` / `attention_required` with all four counts at 0. This is the text-only-blocked case the signal is built to catch, and it was unasserted.
- **`keeps a blocked parent attention-needed when its only child was cancelled`** — a blocked parent whose sole child is `cancelled` must report `unresolvedBlockerCount: 0` and stay `needs_attention`. This pins the cancelled-child edge count on its own, without live explicit blockers masking it.

No production code touched.

## Verification

- `node_modules/.bin/vitest run server/src/__tests__/issue-blocker-attention.test.ts` on this branch → **26 passed**.
- Control run, to prove the guards bite: reverted the #7577 filter in `listIssueBlockerAttentionMap` back to `ne(issues.status, "done")` → **2 failed / 24 passed**, both cancelled-child tests:
  - `ignores cancelled direct children …`: `unresolvedBlockerCount` 3 instead of 2, state `needs_attention` instead of `covered`
  - `keeps a blocked parent attention-needed when its only child was cancelled`: `unresolvedBlockerCount` 1 instead of 0
  Restored the filter → 26 passed again.
- The zero-edge test passes both before and after that revert, as intended: it is the negative control that proves the fix does not blind the detector.

## Risks

- Test-only; no runtime behaviour changes, no schema or API surface touched.
- The new tests use the file's existing `createCompany` / `insertIssue` helpers and fresh issue prefixes (`PBE`, `PBF`), so they do not interact with sibling cases.

## Model Used

- Claude Opus 5 (1M context) via Claude Code CLI, tool-enabled; used for repository inspection, test authoring, and local vitest execution including the revert-based control run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable; test-only change)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
