### PR TITLE
fix: preserve live generic timer checkouts

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -136,8 +136,10 @@ same-company run. This includes generic timer or on-demand runs whose original
 context snapshot did not name the issue before checkout. A persisted `running`
 row with no live execution is first failed by orphan-run recovery; its terminal
 status then makes the link eligible for stale-lock cleanup. Stranded escalation
-compares both link values at its mutation boundary, so a checkout acquired
-during reconciliation is not overwritten.
+locks the issue row and commits its recovery-action mutation with the issue
+transition in one transaction. The transition compares the source status,
+assignees, and both run links, so a checkout or terminal transition acquired
+during reconciliation is not overwritten and cannot inherit a recovery attempt.
 
 Paperclip already clears stale execution locks and can adopt some stale checkout locks when the original run is gone.
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -131,6 +131,14 @@ These are related but not identical:
 - `checkoutRunId` answers who currently owns execution rights for the issue
 - `executionRunId` answers which run is actually live right now
 
+Either link counts as a live execution path while it points to a non-terminal
+same-company run. This includes generic timer or on-demand runs whose original
+context snapshot did not name the issue before checkout. A persisted `running`
+row with no live execution is first failed by orphan-run recovery; its terminal
+status then makes the link eligible for stale-lock cleanup. Stranded escalation
+compares both link values at its mutation boundary, so a checkout acquired
+during reconciliation is not overwritten.
+
 Paperclip already clears stale execution locks and can adopt some stale checkout locks when the original run is gone.
 
 The active-lock lifecycle is part of the checkout contract:

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5219,7 +5219,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).not.toBe(timerRunId);
   });
 
-  it("does not overwrite a generic timer checkout acquired during stranded escalation", async () => {
+  it.each(["new", "existing"] as const)(
+    "does not overwrite a generic timer checkout or leak a %s recovery action during stranded escalation",
+    async (recoveryActionState) => {
     const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
@@ -5244,6 +5246,25 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       startedAt: now,
       updatedAt: now,
     });
+    if (recoveryActionState === "existing") {
+      await db.insert(issueRecoveryActions).values({
+        companyId,
+        sourceIssueId: issueId,
+        kind: "stranded_assigned_issue",
+        status: "active",
+        ownerType: "agent",
+        ownerAgentId: agentId,
+        previousOwnerAgentId: agentId,
+        returnOwnerAgentId: agentId,
+        cause: "stranded_assigned_issue",
+        fingerprint: `preexisting:${issueId}`,
+        evidence: { sentinel: "preserve-me" },
+        nextAction: "Preserve the pre-existing recovery action.",
+        wakePolicy: { type: "wake_owner" },
+        attemptCount: 3,
+        lastAttemptAt: now,
+      });
+    }
     await db.execute(sql`
       create or replace function test_link_timer_run_during_recovery()
       returns trigger
@@ -5271,7 +5292,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     `);
     await db.execute(sql`
       create trigger test_link_timer_run_during_recovery
-      after insert on issue_recovery_actions
+      after insert or update on issue_recovery_actions
       for each row execute function test_link_timer_run_during_recovery();
     `);
 
@@ -5293,9 +5314,123 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         checkoutRunId: timerRunId,
         executionRunId: timerRunId,
       });
+
+      const recoveryActions = await db
+        .select()
+        .from(issueRecoveryActions)
+        .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+      if (recoveryActionState === "new") {
+        expect(recoveryActions).toEqual([]);
+      } else {
+        expect(recoveryActions).toHaveLength(1);
+        expect(recoveryActions[0]).toMatchObject({
+          status: "active",
+          attemptCount: 3,
+          fingerprint: `preexisting:${issueId}`,
+          evidence: { sentinel: "preserve-me" },
+        });
+      }
+
+      const recoveryWakes = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.reason, "source_scoped_recovery_action"));
+      expect(recoveryWakes).toEqual([]);
+
+      const comments = await db
+        .select()
+        .from(issueComments)
+        .where(eq(issueComments.issueId, issueId));
+      expect(comments).toEqual([]);
+
+      const activity = await db
+        .select()
+        .from(activityLog)
+        .where(eq(activityLog.entityId, issueId));
+      expect(activity).toEqual([]);
     } finally {
       await db.execute(sql`drop trigger if exists test_link_timer_run_during_recovery on issue_recovery_actions`);
       await db.execute(sql`drop function if exists test_link_timer_run_during_recovery()`);
+    }
+  });
+
+  it("does not reblock a generic timer checkout acquired while the recovery wake is enqueued", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    const timerRunId = randomUUID();
+    const now = new Date("2026-03-19T00:06:00.000Z");
+
+    await db.insert(heartbeatRuns).values({
+      id: timerRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "test_reblock_timer_race",
+      status: "running",
+      contextSnapshot: {
+        wakeReason: "heartbeat_timer",
+        source: "heartbeat_timer",
+      },
+      startedAt: now,
+      updatedAt: now,
+    });
+    await db.execute(sql`
+      create or replace function test_link_timer_run_before_reblock()
+      returns trigger
+      language plpgsql
+      as $$
+      begin
+        if new.reason = 'source_scoped_recovery_action' then
+          update issues
+          set
+            status = 'in_progress',
+            checkout_run_id = (
+              select id from heartbeat_runs
+              where company_id = new.company_id
+                and trigger_detail = 'test_reblock_timer_race'
+              limit 1
+            ),
+            execution_run_id = (
+              select id from heartbeat_runs
+              where company_id = new.company_id
+                and trigger_detail = 'test_reblock_timer_race'
+              limit 1
+            )
+          where id = (new.payload ->> 'issueId')::uuid;
+        end if;
+        return new;
+      end;
+      $$;
+    `);
+    await db.execute(sql`
+      create trigger test_link_timer_run_before_reblock
+      after insert on agent_wakeup_requests
+      for each row execute function test_link_timer_run_before_reblock();
+    `);
+
+    try {
+      const heartbeat = heartbeatService(db);
+      await heartbeat.reconcileStrandedAssignedIssues();
+
+      const issue = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue).toMatchObject({
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: timerRunId,
+        executionRunId: timerRunId,
+      });
+    } finally {
+      await db.execute(sql`drop trigger if exists test_link_timer_run_before_reblock on agent_wakeup_requests`);
+      await db.execute(sql`drop function if exists test_link_timer_run_before_reblock()`);
     }
   });
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -115,6 +115,8 @@ import {
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
 } from "../services/recovery/index.ts";
+import { recoveryService } from "../services/recovery/service.ts";
+import { issueService } from "../services/issues.ts";
 import {
   UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
   UNMANAGED_BACKGROUND_TASK_STOP_REASON,
@@ -5219,9 +5221,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).not.toBe(timerRunId);
   });
 
-  it.each(["new", "existing"] as const)(
-    "does not overwrite a generic timer checkout or leak a %s recovery action during stranded escalation",
-    async (recoveryActionState) => {
+  it("keeps two reconcilers from leaking recovery mutations when a generic timer checkout wins", async () => {
     const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "succeeded",
@@ -5246,112 +5246,157 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       startedAt: now,
       updatedAt: now,
     });
-    if (recoveryActionState === "existing") {
-      await db.insert(issueRecoveryActions).values({
-        companyId,
-        sourceIssueId: issueId,
-        kind: "stranded_assigned_issue",
-        status: "active",
-        ownerType: "agent",
-        ownerAgentId: agentId,
-        previousOwnerAgentId: agentId,
-        returnOwnerAgentId: agentId,
-        cause: "stranded_assigned_issue",
-        fingerprint: `preexisting:${issueId}`,
-        evidence: { sentinel: "preserve-me" },
-        nextAction: "Preserve the pre-existing recovery action.",
-        wakePolicy: { type: "wake_owner" },
-        attemptCount: 3,
-        lastAttemptAt: now,
-      });
-    }
-    await db.execute(sql`
-      create or replace function test_link_timer_run_during_recovery()
-      returns trigger
-      language plpgsql
-      as $$
-      begin
-        update issues
-        set
-          checkout_run_id = (
-            select id from heartbeat_runs
-            where company_id = new.company_id
-              and trigger_detail = 'test_recovery_lock_race'
-            limit 1
-          ),
-          execution_run_id = (
-            select id from heartbeat_runs
-            where company_id = new.company_id
-              and trigger_detail = 'test_recovery_lock_race'
-            limit 1
-          )
-        where id = new.source_issue_id;
-        return new;
-      end;
-      $$;
-    `);
-    await db.execute(sql`
-      create trigger test_link_timer_run_during_recovery
-      after insert or update on issue_recovery_actions
-      for each row execute function test_link_timer_run_during_recovery();
-    `);
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "stranded_assigned_issue",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "stranded_assigned_issue",
+      fingerprint: `preexisting:${issueId}`,
+      evidence: { sentinel: "preserve-me" },
+      nextAction: "Preserve the pre-existing recovery action.",
+      wakePolicy: { type: "wake_owner" },
+      attemptCount: 3,
+      lastAttemptAt: now,
+    });
 
-    try {
-      const heartbeat = heartbeatService(db);
-      const result = await heartbeat.reconcileStrandedAssignedIssues();
+    let arrivals = 0;
+    let releaseMutation!: () => void;
+    let allReconcilersReady!: () => void;
+    const mutationReleased = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    const reconcilersReady = new Promise<void>((resolve) => {
+      allReconcilersReady = resolve;
+    });
+    const beforeStrandedEscalationMutation = async () => {
+      arrivals += 1;
+      if (arrivals === 2) allReconcilersReady();
+      await mutationReleased;
+    };
+    const enqueueWakeup = async () => null;
+    const reconcilerA = recoveryService(db, { enqueueWakeup, beforeStrandedEscalationMutation });
+    const reconcilerB = recoveryService(db, { enqueueWakeup, beforeStrandedEscalationMutation });
 
-      expect(result.escalated).toBe(0);
-      expect(result.issueIds).toEqual([]);
+    const reconciliationA = reconcilerA.reconcileStrandedAssignedIssues();
+    const reconciliationB = reconcilerB.reconcileStrandedAssignedIssues();
+    await reconcilersReady;
+    const checkedOut = await issueService(db).checkout(
+      issueId,
+      agentId,
+      ["in_progress"],
+      timerRunId,
+    );
+    expect(checkedOut).toMatchObject({
+      status: "in_progress",
+      checkoutRunId: timerRunId,
+      executionRunId: timerRunId,
+    });
+    releaseMutation();
 
-      const issue = await db
-        .select()
-        .from(issues)
-        .where(eq(issues.id, issueId))
-        .then((rows) => rows[0] ?? null);
-      expect(issue).toMatchObject({
-        status: "in_progress",
-        assigneeAgentId: agentId,
-        checkoutRunId: timerRunId,
-        executionRunId: timerRunId,
-      });
+    const [resultA, resultB] = await Promise.all([reconciliationA, reconciliationB]);
+    expect(resultA.escalated).toBe(0);
+    expect(resultB.escalated).toBe(0);
 
-      const recoveryActions = await db
-        .select()
-        .from(issueRecoveryActions)
-        .where(eq(issueRecoveryActions.sourceIssueId, issueId));
-      if (recoveryActionState === "new") {
-        expect(recoveryActions).toEqual([]);
-      } else {
-        expect(recoveryActions).toHaveLength(1);
-        expect(recoveryActions[0]).toMatchObject({
-          status: "active",
-          attemptCount: 3,
-          fingerprint: `preexisting:${issueId}`,
-          evidence: { sentinel: "preserve-me" },
-        });
-      }
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: timerRunId,
+      executionRunId: timerRunId,
+    });
 
-      const recoveryWakes = await db
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(1);
+    expect(recoveryActions[0]).toMatchObject({
+      status: "active",
+      attemptCount: 3,
+      fingerprint: `preexisting:${issueId}`,
+      evidence: { sentinel: "preserve-me" },
+    });
+    expect(
+      await db
         .select()
         .from(agentWakeupRequests)
-        .where(eq(agentWakeupRequests.reason, "source_scoped_recovery_action"));
-      expect(recoveryWakes).toEqual([]);
+        .where(eq(agentWakeupRequests.reason, "source_scoped_recovery_action")),
+    ).toEqual([]);
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, issueId))).toEqual([]);
+    expect(await db.select().from(activityLog).where(eq(activityLog.entityId, issueId))).toEqual([]);
+  });
 
-      const comments = await db
-        .select()
-        .from(issueComments)
-        .where(eq(issueComments.issueId, issueId));
-      expect(comments).toEqual([]);
+  it("preserves a concurrent terminal transition with null run links and no recovery side effects", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
 
-      const activity = await db
+    let releaseMutation!: () => void;
+    let reconcilerReady!: () => void;
+    const mutationReleased = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    const ready = new Promise<void>((resolve) => {
+      reconcilerReady = resolve;
+    });
+    const reconciler = recoveryService(db, {
+      enqueueWakeup: async () => null,
+      beforeStrandedEscalationMutation: async () => {
+        reconcilerReady();
+        await mutationReleased;
+      },
+    });
+
+    const reconciliation = reconciler.reconcileStrandedAssignedIssues();
+    await ready;
+    const terminal = await issueService(db).update(issueId, { status: "done" });
+    expect(terminal).toMatchObject({
+      status: "done",
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+    releaseMutation();
+
+    const result = await reconciliation;
+    expect(result.escalated).toBe(0);
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue).toMatchObject({
+      status: "done",
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+    expect(issue?.completedAt).not.toBeNull();
+    expect(
+      await db
         .select()
-        .from(activityLog)
-        .where(eq(activityLog.entityId, issueId));
-      expect(activity).toEqual([]);
-    } finally {
-      await db.execute(sql`drop trigger if exists test_link_timer_run_during_recovery on issue_recovery_actions`);
-      await db.execute(sql`drop function if exists test_link_timer_run_during_recovery()`);
-    }
+        .from(issueRecoveryActions)
+        .where(eq(issueRecoveryActions.sourceIssueId, issueId)),
+    ).toEqual([]);
+    expect(
+      await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.reason, "source_scoped_recovery_action")),
+    ).toEqual([]);
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, issueId))).toEqual([]);
+    expect(await db.select().from(activityLog).where(eq(activityLog.entityId, issueId))).toEqual([]);
   });
 
   it("does not reblock a generic timer checkout acquired while the recovery wake is enqueued", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4957,6 +4957,134 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Next action:");
   });
 
+  it("does not overwrite a generic timer checkout acquired before direct recovery-issue escalation", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const sourceIssueId = randomUUID();
+    const timerRunId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const now = new Date("2026-03-19T00:06:00.000Z");
+
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      title: "Original source issue",
+      status: "blocked",
+      priority: "medium",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    await db
+      .update(issues)
+      .set({
+        title: "Recover stalled issue from previous adapter failure",
+        parentId: sourceIssueId,
+        originKind: "stranded_issue_recovery",
+        originId: sourceIssueId,
+        originRunId: runId,
+        originFingerprint: [
+          "stranded_issue_recovery",
+          companyId,
+          sourceIssueId,
+          runId,
+        ].join(":"),
+      })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "running",
+        finishedAt: null,
+        error: null,
+        errorCode: null,
+        updatedAt: now,
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    await db
+      .update(agentWakeupRequests)
+      .set({
+        status: "claimed",
+        finishedAt: null,
+        error: null,
+        updatedAt: now,
+      })
+      .where(eq(agentWakeupRequests.runId, runId));
+    await db.insert(heartbeatRuns).values({
+      id: timerRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "test_direct_recovery_issue_checkout_race",
+      status: "running",
+      contextSnapshot: {
+        wakeReason: "heartbeat_timer",
+        source: "heartbeat_timer",
+      },
+      startedAt: now,
+      updatedAt: now,
+    });
+    await db.execute(sql`
+      create or replace function test_checkout_before_direct_recovery_escalation()
+      returns trigger
+      language plpgsql
+      as $$
+      begin
+        if old.id = ${sql.raw(`'${issueId}'::uuid`)}
+          and old.checkout_run_id = ${sql.raw(`'${runId}'::uuid`)}
+          and new.checkout_run_id is null
+        then
+          new.status := 'in_progress';
+          new.checkout_run_id := ${sql.raw(`'${timerRunId}'::uuid`)};
+          new.execution_run_id := ${sql.raw(`'${timerRunId}'::uuid`)};
+        end if;
+        return new;
+      end;
+      $$;
+    `);
+    await db.execute(sql`
+      create trigger test_checkout_before_direct_recovery_escalation
+      before update on issues
+      for each row execute function test_checkout_before_direct_recovery_escalation();
+    `);
+
+    try {
+      const heartbeat = heartbeatService(db);
+      await heartbeat.cancelRun(runId, "force direct recovery-issue escalation");
+
+      const issue = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue).toMatchObject({
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: timerRunId,
+        executionRunId: timerRunId,
+      });
+      expect(
+        await db
+          .select()
+          .from(issueRecoveryActions)
+          .where(eq(issueRecoveryActions.sourceIssueId, issueId)),
+      ).toEqual([]);
+      expect(
+        await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.reason, "source_scoped_recovery_action")),
+      ).toEqual([]);
+      expect(await db.select().from(issueComments).where(eq(issueComments.issueId, issueId))).toEqual([]);
+      expect(await db.select().from(activityLog).where(eq(activityLog.entityId, issueId))).toEqual([]);
+    } finally {
+      await db.execute(sql`drop trigger if exists test_checkout_before_direct_recovery_escalation on issues`);
+      await db.execute(sql`drop function if exists test_checkout_before_direct_recovery_escalation()`);
+    }
+  });
+
   it("assigns open unassigned blockers back to their creator agent", async () => {
     const companyId = randomUUID();
     const creatorAgentId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5087,6 +5087,218 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it.each(["checkoutRunId", "executionRunId"] as const)(
+    "does not reap a live generic timer checkout linked through %s",
+    async (linkColumn) => {
+      const { companyId, agentId, issueId, runId: staleRunId } = await seedStrandedIssueFixture({
+        status: "in_progress",
+        runStatus: "failed",
+      });
+      const timerRunId = randomUUID();
+      const timerWakeId = randomUUID();
+      const now = new Date("2026-03-19T00:06:00.000Z");
+
+      await db.insert(agentWakeupRequests).values({
+        id: timerWakeId,
+        companyId,
+        agentId,
+        source: "timer",
+        triggerDetail: "system",
+        reason: "heartbeat_timer",
+        payload: {},
+        status: "claimed",
+        runId: timerRunId,
+        claimedAt: now,
+      });
+      await db.insert(heartbeatRuns).values({
+        id: timerRunId,
+        companyId,
+        agentId,
+        invocationSource: "timer",
+        triggerDetail: "system",
+        status: "running",
+        wakeupRequestId: timerWakeId,
+        contextSnapshot: {
+          wakeReason: "heartbeat_timer",
+          source: "heartbeat_timer",
+        },
+        startedAt: now,
+        updatedAt: now,
+      });
+      await db
+        .update(issues)
+        .set({
+          checkoutRunId: linkColumn === "checkoutRunId" ? timerRunId : null,
+          executionRunId: linkColumn === "executionRunId" ? timerRunId : null,
+          updatedAt: now,
+        })
+        .where(eq(issues.id, issueId));
+
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+      expect(result.continuationRequeued).toBe(0);
+      expect(result.escalated).toBe(0);
+      expect(result.issueIds).toEqual([]);
+
+      const issue = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue).toMatchObject({
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        [linkColumn]: timerRunId,
+      });
+
+      const recoveryActions = await db
+        .select()
+        .from(issueRecoveryActions)
+        .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+      expect(recoveryActions).toEqual([]);
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.companyId, companyId));
+      expect(runs.map((row) => row.id).sort()).toEqual([staleRunId, timerRunId].sort());
+    },
+  );
+
+  it("reaps a process-lost generic timer run before its issue link can suppress recovery indefinitely", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+    const timerRunId = randomUUID();
+    const staleAt = new Date(Date.now() - 60_000);
+
+    await db.insert(heartbeatRuns).values({
+      id: timerRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        wakeReason: "heartbeat_timer",
+        source: "heartbeat_timer",
+      },
+      startedAt: staleAt,
+      updatedAt: staleAt,
+    });
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: timerRunId,
+        executionRunId: timerRunId,
+        updatedAt: staleAt,
+      })
+      .where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const reaped = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 1 });
+
+    expect(reaped).toEqual({ reaped: 1, runIds: [timerRunId] });
+    const timerRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, timerRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(timerRun).toMatchObject({
+      status: "failed",
+      errorCode: "process_lost",
+    });
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.checkoutRunId).not.toBe(timerRunId);
+    expect(issue?.executionRunId).not.toBe(timerRunId);
+  });
+
+  it("does not overwrite a generic timer checkout acquired during stranded escalation", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    const timerRunId = randomUUID();
+    const now = new Date("2026-03-19T00:06:00.000Z");
+
+    await db.insert(heartbeatRuns).values({
+      id: timerRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "test_recovery_lock_race",
+      status: "running",
+      contextSnapshot: {
+        wakeReason: "heartbeat_timer",
+        source: "heartbeat_timer",
+      },
+      startedAt: now,
+      updatedAt: now,
+    });
+    await db.execute(sql`
+      create or replace function test_link_timer_run_during_recovery()
+      returns trigger
+      language plpgsql
+      as $$
+      begin
+        update issues
+        set
+          checkout_run_id = (
+            select id from heartbeat_runs
+            where company_id = new.company_id
+              and trigger_detail = 'test_recovery_lock_race'
+            limit 1
+          ),
+          execution_run_id = (
+            select id from heartbeat_runs
+            where company_id = new.company_id
+              and trigger_detail = 'test_recovery_lock_race'
+            limit 1
+          )
+        where id = new.source_issue_id;
+        return new;
+      end;
+      $$;
+    `);
+    await db.execute(sql`
+      create trigger test_link_timer_run_during_recovery
+      after insert on issue_recovery_actions
+      for each row execute function test_link_timer_run_during_recovery();
+    `);
+
+    try {
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+      expect(result.escalated).toBe(0);
+      expect(result.issueIds).toEqual([]);
+
+      const issue = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue).toMatchObject({
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        checkoutRunId: timerRunId,
+        executionRunId: timerRunId,
+      });
+    } finally {
+      await db.execute(sql`drop trigger if exists test_link_timer_run_during_recovery on issue_recovery_actions`);
+      await db.execute(sql`drop function if exists test_link_timer_run_during_recovery()`);
+    }
+  });
+
   it("does not continue seeded in-progress work that has no run linkage", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1137,17 +1137,26 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(comments[0]?.body).toContain("Recovery action:");
   });
 
-  it("preserves a null-link terminal transition that lands while the recovery wake is enqueued", async () => {
+  it("preserves a null-link terminal transition after the post-wake snapshot", async () => {
     const { managerId, coderId, sourceIssue } = await seedCompany();
     await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
     const enqueueWakeup = vi.fn(async () => {
       await db
         .update(issues)
-        .set({ status: "done", checkoutRunId: null, executionRunId: null })
+        .set({ status: "in_progress", checkoutRunId: null, executionRunId: null })
         .where(eq(issues.id, sourceIssue.id));
       return null;
     });
-    const recovery = recoveryService(db, { enqueueWakeup });
+    const beforeStrandedPostWakeReblockMutation = vi.fn(async () => {
+      await db
+        .update(issues)
+        .set({ status: "done", checkoutRunId: null, executionRunId: null })
+        .where(eq(issues.id, sourceIssue.id));
+    });
+    const recovery = recoveryService(db, {
+      enqueueWakeup,
+      beforeStrandedPostWakeReblockMutation,
+    });
 
     await recovery.escalateStrandedAssignedIssue({
       issue: sourceIssue,
@@ -1174,13 +1183,41 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       checkoutRunId: null,
       executionRunId: null,
     });
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actionRows).toHaveLength(1);
+    expect(actionRows[0]?.attemptCount).toBe(1);
     expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(beforeStrandedPostWakeReblockMutation).toHaveBeenCalledTimes(1);
+    expect(
+      await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(activityLog).where(eq(activityLog.entityId, sourceIssue.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(issueRelations).where(eq(issueRelations.relatedIssueId, sourceIssue.id)),
+    ).toHaveLength(0);
   });
 
-  it("preserves a null-link reassignment that lands while the recovery wake is enqueued", async () => {
+  it("preserves a null-link reassignment after the post-wake snapshot", async () => {
     const { managerId, coderId, sourceIssue } = await seedCompany();
     await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
     const enqueueWakeup = vi.fn(async () => {
+      await db
+        .update(issues)
+        .set({
+          status: "in_progress",
+          assigneeAgentId: coderId,
+          checkoutRunId: null,
+          executionRunId: null,
+        })
+        .where(eq(issues.id, sourceIssue.id));
+      return null;
+    });
+    const beforeStrandedPostWakeReblockMutation = vi.fn(async () => {
       await db
         .update(issues)
         .set({
@@ -1190,9 +1227,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
           executionRunId: null,
         })
         .where(eq(issues.id, sourceIssue.id));
-      return null;
     });
-    const recovery = recoveryService(db, { enqueueWakeup });
+    const recovery = recoveryService(db, {
+      enqueueWakeup,
+      beforeStrandedPostWakeReblockMutation,
+    });
 
     await recovery.escalateStrandedAssignedIssue({
       issue: sourceIssue,
@@ -1219,7 +1258,23 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       checkoutRunId: null,
       executionRunId: null,
     });
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actionRows).toHaveLength(1);
+    expect(actionRows[0]?.attemptCount).toBe(1);
     expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(beforeStrandedPostWakeReblockMutation).toHaveBeenCalledTimes(1);
+    expect(
+      await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(activityLog).where(eq(activityLog.entityId, sourceIssue.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(issueRelations).where(eq(issueRelations.relatedIssueId, sourceIssue.id)),
+    ).toHaveLength(0);
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1137,6 +1137,91 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(comments[0]?.body).toContain("Recovery action:");
   });
 
+  it("preserves a null-link terminal transition that lands while the recovery wake is enqueued", async () => {
+    const { managerId, coderId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
+    const enqueueWakeup = vi.fn(async () => {
+      await db
+        .update(issues)
+        .set({ status: "done", checkoutRunId: null, executionRunId: null })
+        .where(eq(issues.id, sourceIssue.id));
+      return null;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedIssue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "done",
+      assigneeAgentId: coderId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a null-link reassignment that lands while the recovery wake is enqueued", async () => {
+    const { managerId, coderId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
+    const enqueueWakeup = vi.fn(async () => {
+      await db
+        .update(issues)
+        .set({
+          status: "in_progress",
+          assigneeAgentId: managerId,
+          checkoutRunId: null,
+          executionRunId: null,
+        })
+        .where(eq(issues.id, sourceIssue.id));
+      return null;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedIssue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: managerId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+  });
+
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {
     const { companyId, managerId, sourceIssueId, prefix } = await seedCompany();
     const recoveryIssueId = randomUUID();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1137,6 +1137,88 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(comments[0]?.body).toContain("Recovery action:");
   });
 
+  it("preserves recovery resolution completed before the post-wake snapshot", async () => {
+    const { companyId, managerId, coderId, sourceIssue } = await seedCompany();
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));
+    const recoveryActionsSvc = issueRecoveryActionService(db);
+    const enqueueWakeup = vi.fn(async () => {
+      const activeAction = await recoveryActionsSvc.getActiveForIssue(
+        companyId,
+        sourceIssue.id,
+      );
+      expect(activeAction).not.toBeNull();
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(issues)
+          .set({
+            status: "todo",
+            assigneeAgentId: coderId,
+            checkoutRunId: null,
+            executionRunId: null,
+          })
+          .where(eq(issues.id, sourceIssue.id));
+        const resolvedAction = await recoveryActionsSvc.resolveActiveForIssue({
+          companyId,
+          sourceIssueId: sourceIssue.id,
+          actionId: activeAction!.id,
+          status: "resolved",
+          outcome: "handed_back",
+          resolutionNote: "Recovery owner restored the source issue.",
+        }, tx);
+        expect(resolvedAction).not.toBeNull();
+      });
+      return null;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [updatedIssue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssue.id));
+    expect(updatedIssue).toMatchObject({
+      status: "todo",
+      assigneeAgentId: coderId,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actionRows).toHaveLength(1);
+    expect(actionRows[0]).toMatchObject({
+      status: "resolved",
+      outcome: "handed_back",
+      attemptCount: 1,
+    });
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(
+      await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(activityLog).where(eq(activityLog.entityId, sourceIssue.id)),
+    ).toHaveLength(1);
+    expect(
+      await db.select().from(issueRelations).where(eq(issueRelations.relatedIssueId, sourceIssue.id)),
+    ).toHaveLength(0);
+  });
+
   it("preserves a null-link terminal transition after the post-wake snapshot", async () => {
     const { managerId, coderId, sourceIssue } = await seedCompany();
     await db.update(agents).set({ status: "paused" }).where(eq(agents.id, managerId));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15210,6 +15210,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         issue: promotionResult.issue,
         previousStatus: promotionResult.previousStatus as "todo" | "in_progress" | "in_review",
         latestRun: run,
+        expectedCheckoutRunId: null,
+        expectedExecutionRunId: null,
+        expectedStatus: promotionResult.issue.status as "todo" | "in_progress" | "in_review",
+        expectedAssigneeAgentId: promotionResult.issue.assigneeAgentId,
+        expectedAssigneeUserId: promotionResult.issue.assigneeUserId,
       });
       return;
     }

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -123,8 +123,12 @@ export function issueRecoveryActionService(db: Db) {
     }
   }
 
-  async function getActiveForIssue(companyId: string, sourceIssueId: string): Promise<IssueRecoveryAction | null> {
-    const row = await db
+  async function getActiveForIssue(
+    companyId: string,
+    sourceIssueId: string,
+    dbOrTx: DbOrTransaction = db,
+  ): Promise<IssueRecoveryAction | null> {
+    const row = await dbOrTx
       .select()
       .from(issueRecoveryActions)
       .where(
@@ -164,6 +168,7 @@ export function issueRecoveryActionService(db: Db) {
     input: UpsertIssueRecoveryActionInput,
     retryCount: number,
     error?: unknown,
+    dbOrTx: DbOrTransaction = db,
   ): Promise<IssueRecoveryAction> {
     if (retryCount >= MAX_UPSERT_RETRIES) {
       if (error) throw error;
@@ -171,18 +176,19 @@ export function issueRecoveryActionService(db: Db) {
         `Failed to upsert active recovery action for issue ${input.sourceIssueId} after ${MAX_UPSERT_RETRIES} retries`,
       );
     }
-    return upsertSourceScopedUnlocked(input, retryCount + 1);
+    return upsertSourceScopedUnlocked(input, retryCount + 1, dbOrTx);
   }
 
   async function upsertSourceScopedUnlocked(
     input: UpsertIssueRecoveryActionInput,
     retryCount = 0,
+    dbOrTx: DbOrTransaction = db,
   ): Promise<IssueRecoveryAction> {
-    const existing = await getActiveForIssue(input.companyId, input.sourceIssueId);
+    const existing = await getActiveForIssue(input.companyId, input.sourceIssueId, dbOrTx);
     const now = new Date();
     const ownerType = input.ownerType ?? (input.ownerAgentId ? "agent" : "board");
     if (existing) {
-      const [updated] = await db
+      const [updated] = await dbOrTx
         .update(issueRecoveryActions)
         .set({
           recoveryIssueId: input.recoveryIssueId ?? null,
@@ -216,13 +222,13 @@ export function issueRecoveryActionService(db: Db) {
         )
         .returning();
       if (!updated) {
-        return retryUpsertSourceScoped(input, retryCount);
+        return retryUpsertSourceScoped(input, retryCount, undefined, dbOrTx);
       }
       return toReadModel(updated!);
     }
 
     try {
-      const [created] = await db
+      const [created] = await dbOrTx
         .insert(issueRecoveryActions)
         .values({
           companyId: input.companyId,
@@ -250,14 +256,15 @@ export function issueRecoveryActionService(db: Db) {
       return toReadModel(created!);
     } catch (error) {
       if (!isUniqueRecoveryActionConflict(error)) throw error;
-      return retryUpsertSourceScoped(input, retryCount, error);
+      return retryUpsertSourceScoped(input, retryCount, error, dbOrTx);
     }
   }
 
   async function upsertSourceScoped(
     input: UpsertIssueRecoveryActionInput,
+    dbOrTx: DbOrTransaction = db,
   ): Promise<IssueRecoveryAction> {
-    return runExclusiveUpsert(input, () => upsertSourceScopedUnlocked(input));
+    return runExclusiveUpsert(input, () => upsertSourceScopedUnlocked(input, 0, dbOrTx));
   }
 
   async function resolveActiveForIssue(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6569,6 +6569,8 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        expectedCheckoutRunId?: string | null;
+        expectedExecutionRunId?: string | null;
       },
       dbOrTx: any = db,
     ) => {
@@ -6584,6 +6586,8 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        expectedCheckoutRunId,
+        expectedExecutionRunId,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -6741,7 +6745,21 @@ export function issueService(db: Db) {
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(eq(issues.id, id))
+          .where(
+            and(
+              eq(issues.id, id),
+              expectedCheckoutRunId === undefined
+                ? undefined
+                : expectedCheckoutRunId === null
+                  ? isNull(issues.checkoutRunId)
+                  : eq(issues.checkoutRunId, expectedCheckoutRunId),
+              expectedExecutionRunId === undefined
+                ? undefined
+                : expectedExecutionRunId === null
+                  ? isNull(issues.executionRunId)
+                  : eq(issues.executionRunId, expectedExecutionRunId),
+            ),
+          )
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6571,6 +6571,9 @@ export function issueService(db: Db) {
         actorUserId?: string | null;
         expectedCheckoutRunId?: string | null;
         expectedExecutionRunId?: string | null;
+        expectedStatus?: typeof issues.$inferSelect.status;
+        expectedAssigneeAgentId?: string | null;
+        expectedAssigneeUserId?: string | null;
       },
       dbOrTx: any = db,
     ) => {
@@ -6588,6 +6591,9 @@ export function issueService(db: Db) {
         actorUserId,
         expectedCheckoutRunId,
         expectedExecutionRunId,
+        expectedStatus,
+        expectedAssigneeAgentId,
+        expectedAssigneeUserId,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -6758,6 +6764,17 @@ export function issueService(db: Db) {
                 : expectedExecutionRunId === null
                   ? isNull(issues.executionRunId)
                   : eq(issues.executionRunId, expectedExecutionRunId),
+              expectedStatus === undefined ? undefined : eq(issues.status, expectedStatus),
+              expectedAssigneeAgentId === undefined
+                ? undefined
+                : expectedAssigneeAgentId === null
+                  ? isNull(issues.assigneeAgentId)
+                  : eq(issues.assigneeAgentId, expectedAssigneeAgentId),
+              expectedAssigneeUserId === undefined
+                ? undefined
+                : expectedAssigneeUserId === null
+                  ? isNull(issues.assigneeUserId)
+                  : eq(issues.assigneeUserId, expectedAssigneeUserId),
             ),
           )
           .returning()

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3457,7 +3457,7 @@ export function recoveryService(db: Db, deps: {
     });
 
     if (recoveryAction.ownerAgentId && recoveryAction.ownerAgentId === input.issue.assigneeAgentId) {
-      const [currentIssue] = await db
+      const [observedIssue] = await db
         .select({
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
@@ -3469,25 +3469,70 @@ export function recoveryService(db: Db, deps: {
         .where(eq(issues.id, input.issue.id))
         .limit(1);
       if (
-        currentIssue &&
-        currentIssue.checkoutRunId === null &&
-        currentIssue.executionRunId === null &&
-        currentIssue.status !== "blocked" &&
-        currentIssue.status !== "done" &&
-        currentIssue.status !== "cancelled" &&
-        currentIssue.assigneeAgentId === recoveryAction.ownerAgentId &&
-        currentIssue.assigneeUserId === input.issue.assigneeUserId
+        observedIssue &&
+        observedIssue.checkoutRunId === null &&
+        observedIssue.executionRunId === null &&
+        observedIssue.status !== "blocked" &&
+        observedIssue.status !== "done" &&
+        observedIssue.status !== "cancelled" &&
+        observedIssue.assigneeAgentId === recoveryAction.ownerAgentId &&
+        observedIssue.assigneeUserId === input.issue.assigneeUserId
       ) {
         await deps.beforeStrandedPostWakeReblockMutation?.();
-        const reblocked = await issuesSvc.update(input.issue.id, {
-          status: "blocked",
-          blockedByIssueIds: blockerIds,
-          assigneeAgentId: recoveryAction.ownerAgentId,
-          expectedCheckoutRunId: null,
-          expectedExecutionRunId: null,
-          expectedStatus: currentIssue.status,
-          expectedAssigneeAgentId: currentIssue.assigneeAgentId,
-          expectedAssigneeUserId: currentIssue.assigneeUserId,
+        const reblocked = await db.transaction(async (tx) => {
+          const [lockedIssue] = await tx
+            .select({
+              status: issues.status,
+              assigneeAgentId: issues.assigneeAgentId,
+              assigneeUserId: issues.assigneeUserId,
+              checkoutRunId: issues.checkoutRunId,
+              executionRunId: issues.executionRunId,
+            })
+            .from(issues)
+            .where(
+              and(
+                eq(issues.companyId, input.issue.companyId),
+                eq(issues.id, input.issue.id),
+              ),
+            )
+            .for("update")
+            .limit(1);
+          if (
+            !lockedIssue ||
+            lockedIssue.status !== observedIssue.status ||
+            lockedIssue.assigneeAgentId !== observedIssue.assigneeAgentId ||
+            lockedIssue.assigneeUserId !== observedIssue.assigneeUserId ||
+            lockedIssue.checkoutRunId !== observedIssue.checkoutRunId ||
+            lockedIssue.executionRunId !== observedIssue.executionRunId
+          ) {
+            return null;
+          }
+
+          const [lockedRecoveryAction] = await tx
+            .select({ id: issueRecoveryActions.id })
+            .from(issueRecoveryActions)
+            .where(
+              and(
+                eq(issueRecoveryActions.id, recoveryAction.id),
+                eq(issueRecoveryActions.companyId, input.issue.companyId),
+                eq(issueRecoveryActions.sourceIssueId, input.issue.id),
+                inArray(issueRecoveryActions.status, ["active", "escalated"]),
+              ),
+            )
+            .for("update")
+            .limit(1);
+          if (!lockedRecoveryAction) return null;
+
+          return issuesSvc.update(input.issue.id, {
+            status: "blocked",
+            blockedByIssueIds: blockerIds,
+            assigneeAgentId: recoveryAction.ownerAgentId,
+            expectedCheckoutRunId: lockedIssue.checkoutRunId,
+            expectedExecutionRunId: lockedIssue.executionRunId,
+            expectedStatus: lockedIssue.status,
+            expectedAssigneeAgentId: lockedIssue.assigneeAgentId,
+            expectedAssigneeUserId: lockedIssue.assigneeUserId,
+          }, tx);
         });
         if (reblocked) return reblocked;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3258,11 +3258,31 @@ export function recoveryService(db: Db, deps: {
           .for("update")
           .limit(1)
           .then((rows) => rows[0] ?? null);
+        const activeRecoveryAction = lockedIssue
+          ? await recoveryActionsSvc.getActiveForIssue(
+            lockedIssue.companyId,
+            lockedIssue.id,
+            tx,
+          )
+          : null;
+        const matchesObservedIssue = Boolean(
+          lockedIssue &&
+          lockedIssue.status === input.issue.status &&
+          lockedIssue.assigneeAgentId === input.issue.assigneeAgentId &&
+          lockedIssue.assigneeUserId === input.issue.assigneeUserId
+        );
+        const matchesExistingRecoveryDisposition = Boolean(
+          lockedIssue &&
+          activeRecoveryAction &&
+          lockedIssue.status === "blocked" &&
+          lockedIssue.assigneeAgentId === (
+            activeRecoveryAction.ownerAgentId ?? input.issue.assigneeAgentId
+          ) &&
+          lockedIssue.assigneeUserId === input.issue.assigneeUserId
+        );
         if (
           !lockedIssue ||
-          lockedIssue.status !== input.issue.status ||
-          lockedIssue.assigneeAgentId !== input.issue.assigneeAgentId ||
-          lockedIssue.assigneeUserId !== input.issue.assigneeUserId
+          (!matchesObservedIssue && !matchesExistingRecoveryDisposition)
         ) {
           return null;
         }
@@ -3281,7 +3301,7 @@ export function recoveryService(db: Db, deps: {
           tx,
         );
         const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
-          issue: lockedIssue,
+          issue: input.issue,
           previousStatus: input.previousStatus,
           latestRun: input.latestRun,
           recoveryCause,
@@ -3440,14 +3460,22 @@ export function recoveryService(db: Db, deps: {
         .select({
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, input.issue.id))
         .limit(1);
       if (
         currentIssue &&
-        (currentIssue.status !== "blocked" ||
-          currentIssue.assigneeAgentId !== recoveryAction.ownerAgentId)
+        currentIssue.checkoutRunId === null &&
+        currentIssue.executionRunId === null &&
+        currentIssue.status !== "blocked" &&
+        currentIssue.status !== "done" &&
+        currentIssue.status !== "cancelled" &&
+        currentIssue.assigneeAgentId === recoveryAction.ownerAgentId &&
+        currentIssue.assigneeUserId === input.issue.assigneeUserId
       ) {
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
@@ -3455,6 +3483,9 @@ export function recoveryService(db: Db, deps: {
           assigneeAgentId: recoveryAction.ownerAgentId,
           expectedCheckoutRunId: null,
           expectedExecutionRunId: null,
+          expectedStatus: currentIssue.status,
+          expectedAssigneeAgentId: currentIssue.assigneeAgentId,
+          expectedAssigneeUserId: currentIssue.assigneeUserId,
         });
         if (reblocked) return reblocked;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2913,6 +2913,57 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
   }
 
+  async function compensateStrandedRecoveryActionCasMiss(input: {
+    previousAction: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>>;
+    attemptedAction: Awaited<ReturnType<typeof recoveryActionsSvc.upsertSourceScoped>>;
+  }) {
+    if (!input.previousAction) {
+      await db
+        .delete(issueRecoveryActions)
+        .where(and(
+          eq(issueRecoveryActions.id, input.attemptedAction.id),
+          eq(issueRecoveryActions.attemptCount, input.attemptedAction.attemptCount),
+          inArray(issueRecoveryActions.status, ["active", "escalated"]),
+        ));
+      return;
+    }
+
+    const previous = input.previousAction;
+    const asDate = (value: string | Date | null) =>
+      typeof value === "string" ? new Date(value) : value;
+    await db
+      .update(issueRecoveryActions)
+      .set({
+        recoveryIssueId: previous.recoveryIssueId,
+        kind: previous.kind,
+        status: previous.status,
+        ownerType: previous.ownerType,
+        ownerAgentId: previous.ownerAgentId,
+        ownerUserId: previous.ownerUserId,
+        previousOwnerAgentId: previous.previousOwnerAgentId,
+        returnOwnerAgentId: previous.returnOwnerAgentId,
+        cause: previous.cause,
+        fingerprint: previous.fingerprint,
+        evidence: previous.evidence,
+        nextAction: previous.nextAction,
+        wakePolicy: previous.wakePolicy,
+        monitorPolicy: previous.monitorPolicy,
+        attemptCount: previous.attemptCount,
+        maxAttempts: previous.maxAttempts,
+        timeoutAt: asDate(previous.timeoutAt),
+        lastAttemptAt: asDate(previous.lastAttemptAt),
+        outcome: previous.outcome,
+        resolutionNote: previous.resolutionNote,
+        resolvedAt: asDate(previous.resolvedAt),
+        updatedAt: asDate(previous.updatedAt)!,
+      })
+      .where(and(
+        eq(issueRecoveryActions.id, input.attemptedAction.id),
+        eq(issueRecoveryActions.attemptCount, input.attemptedAction.attemptCount),
+        inArray(issueRecoveryActions.status, ["active", "escalated"]),
+      ));
+  }
+
   function readProviderQuotaRetryAt(latestRun: LatestIssueRun, now: Date) {
     const result = parseObject(latestRun?.resultJson);
     const context = parseObject(latestRun?.contextSnapshot);
@@ -3213,6 +3264,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    const previousRecoveryAction = await recoveryActionsSvc.getActiveForIssue(
+      input.issue.companyId,
+      input.issue.id,
+    );
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,
       previousStatus: input.previousStatus,
@@ -3221,6 +3277,32 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recoveryOwnerAgentId: input.recoveryOwnerAgentId,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
     });
+    const updated = await issuesSvc.update(input.issue.id, {
+      status: "blocked",
+      blockedByIssueIds: blockerIds,
+      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      expectedCheckoutRunId: executionPath.checkoutRunId,
+      expectedExecutionRunId: executionPath.executionRunId,
+    });
+    if (!updated) {
+      const currentIssue = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, input.issue.id))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      // Another reconciler may have won the same recovery race. Its blocked
+      // state owns the shared source-scoped action; every other CAS miss must
+      // restore the action snapshot so a productive checkout or unrelated
+      // issue transition cannot inherit recovery side effects.
+      if (currentIssue?.status !== "blocked") {
+        await compensateStrandedRecoveryActionCasMiss({
+          previousAction: previousRecoveryAction,
+          attemptedAction: recoveryAction,
+        });
+      }
+      return null;
+    }
     const isProviderQuotaWait = recoveryCause === "provider_quota" &&
       !recoveryAction.ownerAgentId &&
       Boolean(recoveryAction.returnOwnerAgentId);
@@ -3232,15 +3314,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
-      blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
-      expectedCheckoutRunId: executionPath.checkoutRunId,
-      expectedExecutionRunId: executionPath.executionRunId,
-    });
-    if (!updated) return null;
     if (isProviderQuotaWait) return updated;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -3376,6 +3449,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           status: "blocked",
           blockedByIssueIds: blockerIds,
           assigneeAgentId: recoveryAction.ownerAgentId,
+          expectedCheckoutRunId: null,
+          expectedExecutionRunId: null,
         });
         if (reblocked) return reblocked;
       }
@@ -3612,7 +3687,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
-        const updated = await escalateStrandedRecoveryIssueInPlace({
+        const updated = await escalateStrandedAssignedIssue({
           issue,
           previousStatus: issue.status as StrandedPreviousStatus,
           latestRun,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -87,6 +87,7 @@ const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiv
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON = "execution_review_participant_recovery";
 const RESOLVED_DEPENDENCY_WAKE_BACKSTOP_CANDIDATE_LIMIT = 500;
+class StrandedRecoveryMutationCasMiss extends Error {}
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -124,6 +125,8 @@ type RecoveryWakeup = (
   agentId: string,
   opts?: RecoveryWakeupOptions,
 ) => Promise<typeof heartbeatRuns.$inferSelect | null>;
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type DbOrTransaction = Db | DbTransaction;
 
 type ResolvedDependencyWakeBackstopSource =
   | "issue_graph_liveness.backstop"
@@ -680,7 +683,10 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
   ].join("\n");
 }
 
-export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup }) {
+export function recoveryService(db: Db, deps: {
+  enqueueWakeup: RecoveryWakeup;
+  beforeStrandedEscalationMutation?: () => Promise<void>;
+}) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -806,9 +812,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { consecutive, latestFinishedAt };
   }
 
-  async function readActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
+  async function readActiveExecutionPath(
+    companyId: string,
+    issueId: string,
+    agentId?: string | null,
+    dbOrTx: DbOrTransaction = db,
+  ) {
     const [contextRun, linkedState, deferredWake] = await Promise.all([
-      db
+      dbOrTx
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
         .where(
@@ -821,7 +832,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         )
         .limit(1)
         .then((rows) => rows[0] ?? null),
-      db
+      dbOrTx
         .select({
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
@@ -848,7 +859,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         )
         .limit(1)
         .then((rows) => rows[0] ?? null),
-      db
+      dbOrTx
         .select({ id: agentWakeupRequests.id })
         .from(agentWakeupRequests)
         .where(
@@ -2793,7 +2804,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause?: StrandedRecoveryCause;
     recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
-  }) {
+  }, dbOrTx: DbOrTransaction = db) {
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
     const routing = await resolveStrandedRecoveryRouting({
       issue: input.issue,
@@ -2871,7 +2882,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         : null,
       maxAttempts: null,
       lastAttemptAt: now,
-    });
+    }, dbOrTx);
 
     return action;
   }
@@ -2911,57 +2922,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         recoveryCause: input.recoveryCause,
       }, "status_only"),
     });
-  }
-
-  async function compensateStrandedRecoveryActionCasMiss(input: {
-    previousAction: Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>>;
-    attemptedAction: Awaited<ReturnType<typeof recoveryActionsSvc.upsertSourceScoped>>;
-  }) {
-    if (!input.previousAction) {
-      await db
-        .delete(issueRecoveryActions)
-        .where(and(
-          eq(issueRecoveryActions.id, input.attemptedAction.id),
-          eq(issueRecoveryActions.attemptCount, input.attemptedAction.attemptCount),
-          inArray(issueRecoveryActions.status, ["active", "escalated"]),
-        ));
-      return;
-    }
-
-    const previous = input.previousAction;
-    const asDate = (value: string | Date | null) =>
-      typeof value === "string" ? new Date(value) : value;
-    await db
-      .update(issueRecoveryActions)
-      .set({
-        recoveryIssueId: previous.recoveryIssueId,
-        kind: previous.kind,
-        status: previous.status,
-        ownerType: previous.ownerType,
-        ownerAgentId: previous.ownerAgentId,
-        ownerUserId: previous.ownerUserId,
-        previousOwnerAgentId: previous.previousOwnerAgentId,
-        returnOwnerAgentId: previous.returnOwnerAgentId,
-        cause: previous.cause,
-        fingerprint: previous.fingerprint,
-        evidence: previous.evidence,
-        nextAction: previous.nextAction,
-        wakePolicy: previous.wakePolicy,
-        monitorPolicy: previous.monitorPolicy,
-        attemptCount: previous.attemptCount,
-        maxAttempts: previous.maxAttempts,
-        timeoutAt: asDate(previous.timeoutAt),
-        lastAttemptAt: asDate(previous.lastAttemptAt),
-        outcome: previous.outcome,
-        resolutionNote: previous.resolutionNote,
-        resolvedAt: asDate(previous.resolvedAt),
-        updatedAt: asDate(previous.updatedAt)!,
-      })
-      .where(and(
-        eq(issueRecoveryActions.id, input.attemptedAction.id),
-        eq(issueRecoveryActions.attemptCount, input.attemptedAction.attemptCount),
-        inArray(issueRecoveryActions.status, ["active", "escalated"]),
-      ));
   }
 
   function readProviderQuotaRetryAt(latestRun: LatestIssueRun, now: Date) {
@@ -3102,11 +3062,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     latestRun: LatestIssueRun;
     expectedCheckoutRunId?: string | null;
     expectedExecutionRunId?: string | null;
+    expectedStatus?: StrandedPreviousStatus;
+    expectedAssigneeAgentId?: string | null;
+    expectedAssigneeUserId?: string | null;
   }) {
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
       expectedCheckoutRunId: input.expectedCheckoutRunId,
       expectedExecutionRunId: input.expectedExecutionRunId,
+      expectedStatus: input.expectedStatus,
+      expectedAssigneeAgentId: input.expectedAssigneeAgentId,
+      expectedAssigneeUserId: input.expectedAssigneeUserId,
     });
     if (!updated) return null;
 
@@ -3161,8 +3127,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
 
-  async function existingUnresolvedBlockerIssues(companyId: string, issueId: string) {
-    return db
+  async function existingUnresolvedBlockerIssues(
+    companyId: string,
+    issueId: string,
+    dbOrTx: DbOrTransaction = db,
+  ) {
+    return dbOrTx
       .select({ id: issueRelations.issueId, identifier: issues.identifier })
       .from(issueRelations)
       .innerJoin(
@@ -3182,8 +3152,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       );
   }
 
-  async function existingUnresolvedBlockerIssueIds(companyId: string, issueId: string) {
-    return existingUnresolvedBlockerIssues(companyId, issueId).then((rows) => rows.map((row) => row.id));
+  async function existingUnresolvedBlockerIssueIds(
+    companyId: string,
+    issueId: string,
+    dbOrTx: DbOrTransaction = db,
+  ) {
+    return existingUnresolvedBlockerIssues(companyId, issueId, dbOrTx).then(
+      (rows) => rows.map((row) => row.id),
+    );
   }
 
   async function resolveContinuationWaitingOnReview(issue: typeof issues.$inferSelect) {
@@ -3260,49 +3236,77 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         latestRun: input.latestRun,
         expectedCheckoutRunId: executionPath.checkoutRunId,
         expectedExecutionRunId: executionPath.executionRunId,
+        expectedStatus: input.issue.status as StrandedPreviousStatus,
+        expectedAssigneeAgentId: input.issue.assigneeAgentId,
+        expectedAssigneeUserId: input.issue.assigneeUserId,
       });
     }
 
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const previousRecoveryAction = await recoveryActionsSvc.getActiveForIssue(
-      input.issue.companyId,
-      input.issue.id,
-    );
-    const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
-      issue: input.issue,
-      previousStatus: input.previousStatus,
-      latestRun: input.latestRun,
-      recoveryCause,
-      recoveryOwnerAgentId: input.recoveryOwnerAgentId,
-      successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
-    });
-    const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
-      blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
-      expectedCheckoutRunId: executionPath.checkoutRunId,
-      expectedExecutionRunId: executionPath.executionRunId,
-    });
-    if (!updated) {
-      const currentIssue = await db
-        .select({ status: issues.status })
-        .from(issues)
-        .where(eq(issues.id, input.issue.id))
-        .limit(1)
-        .then((rows) => rows[0] ?? null);
-      // Another reconciler may have won the same recovery race. Its blocked
-      // state owns the shared source-scoped action; every other CAS miss must
-      // restore the action snapshot so a productive checkout or unrelated
-      // issue transition cannot inherit recovery side effects.
-      if (currentIssue?.status !== "blocked") {
-        await compensateStrandedRecoveryActionCasMiss({
-          previousAction: previousRecoveryAction,
-          attemptedAction: recoveryAction,
-        });
-      }
-      return null;
+    await deps.beforeStrandedEscalationMutation?.();
+    let mutation: {
+      blockerIds: string[];
+      recoveryAction: Awaited<ReturnType<typeof recoveryActionsSvc.upsertSourceScoped>>;
+      updated: typeof issues.$inferSelect;
+    } | null;
+    try {
+      mutation = await db.transaction(async (tx) => {
+        const lockedIssue = await tx
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, input.issue.companyId), eq(issues.id, input.issue.id)))
+          .for("update")
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (
+          !lockedIssue ||
+          lockedIssue.status !== input.issue.status ||
+          lockedIssue.assigneeAgentId !== input.issue.assigneeAgentId ||
+          lockedIssue.assigneeUserId !== input.issue.assigneeUserId
+        ) {
+          return null;
+        }
+
+        const lockedExecutionPath = await readActiveExecutionPath(
+          lockedIssue.companyId,
+          lockedIssue.id,
+          undefined,
+          tx,
+        );
+        if (lockedExecutionPath.active) return null;
+
+        const blockerIds = await existingUnresolvedBlockerIssueIds(
+          lockedIssue.companyId,
+          lockedIssue.id,
+          tx,
+        );
+        const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
+          issue: lockedIssue,
+          previousStatus: input.previousStatus,
+          latestRun: input.latestRun,
+          recoveryCause,
+          recoveryOwnerAgentId: input.recoveryOwnerAgentId,
+          successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+        }, tx);
+        const updated = await issuesSvc.update(lockedIssue.id, {
+          status: "blocked",
+          blockedByIssueIds: blockerIds,
+          assigneeAgentId: recoveryAction.ownerAgentId ?? lockedIssue.assigneeAgentId,
+          expectedCheckoutRunId: lockedExecutionPath.checkoutRunId,
+          expectedExecutionRunId: lockedExecutionPath.executionRunId,
+          expectedStatus: lockedIssue.status,
+          expectedAssigneeAgentId: lockedIssue.assigneeAgentId,
+          expectedAssigneeUserId: lockedIssue.assigneeUserId,
+        }, tx);
+        if (!updated) throw new StrandedRecoveryMutationCasMiss();
+        return { blockerIds, recoveryAction, updated };
+      });
+    } catch (error) {
+      if (error instanceof StrandedRecoveryMutationCasMiss) return null;
+      throw error;
     }
+    if (!mutation) return null;
+    const { blockerIds, recoveryAction, updated } = mutation;
     const isProviderQuotaWait = recoveryCause === "provider_quota" &&
       !recoveryAction.ownerAgentId &&
       Boolean(recoveryAction.returnOwnerAgentId);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -806,8 +806,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return { consecutive, latestFinishedAt };
   }
 
-  async function hasActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
-    const [run, deferredWake] = await Promise.all([
+  async function readActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
+    const [contextRun, linkedState, deferredWake] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -817,6 +817,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
             sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
             agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+          activeRunId: heartbeatRuns.id,
+        })
+        .from(issues)
+        .leftJoin(
+          heartbeatRuns,
+          and(
+            or(
+              eq(issues.checkoutRunId, heartbeatRuns.id),
+              eq(issues.executionRunId, heartbeatRuns.id),
+            ),
+            eq(heartbeatRuns.companyId, companyId),
+            inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+            agentId ? eq(heartbeatRuns.agentId, agentId) : sql`true`,
+          ),
+        )
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.id, issueId),
           ),
         )
         .limit(1)
@@ -836,7 +863,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return {
+      active: Boolean(contextRun || linkedState?.activeRunId || deferredWake),
+      checkoutRunId: linkedState?.checkoutRunId ?? null,
+      executionRunId: linkedState?.executionRunId ?? null,
+    };
+  }
+
+  async function hasActiveExecutionPath(companyId: string, issueId: string, agentId?: string | null) {
+    return (await readActiveExecutionPath(companyId, issueId, agentId)).active;
   }
 
   async function hasPendingWakeInteraction(companyId: string, issueId: string) {
@@ -3014,8 +3049,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     issue: typeof issues.$inferSelect;
     previousStatus: StrandedPreviousStatus;
     latestRun: LatestIssueRun;
+    expectedCheckoutRunId?: string | null;
+    expectedExecutionRunId?: string | null;
   }) {
-    const updated = await issuesSvc.update(input.issue.id, { status: "blocked" });
+    const updated = await issuesSvc.update(input.issue.id, {
+      status: "blocked",
+      expectedCheckoutRunId: input.expectedCheckoutRunId,
+      expectedExecutionRunId: input.expectedExecutionRunId,
+    });
     if (!updated) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -3152,11 +3193,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
+    // Re-read the live-path state at the mutation boundary. A generic timer run
+    // can check out an issue after the reconciliation candidate snapshot was
+    // collected, and its original context does not necessarily contain issueId.
+    // The link columns are authoritative for that checkout.
+    const executionPath = await readActiveExecutionPath(input.issue.companyId, input.issue.id);
+    if (executionPath.active) {
+      return null;
+    }
+
     if (isStrandedIssueRecoveryIssue(input.issue)) {
       return escalateStrandedRecoveryIssueInPlace({
         issue: input.issue,
         previousStatus: input.previousStatus,
         latestRun: input.latestRun,
+        expectedCheckoutRunId: executionPath.checkoutRunId,
+        expectedExecutionRunId: executionPath.executionRunId,
       });
     }
 
@@ -3185,6 +3237,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       status: "blocked",
       blockedByIssueIds: blockerIds,
       assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+      expectedCheckoutRunId: executionPath.checkoutRunId,
+      expectedExecutionRunId: executionPath.executionRunId,
     });
     if (!updated) return null;
     if (isProviderQuotaWait) return updated;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -686,6 +686,7 @@ function buildLivenessOriginalIssueComment(finding: IssueLivenessFinding, escala
 export function recoveryService(db: Db, deps: {
   enqueueWakeup: RecoveryWakeup;
   beforeStrandedEscalationMutation?: () => Promise<void>;
+  beforeStrandedPostWakeReblockMutation?: () => Promise<void>;
 }) {
   const issuesSvc = issueService(db);
   const recoveryActionsSvc = issueRecoveryActionService(db);
@@ -3477,6 +3478,7 @@ export function recoveryService(db: Db, deps: {
         currentIssue.assigneeAgentId === recoveryAction.ownerAgentId &&
         currentIssue.assigneeUserId === input.issue.assigneeUserId
       ) {
+        await deps.beforeStrandedPostWakeReblockMutation?.();
         const reblocked = await issuesSvc.update(input.issue.id, {
           status: "blocked",
           blockedByIssueIds: blockerIds,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps agent-owned work live, visible, and recoverable
> - Stranded-work reconciliation decides whether an assigned issue has a live execution path
> - A generic timer run can check out an issue even though its original context snapshot has no issue id
> - Checkout records that relationship authoritatively through `checkoutRunId` and `executionRunId`
> - Link-only CAS prevents one stale reconciler, but overlapping reconcilers can still race through a shared recovery-action attempt
> - The recovery-action upsert and issue escalation therefore need one PostgreSQL ownership boundary
> - Locking the issue row and committing both mutations together makes checkout, terminal transition, and recovery ordering deterministic
> - The benefit is that recovery no longer blocks productive timer work or leaks action, wake, comment, activity, or attempt side effects

## Linked Issues or Issue Description

No public GitHub issue matched this bug in searches for generic timer checkout recovery and `hasActiveExecutionPath`.

### What happened?

`reconcileStrandedAssignedIssues()` could classify an `in_progress` issue as stranded while a generic `heartbeat_timer` run was still running and had successfully checked out the issue. The timer run's original `contextSnapshot` did not contain `issueId`, so the existing context-only lookup missed it even though the issue pointed to the run through its checkout/execution lock. A first CAS amendment still allowed two overlapping reconcilers to mutate the same source-scoped recovery action non-deterministically.

### Expected behavior

A non-terminal run referenced by an issue's `checkoutRunId` or `executionRunId` is a live execution path for the same company. Checkout, terminal transition, and stranded escalation must serialize so a losing recovery pass leaves the issue and all recovery side effects unchanged.

### Steps to reproduce

1. Create an assigned `in_progress` issue with stale prior terminal-run evidence and an existing source-scoped recovery action.
2. Start two reconciliation passes and pause both at the escalation mutation boundary.
3. Complete a generic timer checkout whose original context has no `issueId`.
4. Resume both reconciliation passes.
5. Before the atomic amendment, compensation ordering could delete or restore the shared action and increment its attempt count; after this change, both passes observe the checkout and leave every recovery side effect unchanged.

### Environment

- Paperclip base commit: `ca92f727c5f7e4a6e5d23d05fef188bee9066b81`
- Pull request head: `91e90751eaf2047180aa9fc4dfa0200f6a1b5922`
- Deployment mode: self-hosted server
- Installation: built/package source
- Adapter scope: core bug; not adapter-specific
- Database: PostgreSQL
- Node.js: `v22.22.1`
- OS: Linux

## What Changed

- Added a company-scoped active-run lookup through both `issues.checkoutRunId` and `issues.executionRunId`.
- Locked the source issue row and committed the recovery-action upsert plus issue escalation in one PostgreSQL transaction.
- Extended issue update CAS predicates to cover source status, agent/user assignees, and both run-link columns.
- Made source-scoped recovery-action reads and writes transaction-aware.
- Added deterministic PostgreSQL regressions for two reconcilers plus a real checkout and for a concurrent terminal transition, asserting no leaked action attempt, wake, comment, or activity.
- Documented the atomic stranded-recovery contract.

## Verification

Exact head `91e90751eaf2047180aa9fc4dfa0200f6a1b5922`:

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` — 97 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.
- Remote branch SHA verified as `91e90751eaf2047180aa9fc4dfa0200f6a1b5922`.

## Risks

- Moderate concurrency-path change, bounded to stranded escalation.
- The issue row lock is held only across database reads and the recovery-action/issue mutation; wake, comment, and activity side effects remain after commit.
- Checkout and terminal updates retain their existing SQL guards. The new lock establishes deterministic ordering rather than changing which transition is valid.
- No schema, public API, telemetry, or UI contract changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex based on GPT-5. The exact deployed model identifier and context-window size were not exposed to this session. Tool use and local code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
