### PR TITLE
fix(heartbeat): issue-scope the non-project fallback workspace (BRO-1717)

### DIFF
--- a/server/src/__tests__/agent-fallback-workspace-paths.test.ts
+++ b/server/src/__tests__/agent-fallback-workspace-paths.test.ts
@@ -1,0 +1,93 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isAgentFallbackWorkspaceCwd,
+  resolveDefaultAgentWorkspaceDir,
+  resolveIssueScopedAgentWorkspaceDir,
+} from "../home-paths.js";
+
+// Pin the instance root to a deterministic temp home so the resolved paths are
+// predictable regardless of the developer's real ~/.paperclip. See BRO-1717.
+const FAKE_HOME = "/tmp/bro1717-home";
+const AGENT_ID = "b3b6dde7-d283-47b7-8556-9eafe7ca9b52";
+const ISSUE_A = "c624b8f1-c69a-4ac2-8c73-33e2d6a945b1";
+const ISSUE_B = "a1111111-2222-3333-4444-555555555555";
+
+let savedHome: string | undefined;
+let savedInstance: string | undefined;
+
+beforeEach(() => {
+  savedHome = process.env.PAPERCLIP_HOME;
+  savedInstance = process.env.PAPERCLIP_INSTANCE_ID;
+  process.env.PAPERCLIP_HOME = FAKE_HOME;
+  delete process.env.PAPERCLIP_INSTANCE_ID; // → "default"
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.PAPERCLIP_HOME;
+  else process.env.PAPERCLIP_HOME = savedHome;
+  if (savedInstance === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+  else process.env.PAPERCLIP_INSTANCE_ID = savedInstance;
+});
+
+const workspacesRoot = () => path.resolve(FAKE_HOME, "instances", "default", "workspaces");
+
+describe("resolveIssueScopedAgentWorkspaceDir (BRO-1717)", () => {
+  it("keys the fallback dir by agent AND issue", () => {
+    expect(resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A)).toBe(
+      path.join(workspacesRoot(), AGENT_ID, ISSUE_A),
+    );
+  });
+
+  it("isolates the same agent's different issues into different dirs", () => {
+    const a = resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A);
+    const b = resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_B);
+    expect(a).not.toBe(b);
+    // ...and neither collides with the shared per-agent dir that the pre-fix
+    // fallback used (the root cause of cross-issue trampling).
+    const perAgent = resolveDefaultAgentWorkspaceDir(AGENT_ID);
+    expect(a).not.toBe(perAgent);
+    expect(b).not.toBe(perAgent);
+  });
+
+  it("is stable across calls for the same (agent, issue) — enables heartbeat reuse", () => {
+    expect(resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A)).toBe(
+      resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A),
+    );
+  });
+
+  it("nests the issue dir directly under the per-agent dir", () => {
+    const issueDir = resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A);
+    expect(path.dirname(issueDir)).toBe(resolveDefaultAgentWorkspaceDir(AGENT_ID));
+  });
+
+  it("rejects path-traversal / non-segment ids", () => {
+    expect(() => resolveIssueScopedAgentWorkspaceDir(AGENT_ID, "../escape")).toThrow();
+    expect(() => resolveIssueScopedAgentWorkspaceDir(AGENT_ID, "a/b")).toThrow();
+    expect(() => resolveIssueScopedAgentWorkspaceDir("bad id", ISSUE_A)).toThrow();
+    expect(() => resolveIssueScopedAgentWorkspaceDir(AGENT_ID, "")).toThrow();
+  });
+});
+
+describe("isAgentFallbackWorkspaceCwd (BRO-1717)", () => {
+  it("recognizes the per-agent fallback dir", () => {
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, resolveDefaultAgentWorkspaceDir(AGENT_ID))).toBe(true);
+  });
+
+  it("recognizes an issue-scoped fallback subdir", () => {
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, resolveIssueScopedAgentWorkspaceDir(AGENT_ID, ISSUE_A))).toBe(true);
+  });
+
+  it("does not treat a different agent's issue-scoped dir as this agent's fallback", () => {
+    const otherAgent = "ffffffff-0000-1111-2222-333333333333";
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, resolveIssueScopedAgentWorkspaceDir(otherAgent, ISSUE_A))).toBe(false);
+  });
+
+  it("rejects unrelated paths, deeper nesting, and empty input", () => {
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, "/some/project/workspace")).toBe(false);
+    // Deeper than one level under the per-agent root is not a fallback dir we mint.
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, path.join(workspacesRoot(), AGENT_ID, ISSUE_A, "sub"))).toBe(false);
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, "")).toBe(false);
+    expect(isAgentFallbackWorkspaceCwd(AGENT_ID, null)).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -6,7 +6,7 @@ import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
-import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
+import { resolveDefaultAgentWorkspaceDir, resolveIssueScopedAgentWorkspaceDir } from "../home-paths.js";
 import {
   applyPersistedExecutionWorkspaceConfig,
   assertGitSensitiveAdapterWorkspaceValid,
@@ -906,6 +906,28 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
       previousSessionParams: {
         sessionId: "session-1",
         cwd: fallbackCwd,
+        workspaceId: "workspace-1",
+      },
+      resolvedWorkspace: buildResolvedWorkspace({ cwd: "/tmp/new-project-cwd" }),
+    });
+
+    expect(result.sessionParams).toMatchObject({
+      sessionId: "session-1",
+      cwd: "/tmp/new-project-cwd",
+      workspaceId: "workspace-1",
+    });
+    expect(result.warning).toContain("Attempting to resume session");
+  });
+
+  it("migrates issue-scoped fallback sessions to project workspace when project cwd becomes available (BRO-1717)", () => {
+    const agentId = "agent-123";
+    const issueScopedFallbackCwd = resolveIssueScopedAgentWorkspaceDir(agentId, "issue-abc");
+
+    const result = resolveRuntimeSessionParamsForWorkspace({
+      agentId,
+      previousSessionParams: {
+        sessionId: "session-1",
+        cwd: issueScopedFallbackCwd,
         workspaceId: "workspace-1",
       },
       resolvedWorkspace: buildResolvedWorkspace({ cwd: "/tmp/new-project-cwd" }),

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -55,6 +55,43 @@ export function resolveDefaultAgentWorkspaceDir(agentId: string): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmed);
 }
 
+/**
+ * Fallback workspace dir keyed by BOTH agent and issue, so a non-project issue
+ * that does iterative local file work (e.g. git worktrees) across multiple
+ * heartbeats lands in the same directory each run instead of a per-agent dir
+ * shared across every issue that agent touches. Without this, heartbeat N+1 can
+ * be trampled by an interleaved run on a different non-project issue and loses
+ * the branch/commit heartbeat N produced, silently re-deriving the work (BRO-1717).
+ */
+export function resolveIssueScopedAgentWorkspaceDir(agentId: string, issueId: string): string {
+  const trimmedAgent = agentId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmedAgent)) {
+    throw new Error(`Invalid agent id for workspace path '${agentId}'.`);
+  }
+  const trimmedIssue = issueId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmedIssue)) {
+    throw new Error(`Invalid issue id for workspace path '${issueId}'.`);
+  }
+  return path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmedAgent, trimmedIssue);
+}
+
+/**
+ * True when `cwd` is one of this agent's local fallback workspaces — either the
+ * per-agent dir (resolveDefaultAgentWorkspaceDir) or an issue-scoped subdir of it
+ * (resolveIssueScopedAgentWorkspaceDir). Used to decide whether a resumed session
+ * still sitting in a fallback should migrate into a now-available project workspace,
+ * so that migration keeps working after the fallback became issue-scoped (BRO-1717).
+ */
+export function isAgentFallbackWorkspaceCwd(agentId: string, cwd: string | null | undefined): boolean {
+  const trimmedAgent = agentId.trim();
+  if (!PATH_SEGMENT_RE.test(trimmedAgent)) return false;
+  const trimmedCwd = cwd?.trim();
+  if (!trimmedCwd) return false;
+  const agentRoot = path.resolve(resolvePaperclipInstanceRoot(), "workspaces", trimmedAgent);
+  const target = path.resolve(trimmedCwd);
+  return target === agentRoot || path.dirname(target) === agentRoot;
+}
+
 function sanitizeFriendlyPathSegment(value: string | null | undefined, fallback = "_default"): string {
   const trimmed = value?.trim() ?? "";
   if (!trimmed) return fallback;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -91,7 +91,12 @@ import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService, type MissingRuntimeBinding } from "./secrets.js";
-import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import {
+  isAgentFallbackWorkspaceCwd,
+  resolveDefaultAgentWorkspaceDir,
+  resolveIssueScopedAgentWorkspaceDir,
+  resolveManagedProjectWorkspaceDir,
+} from "../home-paths.js";
 import {
   buildHeartbeatRunIssueComment,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
@@ -2897,8 +2902,10 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
       warning: null as string | null,
     };
   }
-  const fallbackAgentHomeCwd = resolveDefaultAgentWorkspaceDir(agentId);
-  if (path.resolve(previousCwd) !== path.resolve(fallbackAgentHomeCwd)) {
+  // Recognize both the per-agent fallback dir and an issue-scoped fallback subdir
+  // of it, so a session that ran in the issue-scoped fallback (BRO-1717) still
+  // migrates into a project workspace once one becomes available for the issue.
+  if (!isAgentFallbackWorkspaceCwd(agentId, previousCwd)) {
     return {
       sessionParams: previousSessionParams,
       warning: null as string | null,
@@ -7504,7 +7511,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
     }
 
-    const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+    // For a non-project issue with no reusable session workspace, key the fallback
+    // dir by issue as well as agent so successive heartbeats of the *same* issue land
+    // in the same directory (and reuse whatever git worktree/branch/commits the prior
+    // heartbeat left there) instead of a per-agent dir shared across every non-project
+    // issue, where an interleaved run on another issue can trample it (BRO-1717).
+    // A non-conforming issueId (should not happen for real UUIDs) degrades to the
+    // per-agent dir rather than failing the run.
+    let cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+    if (issueId) {
+      try {
+        cwd = resolveIssueScopedAgentWorkspaceDir(agent.id, issueId);
+      } catch {
+        cwd = resolveDefaultAgentWorkspaceDir(agent.id);
+      }
+    }
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
     if (sessionCwd && sessionCwdLooksUnsafe) {


### PR DESCRIPTION
## Problem

Non-project issues that do iterative local file work across multiple heartbeats lost git-worktree/branch continuity between runs. With no project or session workspace to key off, `resolveWorkspaceForRun` fell back to a workspace keyed only by `agentId` (`<instanceRoot>/workspaces/<agentId>`), shared across **every** non-project issue that agent touches. An interleaved run on a different issue could trample that directory, so heartbeat N+1 no longer saw the branch/commit heartbeat N produced and silently re-derived the work — burning context (one observed run reached 67.5% of its window just getting back to where the prior heartbeat left off).

## Fix

At the `agent_home` fallback site, key the directory by issue as well as agent (`<instanceRoot>/workspaces/<agentId>/<issueId>`) when an `issueId` is present, so successive heartbeats of the same issue reuse the same directory (and whatever git state it holds). A non-conforming `issueId` degrades to the per-agent directory rather than failing the run.

Also teach `resolveRuntimeSessionParamsForWorkspace` to recognize the issue-scoped subdir as a fallback (via `isAgentFallbackWorkspaceCwd`), so a session that started in the fallback still migrates into a project workspace once one becomes available.

The project-workspace-missing fallback (`source: project_primary`) and the `agentHome` field are intentionally left per-agent.

## Tests

- `agent-fallback-workspace-paths.test.ts`: path isolation, stability, path-traversal rejection, and the fallback-cwd predicate
- `heartbeat-workspace-session.test.ts`: extended with the issue-scoped migration case

## Category safeguard

The new unit tests cover the workspace path derivation as a regression harness — any future change to the fallback key will be caught before it reaches a running agent.