### PR TITLE
fix(ui): auto-scroll Live Run & Dashboard agent cards to follow streaming output

### DIFF
--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -15,6 +15,7 @@ import { ExternalLink } from "lucide-react";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
+import { useAutoScroll } from "../hooks/useAutoScroll";
 import { usePublishSharedQueryData, useSharedPollingQuery } from "../hooks/useSharedPolling";
 import { Badge } from "@/components/ui/badge";
 
@@ -180,6 +181,8 @@ const AgentRunCard = memo(function AgentRunCard({
   isActive: boolean;
   className?: string;
 }) {
+  // Follow streaming run output (stick-to-bottom unless the user scrolls up).
+  const { ref: scrollRef, onScroll } = useAutoScroll<HTMLDivElement>();
   return (
     <div className={cn(
       "flex h-(--sz-320px) flex-col overflow-hidden rounded-xl border shadow-sm",
@@ -237,7 +240,11 @@ const AgentRunCard = memo(function AgentRunCard({
         )}
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="min-h-0 flex-1 overflow-y-auto p-3"
+      >
         <RunChatSurface
           run={run}
           transcript={transcript}

--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { Link } from "@/lib/router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useVisibilityRefetchInterval } from "@/lib/polling";
@@ -8,6 +8,24 @@ import { formatDateTime } from "../lib/utils";
 import { ExternalLink, Square } from "lucide-react";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
+import { useAutoScroll } from "../hooks/useAutoScroll";
+
+/** Scroll container that auto-follows streaming run output (stick-to-bottom
+ * unless the user scrolls up). One instance per run card. */
+function AutoScrollBox({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  const { ref, onScroll } = useAutoScroll<HTMLDivElement>();
+  return (
+    <div ref={ref} onScroll={onScroll} className={className}>
+      {children}
+    </div>
+  );
+}
 import { StatusBadge } from "./StatusBadge";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 
@@ -148,14 +166,14 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
                 </div>
               </div>
 
-              <div className="max-h-(--sz-320px) overflow-y-auto pr-1">
+              <AutoScrollBox className="max-h-(--sz-320px) overflow-y-auto pr-1">
                 <RunChatSurface
                   run={run}
                   transcript={transcript}
                   hasOutput={hasOutputForRun(run.id)}
                   companyId={companyId}
                 />
-              </div>
+              </AutoScrollBox>
             </section>
           );
         })}

--- a/ui/src/hooks/useAutoScroll.ts
+++ b/ui/src/hooks/useAutoScroll.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Keeps a scroll container pinned to the bottom as its content grows (e.g. a
+ * streaming run transcript), unless the user has scrolled up — in which case it
+ * stops auto-scrolling until they return near the bottom.
+ *
+ * Usage:
+ *   const { ref, onScroll } = useAutoScroll<HTMLDivElement>();
+ *   <div ref={ref} onScroll={onScroll} className="overflow-y-auto">…</div>
+ */
+export function useAutoScroll<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T>(null);
+  // Whether to keep the view pinned to the bottom. A ref (not state) so
+  // scroll-handling never triggers a re-render.
+  const stick = useRef(true);
+
+  // Runs after every render, i.e. whenever streamed content changes the DOM.
+  // Assigning scrollTop does not itself cause a React re-render, so this is safe
+  // without a dependency array.
+  useEffect(() => {
+    const el = ref.current;
+    if (el && stick.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  });
+
+  const onScroll = () => {
+    const el = ref.current;
+    if (!el) return;
+    // Re-engage sticking only when the user is at (or near) the bottom, so
+    // scrolling up to read history pauses auto-scroll.
+    stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+  };
+
+  return { ref, onScroll };
+}


### PR DESCRIPTION
## Problem

The run-output cards render inside a fixed-height `overflow-y-auto` container but never follow their content, so as an agent streams output the newest lines scroll out of view and the user has to drag the scrollbar down on every update. This affects both places these cards appear:

- **`LiveRunWidget`** — the "Live Runs" box on issue pages
- **`ActiveAgentsPanel` → `AgentRunCard`** — the live agent cards on the Dashboard

## Fix

Add a small reusable `useAutoScroll` hook that pins a scroll container to the bottom as its content grows, and wire it into both components' scroll containers.

- Sticks to the bottom on new streamed content.
- **Pauses when the user scrolls up** to read history (re-engages only when they return near the bottom, within 24px), so it never fights a user who is scrolling back.
- Implemented with refs (no extra re-renders) and no dependency array — the effect runs after each render, i.e. whenever streamed content changes the DOM.

## Scope

Three files, additive only: a new `ui/src/hooks/useAutoScroll.ts`, plus wiring in `LiveRunWidget.tsx` and `ActiveAgentsPanel.tsx`. No behavior change to anything other than the scroll-follow of these cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)