### PR TITLE
fix(cli): reject non-UTF-8 content files instead of silently storing U+FFFD

### DIFF
--- a/cli/src/__tests__/utf8-content-file.test.ts
+++ b/cli/src/__tests__/utf8-content-file.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readUtf8ContentFile } from "../commands/client/common.js";
+
+const tempFiles: string[] = [];
+
+function tempFile(bytes: Buffer): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-utf8-"));
+  const filePath = path.join(dir, "body.md");
+  fs.writeFileSync(filePath, bytes);
+  tempFiles.push(dir);
+  return filePath;
+}
+
+afterEach(() => {
+  for (const dir of tempFiles.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("readUtf8ContentFile", () => {
+  it("reads valid UTF-8 content, including non-ASCII text", async () => {
+    const text = "Relatório diário — ação, memória, café ☕";
+    const filePath = tempFile(Buffer.from(text, "utf8"));
+    await expect(readUtf8ContentFile(filePath)).resolves.toBe(text);
+  });
+
+  it("reads plain ASCII content", async () => {
+    const filePath = tempFile(Buffer.from("hello world", "utf8"));
+    await expect(readUtf8ContentFile(filePath)).resolves.toBe("hello world");
+  });
+
+  it("rejects files with legacy ANSI (cp1252) bytes instead of storing U+FFFD", async () => {
+    // "ação café memória" as written by Windows PowerShell 5.1 Set-Content
+    // (default ANSI code page): ç=0xE7, ã=0xE3, é=0xE9, ó=0xF3.
+    const cp1252 = Buffer.from([
+      0x61, 0xe7, 0xe3, 0x6f, 0x20, 0x63, 0x61, 0x66, 0xe9, 0x20, 0x6d, 0x65,
+      0x6d, 0xf3, 0x72, 0x69, 0x61,
+    ]);
+    const filePath = tempFile(cp1252);
+    await expect(readUtf8ContentFile(filePath)).rejects.toThrow(/not valid UTF-8/);
+  });
+
+  it("rejects UTF-16 files (BOM) rather than uploading mangled text", async () => {
+    const filePath = tempFile(Buffer.from("﻿ação", "utf16le"));
+    await expect(readUtf8ContentFile(filePath)).rejects.toThrow(/not valid UTF-8/);
+  });
+});

--- a/cli/src/__tests__/utf8-content-file.test.ts
+++ b/cli/src/__tests__/utf8-content-file.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { readUtf8ContentFile } from "../commands/client/common.js";
+import { decodeUtf8Content, readUtf8ContentFile } from "../commands/client/common.js";
 
 const tempFiles: string[] = [];
 
@@ -46,5 +46,16 @@ describe("readUtf8ContentFile", () => {
   it("rejects UTF-16 files (BOM) rather than uploading mangled text", async () => {
     const filePath = tempFile(Buffer.from("﻿ação", "utf16le"));
     await expect(readUtf8ContentFile(filePath)).rejects.toThrow(/not valid UTF-8/);
+  });
+});
+
+describe("decodeUtf8Content", () => {
+  it("decodes valid UTF-8 buffers (stdin path)", () => {
+    expect(decodeUtf8Content(Buffer.from("ação — memória", "utf8"), "stdin content")).toBe("ação — memória");
+  });
+
+  it("rejects invalid UTF-8 buffers with the source label in the error", () => {
+    const cp1252 = Buffer.from([0x61, 0xe7, 0xe3, 0x6f]);
+    expect(() => decodeUtf8Content(cp1252, "stdin content")).toThrow(/stdin content is not valid UTF-8/);
   });
 });

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -27,6 +27,7 @@ import {
   formatInlineRecord,
   handleCommandError,
   printOutput,
+  readUtf8ContentFile,
   resolveCommandContext,
   type BaseClientOptions,
 } from "./common.js";
@@ -683,7 +684,7 @@ export function registerAgentCommands(program: Command): void {
       .action(async (agentId: string, opts: AgentInstructionsFilePutOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const content = opts.contentFile ? await fs.readFile(opts.contentFile, "utf8") : opts.content;
+          const content = opts.contentFile ? await readUtf8ContentFile(opts.contentFile) : opts.content;
           const payload = upsertAgentInstructionsFileSchema.parse({
             path: opts.path,
             content,

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -1,4 +1,5 @@
 import pc from "picocolors";
+import { readFile } from "node:fs/promises";
 import type { Command } from "commander";
 import { getStoredBoardCredential, loginBoardCli } from "../../client/board-auth.js";
 import { buildCliCommandLabel } from "../../client/command-label.js";
@@ -130,6 +131,29 @@ export function apiPath(strings: TemplateStringsArray, ...values: Array<string |
     path += `${encodeURIComponent(String(value))}${strings[index + 1] ?? ""}`;
   });
   return path;
+}
+
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+/**
+ * Read a user-content file (comment/document/skill bodies) and refuse anything
+ * that is not valid UTF-8. Decoding invalid bytes leniently would silently turn
+ * every non-ASCII character into U+FFFD before upload, corrupting the stored
+ * text permanently. The most common source is Windows PowerShell 5.1, whose
+ * Set-Content/Out-File default to legacy ANSI code pages.
+ */
+export async function readUtf8ContentFile(filePath: string): Promise<string> {
+  const raw = await readFile(filePath);
+  try {
+    return strictUtf8Decoder.decode(raw);
+  } catch {
+    throw new Error(
+      `${filePath} is not valid UTF-8. If the file was written on Windows, ` +
+        `PowerShell 5.1's Set-Content/Out-File default to a legacy ANSI code page; ` +
+        `re-save it as UTF-8 (e.g. "Set-Content -Encoding utf8") and retry. ` +
+        `Refusing to upload it so non-ASCII characters are not permanently replaced with �.`,
+    );
+  }
 }
 
 export function inferContentTypeFromPath(filePath: string): string | undefined {

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -136,24 +136,28 @@ export function apiPath(strings: TemplateStringsArray, ...values: Array<string |
 const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 /**
- * Read a user-content file (comment/document/skill bodies) and refuse anything
- * that is not valid UTF-8. Decoding invalid bytes leniently would silently turn
- * every non-ASCII character into U+FFFD before upload, corrupting the stored
- * text permanently. The most common source is Windows PowerShell 5.1, whose
- * Set-Content/Out-File default to legacy ANSI code pages.
+ * Decode user-supplied content bytes (comment/document/skill bodies) and refuse
+ * anything that is not valid UTF-8. Decoding invalid bytes leniently would
+ * silently turn every non-ASCII character into U+FFFD before upload, corrupting
+ * the stored text permanently. The most common source is Windows PowerShell 5.1,
+ * whose Set-Content/Out-File default to legacy ANSI code pages.
  */
-export async function readUtf8ContentFile(filePath: string): Promise<string> {
-  const raw = await readFile(filePath);
+export function decodeUtf8Content(raw: Uint8Array, sourceLabel: string): string {
   try {
     return strictUtf8Decoder.decode(raw);
   } catch {
     throw new Error(
-      `${filePath} is not valid UTF-8. If the file was written on Windows, ` +
-        `PowerShell 5.1's Set-Content/Out-File default to a legacy ANSI code page; ` +
-        `re-save it as UTF-8 (e.g. "Set-Content -Encoding utf8") and retry. ` +
+      `${sourceLabel} is not valid UTF-8. If the content was produced on Windows, ` +
+        `PowerShell 5.1's Set-Content/Out-File and default pipe encodings use a legacy ANSI code page; ` +
+        `re-encode it as UTF-8 (e.g. "Set-Content -Encoding utf8") and retry. ` +
         `Refusing to upload it so non-ASCII characters are not permanently replaced with �.`,
     );
   }
+}
+
+/** Read a user-content file and strictly decode it as UTF-8 (see decodeUtf8Content). */
+export async function readUtf8ContentFile(filePath: string): Promise<string> {
+  return decodeUtf8Content(await readFile(filePath), filePath);
 }
 
 export function inferContentTypeFromPath(filePath: string): string | undefined {

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -34,6 +34,7 @@ import {
   handleCommandError,
   inferContentTypeFromPath,
   printOutput,
+  readUtf8ContentFile,
   resolveCommandContext,
   type BaseClientOptions,
 } from "./common.js";
@@ -689,7 +690,7 @@ export function registerIssueCommands(program: Command): void {
       .action(async (issueId: string, key: string, opts: IssueDocumentPutOptions) => {
         try {
           const ctx = resolveCommandContext(opts);
-          const body = opts.bodyFile ? await readFile(opts.bodyFile, "utf8") : opts.body;
+          const body = opts.bodyFile ? await readUtf8ContentFile(opts.bodyFile) : opts.body;
           const payload = upsertIssueDocumentSchema.parse({
             title: opts.title,
             format: opts.format,

--- a/cli/src/commands/client/skills.ts
+++ b/cli/src/commands/client/skills.ts
@@ -17,6 +17,7 @@ import { stdin as input, stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import {
   addCommonClientOptions,
+  decodeUtf8Content,
   formatInlineRecord,
   handleCommandError,
   printOutput,
@@ -996,7 +997,7 @@ async function readStdin(): Promise<string> {
   for await (const chunk of process.stdin) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
-  return Buffer.concat(chunks).toString("utf8");
+  return decodeUtf8Content(Buffer.concat(chunks), "stdin content");
 }
 
 async function confirmDangerousAction(yes: boolean | undefined, message: string): Promise<void> {

--- a/cli/src/commands/client/skills.ts
+++ b/cli/src/commands/client/skills.ts
@@ -13,7 +13,6 @@ import type {
   CompanySkillProjectScanResult,
   CompanySkillUpdateStatus,
 } from "@paperclipai/shared";
-import { readFile } from "node:fs/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { createInterface } from "node:readline/promises";
 import {
@@ -21,6 +20,7 @@ import {
   formatInlineRecord,
   handleCommandError,
   printOutput,
+  readUtf8ContentFile,
   resolveCommandContext,
   type BaseClientOptions,
   type ResolvedClientContext,
@@ -988,7 +988,7 @@ async function readBodyFile(filePath: string): Promise<string> {
   if (filePath === "-") {
     return readStdin();
   }
-  return readFile(filePath, "utf8");
+  return readUtf8ContentFile(filePath);
 }
 
 async function readStdin(): Promise<string> {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents and operators feed content into Paperclip through the CLI: comment bodies, issue documents, skill markdown, and instructions files, via `--body-file` / `--content-file`
> - Those files are read with a lenient UTF-8 decode (`readFile(path, "utf8")`), which maps invalid bytes to U+FFFD instead of failing
> - On Windows hosts, files written by PowerShell 5.1 defaults (`Set-Content`/`Out-File` → legacy ANSI code page) are exactly that kind of input, so every non-ASCII character is silently replaced with `�` and then uploaded and stored permanently — no error, original bytes unrecoverable
> - This pull request makes those reads strict: a shared `readUtf8ContentFile` helper decodes with `TextDecoder("utf-8", { fatal: true })` and fails with an actionable error naming the likely cause and remedy
> - The benefit is that data-destroying input is rejected loudly at the door instead of corrupting stored agent/operator content silently

## Linked Issues or Issue Description

Fixes: #10378

## What Changed

- Added `readUtf8ContentFile` to `cli/src/commands/client/common.ts`: reads the file as bytes, decodes with `TextDecoder("utf-8", { fatal: true })`, and throws a descriptive error (naming the PowerShell 5.1 ANSI default and the `Set-Content -Encoding utf8` remedy) on invalid input
- `issue document:put --body-file` now uses the helper (was `readFile(path, "utf8")`)
- `skills create/update --body-file` now uses the helper (stdin path `-` unchanged)
- `agent instructions-file put --content-file` now uses the helper
- Added `cli/src/__tests__/utf8-content-file.test.ts` covering: valid UTF-8 with accents/emoji, plain ASCII, rejection of cp1252 bytes (the exact byte sequence from the real incident), rejection of UTF-16
- Binary asset/attachment uploads are untouched — they never went through the lenient text decode

## Verification

- `cd cli && pnpm vitest run src/__tests__/utf8-content-file.test.ts` → 4/4 passing
- `cd cli && pnpm exec tsc --noEmit` → no errors in the touched files
- Manual repro of the original bug (Windows): `powershell -NoProfile -Command "Set-Content body.md -Value 'ação café memória'"` produces cp1252 bytes (`61 e7 e3 6f ...`); before this change the CLI uploads `a��o caf� mem�ria`; after it, the command fails with the actionable encoding error
- Real-world context: this exact failure corrupted 47 rows (comments, issue descriptions, activity log) for a pt-BR agent fleet on a Windows host; recovery required dictionary-based reconstruction because U+FFFD destroys the original byte

## Risks

- Low risk. Behavioral change is intentional and narrow: inputs that would previously be stored corrupted now fail with an error. Valid UTF-8 (with or without BOM-less multibyte content) behaves identically
- Users who were unknowingly uploading corrupted text will start seeing errors — that is the fix working; the error message tells them how to re-save the file
- No API, schema, or migration changes

## Model Used

- Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code — extended thinking, tool use (code search, test execution). Root-cause analysis, fix, and tests produced with AI assistance; diagnosis validated against a real corrupted production database and a byte-level Windows repro by the human author.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
