### PR TITLE
test(e2e): retry run-lock 409 in signoff-policy agentPatch

### DIFF
--- a/tests/e2e/signoff-policy.spec.ts
+++ b/tests/e2e/signoff-policy.spec.ts
@@ -75,6 +75,39 @@ async function getIssueRunLockState(board: APIRequestContext, issueId: string): 
   };
 }
 
+/**
+ * A lost run-lock race surfaces as one of two 409 conflicts, depending on which
+ * endpoint lost: a PATCH under a stale run id answers "Issue run ownership
+ * conflict", while a checkout that lost the lock answers "Issue checkout
+ * conflict". Only these two are transient and safe to retry under the winning
+ * run id.
+ *
+ * Every other 409 is a genuine outcome the suite's negative paths must observe
+ * unretried — a non-participant's "Issue is checked out by another agent"
+ * rejection, a paused-project refusal, or a lifecycle block. (The missing
+ * comment case is a 400, so it never enters a retry path.) Matching on the
+ * error message, rather than the bare 409 status, keeps those failing for the
+ * right reason.
+ */
+const RUN_LOCK_CONFLICT_ERRORS = new Set([
+  "Issue run ownership conflict",
+  "Issue checkout conflict",
+]);
+
+async function isRunLockConflictResponse(
+  res: Awaited<ReturnType<APIRequestContext["patch"]>>,
+): Promise<boolean> {
+  if (res.status() !== 409) return false;
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return false;
+  }
+  const error = (body as { error?: unknown } | null)?.error;
+  return typeof error === "string" && RUN_LOCK_CONFLICT_ERRORS.has(error);
+}
+
 async function retryAgentPatchWithCurrentLockOnConflict(
   board: APIRequestContext,
   agent: AgentAuth,
@@ -82,7 +115,7 @@ async function retryAgentPatchWithCurrentLockOnConflict(
   failedRes: Awaited<ReturnType<APIRequestContext["patch"]>>,
   patchData: Record<string, unknown>,
 ) {
-  if (failedRes.status() !== 409) return failedRes;
+  if (!(await isRunLockConflictResponse(failedRes))) return failedRes;
   const issueRunLock = await getIssueRunLockState(board, issueId);
   if (issueRunLock.assigneeAgentId !== agent.agentId) return failedRes;
 
@@ -100,17 +133,20 @@ async function retryAgentPatchWithCurrentLockOnConflict(
  * PATCH an issue as an agent, using a freshly invoked heartbeat run.
  *
  * Invoking a heartbeat starts a background run that races this PATCH for the
- * issue's run-lock: the background run may check the issue out (flipping it to
- * `in_progress` under its own run id) a moment before — or after — this PATCH
- * lands, and the server answers the loser with a 409 ("Issue is checked out by
- * another agent"). With `retries: 0` / `workers: 1` a single transient 409
- * fails the whole shard, so we retry a run-lock 409 under the issue's *current*
- * lock, bounded by escalating backoff to cover the race window.
+ * issue's run-lock: the background run may check the issue out (flipping its
+ * checkout run id under its own id) a moment before — or after — this PATCH
+ * lands, and the server answers the loser with a run-ownership 409 ("Issue run
+ * ownership conflict"). With `retries: 0` / `workers: 1` a single transient 409
+ * fails the whole shard, so we retry that specific conflict under the issue's
+ * *current* lock, bounded by escalating backoff to cover the race window.
  *
  * The retry is intentionally narrow so the suite's negative paths keep failing
  * for the right reason:
- *   - It only re-PATCHes while the issue is still assigned to the acting agent,
- *     so a non-participant's genuine 409/403 rejection is returned untouched.
+ *   - It only retries the run-lock conflict itself (see
+ *     `isRunLockConflictResponse`); any other 409 — a non-participant's
+ *     "checked out by another agent" rejection, a lifecycle block — is returned
+ *     untouched for the caller to assert on.
+ *   - It only re-PATCHes while the issue is still assigned to the acting agent.
  *   - It re-PATCHes under the winning run id (or the invoked run id once the
  *     background run has released its lock), so a real validation error such as
  *     the missing-comment 400 surfaces instead of a masking transient 409.
@@ -134,11 +170,11 @@ async function agentPatch(
     });
 
   let res = await patchWith(runId);
-  for (let attempt = 1; attempt < maxAttempts && res.status() === 409; attempt++) {
+  for (let attempt = 1; attempt < maxAttempts && (await isRunLockConflictResponse(res)); attempt++) {
     await new Promise((resolve) => setTimeout(resolve, Math.min(maxBackoffMs, backoffMs * 2 ** (attempt - 1))));
     const issueRunLock = await getIssueRunLockState(board, issueId);
-    // A 409 on an issue no longer assigned to us is a genuine rejection, not a
-    // run-lock race — leave it for the caller to assert on.
+    // A run-lock conflict on an issue no longer assigned to us is a genuine
+    // rejection, not a race — leave it for the caller to assert on.
     if (issueRunLock.assigneeAgentId !== agent.agentId) break;
     const retryRunId = issueRunLock.checkoutRunId ?? issueRunLock.executionRunId ?? runId;
     res = await patchWith(retryRunId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The e2e signoff-policy suite exercises a critical execution-policy flow in the server and tests
> - The `agentPatch` helper drives positive transitions by invoking a heartbeat run and then PATCHing the issue with that run id
> - That helper can race the background heartbeat run for the issue's run-lock
> - When the race is lost, the server returns a transient 409 even though the underlying transition is valid
> - This PR folds bounded current-lock retry behavior into `agentPatch` so the helper follows the winning run id on a transient lock conflict
> - The benefit is a stable signoff-policy e2e shard without weakening the negative validation paths

## Linked Issues or Issue Description

- Related public PR: https://github.com/paperclipai/paperclip/pull/10386
- This PR is a test-only fix for a flaky signoff-policy e2e helper that can lose a run-lock race and see a transient 409.

## What Changed

- Added bounded retry logic to `agentPatch` when PATCH returns a run-lock 409.
- Re-read the issue's current lock before retrying so the helper can re-PATCH under the winning run id.
- Preserved the comment-required 400 and the non-participant rejection behavior.

## Verification

- Deterministic HTTP harness verification from the handoff summary showed the pre-fix helper failing 100/100 with the `:346` 409 signature and the post-fix helper passing 100/100.
- Local full `tsc` / Playwright verification is not runnable in this sandbox because the production image does not include `typescript` or `@playwright/test`.
- The branch diff is a single-file change in `tests/e2e/signoff-policy.spec.ts`.

## Risks

- Low. The retry is bounded and only applies while the issue remains assigned to the acting agent.
- A bug in the retry guard could mask a genuine non-participant or validation failure, but those paths were intentionally preserved.

## Model Used

- OpenAI Codex (GPT-5, tool-using coding agent)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
