### PR TITLE
Authorize unblock owners to resume blocked issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "rollup": ">=4.59.0",
       "react": "^19.2.7",
       "react-dom": "^19.2.7",
-      "lexical": "0.46.0",
+      "lexical": "0.48.0",
       "@lexical/clipboard": "0.46.0",
       "@lexical/link": "0.46.0",
       "@lexical/list": "0.46.0",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1564,6 +1564,7 @@ export {
   type CompanySearchQuery,
   createIssueSchema,
   createIssueInputSchema,
+  issueUnblockDescriptorSchema,
   createChildIssueSchema,
   createAcceptedPlanDecompositionSchema,
   resolveCreateIssueStatusDefault,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -368,6 +368,7 @@ export {
 export {
   createIssueSchema,
   createIssueInputSchema,
+  issueUnblockDescriptorSchema,
   createChildIssueSchema,
   createAcceptedPlanDecompositionSchema,
   resolveCreateIssueStatusDefault,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -419,20 +419,22 @@ function withCreateIssueStatusDefault<T extends z.ZodRawShape>(schema: z.ZodObje
   }, schema);
 }
 
+export const issueUnblockDescriptorSchema = z.object({
+  owner: z.union([
+    z.object({ agentId: z.string().uuid() }).strict(),
+    z.object({ userId: z.string().trim().min(1) }).strict(),
+    z.literal("board"),
+  ]),
+  action: multilineTextSchema.pipe(z.string().trim().min(1).max(2_000)),
+}).strict();
+
 const createIssueBaseSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   projectWorkspaceId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
   parentId: z.string().uuid().optional().nullable(),
   blockedByIssueIds: z.array(z.string().uuid()).optional(),
-  unblockDescriptor: z.object({
-    owner: z.union([
-      z.object({ agentId: z.string().uuid() }).strict(),
-      z.object({ userId: z.string().trim().min(1) }).strict(),
-      z.literal("board"),
-    ]),
-    action: multilineTextSchema.pipe(z.string().trim().min(1).max(2_000)),
-  }).strict().optional().nullable(),
+  unblockDescriptor: issueUnblockDescriptorSchema.optional().nullable(),
   inheritExecutionWorkspaceFromIssueId: z.string().uuid().optional().nullable(),
   title: z.string().min(1),
   description: multilineTextSchema.optional().nullable(),

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1214,6 +1214,78 @@ describeEmbeddedPostgres("authorization service", () => {
       resource,
       scope: { allowIssueUnblockOwner: true },
     })).resolves.toMatchObject({ allowed: false });
+
+    const malformedDescriptors = [
+      { owner: { agentId: unblockOwnerAgent.id } },
+      { owner: { agentId: unblockOwnerAgent.id, userId: "mixed-owner" }, action: "Review" },
+      { owner: { agentId: "not-a-uuid" }, action: "Review" },
+      { owner: { agentId: unblockOwnerAgent.id }, action: "Review", extra: true },
+    ];
+    for (const unblockDescriptor of malformedDescriptors) {
+      await db.update(issues).set({
+        status: "blocked",
+        unblockDescriptor: unblockDescriptor as never,
+      }).where(eq(issues.id, issue.id));
+      await expect(authorization.decide({
+        actor: {
+          type: "agent",
+          agentId: unblockOwnerAgent.id,
+          companyId: company.id,
+          source: "agent_key",
+        },
+        action: "issue:mutate",
+        resource,
+        scope: { allowIssueUnblockOwner: true },
+      })).resolves.toMatchObject({ allowed: false });
+    }
+  });
+
+  it("does not let a low-trust unblock owner cross the assignee mutation boundary", async () => {
+    const company = await createCompany(db, "LowTrustIssueUnblockOwner");
+    const project = await createProject(db, company.id, "AllowedProject");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const lowTrustOwner = await createAgent(db, company.id, {
+      role: "reviewer",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [project.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Blocked issue with low-trust owner",
+      projectId: project.id,
+      status: "blocked",
+      assigneeAgentId: assigneeAgent.id,
+      unblockDescriptor: {
+        owner: { agentId: lowTrustOwner.id },
+        action: "Choose the remediation path",
+      },
+    });
+
+    await expect(authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: lowTrustOwner.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        assigneeAgentId: issue.assigneeAgentId,
+        status: issue.status,
+      },
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: false });
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -20,6 +20,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { authorizationService } from "../services/authorization.js";
+import { issueService } from "../services/issues.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -1286,6 +1287,70 @@ describeEmbeddedPostgres("authorization service", () => {
       },
       scope: { allowIssueUnblockOwner: true },
     })).resolves.toMatchObject({ allowed: false });
+  });
+
+  it("atomically rejects stale unblock-owner issue writes and comments", async () => {
+    const company = await createCompany(db, "UnblockOwnerWriteRace");
+    const assignee = await createAgent(db, company.id);
+    const owner = await createAgent(db, company.id);
+    const replacementOwner = await createAgent(db, company.id);
+    const issue = await createIssue(db, company.id, {
+      status: "blocked",
+      assigneeAgentId: assignee.id,
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Perform the unblock action",
+      },
+    });
+    const svc = issueService(db);
+    const writeOptions = { expectedBlockedUnblockOwnerAgentId: owner.id };
+
+    await db.update(issues).set({
+      unblockDescriptor: {
+        owner: { agentId: replacementOwner.id },
+        action: "Replacement owner action",
+      },
+    }).where(eq(issues.id, issue.id));
+
+    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions)).resolves.toBeNull();
+    await expect(svc.addComment(
+      issue.id,
+      "Stale owner comment",
+      { agentId: owner.id },
+      writeOptions,
+    )).rejects.toMatchObject({ status: 409 });
+    await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issue.id)))
+      .resolves.toHaveLength(0);
+
+    await db.update(issues).set({
+      status: "todo",
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Owner action after status change",
+      },
+    }).where(eq(issues.id, issue.id));
+    await expect(svc.addComment(
+      issue.id,
+      "Comment after issue left blocked",
+      { agentId: owner.id },
+      writeOptions,
+    )).rejects.toMatchObject({ status: 409 });
+
+    await db.update(issues).set({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Current owner action",
+      },
+    }).where(eq(issues.id, issue.id));
+    await expect(svc.addComment(
+      issue.id,
+      "Current owner comment",
+      { agentId: owner.id },
+      writeOptions,
+    )).resolves.toMatchObject({ body: "Current owner comment" });
+    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions))
+      .resolves.toMatchObject({ status: "todo" });
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
@@ -72,11 +73,13 @@ async function createIssue(
   input: {
     id?: string;
     title?: string;
+    status?: "todo" | "in_progress" | "blocked";
     projectId?: string | null;
     parentId?: string | null;
     assigneeAgentId?: string | null;
     originKind?: string | null;
     originId?: string | null;
+    unblockDescriptor?: Record<string, unknown> | null;
   } = {},
 ) {
   return db
@@ -85,13 +88,14 @@ async function createIssue(
       id: input.id ?? randomUUID(),
       companyId,
       title: input.title ?? `Issue ${randomUUID()}`,
-      status: "todo",
+      status: input.status ?? "todo",
       priority: "medium",
       projectId: input.projectId ?? null,
       parentId: input.parentId ?? null,
       assigneeAgentId: input.assigneeAgentId ?? null,
       originKind: input.originKind ?? "manual",
       originId: input.originId ?? null,
+      unblockDescriptor: input.unblockDescriptor ?? null,
     })
     .returning()
     .then((rows) => rows[0]!);
@@ -1132,6 +1136,84 @@ describeEmbeddedPostgres("authorization service", () => {
       allowed: false,
       reason: "deny_unsupported_action",
     });
+  });
+
+  it("allows only the persisted unblock owner to comment on and mutate a blocked assigned issue", async () => {
+    const company = await createCompany(db, "IssueUnblockOwner");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const unblockOwnerAgent = await createAgent(db, company.id, { role: "manager" });
+    const unrelatedAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Blocked issue awaiting owner action",
+      status: "blocked",
+      assigneeAgentId: assigneeAgent.id,
+      unblockDescriptor: {
+        owner: { agentId: unblockOwnerAgent.id },
+        action: "Choose the remediation path",
+      },
+    });
+    const authorization = authorizationService(db);
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: issue.assigneeAgentId,
+      status: issue.status,
+    } as const;
+
+    for (const action of ["issue:comment", "issue:mutate"] as const) {
+      await expect(authorization.decide({
+        actor: {
+          type: "agent",
+          agentId: unblockOwnerAgent.id,
+          companyId: company.id,
+          source: "agent_key",
+        },
+        action,
+        resource,
+        scope: action === "issue:mutate" ? { allowIssueUnblockOwner: true } : null,
+      })).resolves.toMatchObject({
+        allowed: true,
+        reason: "allow_issue_unblock_owner",
+      });
+    }
+
+    await expect(authorization.decide({
+      actor: {
+        type: "agent",
+        agentId: unblockOwnerAgent.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({ allowed: false });
+
+    await expect(authorization.decide({
+      actor: {
+        type: "agent",
+        agentId: unrelatedAgent.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource,
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: false });
+
+    await db.update(issues).set({ status: "todo" }).where(eq(issues.id, issue.id));
+    await expect(authorization.decide({
+      actor: {
+        type: "agent",
+        agentId: unblockOwnerAgent.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource,
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: false });
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1504,6 +1504,57 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("allows the persisted unblock owner to mutate a blocked issue assigned to another agent", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...blockedIssue,
+      ...patch,
+    }));
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      return {
+        allowed: unblockOwnerMutation || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "deny_missing_grant",
+        explanation: unblockOwnerMutation
+          ? "Allowed because the actor is the current unblock owner."
+          : input.action === "issue:read"
+            ? "Allowed by same-company visibility."
+            : "Missing permission.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Owner-provided remediation" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ title: "Owner-provided remediation" }),
+    );
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ allowIssueUnblockOwner: true }),
+    }));
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -803,6 +803,61 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("binds unblock-owner comments to the current blocked owner at insert time", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Perform the unblock action",
+      },
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment" || input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_unblock_owner" : "allow_company_agent",
+      explanation: "Allowed by the current unblock-owner grant.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "The unblock action is complete." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "The unblock action is complete.",
+      expect.any(Object),
+      expect.objectContaining({ expectedBlockedUnblockOwnerAgentId: peerAgentId }),
+    );
+  });
+
+  it("keeps unblock-owner resume off the comment endpoint", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Perform the unblock action",
+      },
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment" || input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_unblock_owner" : "allow_company_agent",
+      explanation: "Allowed by the current unblock-owner grant.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "The unblock action is complete.", resume: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Unblock owners must use the guarded issue PATCH to resume work");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("rejects non-mentioned peer agents from posting comments", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read",
@@ -1555,6 +1610,16 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       issueId,
       expect.objectContaining({ status: "todo", assigneeAgentId: peerAgentId }),
+      expect.any(Object),
+      { expectedBlockedUnblockOwnerAgentId: peerAgentId },
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Remediation is complete",
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
     );
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
       action: "issue:mutate",
@@ -1564,6 +1629,52 @@ describe("agent issue mutation checkout ownership", () => {
       action: "tasks:assign",
       resource: expect.objectContaining({ assigneeAgentId: peerAgentId }),
     }));
+  });
+
+  it("returns conflict when unblock-owner authority changes before the issue write", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockIssueService.update.mockResolvedValue(null);
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      return {
+        allowed: unblockOwnerMutation || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "deny_missing_grant",
+        explanation: unblockOwnerMutation
+          ? "Allowed because the actor is the current unblock owner."
+          : "Missing permission.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Remediation is complete", resume: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Unblock owner authorization became stale");
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "todo" }),
+      expect.any(Object),
+      { expectedBlockedUnblockOwnerAgentId: peerAgentId },
+    );
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects unblock-owner PATCH fields outside the scoped resume flow", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1504,7 +1504,7 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
-  it("allows the persisted unblock owner to mutate a blocked issue assigned to another agent", async () => {
+  it("allows the persisted unblock owner to comment and resume a blocked issue assigned to another agent", async () => {
     const blockedIssue = makeIssue({
       status: "blocked",
       assigneeAgentId: ownerAgentId,
@@ -1518,6 +1518,64 @@ describe("agent issue mutation checkout ownership", () => {
       ...blockedIssue,
       ...patch,
     }));
+    mockAgentService.resolveByReference.mockResolvedValue({
+      ambiguous: false,
+      agent: makeAgent(peerAgentId),
+    });
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      const taskAssignment = input.action === "tasks:assign";
+      return {
+        allowed: unblockOwnerMutation || taskAssignment || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : taskAssignment
+            ? "allow_explicit_grant"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "deny_missing_grant",
+        explanation: unblockOwnerMutation
+          ? "Allowed because the actor is the current unblock owner."
+          : input.action === "issue:read"
+            ? "Allowed by same-company visibility."
+            : "Missing permission.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Remediation is complete", resume: true, assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "todo", assigneeAgentId: peerAgentId }),
+    );
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ allowIssueUnblockOwner: true }),
+    }));
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "tasks:assign",
+      resource: expect.objectContaining({ assigneeAgentId: peerAgentId }),
+    }));
+  });
+
+  it("rejects unblock-owner PATCH fields outside the scoped resume flow", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
     mockAccessService.decide.mockImplementation(async (input: {
       action: string;
       scope?: Record<string, unknown>;
@@ -1534,25 +1592,23 @@ describe("agent issue mutation checkout ownership", () => {
             : "deny_missing_grant",
         explanation: unblockOwnerMutation
           ? "Allowed because the actor is the current unblock owner."
-          : input.action === "issue:read"
-            ? "Allowed by same-company visibility."
-            : "Missing permission.",
+          : "Missing permission.",
       };
     });
+    const app = await createApp(peerActor());
 
-    const res = await request(await createApp(peerActor()))
-      .patch(`/api/issues/${issueId}`)
-      .send({ title: "Owner-provided remediation" });
-
-    expect(res.status, JSON.stringify(res.body)).toBe(200);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      issueId,
-      expect.objectContaining({ title: "Owner-provided remediation" }),
-    );
-    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
-      action: "issue:mutate",
-      scope: expect.objectContaining({ allowIssueUnblockOwner: true }),
-    }));
+    for (const body of [
+      { comment: "Done", title: "Unrelated title change" },
+      { comment: "Done", status: "todo" },
+      { comment: "Done", status: "done" },
+      { comment: "Done", status: "cancelled" },
+      { comment: "Done", assigneeAgentId: peerAgentId },
+    ]) {
+      const res = await request(app).patch(`/api/issues/${issueId}`).send(body);
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Unblock owners may only comment and resume blocked issues");
+    }
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3515,6 +3515,26 @@ export function issueRoutes(
     return decision.reason === "allow_issue_unblock_owner";
   }
 
+  function isScopedIssueUnblockOwnerPatch(value: unknown) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const patch = value as Record<string, unknown>;
+    const allowedKeys = new Set(["comment", "resume", "assigneeAgentId"]);
+    if (Object.keys(patch).some((key) => !allowedKeys.has(key))) return false;
+
+    const comment = typeof patch.comment === "string" ? patch.comment.trim() : "";
+    if (!comment) return false;
+    if ("resume" in patch && patch.resume !== true) return false;
+
+    const requestsRedispatch = patch.resume === true;
+    if (
+      "assigneeAgentId" in patch &&
+      (typeof patch.assigneeAgentId !== "string" || !patch.assigneeAgentId || !requestsRedispatch)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
   async function filterIssuesForActor<T extends Parameters<typeof decideIssueAccess>[1]>(req: Request, rows: T[]) {
     const decisions = await Promise.all(rows.map((issue) => decideIssueAccess(req, issue, "issue:read")));
     return rows.filter((_, index) => decisions[index]?.allowed);
@@ -3604,7 +3624,17 @@ export function issueRoutes(
       return false;
     }
     if (options.allowIssueUnblockOwner && isIssueUnblockOwnerDecision(boundaryDecision)) {
-      return true;
+      if (!isScopedIssueUnblockOwnerPatch(req.body)) {
+        res.status(403).json({
+          error: "Unblock owners may only comment and resume blocked issues",
+          details: {
+            issueId: issue.id,
+            securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+          },
+        });
+        return false;
+      }
+      return "issue_unblock_owner" as const;
     }
     if (issue.assigneeAgentId === null) {
       return true;
@@ -4187,6 +4217,7 @@ export function issueRoutes(
     req: Request,
     res: Response,
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    options: { allowIssueUnblockOwner?: boolean } = {},
   ) {
     if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
 
@@ -4244,6 +4275,7 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
+    if (options.allowIssueUnblockOwner) return true;
     if (!issue.assigneeAgentId) {
       res.status(409).json({
         error: "Issue follow-up requires an assigned agent",
@@ -7719,7 +7751,14 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { allowIssueUnblockOwner: true }))) return;
+    const mutationAccess = await assertAgentIssueMutationAllowed(
+      req,
+      res,
+      existing,
+      { allowIssueUnblockOwner: true },
+    );
+    if (!mutationAccess) return;
+    const isIssueUnblockOwner = mutationAccess === "issue_unblock_owner";
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -7757,7 +7796,10 @@ export function issueRoutes(
     ) {
       return;
     }
-    if (resumeRequested === true && !(await assertExplicitResumeIntentAllowed(req, res, existing))) return;
+    if (
+      resumeRequested === true &&
+      !(await assertExplicitResumeIntentAllowed(req, res, existing, { allowIssueUnblockOwner: isIssueUnblockOwner }))
+    ) return;
     if (resumeRequested !== true && reopenRequested === true && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, existing))) return;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7759,6 +7759,17 @@ export function issueRoutes(
     );
     if (!mutationAccess) return;
     const isIssueUnblockOwner = mutationAccess === "issue_unblock_owner";
+    const ownerWritePrecondition = isIssueUnblockOwner && req.actor.type === "agent" && req.actor.agentId
+      ? { expectedBlockedUnblockOwnerAgentId: req.actor.agentId }
+      : undefined;
+    const persistIssueUpdate = (
+      data: Parameters<typeof svc.update>[1],
+      tx?: Parameters<typeof svc.update>[2],
+    ) => ownerWritePrecondition
+      ? svc.update(id, data, tx, ownerWritePrecondition)
+      : tx
+        ? svc.update(id, data, tx)
+        : svc.update(id, data);
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -8146,19 +8157,55 @@ export function issueRoutes(
       value: Awaited<ReturnType<typeof svc.addStopRelayCommentIfNeeded>>;
     } = { value: null };
     let issue: Awaited<ReturnType<typeof svc.update>>;
+    let atomicOwnerComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
+    const ownerCommentSourceTrust = ownerWritePrecondition && commentBody
+      ? await sourceTrustForActorWrite(existing, actor)
+      : null;
     try {
-      if (transition.decision && decisionId) {
-        const decision = transition.decision;
+      if (ownerWritePrecondition) {
         issue = await db.transaction(async (tx) => {
-          const updated = await svc.update(
-            id,
-            {
-              ...updateFields,
+          const updated = await persistIssueUpdate({
+            ...updateFields,
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+          }, tx);
+          if (!updated) return null;
+
+          if (transition.decision && decisionId) {
+            await tx.insert(issueExecutionDecisions).values({
+              id: decisionId,
+              companyId: updated.companyId,
+              issueId: updated.id,
+              stageId: transition.decision.stageId,
+              stageType: transition.decision.stageType,
               actorAgentId: actor.agentId ?? null,
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
-            },
-            tx,
-          );
+              outcome: transition.decision.outcome,
+              body: transition.decision.body,
+              createdByRunId: actor.runId ?? null,
+            });
+          }
+          if (shouldRelayStop) {
+            stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
+          }
+          if (!commentBody) throw new Error("Unblock-owner PATCH is missing its required result comment");
+          atomicOwnerComment = await svc.addComment(id, commentBody, {
+            agentId: actor.agentId ?? undefined,
+            userId: actor.actorType === "user" ? actor.actorId : undefined,
+            runId: actor.runId,
+          }, {
+            sourceTrust: ownerCommentSourceTrust,
+          }, tx);
+          return updated;
+        });
+      } else if (transition.decision && decisionId) {
+        const decision = transition.decision;
+        issue = await db.transaction(async (tx) => {
+          const updated = await persistIssueUpdate({
+            ...updateFields,
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+          }, tx);
           if (!updated) return null;
 
           await tx.insert(issueExecutionDecisions).values({
@@ -8182,7 +8229,7 @@ export function issueRoutes(
         });
       } else if (shouldRelayStop) {
         issue = await db.transaction(async (tx) => {
-          const updated = await svc.update(id, {
+          const updated = await persistIssueUpdate({
             ...updateFields,
             actorAgentId: actor.agentId ?? null,
             actorUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -8192,7 +8239,7 @@ export function issueRoutes(
           return updated;
         });
       } else {
-        issue = await svc.update(id, {
+        issue = await persistIssueUpdate({
           ...updateFields,
           actorAgentId: actor.agentId ?? null,
           actorUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -8222,6 +8269,10 @@ export function issueRoutes(
       throw err;
     }
     if (!issue) {
+      if (ownerWritePrecondition) {
+        res.status(409).json({ error: "Unblock owner authorization became stale" });
+        return;
+      }
       res.status(404).json({ error: "Issue not found" });
       return;
     }
@@ -8618,17 +8669,19 @@ export function issueRoutes(
       }
     }
 
-    let comment = null;
+    let comment = atomicOwnerComment;
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-      }, {
-        sourceTrust: await sourceTrustForActorWrite(issue, actor),
-      });
+      if (!comment) {
+        comment = await svc.addComment(id, commentBody, {
+          agentId: actor.agentId ?? undefined,
+          userId: actor.actorType === "user" ? actor.actorId : undefined,
+          runId: actor.runId,
+        }, {
+          sourceTrust: await sourceTrustForActorWrite(issue, actor),
+        });
+      }
       await issueReferencesSvc.syncComment(comment.id);
       await externalObjectsSvc.syncCommentSafely(comment.id);
       const commentReferenceSummaryAfter = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
@@ -10028,6 +10081,13 @@ export function issueRoutes(
     if (!issue) return;
     const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, issue);
     if (!commentAccessDecision) return;
+    const commentOwnerWritePrecondition =
+      commentAccessDecision !== true &&
+      isIssueUnblockOwnerDecision(commentAccessDecision) &&
+      req.actor.type === "agent" &&
+      req.actor.agentId
+        ? req.actor.agentId
+        : undefined;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,
@@ -10042,6 +10102,10 @@ export function issueRoutes(
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;
+    if (commentOwnerWritePrecondition && (reopenRequested || resumeRequested || interruptRequested)) {
+      res.status(403).json({ error: "Unblock owners must use the guarded issue PATCH to resume work" });
+      return;
+    }
     const isClosed = isClosedIssueStatus(issue.status);
     const isBlocked = issue.status === "blocked";
     const crossIssueCommentOnlyGrant =
@@ -10341,6 +10405,7 @@ export function issueRoutes(
         presentation: req.body.presentation ?? null,
         metadata: req.body.metadata ?? null,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
+        expectedBlockedUnblockOwnerAgentId: commentOwnerWritePrecondition,
       });
     }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3428,6 +3428,7 @@ export function issueRoutes(
       status: string;
     },
     action: "issue:comment" | "issue:read" | "issue:mutate",
+    additionalScope: Record<string, unknown> = {},
   ) {
     return access.decide({
       actor: req.actor,
@@ -3448,6 +3449,7 @@ export function issueRoutes(
         parentIssueId: issue.parentId,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
+        ...additionalScope,
       },
     });
   }
@@ -3509,6 +3511,10 @@ export function issueRoutes(
     return decision !== true && decision.reason === "allow_direct_parent_report";
   }
 
+  function isIssueUnblockOwnerDecision(decision: Awaited<ReturnType<typeof decideIssueAccess>>) {
+    return decision.reason === "allow_issue_unblock_owner";
+  }
+
   async function filterIssuesForActor<T extends Parameters<typeof decideIssueAccess>[1]>(req: Request, rows: T[]) {
     const decisions = await Promise.all(rows.map((issue) => decideIssueAccess(req, issue, "issue:read")));
     return rows.filter((_, index) => decisions[index]?.allowed);
@@ -3556,6 +3562,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    options: { allowIssueUnblockOwner?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3586,10 +3593,18 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
-    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
+    const boundaryDecision = await decideIssueAccess(
+      req,
+      issue,
+      "issue:mutate",
+      options.allowIssueUnblockOwner ? { allowIssueUnblockOwner: true } : {},
+    );
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
+    }
+    if (options.allowIssueUnblockOwner && isIssueUnblockOwnerDecision(boundaryDecision)) {
+      return true;
     }
     if (issue.assigneeAgentId === null) {
       return true;
@@ -7704,7 +7719,7 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { allowIssueUnblockOwner: true }))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -20,7 +20,12 @@ import type {
   SkillTestAgentKeyScope,
   TaskBridgeAgentKeyScope,
 } from "@paperclipai/shared";
-import { LOW_TRUST_REVIEW_PRESET, extractAgentMentionIds, type LowTrustBoundary } from "@paperclipai/shared";
+import {
+  LOW_TRUST_REVIEW_PRESET,
+  extractAgentMentionIds,
+  issueUnblockDescriptorSchema,
+  type LowTrustBoundary,
+} from "@paperclipai/shared";
 import {
   LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH,
   isIssueWithinLowTrustBoundary,
@@ -213,10 +218,9 @@ function readBoolean(value: unknown): boolean | null {
 }
 
 function issueUnblockOwnerAgentId(value: unknown) {
-  if (!isPlainRecord(value)) return null;
-  const owner = value.owner;
-  if (!isPlainRecord(owner)) return null;
-  return readString(owner.agentId);
+  const parsed = issueUnblockDescriptorSchema.safeParse(value);
+  if (!parsed.success || typeof parsed.data.owner !== "object" || !("agentId" in parsed.data.owner)) return null;
+  return parsed.data.owner.agentId;
 }
 
 type AssignmentPolicyEffect =
@@ -1807,6 +1811,7 @@ export function authorizationService(db: Db) {
       input.action === "issue:comment" ||
       (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
     if (
+      trustResolution.kind === "standard" &&
       issueUnblockOwnerAction &&
       input.resource.type === "issue" &&
       input.resource.issueId

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -102,6 +102,7 @@ export type AuthorizationDecision = {
     | "allow_consented_change"
     | "allow_legacy_agent_creator"
     | "allow_issue_mention_grant"
+    | "allow_issue_unblock_owner"
     | "allow_direct_parent_report"
     | "allow_self"
     | "allow_company_agent"
@@ -211,6 +212,13 @@ function readBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
 }
 
+function issueUnblockOwnerAgentId(value: unknown) {
+  if (!isPlainRecord(value)) return null;
+  const owner = value.owner;
+  if (!isPlainRecord(owner)) return null;
+  return readString(owner.agentId);
+}
+
 type AssignmentPolicyEffect =
   | { kind: "none" }
   | { kind: "restricted"; explanation: string }
@@ -244,6 +252,7 @@ type IssueAuthorizationRow = {
   executionPolicy: unknown;
   originKind: string | null;
   originId: string | null;
+  unblockDescriptor: unknown;
 };
 
 function evaluateAuthorizationPolicyForAssignment(
@@ -750,6 +759,7 @@ export function authorizationService(db: Db) {
         executionPolicy: issues.executionPolicy,
         originKind: issues.originKind,
         originId: issues.originId,
+        unblockDescriptor: issues.unblockDescriptor,
       })
       .from(issues)
       .where(eq(issues.id, issueId))
@@ -1791,6 +1801,28 @@ export function authorizationService(db: Db) {
         reason: "allow_direct_parent_report",
         explanation: "Allowed because the target is the current run issue's direct parent under the standard trust preset.",
       });
+    }
+
+    const issueUnblockOwnerAction =
+      input.action === "issue:comment" ||
+      (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
+    if (
+      issueUnblockOwnerAction &&
+      input.resource.type === "issue" &&
+      input.resource.issueId
+    ) {
+      const issue = await loadIssue(input.resource.issueId);
+      if (
+        issue?.companyId === companyId &&
+        issue.status === "blocked" &&
+        issueUnblockOwnerAgentId(issue.unblockDescriptor) === actorAgentId
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_issue_unblock_owner",
+          explanation: "Allowed because the actor is the current persisted unblock owner.",
+        });
+      }
     }
 
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6571,6 +6571,7 @@ export function issueService(db: Db) {
         actorUserId?: string | null;
       },
       dbOrTx: any = db,
+      options?: { expectedBlockedUnblockOwnerAgentId?: string },
     ) => {
       const existing = await dbOrTx
         .select()
@@ -6738,10 +6739,17 @@ export function issueService(db: Db) {
           projectGoalId: nextProjectGoalId,
           defaultGoalId: defaultCompanyGoal?.id ?? null,
         });
+        const updatePredicate = options?.expectedBlockedUnblockOwnerAgentId
+          ? and(
+              eq(issues.id, id),
+              eq(issues.status, "blocked"),
+              sql`${issues.unblockDescriptor}->'owner'->>'agentId' = ${options.expectedBlockedUnblockOwnerAgentId}`,
+            )
+          : eq(issues.id, id);
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(eq(issues.id, id))
+          .where(updatePredicate)
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;
@@ -7582,60 +7590,84 @@ export function issueService(db: Db) {
         metadata?: IssueCommentMetadata | null;
         sourceTrust?: typeof issueComments.$inferInsert.sourceTrust;
         createdAt?: Date | string | null;
+        expectedBlockedUnblockOwnerAgentId?: string;
       },
       dbOrTx: any = db,
     ) => {
-      const issue = await dbOrTx
-        .select({ companyId: issues.companyId })
-        .from(issues)
-        .where(eq(issues.id, issueId))
-        .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
+      const runAddComment = async (executor: any) => {
+        const expectedOwnerAgentId = options?.expectedBlockedUnblockOwnerAgentId;
+        const issue = expectedOwnerAgentId
+          ? await executor
+              .update(issues)
+              .set({ updatedAt: new Date() })
+              .where(and(
+                eq(issues.id, issueId),
+                eq(issues.status, "blocked"),
+                sql`${issues.unblockDescriptor}->'owner'->>'agentId' = ${expectedOwnerAgentId}`,
+              ))
+              .returning({ companyId: issues.companyId })
+              .then((rows: Array<{ companyId: string }>) => rows[0] ?? null)
+          : await executor
+              .select({ companyId: issues.companyId })
+              .from(issues)
+              .where(eq(issues.id, issueId))
+              .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
 
-      if (!issue) throw notFound("Issue not found");
+        if (!issue) {
+          if (expectedOwnerAgentId) throw conflict("Unblock owner authorization became stale");
+          throw notFound("Issue not found");
+        }
 
-      const currentUserRedactionOptions = {
-        enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
-      };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
-      const authorType = issueCommentAuthorTypeSchema.parse(
-        options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
-      );
-      assertIssueCommentAuthorTypeAllowed(actor, authorType);
-      const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
-      const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
-      const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
-      // Invalid/stale run ids must not 500 the insert — null out unknowns.
-      const createdByRunId = await resolveCommentCreatedByRunId(dbOrTx, issue.companyId, actor.runId);
-      if (actor.runId && !createdByRunId) {
-        logger.warn(
-          { issueId, companyId: issue.companyId, runId: actor.runId },
-          "dropping invalid createdByRunId for issue comment insert",
+        const currentUserRedactionOptions = {
+          enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
+        };
+        const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+        const authorType = issueCommentAuthorTypeSchema.parse(
+          options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
         );
-      }
-      const [comment] = await dbOrTx
-        .insert(issueComments)
-        .values({
-          companyId: issue.companyId,
-          issueId,
-          authorAgentId: actor.agentId ?? null,
-          authorUserId: actor.userId ?? null,
-          authorType,
-          createdByRunId,
-          body: redactedBody,
-          presentation,
-          metadata,
-          sourceTrust: options?.sourceTrust ?? null,
-          ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
-        })
-        .returning();
+        assertIssueCommentAuthorTypeAllowed(actor, authorType);
+        const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
+        const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
+        const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
+        // Invalid/stale run ids must not 500 the insert — null out unknowns.
+        const createdByRunId = await resolveCommentCreatedByRunId(executor, issue.companyId, actor.runId);
+        if (actor.runId && !createdByRunId) {
+          logger.warn(
+            { issueId, companyId: issue.companyId, runId: actor.runId },
+            "dropping invalid createdByRunId for issue comment insert",
+          );
+        }
+        const [comment] = await executor
+          .insert(issueComments)
+          .values({
+            companyId: issue.companyId,
+            issueId,
+            authorAgentId: actor.agentId ?? null,
+            authorUserId: actor.userId ?? null,
+            authorType,
+            createdByRunId,
+            body: redactedBody,
+            presentation,
+            metadata,
+            sourceTrust: options?.sourceTrust ?? null,
+            ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
+          })
+          .returning();
 
-      // Update issue's updatedAt so comment activity is reflected in recency sorting
-      await dbOrTx
-        .update(issues)
-        .set({ updatedAt: new Date() })
-        .where(eq(issues.id, issueId));
+        if (!expectedOwnerAgentId) {
+          // The conditional owner update above already records comment recency.
+          await executor
+            .update(issues)
+            .set({ updatedAt: new Date() })
+            .where(eq(issues.id, issueId));
+        }
 
-      return redactIssueComment(comment, currentUserRedactionOptions.enabled);
+        return redactIssueComment(comment, currentUserRedactionOptions.enabled);
+      };
+
+      return options?.expectedBlockedUnblockOwnerAgentId && dbOrTx === db
+        ? db.transaction(runAddComment)
+        : runAddComment(dbOrTx);
     },
 
     createAttachment: async (input: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work through issues, including explicit blocked-state routing.
> - A blocked issue can name an agent in `unblockDescriptor.owner` to perform the action needed before work resumes.
> - The persisted descriptor routed the responsibility, but issue authorization still treated that agent as an unrelated peer whenever another agent remained assigned.
> - That mismatch prevented the owner from commenting on or updating the exact issue it was asked to unblock.
> - The grant must be derived from current persisted state rather than request-supplied fields, and it must expire as soon as the issue is no longer blocked or the owner changes.
> - This pull request adds that narrow authorization decision and limits the owner PATCH to a recorded result plus the guarded resume path.
> - The benefit is a complete unblock-owner lifecycle without weakening ordinary cross-assignee protections.

## Linked Issues or Issue Description

- Fixes #10395
- Refs #10366
- Refs #10299

## What Changed

- Export and reuse the canonical strict unblock-descriptor schema at the persisted authorization boundary; malformed JSON and non-agent owners fail closed.
- Allow standard-trust `issue:comment` only when the caller is the current persisted agent owner of a currently blocked same-company issue.
- Allow only a result comment plus `resume: true`, with optional non-null agent reassignment, through the main issue PATCH. Raw status changes, terminal transitions, unrelated fields, and assignment without resume remain denied.
- Preserve dependency/pause-hold resume checks and the existing `tasks:assign` authorization before re-dispatch.
- Couple owner-granted PATCH and comment writes to atomic SQL predicates that require the issue to still be blocked and the actor to still be the persisted owner. Stale grants return 409 before mutation; owner comments are comment-only and resume remains on the guarded PATCH flow.
- Add authorization-service and route regressions covering owner success, low-trust/unrelated-agent/malformed-descriptor denial, automatic revocation outside `blocked`, scoped re-dispatch, terminal/unrelated-field denial, and concurrent owner/status changes.
- Align the root Lexical override with the 0.48 UI/lockfile bump merged in #10299. Current `master` retained 0.46 in the override, causing every frozen-install CI lane to fail before tests; this is a one-line manifest correction with no lockfile change.

## Verification

- `pnpm exec vitest run packages/shared/src/validators/issue.test.ts server/src/__tests__/authorization-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 156 passed.
- `pnpm --filter @paperclipai/shared typecheck && pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm install --frozen-lockfile` — passed with the corrected root override and no lockfile changes.
- `pnpm -r typecheck` — passed.
- `pnpm test:run` — 3,007 passed, 2 failed, 1 skipped. Both failures are in pre-existing workspace-runtime auto-port reconciliation tests and reproduce unchanged on clean `origin/master` (`94 passed, 2 failed`).
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts` on clean `origin/master` — 94 passed, the same 2 baseline failures.
- `pnpm build` — passed.
- Red-before-green proof: the new service regression returned `deny_missing_grant`, and the route regression returned `Agent cannot mutate another agent's issue` on unmodified `master`; both pass with this change.

## Risks

- Authorization expansion is security-sensitive. The grant is standard-trust only, limited to comments plus a comment-backed guarded resume, uses the current database row and canonical strict schema, requires same-company actor resolution, requires `status === "blocked"`, and requires exact owner-agent identity.
- Reassignment is optional but can occur only with `resume: true` and still passes normal `tasks:assign` authorization. Terminal transitions and unrelated issue fields are explicitly rejected.
- Owner/status authorization is coupled to the final database write. A concurrent owner or status change yields no update or comment insert and returns 409.
- Low-trust, task-bridge, skill-test, responsible-user, cross-company, recovery, dependency, pause-hold, and wake checks remain in their existing order and are not bypassed.
- No migration, public API shape change, UI code change, or lockfile change.

> This is a bug fix in existing blocked-issue authorization behavior. `ROADMAP.md` has no overlapping unblock-owner or issue-authorization item.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, with reasoning, repository tool use, test execution, and an independent review subagent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change is needed for this internal authorization correction)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
