### PR TITLE
fix(issues): count a scheduled monitor as a covered blocker path

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -720,6 +720,78 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  // `in_review` leaves the shared covered/attention path early and lands in its own
+  // `stalled` branch, so it needs the monitor pinned separately from `in_progress`:
+  // a scheduled monitor is the standard re-review path for a review with no human
+  // reviewer, and without this it reads as a dead chain.
+  it("treats an in_review blocker with a scheduled monitor as a covered waiting path", async () => {
+    const { companyId, agentId } = await createCompany("PBMR");
+    const parentId = await insertIssue({ companyId, identifier: "PBMR-1", title: "Parent", status: "blocked" });
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBMR-2",
+      title: "Monitored review leaf",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }),
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleStalledBlockerIdentifier: null,
+    });
+  });
+
+  it("still flags an in_review blocker whose monitor has elapsed or was never scheduled as stalled", async () => {
+    const { companyId, agentId } = await createCompany("PBMS");
+    const elapsedParentId = await insertIssue({ companyId, identifier: "PBMS-1", title: "Elapsed parent", status: "blocked" });
+    const elapsedLeafId = await insertIssue({
+      companyId,
+      identifier: "PBMS-2",
+      title: "Review leaf whose monitor is already due",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() - 60 * 60 * 1000),
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }),
+    });
+    await block({ companyId, blockerIssueId: elapsedLeafId, blockedIssueId: elapsedParentId });
+
+    const unmonitoredParentId = await insertIssue({ companyId, identifier: "PBMS-3", title: "Unmonitored parent", status: "blocked" });
+    const unmonitoredLeafId = await insertIssue({
+      companyId,
+      identifier: "PBMS-4",
+      title: "Review leaf with no monitor at all",
+      status: "in_review",
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: unmonitoredLeafId, blockedIssueId: unmonitoredParentId });
+
+    const blocked = await svc.list(companyId, { status: "blocked" });
+
+    expect(blocked.find((issue) => issue.id === elapsedParentId)?.blockerAttention).toMatchObject({
+      state: "stalled",
+      reason: "stalled_review",
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 1,
+      sampleStalledBlockerIdentifier: "PBMS-2",
+    });
+    expect(blocked.find((issue) => issue.id === unmonitoredParentId)?.blockerAttention).toMatchObject({
+      state: "stalled",
+      reason: "stalled_review",
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 1,
+      sampleStalledBlockerIdentifier: "PBMS-4",
+    });
+  });
+
   it("does not treat an elapsed or exhausted monitor as a covered waiting path", async () => {
     const { companyId, agentId } = await createCompany("PBME");
     const elapsedParentId = await insertIssue({ companyId, identifier: "PBME-1", title: "Elapsed parent", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -101,6 +101,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originFingerprint?: string | null;
     executionState?: Record<string, unknown> | null;
     description?: string | null;
+    monitorNextCheckAt?: Date | null;
+    monitorAttemptCount?: number | null;
   }) {
     const id = input.id ?? randomUUID();
     await db.insert(issues).values({
@@ -118,8 +120,23 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       originFingerprint: input.originFingerprint ?? "default",
       executionState: input.executionState ?? null,
       description: input.description ?? null,
+      monitorNextCheckAt: input.monitorNextCheckAt ?? null,
+      ...(input.monitorAttemptCount == null ? {} : { monitorAttemptCount: input.monitorAttemptCount }),
     });
     return id;
+  }
+
+  function monitorState(input: { timeoutAt: Date; maxAttempts?: number; attemptCount?: number }) {
+    return {
+      monitor: {
+        kind: "external_service",
+        status: "scheduled",
+        serviceName: "github-checks",
+        timeoutAt: input.timeoutAt.toISOString(),
+        maxAttempts: input.maxAttempts ?? 12,
+        attemptCount: input.attemptCount ?? 0,
+      },
+    } satisfies Record<string, unknown>;
   }
 
   async function block(input: { companyId: string; blockerIssueId: string; blockedIssueId: string }) {
@@ -640,6 +657,121 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       coveredBlockerCount: 0,
       attentionBlockerCount: 1,
       sampleBlockerIdentifier: "PBY-2",
+    });
+  });
+
+  it("treats an in_progress blocker with a scheduled monitor as a covered waiting path", async () => {
+    const { companyId, agentId } = await createCompany("PBMO");
+    const parentId = await insertIssue({ companyId, identifier: "PBMO-1", title: "Parent", status: "blocked" });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBMO-2",
+      title: "Monitored blocker",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }),
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_dependency",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBMO-2",
+    });
+  });
+
+  it("covers a monitored blocker alongside a cancelled child on the same root", async () => {
+    const { companyId, agentId } = await createCompany("PBMC");
+    const parentId = await insertIssue({ companyId, identifier: "PBMC-1", title: "Parent", status: "blocked" });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBMC-2",
+      title: "Monitored blocker",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }),
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBMC-3",
+      title: "Cancelled child",
+      status: "cancelled",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+    });
+  });
+
+  it("does not treat an elapsed or exhausted monitor as a covered waiting path", async () => {
+    const { companyId, agentId } = await createCompany("PBME");
+    const elapsedParentId = await insertIssue({ companyId, identifier: "PBME-1", title: "Elapsed parent", status: "blocked" });
+    const elapsedBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBME-2",
+      title: "Monitor already due",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() - 60 * 60 * 1000),
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }),
+    });
+    await block({ companyId, blockerIssueId: elapsedBlockerId, blockedIssueId: elapsedParentId });
+
+    const exhaustedParentId = await insertIssue({ companyId, identifier: "PBME-3", title: "Exhausted parent", status: "blocked" });
+    const exhaustedBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBME-4",
+      title: "Monitor attempts exhausted",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      monitorAttemptCount: 12,
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000), maxAttempts: 12 }),
+    });
+    await block({ companyId, blockerIssueId: exhaustedBlockerId, blockedIssueId: exhaustedParentId });
+
+    const blocked = await svc.list(companyId, { status: "blocked" });
+
+    expect(blocked.find((issue) => issue.id === elapsedParentId)?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      coveredBlockerCount: 0,
+      attentionBlockerCount: 1,
+      sampleBlockerIdentifier: "PBME-2",
+    });
+    expect(blocked.find((issue) => issue.id === exhaustedParentId)?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      coveredBlockerCount: 0,
+      attentionBlockerCount: 1,
+      sampleBlockerIdentifier: "PBME-4",
+    });
+  });
+
+  it("keeps a blocked issue without any blocker at needs_attention", async () => {
+    const { companyId } = await createCompany("PBNB");
+    const parentId = await insertIssue({ companyId, identifier: "PBNB-1", title: "Blocked with no blocker", status: "blocked" });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
     });
   });
 

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -862,6 +862,43 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("does not treat a cancelled blocker's pending approval as a covered waiting path", async () => {
+    const { companyId, agentId } = await createCompany("PBCA");
+    const parentId = await insertIssue({ companyId, identifier: "PBCA-1", title: "Parent", status: "blocked" });
+    // Cancelling an issue does not cancel an approval already linked to it, so the
+    // approval row stays `pending` and remains resolvable by the board. Resolving it
+    // still cannot move this blocker to `done`, so the parent's edge stays dead and a
+    // human has to clear it — which is what needs_attention means. This matches the
+    // guard master already applies one branch below, where even a human assignee does
+    // not cover a cancelled node (`node.assigneeUserId && node.status !== "cancelled"`).
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBCA-2",
+      title: "Cancelled blocker with a pending approval",
+      status: "cancelled",
+      assigneeAgentId: agentId,
+    });
+    const approvalId = randomUUID();
+    await db.insert(approvals).values({
+      id: approvalId,
+      companyId,
+      type: "request_board_approval",
+      status: "pending",
+      payload: { title: "Approve the cancelled blocker's work" },
+    });
+    await db.insert(issueApprovals).values([{ companyId, issueId: blockerId, approvalId }]);
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      coveredBlockerCount: 0,
+      attentionBlockerCount: 1,
+      sampleBlockerIdentifier: "PBCA-2",
+    });
+  });
+
   it("keeps a blocked issue without any blocker at needs_attention", async () => {
     const { companyId } = await createCompany("PBNB");
     const parentId = await insertIssue({ companyId, identifier: "PBNB-1", title: "Blocked with no blocker", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -763,6 +763,33 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("does not treat a cancelled blocker's retained monitor as a covered waiting path", async () => {
+    const { companyId, agentId } = await createCompany("PBMX");
+    const parentId = await insertIssue({ companyId, identifier: "PBMX-1", title: "Parent", status: "blocked" });
+    // Tree cancellation leaves monitorNextCheckAt/executionState in place, so this
+    // blocker still looks monitored. tickDueIssueMonitors only dispatches
+    // in_progress/in_review issues, so the monitor can never fire again.
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBMX-2",
+      title: "Cancelled blocker with retained monitor",
+      status: "cancelled",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      executionState: monitorState({ timeoutAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }),
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      coveredBlockerCount: 0,
+      attentionBlockerCount: 1,
+      sampleBlockerIdentifier: "PBMX-2",
+    });
+  });
+
   it("keeps a blocked issue without any blocker at needs_attention", async () => {
     const { companyId } = await createCompany("PBNB");
     const parentId = await insertIssue({ companyId, identifier: "PBNB-1", title: "Blocked with no blocker", status: "blocked" });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2501,8 +2501,14 @@ async function listIssueBlockerAttentionMap(
     }
   }
 
+  // A cancelled blocker keeps its monitor fields (tree cancellation does not clear
+  // monitorNextCheckAt), but the dispatcher only wakes in_progress/in_review issues
+  // (tickDueIssueMonitors), so none of those retained fields can still fire. The same
+  // holds for its pending interactions and approvals. Admitting a cancelled node here
+  // would report it as covered and hide exactly the dead wake path this map exists to
+  // surface — the assigneeUserId branch below already carries the same guard.
   const explicitWaitCandidateIds = [...nodesById.values()]
-    .filter((node) => node.status !== "done")
+    .filter((node) => node.status !== "done" && node.status !== "cancelled")
     .map((node) => node.id);
   const explicitWaitingIssueIds = new Set<string>();
   if (explicitWaitCandidateIds.length > 0) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -117,6 +117,7 @@ import {
 import {
   classifyIssueGraphLiveness,
   classifyIssueReviewPaths,
+  hasScheduledIssueMonitorPath,
   type IssueGraphLivenessInput,
   type IssueLivenessFinding,
 } from "./recovery/issue-graph-liveness.js";
@@ -2505,7 +2506,49 @@ async function listIssueBlockerAttentionMap(
     .map((node) => node.id);
   const explicitWaitingIssueIds = new Set<string>();
   if (explicitWaitCandidateIds.length > 0) {
+    // A scheduled monitor is a wake path the harness owns: the issue re-enters
+    // its assignee's queue at monitorNextCheckAt without any human action. The
+    // recovery liveness classifier already counts it (hasScheduledIssueMonitorPath),
+    // so blocker attention has to agree or it flags actively monitored blockers.
+    // Reuse that exact predicate rather than a bare monitorNextCheckAt > now
+    // comparison: it also drops monitors past timeoutAt or maxAttempts, which no
+    // longer fire and therefore must not read as covered.
+    const monitorNowMs = Date.now();
     for (const chunk of chunkList(explicitWaitCandidateIds, ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
+      const monitorRows: Array<{
+        id: string;
+        companyId: string;
+        identifier: string | null;
+        title: string;
+        status: string;
+        executionPolicy: Record<string, unknown> | null;
+        executionState: Record<string, unknown> | null;
+        monitorNextCheckAt: Date | null;
+        monitorAttemptCount: number | null;
+      }> = await dbOrTx
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          identifier: issues.identifier,
+          title: issues.title,
+          status: issues.status,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
+        })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            inArray(issues.id, chunk),
+            isNotNull(issues.monitorNextCheckAt),
+          ),
+        );
+      for (const row of monitorRows) {
+        if (hasScheduledIssueMonitorPath(row, monitorNowMs)) explicitWaitingIssueIds.add(row.id);
+      }
+
       const interactionRows: Array<{ issueId: string }> = await dbOrTx
         .select({ issueId: issueThreadInteractions.issueId })
         .from(issueThreadInteractions)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Blocker attention is the early-warning signal on that board: for every `blocked` issue it decides whether each blocking edge is `covered` (someone or something will resume it) or needs a human to step in
> - Two places in the server answer that same question — `listIssueBlockerAttentionMap` in `server/src/services/issues.ts` and the recovery liveness classifier in `server/src/services/recovery/issue-graph-liveness.ts` — and they answer it from different term lists
> - The recovery classifier counts a scheduled monitor as a waiting path; blocker attention does not, so a blocker parked on a monitor has no active run and no queued wake and falls through to the terminal `covered: false, stalled: false` branch
> - The result is a false positive on the healthiest cards on a board: a dependency that is already scheduled to resume on its own is reported as needing intervention, which is exactly the noise that makes the signal unusable
> - This pull request reuses the classifier's own exported predicate, `hasScheduledIssueMonitorPath`, inside `listIssueBlockerAttentionMap`, so both classifiers share one predicate instead of two drifting copies
> - The benefit is that a monitored blocker reads as `covered`, while every other attention case — including an idle assigned leaf with no wake path — keeps its current behaviour

## Linked Issues or Issue Description

No public GitHub issue exists for this; describing it here as a bug report.

**What happened.** On a live board, a `blocked` issue whose only explicit blocker was `in_progress` with `executionState.monitor.status = "scheduled"`, `monitorNextCheckAt` roughly 40 minutes out, and `attemptCount 0 / maxAttempts 12` was reported as `blockerAttention.state = "needs_attention"` with `attentionBlockerCount: 2, coveredBlockerCount: 0`. `sampleBlockerIdentifier` pointed at exactly that monitored blocker, which is what identifies it as the attention edge rather than an inference from the counts.

**What was expected.** The blocker has a live wake path — the harness re-enters it into its assignee's queue at `monitorNextCheckAt` with no human action — so it should classify as `covered`, the same way the recovery liveness classifier already treats it.

**Why it matters.** `blockerAttention` is a "who needs a human right now" signal. A blocker that is provably scheduled to resume is the one case that most looks healthy, so a false positive here trains operators to ignore the field.

## Overlapping open PRs — disclosed, not silently duplicated

Four other open PRs touch this lane. Measured against this branch on 2026-08-25:

| PR | Scope | Predicate |
|---|---|---|
| **#8759** (2026-06-29) | `in_review` blocker + `executionPolicy`/`monitorNextCheckAt` on `IssueRelationIssueSummary` | monitor fields on the relation summary |
| **#10502** (2026-08-02) | `in_review` lanes, also touches `issue-graph-liveness.ts` | monitor-backed review lanes |
| **#11847** (2026-08-21) | `in_review` branch only | bare `monitorNextCheckAt > now` |
| **#12035** (2026-08-23) | execution policy / watchdogs "live continuation"; overlaps the same test file | separate subject |
| **this PR** (2026-07-28) | **every** non-`done`, non-`cancelled` blocker node — `in_progress`, `todo`, `blocked`, `in_review` | reuses `hasScheduledIssueMonitorPath` |

Two differences are measured rather than asserted:

1. **Scope.** The three `in_review` PRs do not reach the case this bug report is about — an `in_progress` blocker whose only wake path is its monitor. On current `master` that edge still reads `needs_attention`.
2. **Exhaustion.** Replacing `hasScheduledIssueMonitorPath(row, now)` in this branch with the bare `monitorNextCheckAt > now` comparison that #11847 uses turns **1 test red**: `does not treat an elapsed or exhausted monitor as a covered waiting path`. A monitor past `timeoutAt` or at `attemptCount >= maxAttempts` never fires again, so counting it as covered hides exactly the dead wake path this map exists to surface.

Maintainers may still prefer one of the narrower PRs, or want #8759's relation-summary metadata layered on top — flagging the overlap rather than competing quietly. #8759's closed predecessor was #8751.

## What Changed

Rebased onto `d1573244b` on 2026-08-25 (523 commits of drift). **The `issue-graph-liveness.ts` change from the original version of this PR is gone**: `master` has since exported `hasScheduledIssueMonitorPath` itself, with the same validity rules this PR needed. The branch now touches one implementation file instead of two.

- `server/src/services/issues.ts`: inside `listIssueBlockerAttentionMap`, query the monitor columns for the candidate nodes (bounded by the existing chunking, filtered with `isNotNull(monitorNextCheckAt)`) and add every row satisfying `hasScheduledIssueMonitorPath` to `explicitWaitingIssueIds`, alongside pending interactions, pending approvals, open liveness escalations and open recovery actions.
- `server/src/services/issues.ts`: exclude `cancelled` nodes from `explicitWaitCandidateIds`. Tree cancellation does not clear `monitorNextCheckAt`, but `tickDueIssueMonitors` only wakes `in_progress`/`in_review` issues, so a cancelled node's retained monitor — and its pending interactions and approvals — cannot fire. The `assigneeUserId` branch below already carries the same guard.
- `server/src/__tests__/issue-blocker-attention.test.ts`: eight new cases (below).

Deliberately **not** changed: `in_progress` does not become covered by itself. An `in_progress` blocker with no run, no queued wake and no monitor is the signature of a crashed run, and the existing tests pinning an idle assigned leaf to `needs_attention` pass unchanged. Only a demonstrated wake path covers a blocker; a bare status does not.

## Verification

Run on the rebased head `74613ae6` (`server/`, local vitest):

```
vitest run src/__tests__/issue-blocker-attention.test.ts        # 33 passed (33)
vitest run src/__tests__/attention-service.test.ts \
  src/__tests__/issue-liveness.test.ts \
  src/__tests__/recovery-classifiers.test.ts                    # 48 passed (48)
```

**Not claimed as green:** `src/__tests__/heartbeat-issue-liveness-escalation.test.ts` fails to load locally with `z.string(...).guid is not a function` (`src/services/environment-config.ts:36`). A control run of the same file on unmodified `d1573244b` fails identically, so this is a local zod version skew, not this change. CI is the authority on that file.

**Typecheck, paired against unmodified `master`.** `tsc --noEmit` in `server/` on the head and on `d1573244b`, error lines normalised for line/column drift: `comm -23 head base` is **empty — 0 new type errors**. Both trees carry a large pre-existing error count from the local dependency state (752 head / 790 base error lines, the 38-line difference sitting entirely in `packages/adapters/*` and unrelated to this diff); `server/src/services/issues.ts` has **0** errors in both.

**Mutation probes, one per call site** (each applied to the finished branch, then reverted):

| Mutation | Expected | Result |
|---|---|---|
| revert `services/issues.ts` to `master`, keep the tests | new cases go red | **4 red** |
| drop only the `cancelled` guard from `explicitWaitCandidateIds` | cancelled case goes red | **1 red** |
| replace `hasScheduledIssueMonitorPath(row, now)` with bare `nextCheckAt > now` | exhaustion case goes red | **1 red** |

The second and third probes matter because both branches are individually green under the full revert for the wrong reason — the cancelled test passes on `master` only because `master` has no monitor→covered mapping at all to be fooled by.

New cases in `issue-blocker-attention.test.ts`:

- **positive** — `in_progress` blocker with a scheduled monitor → `covered`, `coveredBlockerCount: 1`, `attentionBlockerCount: 0`.
- **positive** — `in_review` blocker with a scheduled monitor → `covered`.
- **positive** — monitored blocker alongside a `cancelled` child on the same root.
- **negative** — elapsed `monitorNextCheckAt`, and exhausted `attemptCount >= maxAttempts`, stay `needs_attention`.
- **negative** — an `in_review` blocker whose monitor elapsed or was never scheduled stays flagged.
- **negative** — a `cancelled` blocker's retained monitor does not read as covered.
- **negative** — `blocked` with no blocker at all stays `needs_attention`.

## Risks

Low risk, with two things worth a reviewer's eye:

- **Widening risk** — the monitor lookup only ever *adds* ids to `explicitWaitingIssueIds`, so it can turn `needs_attention` into `covered` but never the reverse. If the predicate were too permissive it would hide real attention cases; that is why the validity rules (future `nextCheckAt`, unexpired `timeoutAt`, attempts remaining) are reused rather than reimplemented, and why the negative tests pin them.
- **Narrowing risk, in the other direction — measured, and the one call worth a maintainer's decision.** The `cancelled` exclusion sits on the shared `explicitWaitCandidateIds`, so it also removes cancelled nodes from the pending-interaction and pending-approval lookups. Greptile raised this as a P1 and the premise checks out: cancelling an issue does not cancel an approval already linked to it, so that row stays `pending`. Measured both ways — a `blocked` parent whose only blocker is `cancelled` with a `pending` approval reads **`covered` on `master`** and **`needs_attention` on this branch**. Pinned by `does not treat a cancelled blocker's pending approval as a covered waiting path`.
  I believe `needs_attention` is right: resolving that approval cannot move the blocker to `done`, so the parent's edge stays dead either way, and `master` already refuses to cover a cancelled node via the stronger `assigneeUserId` path (`node.assigneeUserId && node.status !== "cancelled"`). But it is scope beyond the monitor path this PR is named for. If you prefer the minimal read, the narrow variant is one line — leave `explicitWaitCandidateIds` at `status !== "done"` and filter `cancelled` inside the monitor loop only. Say the word and I will push it.
- **One extra query per chunk** — a `select` over the already-chunked candidate ids, narrowed by `isNotNull(monitorNextCheckAt)`. It sits in the same loop as the existing interaction and approval queries and follows their chunking, so it adds no new unbounded scan.
- No migration, no API shape change, no change to `unresolvedBlockerCount`.

## Model Used

Claude Opus 5 (`claude-opus-5`) via Claude Code, extended thinking, with tool use (repo search, local test runs, paired control runs, live-instance API reads).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — re-run on 2026-08-25 after the rebase; four overlapping open PRs (#8759, #10502, #11847, #12035) are compared in the table above, plus #8759's closed predecessor #8751
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details — the branch is `aur1528-blocker-attention-in-progress`; the `aur1528` prefix is an internal tracker id and should not be there. GitHub cannot switch the head branch of an open PR, so renaming would mean closing this PR and reopening a new one, discarding this review thread. Leaving it visible rather than silently ticking it; happy to re-open under `fix/monitored-blocker-covered-path` if a maintainer prefers that.
- [x] I have run tests locally and they pass — see Verification above, including the paired control runs and the three mutation probes
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs cover blocker-attention internals; the rationale lives in the code comments at the two changed sites
- [ ] All Paperclip CI gates are green — the round on `74613ae6` was 26 success / 1 skipped / 2 failure. `verify` is the aggregator; the single real failure was a 15 s timeout in `plugin-worker-manager.test.ts`, which timed out on the unrelated branch `fix/warn-on-adapter-cwd-fallback` in the same window. Evidence in the thread comment below; re-triggered by amending to an identical tree.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — `Greptile Review` was `success` on `74613ae6`; re-running on the current head
- [x] I will address all Greptile and reviewer comments before requesting merge

