### PR TITLE
fix: authorize unblock owners to return results

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1759,6 +1759,7 @@ export {
   type CompanySearchQuery,
   createIssueSchema,
   createIssueInputSchema,
+  issueUnblockDescriptorSchema,
   createChildIssueSchema,
   createAcceptedPlanDecompositionSchema,
   resolveCreateIssueStatusDefault,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -400,6 +400,7 @@ export {
 export {
   createIssueSchema,
   createIssueInputSchema,
+  issueUnblockDescriptorSchema,
   createChildIssueSchema,
   createAcceptedPlanDecompositionSchema,
   resolveCreateIssueStatusDefault,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -429,20 +429,22 @@ function withCreateIssueStatusDefault<T extends z.ZodRawShape>(schema: z.ZodObje
   }, schema);
 }
 
+export const issueUnblockDescriptorSchema = z.object({
+  owner: z.union([
+    z.object({ agentId: z.string().uuid() }).strict(),
+    z.object({ userId: z.string().trim().min(1) }).strict(),
+    z.literal("board"),
+  ]),
+  action: multilineTextSchema.pipe(z.string().trim().min(1).max(2_000)),
+}).strict();
+
 const createIssueBaseSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   projectWorkspaceId: z.string().uuid().optional().nullable(),
   goalId: z.string().uuid().optional().nullable(),
   parentId: z.string().uuid().optional().nullable(),
   blockedByIssueIds: z.array(z.string().uuid()).optional(),
-  unblockDescriptor: z.object({
-    owner: z.union([
-      z.object({ agentId: z.string().uuid() }).strict(),
-      z.object({ userId: z.string().trim().min(1) }).strict(),
-      z.literal("board"),
-    ]),
-    action: multilineTextSchema.pipe(z.string().trim().min(1).max(2_000)),
-  }).strict().optional().nullable(),
+  unblockDescriptor: issueUnblockDescriptorSchema.optional().nullable(),
   inheritExecutionWorkspaceFromIssueId: z.string().uuid().optional().nullable(),
   title: z.string().min(1),
   description: multilineTextSchema.optional().nullable(),

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1500,6 +1500,46 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("preserves assignee authority when the assignee is also the unblock owner", async () => {
+    const company = await createCompany(db, "IssueAssigneeUnblockOwner");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Blocked issue owned by its assignee",
+      status: "blocked",
+      assigneeAgentId: assigneeAgent.id,
+      unblockDescriptor: {
+        owner: { agentId: assigneeAgent.id },
+        action: "Complete the unblock action",
+      },
+    });
+    const authorization = authorizationService(db);
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: issue.assigneeAgentId,
+      status: issue.status,
+    } as const;
+
+    for (const action of ["issue:comment", "issue:mutate"] as const) {
+      await expect(authorization.decide({
+        actor: {
+          type: "agent",
+          agentId: assigneeAgent.id,
+          companyId: company.id,
+          source: "agent_key",
+        },
+        action,
+        resource,
+        scope: action === "issue:mutate" ? { allowIssueUnblockOwner: true } : null,
+      })).resolves.toMatchObject({
+        allowed: true,
+        reason: "allow_self",
+      });
+    }
+  });
+
   it("allows only the persisted unblock owner to comment on and mutate a blocked assigned issue", async () => {
     const company = await createCompany(db, "IssueUnblockOwner");
     const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1684,6 +1684,23 @@ describeEmbeddedPostgres("authorization service", () => {
       .resolves.toHaveLength(0);
 
     await db.update(issues).set({
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Malformed owner action",
+        extra: true,
+      } as never,
+    }).where(eq(issues.id, issue.id));
+    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions)).resolves.toBeNull();
+    await expect(svc.addComment(
+      issue.id,
+      "Comment after descriptor became malformed",
+      { agentId: owner.id },
+      writeOptions,
+    )).rejects.toMatchObject({ status: 409 });
+    await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issue.id)))
+      .resolves.toHaveLength(0);
+
+    await db.update(issues).set({
       status: "todo",
       unblockDescriptor: {
         owner: { agentId: owner.id },

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1575,6 +1575,78 @@ describeEmbeddedPostgres("authorization service", () => {
       resource,
       scope: { allowIssueUnblockOwner: true },
     })).resolves.toMatchObject({ allowed: false });
+
+    const malformedDescriptors = [
+      { owner: { agentId: unblockOwnerAgent.id } },
+      { owner: { agentId: unblockOwnerAgent.id, userId: "mixed-owner" }, action: "Review" },
+      { owner: { agentId: "not-a-uuid" }, action: "Review" },
+      { owner: { agentId: unblockOwnerAgent.id }, action: "Review", extra: true },
+    ];
+    for (const unblockDescriptor of malformedDescriptors) {
+      await db.update(issues).set({
+        status: "blocked",
+        unblockDescriptor: unblockDescriptor as never,
+      }).where(eq(issues.id, issue.id));
+      await expect(authorization.decide({
+        actor: {
+          type: "agent",
+          agentId: unblockOwnerAgent.id,
+          companyId: company.id,
+          source: "agent_key",
+        },
+        action: "issue:mutate",
+        resource,
+        scope: { allowIssueUnblockOwner: true },
+      })).resolves.toMatchObject({ allowed: false });
+    }
+  });
+
+  it("does not let a low-trust unblock owner cross the assignee mutation boundary", async () => {
+    const company = await createCompany(db, "LowTrustIssueUnblockOwner");
+    const project = await createProject(db, company.id, "AllowedProject");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const lowTrustOwner = await createAgent(db, company.id, {
+      role: "reviewer",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [project.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Blocked issue with low-trust owner",
+      projectId: project.id,
+      status: "blocked",
+      assigneeAgentId: assigneeAgent.id,
+      unblockDescriptor: {
+        owner: { agentId: lowTrustOwner.id },
+        action: "Choose the remediation path",
+      },
+    });
+
+    await expect(authorizationService(db).decide({
+      actor: {
+        type: "agent",
+        agentId: lowTrustOwner.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        assigneeAgentId: issue.assigneeAgentId,
+        status: issue.status,
+      },
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: false });
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1715,11 +1715,18 @@ describeEmbeddedPostgres("authorization service", () => {
       expectedUpdatedAt: Date,
       action: "issue:comment" | "issue:mutate",
       callback: (tx: ReturnType<typeof createDb>) => Promise<T>,
+      assignment?: {
+        projectId: string | null;
+        parentIssueId: string | null;
+        assigneeAgentId: string | null;
+        assigneeUserId: string | null;
+      },
     ) => svc.runBlockedUnblockOwnerTransaction({
       issueId: issue.id,
       expectedUpdatedAt,
       actor,
       action,
+      ...(assignment ? { assignment } : {}),
     }, callback);
 
     await db.update(issues).set({
@@ -1769,6 +1776,11 @@ describeEmbeddedPostgres("authorization service", () => {
         tx,
       );
       return { updated, comment };
+    }, {
+      projectId: currentIssue!.projectId,
+      parentIssueId: currentIssue!.parentId,
+      assigneeAgentId: owner.id,
+      assigneeUserId: null,
     });
     expect(result.updated).toMatchObject({ status: "todo", assigneeAgentId: owner.id });
     expect(result.comment).toMatchObject({ body: "Current owner comment" });
@@ -1872,6 +1884,65 @@ describeEmbeddedPostgres("authorization service", () => {
       delegatedCallbackRan = true;
     })).rejects.toMatchObject({ status: 409 });
     expect(delegatedCallbackRan).toBe(false);
+  });
+
+  it("rechecks protected self-assignment inside the unblock-owner transaction", async () => {
+    const company = await createCompany(db, "UnblockOwnerAssignmentRace");
+    const project = await createProject(db, company.id);
+    const owner = await createAgent(db, company.id, {
+      permissions: {
+        authorizationPolicy: {
+          assignmentPolicy: { mode: "protected" },
+        },
+      },
+    });
+    const assignee = await createAgent(db, company.id);
+    await grantAgentPermission(db, company.id, owner.id, "tasks:assign");
+    const issue = await createIssue(db, company.id, {
+      projectId: project.id,
+      status: "blocked",
+      assigneeAgentId: assignee.id,
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Perform the unblock action",
+      },
+    });
+    const actor = {
+      type: "agent" as const,
+      agentId: owner.id,
+      companyId: company.id,
+      source: "agent_key" as const,
+    };
+    const assignment = {
+      projectId: project.id,
+      parentIssueId: null,
+      assigneeAgentId: owner.id,
+      assigneeUserId: null,
+    };
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, issueId: issue.id, ...assignment },
+      scope: { issueId: issue.id, ...assignment },
+    })).resolves.toMatchObject({ allowed: true });
+
+    await db.delete(principalPermissionGrants).where(and(
+      eq(principalPermissionGrants.companyId, company.id),
+      eq(principalPermissionGrants.principalType, "agent"),
+      eq(principalPermissionGrants.principalId, owner.id),
+      eq(principalPermissionGrants.permissionKey, "tasks:assign"),
+    ));
+    let callbackRan = false;
+    await expect(issueService(db).runBlockedUnblockOwnerTransaction({
+      issueId: issue.id,
+      expectedUpdatedAt: issue.updatedAt,
+      actor,
+      action: "issue:mutate",
+      assignment,
+    }, async () => {
+      callbackRan = true;
+    })).rejects.toMatchObject({ status: 409 });
+    expect(callbackRan).toBe(false);
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { and, eq } from "drizzle-orm";
 import {
@@ -73,11 +74,13 @@ async function createIssue(
   input: {
     id?: string;
     title?: string;
+    status?: "todo" | "in_progress" | "blocked";
     projectId?: string | null;
     parentId?: string | null;
     assigneeAgentId?: string | null;
     originKind?: string | null;
     originId?: string | null;
+    unblockDescriptor?: Record<string, unknown> | null;
   } = {},
 ) {
   return db
@@ -86,13 +89,14 @@ async function createIssue(
       id: input.id ?? randomUUID(),
       companyId,
       title: input.title ?? `Issue ${randomUUID()}`,
-      status: "todo",
+      status: input.status ?? "todo",
       priority: "medium",
       projectId: input.projectId ?? null,
       parentId: input.parentId ?? null,
       assigneeAgentId: input.assigneeAgentId ?? null,
       originKind: input.originKind ?? "manual",
       originId: input.originId ?? null,
+      unblockDescriptor: input.unblockDescriptor ?? null,
     })
     .returning()
     .then((rows) => rows[0]!);
@@ -1493,6 +1497,84 @@ describeEmbeddedPostgres("authorization service", () => {
       allowed: false,
       reason: "deny_unsupported_action",
     });
+  });
+
+  it("allows only the persisted unblock owner to comment on and mutate a blocked assigned issue", async () => {
+    const company = await createCompany(db, "IssueUnblockOwner");
+    const assigneeAgent = await createAgent(db, company.id, { role: "engineer" });
+    const unblockOwnerAgent = await createAgent(db, company.id, { role: "manager" });
+    const unrelatedAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Blocked issue awaiting owner action",
+      status: "blocked",
+      assigneeAgentId: assigneeAgent.id,
+      unblockDescriptor: {
+        owner: { agentId: unblockOwnerAgent.id },
+        action: "Choose the remediation path",
+      },
+    });
+    const authorization = authorizationService(db);
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: issue.assigneeAgentId,
+      status: issue.status,
+    } as const;
+
+    for (const action of ["issue:comment", "issue:mutate"] as const) {
+      await expect(authorization.decide({
+        actor: {
+          type: "agent",
+          agentId: unblockOwnerAgent.id,
+          companyId: company.id,
+          source: "agent_key",
+        },
+        action,
+        resource,
+        scope: action === "issue:mutate" ? { allowIssueUnblockOwner: true } : null,
+      })).resolves.toMatchObject({
+        allowed: true,
+        reason: "allow_issue_unblock_owner",
+      });
+    }
+
+    await expect(authorization.decide({
+      actor: {
+        type: "agent",
+        agentId: unblockOwnerAgent.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({ allowed: false });
+
+    await expect(authorization.decide({
+      actor: {
+        type: "agent",
+        agentId: unrelatedAgent.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource,
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: false });
+
+    await db.update(issues).set({ status: "todo" }).where(eq(issues.id, issue.id));
+    await expect(authorization.decide({
+      actor: {
+        type: "agent",
+        agentId: unblockOwnerAgent.id,
+        companyId: company.id,
+        source: "agent_key",
+      },
+      action: "issue:mutate",
+      resource,
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: false });
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { and, eq } from "drizzle-orm";
 import {
@@ -1690,7 +1690,7 @@ describeEmbeddedPostgres("authorization service", () => {
     })).resolves.toMatchObject({ allowed: false });
   });
 
-  it("atomically rejects stale unblock-owner issue writes and comments", async () => {
+  it("authorizes unblock-owner writes from one locked, fresh transaction snapshot", async () => {
     const company = await createCompany(db, "UnblockOwnerWriteRace");
     const assignee = await createAgent(db, company.id);
     const owner = await createAgent(db, company.id);
@@ -1704,7 +1704,23 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     });
     const svc = issueService(db);
-    const writeOptions = { expectedBlockedUnblockOwnerAgentId: owner.id };
+    const actor = {
+      type: "agent",
+      agentId: owner.id,
+      companyId: company.id,
+      source: "agent_key",
+    } as const;
+
+    const runOwnerTransaction = <T>(
+      expectedUpdatedAt: Date,
+      action: "issue:comment" | "issue:mutate",
+      callback: (tx: ReturnType<typeof createDb>) => Promise<T>,
+    ) => svc.runBlockedUnblockOwnerTransaction({
+      issueId: issue.id,
+      expectedUpdatedAt,
+      actor,
+      action,
+    }, callback);
 
     await db.update(issues).set({
       unblockDescriptor: {
@@ -1713,62 +1729,149 @@ describeEmbeddedPostgres("authorization service", () => {
       },
     }).where(eq(issues.id, issue.id));
 
-    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions)).resolves.toBeNull();
-    await expect(svc.addComment(
+    await expect(runOwnerTransaction(issue.updatedAt, "issue:comment", async (tx) => svc.addComment(
       issue.id,
       "Stale owner comment",
       { agentId: owner.id },
-      writeOptions,
-    )).rejects.toMatchObject({ status: 409 });
+      undefined,
+      tx,
+    ))).rejects.toMatchObject({ status: 409 });
     await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issue.id)))
       .resolves.toHaveLength(0);
 
-    await db.update(issues).set({
+    const [restored] = await db.update(issues).set({
       unblockDescriptor: {
         owner: { agentId: owner.id },
-        action: "Malformed owner action",
-        extra: true,
-      } as never,
-    }).where(eq(issues.id, issue.id));
-    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions)).resolves.toBeNull();
-    await expect(svc.addComment(
-      issue.id,
-      "Comment after descriptor became malformed",
-      { agentId: owner.id },
-      writeOptions,
-    )).rejects.toMatchObject({ status: 409 });
-    await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issue.id)))
-      .resolves.toHaveLength(0);
-
-    await db.update(issues).set({
-      status: "todo",
-      unblockDescriptor: {
-        owner: { agentId: owner.id },
-        action: "Owner action after status change",
+        action: "Current owner action",
       },
-    }).where(eq(issues.id, issue.id));
-    await expect(svc.addComment(
-      issue.id,
-      "Comment after issue left blocked",
-      { agentId: owner.id },
-      writeOptions,
-    )).rejects.toMatchObject({ status: 409 });
+      updatedAt: new Date(issue.updatedAt.getTime() + 1_000),
+    }).where(eq(issues.id, issue.id)).returning();
 
     await db.update(issues).set({
+      title: "A stronger concurrent edit",
+      updatedAt: new Date(restored.updatedAt.getTime() + 1_000),
+    }).where(eq(issues.id, issue.id));
+    await expect(runOwnerTransaction(restored.updatedAt, "issue:mutate", async (tx) => svc.update(
+      issue.id,
+      { status: "todo" },
+      tx,
+    ))).rejects.toMatchObject({ status: 409 });
+
+    const currentIssue = await svc.getById(issue.id);
+    expect(currentIssue).not.toBeNull();
+    const result = await runOwnerTransaction(currentIssue!.updatedAt, "issue:mutate", async (tx) => {
+      const updated = await svc.update(issue.id, { status: "todo", assigneeAgentId: owner.id }, tx);
+      const comment = await svc.addComment(
+        issue.id,
+        "Current owner comment",
+        { agentId: owner.id },
+        undefined,
+        tx,
+      );
+      return { updated, comment };
+    });
+    expect(result.updated).toMatchObject({ status: "todo", assigneeAgentId: owner.id });
+    expect(result.comment).toMatchObject({ body: "Current owner comment" });
+
+    const [blockedAgain] = await db.update(issues).set({
       status: "blocked",
       unblockDescriptor: {
         owner: { agentId: owner.id },
         action: "Current owner action",
       },
-    }).where(eq(issues.id, issue.id));
-    await expect(svc.addComment(
+      updatedAt: new Date(result.updated!.updatedAt.getTime() + 1_000),
+    }).where(eq(issues.id, issue.id)).returning();
+    await db.update(agents).set({ status: "terminated" }).where(eq(agents.id, owner.id));
+    await expect(runOwnerTransaction(blockedAgain.updatedAt, "issue:comment", async (tx) => svc.addComment(
       issue.id,
-      "Current owner comment",
+      "Terminated owner comment",
       { agentId: owner.id },
-      writeOptions,
-    )).resolves.toMatchObject({ body: "Current owner comment" });
-    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions))
-      .resolves.toMatchObject({ status: "todo" });
+      undefined,
+      tx,
+    ))).rejects.toMatchObject({ status: 409 });
+
+    const bridgeOwner = await createAgent(db, company.id);
+    const bridgeIssue = await createIssue(db, company.id, {
+      status: "blocked",
+      assigneeAgentId: assignee.id,
+      unblockDescriptor: {
+        owner: { agentId: bridgeOwner.id },
+        action: "Bridge owner action",
+      },
+    });
+    let bridgeCallbackRan = false;
+    await expect(svc.runBlockedUnblockOwnerTransaction({
+      issueId: bridgeIssue.id,
+      expectedUpdatedAt: bridgeIssue.updatedAt,
+      actor: {
+        type: "agent",
+        agentId: bridgeOwner.id,
+        companyId: company.id,
+        source: "agent_key",
+        keyId: randomUUID(),
+        keyScope: {
+          kind: "task_bridge",
+          parentIssueId: issue.id,
+          allowedAssigneeAgentIds: [bridgeOwner.id],
+        },
+      },
+      action: "issue:comment",
+    }, async () => {
+      bridgeCallbackRan = true;
+    })).rejects.toMatchObject({ status: 409 });
+    expect(bridgeCallbackRan).toBe(false);
+
+    const delegatedOwner = await createAgent(db, company.id);
+    const delegatedIssue = await createIssue(db, company.id, {
+      status: "blocked",
+      assigneeAgentId: assignee.id,
+      unblockDescriptor: {
+        owner: { agentId: delegatedOwner.id },
+        action: "Delegated owner action",
+      },
+    });
+    const responsibleUserId = await createUser(db);
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: responsibleUserId,
+      status: "active",
+      membershipRole: "operator",
+    });
+    const delegatedActor = {
+      type: "agent" as const,
+      agentId: delegatedOwner.id,
+      companyId: company.id,
+      onBehalfOfUserId: responsibleUserId,
+      source: "agent_jwt" as const,
+    };
+    await expect(authorizationService(db).decide({
+      actor: delegatedActor,
+      action: "issue:comment",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: delegatedIssue.id,
+        assigneeAgentId: assignee.id,
+        status: "blocked",
+      },
+      scope: { allowIssueUnblockOwner: true },
+    })).resolves.toMatchObject({ allowed: true });
+    await db.update(companyMemberships).set({ status: "inactive" }).where(and(
+      eq(companyMemberships.companyId, company.id),
+      eq(companyMemberships.principalType, "user"),
+      eq(companyMemberships.principalId, responsibleUserId),
+    ));
+    let delegatedCallbackRan = false;
+    await expect(svc.runBlockedUnblockOwnerTransaction({
+      issueId: delegatedIssue.id,
+      expectedUpdatedAt: delegatedIssue.updatedAt,
+      actor: delegatedActor,
+      action: "issue:comment",
+    }, async () => {
+      delegatedCallbackRan = true;
+    })).rejects.toMatchObject({ status: 409 });
+    expect(delegatedCallbackRan).toBe(false);
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1708,7 +1708,7 @@ describeEmbeddedPostgres("authorization service", () => {
       type: "agent",
       agentId: owner.id,
       companyId: company.id,
-      source: "agent_key",
+      source: "agent_jwt",
     } as const;
 
     const runOwnerTransaction = <T>(
@@ -1911,7 +1911,7 @@ describeEmbeddedPostgres("authorization service", () => {
       type: "agent" as const,
       agentId: owner.id,
       companyId: company.id,
-      source: "agent_key" as const,
+      source: "agent_jwt" as const,
     };
     const assignment = {
       projectId: project.id,

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -21,6 +21,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { authorizationService } from "../services/authorization.js";
+import { issueService } from "../services/issues.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -1647,6 +1648,70 @@ describeEmbeddedPostgres("authorization service", () => {
       },
       scope: { allowIssueUnblockOwner: true },
     })).resolves.toMatchObject({ allowed: false });
+  });
+
+  it("atomically rejects stale unblock-owner issue writes and comments", async () => {
+    const company = await createCompany(db, "UnblockOwnerWriteRace");
+    const assignee = await createAgent(db, company.id);
+    const owner = await createAgent(db, company.id);
+    const replacementOwner = await createAgent(db, company.id);
+    const issue = await createIssue(db, company.id, {
+      status: "blocked",
+      assigneeAgentId: assignee.id,
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Perform the unblock action",
+      },
+    });
+    const svc = issueService(db);
+    const writeOptions = { expectedBlockedUnblockOwnerAgentId: owner.id };
+
+    await db.update(issues).set({
+      unblockDescriptor: {
+        owner: { agentId: replacementOwner.id },
+        action: "Replacement owner action",
+      },
+    }).where(eq(issues.id, issue.id));
+
+    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions)).resolves.toBeNull();
+    await expect(svc.addComment(
+      issue.id,
+      "Stale owner comment",
+      { agentId: owner.id },
+      writeOptions,
+    )).rejects.toMatchObject({ status: 409 });
+    await expect(db.select().from(issueComments).where(eq(issueComments.issueId, issue.id)))
+      .resolves.toHaveLength(0);
+
+    await db.update(issues).set({
+      status: "todo",
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Owner action after status change",
+      },
+    }).where(eq(issues.id, issue.id));
+    await expect(svc.addComment(
+      issue.id,
+      "Comment after issue left blocked",
+      { agentId: owner.id },
+      writeOptions,
+    )).rejects.toMatchObject({ status: 409 });
+
+    await db.update(issues).set({
+      status: "blocked",
+      unblockDescriptor: {
+        owner: { agentId: owner.id },
+        action: "Current owner action",
+      },
+    }).where(eq(issues.id, issue.id));
+    await expect(svc.addComment(
+      issue.id,
+      "Current owner comment",
+      { agentId: owner.id },
+      writeOptions,
+    )).resolves.toMatchObject({ body: "Current owner comment" });
+    await expect(svc.update(issue.id, { status: "todo" }, db, writeOptions))
+      .resolves.toMatchObject({ status: "todo" });
   });
 
   it("allows mentioned agents to read and comment on assigned issues without granting issue mutation", async () => {

--- a/server/src/__tests__/heartbeat-scheduling-suppression.test.ts
+++ b/server/src/__tests__/heartbeat-scheduling-suppression.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveHeartbeatSchedulingSuppression,
   resolveSkillTestRunCompletionForHeartbeatOutcome,
+  shouldSuppressCurrentIssueAssigneeWake,
 } from "../services/heartbeat.ts";
 
 describe("heartbeat scheduling suppression", () => {
@@ -55,6 +56,22 @@ describe("heartbeat scheduling suppression", () => {
       suppressed: true,
       reason: "database_restore_in_progress",
     });
+  });
+
+  it("suppresses guarded wakeups after reassignment or terminal status", () => {
+    expect(shouldSuppressCurrentIssueAssigneeWake(null, "agent-1")).toBe(true);
+    expect(shouldSuppressCurrentIssueAssigneeWake({
+      assigneeAgentId: "agent-2",
+      status: "todo",
+    }, "agent-1")).toBe(true);
+    expect(shouldSuppressCurrentIssueAssigneeWake({
+      assigneeAgentId: "agent-1",
+      status: "done",
+    }, "agent-1")).toBe(true);
+    expect(shouldSuppressCurrentIssueAssigneeWake({
+      assigneeAgentId: "agent-1",
+      status: "todo",
+    }, "agent-1")).toBe(false);
   });
 
   it("maps unsuccessful heartbeat outcomes to terminal skill test run outcomes", () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1595,7 +1595,7 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).not.toHaveBeenCalled();
     },
   );
-  it("allows the persisted unblock owner to mutate a blocked issue assigned to another agent", async () => {
+  it("allows the persisted unblock owner to comment and resume a blocked issue assigned to another agent", async () => {
     const blockedIssue = makeIssue({
       status: "blocked",
       assigneeAgentId: ownerAgentId,
@@ -1609,6 +1609,64 @@ describe("agent issue mutation checkout ownership", () => {
       ...blockedIssue,
       ...patch,
     }));
+    mockAgentService.resolveByReference.mockResolvedValue({
+      ambiguous: false,
+      agent: makeAgent(peerAgentId),
+    });
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      const taskAssignment = input.action === "tasks:assign";
+      return {
+        allowed: unblockOwnerMutation || taskAssignment || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : taskAssignment
+            ? "allow_explicit_grant"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "deny_missing_grant",
+        explanation: unblockOwnerMutation
+          ? "Allowed because the actor is the current unblock owner."
+          : input.action === "issue:read"
+            ? "Allowed by same-company visibility."
+            : "Missing permission.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Remediation is complete", resume: true, assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "todo", assigneeAgentId: peerAgentId }),
+    );
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ allowIssueUnblockOwner: true }),
+    }));
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "tasks:assign",
+      resource: expect.objectContaining({ assigneeAgentId: peerAgentId }),
+    }));
+  });
+
+  it("rejects unblock-owner PATCH fields outside the scoped resume flow", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
     mockAccessService.decide.mockImplementation(async (input: {
       action: string;
       scope?: Record<string, unknown>;
@@ -1625,25 +1683,23 @@ describe("agent issue mutation checkout ownership", () => {
             : "deny_missing_grant",
         explanation: unblockOwnerMutation
           ? "Allowed because the actor is the current unblock owner."
-          : input.action === "issue:read"
-            ? "Allowed by same-company visibility."
-            : "Missing permission.",
+          : "Missing permission.",
       };
     });
+    const app = await createApp(peerActor());
 
-    const res = await request(await createApp(peerActor()))
-      .patch(`/api/issues/${issueId}`)
-      .send({ title: "Owner-provided remediation" });
-
-    expect(res.status, JSON.stringify(res.body)).toBe(200);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      issueId,
-      expect.objectContaining({ title: "Owner-provided remediation" }),
-    );
-    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
-      action: "issue:mutate",
-      scope: expect.objectContaining({ allowIssueUnblockOwner: true }),
-    }));
+    for (const body of [
+      { comment: "Done", title: "Unrelated title change" },
+      { comment: "Done", status: "todo" },
+      { comment: "Done", status: "done" },
+      { comment: "Done", status: "cancelled" },
+      { comment: "Done", assigneeAgentId: peerAgentId },
+    ]) {
+      const res = await request(app).patch(`/api/issues/${issueId}`).send(body);
+      expect(res.status, JSON.stringify(res.body)).toBe(403);
+      expect(res.body.error).toBe("Unblock owners may only comment and resume blocked issues");
+    }
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -880,7 +880,7 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       ownerAgentId,
       expect.objectContaining({
-        reason: "issue_comment_mentioned",
+        reason: "issue_commented",
       }),
     );
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1595,6 +1595,56 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).not.toHaveBeenCalled();
     },
   );
+  it("allows the persisted unblock owner to mutate a blocked issue assigned to another agent", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...blockedIssue,
+      ...patch,
+    }));
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      return {
+        allowed: unblockOwnerMutation || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "deny_missing_grant",
+        explanation: unblockOwnerMutation
+          ? "Allowed because the actor is the current unblock owner."
+          : input.action === "issue:read"
+            ? "Allowed by same-company visibility."
+            : "Missing permission.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Owner-provided remediation" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ title: "Owner-provided remediation" }),
+    );
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({ allowIssueUnblockOwner: true }),
+    }));
+  });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -854,15 +854,16 @@ describe("agent issue mutation checkout ownership", () => {
       reason: input.action === "issue:comment" ? "allow_issue_unblock_owner" : "allow_company_agent",
       explanation: "Allowed by the current unblock-owner grant.",
     }));
+    mockIssueService.findMentionedAgents.mockResolvedValue([ownerAgentId]);
 
     const res = await request(await createApp(peerActor()))
       .post(`/api/issues/${issueId}/comments`)
-      .send({ body: "The unblock action is complete." });
+      .send({ body: "The unblock action is complete, @owner." });
 
     expect(res.status, JSON.stringify(res.body)).toBe(201);
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
       issueId,
-      "The unblock action is complete.",
+      "The unblock action is complete, @owner.",
       expect.any(Object),
       expect.any(Object),
       expect.any(Object),
@@ -879,9 +880,12 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       ownerAgentId,
       expect.objectContaining({
-        reason: "issue_commented",
-        currentIssueAssigneeGuard: { issueId },
+        reason: "issue_comment_mentioned",
       }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      ownerAgentId,
+      expect.objectContaining({ currentIssueAssigneeGuard: { issueId } }),
     );
   });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -847,7 +847,6 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.getById
       .mockResolvedValueOnce(blockedIssue)
       .mockResolvedValueOnce(blockedIssue)
-      .mockResolvedValueOnce(blockedIssue)
       .mockResolvedValue(latestIssue);
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:comment" || input.action === "issue:read",
@@ -877,9 +876,12 @@ describe("agent issue mutation checkout ownership", () => {
       expect.any(Function),
     );
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       ownerAgentId,
-      expect.objectContaining({ reason: "issue_commented" }),
+      expect.objectContaining({
+        reason: "issue_commented",
+        currentIssueAssigneeGuard: { issueId },
+      }),
     );
   });
 
@@ -1793,7 +1795,6 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.getById
       .mockResolvedValueOnce(blockedIssue)
       .mockResolvedValueOnce(ownerResult)
-      .mockResolvedValueOnce(ownerResult)
       .mockResolvedValue(latestIssue);
     mockIssueService.update.mockResolvedValue(ownerResult);
     mockAgentService.resolveByReference.mockResolvedValue({
@@ -1824,12 +1825,15 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body).toMatchObject({ status: "todo", assigneeAgentId: latestAssigneeAgentId });
-    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
-      latestAssigneeAgentId,
-      expect.objectContaining({ reason: "issue_assigned" }),
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      peerAgentId,
+      expect.objectContaining({
+        reason: "issue_assigned",
+        currentIssueAssigneeGuard: { issueId },
+      }),
     );
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
-      peerAgentId,
+      latestAssigneeAgentId,
       expect.objectContaining({ reason: "issue_assigned" }),
     );
   });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -832,14 +832,23 @@ describe("agent issue mutation checkout ownership", () => {
   });
 
   it("binds unblock-owner comments to the current blocked owner at insert time", async () => {
-    mockIssueService.getById.mockResolvedValue(makeIssue({
+    const blockedIssue = makeIssue({
       status: "blocked",
       assigneeAgentId: ownerAgentId,
       unblockDescriptor: {
         owner: { agentId: peerAgentId },
         action: "Perform the unblock action",
       },
-    }));
+    });
+    const latestIssue = {
+      ...blockedIssue,
+      assigneeAgentId: "88888888-8888-4888-8888-888888888888",
+    };
+    mockIssueService.getById
+      .mockResolvedValueOnce(blockedIssue)
+      .mockResolvedValueOnce(blockedIssue)
+      .mockResolvedValueOnce(blockedIssue)
+      .mockResolvedValue(latestIssue);
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:comment" || input.action === "issue:read",
       action: input.action,
@@ -866,6 +875,11 @@ describe("agent issue mutation checkout ownership", () => {
         actor: expect.objectContaining({ type: "agent", agentId: peerAgentId }),
       }),
       expect.any(Function),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      ownerAgentId,
+      expect.objectContaining({ reason: "issue_commented" }),
     );
   });
 
@@ -1682,7 +1696,7 @@ describe("agent issue mutation checkout ownership", () => {
     };
     mockIssueService.getById
       .mockResolvedValueOnce(blockedIssue)
-      .mockResolvedValueOnce(updatedIssue);
+      .mockResolvedValue(updatedIssue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...updatedIssue,
       ...patch,
@@ -1754,7 +1768,7 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.body).toMatchObject({ status: "todo", assigneeAgentId: peerAgentId });
   });
 
-  it("uses the latest committed issue for unblock-owner responses and wake dispatch", async () => {
+  it("suppresses a stale owner wake after a post-reread reassignment", async () => {
     const latestAssigneeAgentId = "88888888-8888-4888-8888-888888888888";
     const blockedIssue = makeIssue({
       status: "blocked",
@@ -1778,6 +1792,8 @@ describe("agent issue mutation checkout ownership", () => {
     };
     mockIssueService.getById
       .mockResolvedValueOnce(blockedIssue)
+      .mockResolvedValueOnce(ownerResult)
+      .mockResolvedValueOnce(ownerResult)
       .mockResolvedValue(latestIssue);
     mockIssueService.update.mockResolvedValue(ownerResult);
     mockAgentService.resolveByReference.mockResolvedValue({
@@ -1808,12 +1824,9 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body).toMatchObject({ status: "todo", assigneeAgentId: latestAssigneeAgentId });
-    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       latestAssigneeAgentId,
-      expect.objectContaining({
-        reason: "issue_assigned",
-        payload: expect.objectContaining({ issueId }),
-      }),
+      expect.objectContaining({ reason: "issue_assigned" }),
     );
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       peerAgentId,

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -826,6 +826,61 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("binds unblock-owner comments to the current blocked owner at insert time", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Perform the unblock action",
+      },
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment" || input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_unblock_owner" : "allow_company_agent",
+      explanation: "Allowed by the current unblock-owner grant.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "The unblock action is complete." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "The unblock action is complete.",
+      expect.any(Object),
+      expect.objectContaining({ expectedBlockedUnblockOwnerAgentId: peerAgentId }),
+    );
+  });
+
+  it("keeps unblock-owner resume off the comment endpoint", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Perform the unblock action",
+      },
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:comment" || input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:comment" ? "allow_issue_unblock_owner" : "allow_company_agent",
+      explanation: "Allowed by the current unblock-owner grant.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "The unblock action is complete.", resume: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Unblock owners must use the guarded issue PATCH to resume work");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("keeps visible peer comments agent-class even when authorType tries to smuggle user wake privilege", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:read" || input.action === "issue:comment",
@@ -1646,6 +1701,16 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       issueId,
       expect.objectContaining({ status: "todo", assigneeAgentId: peerAgentId }),
+      expect.any(Object),
+      { expectedBlockedUnblockOwnerAgentId: peerAgentId },
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Remediation is complete",
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
     );
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
       action: "issue:mutate",
@@ -1655,6 +1720,52 @@ describe("agent issue mutation checkout ownership", () => {
       action: "tasks:assign",
       resource: expect.objectContaining({ assigneeAgentId: peerAgentId }),
     }));
+  });
+
+  it("returns conflict when unblock-owner authority changes before the issue write", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockIssueService.update.mockResolvedValue(null);
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      return {
+        allowed: unblockOwnerMutation || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "deny_missing_grant",
+        explanation: unblockOwnerMutation
+          ? "Allowed because the actor is the current unblock owner."
+          : "Missing permission.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Remediation is complete", resume: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.error).toBe("Unblock owner authorization became stale");
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "todo" }),
+      expect.any(Object),
+      { expectedBlockedUnblockOwnerAgentId: peerAgentId },
+    );
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects unblock-owner PATCH fields outside the scoped resume flow", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -31,6 +31,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   remove: vi.fn(),
   removeAttachment: vi.fn(),
+  runBlockedUnblockOwnerTransaction: vi.fn(),
   update: vi.fn(),
   findMentionedAgents: vi.fn(),
 }));
@@ -524,6 +525,10 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueService.remove.mockReset();
     mockIssueService.removeAttachment.mockReset();
+    mockIssueService.runBlockedUnblockOwnerTransaction.mockReset();
+    mockIssueService.runBlockedUnblockOwnerTransaction.mockImplementation(
+      async (_input: unknown, callback: (tx: Record<string, never>) => Promise<unknown>) => callback({}),
+    );
     mockIssueService.update.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
     mockLogActivity.mockClear();
@@ -851,7 +856,16 @@ describe("agent issue mutation checkout ownership", () => {
       issueId,
       "The unblock action is complete.",
       expect.any(Object),
-      expect.objectContaining({ expectedBlockedUnblockOwnerAgentId: peerAgentId }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockIssueService.runBlockedUnblockOwnerTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId,
+        action: "issue:comment",
+        actor: expect.objectContaining({ type: "agent", agentId: peerAgentId }),
+      }),
+      expect.any(Function),
     );
   });
 
@@ -1654,14 +1668,23 @@ describe("agent issue mutation checkout ownership", () => {
     const blockedIssue = makeIssue({
       status: "blocked",
       assigneeAgentId: ownerAgentId,
+      updatedAt: new Date("2026-07-31T08:00:00.000Z"),
       unblockDescriptor: {
         owner: { agentId: peerAgentId },
         action: "Choose the remediation path",
       },
     });
-    mockIssueService.getById.mockResolvedValue(blockedIssue);
-    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+    const updatedIssue = {
       ...blockedIssue,
+      status: "todo",
+      assigneeAgentId: peerAgentId,
+      updatedAt: new Date(blockedIssue.updatedAt.getTime() + 1_000),
+    };
+    mockIssueService.getById
+      .mockResolvedValueOnce(blockedIssue)
+      .mockResolvedValueOnce(updatedIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...updatedIssue,
       ...patch,
     }));
     mockAgentService.resolveByReference.mockResolvedValue({
@@ -1702,7 +1725,6 @@ describe("agent issue mutation checkout ownership", () => {
       issueId,
       expect.objectContaining({ status: "todo", assigneeAgentId: peerAgentId }),
       expect.any(Object),
-      { expectedBlockedUnblockOwnerAgentId: peerAgentId },
     );
     expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
@@ -1720,6 +1742,125 @@ describe("agent issue mutation checkout ownership", () => {
       action: "tasks:assign",
       resource: expect.objectContaining({ assigneeAgentId: peerAgentId }),
     }));
+    expect(mockIssueService.runBlockedUnblockOwnerTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId,
+        expectedUpdatedAt: blockedIssue.updatedAt,
+        action: "issue:mutate",
+        actor: expect.objectContaining({ type: "agent", agentId: peerAgentId }),
+      }),
+      expect.any(Function),
+    );
+    expect(res.body).toMatchObject({ status: "todo", assigneeAgentId: peerAgentId });
+  });
+
+  it("uses the latest committed issue for unblock-owner responses and wake dispatch", async () => {
+    const latestAssigneeAgentId = "88888888-8888-4888-8888-888888888888";
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      updatedAt: new Date("2026-07-31T08:10:00.000Z"),
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    const ownerResult = {
+      ...blockedIssue,
+      status: "todo",
+      assigneeAgentId: peerAgentId,
+      updatedAt: new Date("2026-07-31T08:10:01.000Z"),
+    };
+    const latestIssue = {
+      ...ownerResult,
+      assigneeAgentId: latestAssigneeAgentId,
+      updatedAt: new Date("2026-07-31T08:10:02.000Z"),
+    };
+    mockIssueService.getById
+      .mockResolvedValueOnce(blockedIssue)
+      .mockResolvedValue(latestIssue);
+    mockIssueService.update.mockResolvedValue(ownerResult);
+    mockAgentService.resolveByReference.mockResolvedValue({
+      ambiguous: false,
+      agent: makeAgent(peerAgentId),
+    });
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      return {
+        allowed: unblockOwnerMutation || input.action === "tasks:assign" || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "allow_explicit_grant",
+        explanation: "Allowed by the test fixture.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Remediation is complete", resume: true, assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ status: "todo", assigneeAgentId: latestAssigneeAgentId });
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      latestAssigneeAgentId,
+      expect.objectContaining({
+        reason: "issue_assigned",
+        payload: expect.objectContaining({ issueId }),
+      }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      peerAgentId,
+      expect.objectContaining({ reason: "issue_assigned" }),
+    );
+  });
+
+  it("rejects an unblock owner attempting to resume the issue to another agent", async () => {
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ownerAgentId,
+      unblockDescriptor: {
+        owner: { agentId: peerAgentId },
+        action: "Choose the remediation path",
+      },
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockAgentService.resolveByReference.mockResolvedValue({
+      ambiguous: false,
+      agent: makeAgent(ownerAgentId),
+    });
+    mockAccessService.decide.mockImplementation(async (input: {
+      action: string;
+      scope?: Record<string, unknown>;
+    }) => {
+      const unblockOwnerMutation =
+        input.action === "issue:mutate" && input.scope?.allowIssueUnblockOwner === true;
+      return {
+        allowed: unblockOwnerMutation || input.action === "tasks:assign" || input.action === "issue:read",
+        action: input.action,
+        reason: unblockOwnerMutation
+          ? "allow_issue_unblock_owner"
+          : input.action === "issue:read"
+            ? "allow_company_agent"
+            : "allow_explicit_grant",
+        explanation: "Allowed by the test fixture.",
+      };
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: "Remediation is complete", resume: true, assigneeAgentId: ownerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Unblock owners may only claim resumed work for themselves");
+    expect(mockIssueService.runBlockedUnblockOwnerTransaction).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("returns conflict when unblock-owner authority changes before the issue write", async () => {
@@ -1763,7 +1904,10 @@ describe("agent issue mutation checkout ownership", () => {
       issueId,
       expect.objectContaining({ status: "todo" }),
       expect.any(Object),
-      { expectedBlockedUnblockOwnerAgentId: peerAgentId },
+    );
+    expect(mockIssueService.runBlockedUnblockOwnerTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ issueId, action: "issue:mutate" }),
+      expect.any(Function),
     );
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10286,38 +10286,34 @@ export function issueRoutes(
       };
     }
 
+    const assigneeChanged =
+      issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
+    const statusChangedFromBacklog =
+      existing.status === "backlog" &&
+      issue.status !== "backlog" &&
+      req.body.status !== undefined;
+    const statusChangedFromClosedToTodo =
+      isClosedIssueStatus(existing.status) &&
+      issue.status === "todo" &&
+      req.body.status !== undefined;
+    const userResumedFromReviewToTodo =
+      actor.actorType === "user" &&
+      existing.status === "in_review" &&
+      issue.status === "todo" &&
+      req.body.status !== undefined;
+    const previousExecutionState = parseIssueExecutionState(existing.executionState);
+    const nextExecutionState = parseIssueExecutionState(issue.executionState);
+    const executionStageWakeup = buildExecutionStageWakeup({
+      issueId: issue.id,
+      previousState: previousExecutionState,
+      nextState: nextExecutionState,
+      interruptedRunId,
+      requestedByActorType: actor.actorType,
+      requestedByActorId: actor.actorId,
+    });
+
     // Merge all wakeups from this update into one enqueue per agent to avoid duplicate runs.
-    const committedIssue = issue;
     void (async () => {
-      const issue = isIssueUnblockOwner
-        ? await svc.getById(committedIssue.id)
-        : committedIssue;
-      if (!issue) return;
-      const assigneeChanged =
-        issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
-      const statusChangedFromBacklog =
-        existing.status === "backlog" &&
-        issue.status !== "backlog" &&
-        req.body.status !== undefined;
-      const statusChangedFromClosedToTodo =
-        isClosedIssueStatus(existing.status) &&
-        issue.status === "todo" &&
-        req.body.status !== undefined;
-      const userResumedFromReviewToTodo =
-        actor.actorType === "user" &&
-        existing.status === "in_review" &&
-        issue.status === "todo" &&
-        req.body.status !== undefined;
-      const previousExecutionState = parseIssueExecutionState(existing.executionState);
-      const nextExecutionState = parseIssueExecutionState(issue.executionState);
-      const executionStageWakeup = buildExecutionStageWakeup({
-        issueId: issue.id,
-        previousState: previousExecutionState,
-        nextState: nextExecutionState,
-        interruptedRunId,
-        requestedByActorType: actor.actorType,
-        requestedByActorId: actor.actorId,
-      });
       type WakeupRequest = NonNullable<Parameters<typeof heartbeat.wakeup>[1]>;
       type DependencyReadinessProvider = {
         getDependencyReadiness?: typeof svc.getDependencyReadiness;
@@ -10386,6 +10382,7 @@ export function issueRoutes(
           source: "assignment",
           triggerDetail: "system",
           reason: "issue_assigned",
+          ...(isIssueUnblockOwner ? { currentIssueAssigneeGuard: { issueId: issue.id } } : {}),
           payload: {
             issueId: issue.id,
             ...(comment ? { commentId: comment.id } : {}),
@@ -10425,6 +10422,7 @@ export function issueRoutes(
           source: "automation",
           triggerDetail: "system",
           reason: "issue_status_changed",
+          ...(isIssueUnblockOwner ? { currentIssueAssigneeGuard: { issueId: issue.id } } : {}),
           payload: {
             issueId: issue.id,
             mutation: "update",
@@ -10456,6 +10454,7 @@ export function issueRoutes(
             source: "automation",
             triggerDetail: "system",
             reason: reopened ? "issue_reopened_via_comment" : "issue_commented",
+            ...(isIssueUnblockOwner ? { currentIssueAssigneeGuard: { issueId: issue.id } } : {}),
             payload: {
               issueId: id,
               commentId: comment.id,
@@ -10655,31 +10654,7 @@ export function issueRoutes(
         }
       }
 
-      const assigneeDirectedReasons = new Set([
-        "issue_assigned",
-        "issue_status_changed",
-        "issue_commented",
-        "issue_reopened_via_comment",
-      ]);
       for (const { agentId, wakeup } of wakeups.values()) {
-        if (
-          isIssueUnblockOwner &&
-          typeof wakeup.reason === "string" &&
-          assigneeDirectedReasons.has(wakeup.reason) &&
-          wakeup.payload &&
-          typeof wakeup.payload === "object" &&
-          wakeup.payload.issueId === issue.id
-        ) {
-          const currentIssue = await svc.getById(issue.id);
-          if (
-            !currentIssue ||
-            currentIssue.assigneeAgentId !== agentId ||
-            currentIssue.status === "backlog" ||
-            isClosedIssueStatus(currentIssue.status)
-          ) {
-            continue;
-          }
-        }
         heartbeat
           .wakeup(agentId, wakeup)
           .then((wakeRun) => {
@@ -10723,7 +10698,6 @@ export function issueRoutes(
         res.status(409).json({ error: "Issue access changed after unblock-owner update; reload" });
         return;
       }
-      issue = responseIssue;
       issueResponse = { ...issueResponse, ...responseIssue };
     }
     const changes = issueResponse.changes ?? {};
@@ -12438,12 +12412,7 @@ export function issueRoutes(
     });
 
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
-    const committedCommentIssue = currentIssue;
     void (async () => {
-      const currentIssue = isIssueUnblockOwnerComment
-        ? await svc.getById(committedCommentIssue.id)
-        : committedCommentIssue;
-      if (!currentIssue) return;
       type WakeupRequest = NonNullable<Parameters<typeof heartbeat.wakeup>[1]>;
       const wakeups = new Map<string, { agentId: string; wakeup: WakeupRequest }>();
       const addWakeup = (agentId: string, wakeup: WakeupRequest) => {
@@ -12532,6 +12501,9 @@ export function issueRoutes(
             source: "automation",
             triggerDetail: "system",
             reason: "issue_reopened_via_comment",
+            ...(isIssueUnblockOwnerComment
+              ? { currentIssueAssigneeGuard: { issueId: currentIssue.id } }
+              : {}),
             payload: {
               issueId: currentIssue.id,
               commentId: comment.id,
@@ -12559,6 +12531,9 @@ export function issueRoutes(
             source: "automation",
             triggerDetail: "system",
             reason: "issue_commented",
+            ...(isIssueUnblockOwnerComment
+              ? { currentIssueAssigneeGuard: { issueId: currentIssue.id } }
+              : {}),
             payload: {
               issueId: currentIssue.id,
               commentId: comment.id,
@@ -12598,7 +12573,7 @@ export function issueRoutes(
 
       let mentionedIds: string[] = [];
       try {
-        mentionedIds = await svc.findMentionedAgents(currentIssue.companyId, req.body.body);
+        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
       } catch (err) {
         logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
       }
@@ -12682,25 +12657,7 @@ export function issueRoutes(
         }
       }
 
-      const assigneeDirectedReasons = new Set(["issue_commented", "issue_reopened_via_comment"]);
       for (const { agentId, wakeup } of wakeups.values()) {
-        if (
-          isIssueUnblockOwnerComment &&
-          typeof wakeup.reason === "string" &&
-          assigneeDirectedReasons.has(wakeup.reason) &&
-          wakeup.payload &&
-          typeof wakeup.payload === "object" &&
-          wakeup.payload.issueId === currentIssue.id
-        ) {
-          const latestIssue = await svc.getById(currentIssue.id);
-          if (
-            !latestIssue ||
-            latestIssue.assigneeAgentId !== agentId ||
-            isClosedIssueStatus(latestIssue.status)
-          ) {
-            continue;
-          }
-        }
         heartbeat
           .wakeup(agentId, wakeup)
           .then((wakeRun) => {
@@ -12739,7 +12696,6 @@ export function issueRoutes(
         res.status(409).json({ error: "Issue changed after unblock-owner comment; reload" });
         return;
       }
-      currentIssue = responseIssue;
     }
     res.status(201).json(comment);
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3979,6 +3979,7 @@ export function issueRoutes(
 
   function isDefaultOpenIssueWriteDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {
     return decision !== true && decision.reason === "allow_visible_issue_write";
+  }
 
   function isIssueUnblockOwnerDecision(decision: Awaited<ReturnType<typeof decideIssueAccess>>) {
     return decision.reason === "allow_issue_unblock_owner";
@@ -4095,6 +4096,14 @@ export function issueRoutes(
       return denyIssueWrite(req, res, issue, issueWriteDenialCodeForDecision(boundaryDecision));
     }
     if (options.allowIssueUnblockOwner && isIssueUnblockOwnerDecision(boundaryDecision)) {
+      if (
+        "assigneeAgentId" in req.body &&
+        req.body.assigneeAgentId !== undefined &&
+        req.body.assigneeAgentId !== actorAgentId
+      ) {
+        res.status(403).json({ error: "Unblock owners may only claim resumed work for themselves" });
+        return false;
+      }
       if (!isScopedIssueUnblockOwnerPatch(req.body)) {
         res.status(403).json({
           error: "Unblock owners may only comment and resume blocked issues",
@@ -9084,17 +9093,10 @@ export function issueRoutes(
     const issueMutationAuthorizationReason = req.actor.type === "agent"
       ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate", { allowIssueUnblockOwner: true }))
       : issueWriteAuthorizationReason(req, true);
-    const ownerWritePrecondition = isIssueUnblockOwner && req.actor.type === "agent" && req.actor.agentId
-      ? { expectedBlockedUnblockOwnerAgentId: req.actor.agentId }
-      : undefined;
     const persistIssueUpdate = (
       data: Parameters<typeof svc.update>[1],
       tx?: Parameters<typeof svc.update>[2],
-    ) => ownerWritePrecondition
-      ? svc.update(id, data, tx, undefined, ownerWritePrecondition)
-      : tx
-        ? svc.update(id, data, tx)
-        : svc.update(id, data);
+    ) => tx ? svc.update(id, data, tx) : svc.update(id, data);
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -9634,7 +9636,7 @@ export function issueRoutes(
     }
     let issue: Awaited<ReturnType<typeof svc.update>>;
     let atomicOwnerComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
-    const ownerCommentSourceTrust = ownerWritePrecondition && commentBody
+    const ownerCommentSourceTrust = isIssueUnblockOwner && commentBody
       ? await sourceTrustForActorWrite(existing, actor)
       : null;
     // Clear the reopen-pending flag if this update leaves the issue terminal, so
@@ -9656,8 +9658,13 @@ export function issueRoutes(
       || persistReviewActivityTransactionally
       || reviewPolicySensitiveMutationRequested;
     try {
-      if (ownerWritePrecondition) {
-        issue = await db.transaction(async (tx) => {
+      if (isIssueUnblockOwner) {
+        issue = await svc.runBlockedUnblockOwnerTransaction({
+          issueId: id,
+          expectedUpdatedAt: existing.updatedAt,
+          actor: req.actor,
+          action: "issue:mutate",
+        }, async (tx) => {
           const updated = await persistIssueUpdate({
             ...updateFields,
             actorAgentId: actor.agentId ?? null,
@@ -9753,7 +9760,7 @@ export function issueRoutes(
       throw err;
     }
     if (!issue) {
-      if (ownerWritePrecondition) {
+      if (isIssueUnblockOwner) {
         res.status(409).json({ error: "Unblock owner authorization became stale" });
         return;
       }
@@ -9761,6 +9768,15 @@ export function issueRoutes(
       return;
     }
     for (const publication of postCommitActivityPublications) publishActivity(publication);
+
+    if (isIssueUnblockOwner) {
+      const latestIssue = await svc.getById(id);
+      if (!latestIssue) {
+        res.status(409).json({ error: "Issue changed after unblock-owner recovery" });
+        return;
+      }
+      issue = { ...issue, ...latestIssue };
+    }
 
     if (enteringBlocked) {
       const blockedIssue = issue;
@@ -11889,13 +11905,12 @@ export function issueRoutes(
     const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, issue);
     if (!commentAccessDecision) return;
     const commentAuthorizationReason = issueWriteAuthorizationReason(req, commentAccessDecision);
-    const commentOwnerWritePrecondition =
+    const isIssueUnblockOwnerComment = Boolean(
       commentAccessDecision !== true &&
       isIssueUnblockOwnerDecision(commentAccessDecision) &&
       req.actor.type === "agent" &&
-      req.actor.agentId
-        ? req.actor.agentId
-        : undefined;
+      req.actor.agentId,
+    );
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,
@@ -11908,7 +11923,7 @@ export function issueRoutes(
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;
-    if (commentOwnerWritePrecondition && (reopenRequested || resumeRequested || interruptRequested)) {
+    if (isIssueUnblockOwnerComment && (reopenRequested || resumeRequested || interruptRequested)) {
       res.status(403).json({ error: "Unblock owners must use the guarded issue PATCH to resume work" });
       return;
     }
@@ -12250,19 +12265,35 @@ export function issueRoutes(
         requestedByActorId: actor.actorId,
       });
     } else {
-      comment = await svc.addComment(id, req.body.body, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-        onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
-      }, {
+      const commentOptions = {
         authorType: req.body.authorType ?? (actor.actorType === "agent" ? "agent" : "user"),
         presentation: commentPresentation,
         metadata: req.body.metadata ?? null,
         authorizationReason: commentAuthorizationReason,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
-        expectedBlockedUnblockOwnerAgentId: commentOwnerWritePrecondition,
-      });
+      };
+      const commentActor = {
+        agentId: actor.agentId ?? undefined,
+        userId: actor.actorType === "user" ? actor.actorId : undefined,
+        runId: actor.runId,
+        onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
+      };
+      const addComment = (tx?: Parameters<typeof svc.addComment>[4]) => tx
+        ? svc.addComment(id, req.body.body, commentActor, commentOptions, tx)
+        : svc.addComment(id, req.body.body, commentActor, commentOptions);
+      comment = isIssueUnblockOwnerComment
+        ? await svc.runBlockedUnblockOwnerTransaction({
+            issueId: id,
+            expectedUpdatedAt: issue.updatedAt,
+            actor: req.actor,
+            action: "issue:comment",
+          }, addComment)
+        : await addComment();
+      if (isIssueUnblockOwnerComment) {
+        const latestIssue = await svc.getById(id);
+        if (!latestIssue) throw conflict("Issue changed after unblock-owner comment");
+        currentIssue = latestIssue;
+      }
     }
 
     await issueReferencesSvc.syncComment(comment.id);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12411,6 +12411,13 @@ export function issueRoutes(
       blockedToTodoRecovery: reopened && reopenFromStatus === "blocked" && currentIssue.status === "todo",
     });
 
+    let mentionedIds: string[] = [];
+    try {
+      mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
+    } catch (err) {
+      logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
+    }
+
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
     void (async () => {
       type WakeupRequest = NonNullable<Parameters<typeof heartbeat.wakeup>[1]>;
@@ -12424,12 +12431,6 @@ export function issueRoutes(
         if (wakeups.has(key)) return;
         wakeups.set(key, { agentId, wakeup });
       };
-      let mentionedIds: string[] = [];
-      try {
-        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
-      } catch (err) {
-        logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
-      }
       const addDependencyResolvedWakeup = async (input: {
         agentId: string;
         dependentIssueId: string;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12316,11 +12316,10 @@ export function issueRoutes(
             action: "issue:comment",
           }, addComment)
         : await addComment();
-      if (isIssueUnblockOwnerComment) {
-        const latestIssue = await svc.getById(id);
-        if (!latestIssue) throw conflict("Issue changed after unblock-owner comment");
-        currentIssue = latestIssue;
-      }
+      // The unblock-owner transaction verified the in-hand snapshot is still
+      // current at insert time; do not re-read afterwards, or a concurrent
+      // mutation in that window would retarget the owner's wake away from the
+      // insert-time assignee.
     }
 
     await issueReferencesSvc.syncComment(comment.id);
@@ -12488,13 +12487,17 @@ export function issueRoutes(
       // the wrong (or no-longer-relevant) agent off stale state. The comment
       // is already committed, so a failed re-fetch is logged and falls back to
       // the in-hand snapshot rather than aborting this best-effort wake block.
-      const wakeIssueSnapshot = (await svc.getById(currentIssue.id).catch((err) => {
-        logger.warn(
-          { err, issueId: currentIssue.id },
-          "failed to re-fetch issue for comment wake decision; falling back to in-hand snapshot",
-        );
-        return null;
-      })) ?? currentIssue;
+      // Unblock-owner comments already carry a transaction-verified snapshot;
+      // re-reading here would let a concurrent mutation retarget the wake.
+      const wakeIssueSnapshot = isIssueUnblockOwnerComment
+        ? currentIssue
+        : (await svc.getById(currentIssue.id).catch((err) => {
+            logger.warn(
+              { err, issueId: currentIssue.id },
+              "failed to re-fetch issue for comment wake decision; falling back to in-hand snapshot",
+            );
+            return null;
+          })) ?? currentIssue;
       const assigneeId = wakeIssueSnapshot.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12421,18 +12421,15 @@ export function issueRoutes(
             ? wakeup.payload.issueId
             : currentIssue.id;
         const key = `${agentId}:${wakeIssueId}`;
-        const existing = wakeups.get(key);
-        if (
-          existing &&
-          !(
-            wakeup.reason === "issue_comment_mentioned" &&
-            Boolean(existing.wakeup.currentIssueAssigneeGuard)
-          )
-        ) {
-          return;
-        }
+        if (wakeups.has(key)) return;
         wakeups.set(key, { agentId, wakeup });
       };
+      let mentionedIds: string[] = [];
+      try {
+        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
+      } catch (err) {
+        logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
+      }
       const addDependencyResolvedWakeup = async (input: {
         agentId: string;
         dependentIssueId: string;
@@ -12540,7 +12537,7 @@ export function issueRoutes(
             source: "automation",
             triggerDetail: "system",
             reason: "issue_commented",
-            ...(isIssueUnblockOwnerComment
+            ...(isIssueUnblockOwnerComment && !mentionedIds.includes(assigneeId)
               ? { currentIssueAssigneeGuard: { issueId: currentIssue.id } }
               : {}),
             payload: {
@@ -12578,13 +12575,6 @@ export function issueRoutes(
             },
           });
         }
-      }
-
-      let mentionedIds: string[] = [];
-      try {
-        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
-      } catch (err) {
-        logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
       }
 
       for (const mentionedId of mentionedIds) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12421,7 +12421,16 @@ export function issueRoutes(
             ? wakeup.payload.issueId
             : currentIssue.id;
         const key = `${agentId}:${wakeIssueId}`;
-        if (wakeups.has(key)) return;
+        const existing = wakeups.get(key);
+        if (
+          existing &&
+          !(
+            wakeup.reason === "issue_comment_mentioned" &&
+            Boolean(existing.wakeup.currentIssueAssigneeGuard)
+          )
+        ) {
+          return;
+        }
         wakeups.set(key, { agentId, wakeup });
       };
       const addDependencyResolvedWakeup = async (input: {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3984,6 +3984,26 @@ export function issueRoutes(
     return decision.reason === "allow_issue_unblock_owner";
   }
 
+  function isScopedIssueUnblockOwnerPatch(value: unknown) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const patch = value as Record<string, unknown>;
+    const allowedKeys = new Set(["comment", "resume", "assigneeAgentId"]);
+    if (Object.keys(patch).some((key) => !allowedKeys.has(key))) return false;
+
+    const comment = typeof patch.comment === "string" ? patch.comment.trim() : "";
+    if (!comment) return false;
+    if ("resume" in patch && patch.resume !== true) return false;
+
+    const requestsRedispatch = patch.resume === true;
+    if (
+      "assigneeAgentId" in patch &&
+      (typeof patch.assigneeAgentId !== "string" || !patch.assigneeAgentId || !requestsRedispatch)
+    ) {
+      return false;
+    }
+    return true;
+  }
+
   async function filterIssuesForActor<T extends Parameters<typeof decideIssueAccess>[1]>(req: Request, rows: T[]) {
     const decisions = await Promise.all(rows.map((issue) => decideIssueAccess(req, issue, "issue:read")));
     return rows.filter((_, index) => decisions[index]?.allowed);
@@ -4075,7 +4095,17 @@ export function issueRoutes(
       return denyIssueWrite(req, res, issue, issueWriteDenialCodeForDecision(boundaryDecision));
     }
     if (options.allowIssueUnblockOwner && isIssueUnblockOwnerDecision(boundaryDecision)) {
-      return true;
+      if (!isScopedIssueUnblockOwnerPatch(req.body)) {
+        res.status(403).json({
+          error: "Unblock owners may only comment and resume blocked issues",
+          details: {
+            issueId: issue.id,
+            securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+          },
+        });
+        return false;
+      }
+      return "issue_unblock_owner" as const;
     }
     if (issue.assigneeAgentId === null) {
       return true;
@@ -5050,7 +5080,7 @@ export function issueRoutes(
     req: Request,
     res: Response,
     issue: Parameters<typeof decideIssueAccess>[1],
-    options: { resumeIntent?: boolean } = {},
+    options: { resumeIntent?: boolean; allowIssueUnblockOwner?: boolean } = {},
   ) {
     if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
 
@@ -5111,6 +5141,7 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
+    if (options.allowIssueUnblockOwner) return true;
     if (!issue.assigneeAgentId) {
       res.status(409).json({
         error: "Issue follow-up requires an assigned agent",
@@ -9049,6 +9080,7 @@ export function issueRoutes(
       { allowVisibleIssueWrite: true, allowIssueUnblockOwner: true },
     );
     if (!issueMutationAccess) return;
+    const isIssueUnblockOwner = issueMutationAccess === "issue_unblock_owner";
     const issueMutationAuthorizationReason = req.actor.type === "agent"
       ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate", { allowIssueUnblockOwner: true }))
       : issueWriteAuthorizationReason(req, true);
@@ -9115,7 +9147,7 @@ export function issueRoutes(
     }
     if (
       resumeRequested === true &&
-      !(await assertExplicitResumeIntentAllowed(req, res, existing, { resumeIntent: true }))
+      !(await assertExplicitResumeIntentAllowed(req, res, existing, { resumeIntent: true, allowIssueUnblockOwner: isIssueUnblockOwner }))
     ) return;
     const agentStatusTransitionRequiresResumeAuthority =
       req.actor.type === "agent" &&

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9084,6 +9084,17 @@ export function issueRoutes(
     const issueMutationAuthorizationReason = req.actor.type === "agent"
       ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate", { allowIssueUnblockOwner: true }))
       : issueWriteAuthorizationReason(req, true);
+    const ownerWritePrecondition = isIssueUnblockOwner && req.actor.type === "agent" && req.actor.agentId
+      ? { expectedBlockedUnblockOwnerAgentId: req.actor.agentId }
+      : undefined;
+    const persistIssueUpdate = (
+      data: Parameters<typeof svc.update>[1],
+      tx?: Parameters<typeof svc.update>[2],
+    ) => ownerWritePrecondition
+      ? svc.update(id, data, tx, undefined, ownerWritePrecondition)
+      : tx
+        ? svc.update(id, data, tx)
+        : svc.update(id, data);
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -9622,6 +9633,10 @@ export function issueRoutes(
       }
     }
     let issue: Awaited<ReturnType<typeof svc.update>>;
+    let atomicOwnerComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
+    const ownerCommentSourceTrust = ownerWritePrecondition && commentBody
+      ? await sourceTrustForActorWrite(existing, actor)
+      : null;
     // Clear the reopen-pending flag if this update leaves the issue terminal, so
     // the rebuilt worktree does not leak. The guard reads `issue` when the
     // response ends, so it also covers a null return and a thrown error. It clears
@@ -9641,7 +9656,45 @@ export function issueRoutes(
       || persistReviewActivityTransactionally
       || reviewPolicySensitiveMutationRequested;
     try {
-      if (shouldUseTransactionalIssueUpdate) {
+      if (ownerWritePrecondition) {
+        issue = await db.transaction(async (tx) => {
+          const updated = await persistIssueUpdate({
+            ...updateFields,
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+          }, tx);
+          if (!updated) return null;
+
+          if (transition.decision && decisionId) {
+            await tx.insert(issueExecutionDecisions).values({
+              id: decisionId,
+              companyId: updated.companyId,
+              issueId: updated.id,
+              stageId: transition.decision.stageId,
+              stageType: transition.decision.stageType,
+              actorAgentId: actor.agentId ?? null,
+              actorUserId: actor.actorType === "user" ? actor.actorId : null,
+              outcome: transition.decision.outcome,
+              body: transition.decision.body,
+              createdByRunId: actor.runId ?? null,
+            });
+          }
+          if (shouldRelayStop) {
+            stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
+          }
+          if (!commentBody) throw new Error("Unblock-owner PATCH is missing its required result comment");
+          atomicOwnerComment = await svc.addComment(id, commentBody, {
+            agentId: actor.agentId ?? undefined,
+            userId: actor.actorType === "user" ? actor.actorId : undefined,
+            runId: actor.runId,
+            onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
+          }, {
+            authorizationReason: issueMutationAuthorizationReason,
+            sourceTrust: ownerCommentSourceTrust,
+          }, tx);
+          return updated;
+        });
+      } else if (shouldUseTransactionalIssueUpdate) {
         issue = await db.transaction(async (tx) => {
           if (
             reviewPolicySensitiveMutationRequested
@@ -9700,6 +9753,10 @@ export function issueRoutes(
       throw err;
     }
     if (!issue) {
+      if (ownerWritePrecondition) {
+        res.status(409).json({ error: "Unblock owner authorization became stale" });
+        return;
+      }
       res.status(404).json({ error: "Issue not found" });
       return;
     }
@@ -10099,20 +10156,22 @@ export function issueRoutes(
       }
     }
 
-    let comment = null;
+    let comment = atomicOwnerComment;
     let lostReviewPathRef: string | null = null;
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-        onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
-      }, {
-        authorizationReason: issueMutationAuthorizationReason,
-        sourceTrust: await sourceTrustForActorWrite(issue, actor),
-      });
+      if (!comment) {
+        comment = await svc.addComment(id, commentBody, {
+          agentId: actor.agentId ?? undefined,
+          userId: actor.actorType === "user" ? actor.actorId : undefined,
+          runId: actor.runId,
+          onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
+        }, {
+          authorizationReason: issueMutationAuthorizationReason,
+          sourceTrust: await sourceTrustForActorWrite(issue, actor),
+        });
+      }
       await issueReferencesSvc.syncComment(comment.id);
       await externalObjectsSvc.syncCommentSafely(comment.id);
       const commentReferenceSummaryAfter = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
@@ -11830,6 +11889,13 @@ export function issueRoutes(
     const commentAccessDecision = await assertAgentIssueCommentAllowed(req, res, issue);
     if (!commentAccessDecision) return;
     const commentAuthorizationReason = issueWriteAuthorizationReason(req, commentAccessDecision);
+    const commentOwnerWritePrecondition =
+      commentAccessDecision !== true &&
+      isIssueUnblockOwnerDecision(commentAccessDecision) &&
+      req.actor.type === "agent" &&
+      req.actor.agentId
+        ? req.actor.agentId
+        : undefined;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,
@@ -11842,6 +11908,10 @@ export function issueRoutes(
     const reopenRequested = req.body.reopen === true;
     const resumeRequested = req.body.resume === true;
     const interruptRequested = req.body.interrupt === true;
+    if (commentOwnerWritePrecondition && (reopenRequested || resumeRequested || interruptRequested)) {
+      res.status(403).json({ error: "Unblock owners must use the guarded issue PATCH to resume work" });
+      return;
+    }
     const isClosed = isClosedIssueStatus(issue.status);
     const isBlocked = issue.status === "blocked";
     const crossIssueCommentOnlyGrant =
@@ -12191,6 +12261,7 @@ export function issueRoutes(
         metadata: req.body.metadata ?? null,
         authorizationReason: commentAuthorizationReason,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
+        expectedBlockedUnblockOwnerAgentId: commentOwnerWritePrecondition,
       });
     }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9491,9 +9491,10 @@ export function issueRoutes(
       !!existing.createdByUserId &&
       nextAssigneeUserId === existing.createdByUserId;
 
+    let assignmentScope: TaskAssignmentAuthorizationScope | null = null;
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
       if (!isAgentReturningIssueToCreator) {
-        await assertCanAssignTasks(req, existing.companyId, {
+        assignmentScope = {
           issueId: existing.id,
           projectId: await resolveAssignmentProjectId({
             companyId: existing.companyId,
@@ -9509,7 +9510,8 @@ export function issueRoutes(
             : updateFields.parentId) as string | null | undefined,
           assigneeAgentId: nextAssigneeAgentId,
           assigneeUserId: nextAssigneeUserId,
-        });
+        };
+        await assertCanAssignTasks(req, existing.companyId, assignmentScope);
       }
     }
 
@@ -9664,6 +9666,14 @@ export function issueRoutes(
           expectedUpdatedAt: existing.updatedAt,
           actor: req.actor,
           action: "issue:mutate",
+          ...(assignmentScope ? {
+            assignment: {
+              projectId: assignmentScope.projectId ?? null,
+              parentIssueId: assignmentScope.parentIssueId ?? null,
+              assigneeAgentId: assignmentScope.assigneeAgentId ?? null,
+              assigneeUserId: assignmentScope.assigneeUserId ?? null,
+            },
+          } : {}),
         }, async (tx) => {
           const updated = await persistIssueUpdate({
             ...updateFields,
@@ -9973,12 +9983,13 @@ export function issueRoutes(
     });
 
     if (existing.status === "in_progress" && issue.status !== existing.status && issue.status !== "in_progress") {
-      await listSuccessfulRunHandoffStates(db, issue.companyId, [issue.id], { hydrateLiveness: false })
+      const resolvedIssue = issue;
+      await listSuccessfulRunHandoffStates(db, resolvedIssue.companyId, [resolvedIssue.id], { hydrateLiveness: false })
         .then(async (handoffStates) => {
-          const handoff = handoffStates.get(issue.id);
+          const handoff = handoffStates.get(resolvedIssue.id);
           if (handoff?.state !== "required") return;
           await logActivity(db, {
-            companyId: issue.companyId,
+            companyId: resolvedIssue.companyId,
             actorType: actor.actorType,
             actorId: actor.actorId,
             agentId: actor.agentId,
@@ -9986,17 +9997,17 @@ export function issueRoutes(
             agentApiKeyId: actor.agentApiKeyId,
             action: "issue.successful_run_handoff_resolved",
             entityType: "issue",
-            entityId: issue.id,
+            entityId: resolvedIssue.id,
             details: {
-              identifier: issue.identifier,
+              identifier: resolvedIssue.identifier,
               sourceRunId: handoff.sourceRunId,
               correctiveRunId: handoff.correctiveRunId,
-              resolvedByStatus: issue.status,
+              resolvedByStatus: resolvedIssue.status,
             },
           });
         })
         .catch((err) => {
-          logger.warn({ err, issueId: issue.id }, "failed to log successful run handoff resolution");
+          logger.warn({ err, issueId: resolvedIssue.id }, "failed to log successful run handoff resolution");
         });
     }
 
@@ -10275,34 +10286,38 @@ export function issueRoutes(
       };
     }
 
-    const assigneeChanged =
-      issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
-    const statusChangedFromBacklog =
-      existing.status === "backlog" &&
-      issue.status !== "backlog" &&
-      req.body.status !== undefined;
-    const statusChangedFromClosedToTodo =
-      isClosedIssueStatus(existing.status) &&
-      issue.status === "todo" &&
-      req.body.status !== undefined;
-    const userResumedFromReviewToTodo =
-      actor.actorType === "user" &&
-      existing.status === "in_review" &&
-      issue.status === "todo" &&
-      req.body.status !== undefined;
-    const previousExecutionState = parseIssueExecutionState(existing.executionState);
-    const nextExecutionState = parseIssueExecutionState(issue.executionState);
-    const executionStageWakeup = buildExecutionStageWakeup({
-      issueId: issue.id,
-      previousState: previousExecutionState,
-      nextState: nextExecutionState,
-      interruptedRunId,
-      requestedByActorType: actor.actorType,
-      requestedByActorId: actor.actorId,
-    });
-
     // Merge all wakeups from this update into one enqueue per agent to avoid duplicate runs.
+    const committedIssue = issue;
     void (async () => {
+      const issue = isIssueUnblockOwner
+        ? await svc.getById(committedIssue.id)
+        : committedIssue;
+      if (!issue) return;
+      const assigneeChanged =
+        issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
+      const statusChangedFromBacklog =
+        existing.status === "backlog" &&
+        issue.status !== "backlog" &&
+        req.body.status !== undefined;
+      const statusChangedFromClosedToTodo =
+        isClosedIssueStatus(existing.status) &&
+        issue.status === "todo" &&
+        req.body.status !== undefined;
+      const userResumedFromReviewToTodo =
+        actor.actorType === "user" &&
+        existing.status === "in_review" &&
+        issue.status === "todo" &&
+        req.body.status !== undefined;
+      const previousExecutionState = parseIssueExecutionState(existing.executionState);
+      const nextExecutionState = parseIssueExecutionState(issue.executionState);
+      const executionStageWakeup = buildExecutionStageWakeup({
+        issueId: issue.id,
+        previousState: previousExecutionState,
+        nextState: nextExecutionState,
+        interruptedRunId,
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
       type WakeupRequest = NonNullable<Parameters<typeof heartbeat.wakeup>[1]>;
       type DependencyReadinessProvider = {
         getDependencyReadiness?: typeof svc.getDependencyReadiness;
@@ -10640,7 +10655,31 @@ export function issueRoutes(
         }
       }
 
+      const assigneeDirectedReasons = new Set([
+        "issue_assigned",
+        "issue_status_changed",
+        "issue_commented",
+        "issue_reopened_via_comment",
+      ]);
       for (const { agentId, wakeup } of wakeups.values()) {
+        if (
+          isIssueUnblockOwner &&
+          typeof wakeup.reason === "string" &&
+          assigneeDirectedReasons.has(wakeup.reason) &&
+          wakeup.payload &&
+          typeof wakeup.payload === "object" &&
+          wakeup.payload.issueId === issue.id
+        ) {
+          const currentIssue = await svc.getById(issue.id);
+          if (
+            !currentIssue ||
+            currentIssue.assigneeAgentId !== agentId ||
+            currentIssue.status === "backlog" ||
+            isClosedIssueStatus(currentIssue.status)
+          ) {
+            continue;
+          }
+        }
         heartbeat
           .wakeup(agentId, wakeup)
           .then((wakeRun) => {
@@ -10673,6 +10712,20 @@ export function issueRoutes(
     })();
 
     await queueTaskWatchdogEvaluation(issue, actor.runId);
+    if (isIssueUnblockOwner) {
+      const responseIssue = await svc.getById(issue.id);
+      if (!responseIssue) {
+        res.status(409).json({ error: "Issue changed after unblock-owner update; reload and retry" });
+        return;
+      }
+      const responseAccess = await decideIssueAccess(req, responseIssue, "issue:read");
+      if (!responseAccess.allowed) {
+        res.status(409).json({ error: "Issue access changed after unblock-owner update; reload" });
+        return;
+      }
+      issue = responseIssue;
+      issueResponse = { ...issueResponse, ...responseIssue };
+    }
     const changes = issueResponse.changes ?? {};
     if (prefersMinimalIssueUpdateResponse(req)) {
       res.setHeader("Preference-Applied", "return=minimal");
@@ -12385,7 +12438,12 @@ export function issueRoutes(
     });
 
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
+    const committedCommentIssue = currentIssue;
     void (async () => {
+      const currentIssue = isIssueUnblockOwnerComment
+        ? await svc.getById(committedCommentIssue.id)
+        : committedCommentIssue;
+      if (!currentIssue) return;
       type WakeupRequest = NonNullable<Parameters<typeof heartbeat.wakeup>[1]>;
       const wakeups = new Map<string, { agentId: string; wakeup: WakeupRequest }>();
       const addWakeup = (agentId: string, wakeup: WakeupRequest) => {
@@ -12540,7 +12598,7 @@ export function issueRoutes(
 
       let mentionedIds: string[] = [];
       try {
-        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
+        mentionedIds = await svc.findMentionedAgents(currentIssue.companyId, req.body.body);
       } catch (err) {
         logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
       }
@@ -12624,7 +12682,25 @@ export function issueRoutes(
         }
       }
 
+      const assigneeDirectedReasons = new Set(["issue_commented", "issue_reopened_via_comment"]);
       for (const { agentId, wakeup } of wakeups.values()) {
+        if (
+          isIssueUnblockOwnerComment &&
+          typeof wakeup.reason === "string" &&
+          assigneeDirectedReasons.has(wakeup.reason) &&
+          wakeup.payload &&
+          typeof wakeup.payload === "object" &&
+          wakeup.payload.issueId === currentIssue.id
+        ) {
+          const latestIssue = await svc.getById(currentIssue.id);
+          if (
+            !latestIssue ||
+            latestIssue.assigneeAgentId !== agentId ||
+            isClosedIssueStatus(latestIssue.status)
+          ) {
+            continue;
+          }
+        }
         heartbeat
           .wakeup(agentId, wakeup)
           .then((wakeRun) => {
@@ -12657,6 +12733,14 @@ export function issueRoutes(
     })();
 
     await queueTaskWatchdogEvaluation(currentIssue, actor.runId);
+    if (isIssueUnblockOwnerComment) {
+      const responseIssue = await svc.getById(currentIssue.id);
+      if (!responseIssue) {
+        res.status(409).json({ error: "Issue changed after unblock-owner comment; reload" });
+        return;
+      }
+      currentIssue = responseIssue;
+    }
     res.status(201).json(comment);
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3809,6 +3809,7 @@ export function issueRoutes(
       status: string;
     },
     action: "issue:comment" | "issue:read" | "issue:mutate",
+    additionalScope: Record<string, unknown> = {},
   ) {
     return access.decide({
       actor: req.actor,
@@ -3829,6 +3830,7 @@ export function issueRoutes(
         parentIssueId: issue.parentId,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
+        ...additionalScope,
       },
     });
   }
@@ -3977,6 +3979,9 @@ export function issueRoutes(
 
   function isDefaultOpenIssueWriteDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {
     return decision !== true && decision.reason === "allow_visible_issue_write";
+
+  function isIssueUnblockOwnerDecision(decision: Awaited<ReturnType<typeof decideIssueAccess>>) {
+    return decision.reason === "allow_issue_unblock_owner";
   }
 
   async function filterIssuesForActor<T extends Parameters<typeof decideIssueAccess>[1]>(req: Request, rows: T[]) {
@@ -4029,7 +4034,7 @@ export function issueRoutes(
       /** Used only to name the task in denial copy (plan §6). */
       identifier?: string | null;
     },
-    options: { allowVisibleIssueWrite?: boolean } = {},
+    options: { allowVisibleIssueWrite?: boolean; allowIssueUnblockOwner?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -4060,9 +4065,17 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
-    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
+    const boundaryDecision = await decideIssueAccess(
+      req,
+      issue,
+      "issue:mutate",
+      options.allowIssueUnblockOwner ? { allowIssueUnblockOwner: true } : {},
+    );
     if (!boundaryDecision.allowed) {
       return denyIssueWrite(req, res, issue, issueWriteDenialCodeForDecision(boundaryDecision));
+    }
+    if (options.allowIssueUnblockOwner && isIssueUnblockOwnerDecision(boundaryDecision)) {
+      return true;
     }
     if (issue.assigneeAgentId === null) {
       return true;
@@ -9033,11 +9046,11 @@ export function issueRoutes(
       req,
       res,
       existing,
-      { allowVisibleIssueWrite: true },
+      { allowVisibleIssueWrite: true, allowIssueUnblockOwner: true },
     );
     if (!issueMutationAccess) return;
     const issueMutationAuthorizationReason = req.actor.type === "agent"
-      ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate"))
+      ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate", { allowIssueUnblockOwner: true }))
       : issueWriteAuthorizationReason(req, true);
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2380,8 +2380,11 @@ export function authorizationService(db: Db) {
       grant: userDecision.grant,
     });
 
+    const shadowMode =
+      responsibleUserAuthzShadowMode() &&
+      !scopeBoolean(input.scope, "forceResponsibleUserEnforcement");
     logger.warn({
-      authzMode: responsibleUserAuthzShadowMode() ? "shadow" : "enforce",
+      authzMode: shadowMode ? "shadow" : "enforce",
       code: denied.code,
       reason: userDecision.reason,
       action: input.action,
@@ -2391,7 +2394,7 @@ export function authorizationService(db: Db) {
       responsibleUserId,
     }, "responsible-user authorization intersection denied");
 
-    return responsibleUserAuthzShadowMode() ? agentDecision : denied;
+    return shadowMode ? agentDecision : denied;
   }
 
   async function decide(input: {

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -20,7 +20,12 @@ import type {
   SkillTestAgentKeyScope,
   TaskBridgeAgentKeyScope,
 } from "@paperclipai/shared";
-import { LOW_TRUST_REVIEW_PRESET, extractAgentMentionIds, type LowTrustBoundary } from "@paperclipai/shared";
+import {
+  LOW_TRUST_REVIEW_PRESET,
+  extractAgentMentionIds,
+  issueUnblockDescriptorSchema,
+  type LowTrustBoundary,
+} from "@paperclipai/shared";
 import {
   LOW_TRUST_ISSUE_ANCESTRY_MAX_DEPTH,
   isIssueWithinLowTrustBoundary,
@@ -223,10 +228,9 @@ function readBoolean(value: unknown): boolean | null {
 }
 
 function issueUnblockOwnerAgentId(value: unknown) {
-  if (!isPlainRecord(value)) return null;
-  const owner = value.owner;
-  if (!isPlainRecord(owner)) return null;
-  return readString(owner.agentId);
+  const parsed = issueUnblockDescriptorSchema.safeParse(value);
+  if (!parsed.success || typeof parsed.data.owner !== "object" || !("agentId" in parsed.data.owner)) return null;
+  return parsed.data.owner.agentId;
 }
 
 type AssignmentPolicyEffect =
@@ -1941,6 +1945,7 @@ export function authorizationService(db: Db) {
       input.action === "issue:comment" ||
       (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
     if (
+      trustResolution.kind === "standard" &&
       issueUnblockOwnerAction &&
       input.resource.type === "issue" &&
       input.resource.issueId

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -607,7 +607,11 @@ export function authorizationService(db: Db) {
     actor: AuthorizationActor;
     companyId: string;
     userId: string;
+    fresh?: boolean;
   }): Promise<ResponsibleUserSnapshot> {
+    if (input.fresh) {
+      return loadResponsibleUserSnapshot(input.companyId, input.userId);
+    }
     const actorWithMemo = input.actor as ResponsibleUserActorWithMemo;
     const key = `${input.companyId}:${input.userId}`;
     actorWithMemo.__responsibleUserSnapshotMemo ??= new Map();
@@ -2188,6 +2192,7 @@ export function authorizationService(db: Db) {
       (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
     if (
       trustResolution.kind === "standard" &&
+      isSimpleAssignableAgentStatus(actorAgent.status) &&
       issueUnblockOwnerAction &&
       input.resource.type === "issue" &&
       input.resource.issueId
@@ -2313,6 +2318,7 @@ export function authorizationService(db: Db) {
       actor: input.actor,
       companyId,
       userId: responsibleUserId,
+      fresh: scopeBoolean(input.scope, "requireFreshResponsibleUser"),
     });
     const denyCode: AuthorizationDecision["code"] =
       snapshot.userExists && snapshot.activeMembership

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1941,30 +1941,6 @@ export function authorizationService(db: Db) {
       });
     }
 
-    const issueUnblockOwnerAction =
-      input.action === "issue:comment" ||
-      (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
-    if (
-      trustResolution.kind === "standard" &&
-      issueUnblockOwnerAction &&
-      input.resource.type === "issue" &&
-      input.resource.issueId
-    ) {
-      const issue = await loadIssue(input.resource.issueId);
-      if (
-        issue?.companyId === companyId &&
-        issue.status === "blocked" &&
-        issueUnblockOwnerAgentId(issue.unblockDescriptor) === actorAgentId
-      ) {
-        return allow({
-          action: input.action,
-          reason: "allow_issue_unblock_owner",
-          explanation: "Allowed because the actor is the current persisted unblock owner.",
-        });
-      }
-    }
-
-
     if (input.action === "inbox:manage") {
       if (!isSimpleAssignableAgentStatus(actorAgent.status)) {
         return deny({
@@ -2206,6 +2182,28 @@ export function authorizationService(db: Db) {
         return allowIssueMentionGrant(input.action);
       }
       if (visibleIssueWriteDecision) return visibleIssueWriteDecision;
+    }
+    const issueUnblockOwnerAction =
+      input.action === "issue:comment" ||
+      (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
+    if (
+      trustResolution.kind === "standard" &&
+      issueUnblockOwnerAction &&
+      input.resource.type === "issue" &&
+      input.resource.issueId
+    ) {
+      const issue = await loadIssue(input.resource.issueId);
+      if (
+        issue?.companyId === companyId &&
+        issue.status === "blocked" &&
+        issueUnblockOwnerAgentId(issue.unblockDescriptor) === actorAgentId
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_issue_unblock_owner",
+          explanation: "Allowed because the actor is the current persisted unblock owner.",
+        });
+      }
     }
     if (
       input.action === "agent_config:update" &&

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2185,30 +2185,40 @@ export function authorizationService(db: Db) {
       ) {
         return allowIssueMentionGrant(input.action);
       }
-      if (visibleIssueWriteDecision) return visibleIssueWriteDecision;
-    }
-    const issueUnblockOwnerAction =
-      input.action === "issue:comment" ||
-      (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
-    if (
-      trustResolution.kind === "standard" &&
-      isSimpleAssignableAgentStatus(actorAgent.status) &&
-      issueUnblockOwnerAction &&
-      input.resource.type === "issue" &&
-      input.resource.issueId
-    ) {
-      const issue = await loadIssue(input.resource.issueId);
-      if (
-        issue?.companyId === companyId &&
-        issue.status === "blocked" &&
-        issueUnblockOwnerAgentId(issue.unblockDescriptor) === actorAgentId
-      ) {
-        return allow({
+      const issueUnblockOwnerAction =
+        input.action === "issue:comment" ||
+        (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
+      const unblockGatedIssue =
+        trustResolution.kind === "standard" &&
+        resource?.issueId &&
+        resource.assigneeAgentId &&
+        resource.status === "blocked"
+          ? await loadIssue(resource.issueId)
+          : null;
+      if (unblockGatedIssue) {
+        if (
+          issueUnblockOwnerAction &&
+          isSimpleAssignableAgentStatus(actorAgent.status) &&
+          unblockGatedIssue.companyId === companyId &&
+          unblockGatedIssue.status === "blocked" &&
+          issueUnblockOwnerAgentId(unblockGatedIssue.unblockDescriptor) === actorAgentId
+        ) {
+          return allow({
+            action: input.action,
+            reason: "allow_issue_unblock_owner",
+            explanation: "Allowed because the actor is the current persisted unblock owner.",
+          });
+        }
+        // A blocked assigned issue with a persisted unblock owner stays
+        // owner-gated: the default-open visible-issue write rule must not
+        // bypass the owner boundary.
+        return deny({
           action: input.action,
-          reason: "allow_issue_unblock_owner",
-          explanation: "Allowed because the actor is the current persisted unblock owner.",
+          reason: "deny_missing_grant",
+          explanation: "Blocked assigned issues only accept writes from the assignee or the persisted unblock owner.",
         });
       }
+      if (visibleIssueWriteDecision) return visibleIssueWriteDecision;
     }
     if (
       input.action === "agent_config:update" &&

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -107,6 +107,7 @@ export type AuthorizationDecision = {
     | "allow_consented_change"
     | "allow_legacy_agent_creator"
     | "allow_issue_mention_grant"
+    | "allow_issue_unblock_owner"
     | "allow_direct_parent_report"
     | "allow_visible_issue_write"
     | "allow_self"
@@ -221,6 +222,13 @@ function readBoolean(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
 }
 
+function issueUnblockOwnerAgentId(value: unknown) {
+  if (!isPlainRecord(value)) return null;
+  const owner = value.owner;
+  if (!isPlainRecord(owner)) return null;
+  return readString(owner.agentId);
+}
+
 type AssignmentPolicyEffect =
   | { kind: "none" }
   | { kind: "restricted"; explanation: string }
@@ -254,6 +262,7 @@ type IssueAuthorizationRow = {
   executionPolicy: unknown;
   originKind: string | null;
   originId: string | null;
+  unblockDescriptor: unknown;
 };
 
 function evaluateAuthorizationPolicyForAssignment(
@@ -743,6 +752,7 @@ export function authorizationService(db: Db) {
         executionPolicy: issues.executionPolicy,
         originKind: issues.originKind,
         originId: issues.originId,
+        unblockDescriptor: issues.unblockDescriptor,
       })
       .from(issues)
       .where(eq(issues.id, issueId))
@@ -1925,6 +1935,28 @@ export function authorizationService(db: Db) {
         reason: "allow_direct_parent_report",
         explanation: "Allowed because the target is the current run issue's direct parent under the standard trust preset.",
       });
+    }
+
+    const issueUnblockOwnerAction =
+      input.action === "issue:comment" ||
+      (input.action === "issue:mutate" && scopeBoolean(input.scope, "allowIssueUnblockOwner"));
+    if (
+      issueUnblockOwnerAction &&
+      input.resource.type === "issue" &&
+      input.resource.issueId
+    ) {
+      const issue = await loadIssue(input.resource.issueId);
+      if (
+        issue?.companyId === companyId &&
+        issue.status === "blocked" &&
+        issueUnblockOwnerAgentId(issue.unblockDescriptor) === actorAgentId
+      ) {
+        return allow({
+          action: input.action,
+          reason: "allow_issue_unblock_owner",
+          explanation: "Allowed because the actor is the current persisted unblock owner.",
+        });
+      }
     }
 
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2551,6 +2551,22 @@ interface WakeupOptions {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  currentIssueAssigneeGuard?: {
+    issueId: string;
+  };
+}
+
+export function shouldSuppressCurrentIssueAssigneeWake(
+  currentIssue: { assigneeAgentId: string | null; status: string } | null | undefined,
+  agentId: string,
+) {
+  return (
+    !currentIssue ||
+    currentIssue.assigneeAgentId !== agentId ||
+    currentIssue.status === "backlog" ||
+    currentIssue.status === "done" ||
+    currentIssue.status === "cancelled"
+  );
 }
 
 type UsageTotals = {
@@ -17542,6 +17558,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
+    if (opts.currentIssueAssigneeGuard) {
+      const [currentIssue] = await db
+        .select({
+          assigneeAgentId: issues.assigneeAgentId,
+          status: issues.status,
+        })
+        .from(issues)
+        .where(eq(issues.id, opts.currentIssueAssigneeGuard.issueId))
+        .limit(1);
+      if (shouldSuppressCurrentIssueAssigneeWake(currentIssue, agentId)) {
+        return null;
+      }
+    }
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
     const contextSnapshot: Record<string, unknown> = { ...(opts.contextSnapshot ?? {}) };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -17558,19 +17558,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
-    if (opts.currentIssueAssigneeGuard) {
-      const [currentIssue] = await db
-        .select({
-          assigneeAgentId: issues.assigneeAgentId,
-          status: issues.status,
-        })
-        .from(issues)
-        .where(eq(issues.id, opts.currentIssueAssigneeGuard.issueId))
-        .limit(1);
-      if (shouldSuppressCurrentIssueAssigneeWake(currentIssue, agentId)) {
-        return null;
-      }
-    }
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
     const contextSnapshot: Record<string, unknown> = { ...(opts.contextSnapshot ?? {}) };
@@ -17898,6 +17885,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             source,
             triggerDetail,
             reason: "issue_execution_issue_not_found",
+            payload,
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
+        if (
+          opts.currentIssueAssigneeGuard &&
+          (
+            opts.currentIssueAssigneeGuard.issueId !== issue.id ||
+            shouldSuppressCurrentIssueAssigneeWake(issue, agentId)
+          )
+        ) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_assignee_guard_failed",
             payload,
             status: "skipped",
             requestedByActorType: opts.requestedByActorType ?? null,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7543,6 +7543,7 @@ export function issueService(db: Db) {
       },
       dbOrTx: any = db,
       postCommitActivityPublications?: ActivityPublication[],
+      options?: { expectedBlockedUnblockOwnerAgentId?: string },
     ) => {
       const ownedActivityPublications: ActivityPublication[] = [];
       const activityPublications = postCommitActivityPublications ?? ownedActivityPublications;
@@ -7740,10 +7741,17 @@ export function issueService(db: Db) {
           projectGoalId: nextProjectGoalId,
           defaultGoalId: defaultCompanyGoal?.id ?? null,
         });
+        const updatePredicate = options?.expectedBlockedUnblockOwnerAgentId
+          ? and(
+              eq(issues.id, id),
+              eq(issues.status, "blocked"),
+              sql`${issues.unblockDescriptor}->'owner'->>'agentId' = ${options.expectedBlockedUnblockOwnerAgentId}`,
+            )
+          : eq(issues.id, id);
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(eq(issues.id, id))
+          .where(updatePredicate)
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;
@@ -8706,107 +8714,131 @@ export function issueService(db: Db) {
         authorizationReason?: string | null;
         sourceTrust?: typeof issueComments.$inferInsert.sourceTrust;
         createdAt?: Date | string | null;
+        expectedBlockedUnblockOwnerAgentId?: string;
       },
       dbOrTx: any = db,
     ) => {
-      const issue = await dbOrTx
-        .select({ companyId: issues.companyId })
-        .from(issues)
-        .where(eq(issues.id, issueId))
-        .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
+      const runAddComment = async (executor: any) => {
+        const expectedOwnerAgentId = options?.expectedBlockedUnblockOwnerAgentId;
+        const issue = expectedOwnerAgentId
+          ? await executor
+              .update(issues)
+              .set({ updatedAt: new Date() })
+              .where(and(
+                eq(issues.id, issueId),
+                eq(issues.status, "blocked"),
+                sql`${issues.unblockDescriptor}->'owner'->>'agentId' = ${expectedOwnerAgentId}`,
+              ))
+              .returning({ companyId: issues.companyId })
+              .then((rows: Array<{ companyId: string }>) => rows[0] ?? null)
+          : await executor
+              .select({ companyId: issues.companyId })
+              .from(issues)
+              .where(eq(issues.id, issueId))
+              .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
 
-      if (!issue) throw notFound("Issue not found");
-
-      const currentUserRedactionOptions = {
-        enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
-      };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
-      const authorType = issueCommentAuthorTypeSchema.parse(
-        options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
-      );
-      assertIssueCommentAuthorTypeAllowed(actor, authorType);
-      const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
-      const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
-      // Invalid/stale run ids must not 500 the insert — null out unknowns.
-      const createdByRunId = await resolveCommentCreatedByRunId(dbOrTx, issue.companyId, actor.runId);
-      if (actor.runId && !createdByRunId) {
-        logger.warn(
-          { issueId, companyId: issue.companyId, runId: actor.runId },
-          "dropping invalid createdByRunId for issue comment insert",
-        );
-      }
-      const onBehalfOfUserId = actor.agentId
-        ? await resolveCommentResponsibleUserId(
-            dbOrTx,
-            issue.companyId,
-            createdByRunId,
-            actor.onBehalfOfUserId,
-          )
-        : null;
-      const metadata = issueCommentMetadataSchema.nullable().parse(
-        actor.agentId
-          ? withAgentCommentAuthorizationMetadata(options?.metadata ?? null, options?.authorizationReason)
-          : options?.metadata ?? null,
-      );
-      const [comment] = await dbOrTx
-        .insert(issueComments)
-        .values({
-          companyId: issue.companyId,
-          issueId,
-          authorAgentId: actor.agentId ?? null,
-          authorUserId: actor.userId ?? null,
-          onBehalfOfUserId,
-          authorType,
-          createdByRunId,
-          body: redactedBody,
-          presentation,
-          metadata,
-          sourceTrust: options?.sourceTrust ?? null,
-          ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
-        })
-        .returning();
-
-      // Update issue's updatedAt so comment activity is reflected in recency sorting
-      await dbOrTx
-        .update(issues)
-        .set({ updatedAt: new Date() })
-        .where(eq(issues.id, issueId));
-
-      if (
-        authorType === "user" &&
-        actor.userId &&
-        actor.userId !== "board-concierge" &&
-        !createdByRunId
-      ) {
-        const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
-        const expiredInteractions = await issueThreadInteractionService(dbOrTx)
-          .expireRequestConfirmationsSupersededByComment(
-            { id: issueId, companyId: issue.companyId },
-            comment,
-            { agentId: actor.agentId, userId: actor.userId },
-          );
-        for (const interaction of expiredInteractions) {
-          await logActivity(dbOrTx, {
-            companyId: issue.companyId,
-            actorType: "user",
-            actorId: actor.userId,
-            agentId: actor.agentId ?? null,
-            runId: createdByRunId,
-            action: "issue.thread_interaction_expired",
-            entityType: "issue",
-            entityId: issueId,
-            details: {
-              interactionId: interaction.id,
-              interactionKind: interaction.kind,
-              interactionStatus: interaction.status,
-              source: "issue.comment.service",
-              result: interaction.result ?? null,
-            },
-          });
+        if (!issue) {
+          if (expectedOwnerAgentId) throw conflict("Unblock owner authorization became stale");
+          throw notFound("Issue not found");
         }
-      }
 
-      return redactIssueComment(comment, currentUserRedactionOptions.enabled);
+        const currentUserRedactionOptions = {
+          enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
+        };
+        const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+        const authorType = issueCommentAuthorTypeSchema.parse(
+          options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
+        );
+        assertIssueCommentAuthorTypeAllowed(actor, authorType);
+        const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
+        const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
+        // Invalid/stale run ids must not 500 the insert — null out unknowns.
+        const createdByRunId = await resolveCommentCreatedByRunId(executor, issue.companyId, actor.runId);
+        if (actor.runId && !createdByRunId) {
+          logger.warn(
+            { issueId, companyId: issue.companyId, runId: actor.runId },
+            "dropping invalid createdByRunId for issue comment insert",
+          );
+        }
+        const onBehalfOfUserId = actor.agentId
+          ? await resolveCommentResponsibleUserId(
+              executor,
+              issue.companyId,
+              createdByRunId,
+              actor.onBehalfOfUserId,
+            )
+          : null;
+        const metadata = issueCommentMetadataSchema.nullable().parse(
+          actor.agentId
+            ? withAgentCommentAuthorizationMetadata(options?.metadata ?? null, options?.authorizationReason)
+            : options?.metadata ?? null,
+        );
+        const [comment] = await executor
+          .insert(issueComments)
+          .values({
+            companyId: issue.companyId,
+            issueId,
+            authorAgentId: actor.agentId ?? null,
+            authorUserId: actor.userId ?? null,
+            onBehalfOfUserId,
+            authorType,
+            createdByRunId,
+            body: redactedBody,
+            presentation,
+            metadata,
+            sourceTrust: options?.sourceTrust ?? null,
+            ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
+          })
+          .returning();
+
+        if (!expectedOwnerAgentId) {
+          // The conditional owner update above already records comment recency.
+          await executor
+            .update(issues)
+            .set({ updatedAt: new Date() })
+            .where(eq(issues.id, issueId));
+        }
+
+        if (
+          authorType === "user" &&
+          actor.userId &&
+          actor.userId !== "board-concierge" &&
+          !createdByRunId
+        ) {
+          const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+          const expiredInteractions = await issueThreadInteractionService(executor)
+            .expireRequestConfirmationsSupersededByComment(
+              { id: issueId, companyId: issue.companyId },
+              comment,
+              { agentId: actor.agentId, userId: actor.userId },
+            );
+          for (const interaction of expiredInteractions) {
+            await logActivity(executor, {
+              companyId: issue.companyId,
+              actorType: "user",
+              actorId: actor.userId,
+              agentId: actor.agentId ?? null,
+              runId: createdByRunId,
+              action: "issue.thread_interaction_expired",
+              entityType: "issue",
+              entityId: issueId,
+              details: {
+                interactionId: interaction.id,
+                interactionKind: interaction.kind,
+                interactionStatus: interaction.status,
+                source: "issue.comment.service",
+                result: interaction.result ?? null,
+              },
+            });
+          }
+        }
+
+        return redactIssueComment(comment, currentUserRedactionOptions.enabled);
+      };
+
+      return options?.expectedBlockedUnblockOwnerAgentId && dbOrTx === db
+        ? db.transaction(runAddComment)
+        : runAddComment(dbOrTx);
     },
 
     createAttachment: async (input: {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5481,6 +5481,24 @@ export function issueService(db: Db) {
         throw conflict("Unblock owner authorization became stale");
       }
 
+      // Scoped assignment grants can depend on the company hierarchy, so lock
+      // the full hierarchy before evaluating grant scope in this transaction.
+      await tx
+        .select({ id: agents.id })
+        .from(agents)
+        .where(eq(agents.companyId, lockedIssue!.companyId))
+        .for("update");
+
+      await tx
+        .select({ companyId: companyMemberships.companyId })
+        .from(companyMemberships)
+        .where(and(
+          eq(companyMemberships.companyId, lockedIssue!.companyId),
+          eq(companyMemberships.principalType, "agent"),
+          eq(companyMemberships.principalId, actorAgentId),
+        ))
+        .for("update");
+
       if (lockedIssue!.projectId) {
         await tx
           .select({ id: projects.id })
@@ -5488,6 +5506,16 @@ export function issueService(db: Db) {
           .where(and(
             eq(projects.id, lockedIssue!.projectId),
             eq(projects.companyId, lockedIssue!.companyId),
+          ))
+          .for("update");
+      }
+      if (lockedIssue!.parentId && lockedIssue!.parentId !== lockedIssue!.id) {
+        await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(and(
+            eq(issues.id, lockedIssue!.parentId),
+            eq(issues.companyId, lockedIssue!.companyId),
           ))
           .for("update");
       }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -32,6 +32,7 @@ import {
   issueThreadInteractions,
   issues,
   labels,
+  principalPermissionGrants,
   projectWorkspaces,
   projects,
   workspaceOperations,
@@ -5433,6 +5434,12 @@ export function issueService(db: Db) {
       expectedUpdatedAt: Date | string;
       actor: AuthorizationActor;
       action: Extract<AuthorizationAction, "issue:comment" | "issue:mutate">;
+      assignment?: {
+        projectId: string | null;
+        parentIssueId: string | null;
+        assigneeAgentId: string | null;
+        assigneeUserId: string | null;
+      };
     },
     operation: (tx: any) => Promise<T>,
   ): Promise<T> {
@@ -5474,6 +5481,27 @@ export function issueService(db: Db) {
         throw conflict("Unblock owner authorization became stale");
       }
 
+      if (lockedIssue!.projectId) {
+        await tx
+          .select({ id: projects.id })
+          .from(projects)
+          .where(and(
+            eq(projects.id, lockedIssue!.projectId),
+            eq(projects.companyId, lockedIssue!.companyId),
+          ))
+          .for("update");
+      }
+      if (input.actor.runId) {
+        await tx
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(and(
+            eq(heartbeatRuns.id, input.actor.runId),
+            eq(heartbeatRuns.companyId, lockedIssue!.companyId),
+          ))
+          .for("update");
+      }
+
       const responsibleUserId = input.actor.onBehalfOfUserId?.trim();
       if (responsibleUserId) {
         await tx
@@ -5492,11 +5520,33 @@ export function issueService(db: Db) {
           .for("update");
       }
 
+      const grantPrincipals = [
+        and(
+          eq(principalPermissionGrants.principalType, "agent"),
+          eq(principalPermissionGrants.principalId, actorAgentId),
+        ),
+        ...(responsibleUserId
+          ? [and(
+              eq(principalPermissionGrants.principalType, "user"),
+              eq(principalPermissionGrants.principalId, responsibleUserId),
+            )]
+          : []),
+      ];
+      await tx
+        .select({ id: principalPermissionGrants.id })
+        .from(principalPermissionGrants)
+        .where(and(
+          eq(principalPermissionGrants.companyId, lockedIssue!.companyId),
+          or(...grantPrincipals),
+        ))
+        .for("update");
+
       const actor = { ...input.actor, onBehalfOfMemberships: undefined } as AuthorizationActor & {
         __responsibleUserSnapshotMemo?: unknown;
       };
       delete actor.__responsibleUserSnapshotMemo;
-      const decision = await authorizationService(tx as unknown as Db).decide({
+      const lockedAuthorization = authorizationService(tx as unknown as Db);
+      const decision = await lockedAuthorization.decide({
         actor,
         action: input.action,
         resource: {
@@ -5517,10 +5567,36 @@ export function issueService(db: Db) {
           assigneeUserId: lockedIssue!.assigneeUserId,
           allowIssueUnblockOwner: true,
           requireFreshResponsibleUser: true,
+          forceResponsibleUserEnforcement: true,
         },
       });
       if (!decision.allowed || decision.reason !== "allow_issue_unblock_owner") {
         throw conflict("Unblock owner authorization became stale");
+      }
+
+      if (input.assignment) {
+        const assignmentDecision = await lockedAuthorization.decide({
+          actor,
+          action: "tasks:assign",
+          resource: {
+            type: "issue",
+            companyId: lockedIssue!.companyId,
+            issueId: lockedIssue!.id,
+            projectId: input.assignment.projectId,
+            parentIssueId: input.assignment.parentIssueId,
+            assigneeAgentId: input.assignment.assigneeAgentId,
+            assigneeUserId: input.assignment.assigneeUserId,
+          },
+          scope: {
+            issueId: lockedIssue!.id,
+            ...input.assignment,
+            requireFreshResponsibleUser: true,
+            forceResponsibleUserEnforcement: true,
+          },
+        });
+        if (!assignmentDecision.allowed) {
+          throw conflict("Unblock owner assignment authorization became stale");
+        }
       }
 
       return operation(tx);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -132,6 +132,7 @@ import {
 } from "./activity-log.js";
 import { buildIssueChanges } from "./issue-change-receipt.js";
 import { issueThreadInteractionAttentionAgentAllowed } from "./issue-thread-interaction-resolution.js";
+import { authorizationService, type AuthorizationAction, type AuthorizationActor } from "./authorization.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -5426,6 +5427,106 @@ export function issueService(db: Db) {
     return { comment, parent };
   }
 
+  async function runBlockedUnblockOwnerTransaction<T>(
+    input: {
+      issueId: string;
+      expectedUpdatedAt: Date | string;
+      actor: AuthorizationActor;
+      action: Extract<AuthorizationAction, "issue:comment" | "issue:mutate">;
+    },
+    operation: (tx: any) => Promise<T>,
+  ): Promise<T> {
+    const actorAgentId = input.actor.type === "agent" ? input.actor.agentId?.trim() : null;
+    if (!actorAgentId) throw conflict("Unblock owner authorization became stale");
+
+    return db.transaction(async (tx) => {
+      const lockedIssue = await tx
+        .select()
+        .from(issues)
+        .where(eq(issues.id, input.issueId))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      const expectedUpdatedAt = new Date(input.expectedUpdatedAt).getTime();
+      if (
+        !isStrictBlockedUnblockOwner(lockedIssue, actorAgentId) ||
+        !Number.isFinite(expectedUpdatedAt) ||
+        lockedIssue!.updatedAt.getTime() !== expectedUpdatedAt
+      ) {
+        throw conflict("Unblock owner authorization became stale");
+      }
+
+      const lockedOwner = await tx
+        .select({
+          id: agents.id,
+          companyId: agents.companyId,
+          status: agents.status,
+        })
+        .from(agents)
+        .where(eq(agents.id, actorAgentId))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (
+        !lockedOwner ||
+        lockedOwner.companyId !== lockedIssue!.companyId ||
+        lockedOwner.status === "pending_approval" ||
+        lockedOwner.status === "terminated"
+      ) {
+        throw conflict("Unblock owner authorization became stale");
+      }
+
+      const responsibleUserId = input.actor.onBehalfOfUserId?.trim();
+      if (responsibleUserId) {
+        await tx
+          .select({ id: authUsers.id })
+          .from(authUsers)
+          .where(eq(authUsers.id, responsibleUserId))
+          .for("update");
+        await tx
+          .select({ companyId: companyMemberships.companyId })
+          .from(companyMemberships)
+          .where(and(
+            eq(companyMemberships.companyId, lockedIssue!.companyId),
+            eq(companyMemberships.principalType, "user"),
+            eq(companyMemberships.principalId, responsibleUserId),
+          ))
+          .for("update");
+      }
+
+      const actor = { ...input.actor, onBehalfOfMemberships: undefined } as AuthorizationActor & {
+        __responsibleUserSnapshotMemo?: unknown;
+      };
+      delete actor.__responsibleUserSnapshotMemo;
+      const decision = await authorizationService(tx as unknown as Db).decide({
+        actor,
+        action: input.action,
+        resource: {
+          type: "issue",
+          companyId: lockedIssue!.companyId,
+          issueId: lockedIssue!.id,
+          projectId: lockedIssue!.projectId,
+          parentIssueId: lockedIssue!.parentId,
+          assigneeAgentId: lockedIssue!.assigneeAgentId,
+          assigneeUserId: lockedIssue!.assigneeUserId,
+          status: lockedIssue!.status,
+        },
+        scope: {
+          issueId: lockedIssue!.id,
+          projectId: lockedIssue!.projectId,
+          parentIssueId: lockedIssue!.parentId,
+          assigneeAgentId: lockedIssue!.assigneeAgentId,
+          assigneeUserId: lockedIssue!.assigneeUserId,
+          allowIssueUnblockOwner: true,
+          requireFreshResponsibleUser: true,
+        },
+      });
+      if (!decision.allowed || decision.reason !== "allow_issue_unblock_owner") {
+        throw conflict("Unblock owner authorization became stale");
+      }
+
+      return operation(tx);
+    });
+  }
+
   async function archiveInbox(
     companyId: string,
     issueId: string,
@@ -5468,6 +5569,7 @@ export function issueService(db: Db) {
   return {
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
+    runBlockedUnblockOwnerTransaction,
     addStopRelayCommentIfNeeded,
 
     list: async (companyId: string, filters?: IssueFilters) => {
@@ -7558,7 +7660,6 @@ export function issueService(db: Db) {
       },
       dbOrTx: any = db,
       postCommitActivityPublications?: ActivityPublication[],
-      options?: { expectedBlockedUnblockOwnerAgentId?: string },
     ) => {
       const ownedActivityPublications: ActivityPublication[] = [];
       const activityPublications = postCommitActivityPublications ?? ownedActivityPublications;
@@ -7737,10 +7838,6 @@ export function issueService(db: Db) {
             ? getIssueRelationSummaryMap(existing.companyId, [id], tx)
             : Promise.resolve(new Map<string, IssueRelationSummaryMap>()),
         ]);
-        const expectedOwnerAgentId = options?.expectedBlockedUnblockOwnerAgentId;
-        if (expectedOwnerAgentId) {
-          if (!isStrictBlockedUnblockOwner(receiptExisting, expectedOwnerAgentId)) return null;
-        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
         const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
           getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),
@@ -8726,36 +8823,19 @@ export function issueService(db: Db) {
         authorizationReason?: string | null;
         sourceTrust?: typeof issueComments.$inferInsert.sourceTrust;
         createdAt?: Date | string | null;
-        expectedBlockedUnblockOwnerAgentId?: string;
       },
       dbOrTx: any = db,
     ) => {
       const runAddComment = async (executor: any) => {
-        const expectedOwnerAgentId = options?.expectedBlockedUnblockOwnerAgentId;
-        const issue = expectedOwnerAgentId
-          ? await executor
-              .select({
-                companyId: issues.companyId,
-                status: issues.status,
-                unblockDescriptor: issues.unblockDescriptor,
-              })
-              .from(issues)
-              .where(eq(issues.id, issueId))
-              .for("update")
-              .then((rows: Array<{ companyId: string; status: string; unblockDescriptor: unknown }>) => rows[0] ?? null)
-          : await executor
-              .select({
-                companyId: issues.companyId,
-                status: issues.status,
-                unblockDescriptor: issues.unblockDescriptor,
-              })
-              .from(issues)
-              .where(eq(issues.id, issueId))
-              .then((rows: Array<{ companyId: string; status: string; unblockDescriptor: unknown }>) => rows[0] ?? null);
-
-        if (expectedOwnerAgentId && !isStrictBlockedUnblockOwner(issue, expectedOwnerAgentId)) {
-          throw conflict("Unblock owner authorization became stale");
-        }
+        const issue = await executor
+          .select({
+            companyId: issues.companyId,
+            status: issues.status,
+            unblockDescriptor: issues.unblockDescriptor,
+          })
+          .from(issues)
+          .where(eq(issues.id, issueId))
+          .then((rows: Array<{ companyId: string; status: string; unblockDescriptor: unknown }>) => rows[0] ?? null);
         if (!issue) throw notFound("Issue not found");
 
         const currentUserRedactionOptions = {
@@ -8849,9 +8929,7 @@ export function issueService(db: Db) {
         return redactIssueComment(comment, currentUserRedactionOptions.enabled);
       };
 
-      return options?.expectedBlockedUnblockOwnerAgentId && dbOrTx === db
-        ? db.transaction(runAddComment)
-        : runAddComment(dbOrTx);
+      return runAddComment(dbOrTx);
     },
 
     createAttachment: async (input: {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4,6 +4,7 @@ import { and, asc, desc, eq, gt, gte, inArray, isNull, like, lt, ne, notInArray,
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
+  agentApiKeys,
   agentWakeupRequests,
   agents,
   authUsers,
@@ -65,6 +66,7 @@ import {
   issueCommentPresentationSchema,
   issueUnblockDescriptorSchema,
   isUuidLike,
+  normalizeAgentApiKeyScope,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
 import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
@@ -5479,6 +5481,35 @@ export function issueService(db: Db) {
         lockedOwner.status === "terminated"
       ) {
         throw conflict("Unblock owner authorization became stale");
+      }
+
+      if (input.actor.source === "agent_key") {
+        const keyId = input.actor.keyId?.trim();
+        if (!keyId) throw conflict("Unblock owner authorization became stale");
+        const lockedKey = await tx
+          .select({
+            id: agentApiKeys.id,
+            agentId: agentApiKeys.agentId,
+            companyId: agentApiKeys.companyId,
+            responsibleUserId: agentApiKeys.responsibleUserId,
+            scopeConfig: agentApiKeys.scopeConfig,
+            revokedAt: agentApiKeys.revokedAt,
+          })
+          .from(agentApiKeys)
+          .where(eq(agentApiKeys.id, keyId))
+          .for("update")
+          .then((rows) => rows[0] ?? null);
+        if (
+          !lockedKey ||
+          lockedKey.agentId !== actorAgentId ||
+          lockedKey.companyId !== lockedIssue!.companyId ||
+          lockedKey.revokedAt ||
+          lockedKey.responsibleUserId !== (input.actor.onBehalfOfUserId ?? null) ||
+          JSON.stringify(normalizeAgentApiKeyScope(lockedKey.scopeConfig)) !==
+            JSON.stringify(normalizeAgentApiKeyScope(input.actor.keyScope))
+        ) {
+          throw conflict("Unblock owner authorization became stale");
+        }
       }
 
       // Scoped assignment grants can depend on the company hierarchy, so lock

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -62,6 +62,7 @@ import {
   issueCommentAuthorTypeSchema,
   issueCommentMetadataSchema,
   issueCommentPresentationSchema,
+  issueUnblockDescriptorSchema,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
@@ -519,6 +520,20 @@ export function deriveIssueCommentRunLogAttribution(
   }
 
   return derivedByCommentId;
+}
+
+function isStrictBlockedUnblockOwner(
+  issue: { status: string; unblockDescriptor: unknown } | null,
+  expectedOwnerAgentId: string,
+) {
+  if (!issue || issue.status !== "blocked") return false;
+  const parsed = issueUnblockDescriptorSchema.safeParse(issue.unblockDescriptor);
+  return Boolean(
+    parsed.success &&
+    typeof parsed.data.owner === "object" &&
+    "agentId" in parsed.data.owner &&
+    parsed.data.owner.agentId === expectedOwnerAgentId,
+  );
 }
 
 // Express's default `qs` parser binds repeated query keys to a `string[]`,
@@ -7722,6 +7737,10 @@ export function issueService(db: Db) {
             ? getIssueRelationSummaryMap(existing.companyId, [id], tx)
             : Promise.resolve(new Map<string, IssueRelationSummaryMap>()),
         ]);
+        const expectedOwnerAgentId = options?.expectedBlockedUnblockOwnerAgentId;
+        if (expectedOwnerAgentId) {
+          if (!isStrictBlockedUnblockOwner(receiptExisting, expectedOwnerAgentId)) return null;
+        }
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
         const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
           getProjectDefaultGoalId(tx, existing.companyId, existing.projectId),
@@ -7741,17 +7760,10 @@ export function issueService(db: Db) {
           projectGoalId: nextProjectGoalId,
           defaultGoalId: defaultCompanyGoal?.id ?? null,
         });
-        const updatePredicate = options?.expectedBlockedUnblockOwnerAgentId
-          ? and(
-              eq(issues.id, id),
-              eq(issues.status, "blocked"),
-              sql`${issues.unblockDescriptor}->'owner'->>'agentId' = ${options.expectedBlockedUnblockOwnerAgentId}`,
-            )
-          : eq(issues.id, id);
         const updated = await tx
           .update(issues)
           .set(patch)
-          .where(updatePredicate)
+          .where(eq(issues.id, id))
           .returning()
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!updated) return null;
@@ -8722,25 +8734,29 @@ export function issueService(db: Db) {
         const expectedOwnerAgentId = options?.expectedBlockedUnblockOwnerAgentId;
         const issue = expectedOwnerAgentId
           ? await executor
-              .update(issues)
-              .set({ updatedAt: new Date() })
-              .where(and(
-                eq(issues.id, issueId),
-                eq(issues.status, "blocked"),
-                sql`${issues.unblockDescriptor}->'owner'->>'agentId' = ${expectedOwnerAgentId}`,
-              ))
-              .returning({ companyId: issues.companyId })
-              .then((rows: Array<{ companyId: string }>) => rows[0] ?? null)
-          : await executor
-              .select({ companyId: issues.companyId })
+              .select({
+                companyId: issues.companyId,
+                status: issues.status,
+                unblockDescriptor: issues.unblockDescriptor,
+              })
               .from(issues)
               .where(eq(issues.id, issueId))
-              .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
+              .for("update")
+              .then((rows: Array<{ companyId: string; status: string; unblockDescriptor: unknown }>) => rows[0] ?? null)
+          : await executor
+              .select({
+                companyId: issues.companyId,
+                status: issues.status,
+                unblockDescriptor: issues.unblockDescriptor,
+              })
+              .from(issues)
+              .where(eq(issues.id, issueId))
+              .then((rows: Array<{ companyId: string; status: string; unblockDescriptor: unknown }>) => rows[0] ?? null);
 
-        if (!issue) {
-          if (expectedOwnerAgentId) throw conflict("Unblock owner authorization became stale");
-          throw notFound("Issue not found");
+        if (expectedOwnerAgentId && !isStrictBlockedUnblockOwner(issue, expectedOwnerAgentId)) {
+          throw conflict("Unblock owner authorization became stale");
         }
+        if (!issue) throw notFound("Issue not found");
 
         const currentUserRedactionOptions = {
           enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
@@ -8791,13 +8807,10 @@ export function issueService(db: Db) {
           })
           .returning();
 
-        if (!expectedOwnerAgentId) {
-          // The conditional owner update above already records comment recency.
-          await executor
-            .update(issues)
-            .set({ updatedAt: new Date() })
-            .where(eq(issues.id, issueId));
-        }
+        await executor
+          .update(issues)
+          .set({ updatedAt: new Date() })
+          .where(eq(issues.id, issueId));
 
         if (
           authorType === "user" &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates issue ownership, blocked-state recovery, and agent execution through the issue lifecycle.
> - A strict `unblockDescriptor` persists which actor should perform a blocked issue's next action without transferring assignment.
> - The named agent can be routed and woken while the issue remains assigned to another agent.
> - Existing issue authorization then rejects that named owner from returning a result because it only recognizes assignment, checkout, mention, and direct-parent grants.
> - Broad manager or cross-assignee mutation authority would violate least privilege and make stale descriptors dangerous.
> - This pull request grants only the current strict persisted standard-trust owner a result-comment path and a narrow comment or resume PATCH.
> - The write uses the same locked row and transaction as the authorization decision.
> - The benefit is a complete event-driven unblock loop without assignment transfer, board intervention, or authority surviving a descriptor or status race.

## Linked Issues or Issue Description

- Fixes: #10395
- Supersedes: #10401
- Refs: #10361
- Refs: #10366
- Refs: #10112

## What Changed

- Exported the existing strict unblock-descriptor schema and use it to parse persisted authorization state.
- Malformed, mixed-owner, extra-field, missing-action, and invalid-UUID descriptors grant nothing.
- Added an authorization decision for a standard-trust same-company agent that is the current persisted owner of a currently blocked issue.
- Kept `issue:mutate` opt-in behind an explicit route scope. Ordinary authorization consumers do not inherit the grant.
- Restricted owner PATCH bodies to a required result comment plus optional `resume: true` and optional `assigneeAgentId` only when resuming.
- Preserved independent `tasks:assign`, responsible-user, low-trust, task-bridge, skill-test, cheap-recovery, transition, and checkout controls.
- Executes owner writes through a service-owned transaction that locks the issue, owner, full scoped-grant agent hierarchy, direct agent-key state, actor membership, project and parent-issue trust policies, active run, applicable permission grants, and delegated responsible-user rows.
- Requires the exact issue version and fresh issue-mutation plus assignment decisions inside that transaction; request/global responsible-user caches, task-bridge keys, trust rules, company boundaries, and delegated-user restrictions remain fail-closed even when deployment-wide responsible-user mode is shadow.
- Bounds standalone comments and combined resume-plus-comment writes to that transaction. Stale owner, status, eligibility, membership, or issue-version changes return 409 without a partial write.
- Requires any resumed assignment to claim the issue for the unblock owner itself.
- Uses final response rereads plus a centralized current-assignee guard inside the heartbeat issue-row-lock transaction for PATCH and comment wakeups, so a stronger committed reassignment cannot be replaced or targeted as the stale owner result.
- Added Postgres-backed and route regressions for strict parsing, low-trust/task-bridge/delegated-user denial, stale snapshots, non-blocked or inactive owners, field smuggling, third-party claims, atomic rollback, and latest-result dispatch.
- No user-facing documentation change is required. This completes an internal issue-lifecycle authorization path.

## Verification

- Affected Vitest run across authorization, ownership routes, validators, issue service, comment routes, and guarded heartbeat scheduling: **349 tests passed**.
- `pnpm --filter @paperclipai/shared typecheck` passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm --filter @paperclipai/shared build` passed.
- `pnpm --filter @paperclipai/server build` passed.
- `git merge-tree --write-tree HEAD origin/pr-10366` completed without conflicts against current PR #10366 head `7d425f240`.
- Independent security, transaction, race, and scope reviews checked the exact rebased PR delta before publication.

## Risks

- This extends write authority only for the strict current agent owner while the issue remains blocked.
- It does not add general manager authority or transfer assignment.
- Owner PATCH is smaller than the normal issue PATCH surface and always requires a result comment.
- Resume can claim only the unblock owner and still requires the existing `tasks:assign` authorization decision.
- Locked issue, owner, policy, run, grant, and delegated-user rows plus fresh full decisions prevent authorization/write TOCTOU and partial update-without-comment outcomes.
- Stale authority returns 409.
- No schema migration or production backport is included.
- `ROADMAP.md` was checked. This is a narrow correctness fix within shipped enforced outcomes and self-healing behavior. It is not a new roadmap subsystem.

## Model Used

- OpenAI Codex, GPT-5.6 (`gpt-5.6-sol`), with repository tool use, code execution, and independent delegated security review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
