### PR TITLE
perf(ui): load issue detail from an aggregate view

### DIFF
--- a/server/src/__tests__/issue-interactions-read-only-contract.test.ts
+++ b/server/src/__tests__/issue-interactions-read-only-contract.test.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 
-describe("issue interactions GET contract", () => {
-  it("does not perform expiry sweeps or activity writes", () => {
+describe("aggregate issue view interactions contract", () => {
+  it("hydrates interactions without expiry sweeps or activity writes", () => {
     const source = fs.readFileSync(new URL("../routes/issues.ts", import.meta.url), "utf8");
-    const start = source.indexOf('router.get("/issues/:id/interactions"');
-    const end = source.indexOf('router.post("/issues/:id/interactions"', start);
+    const start = source.indexOf('router.get("/issues/:id/view"');
+    const end = source.indexOf('router.get("/issues/:id/watchdog"', start);
     const handler = source.slice(start, end);
 
     expect(start).toBeGreaterThanOrEqual(0);

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -85,6 +85,9 @@ function registerModuleMocks() {
       })),
       hasPermission: vi.fn(async () => true),
     }),
+    activityService: () => ({
+      runsForIssue: vi.fn(async () => []),
+    }),
     agentService: () => ({
       getById: vi.fn(async () => ({ id: CREATED_AGENT_ID, companyId: "company-1", permissions: null })),
       resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({

--- a/server/src/__tests__/logger-tz.test.ts
+++ b/server/src/__tests__/logger-tz.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
  */
 
 const mockTransport = vi.hoisted(() => vi.fn(() => ({ write: vi.fn() })));
+const mockDestination = vi.hoisted(() => vi.fn(() => ({ write: vi.fn() })));
 const mockPino = vi.hoisted(() => {
   const fn = vi.fn(() => ({
     info: vi.fn(),
@@ -25,13 +26,8 @@ const mockPino = vi.hoisted(() => {
     child: vi.fn(),
   }));
   (fn as any).transport = mockTransport;
+  (fn as any).destination = mockDestination;
   return fn;
-});
-
-// Mock fs so the module-level mkdirSync call is a no-op in tests.
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, mkdirSync: vi.fn() };
 });
 
 vi.mock("pino", () => ({
@@ -52,6 +48,7 @@ describe("logger translateTime respects TZ environment variable", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
+    vi.stubEnv("PAPERCLIP_LOG_DIR", "");
     vi.clearAllMocks();
   });
 
@@ -61,18 +58,42 @@ describe("logger translateTime respects TZ environment variable", () => {
 
     expect(mockTransport).toHaveBeenCalledOnce();
     const transport = mockTransport.mock.calls[0][0] as {
-      target: string;
-      options: Record<string, unknown>;
+      targets: Array<{ target: string; options: Record<string, unknown> }>;
     };
-    expect(transport.target).toBe("pino-pretty");
-    expect(transport.options.translateTime).toBe("SYS:HH:MM:ss");
+    expect(transport.targets[0].target).toBe("pino-pretty");
+    expect(transport.targets[0].options.translateTime).toBe("SYS:HH:MM:ss");
   });
 
-  it("does not construct a pretty transport in production", async () => {
+  it("persists production logs when file logging is configured", async () => {
+    const { readConfigFile } = await import("../config-file.js");
+    vi.mocked(readConfigFile).mockReturnValueOnce({
+      logging: { mode: "file", logDir: "/configured/logs" },
+    } as ReturnType<typeof readConfigFile>);
     vi.stubEnv("NODE_ENV", "production");
     await import("../middleware/logger.js");
 
     expect(mockTransport).not.toHaveBeenCalled();
+    expect(mockDestination).toHaveBeenCalledWith({
+      dest: "/configured/logs/server.log",
+      mkdir: true,
+      sync: false,
+    });
+    expect(mockPino).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "info" }),
+      expect.anything(),
+    );
+  });
+
+  it("keeps production cloud logging on stdout without a file destination", async () => {
+    const { readConfigFile } = await import("../config-file.js");
+    vi.mocked(readConfigFile).mockReturnValueOnce({
+      logging: { mode: "cloud", logDir: "/unused" },
+    } as ReturnType<typeof readConfigFile>);
+    vi.stubEnv("NODE_ENV", "production");
+    await import("../middleware/logger.js");
+
+    expect(mockTransport).not.toHaveBeenCalled();
+    expect(mockDestination).not.toHaveBeenCalled();
     expect(mockPino).toHaveBeenCalledWith(expect.objectContaining({ level: "info" }));
   });
 

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -1,8 +1,22 @@
+import path from "node:path";
 import pino from "pino";
 import { pinoHttp } from "pino-http";
+import { readConfigFile } from "../config-file.js";
+import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { HTTP_LOG_REDACT_PATHS } from "./http-log-redaction.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
 import { redactSensitive } from "./redact-sensitive.js";
+
+function resolveServerLogging(): { mode: "file" | "cloud"; logFile: string } {
+  const envLogDir = process.env.PAPERCLIP_LOG_DIR?.trim();
+  const fileLogging = readConfigFile()?.logging;
+  const mode = envLogDir ? "file" : (fileLogging?.mode ?? "file");
+  const logDir = resolveHomeAwarePath(
+    envLogDir || fileLogging?.logDir?.trim() || resolveDefaultLogsDir(),
+  );
+
+  return { mode, logFile: path.join(logDir, "server.log") };
+}
 
 const sharedOpts = {
   translateTime: "SYS:HH:MM:ss",
@@ -11,12 +25,33 @@ const sharedOpts = {
 };
 
 const isProduction = process.env.NODE_ENV === "production";
-export const logger = isProduction
-  ? pino({ level: process.env.PAPERCLIP_LOG_LEVEL?.trim() || "info", redact: [...HTTP_LOG_REDACT_PATHS] })
-  : pino({ level: process.env.PAPERCLIP_LOG_LEVEL?.trim() || "debug", redact: [...HTTP_LOG_REDACT_PATHS] }, pino.transport({
+const logging = resolveServerLogging();
+const level = process.env.PAPERCLIP_LOG_LEVEL?.trim() || (isProduction ? "info" : "debug");
+const loggerOptions = { level, redact: [...HTTP_LOG_REDACT_PATHS] };
+
+export const logger = (() => {
+  if (isProduction) {
+    if (logging.mode === "cloud") return pino(loggerOptions);
+    return pino(loggerOptions, pino.destination({ dest: logging.logFile, mkdir: true, sync: false }));
+  }
+
+  const targets: pino.TransportTargetOptions[] = [
+    {
       target: "pino-pretty",
       options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: true, destination: 1 },
-    }));
+      level,
+    },
+  ];
+  if (logging.mode === "file") {
+    targets.push({
+      target: "pino/file",
+      options: { destination: logging.logFile, mkdir: true },
+      level,
+    });
+  }
+
+  return pino(loggerOptions, pino.transport({ targets }));
+})();
 
 export const httpLogger = pinoHttp({
   logger,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -154,7 +154,6 @@ import type { TaskWatchdogServiceDeps, taskWatchdogService } from "../services/t
 import { logger } from "../middleware/logger.js";
 import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
-import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { createRequestPromiseMemo } from "../lib/request-promise-memo.js";
 import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 import {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2719,7 +2719,11 @@ export function issueRoutes(
   const router = Router();
   const svc = issueService(db);
   const runRedactions = createRunSecretRedactionRegistry(db);
-  const activitySvc = activityService(db);
+  let activitySvc: ReturnType<typeof activityService> | null = null;
+  const getActivityService = () => {
+    activitySvc ??= activityService(db);
+    return activitySvc;
+  };
   const access = accessService(db);
   const heartbeat = heartbeatService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
@@ -6136,7 +6140,7 @@ export function issueRoutes(
       issueThreadInteractionsSvc.listForIssue(issue.id),
       svc.listAttachments(issue.id).then((rows) => rows.map(withContentPath)),
       svc.list(issue.companyId, { descendantOf: issue.id, includeBlockedBy: true }),
-      activitySvc.runsForIssue(issue.companyId, issue.id),
+      getActivityService().runsForIssue(issue.companyId, issue.id),
     ]);
     const childIssues = await actorCanReadCompanyScope(req, issue.companyId)
       ? rawChildIssues

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -110,6 +110,7 @@ import { validate } from "../middleware/validate.js";
 import * as serviceIndex from "../services/index.js";
 import {
   accessService,
+  activityService,
   agentService,
   companySkillService,
   companyService,
@@ -151,6 +152,7 @@ import {
 } from "../services/task-watchdog-scope.js";
 import type { TaskWatchdogServiceDeps, taskWatchdogService } from "../services/task-watchdogs.js";
 import { logger } from "../middleware/logger.js";
+import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { createRequestPromiseMemo } from "../lib/request-promise-memo.js";
@@ -2717,6 +2719,7 @@ export function issueRoutes(
   const router = Router();
   const svc = issueService(db);
   const runRedactions = createRunSecretRedactionRegistry(db);
+  const activitySvc = activityService(db);
   const access = accessService(db);
   const heartbeat = heartbeatService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
@@ -2753,6 +2756,91 @@ export function issueRoutes(
   function getIssueById(req: Request, id: string) {
     if (req.method !== "GET") return svc.getById(id);
     return memoizeIssueRead(req, id, () => svc.getById(id));
+  }
+
+  async function buildIssueDetailResponse(req: Request, issue: Awaited<ReturnType<typeof svc.getById>> & {}) {
+    const inboxArchiveFieldsPromise = req.actor.type === "board" && req.actor.userId
+      ? svc.getActiveInboxArchiveFields(issue, req.actor.userId)
+      : Promise.resolve({});
+    const [
+      { project, goal },
+      ancestors,
+      mentionedProjectIds,
+      documentPayload,
+      relations,
+      blockerAttention,
+      reviewAttention,
+      productivityReview,
+      referenceSummary,
+      successfulRunHandoffStates,
+      scheduledRetry,
+      activeRecoveryAction,
+      linkedCases,
+      inboxArchiveFields,
+    ] = await Promise.all([
+      resolveIssueProjectAndGoal(issue),
+      svc.getAncestors(issue.id),
+      svc.findMentionedProjectIds(issue.id, { includeCommentBodies: false }),
+      documentsSvc.getIssueDocumentPayload(issue),
+      svc.getRelationSummaries(issue.id),
+      svc.listBlockerAttention(issue.companyId, [issue]).then((map) => map.get(issue.id) ?? null),
+      svc.listReviewAttention(issue.companyId, [issue]).then((map) => map.get(issue.id) ?? null),
+      svc.listProductivityReviews(issue.companyId, [issue.id]).then((map) => map.get(issue.id) ?? null),
+      issueReferencesSvc.listIssueReferenceSummary(issue.id),
+      listSuccessfulRunHandoffStates(db, issue.companyId, [issue.id]),
+      svc.getCurrentScheduledRetry(issue.id),
+      recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id),
+      listIssueLinkedCases(db, issue.companyId, issue.id),
+      inboxArchiveFieldsPromise,
+    ]);
+    const recoveryActionsByRelationIssue = await relationRecoveryActionMap(
+      recoveryActionsSvc,
+      issue.companyId,
+      relations,
+    );
+    const relationsWithRecoveryActions = withRecoveryActionsOnRelationSummaries(
+      relations,
+      recoveryActionsByRelationIssue,
+    );
+    const revalidatedActiveRecoveryAction = await revalidateActiveSourceRecoveryForRead({
+      issue,
+      trigger: "read_projection",
+      actor: getActorInfo(req),
+      activeRecoveryAction,
+    });
+    const [mentionedProjects, currentExecutionWorkspace, workProducts] = await Promise.all([
+      mentionedProjectIds.length > 0
+        ? projectsSvc.listByIds(issue.companyId, mentionedProjectIds)
+        : Promise.resolve([]),
+      issue.executionWorkspaceId
+        ? executionWorkspacesSvc.getById(issue.executionWorkspaceId)
+        : Promise.resolve(null),
+      workProductsSvc.listForIssue(issue.id),
+    ]);
+
+    return {
+      ...issue,
+      ...inboxArchiveFields,
+      goalId: goal?.id ?? issue.goalId,
+      ancestors,
+      ...(blockerAttention ? { blockerAttention } : {}),
+      ...(reviewAttention ? { reviewAttention } : {}),
+      productivityReview,
+      successfulRunHandoff: successfulRunHandoffStates.get(issue.id) ?? null,
+      scheduledRetry,
+      activeRecoveryAction: revalidatedActiveRecoveryAction,
+      blockedBy: relationsWithRecoveryActions.blockedBy,
+      blocks: relationsWithRecoveryActions.blocks,
+      relatedWork: referenceSummary,
+      referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+      ...documentPayload,
+      project: compactIssueProject(project),
+      goal: goal ?? null,
+      mentionedProjects,
+      currentExecutionWorkspace: compactIssueExecutionWorkspace(currentExecutionWorkspace),
+      workProducts,
+      linkedCases,
+    };
   }
 
   const issueDetailEtag = privateJsonEtag();
@@ -6031,85 +6119,43 @@ export function issueRoutes(
     const issue = await getAccessibleResource(req, res, getIssueById(req, id), "Issue not found");
     if (!issue) return;
     if (!(await assertIssueReadAllowed(req, res, issue))) return;
-    const inboxArchiveFieldsPromise = req.actor.type === "board" && req.actor.userId
-      ? svc.getActiveInboxArchiveFields(issue, req.actor.userId)
-      : Promise.resolve({});
-    const [
-      { project, goal },
-      ancestors,
-      mentionedProjectIds,
-      documentPayload,
-      relations,
-      blockerAttention,
-      reviewAttention,
-      productivityReview,
-      referenceSummary,
-      successfulRunHandoffStates,
-      scheduledRetry,
-      activeRecoveryAction,
-      linkedCases,
-      inboxArchiveFields,
-    ] = await Promise.all([
-      resolveIssueProjectAndGoal(issue),
-      svc.getAncestors(issue.id),
-      svc.findMentionedProjectIds(issue.id, { includeCommentBodies: false }),
-      documentsSvc.getIssueDocumentPayload(issue),
-      svc.getRelationSummaries(issue.id),
-      svc.listBlockerAttention(issue.companyId, [issue]).then((map) => map.get(issue.id) ?? null),
-      svc.listReviewAttention(issue.companyId, [issue]).then((map) => map.get(issue.id) ?? null),
-      svc.listProductivityReviews(issue.companyId, [issue.id]).then((map) => map.get(issue.id) ?? null),
-      issueReferencesSvc.listIssueReferenceSummary(issue.id),
-      listSuccessfulRunHandoffStates(db, issue.companyId, [issue.id]),
-      svc.getCurrentScheduledRetry(issue.id),
-      recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id),
-      listIssueLinkedCases(db, issue.companyId, issue.id),
-      inboxArchiveFieldsPromise,
-    ]);
-    const recoveryActionsByRelationIssue = await relationRecoveryActionMap(
-      recoveryActionsSvc,
-      issue.companyId,
-      relations,
-    );
-    const relationsWithRecoveryActions = withRecoveryActionsOnRelationSummaries(
-      relations,
-      recoveryActionsByRelationIssue,
-    );
-    const revalidatedActiveRecoveryAction = await revalidateActiveSourceRecoveryForRead({
-      issue,
-      trigger: "read_projection",
-      actor: getActorInfo(req),
-      activeRecoveryAction,
-    });
-    const mentionedProjects = mentionedProjectIds.length > 0
-      ? await projectsSvc.listByIds(issue.companyId, mentionedProjectIds)
-      : [];
-    const currentExecutionWorkspace = issue.executionWorkspaceId
-      ? await executionWorkspacesSvc.getById(issue.executionWorkspaceId)
-      : null;
-    const workProducts = await workProductsSvc.listForIssue(issue.id);
     res.setHeader("Server-Timing", `paperclip_issue;dur=${(performance.now() - requestStartedAt).toFixed(1)}`);
+    res.json(await buildIssueDetailResponse(req, issue));
+  });
+
+  router.get("/issues/:id/view", async (req, res) => {
+    const requestStartedAt = performance.now();
+    const id = req.params.id as string;
+    const issue = await getAccessibleResource(req, res, getIssueById(req, id), "Issue not found");
+    if (!issue) return;
+    if (!(await assertIssueReadAllowed(req, res, issue))) return;
+
+    const [detail, rawComments, interactions, attachments, rawChildIssues, runs] = await Promise.all([
+      buildIssueDetailResponse(req, issue),
+      svc.listComments(issue.id, { order: "desc", limit: 50 }),
+      issueThreadInteractionsSvc.listForIssue(issue.id),
+      svc.listAttachments(issue.id).then((rows) => rows.map(withContentPath)),
+      svc.list(issue.companyId, { descendantOf: issue.id, includeBlockedBy: true }),
+      activitySvc.runsForIssue(issue.companyId, issue.id),
+    ]);
+    const childIssues = await actorCanReadCompanyScope(req, issue.companyId)
+      ? rawChildIssues
+      : await filterIssuesForActor(req, rawChildIssues);
+    const liveRuns = runs.filter((run) => run.status === "queued" || run.status === "running");
+    const activeRun = liveRuns.find((run) => run.runId === issue.executionRunId) ?? liveRuns[0] ?? null;
+    const comments = await runRedactions.redactForIssue(issue.companyId, issue.id, rawComments);
+
+    res.setHeader("Server-Timing", `paperclip_issue_view;dur=${(performance.now() - requestStartedAt).toFixed(1)}`);
     res.json({
-      ...issue,
-      ...inboxArchiveFields,
-      goalId: goal?.id ?? issue.goalId,
-      ancestors,
-      ...(blockerAttention ? { blockerAttention } : {}),
-      ...(reviewAttention ? { reviewAttention } : {}),
-      productivityReview,
-      successfulRunHandoff: successfulRunHandoffStates.get(issue.id) ?? null,
-      scheduledRetry,
-      activeRecoveryAction: revalidatedActiveRecoveryAction,
-      blockedBy: relationsWithRecoveryActions.blockedBy,
-      blocks: relationsWithRecoveryActions.blocks,
-      relatedWork: referenceSummary,
-      referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
-      ...documentPayload,
-      project: compactIssueProject(project),
-      goal: goal ?? null,
-      mentionedProjects,
-      currentExecutionWorkspace: compactIssueExecutionWorkspace(currentExecutionWorkspace),
-      workProducts,
-      linkedCases,
+      detail,
+      comments,
+      interactions,
+      attachments,
+      workProducts: detail.workProducts,
+      childIssues,
+      runs,
+      liveRuns,
+      activeRun,
     });
   });
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2136,6 +2136,15 @@ registry.registerPath({
 });
 
 registry.registerPath({
+  method: "get",
+  path: "/api/issues/{id}/view",
+  tags: ["issues"],
+  summary: "Get the aggregate issue detail view",
+  request: { params: z.object({ id: z.string() }) },
+  responses: { 200: r.ok(), 304: { description: "Not Modified" }, 401: r.unauthorized, 404: r.notFound },
+});
+
+registry.registerPath({
   method: "patch",
   path: "/api/issues/{id}",
   tags: ["issues"],

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -30,6 +30,20 @@ import type {
   UpsertIssueDocument,
 } from "@paperclipai/shared";
 import { api, type RequestOptions } from "./client";
+import type { RunForIssue } from "./activity";
+import type { ActiveRunForIssue, LiveRunForIssue } from "./heartbeats";
+
+export type IssueViewResponse = {
+  detail: Issue;
+  comments: IssueComment[];
+  interactions: IssueThreadInteraction[];
+  attachments: IssueAttachment[];
+  workProducts: IssueWorkProduct[];
+  childIssues: Issue[];
+  runs: RunForIssue[];
+  liveRuns: LiveRunForIssue[];
+  activeRun: ActiveRunForIssue | null;
+};
 
 export type IssueUpdateResponse = Issue & {
   comment?: IssueComment | null;
@@ -152,6 +166,9 @@ export const issuesApi = {
   get: (id: string, options?: RequestOptions) => options
     ? api.get<Issue>(`/issues/${id}`, options)
     : api.get<Issue>(`/issues/${id}`),
+  getView: (id: string, options?: RequestOptions) => options
+    ? api.get<IssueViewResponse>(`/issues/${id}/view`, options)
+    : api.get<IssueViewResponse>(`/issues/${id}/view`),
   getWatchdog: (id: string) => api.get<IssueWatchdog | null>(`/issues/${id}/watchdog`),
   upsertWatchdog: (id: string, data: UpsertIssueWatchdog) =>
     api.put<IssueWatchdog>(`/issues/${id}/watchdog`, data),

--- a/ui/src/context/LiveUpdatesProvider.test.ts
+++ b/ui/src/context/LiveUpdatesProvider.test.ts
@@ -100,6 +100,30 @@ describe("LiveUpdatesProvider issue invalidation", () => {
     });
   });
 
+  it("refreshes attachments when attachment activity arrives", () => {
+    const invalidations: unknown[] = [];
+    const queryClient = {
+      invalidateQueries: (input: unknown) => invalidations.push(input),
+      getQueryData: () => undefined,
+    };
+
+    __liveUpdatesTestUtils.invalidateActivityQueries(
+      queryClient as never,
+      "company-1",
+      {
+        entityType: "issue",
+        entityId: "issue-1",
+        action: "issue.attachment_added",
+        details: { attachmentId: "attachment-1" },
+      },
+      { userId: null, agentId: null },
+    );
+
+    expect(invalidations).toContainEqual({
+      queryKey: queryKeys.issues.attachments("issue-1"),
+    });
+  });
+
   it("keeps heartbeat progress invalidation scoped away from hot list queries", () => {
     const invalidations: unknown[] = [];
     const queryClient = {

--- a/ui/src/context/LiveUpdatesProvider.tsx
+++ b/ui/src/context/LiveUpdatesProvider.tsx
@@ -1014,6 +1014,9 @@ function invalidateActivityQueries(
         if (action?.startsWith("issue.thread_interaction_")) {
           queryClient.invalidateQueries({ queryKey: queryKeys.issues.interactions(ref), ...invalidationOptions });
         }
+        if (action === "issue.attachment_added" || action === "issue.attachment_removed") {
+          queryClient.invalidateQueries({ queryKey: queryKeys.issues.attachments(ref), ...invalidationOptions });
+        }
       }
     }
     return;

--- a/ui/src/lib/issueDetailCache.test.ts
+++ b/ui/src/lib/issueDetailCache.test.ts
@@ -12,9 +12,23 @@ import { queryKeys } from "./queryKeys";
 
 vi.mock("@/api/issues", () => ({
   issuesApi: {
-    get: vi.fn(),
+    getView: vi.fn(),
   },
 }));
+
+function createIssueView(detail: Issue) {
+  return {
+    detail,
+    comments: [],
+    interactions: [],
+    attachments: [],
+    workProducts: [],
+    childIssues: [],
+    runs: [],
+    liveRuns: [],
+    activeRun: null,
+  };
+}
 
 function createIssue(overrides: Partial<Issue> = {}): Issue {
   return {
@@ -94,7 +108,7 @@ describe("issueDetailCache", () => {
 
     expect(getCachedIssueDetail(queryClient, issue.identifier)).toEqual(issue);
     expect(getCachedIssueDetail(queryClient, issue.id)).toEqual(issue);
-    expect(issuesApi.get).not.toHaveBeenCalled();
+    expect(issuesApi.getView).not.toHaveBeenCalled();
   });
 
   it("does not seed partial issue snapshots during prefetch", async () => {
@@ -106,11 +120,11 @@ describe("issueDetailCache", () => {
       status: issue.status,
       priority: issue.priority,
     } as Issue;
-    vi.mocked(issuesApi.get).mockResolvedValue(issue);
+    vi.mocked(issuesApi.getView).mockResolvedValue(createIssueView(issue));
 
     await prefetchIssueDetail(queryClient, issue.identifier!, { issue: partialIssue });
 
-    expect(issuesApi.get).toHaveBeenCalledWith(issue.identifier);
+    expect(issuesApi.getView).toHaveBeenCalledWith(issue.identifier);
     expect(getCachedIssueDetail(queryClient, issue.identifier)).toEqual(issue);
   });
 
@@ -132,7 +146,7 @@ describe("issueDetailCache", () => {
 
   it("hydrates both cache aliases from a fetched issue detail response", async () => {
     const issue = createIssue();
-    vi.mocked(issuesApi.get).mockResolvedValue(issue);
+    vi.mocked(issuesApi.getView).mockResolvedValue(createIssueView(issue));
 
     const result = await fetchIssueDetail(queryClient, issue.identifier!);
 

--- a/ui/src/lib/issueDetailCache.test.ts
+++ b/ui/src/lib/issueDetailCache.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
-import type { Issue } from "@paperclipai/shared";
+import type { Issue, IssueComment } from "@paperclipai/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { issuesApi } from "@/api/issues";
 import {
@@ -9,6 +9,7 @@ import {
   seedIssueDetailCache,
 } from "./issueDetailCache";
 import { queryKeys } from "./queryKeys";
+import { createCoalescingQueryClient, createInvalidationBatcher } from "./query-invalidation-batcher";
 
 vi.mock("@/api/issues", () => ({
   issuesApi: {
@@ -19,7 +20,7 @@ vi.mock("@/api/issues", () => ({
 function createIssueView(detail: Issue) {
   return {
     detail,
-    comments: [],
+    comments: [] as IssueComment[],
     interactions: [],
     attachments: [],
     workProducts: [],
@@ -153,5 +154,54 @@ describe("issueDetailCache", () => {
     expect(result).toEqual(issue);
     expect(queryClient.getQueryData(queryKeys.issues.detail(issue.identifier!))).toEqual(issue);
     expect(queryClient.getQueryData(queryKeys.issues.detail(issue.id))).toEqual(issue);
+  });
+
+  it("does not overwrite a collection with a queued live invalidation", async () => {
+    const issue = createIssue();
+    const commentsKey = queryKeys.issues.comments(issue.identifier!);
+    const cachedComment = { id: "live-comment" } as IssueComment;
+    const staleComment = { id: "aggregate-comment" } as IssueComment;
+    const cachedComments = { pages: [[cachedComment]], pageParams: [null] };
+    let resolveView!: (view: ReturnType<typeof createIssueView>) => void;
+    vi.mocked(issuesApi.getView).mockReturnValue(new Promise((resolve) => {
+      resolveView = resolve;
+    }));
+    queryClient.setQueryData(commentsKey, cachedComments);
+    const batcher = createInvalidationBatcher(queryClient, 300);
+    const liveUpdatesClient = createCoalescingQueryClient(queryClient, batcher);
+
+    const detailPromise = fetchIssueDetail(queryClient, issue.identifier!);
+    await Promise.resolve();
+    void liveUpdatesClient.invalidateQueries({ queryKey: commentsKey });
+    expect(queryClient.getQueryState(commentsKey)?.isInvalidated).toBe(true);
+    resolveView({ ...createIssueView(issue), comments: [staleComment] });
+    await detailPromise;
+
+    expect(queryClient.getQueryData(commentsKey)).toEqual(cachedComments);
+    expect(queryClient.getQueryState(commentsKey)?.isInvalidated).toBe(true);
+    batcher.dispose();
+  });
+
+  it("does not overwrite issue detail with a queued live invalidation", async () => {
+    const aggregateIssue = createIssue({ title: "Aggregate snapshot" });
+    const liveIssue = createIssue({ title: "Live snapshot" });
+    const detailKey = queryKeys.issues.detail(liveIssue.identifier!);
+    let resolveView!: (view: ReturnType<typeof createIssueView>) => void;
+    vi.mocked(issuesApi.getView).mockReturnValue(new Promise((resolve) => {
+      resolveView = resolve;
+    }));
+    queryClient.setQueryData(detailKey, liveIssue);
+    const batcher = createInvalidationBatcher(queryClient, 300);
+    const liveUpdatesClient = createCoalescingQueryClient(queryClient, batcher);
+
+    const detailPromise = fetchIssueDetail(queryClient, liveIssue.identifier!);
+    await Promise.resolve();
+    void liveUpdatesClient.invalidateQueries({ queryKey: detailKey });
+    expect(queryClient.getQueryState(detailKey)?.isInvalidated).toBe(true);
+    resolveView(createIssueView(aggregateIssue));
+
+    expect(await detailPromise).toEqual(liveIssue);
+    expect(queryClient.getQueryData(detailKey)).toEqual(liveIssue);
+    batcher.dispose();
   });
 });

--- a/ui/src/lib/issueDetailCache.ts
+++ b/ui/src/lib/issueDetailCache.ts
@@ -129,6 +129,15 @@ export async function fetchIssueDetail(
   }));
   const view = options ? await issuesApi.getView(issueRef, options) : await issuesApi.getView(issueRef);
   const refs = collectIssueRefs(issueRef, view.detail);
+  const invalidatedLiveIssue = refs
+    .map((ref) => {
+      const queryKey = queryKeys.issues.detail(ref);
+      const data = queryClient.getQueryData<Issue>(queryKey);
+      return queryClient.getQueryState(queryKey)?.isInvalidated && isCompleteIssueSnapshot(data)
+        ? data
+        : null;
+    })
+    .find((data): data is Issue => data !== null);
   const freshestLiveIssue = refs
     .map((ref) => {
       const queryKey = queryKeys.issues.detail(ref);
@@ -142,9 +151,14 @@ export async function fetchIssueDetail(
     })
     .filter((entry): entry is { data: Issue; dataUpdatedAt: number } => entry !== null)
     .sort((left, right) => right.dataUpdatedAt - left.dataUpdatedAt)[0]?.data;
-  const issue = seedIssueDetailCache(queryClient, freshestLiveIssue ?? view.detail, { issueRef });
+  const issue = seedIssueDetailCache(
+    queryClient,
+    invalidatedLiveIssue ?? freshestLiveIssue ?? view.detail,
+    { issueRef },
+  );
   const hydrateIfNotUpdatedDuringRequest = <T>(queryKey: readonly unknown[], value: T) => {
-    if ((queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0) >= requestedAt) return;
+    const state = queryClient.getQueryState(queryKey);
+    if (state?.isInvalidated || (state?.dataUpdatedAt ?? 0) >= requestedAt) return;
     queryClient.setQueryData(queryKey, value);
   };
   for (const ref of refs) {

--- a/ui/src/lib/issueDetailCache.ts
+++ b/ui/src/lib/issueDetailCache.ts
@@ -122,7 +122,7 @@ export async function fetchIssueDetail(
   const issue = seedIssueDetailCache(queryClient, view.detail, { issueRef });
   const refs = collectIssueRefs(issueRef, issue);
   const hydrateIfNotUpdatedDuringRequest = <T>(queryKey: readonly unknown[], value: T) => {
-    if ((queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0) > requestedAt) return;
+    if ((queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0) >= requestedAt) return;
     queryClient.setQueryData(queryKey, value);
   };
   for (const ref of refs) {

--- a/ui/src/lib/issueDetailCache.ts
+++ b/ui/src/lib/issueDetailCache.ts
@@ -117,22 +117,27 @@ export async function fetchIssueDetail(
   issueRef: string,
   options?: { signal?: AbortSignal },
 ): Promise<Issue> {
+  const requestedAt = Date.now();
   const view = options ? await issuesApi.getView(issueRef, options) : await issuesApi.getView(issueRef);
   const issue = seedIssueDetailCache(queryClient, view.detail, { issueRef });
   const refs = collectIssueRefs(issueRef, issue);
+  const hydrateIfNotUpdatedDuringRequest = <T>(queryKey: readonly unknown[], value: T) => {
+    if ((queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0) > requestedAt) return;
+    queryClient.setQueryData(queryKey, value);
+  };
   for (const ref of refs) {
-    queryClient.setQueryData<InfiniteData<typeof view.comments, string | null>>(
+    hydrateIfNotUpdatedDuringRequest<InfiniteData<typeof view.comments, string | null>>(
       queryKeys.issues.comments(ref),
       { pages: [view.comments], pageParams: [null] },
     );
-    queryClient.setQueryData(queryKeys.issues.interactions(ref), view.interactions);
-    queryClient.setQueryData(queryKeys.issues.attachments(ref), view.attachments);
-    queryClient.setQueryData(queryKeys.issues.workProducts(ref), view.workProducts);
-    queryClient.setQueryData(queryKeys.issues.runs(ref), view.runs);
-    queryClient.setQueryData(queryKeys.issues.liveRuns(ref), view.liveRuns);
-    queryClient.setQueryData(queryKeys.issues.activeRun(ref), view.activeRun);
+    hydrateIfNotUpdatedDuringRequest(queryKeys.issues.interactions(ref), view.interactions);
+    hydrateIfNotUpdatedDuringRequest(queryKeys.issues.attachments(ref), view.attachments);
+    hydrateIfNotUpdatedDuringRequest(queryKeys.issues.workProducts(ref), view.workProducts);
+    hydrateIfNotUpdatedDuringRequest(queryKeys.issues.runs(ref), view.runs);
+    hydrateIfNotUpdatedDuringRequest(queryKeys.issues.liveRuns(ref), view.liveRuns);
+    hydrateIfNotUpdatedDuringRequest(queryKeys.issues.activeRun(ref), view.activeRun);
   }
-  queryClient.setQueryData(
+  hydrateIfNotUpdatedDuringRequest(
     queryKeys.issues.listByDescendantRoot(issue.companyId, issue.id),
     view.childIssues,
   );

--- a/ui/src/lib/issueDetailCache.ts
+++ b/ui/src/lib/issueDetailCache.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from "@tanstack/react-query";
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 import type { Issue, IssueComment } from "@paperclipai/shared";
 import { issuesApi } from "@/api/issues";
 import { queryKeys } from "@/lib/queryKeys";
@@ -117,8 +117,26 @@ export async function fetchIssueDetail(
   issueRef: string,
   options?: { signal?: AbortSignal },
 ): Promise<Issue> {
-  const issue = options ? await issuesApi.get(issueRef, options) : await issuesApi.get(issueRef);
-  return seedIssueDetailCache(queryClient, issue, { issueRef });
+  const view = options ? await issuesApi.getView(issueRef, options) : await issuesApi.getView(issueRef);
+  const issue = seedIssueDetailCache(queryClient, view.detail, { issueRef });
+  const refs = collectIssueRefs(issueRef, issue);
+  for (const ref of refs) {
+    queryClient.setQueryData<InfiniteData<typeof view.comments, string | null>>(
+      queryKeys.issues.comments(ref),
+      { pages: [view.comments], pageParams: [null] },
+    );
+    queryClient.setQueryData(queryKeys.issues.interactions(ref), view.interactions);
+    queryClient.setQueryData(queryKeys.issues.attachments(ref), view.attachments);
+    queryClient.setQueryData(queryKeys.issues.workProducts(ref), view.workProducts);
+    queryClient.setQueryData(queryKeys.issues.runs(ref), view.runs);
+    queryClient.setQueryData(queryKeys.issues.liveRuns(ref), view.liveRuns);
+    queryClient.setQueryData(queryKeys.issues.activeRun(ref), view.activeRun);
+  }
+  queryClient.setQueryData(
+    queryKeys.issues.listByDescendantRoot(issue.companyId, issue.id),
+    view.childIssues,
+  );
+  return issue;
 }
 
 export function getIssueDetailQueryOptions(
@@ -158,6 +176,10 @@ export function prefetchIssueDetail(
  * query key IssueDetail mounts, so a subsequent navigation paints comments from
  * cache instead of waiting on a fetch. Keyed by issue ref and always background
  * revalidated by the mounted query, so it never surfaces stale cross-issue data.
+ *
+ * `prefetchInfiniteQuery` respects `staleTime`: if the comments cache is already
+ * fresh (e.g. seeded by the aggregate `getView` fetch), this is a no-op and does
+ * not issue a redundant request.
  */
 export function prefetchIssueComments(queryClient: QueryClient, issueRef: string) {
   return queryClient.prefetchInfiniteQuery({

--- a/ui/src/lib/issueDetailCache.ts
+++ b/ui/src/lib/issueDetailCache.ts
@@ -118,9 +118,31 @@ export async function fetchIssueDetail(
   options?: { signal?: AbortSignal },
 ): Promise<Issue> {
   const requestedAt = Date.now();
+  const cachedIssueBeforeRequest = getCachedIssueDetail(queryClient, issueRef);
+  const detailRefsBeforeRequest = collectIssueRefs(issueRef, cachedIssueBeforeRequest);
+  const detailStateBeforeRequest = new Map(detailRefsBeforeRequest.map((ref) => {
+    const queryKey = queryKeys.issues.detail(ref);
+    return [ref, {
+      data: queryClient.getQueryData<Issue>(queryKey),
+      dataUpdatedAt: queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0,
+    }] as const;
+  }));
   const view = options ? await issuesApi.getView(issueRef, options) : await issuesApi.getView(issueRef);
-  const issue = seedIssueDetailCache(queryClient, view.detail, { issueRef });
-  const refs = collectIssueRefs(issueRef, issue);
+  const refs = collectIssueRefs(issueRef, view.detail);
+  const freshestLiveIssue = refs
+    .map((ref) => {
+      const queryKey = queryKeys.issues.detail(ref);
+      const data = queryClient.getQueryData<Issue>(queryKey);
+      const dataUpdatedAt = queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0;
+      const before = detailStateBeforeRequest.get(ref);
+      const changedDuringRequest = data !== before?.data || dataUpdatedAt !== (before?.dataUpdatedAt ?? 0);
+      return isCompleteIssueSnapshot(data) && changedDuringRequest && dataUpdatedAt >= requestedAt
+        ? { data, dataUpdatedAt }
+        : null;
+    })
+    .filter((entry): entry is { data: Issue; dataUpdatedAt: number } => entry !== null)
+    .sort((left, right) => right.dataUpdatedAt - left.dataUpdatedAt)[0]?.data;
+  const issue = seedIssueDetailCache(queryClient, freshestLiveIssue ?? view.detail, { issueRef });
   const hydrateIfNotUpdatedDuringRequest = <T>(queryKey: readonly unknown[], value: T) => {
     if ((queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0) >= requestedAt) return;
     queryClient.setQueryData(queryKey, value);

--- a/ui/src/lib/issueDetailQuery.test.tsx
+++ b/ui/src/lib/issueDetailQuery.test.tsx
@@ -98,7 +98,7 @@ describe("getIssueDetailQueryOptions", () => {
     queryClient.clear();
   });
 
-  it("preserves socket updates received while the aggregate view is loading", async () => {
+  it("preserves same-millisecond socket updates received while the aggregate view is loading", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-13T20:00:00.000Z"));
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -109,7 +109,6 @@ describe("getIssueDetailQueryOptions", () => {
     }));
 
     const pending = fetchIssueDetail(queryClient, "PAP-1442", { signal: new AbortController().signal });
-    vi.setSystemTime(new Date("2026-04-13T20:00:00.001Z"));
     queryClient.setQueryData(queryKeys.issues.interactions("PAP-1442"), [{ id: "socket-update" }]);
     resolveView({
       detail: issue,

--- a/ui/src/lib/issueDetailQuery.test.tsx
+++ b/ui/src/lib/issueDetailQuery.test.tsx
@@ -1,22 +1,15 @@
-// @vitest-environment jsdom
-
-import { act } from "react";
-import { createRoot } from "react-dom/client";
 import type { Issue } from "@paperclipai/shared";
-import { QueryClient, QueryClientProvider, useQuery, useQueryClient } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { issuesApi } from "@/api/issues";
 import { queryKeys } from "@/lib/queryKeys";
-import { getIssueDetailQueryOptions } from "./issueDetailCache";
+import { fetchIssueDetail } from "./issueDetailCache";
 
 vi.mock("@/api/issues", () => ({
   issuesApi: {
-    get: vi.fn(),
+    getView: vi.fn(),
   },
 }));
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
   const now = new Date("2026-04-13T20:00:00.000Z");
@@ -60,39 +53,12 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
   };
 }
 
-function IssueDetailQueryHarness({
-  issueRef,
-  placeholderIssue,
-}: {
-  issueRef: string;
-  placeholderIssue?: Pick<Issue, "id" | "identifier"> | null;
-}) {
-  const queryClient = useQueryClient();
-  const query = useQuery({
-    ...getIssueDetailQueryOptions(queryClient, issueRef, { placeholderIssue }),
-  });
-
-  return <div>{query.data?.description ?? "EMPTY"}</div>;
-}
-
-async function flush() {
-  // Multiple act cycles to allow React Query to process the async queryFn
-  for (let i = 0; i < 5; i++) {
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
-    });
-  }
-}
-
 describe("getIssueDetailQueryOptions", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
   it("treats cached issue data as placeholder and still fetches full detail", async () => {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -105,30 +71,29 @@ describe("getIssueDetailQueryOptions", () => {
 
     queryClient.setQueryData(queryKeys.issues.detail("issue-1"), partialIssue);
     queryClient.setQueryData(queryKeys.issues.detail("PAP-1442"), partialIssue);
-    vi.mocked(issuesApi.get).mockResolvedValue(fullIssue);
-
-    await act(async () => {
-      root.render(
-        <QueryClientProvider client={queryClient}>
-          <IssueDetailQueryHarness
-            issueRef="PAP-1442"
-            placeholderIssue={{ id: partialIssue.id, identifier: partialIssue.identifier }}
-          />
-        </QueryClientProvider>,
-      );
+    vi.mocked(issuesApi.getView).mockResolvedValue({
+      detail: fullIssue,
+      comments: [],
+      interactions: [],
+      attachments: [],
+      workProducts: [],
+      childIssues: [],
+      runs: [],
+      liveRuns: [],
+      activeRun: null,
     });
 
-    await flush();
+    const result = await fetchIssueDetail(queryClient, "PAP-1442", { signal: new AbortController().signal });
 
-    expect(issuesApi.get).toHaveBeenCalledWith("PAP-1442", {
+    expect(issuesApi.getView).toHaveBeenCalledWith("PAP-1442", {
       signal: expect.any(AbortSignal),
     });
-    expect(container.textContent).toContain("GitHub Security Advisory body");
-
-    await act(async () => {
-      root.unmount();
+    expect(result.description).toBe("GitHub Security Advisory body");
+    expect(queryClient.getQueryData(queryKeys.issues.comments("issue-1"))).toEqual({
+      pages: [[]],
+      pageParams: [null],
     });
+
     queryClient.clear();
-    container.remove();
   });
 });

--- a/ui/src/lib/issueDetailQuery.test.tsx
+++ b/ui/src/lib/issueDetailQuery.test.tsx
@@ -109,6 +109,10 @@ describe("getIssueDetailQueryOptions", () => {
     }));
 
     const pending = fetchIssueDetail(queryClient, "PAP-1442", { signal: new AbortController().signal });
+    queryClient.setQueryData(
+      queryKeys.issues.detail("PAP-1442"),
+      makeIssue({ executionRunId: "socket-run" }),
+    );
     queryClient.setQueryData(queryKeys.issues.interactions("PAP-1442"), [{ id: "socket-update" }]);
     resolveView({
       detail: issue,
@@ -124,6 +128,8 @@ describe("getIssueDetailQueryOptions", () => {
 
     await pending;
 
+    expect(queryClient.getQueryData<Issue>(queryKeys.issues.detail("PAP-1442"))?.executionRunId).toBe("socket-run");
+    expect(queryClient.getQueryData<Issue>(queryKeys.issues.detail("issue-1"))?.executionRunId).toBe("socket-run");
     expect(queryClient.getQueryData(queryKeys.issues.interactions("PAP-1442"))).toEqual([
       { id: "socket-update" },
     ]);

--- a/ui/src/lib/issueDetailQuery.test.tsx
+++ b/ui/src/lib/issueDetailQuery.test.tsx
@@ -55,6 +55,7 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
 
 describe("getIssueDetailQueryOptions", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -94,6 +95,39 @@ describe("getIssueDetailQueryOptions", () => {
       pageParams: [null],
     });
 
+    queryClient.clear();
+  });
+
+  it("preserves socket updates received while the aggregate view is loading", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T20:00:00.000Z"));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const issue = makeIssue();
+    let resolveView!: (view: Awaited<ReturnType<typeof issuesApi.getView>>) => void;
+    vi.mocked(issuesApi.getView).mockReturnValue(new Promise((resolve) => {
+      resolveView = resolve;
+    }));
+
+    const pending = fetchIssueDetail(queryClient, "PAP-1442", { signal: new AbortController().signal });
+    vi.setSystemTime(new Date("2026-04-13T20:00:00.001Z"));
+    queryClient.setQueryData(queryKeys.issues.interactions("PAP-1442"), [{ id: "socket-update" }]);
+    resolveView({
+      detail: issue,
+      comments: [],
+      interactions: [{ id: "aggregate-snapshot" }],
+      attachments: [],
+      workProducts: [],
+      childIssues: [],
+      runs: [],
+      liveRuns: [],
+      activeRun: null,
+    } as unknown as Awaited<ReturnType<typeof issuesApi.getView>>);
+
+    await pending;
+
+    expect(queryClient.getQueryData(queryKeys.issues.interactions("PAP-1442"))).toEqual([
+      { id: "socket-update" },
+    ]);
     queryClient.clear();
   });
 });

--- a/ui/src/lib/query-invalidation-batcher.test.ts
+++ b/ui/src/lib/query-invalidation-batcher.test.ts
@@ -25,10 +25,14 @@ describe("createInvalidationBatcher", () => {
     const batcher = createInvalidationBatcher(client, 300);
 
     for (let i = 0; i < 20; i++) batcher.schedule({ queryKey: ["dashboard", "c1"] });
-    expect(client.invalidateQueries).not.toHaveBeenCalled(); // nothing until flush
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(client.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["dashboard", "c1"],
+      refetchType: "none",
+    });
 
     vi.advanceTimersByTime(300);
-    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(2);
     expect(client.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["dashboard", "c1"] });
   });
 
@@ -41,8 +45,9 @@ describe("createInvalidationBatcher", () => {
     batcher.schedule({ queryKey: ["a"] }); // dup of first
     batcher.schedule({ queryKey: ["a"], refetchType: "inactive" }); // distinct variant
 
-    vi.advanceTimersByTime(300);
     expect(client.invalidateQueries).toHaveBeenCalledTimes(3);
+    vi.advanceTimersByTime(300);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(6);
   });
 
   it("never coalesces predicate-based invalidations", () => {
@@ -53,8 +58,9 @@ describe("createInvalidationBatcher", () => {
     batcher.schedule({ predicate: () => true });
     batcher.schedule({ predicate: () => false });
 
-    vi.advanceTimersByTime(300);
     expect(client.invalidateQueries).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(300);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(4);
   });
 
   it("schedule() resolves only after the flush has invalidated", async () => {
@@ -68,12 +74,12 @@ describe("createInvalidationBatcher", () => {
 
     await Promise.resolve();
     expect(resolved).toBe(false); // not yet — window still open
-    expect(client.invalidateQueries).not.toHaveBeenCalled();
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(300);
     await p;
     expect(resolved).toBe(true);
-    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(2);
   });
 
   it("starts a fresh window after flushing", () => {
@@ -82,11 +88,11 @@ describe("createInvalidationBatcher", () => {
 
     batcher.schedule({ queryKey: ["a"] });
     vi.advanceTimersByTime(300);
-    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(2);
 
     batcher.schedule({ queryKey: ["a"] });
     vi.advanceTimersByTime(300);
-    expect(client.invalidateQueries).toHaveBeenCalledTimes(2);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(4);
   });
 
   it("dispose cancels a pending flush", () => {
@@ -96,7 +102,8 @@ describe("createInvalidationBatcher", () => {
     batcher.schedule({ queryKey: ["a"] });
     batcher.dispose();
     vi.advanceTimersByTime(1000);
-    expect(client.invalidateQueries).not.toHaveBeenCalled();
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(client.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["a"], refetchType: "none" });
   });
 
   it("flush() invalidates immediately", () => {
@@ -105,7 +112,7 @@ describe("createInvalidationBatcher", () => {
 
     batcher.schedule({ queryKey: ["a"] });
     batcher.flush();
-    expect(client.invalidateQueries).toHaveBeenCalledTimes(1);
+    expect(client.invalidateQueries).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -133,9 +140,10 @@ describe("createCoalescingQueryClient", () => {
     // invalidateQueries is deferred through the batcher.
     void proxied.invalidateQueries({ queryKey: ["k"] });
     void proxied.invalidateQueries({ queryKey: ["k"] });
-    expect(realInvalidate).not.toHaveBeenCalled();
+    expect(realInvalidate).toHaveBeenCalledTimes(1);
+    expect(realInvalidate).toHaveBeenCalledWith({ queryKey: ["k"], refetchType: "none" });
 
     vi.advanceTimersByTime(300);
-    expect(realInvalidate).toHaveBeenCalledTimes(1);
+    expect(realInvalidate).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/lib/query-invalidation-batcher.ts
+++ b/ui/src/lib/query-invalidation-batcher.ts
@@ -69,7 +69,14 @@ export function createInvalidationBatcher(
   };
 
   const schedule = (filters: InvalidateQueryFilters): Promise<void> => {
-    pending.set(serializeFilters(filters), filters);
+    const key = serializeFilters(filters);
+    if (!pending.has(key)) {
+      pending.set(key, filters);
+      // Mark matching queries stale synchronously so reads that finish before
+      // the trailing flush cannot overwrite state invalidated by a live event.
+      // Only the potentially expensive refetch remains coalesced.
+      void queryClient.invalidateQueries({ ...filters, refetchType: "none" });
+    }
     if (windowDeferred === null) {
       windowDeferred = createDeferred();
     }

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -20,6 +20,7 @@ import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 
 const mockIssuesApi = vi.hoisted(() => ({
   get: vi.fn(),
+  getView: vi.fn(),
   list: vi.fn(),
   listAcceptedPlanDecompositions: vi.fn(),
   listComments: vi.fn(),
@@ -1033,6 +1034,29 @@ describe("IssueDetail", () => {
     } as Response);
 
     mockIssuesApi.list.mockResolvedValue([]);
+    mockIssuesApi.getView.mockImplementation(async (...args: Parameters<typeof mockIssuesApi.get>) => {
+      const detail = await mockIssuesApi.get(...args);
+      const [comments, attachments, workProducts, childIssues, runs, liveRuns, activeRun] = await Promise.all([
+        mockIssuesApi.listComments(detail.id, { order: "desc", limit: 50 }),
+        mockIssuesApi.listAttachments(detail.id),
+        mockIssuesApi.listWorkProducts(detail.id),
+        mockIssuesApi.list(detail.companyId, { descendantOf: detail.id, includeBlockedBy: true }),
+        mockActivityApi.runsForIssue(detail.id),
+        mockHeartbeatsApi.liveRunsForIssue(detail.id),
+        mockHeartbeatsApi.activeRunForIssue(detail.id),
+      ]);
+      return {
+        detail,
+        comments,
+        interactions: [],
+        attachments,
+        workProducts,
+        childIssues,
+        runs,
+        liveRuns,
+        activeRun,
+      };
+    });
     mockIssuesApi.listComments.mockResolvedValue([]);
     mockIssuesApi.listAttachments.mockResolvedValue([]);
     mockIssuesApi.listWorkProducts.mockResolvedValue([]);

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -39,7 +39,7 @@ import {
   rememberIssueDetailLocationState,
 } from "../lib/issueDetailBreadcrumb";
 import { resolveIssueActiveRun, shouldTrackIssueActiveRun } from "../lib/issueActiveRun";
-import { getIssueDetailQueryOptions } from "../lib/issueDetailCache";
+import { getIssueDetailQueryOptions, ISSUE_DETAIL_STALE_TIME_MS } from "../lib/issueDetailCache";
 import {
   beginIssueDetailNavigation,
   ISSUE_DETAIL_CONTENT_MEASURE,
@@ -1082,7 +1082,8 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   const { data: liveRuns } = useQuery({
     queryKey: queryKeys.issues.liveRuns(issueId),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId),
-    refetchInterval: 3000,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
+    refetchInterval: false,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId),
   });
   const resolvedLiveRuns = liveRuns ?? [];
@@ -1091,7 +1092,8 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
     queryKey: queryKeys.issues.activeRun(issueId),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId),
     enabled: !!executionRunId || issueStatus === "in_progress",
-    refetchInterval: liveRunCount > 0 ? false : 3000,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
+    refetchInterval: false,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId),
   });
   const resolvedActiveRun = useMemo(
@@ -1102,7 +1104,8 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   const { data: linkedRuns } = useQuery({
     queryKey: queryKeys.issues.runs(issueId),
     queryFn: () => activityApi.runsForIssue(issueId),
-    refetchInterval: hasLiveRuns ? 5000 : false,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
+    refetchInterval: false,
     placeholderData: keepPreviousDataForSameQueryTail<RunForIssue[]>(issueId),
   });
   const resolvedActivity = activity ?? [];
@@ -1686,6 +1689,7 @@ export function IssueDetail() {
       } : null,
     }),
     enabled: !!issueId,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
   });
   const resolvedCompanyId = issue?.companyId ?? selectedCompanyId;
   const externalObjectsState = useIssueExternalObjects(issue?.id ?? null);
@@ -1711,7 +1715,8 @@ export function IssueDetail() {
         limit: ISSUE_COMMENT_PAGE_SIZE,
         ...(pageParam ? { after: pageParam } : {}),
       }),
-    enabled: !!issueId,
+    enabled: !!issue,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) =>
       getNextIssueCommentPageParam(lastPage, ISSUE_COMMENT_PAGE_SIZE),
@@ -1755,29 +1760,33 @@ export function IssueDetail() {
   const { data: interactions = [] } = useQuery({
     queryKey: queryKeys.issues.interactions(issueId!),
     queryFn: () => issuesApi.listInteractions(issueId!),
-    enabled: !!issueId,
+    enabled: !!issue,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
     placeholderData: keepPreviousDataForSameQueryTail<IssueThreadInteraction[]>(issueId ?? "pending"),
   });
 
   const { data: attachments, isLoading: attachmentsLoading } = useQuery({
     queryKey: queryKeys.issues.attachments(issueId!),
     queryFn: () => issuesApi.listAttachments(issueId!),
-    enabled: !!issueId,
+    enabled: !!issue,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
     placeholderData: keepPreviousDataForSameQueryTail<IssueAttachment[]>(issueId ?? "pending"),
   });
 
   const { data: workProducts } = useQuery({
     queryKey: queryKeys.issues.workProducts(issueId!),
     queryFn: () => issuesApi.listWorkProducts(issueId!),
-    enabled: !!issueId,
+    enabled: !!issue,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
     placeholderData: keepPreviousDataForSameQueryTail<IssueWorkProduct[]>(issueId ?? "pending"),
   });
 
   const { data: liveRunCount = 0 } = useQuery<LiveRunForIssue[], Error, number>({
     queryKey: queryKeys.issues.liveRuns(issueId!),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId!),
-    enabled: !!issueId,
-    refetchInterval: 3000,
+    enabled: !!issue,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
+    refetchInterval: false,
     select: (runs) => runs.length,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId ?? "pending"),
   });
@@ -1785,8 +1794,9 @@ export function IssueDetail() {
   const { data: hasActiveRun = false } = useQuery<ActiveRunForIssue | null, Error, boolean>({
     queryKey: queryKeys.issues.activeRun(issueId!),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId!),
-    enabled: !!issueId && (!!issue?.executionRunId || issue?.status === "in_progress"),
-    refetchInterval: liveRunCount > 0 ? false : 3000,
+    enabled: !!issue && (!!issue.executionRunId || issue.status === "in_progress"),
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
+    refetchInterval: false,
     select: (run) => !!run,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId ?? "pending"),
   });
@@ -1809,6 +1819,7 @@ export function IssueDetail() {
         : ["issues", "parent", "pending"],
     queryFn: () => issuesApi.list(resolvedCompanyId!, { descendantOf: issue!.id, includeBlockedBy: true }),
     enabled: !!resolvedCompanyId && !!issue?.id,
+    staleTime: ISSUE_DETAIL_STALE_TIME_MS,
     placeholderData: keepPreviousDataForSameQueryTail<Issue[]>(issue?.id ?? "pending"),
   });
   const {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue-detail page is a core control-plane surface where operators read context, comments, activity, and live execution state
> - That page previously hydrated through multiple independent requests and continued polling data that the live-update channel could keep current
> - The request fan-out delayed useful paint and duplicated work during navigation
> - The server can return the initial issue-view projection in one private, cache-aware response while the client hydrates its existing query caches
> - This pull request adds that aggregate read path, removes redundant polling, and attaches the issue to live updates immediately
> - The benefit is faster issue-detail navigation with fewer requests while preserving existing cache boundaries and live behavior

## Linked Issues or Issue Description

### Subsystem affected

Cross-cutting: `server/` REST API and `ui/` React board.

### Problem or motivation

Opening an issue detail required several serial or parallel client requests for detail, comments, interactions, attachments, work products, children, and run state. The page also retained periodic polling after live updates were available, delaying useful paint and duplicating authorization, routing, and network work.

### Proposed solution

Add a company-scoped aggregate read endpoint with private ETags, hydrate the existing client caches from its response, remove redundant polling, and attach the current issue to the live-update subscription. Navigation should paint from one aggregate issue-view request while preserving the existing query-cache contracts.

### Alternatives considered

Keeping the existing request fan-out and only prefetching each query would preserve more independent requests and still incur duplicated authorization, routing, and network overhead. Replacing all existing query caches with a new monolithic client cache would create a larger and riskier UI refactor.

### Roadmap alignment

This is a focused performance improvement to an existing core workflow and does not introduce a new roadmap capability.

### Additional context

The implementation is deliberately additive: existing issue-detail endpoints remain available, and the aggregate response seeds their current client cache keys.

## What Changed

- Added `GET /api/issues/:id/view` to return issue detail, recent comments, interactions, attachments, work products, child issues, runs, live runs, and the active run in one response.
- Added private JSON ETag handling and request timing instrumentation for authenticated issue reads.
- Hydrated existing issue-detail query caches from the aggregate response so downstream components keep their current cache contracts.
- Removed redundant issue-detail polling and subscribed the active issue to live updates immediately.
- Added server and UI coverage for read-only interaction contracts, private ETags, aggregate hydration, and socket attachment.
- Added the shared issue-comment page-size export required by both render and hydration paths; no user-facing documentation changes are required.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-interactions-read-only-contract.test.ts server/src/__tests__/issue-thread-interaction-routes.test.ts server/src/__tests__/private-json-etag.test.ts server/src/__tests__/external-object-routes.test.ts server/src/__tests__/issue-activity-events-routes.test.ts server/src/__tests__/document-annotation-routes.test.ts server/src/__tests__/issue-attachment-routes.test.ts ui/src/context/LiveUpdatesProvider.test.ts ui/src/lib/issueDetailCache.test.ts ui/src/lib/issueDetailQuery.test.tsx ui/src/pages/IssueDetail.test.tsx` — 11 files, 148 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:token-gates` — passed.

## Risks

- The aggregate endpoint duplicates the shape of several existing reads; tests protect the read-only interaction contract and cache hydration, but future additions to issue detail may need to update the aggregate projection too.
- Private ETags change authenticated JSON response behavior by allowing `304 Not Modified`; middleware tests cover payload changes and private cache headers.
- No schema changes, migrations, lockfile changes, workflow changes, or public API removals.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.4 and GPT-5.6 Sol via Codex CLI, exact model IDs `gpt-5.4` and `gpt-5.6-sol`, with repository inspection, code execution, test execution, and Git/GitHub tooling. The runtimes do not expose context-window sizes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge



