### PR TITLE
fix(heartbeat): issue-scope the non-project fallback workspace

### DIFF
--- a/server/src/__tests__/agent-fallback-workspace-paths.test.ts
+++ b/server/src/__tests__/agent-fallback-workspace-paths.test.ts
@@ -1,0 +1,93 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isAgentFallbackWorkspaceCwd,
+  resolveDefaultAgentWorkspaceDir,
+  resolveIssueScopedAgentWorkspaceDir,
+} from "../home-paths.js";
+
+// Pin the instance root to a deterministic temp home so the resolved paths are
+// predictable regardless of the developer's real ~/.paperclip.
+const FAKE_HOME = "/tmp/paperclip-fallback-ws-test-home";
+const AGENT_ID = "b3b6dde7-d283-47b7-8556-9eafe7ca9b52";
+const ISSUE_A = "c624b8f1-c69a-4ac2-8c73-33e2d6a945b1";
+const ISSUE_B = "a1111111-2222-3333-4444-555555555555";
+
+let savedHome: string | undefined;
+let savedInstance: string | undefined;
+
+beforeEach(() => {
+  savedHome = process.env.PAPERCLIP_HOME;
+  savedInstance = process.env.PAPERCLIP_INSTANCE_ID;
+  process.env.PAPERCLIP_HOME = FAKE_HOME;
+  delete process.env.PAPERCLIP_INSTANCE_ID; // → "default"
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.PAPERCLIP_HOME;
+  else process.env.PAPERCLIP_HOME = savedHome;
+  if (savedInstance === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+  else process.env.PAPERCLIP_INSTANCE_ID = savedInstance;
+});
+
+const workspacesRoot = () => path.resolve(FAKE_HOME, "instances", "default", "workspaces");
+
+describe("resolveIssueScopedAgentWorkspaceDir", () => {
+  it("keys the fallback dir by agent AND issue", () => {
+    expect(resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A)).toBe(
+      path.join(workspacesRoot(), AGENT_ID, ISSUE_A),
+    );
+  });
+
+  it("isolates the same agent's different issues into different dirs", () => {
+    const a = resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A);
+    const b = resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_B);
+    expect(a).not.toBe(b);
+    // ...and neither collides with the shared per-agent dir that the pre-fix
+    // fallback used (the root cause of cross-issue trampling).
+    const perAgent = resolveDefaultAgentWorkspaceDir(AGENT_ID);
+    expect(a).not.toBe(perAgent);
+    expect(b).not.toBe(perAgent);
+  });
+
+  it("is stable across calls for the same (agent, issue) — enables heartbeat reuse", () => {
+    expect(resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A)).toBe(
+      resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A),
+    );
+  });
+
+  it("nests the issue dir directly under the per-agent dir", () => {
+    const issueDir = resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A);
+    expect(path.dirname(issueDir)).toBe(resolveDefaultAgentWorkspaceDir(AGENT_ID));
+  });
+
+  it("rejects path-traversal / non-segment ids", () => {
+    expect(() => resolveIssueScopedAgentWorkspaceDir(AGENT_ID, "../escape")).toThrow();
+    expect(() => resolveIssueScopedAgentWorkspaceDir(AGENT_ID, "a/b")).toThrow();
+    expect(() => resolveIssueScopedAgentWorkspaceDir("bad id", ISSUE_A)).toThrow();
+    expect(() => resolveIssueScopedAgentWorkspaceDir(AGENT_ID, "")).toThrow();
+  });
+});
+
+describe("isAgentFallbackWorkspaceCwd", () => {
+  it("recognizes the per-agent fallback dir", () => {
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, resolveDefaultAgentWorkspaceDir(AGENT_ID))).toBe(true);
+  });
+
+  it("recognizes an issue-scoped fallback subdir", () => {
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A))).toBe(true);
+  });
+
+  it("does not treat a different agent's issue-scoped dir as this agent's fallback", () => {
+    const otherAgent = "ffffffff-0000-1111-2222-333333333333";
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, resolveIssueScopedAgentWorkspaceDir(otherAgent, ISSUE_A))).toBe(false);
+  });
+
+  it("rejects unrelated paths, deeper nesting, and empty input", () => {
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, "/some/project/workspace")).toBe(false);
+    // Deeper than one level under the per-agent root is not a fallback dir we mint.
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, path.join(workspacesRoot(), AGENT_ID, ISSUE_A, "sub"))).toBe(false);
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, "")).toBe(false);
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, null)).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
-import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
+import { resolveDefaultAgentWorkspaceDir, resolveIssueScopedAgentWorkspaceDir } from "../home-paths.js";
 import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
@@ -906,6 +906,28 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
       previousSessionParams: {
         sessionId: "session-1",
         cwd: fallbackCwd,
+        workspaceId: "workspace-1",
+      },
+      resolvedWorkspace: buildResolvedWorkspace({ cwd: "/tmp/new-project-cwd" }),
+    });
+
+    expect(result.sessionParams).toMatchObject({
+      sessionId: "session-1",
+      cwd: "/tmp/new-project-cwd",
+      workspaceId: "workspace-1",
+    });
+    expect(result.warning).toContain("Attempting to resume session");
+  });
+
+  it("migrates issue-scoped fallback sessions to project workspace when project cwd becomes available", () => {
+    const agentId = "agent-123";
+    const issueScopedFallbackCwd = resolveIssueScopedAgentWorkspaceDir(agentId, "issue-abc");
+
+    const result = resolveRuntimeSessionParamsForWorkspace({
+      agentId,
+      previousSessionParams: {
+        sessionId: "session-1",
+        cwd: issueScopedFallbackCwd,
         workspaceId: "workspace-1",
       },
       resolvedWorkspace: buildResolvedWorkspace({ cwd: "/tmp/new-project-cwd" }),

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -55,6 +55,43 @@ export function resolveDefaultAgentWorkspaceDir(agentId: string): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmed);
 }
 
+/**
+ * Fallback workspace dir keyed by BOTH agent and issue, so a non-project issue
+ * that does iterative local file work (e.g. git worktrees) across multiple
+ * heartbeats lands in the same directory each run instead of a per-agent dir
+ * shared across every issue that agent touches. Without this, heartbeat N+1 can
+ * be trampled by an interleaved run on a different non-project issue and loses
+ * the branch/commit heartbeat N produced, silently re-deriving the work.
+ */
+export function resolveIssueScopedAgentWorkspaceDir(agentId: string, issueId: string): string {
+  const trimmedAgent = agentId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmedAgent)) {
+    throw new Error(`Invalid agent id for workspace path '${agentId}'.`);
+  }
+  const trimmedIssue = issueId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmedIssue)) {
+    throw new Error(`Invalid issue id for workspace path '${issueId}'.`);
+  }
+  return path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmedAgent, trimmedIssue);
+}
+
+/**
+ * True when `cwd` is one of this agent's local fallback workspaces — either the
+ * per-agent dir (resolveDefaultAgentWorkspaceDir) or an issue-scoped subdir of it
+ * (resolveIssueScopedAgentWorkspaceDir). Used to decide whether a resumed session
+ * still sitting in a fallback should migrate into a now-available project workspace,
+ * so that migration keeps working after the fallback became issue-scoped.
+ */
+export function isAgentFallbackWorkspaceCwd(agentId: string, cwd: string | null | undefined): boolean {
+  const trimmedAgent = agentId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmedAgent)) return false;
+  const trimmedCwd = cwd?.trim();
+  if (!trimmedCwd) return false;
+  const agentRoot = path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmedAgent);
+  const target = path.resolve(trimmedCwd);
+  return target === agentRoot || path.dirname(target) === agentRoot;
+}
+
 function sanitizeFriendlyPathSegment(value: string | null | undefined, fallback = "_default"): string {
   const trimmed = value?.trim() ?? "";
   if (!trimmed) return fallback;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -91,7 +91,12 @@ import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService, type MissingRuntimeBinding } from "./secrets.js";
-import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import {
+  isAgentFallbackWorkspaceCwd,
+  resolveDefaultAgentWorkspaceDir,
+  resolveIssueScopedAgentWorkspaceDir,
+  resolveManagedProjectWorkspaceDir,
+} from "../home-paths.js";
 import {
   buildHeartbeatRunIssueComment,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
@@ -2897,8 +2902,10 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
       warning: null as string | null,
     };
   }
-  const fallbackAgentHomeCwd = resolveDefaultAgentWorkspaceDir(agentId);
-  if (path.resolve(previousCwd) !== path.resolve(fallbackAgentHomeCwd)) {
+  // Recognize both the per-agent fallback dir and an issue-scoped fallback subdir
+  // of it, so a session that ran in the issue-scoped fallback still migrates into
+  // a project workspace once one becomes available for the issue.
+  if (!isAgentFallbackWorkspaceCwd(agentId, previousCwd)) {
     return {
       sessionParams: previousSessionParams,
       warning: null as string | null,
@@ -7504,7 +7511,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+    // For a non-project issue with no reusable session workspace, key the fallback
+    // dir by issue as well as agent so successive heartbeats of the *same* issue land
+    // in the same directory (and reuse whatever git worktree/branch/commits the prior
+    // heartbeat left there) instead of a per-agent dir shared across every non-project
+    // issue, where an interleaved run on another issue can trample it.
+    // A non-conforming issueId (should not happen for real UUIDs) degrades to the
+    // per-agent dir rather than failing the run.
+    let cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+    if (issueId) {
+      try {
+        cwd = resolveIssueScopedAgentWorkspaceDir(agent.id, issueId);
+      } catch {
+        cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+      }
+    }
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
     if (sessionCwd && sessionCwdLooksUnsafe) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents run on repeated **heartbeats**; each run needs an execution workspace (cwd), resolved by `resolveWorkspaceForRun` in `server/src/services/heartbeat.ts`
> - For an issue **with no project binding** and no reusable session workspace, resolution falls back to a local dir keyed **only by agentId** (`<instanceRoot>/workspaces/<agentId>`)
> - That single dir is shared across *every* non-project issue the agent touches, so iterative local file work (git worktrees/commits) done on one issue in heartbeat N can be trampled by an interleaved run on another issue before heartbeat N+1
> - Heartbeat N+1 then no longer sees N's branch/commit and silently re-derives the same work, burning the run's context window
> - This pull request keys the fallback dir by issue as well as agent so successive heartbeats of the same issue reuse the same directory and its git state
> - The benefit is that comment-driven, multi-heartbeat work on non-project issues keeps its execution state across runs instead of silently repeating itself

## Linked Issues or Issue Description

No public GitHub issue exists, so the underlying bug is described inline following the bug-report template:

**What happened?**

A non-project issue that iterates local file work across heartbeats (comment-driven back-and-forth — e.g. a skill iterating a local 3D model via git worktrees) does not reliably reuse the previous heartbeat's git worktree/branch. In one observed run, heartbeat N committed a fix to a branch; heartbeat N+1 (fired by the next comment) started from a directory that no longer contained that commit, re-derived and re-applied the same change from scratch, and reached ~67% of its context window just getting back to where the prior heartbeat had left off.

**Expected behavior**

Successive heartbeats of the same non-project issue should resume from the same execution directory and see the git state (branch/commit) the previous heartbeat produced.

**Steps to reproduce**

1. Create an issue with no project binding (no `projectId`/`projectWorkspaceId`).
2. On heartbeat N, have the agent do local git work (e.g. `git worktree`/commit) in its run cwd and commit.
3. Between heartbeats, let the same agent take another run on a different non-project issue (shares the same per-agent fallback dir).
4. On heartbeat N+1 of the first issue, observe the run cwd no longer contains N's commit/branch, so the work is re-derived.

**Paperclip version or commit**

Reproduces on current `master` (`server/src/services/heartbeat.ts`, `resolveWorkspaceForRun` → `agent_home` fallback via `resolveDefaultAgentWorkspaceDir`).

**Deployment mode**

Self-hosted single instance; local adapter execution.

## What Changed

- Added `resolveIssueScopedAgentWorkspaceDir(agentId, issueId)` in `server/src/home-paths.ts` → `<instanceRoot>/workspaces/<agentId>/<issueId>`, with the same path-segment validation used by the per-agent variant (path-traversal guard).
- Added `isAgentFallbackWorkspaceCwd(agentId, cwd)` in `server/src/home-paths.ts` — recognizes both the per-agent fallback dir and a one-level issue-scoped subdir of it.
- In `resolveWorkspaceForRun` (`heartbeat.ts`), at the `agent_home` fallback site, use the issue-scoped dir when an `issueId` is present so same-issue heartbeats reuse the same directory. A non-conforming `issueId` degrades to the per-agent dir instead of failing the run.
- In `resolveRuntimeSessionParamsForWorkspace` (`heartbeat.ts`), replaced the exact per-agent-dir comparison with `isAgentFallbackWorkspaceCwd`, so a session started in the issue-scoped fallback still migrates into a project workspace once one becomes available.
- Left intentionally per-agent: the project-workspace-missing fallback (`source: "project_primary"`) and the `agentHome` field.
- Tests: new `server/src/__tests__/agent-fallback-workspace-paths.test.ts`; extended `server/src/__tests__/heartbeat-workspace-session.test.ts`.

## Verification

- `cd server && npx vitest run src/__tests__/agent-fallback-workspace-paths.test.ts src/__tests__/heartbeat-workspace-session.test.ts` → **129 passed**.
- New tests assert: issue-scoped path is keyed by (agent, issue), differs from the shared per-agent dir, is stable across calls (the reuse property), nests directly under the per-agent dir, rejects path-traversal/non-segment ids; and that a resumed session sitting in the issue-scoped fallback still migrates into a newly-available project workspace.
- CI (fresh package build) is the authoritative typecheck for this change.

## Risks

**Low risk.** Behavior changes only on the `agent_home` fallback path for issues that carry an `issueId` — which is the exact path that was losing continuity. Project-bound resolution, session-workspace reuse, and the git-worktree launch guards are untouched (issue-scoped dirs are only minted where no project workspace is expected). Existing per-agent fallbacks for issue-less runs are unchanged. New directories are created lazily via `mkdir -p`; no migration of existing dirs is required.

## Model Used

Claude Opus 4.8 (model id `claude-opus-4-8`, 1M-context variant), extended thinking, with tool use / code execution in an agentic coding harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and found none (searched open PRs for "fallback workspace", "issue-scoped", "resolveWorkspaceForRun", "agent workspace dir")
- [x] I have either (a) linked existing issues OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs cover fallback workspace path internals)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (running)
- [ ] Greptile is 5/5 with no open P2s (re-running)
- [x] I will address all Greptile and reviewer comments before requesting merge
