### PR TITLE
fix(runtime): launch adapters from realized workspace

### DIFF
--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -104,6 +104,20 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(opts.onSpawn).toBe(onSpawn);
   });
 
+  it("launches Hermes from the runtime-provided execution workspace cwd", async () => {
+    const executionWorkspaceCwd = "/workspace/WPR2-pr-1542";
+    const { ctx } = makeCtx({ cwd: executionWorkspaceCwd, worktreeMode: true });
+
+    await execute(ctx as any);
+
+    const mocked = vi.mocked(serverUtils.runChildProcess);
+    const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+    const args = lastCall[2] as string[];
+    const opts = lastCall[3] as Record<string, unknown>;
+    expect(args).toContain("-w");
+    expect(opts.cwd).toBe(executionWorkspaceCwd);
+  });
+
   it("runChildProcess opts type includes onSpawn", () => {
     // Type-level assertion: if onSpawn were removed from the type,
     // this file would fail to compile. The runtime test above catches

--- a/packages/adapters/hermes/src/server/execute.onspawn.test.ts
+++ b/packages/adapters/hermes/src/server/execute.onspawn.test.ts
@@ -69,6 +69,7 @@ function makeCtx(overrides: Record<string, unknown> = {}) {
         issueId: "issue-1",
         wakeReason: "manual",
         paperclipWake: null,
+        ...((overrides.context as Record<string, unknown> | undefined) ?? {}),
       },
       onLog: vi.fn(async () => undefined),
       onMeta: vi.fn(async () => undefined),
@@ -104,18 +105,55 @@ describe("hermes-local adapter onSpawn forwarding", () => {
     expect(opts.onSpawn).toBe(onSpawn);
   });
 
-  it("launches Hermes from the runtime-provided execution workspace cwd", async () => {
-    const executionWorkspaceCwd = "/workspace/WPR2-pr-1542";
-    const { ctx } = makeCtx({ cwd: executionWorkspaceCwd, worktreeMode: true });
+  it("uses the realized Paperclip worktree CWD for -w launches", async () => {
+    const worktreeCwd = process.cwd();
+    const { ctx } = makeCtx({
+      worktreeMode: true,
+      context: { paperclipWorkspace: { cwd: worktreeCwd } },
+    });
 
     await execute(ctx as any);
 
-    const mocked = vi.mocked(serverUtils.runChildProcess);
-    const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
-    const args = lastCall[2] as string[];
-    const opts = lastCall[3] as Record<string, unknown>;
-    expect(args).toContain("-w");
-    expect(opts.cwd).toBe(executionWorkspaceCwd);
+    const call = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)!;
+    expect(call[2]).toContain("-w");
+    expect((call[3] as Record<string, unknown>).cwd).toBe(worktreeCwd);
+  });
+
+  it("preserves a valid explicit CWD override for a worktree launch", async () => {
+    const explicitCwd = process.cwd();
+    const { ctx } = makeCtx({
+      worktreeMode: true,
+      cwd: explicitCwd,
+      context: { paperclipWorkspace: { cwd: "/tmp" } },
+    });
+
+    await execute(ctx as any);
+
+    const call = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)!;
+    expect((call[3] as Record<string, unknown>).cwd).toBe(explicitCwd);
+  });
+
+  it("preserves ordinary non-worktree CWD behavior", async () => {
+    const { ctx } = makeCtx({ cwd: "/tmp" });
+
+    await execute(ctx as any);
+
+    const call = vi.mocked(serverUtils.runChildProcess).mock.calls.at(-1)!;
+    expect(call[2]).not.toContain("-w");
+    expect((call[3] as Record<string, unknown>).cwd).toBe("/tmp");
+  });
+
+  it("rejects a worktree launch when no valid Git workspace CWD exists", async () => {
+    const { ctx } = makeCtx({
+      worktreeMode: true,
+      context: { paperclipWorkspace: { cwd: "/tmp" } },
+    });
+
+    const result = await execute(ctx as any);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("not a Git worktree");
+    expect(serverUtils.runChildProcess).not.toHaveBeenCalled();
   });
 
   it("runChildProcess opts type includes onSpawn", () => {

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -18,7 +18,9 @@
  *   --source           session source tag for filtering
  */
 
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import { promisify } from "node:util";
 import path from "node:path";
 
 import type {
@@ -31,7 +33,6 @@ import {
   runChildProcess,
   buildPaperclipEnv,
   renderTemplate,
-  ensureAbsoluteDirectory,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   joinPromptSections,
   renderPaperclipWakePrompt,
@@ -68,6 +69,27 @@ function cfgStringArray(v: unknown): string[] | undefined {
   return Array.isArray(v) && v.every((i) => typeof i === "string")
     ? (v as string[])
     : undefined;
+}
+
+const execFileAsync = promisify(execFile);
+
+async function isGitWorktree(cwd: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd,
+      timeout: 5_000,
+    });
+    return stdout.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+function realizedWorkspaceCwd(ctx: AdapterExecutionContext): string | undefined {
+  const context = (ctx as { context?: Record<string, unknown> }).context;
+  const workspace = context?.paperclipWorkspace;
+  if (!workspace || typeof workspace !== "object") return undefined;
+  return cfgString((workspace as Record<string, unknown>).cwd);
 }
 
 export function resolveHermesCommand(config: Record<string, unknown>): string {
@@ -405,6 +427,36 @@ export async function execute(
     prompt = agentInstructions + "\n\n---\n\n" + prompt;
   }
 
+  // ── Resolve working directory ──────────────────────────────────────────
+  // A realized Paperclip workspace is the source of truth for isolated Hermes
+  // worktrees. An adapter override wins only when it is itself a Git worktree.
+  const explicitCwd = cfgString(config.cwd);
+  const workspaceCwd = realizedWorkspaceCwd(ctx);
+  let cwd: string;
+  if (worktreeMode) {
+    const explicitCandidate = explicitCwd ? path.resolve(explicitCwd) : undefined;
+    const explicitIsWorktree = explicitCandidate ? await isGitWorktree(explicitCandidate) : false;
+    const candidate = explicitIsWorktree
+      ? explicitCandidate
+      : workspaceCwd || cfgString(ctx.config?.workspaceDir);
+
+    if (!candidate) {
+      const errorMessage = "Hermes worktree routing failed: no realized Git workspace CWD was supplied.";
+      await ctx.onLog("stderr", `[hermes] ${errorMessage}\n`);
+      return { exitCode: 1, signal: null, timedOut: false, provider: resolvedProvider, model, errorMessage };
+    }
+
+    cwd = path.resolve(candidate);
+    if (!(await isGitWorktree(cwd))) {
+      const errorMessage = `Hermes worktree routing failed: resolved CWD is not a Git worktree: ${cwd}`;
+      await ctx.onLog("stderr", `[hermes] ${errorMessage}\n`);
+      return { exitCode: 1, signal: null, timedOut: false, provider: resolvedProvider, model, errorMessage };
+    }
+  } else {
+    // Preserve ordinary non-worktree behavior, including the historical "." fallback.
+    cwd = explicitCwd || cfgString(ctx.config?.workspaceDir) || ".";
+  }
+
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
   const useQuiet = cfgBoolean(config.quiet) === true; // default false
@@ -475,15 +527,6 @@ export async function execute(
   if (envCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = envCommentId;
   const wakePayloadJson = stringifyPaperclipWakePayload(ctxContext.paperclipWake);
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
-
-  // ── Resolve working directory ──────────────────────────────────────────
-  const cwd =
-    cfgString(config.cwd) || cfgString(ctx.config?.workspaceDir) || ".";
-  try {
-    await ensureAbsoluteDirectory(cwd);
-  } catch {
-    // Non-fatal
-  }
 
   // ── Log start ──────────────────────────────────────────────────────────
   await ctx.onLog(

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -15,6 +15,7 @@ import {
   buildExplicitResumeSessionOverride,
   buildEffectiveRunSessionConfigMetadata,
   buildEffectiveRunWorkspaceConfigMetadata,
+  bindRuntimeConfigToExecutionWorkspace,
   buildWorkspaceConfigFreshnessOperation,
   deriveTaskKeyWithHeartbeatFallback,
   extractWakeCommentIds,
@@ -60,6 +61,23 @@ function buildResolvedWorkspace(overrides: Partial<ResolvedWorkspaceForRun> = {}
     ...overrides,
   };
 }
+
+describe("bindRuntimeConfigToExecutionWorkspace", () => {
+  it("overrides a persisted adapter cwd with the realized execution workspace cwd", () => {
+    const config = {
+      cwd: "/paperclip/server",
+      model: "gpt-5.5",
+      env: { KEEP: "value" },
+    };
+
+    expect(bindRuntimeConfigToExecutionWorkspace(config, "/workspace/WPR2-pr-1542")).toEqual({
+      cwd: "/workspace/WPR2-pr-1542",
+      model: "gpt-5.5",
+      env: { KEEP: "value" },
+    });
+    expect(config.cwd).toBe("/paperclip/server");
+  });
+});
 
 type WorkspaceValidationInput = Parameters<typeof assertGitSensitiveAdapterWorkspaceValid>[0];
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1727,6 +1727,21 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
   }
 }
 
+/**
+ * The execution workspace is realized after the adapter configuration has been
+ * resolved. Its CWD must therefore override any persisted adapter CWD, so the
+ * child process starts in the workspace that passed runtime preflight.
+ */
+export function bindRuntimeConfigToExecutionWorkspace(
+  runtimeConfig: Record<string, unknown>,
+  executionWorkspaceCwd: string,
+): Record<string, unknown> {
+  return {
+    ...runtimeConfig,
+    cwd: executionWorkspaceCwd,
+  };
+}
+
 const heartbeatRunProcessGroupIdColumn =
   heartbeatRuns.processGroupId ?? sql<number | null>`NULL`.as("processGroupId");
 
@@ -12468,6 +12483,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (executionWorkspace.projectId && !readNonEmptyString(context.projectId)) {
       context.projectId = executionWorkspace.projectId;
     }
+    runtimeConfig = bindRuntimeConfigToExecutionWorkspace(runtimeConfig, executionWorkspace.cwd);
     const runtimeSessionFallback = taskKey || resetTaskSession
       ? null
       : isCanonicalSessionIdForAdapter(agent.adapterType, runtime.sessionId)


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs local coding agents through adapters, so the selected process CWD is part of the execution contract.
> - Isolated execution workspaces may realize a Git worktree after the agent configuration was initially resolved.
> - The Hermes adapter could retain a fallback checkout CWD even when Paperclip had successfully realized a different workspace.
> - Git-sensitive Hermes behavior such as `--worktree` then ran outside the intended repository and failed before the agent could work.
> - This pull request binds the runtime CWD to the realized execution workspace and validates `-w` CWD before launch.
> - The result is a launch path whose process directory matches the provisioned workspace and fails closed without a Git worktree.

## Linked Issues or Issue Description

Related public PRs: Refs #7657, #8997, #9549. This PR addresses local Hermes child-process CWD handoff and validation specifically.

### Bug

**What happened:** A provisioned local Git worktree could be recorded in Paperclip execution context while the Hermes child process retained a stale fallback checkout directory. The adapter also accepted a `-w` launch without proving that its CWD was a Git worktree.

**Expected behavior:** A `worktreeMode` Hermes run must start in the realized workspace unless a valid explicit adapter CWD override exists. The adapter must reject an invalid selected CWD before it spawns Hermes.

**Impact:** A valid provisioned worktree could be unusable for local runs, blocking issue execution despite successful workspace provisioning.

**Scope:** This changes Paperclip runtime CWD handoff and Hermes adapter validation only. It does not change external product repositories or their GitHub policies.

## What Changed

- Bind the realized execution-workspace CWD into adapter runtime configuration after provisioning.
- Resolve Hermes `-w` launches from a validated explicit adapter CWD or the realized Paperclip workspace CWD.
- Verify `git rev-parse --is-inside-work-tree` before spawning Hermes and return a non-zero routing error if validation fails.
- Add regression coverage for realized CWD selection, valid overrides, non-worktree behavior, and invalid-routing rejection.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts` — 119 passed (prior PR evidence).
- `pnpm --filter @paperclipai/hermes-paperclip-adapter test -- execute.onspawn.test.ts` — 6 passed.
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` — passed.
- `git diff --check` — passed.

## Risks

Low risk. `worktreeMode` now fails closed when no selected CWD is a Git worktree. This is intentional because Hermes `-w` cannot safely route a task without a repository. Rollback is reverting commit `9ccb203d1` and restoring the prior adapter build.

## Model Used

OpenAI Codex, GPT-5.6, tool-assisted code navigation, implementation, and targeted test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references are used)
- [x] My branch name describes the change and contains no internal instance-derived details
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge