### PR TITLE
fix(heartbeat): make agent wakeup idempotency keys actually deduplicate

### DIFF
--- a/packages/db/src/migrations/0196_agent_wakeup_idempotency_key_unique.sql
+++ b/packages/db/src/migrations/0196_agent_wakeup_idempotency_key_unique.sql
@@ -12,10 +12,17 @@
 -- one was skipped would silently drop work, which is worse than a duplicate
 -- run.
 --
--- Step 1: collapse any pre-existing duplicates so the index below can be
+-- Step 1: resolve any pre-existing duplicates so the index below can be
 -- created. Keep one row per (company_id, idempotency_key) -- preferring one
--- that actually carries a run -- and mark the rest coalesced, which is what
--- they always were: a second request for a wake that had already happened.
+-- that actually carries a run -- and release the key on the rest, recording
+-- the released value in `error`.
+--
+-- Only the key is touched. Status and run linkage are left exactly as they
+-- are, because a duplicate wake may still own a live queued run: rewriting its
+-- status would either lie about that run or, worse, let the row re-enter the
+-- index on its next lifecycle transition (queued -> claimed) and make the
+-- claim fail with a unique violation. A row with a NULL key is outside the
+-- partial index for good, whatever it does next.
 WITH ranked AS (
   SELECT
     id,
@@ -29,10 +36,12 @@ WITH ranked AS (
 )
 UPDATE agent_wakeup_requests
 SET
-  status = 'coalesced',
-  coalesced_count = coalesced_count + 1,
-  finished_at = COALESCE(finished_at, now()),
-  error = COALESCE(error, 'Collapsed by migration 0196: duplicate idempotency_key'),
+  idempotency_key = NULL,
+  error = COALESCE(
+    error,
+    'Migration 0196 released duplicate idempotency_key ' || idempotency_key
+      || '; the surviving wake for that key keeps it'
+  ),
   updated_at = now()
 WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
 --> statement-breakpoint

--- a/packages/db/src/migrations/0196_agent_wakeup_idempotency_key_unique.sql
+++ b/packages/db/src/migrations/0196_agent_wakeup_idempotency_key_unique.sql
@@ -1,0 +1,48 @@
+-- Make agent_wakeup_requests.idempotency_key actually deduplicate.
+--
+-- The column existed but nothing enforced or read it: enqueueWakeup only wrote
+-- it, and there was no unique index. Callers that passed a key got a field on
+-- the row, not deduplication. Two concurrent enqueues could both miss the
+-- other's not-yet-visible wake row and both queue a run with the same key.
+--
+-- Uniqueness is scoped to (company_id, idempotency_key) and restricted to the
+-- statuses in which a wake still represents a run that took effect. Statuses
+-- that mean "this wake did NOT happen" (skipped, coalesced, failed, cancelled)
+-- stay outside the index on purpose: blocking a later wake because an earlier
+-- one was skipped would silently drop work, which is worse than a duplicate
+-- run.
+--
+-- Step 1: collapse any pre-existing duplicates so the index below can be
+-- created. Keep one row per (company_id, idempotency_key) -- preferring one
+-- that actually carries a run -- and mark the rest coalesced, which is what
+-- they always were: a second request for a wake that had already happened.
+WITH ranked AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY company_id, idempotency_key
+      ORDER BY (run_id IS NULL), requested_at ASC, id ASC
+    ) AS rn
+  FROM agent_wakeup_requests
+  WHERE idempotency_key IS NOT NULL
+    AND status IN ('queued', 'claimed', 'deferred_issue_execution', 'completed')
+)
+UPDATE agent_wakeup_requests
+SET
+  status = 'coalesced',
+  coalesced_count = coalesced_count + 1,
+  finished_at = COALESCE(finished_at, now()),
+  error = COALESCE(error, 'Collapsed by migration 0196: duplicate idempotency_key'),
+  updated_at = now()
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+--> statement-breakpoint
+
+-- Step 2: enforce uniqueness going forward. A partial unique index lets the
+-- enqueue race lose cleanly: the losing INSERT is an ON CONFLICT DO NOTHING in
+-- enqueueWakeup, which then resolves to the winner's run instead of creating a
+-- second one.
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: Drizzle migrations run transactionally, so CONCURRENTLY is unavailable; the index is partial over a column that is NULL on the overwhelming majority of rows, so the build touches a small fraction of the table.
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_wakeup_requests_company_idempotency_key_uq"
+  ON "agent_wakeup_requests" ("company_id", "idempotency_key")
+  WHERE idempotency_key IS NOT NULL
+    AND status IN ('queued', 'claimed', 'deferred_issue_execution', 'completed');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1359,6 +1359,13 @@
       "when": 1785170000001,
       "tag": "0195_built_in_agent_unique_marker",
       "breakpoints": true
+    },
+    {
+      "idx": 196,
+      "version": "7",
+      "when": 1785170000002,
+      "tag": "0196_agent_wakeup_idempotency_key_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_wakeup_requests.ts
+++ b/packages/db/src/schema/agent_wakeup_requests.ts
@@ -1,6 +1,30 @@
-import { pgTable, uuid, text, timestamp, jsonb, integer, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { pgTable, uuid, text, timestamp, jsonb, integer, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
+
+/**
+ * Wake statuses in which a request still represents a wake that took effect,
+ * so a second request carrying the same idempotency key must not create a
+ * second run.
+ *
+ * Deliberately excludes every status that means "this wake did NOT happen"
+ * (`skipped`, `coalesced`, `failed`, `cancelled`): suppressing a later wake
+ * because an earlier one was skipped would silently drop work, which is a
+ * worse failure than an occasional duplicate run.
+ */
+export const IDEMPOTENT_AGENT_WAKEUP_STATUSES = [
+  "queued",
+  "claimed",
+  "deferred_issue_execution",
+  "completed",
+] as const;
+
+export type IdempotentAgentWakeupStatus = (typeof IDEMPOTENT_AGENT_WAKEUP_STATUSES)[number];
+
+const idempotentStatusList = sql.raw(
+  IDEMPOTENT_AGENT_WAKEUP_STATUSES.map((status) => `'${status}'`).join(", "),
+);
 
 export const agentWakeupRequests = pgTable(
   "agent_wakeup_requests",
@@ -36,5 +60,12 @@ export const agentWakeupRequests = pgTable(
       table.requestedAt,
     ),
     agentRequestedIdx: index("agent_wakeup_requests_agent_requested_idx").on(table.agentId, table.requestedAt),
+    // Makes the idempotency key enforceable instead of decorative: the enqueue
+    // path checks for a live wake with the same key first, and this index wins
+    // the race the check cannot see (two concurrent enqueues both missing the
+    // other's uncommitted row).
+    companyIdempotencyKeyUq: uniqueIndex("agent_wakeup_requests_company_idempotency_key_uq")
+      .on(table.companyId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null and ${table.status} in (${idempotentStatusList})`),
   }),
 );

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -22,7 +22,11 @@ export { agentConfigRevisions } from "./agent_config_revisions.js";
 export { agentApiKeys } from "./agent_api_keys.js";
 export { agentRuntimeState } from "./agent_runtime_state.js";
 export { agentTaskSessions } from "./agent_task_sessions.js";
-export { agentWakeupRequests } from "./agent_wakeup_requests.js";
+export {
+  agentWakeupRequests,
+  IDEMPOTENT_AGENT_WAKEUP_STATUSES,
+  type IdempotentAgentWakeupStatus,
+} from "./agent_wakeup_requests.js";
 export { projects } from "./projects.js";
 export { projectMemberships } from "./project_memberships.js";
 export { documentMemberships } from "./document_memberships.js";

--- a/server/src/__tests__/agent-wakeup-idempotency-key.test.ts
+++ b/server/src/__tests__/agent-wakeup-idempotency-key.test.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentWakeupRequests,
+  agents,
+  companies,
+  companySkills,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Idempotency key wake test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres wake idempotency tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agent wakeup idempotency keys", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let agentId!: string;
+
+  const seedCompanyAndAgent = async () => {
+    companyId = randomUUID();
+    agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+  };
+
+  const wake = (idempotencyKey: string) =>
+    heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "wake_idempotency_test",
+      idempotencyKey,
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+  const wakeRowsWithKey = (idempotencyKey: string) =>
+    db
+      .select({
+        id: agentWakeupRequests.id,
+        status: agentWakeupRequests.status,
+        reason: agentWakeupRequests.reason,
+        runId: agentWakeupRequests.runId,
+      })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.idempotencyKey, idempotencyKey),
+        ),
+      );
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-wake-idempotency-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 30_000);
+
+  afterEach(async () => {
+    const runIds = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .then((runs) => runs.map((run) => run.id));
+    await Promise.all(runIds.map((runId) => heartbeat.waitForRunExecutionDrain(runId)));
+    runningProcesses.clear();
+    mockAdapterExecute.mockClear();
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("queues one run when the same idempotency key is enqueued twice", async () => {
+    await seedCompanyAndAgent();
+    const idempotencyKey = `wake-idempotency:${randomUUID()}`;
+
+    const first = await wake(idempotencyKey);
+    expect(first).not.toBeNull();
+
+    const second = await wake(idempotencyKey);
+    expect(second?.id).toBe(first?.id);
+
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    expect(runs).toHaveLength(1);
+
+    const rows = await wakeRowsWithKey(idempotencyKey);
+    expect(rows.filter((row) => row.status !== "skipped")).toHaveLength(1);
+    expect(rows.some((row) => row.reason === "wake.duplicate_idempotency_key")).toBe(true);
+  });
+
+  it("queues one run when two enqueues with the same key race", async () => {
+    await seedCompanyAndAgent();
+    const idempotencyKey = `wake-idempotency-race:${randomUUID()}`;
+
+    const [first, second] = await Promise.all([wake(idempotencyKey), wake(idempotencyKey)]);
+
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    expect(runs).toHaveLength(1);
+    expect([first?.id, second?.id].filter(Boolean)).toContain(runs[0]!.id);
+  });
+
+  it("does not wake again once a wake with the key has completed", async () => {
+    await seedCompanyAndAgent();
+    const idempotencyKey = `wake-idempotency-completed:${randomUUID()}`;
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "wake_idempotency_test",
+      status: "completed",
+      idempotencyKey,
+      finishedAt: new Date(),
+    });
+
+    const run = await wake(idempotencyKey);
+
+    expect(run).toBeNull();
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    expect(runs).toHaveLength(0);
+  });
+
+  // The risk the unique index has to avoid: a key that was written on a wake
+  // that never happened must stay reusable, or suppressed wakes would silently
+  // become permanent.
+  it("still wakes when the only row with the key was skipped", async () => {
+    await seedCompanyAndAgent();
+    const idempotencyKey = `wake-idempotency-skipped:${randomUUID()}`;
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "heartbeat.scheduling_suppressed",
+      status: "skipped",
+      idempotencyKey,
+      finishedAt: new Date(),
+    });
+
+    const run = await wake(idempotencyKey);
+
+    expect(run).not.toBeNull();
+    const runs = await db.select({ id: heartbeatRuns.id }).from(heartbeatRuns);
+    expect(runs).toHaveLength(1);
+  });
+
+  it("rejects a second live wake row with the same key at the database level", async () => {
+    await seedCompanyAndAgent();
+    const idempotencyKey = `wake-idempotency-index:${randomUUID()}`;
+    const row = {
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "wake_idempotency_test",
+      status: "queued",
+      idempotencyKey,
+    };
+
+    await db.insert(agentWakeupRequests).values(row);
+    await expect(db.insert(agentWakeupRequests).values(row)).rejects.toMatchObject({ cause: { code: "23505" } });
+
+    // …but a row whose status says the wake did not happen stays insertable.
+    await db.insert(agentWakeupRequests).values({ ...row, status: "skipped", finishedAt: new Date() });
+    const rows = await wakeRowsWithKey(idempotencyKey);
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/server/src/__tests__/agent-wakeup-idempotency-key.test.ts
+++ b/server/src/__tests__/agent-wakeup-idempotency-key.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { readFileSync } from "node:fs";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -50,6 +51,16 @@ if (!embeddedPostgresSupport.supported) {
     `Skipping embedded Postgres wake idempotency tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
   );
 }
+
+// The migration is read rather than restated so this test cannot drift away
+// from what actually runs against an existing database.
+const MIGRATION_STEPS = readFileSync(
+  new URL("../../../packages/db/src/migrations/0196_agent_wakeup_idempotency_key_unique.sql", import.meta.url),
+  "utf8",
+)
+  .split("--> statement-breakpoint")
+  .map((step) => step.trim())
+  .filter(Boolean);
 
 describeEmbeddedPostgres("agent wakeup idempotency keys", () => {
   let db!: ReturnType<typeof createDb>;
@@ -234,5 +245,73 @@ describeEmbeddedPostgres("agent wakeup idempotency keys", () => {
     await db.insert(agentWakeupRequests).values({ ...row, status: "skipped", finishedAt: new Date() });
     const rows = await wakeRowsWithKey(idempotencyKey);
     expect(rows).toHaveLength(2);
+  });
+
+  // A database that already ran the race carries duplicate keys, and a
+  // duplicate may still own a live queued run. The migration must not leave
+  // that run unclaimable: releasing the key (rather than rewriting the row's
+  // status) keeps it outside the index through every later transition.
+  it("leaves a collapsed duplicate's run claimable after the migration", async () => {
+    await seedCompanyAndAgent();
+    const idempotencyKey = `wake-idempotency-migration:${randomUUID()}`;
+    const survivorId = randomUUID();
+    const duplicateId = randomUUID();
+
+    // Recreate the pre-migration state: the index does not exist yet, so two
+    // wakes can hold the same key, each with its own queued run.
+    await db.execute(sql`drop index "agent_wakeup_requests_company_idempotency_key_uq"`);
+    await db.insert(agentWakeupRequests).values([
+      {
+        id: survivorId,
+        companyId,
+        agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "wake_idempotency_test",
+        status: "queued",
+        idempotencyKey,
+        runId: randomUUID(),
+      },
+      {
+        id: duplicateId,
+        companyId,
+        agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "wake_idempotency_test",
+        status: "queued",
+        idempotencyKey,
+        runId: randomUUID(),
+      },
+    ]);
+
+    for (const step of MIGRATION_STEPS) {
+      await db.execute(sql.raw(step));
+    }
+
+    const rows = await db
+      .select({
+        id: agentWakeupRequests.id,
+        status: agentWakeupRequests.status,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+        error: agentWakeupRequests.error,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    const survivor = rows.find((row) => row.id === survivorId)!;
+    const duplicate = rows.find((row) => row.id === duplicateId)!;
+
+    expect(survivor.idempotencyKey).toBe(idempotencyKey);
+    expect(duplicate.idempotencyKey).toBeNull();
+    expect(duplicate.error).toContain(idempotencyKey);
+    // The duplicate's run is untouched, so it can still be claimed.
+    expect(duplicate.status).toBe("queued");
+
+    await expect(
+      db
+        .update(agentWakeupRequests)
+        .set({ status: "claimed", claimedAt: new Date() })
+        .where(eq(agentWakeupRequests.id, duplicateId)),
+    ).resolves.toBeDefined();
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -33,6 +33,7 @@ import {
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
+  IDEMPOTENT_AGENT_WAKEUP_STATUSES,
   activityLog,
   approvals,
   companyMemberships,
@@ -15236,6 +15237,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await startNextQueuedRunForAgent(promotedRun.agentId);
   }
 
+  type LiveWakeupByIdempotencyKey = {
+    id: string;
+    status: string;
+    runId: string | null;
+  };
+
+  /**
+   * Finds a wake request that still represents a wake that took effect. Rows
+   * whose status says the wake did NOT happen (skipped, coalesced, failed,
+   * cancelled) are excluded so a suppressed wake never blocks a later, real one
+   * that reuses the key.
+   */
+  async function findLiveWakeupByIdempotencyKey(
+    companyId: string,
+    idempotencyKey: string,
+  ): Promise<LiveWakeupByIdempotencyKey | null> {
+    return await db
+      .select({
+        id: agentWakeupRequests.id,
+        status: agentWakeupRequests.status,
+        runId: agentWakeupRequests.runId,
+      })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.idempotencyKey, idempotencyKey),
+          inArray(agentWakeupRequests.status, [...IDEMPOTENT_AGENT_WAKEUP_STATUSES]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
@@ -15286,6 +15321,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       });
     };
+
+    // An idempotency key means "this wake already exists, don't make another".
+    // The lookup catches the settled cases; the partial unique index behind the
+    // inserts below catches the concurrent one the lookup cannot see.
+    const idempotencyKey = opts.idempotencyKey ?? null;
+    const resolveDuplicateWake = async (existing: LiveWakeupByIdempotencyKey | null) => {
+      await writeSkippedHeartbeatRequest("wake.duplicate_idempotency_key", {
+        reason: "A wake with this idempotency key already exists for this company.",
+        existingWakeupRequestId: existing?.id ?? null,
+        existingWakeupStatus: existing?.status ?? null,
+        existingRunId: existing?.runId ?? null,
+      });
+      if (!existing?.runId) return null;
+      return await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, existing.runId))
+        .then((rows) => rows[0] ?? null);
+    };
+    if (idempotencyKey) {
+      const existingWake = await findLiveWakeupByIdempotencyKey(agent.companyId, idempotencyKey);
+      if (existingWake) return await resolveDuplicateWake(existingWake);
+    }
 
     const schedulingSuppression = await getSchedulingSuppression();
     if (schedulingSuppression.suppressed) {
@@ -16085,6 +16143,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               return { kind: "deferred" as const };
             }
 
+            // A concurrent enqueue with the same key may already have written
+            // this row; losing that race is the same outcome as deferring.
             await tx.insert(agentWakeupRequests).values({
               companyId: agent.companyId,
               agentId,
@@ -16096,7 +16156,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               requestedByActorType: opts.requestedByActorType ?? null,
               requestedByActorId: opts.requestedByActorId ?? null,
               idempotencyKey: opts.idempotencyKey ?? null,
-            });
+            }).onConflictDoNothing();
 
             return { kind: "deferred" as const };
           }
@@ -16258,8 +16318,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             requestedByActorId: opts.requestedByActorId ?? null,
             idempotencyKey: opts.idempotencyKey ?? null,
           })
+          .onConflictDoNothing()
           .returning()
-          .then((rows) => rows[0]);
+          .then((rows) => rows[0] ?? null);
+
+        // A concurrent enqueue with the same idempotency key won the race; its
+        // run is the one this call asked for.
+        if (!wakeupRequest) return { kind: "duplicate_idempotency_key" as const };
 
         const newRun = await tx
           .insert(heartbeatRuns)
@@ -16294,6 +16359,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       if (outcome.kind === "deferred" || outcome.kind === "skipped") return null;
+      if (outcome.kind === "duplicate_idempotency_key") {
+        return await resolveDuplicateWake(
+          idempotencyKey ? await findLiveWakeupByIdempotencyKey(agent.companyId, idempotencyKey) : null,
+        );
+      }
       if (outcome.kind === "coalesced") {
         await startNextQueuedRunForAgent(agent.id);
         return outcome.run;
@@ -16432,8 +16502,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           requestedByActorId: opts.requestedByActorId ?? null,
           idempotencyKey: opts.idempotencyKey ?? null,
         })
+        .onConflictDoNothing()
         .returning()
-        .then((rows) => rows[0]);
+        .then((rows) => rows[0] ?? null);
+
+      // A concurrent enqueue with the same idempotency key won the race; its
+      // run is the one this call asked for.
+      if (!wakeupRequest) return { kind: "duplicate_idempotency_key" as const };
 
       const newRun = await tx
         .insert(heartbeatRuns)
@@ -16464,6 +16539,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
 
     if (queueOutcome.kind === "skipped") return null;
+    if (queueOutcome.kind === "duplicate_idempotency_key") {
+      return await resolveDuplicateWake(
+        idempotencyKey ? await findLiveWakeupByIdempotencyKey(agent.companyId, idempotencyKey) : null,
+      );
+    }
     const newRun = queueOutcome.run;
 
     publishLiveEvent({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Every agent invocation goes through the heartbeat wake path: `enqueueWakeup` writes an `agent_wakeup_requests` row and queues the run that executes it
> - That table has an `idempotency_key` column, and callers across recovery, issue monitors, task watchdogs, routable-blocked and the plugin host pass one — but nothing ever enforced or read it: there was no unique index, and `enqueueWakeup` only wrote the value
> - So "wake this agent at most once for this event" was not something the platform could actually promise; callers that needed it had to hand-roll a lookup, and two concurrent enqueues could still each miss the other's uncommitted row and queue two full adapter sessions for the same event
> - This pull request makes the key enforceable: a partial unique index plus a lookup and conflict-tolerant insert in the enqueue path
> - The benefit is that duplicate wakes stop at the database instead of turning into a second paid adapter run, and callers can drop their bespoke deduplication queries

## Linked Issues or Issue Description

No public GitHub issue exists for this, so the underlying bug is described here following `.github/ISSUE_TEMPLATE/bug_report.yml`.

### What happened?

`agent_wakeup_requests.idempotency_key` was inert. `packages/db/src/schema/agent_wakeup_requests.ts` declared only three plain `index(...)` entries and no unique constraint, and `enqueueWakeup` in `server/src/services/heartbeat.ts` wrote `idempotencyKey: opts.idempotencyKey ?? null` on every insert path without ever reading it back. Passing a key therefore had no effect beyond storing a string: the same key could queue any number of runs.

### Expected behavior

Two wake requests carrying the same idempotency key for the same company should produce one wake and one run. The second request should resolve to the first one's run rather than starting a second adapter session.

### Steps to reproduce

1. Call the heartbeat wake path twice for the same agent with the same `idempotencyKey` (for example `heartbeat.wakeup(agentId, { source: "automation", reason: "…", idempotencyKey: "demo:1" })`).
2. Query `agent_wakeup_requests` and `heartbeat_runs`.
3. Before this change: two wake rows and two queued runs. Concurrent callers hit the same thing — each misses the other's not-yet-committed row and both enqueue.

### Paperclip version or commit

Verified against `master` at `ca92f727c`; the branch is based on `4eace88f6`, and the two commits in between are CI-only.

### Deployment mode

Local, embedded Postgres (`local_trusted`); the defect is storage-layer and mode-independent.

### Related PRs (searched, not duplicates)

Refs #4507 — adds an idempotency key to `issue_children_completed` wakes; that key only starts working once something enforces it, which is what this PR does. Refs #5253 — wake dedupe by cooldown/telemetry rather than by the existing key column. Refs #9283 — also indexes `agent_wakeup_requests`, but on the jsonb `issueId` lookup path, not on `idempotency_key`.

## What Changed

- Added a partial unique index `agent_wakeup_requests_company_idempotency_key_uq` on `(company_id, idempotency_key)`, scoped to the statuses in which a wake still represents a run that took effect (`queued`, `claimed`, `deferred_issue_execution`, `completed`), exported from the schema as `IDEMPOTENT_AGENT_WAKEUP_STATUSES` so the runtime and the index cannot drift apart.
- Migration `0196_agent_wakeup_idempotency_key_unique.sql` creates the index and first resolves any pre-existing duplicates by releasing the key on all but one row per `(company_id, idempotency_key)` (recording the released value in `error`), so the migration cannot fail on an installation where the race already happened. It deliberately touches only the key: a duplicate wake may still own a live queued run, and rewriting its status would let it re-enter the index on its next `queued -> claimed` transition and make that claim fail.
- `enqueueWakeup` now looks up a live wake for the key before doing any work and returns that wake's run instead of queueing a second one, recording the suppression as a `wake.duplicate_idempotency_key` skip row so it stays visible in the wake history.
- The three inserts in `enqueueWakeup` that write a guarded status (`deferred_issue_execution` and the two `queued` paths) use `ON CONFLICT DO NOTHING` and resolve to the winner's run, so the concurrent case the lookup cannot see loses cleanly instead of raising a 23505 at the caller.
- Added `server/src/__tests__/agent-wakeup-idempotency-key.test.ts` covering the sequential case, the concurrent case, the already-completed case, the index itself, the non-suppression guard below, and the migration's duplicate cleanup (seeded pre-migration state, migration statements read from the migration file, collapsed duplicate must stay claimable).

Deliberately **not** included: statuses that mean the wake did *not* happen (`skipped`, `coalesced`, `failed`, `cancelled`) stay outside the index. Suppressing a later wake because an earlier one was skipped would silently drop work, which is a worse failure than an occasional duplicate run. This matches the status sets the existing hand-rolled lookups in `server/src/services/recovery/` already used.

## Verification

- `npx vitest run server/src/__tests__/agent-wakeup-idempotency-key.test.ts` — 6 passed. Against unmodified `master` (same test file, no source change) 4 of the first 5 fail and only the non-suppression guard passes, which is the intended before/after split. The migration-cleanup test likewise fails against the first revision of this PR's migration, which is what it was added for.
- `npx vitest run server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts server/src/__tests__/routable-blocked.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts server/src/__tests__/run-continuations.test.ts server/src/__tests__/heartbeat-dependency-scheduling.test.ts` — 54 passed. These are the suites whose callers pass an idempotency key.
- `npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/heartbeat-retry-scheduling.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts` — passed.
- `packages/db` `check-migration-numbering` and `check-migration-safety` both pass; the migration is applied by every suite above, since each boots an embedded Postgres and migrates it.

## Risks

- **Behavioral change for every caller that already passes a key.** Each existing caller was audited: run-liveness continuations and successful-run handoffs key on an attempt counter, `source_scoped_recovery_action` keys on `attemptCount`, issue monitors key on the scheduled timestamp, routable-blocked keys on `blockedTransitionAt`, task watchdogs key on a stop fingerprint. All of them mint a fresh key per intended wake, so none of them loses a wake. The one caller that could reuse a key is the plugin host's `idempotencyKeyPrefix` (`{prefix}:{issueId}`) — a plugin passing a constant prefix now gets one wake per issue, which is what asking for an idempotency key means.
- **Migration on a large table.** `agent_wakeup_requests` is in the known-large list, and Drizzle runs migrations transactionally so `CONCURRENTLY` is unavailable; the safety-ignore marker documents this. The index is partial over a column that is NULL on the overwhelming majority of rows (in a real instance, 66 of 3844), so the build touches a small fraction of the table.
- Low risk of a duplicate skip row per suppressed wake, which is the same pattern the other suppression paths in `enqueueWakeup` already use.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`, 1M context) via Claude Code, extended thinking with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for similar or duplicate PRs and confirmed this is not a duplicate of prior PRs
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs cover this internal invariant; the rule is documented in code where it is enforced)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
