### PR TITLE
fix(heartbeat): count dequeue-time staleness cancels as no-progress in the re-wake throttle

### DIFF
--- a/server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts
+++ b/server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts
@@ -151,8 +151,11 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
     agentId: string;
     issueId: string;
     status?: string;
+    errorCode?: string;
     finishedSecondsAgo: number;
     startedSecondsAgo?: number;
+    /** Staleness cancels are decided before spawn, so they never start. */
+    neverStarted?: boolean;
   }) {
     const runId = randomUUID();
     const finishedAt = new Date(Date.now() - input.finishedSecondsAgo * 1000);
@@ -165,9 +168,10 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
       agentId: input.agentId,
       invocationSource: "assignment",
       status: input.status ?? "succeeded",
+      errorCode: input.errorCode ?? null,
       responsibleUserId: "responsible-user",
       createdAt: startedAt,
-      startedAt,
+      startedAt: input.neverStarted ? null : startedAt,
       finishedAt,
       contextSnapshot: { issueId: input.issueId, wakeReason: "issue_assigned" },
     });
@@ -264,6 +268,68 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
     await seedTerminalRun({ companyId, agentId, issueId, finishedSecondsAgo: 70 });
     await seedTerminalRun({ companyId, agentId, issueId, finishedSecondsAgo: 40 });
     await seedTerminalRun({ companyId, agentId, issueId, status: "failed", finishedSecondsAgo: 10 });
+
+    const recoveryWake = await assignmentWake(agentId, issueId);
+    expect(recoveryWake).not.toBeNull();
+  });
+
+  // Dequeue-time staleness cancels are the throttle's own mitigation
+  // output. If they broke the streak, the throttle would be blind to the loop it
+  // exists to damp — the observed failure was 358 wakes in 76 minutes on one issue.
+  it("throttles a re-wake storm made of dequeue-time staleness cancels", async () => {
+    const { companyId, agentId, issueId } = await seedCompanyAgentIssue();
+
+    for (const finishedSecondsAgo of [39, 26, 13]) {
+      await seedTerminalRun({
+        companyId,
+        agentId,
+        issueId,
+        status: "cancelled",
+        errorCode: "issue_continuation_waiting_on_review",
+        neverStarted: true,
+        finishedSecondsAgo,
+      });
+    }
+
+    const wake = await assignmentWake(agentId, issueId);
+    expect(wake).toBeNull();
+
+    const skipped = await latestWakeRequest(agentId);
+    expect(skipped?.reason).toBe("issue_rewake_throttled");
+    const heartbeatSkip = (skipped?.payload as Record<string, unknown> | null)?.heartbeatSkip as
+      | Record<string, unknown>
+      | undefined;
+    expect(heartbeatSkip?.noProgressStreak).toBe(3);
+
+    // No new run row: the storm stops costing control-plane writes too.
+    const runCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.companyId, companyId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(runCount).toBe(3);
+  });
+
+  it("does not throttle the wake that follows a crash-shaped cancel", async () => {
+    const { companyId, agentId, issueId } = await seedCompanyAgentIssue();
+
+    await seedTerminalRun({
+      companyId,
+      agentId,
+      issueId,
+      status: "cancelled",
+      errorCode: "issue_continuation_waiting_on_review",
+      neverStarted: true,
+      finishedSecondsAgo: 40,
+    });
+    await seedTerminalRun({
+      companyId,
+      agentId,
+      issueId,
+      status: "cancelled",
+      errorCode: "process_lost",
+      finishedSecondsAgo: 10,
+    });
 
     const recoveryWake = await assignmentWake(agentId, issueId);
     expect(recoveryWake).not.toBeNull();

--- a/server/src/__tests__/issue-rewake-throttle.test.ts
+++ b/server/src/__tests__/issue-rewake-throttle.test.ts
@@ -13,11 +13,13 @@ const NOW = new Date("2026-07-12T18:14:00.000Z");
 function runSample(input: {
   id: string;
   status?: string;
+  errorCode?: string;
   finishedSecondsAgo: number;
 }) {
   return {
     id: input.id,
     status: input.status ?? "succeeded",
+    errorCode: input.errorCode ?? null,
     finishedAt: new Date(NOW.getTime() - input.finishedSecondsAgo * 1000),
   };
 }
@@ -178,6 +180,127 @@ describe("evaluateIssueRewakeThrottle", () => {
       ],
       runIdsWithIssueProgress: new Set(),
       hasNewIssueInputSinceLastRun: true,
+    });
+    expect(decision).toEqual({ blocked: false, noProgressStreak: 0 });
+  });
+
+  // The dequeue-time staleness filter is what cancels these wakes,
+  // so if its verdicts broke the streak the throttle could never damp the loop
+  // it is supposed to damp.
+  it("counts dequeue-time staleness verdicts as no-progress", () => {
+    const decision = evaluateIssueRewakeThrottle({
+      now: NOW,
+      recentTerminalRuns: [
+        runSample({
+          id: "r2",
+          status: "cancelled",
+          errorCode: "issue_continuation_waiting_on_review",
+          finishedSecondsAgo: 13,
+        }),
+        runSample({
+          id: "r1",
+          status: "cancelled",
+          errorCode: "issue_continuation_waiting_on_review",
+          finishedSecondsAgo: 26,
+        }),
+      ],
+      runIdsWithIssueProgress: new Set(),
+      hasNewIssueInputSinceLastRun: false,
+    });
+    expect(decision.blocked).toBe(true);
+    if (decision.blocked) {
+      expect(decision.noProgressStreak).toBe(2);
+      expect(decision.cooldownMs).toBe(ISSUE_REWAKE_BASE_COOLDOWN_MS);
+    }
+  });
+
+  it("escalates a staleness-verdict spin loop to the cooldown ceiling", () => {
+    // Replays the observed 13s-median inter-arrival storm: a full sample of
+    // staleness cancels must reach the 30-minute cap, not stay at 13 seconds.
+    const decision = evaluateIssueRewakeThrottle({
+      now: NOW,
+      recentTerminalRuns: Array.from({ length: 8 }, (_unused, index) =>
+        runSample({
+          id: `stale-${index}`,
+          status: "cancelled",
+          errorCode: "issue_continuation_waiting_on_review",
+          finishedSecondsAgo: 13 * (index + 1),
+        }),
+      ),
+      runIdsWithIssueProgress: new Set(),
+      hasNewIssueInputSinceLastRun: false,
+    });
+    expect(decision.blocked).toBe(true);
+    if (decision.blocked) {
+      expect(decision.noProgressStreak).toBe(8);
+      expect(decision.cooldownMs).toBe(ISSUE_REWAKE_MAX_COOLDOWN_MS);
+    }
+  });
+
+  it("counts every staleness verdict code, and mixes them with no-progress successes", () => {
+    for (const errorCode of [
+      "issue_not_found",
+      "issue_assignee_changed",
+      "issue_terminal_status",
+      "issue_not_in_progress",
+      "issue_execution_lock_changed",
+      "issue_review_participant_changed",
+      "issue_continuation_waiting_on_review",
+    ]) {
+      const decision = evaluateIssueRewakeThrottle({
+        now: NOW,
+        recentTerminalRuns: [
+          runSample({ id: "r2", status: "cancelled", errorCode, finishedSecondsAgo: 10 }),
+          runSample({ id: "r1", finishedSecondsAgo: 40 }),
+        ],
+        runIdsWithIssueProgress: new Set(),
+        hasNewIssueInputSinceLastRun: false,
+      });
+      expect(decision.blocked, errorCode).toBe(true);
+      expect(decision.noProgressStreak).toBe(2);
+    }
+  });
+
+  it("still recovers immediately after a crash-shaped cancel", () => {
+    for (const errorCode of ["process_lost", "provider_quota_exhausted", null]) {
+      const decision = evaluateIssueRewakeThrottle({
+        now: NOW,
+        recentTerminalRuns: [
+          runSample({
+            id: "r3",
+            status: "cancelled",
+            ...(errorCode === null ? {} : { errorCode }),
+            finishedSecondsAgo: 10,
+          }),
+          runSample({
+            id: "r2",
+            status: "cancelled",
+            errorCode: "issue_continuation_waiting_on_review",
+            finishedSecondsAgo: 40,
+          }),
+          runSample({ id: "r1", finishedSecondsAgo: 70 }),
+        ],
+        runIdsWithIssueProgress: new Set(),
+        hasNewIssueInputSinceLastRun: false,
+      });
+      expect(decision, String(errorCode)).toEqual({ blocked: false, noProgressStreak: 0 });
+    }
+  });
+
+  it("does not count a staleness verdict that never recorded a finish time", () => {
+    const decision = evaluateIssueRewakeThrottle({
+      now: NOW,
+      recentTerminalRuns: [
+        {
+          id: "r2",
+          status: "cancelled",
+          errorCode: "issue_terminal_status",
+          finishedAt: null,
+        },
+        runSample({ id: "r1", finishedSecondsAgo: 40 }),
+      ],
+      runIdsWithIssueProgress: new Set(),
+      hasNewIssueInputSinceLastRun: false,
     });
     expect(decision).toEqual({ blocked: false, noProgressStreak: 0 });
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16123,6 +16123,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               id: heartbeatRuns.id,
               status: heartbeatRuns.status,
               finishedAt: heartbeatRuns.finishedAt,
+              // The streak needs the error code to tell a
+              // dequeue-time staleness verdict (no session ever spawned, same
+              // verdict on every retry) apart from a crash-shaped cancel.
+              errorCode: heartbeatRuns.errorCode,
             })
             .from(heartbeatRuns)
             .where(

--- a/server/src/services/issue-rewake-throttle.ts
+++ b/server/src/services/issue-rewake-throttle.ts
@@ -95,6 +95,33 @@ export const ISSUE_NEW_INPUT_ACTIVITY_ACTIONS: string[] = [
   "issue.blockers_resolved_wake_emitted",
 ];
 
+/**
+ * Error codes emitted by the dequeue-time staleness filter
+ * (`evaluateQueuedRunStaleness`). Each is a deterministic "this wake was
+ * invalid" verdict reached *before* the adapter session starts: the run is
+ * cancelled with no process, no tokens, and no issue-visible effect, and
+ * re-waking produces the identical verdict until some external state changes.
+ *
+ * These cancels therefore count as no-progress for the streak. Without that,
+ * the throttle is structurally blind to its own mitigation's output: every
+ * throttled-shaped wake is cancelled here, the cancel breaks the streak, the
+ * streak resets to zero, and the next wake passes — a spin loop bounded only
+ * by how fast the producer re-enqueues (measured: 358 wakes in 76
+ * minutes, 13s median inter-arrival, on `issue_continuation_waiting_on_review`).
+ *
+ * Crash-shaped cancels (`process_lost`, interrupts, failures) stay outside
+ * this set: their follow-up is recovery, which must not be delayed.
+ */
+export const STALE_WAKE_VERDICT_ERROR_CODES: ReadonlySet<string> = new Set([
+  "issue_not_found",
+  "issue_assignee_changed",
+  "issue_terminal_status",
+  "issue_not_in_progress",
+  "issue_execution_lock_changed",
+  "issue_review_participant_changed",
+  "issue_continuation_waiting_on_review",
+]);
+
 export interface IssueRewakeCandidateInput {
   reason: string | null;
   wakeCommentId: string | null;
@@ -118,6 +145,15 @@ export interface RecentIssueRunSample {
   id: string;
   status: string;
   finishedAt: Date | null;
+  errorCode: string | null;
+}
+
+/**
+ * A run cancelled by the dequeue-time staleness filter: no session was ever
+ * spawned, and the same wake would be judged stale again.
+ */
+export function isStaleWakeVerdictRun(run: RecentIssueRunSample): boolean {
+  return run.status === "cancelled" && STALE_WAKE_VERDICT_ERROR_CODES.has(run.errorCode ?? "");
 }
 
 export interface IssueRewakeThrottleInput {
@@ -154,8 +190,15 @@ export function evaluateIssueRewakeThrottle(input: IssueRewakeThrottleInput): Is
 
   let noProgressStreak = 0;
   for (const run of runs) {
-    // A failed/cancelled/interrupted run breaks the streak: its follow-up is
-    // recovery, not a redundant re-poll, and must not be delayed.
+    // A staleness verdict is the dequeue filter saying "this wake was invalid"
+    // before any session started. Repeating it changes nothing, so it counts
+    // as no-progress rather than breaking the streak.
+    if (isStaleWakeVerdictRun(run) && run.finishedAt) {
+      noProgressStreak += 1;
+      continue;
+    }
+    // A failed/crash-cancelled/interrupted run breaks the streak: its follow-up
+    // is recovery, not a redundant re-poll, and must not be delayed.
     if (run.status !== "succeeded" || !run.finishedAt) break;
     if (input.runIdsWithIssueProgress.has(run.id)) break;
     noProgressStreak += 1;


### PR DESCRIPTION
## Problem

`evaluateIssueRewakeThrottle` only counts `succeeded` runs toward its no-progress streak. Every other terminal status breaks the streak, on the reasoning that a failed or cancelled run's follow-up is *recovery* and must not be delayed.

But the dequeue-time staleness filter — the thing that is supposed to stop redundant re-wakes — stops them by **cancelling** them. So the throttle is structurally blind to its own mitigation's output:

```
producer enqueues issue_continuation_needed
  -> throttle sees a `cancelled` newest run, breaks the streak, streak = 0, passes
  -> dequeue filter cancels it as issue_continuation_waiting_on_review
  -> a fresh `cancelled` run appears, back to the top
```

The loop is bounded only by how fast the producer re-enqueues. Measured on one issue in production: **358 wakes in 76 minutes, 13s median inter-arrival**, every one cancelled before spawn. The `issue_continuation_waiting_on_review` verdict is deterministic — it returns the same answer on every retry until the review actually lands — so nothing in the cycle can make progress.

No tokens were billed, but only because the staleness verdict happens before the adapter session starts. That is a single point of luck, not a design property: the same shape with a verdict that lands after spawn bills every iteration.

## Fix

Split cancels into two families instead of treating them as one.

A **staleness verdict** (`issue_continuation_waiting_on_review` and the 6 sibling dequeue-time codes) means: no process was ever created, no tokens spent, no issue-visible effect, and the same verdict will recur on every retry until external state changes. That is the definition of no progress, so it now counts toward the streak and lets the existing escalating cooldown (threshold 2, base 120s, cap 30min) decay the storm.

**Crash-shaped cancels** (`process_lost`, interrupts, failures) still break the streak, so crash recovery stays immediate. That property is the reason the original `!== "succeeded"` check exists and it is preserved exactly.

Liveness is unchanged. When the review or approval actually lands, `hasNewIssueInputSinceLastRun` bypasses the cooldown before the streak is ever consulted, so a genuinely-ready issue never sits behind the backoff.

## Changes

- `issue-rewake-throttle.ts` — `STALE_WAKE_VERDICT_ERROR_CODES` + `isStaleWakeVerdictRun`, consulted in the streak loop.
- `heartbeat.ts` — add `errorCode` to the `recentTerminalRuns` select so the throttle can tell the two families apart (4 lines).
- Tests — 191 of the 239 added lines. Unit tests for the classification, plus a heartbeat-level test that reproduces the storm shape and asserts it now damps.

Cooldown constants are unchanged and the producer side is untouched.

## Verification

Running in production on a fork since 2026-07-26. The storm shape has not recurred; residual no-progress wakes over the following 36 hours were 3 total, with no two consecutive on the same issue.
