### PR TITLE
fix(hermes): retry transient provider failures

### DIFF
--- a/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
+++ b/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
@@ -76,6 +76,7 @@ describe("hermes-local transient provider failure classification", () => {
   it("classifies the captured engine-overload transcript", async () => {
     childResult.current.stdout =
       "API call failed after 3 retries: HTTP 429: The engine is currently overloaded, please try again later\n";
+    childResult.current.stderr = "session_id: 20260729_abcdef12\n";
 
     const result = await execute(makeCtx() as any);
 
@@ -144,6 +145,26 @@ describe("hermes-local transient provider failure classification", () => {
       "API call failed after 3 retries: HTTP 503: Service unavailable",
       "Fatal: invalid local Hermes configuration",
     ].join("\n");
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBeUndefined();
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.resultJson).not.toHaveProperty("errorFamily");
+  });
+
+  it.each([
+    {
+      stdout: "API call failed after 3 retries: HTTP 503: Service unavailable",
+      stderr: "Fatal: invalid local Hermes configuration",
+    },
+    {
+      stdout: "Fatal: invalid local Hermes configuration",
+      stderr: "API call failed after 3 retries: HTTP 503: Service unavailable",
+    },
+  ])("does not classify conflicting mixed-stream output: $stdout | $stderr", async ({ stdout, stderr }) => {
+    childResult.current.stdout = stdout;
+    childResult.current.stderr = stderr;
 
     const result = await execute(makeCtx() as any);
 

--- a/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
+++ b/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
@@ -126,6 +126,19 @@ describe("hermes-local transient provider failure classification", () => {
     expect(result.resultJson).not.toHaveProperty("errorFamily");
   });
 
+  it("does not classify a transient-looking stderr diagnostic before an unrelated terminal error", async () => {
+    childResult.current.stderr = [
+      "API call failed after 3 retries: HTTP 503: Service unavailable",
+      "Fatal: invalid local Hermes configuration",
+    ].join("\n");
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBeUndefined();
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.resultJson).not.toHaveProperty("errorFamily");
+  });
+
   it("does not classify a deterministic 429 quota response as transient", async () => {
     childResult.current.stdout =
       "API call failed after 3 retries: HTTP 429: Monthly quota exhausted; upgrade your plan\n";

--- a/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
+++ b/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const childResult = vi.hoisted(() => ({
+  current: {
+    exitCode: 1 as number | null,
+    signal: null as string | null,
+    timedOut: false,
+    stdout: "",
+    stderr: "",
+  },
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: vi.fn(async () => childResult.current),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => ""),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  rm: vi.fn(async () => undefined),
+  access: vi.fn(async () => undefined),
+  readdir: vi.fn(async () => []),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+import { execute } from "./execute.js";
+
+function makeCtx() {
+  return {
+    runId: "test-run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Hermes",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "/usr/bin/hermes",
+      timeoutSec: 60,
+      graceSec: 5,
+    },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "manual",
+      paperclipWake: null,
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  };
+}
+
+describe("hermes-local transient provider failure classification", () => {
+  beforeEach(() => {
+    childResult.current = {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    };
+  });
+
+  it("classifies the captured engine-overload transcript", async () => {
+    childResult.current.stdout =
+      "API call failed after 3 retries: HTTP 429: The engine is currently overloaded, please try again later\n";
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorMessage).toContain("HTTP 429");
+    expect(result.errorCode).toBe("hermes_transient_upstream");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.resultJson).toMatchObject({ errorFamily: "transient_upstream" });
+  });
+
+  it.each([
+    "API call failed after 3 retries: HTTP 502: Bad gateway",
+    "API call failed after 3 retries: HTTP 503: Service unavailable",
+    "API call failed after 3 retries: HTTP 504: Gateway timeout",
+    "request failed: ECONNRESET",
+    "request failed: ETIMEDOUT",
+    "connection reset by peer",
+    "socket hang up",
+  ])("classifies transient provider signature: %s", async (transcript) => {
+    childResult.current.stderr = transcript;
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBe("hermes_transient_upstream");
+    expect(result.errorFamily).toBe("transient_upstream");
+  });
+
+  it("does not classify an ordinary nonzero exit as transient", async () => {
+    childResult.current.stderr = "Error: invalid tool configuration";
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBeUndefined();
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.resultJson).not.toHaveProperty("errorFamily");
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
+++ b/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
@@ -89,12 +89,12 @@ describe("hermes-local transient provider failure classification", () => {
     "API call failed after 3 retries: HTTP 502: Bad gateway",
     "API call failed after 3 retries: HTTP 503: Service unavailable",
     "API call failed after 3 retries: HTTP 504: Gateway timeout",
-    "request failed: ECONNRESET",
-    "request failed: ETIMEDOUT",
-    "connection reset by peer",
-    "socket hang up",
-  ])("classifies transient provider signature: %s", async (transcript) => {
-    childResult.current.stderr = transcript;
+    "API call failed after 3 retries: request failed: ECONNRESET",
+    "API call failed after 3 retries: request failed: ETIMEDOUT",
+    "API call failed after 3 retries: connection reset by peer",
+    "API call failed after 3 retries: socket hang up",
+  ])("classifies transient signature: %s", async (message) => {
+    childResult.current.stdout = message;
 
     const result = await execute(makeCtx() as any);
 
@@ -104,6 +104,31 @@ describe("hermes-local transient provider failure classification", () => {
 
   it("does not classify an ordinary nonzero exit as transient", async () => {
     childResult.current.stderr = "Error: invalid tool configuration";
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBeUndefined();
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.resultJson).not.toHaveProperty("errorFamily");
+  });
+
+  it("does not classify transient-looking text quoted inside ordinary output", async () => {
+    childResult.current.stdout = [
+      "Tool output from a diagnostic file:",
+      "API call failed after 3 retries: HTTP 503: Service unavailable",
+      "The task then failed validation.",
+    ].join("\n");
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBeUndefined();
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.resultJson).not.toHaveProperty("errorFamily");
+  });
+
+  it("does not classify a deterministic 429 quota response as transient", async () => {
+    childResult.current.stdout =
+      "API call failed after 3 retries: HTTP 429: Monthly quota exhausted; upgrade your plan\n";
 
     const result = await execute(makeCtx() as any);
 

--- a/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
+++ b/packages/adapters/hermes/src/server/execute.transient-errors.test.ts
@@ -126,6 +126,19 @@ describe("hermes-local transient provider failure classification", () => {
     expect(result.resultJson).not.toHaveProperty("errorFamily");
   });
 
+  it("does not classify a quoted envelope followed by ordinary stdout", async () => {
+    childResult.current.stdout = [
+      "API call failed after 3 retries: HTTP 503: Service unavailable",
+      "The model quoted that diagnostic before local validation failed.",
+    ].join("\n");
+
+    const result = await execute(makeCtx() as any);
+
+    expect(result.errorCode).toBeUndefined();
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.resultJson).not.toHaveProperty("errorFamily");
+  });
+
   it("does not classify a transient-looking stderr diagnostic before an unrelated terminal error", async () => {
     childResult.current.stderr = [
       "API call failed after 3 retries: HTTP 503: Service unavailable",

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -234,6 +234,41 @@ interface ParsedOutput {
   errorMessage?: string;
 }
 
+interface TransientProviderFailure {
+  errorMessage: string;
+}
+
+function classifyTransientProviderFailure(
+  stdout: string,
+  stderr: string,
+): TransientProviderFailure | null {
+  const combined = `${stdout}\n${stderr}`.trim();
+  if (!combined) return null;
+
+  const hasGatewayFailure = /\bHTTP(?:\/\d(?:\.\d)?)?\s+(?:502|503|504)\b/i.test(combined);
+  const hasOverloadedRateLimit =
+    /\bHTTP(?:\/\d(?:\.\d)?)?\s+429\b/i.test(combined) &&
+    /engine is currently overloaded|API call failed after \d+ retries|try again later/i.test(combined);
+  const hasTransientTransportFailure =
+    /\b(?:ECONNRESET|ETIMEDOUT)\b|connection (?:was )?reset(?: by peer)?|socket hang up/i.test(combined);
+
+  if (!hasGatewayFailure && !hasOverloadedRateLimit && !hasTransientTransportFailure) {
+    return null;
+  }
+
+  const errorMessage =
+    combined
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) =>
+        /\bHTTP(?:\/\d(?:\.\d)?)?\s+(?:429|502|503|504)\b|\b(?:ECONNRESET|ETIMEDOUT)\b|connection (?:was )?reset(?: by peer)?|socket hang up/i.test(
+          line,
+        ),
+      ) ?? "Hermes provider request failed transiently";
+
+  return { errorMessage };
+}
+
 // ---------------------------------------------------------------------------
 // Response cleaning
 // ---------------------------------------------------------------------------
@@ -543,6 +578,10 @@ export async function execute(
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
+  const transientProviderFailure =
+    result.exitCode !== null && result.exitCode !== 0
+      ? classifyTransientProviderFailure(result.stdout || "", result.stderr || "")
+      : null;
 
   await ctx.onLog(
     "stdout",
@@ -567,6 +606,12 @@ export async function execute(
     executionResult.errorMessage = `Hermes exited with code ${result.exitCode}`;
   }
 
+  if (transientProviderFailure) {
+    executionResult.errorMessage = parsed.errorMessage ?? transientProviderFailure.errorMessage;
+    executionResult.errorCode = "hermes_transient_upstream";
+    executionResult.errorFamily = "transient_upstream";
+  }
+
   if (parsed.usage) {
     executionResult.usage = parsed.usage;
   }
@@ -586,6 +631,7 @@ export async function execute(
     session_id: parsed.sessionId || null,
     usage: parsed.usage || null,
     cost_usd: parsed.costUsd ?? null,
+    ...(transientProviderFailure ? { errorFamily: "transient_upstream" } : {}),
   };
 
   // Store session ID for next run

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -242,31 +242,31 @@ function classifyTransientProviderFailure(
   stdout: string,
   stderr: string,
 ): TransientProviderFailure | null {
-  const combined = `${stdout}\n${stderr}`.trim();
-  if (!combined) return null;
+  const stdoutFirstLine = stdout.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  const stderrFailureLine = stderr
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => /^(?:Error:\s*)?API call failed after \d+ retries:/i.test(line));
+  const failureEnvelope =
+    (/^API call failed after \d+ retries:/i.test(stdoutFirstLine) ? stdoutFirstLine : null) ??
+    stderrFailureLine ??
+    null;
+  if (!failureEnvelope) return null;
 
-  const hasGatewayFailure = /\bHTTP(?:\/\d(?:\.\d)?)?\s+(?:502|503|504)\b/i.test(combined);
+  const hasGatewayFailure = /\bHTTP(?:\/\d(?:\.\d)?)?\s+(?:502|503|504)\b/i.test(failureEnvelope);
   const hasOverloadedRateLimit =
-    /\bHTTP(?:\/\d(?:\.\d)?)?\s+429\b/i.test(combined) &&
-    /engine is currently overloaded|API call failed after \d+ retries|try again later/i.test(combined);
+    /\bHTTP(?:\/\d(?:\.\d)?)?\s+429\b/i.test(failureEnvelope) &&
+    /\bengine is currently overloaded\b/i.test(failureEnvelope);
   const hasTransientTransportFailure =
-    /\b(?:ECONNRESET|ETIMEDOUT)\b|connection (?:was )?reset(?: by peer)?|socket hang up/i.test(combined);
+    /\b(?:ECONNRESET|ETIMEDOUT)\b|connection (?:was )?reset(?: by peer)?|socket hang up/i.test(
+      failureEnvelope,
+    );
 
   if (!hasGatewayFailure && !hasOverloadedRateLimit && !hasTransientTransportFailure) {
     return null;
   }
 
-  const errorMessage =
-    combined
-      .split("\n")
-      .map((line) => line.trim())
-      .find((line) =>
-        /\bHTTP(?:\/\d(?:\.\d)?)?\s+(?:429|502|503|504)\b|\b(?:ECONNRESET|ETIMEDOUT)\b|connection (?:was )?reset(?: by peer)?|socket hang up/i.test(
-          line,
-        ),
-      ) ?? "Hermes provider request failed transiently";
-
-  return { errorMessage };
+  return { errorMessage: failureEnvelope.replace(/^Error:\s*/i, "") };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -243,10 +243,12 @@ function classifyTransientProviderFailure(
   stderr: string,
 ): TransientProviderFailure | null {
   const stdoutFirstLine = stdout.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
-  const stderrFailureLine = stderr
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => /^(?:Error:\s*)?API call failed after \d+ retries:/i.test(line));
+  const stderrOutput = stderr.trim();
+  const stderrFailureLine = /^(?:Error:\s*)?API call failed after \d+ retries:[^\r\n]+$/i.test(
+    stderrOutput,
+  )
+    ? stderrOutput
+    : null;
   const failureEnvelope =
     (/^API call failed after \d+ retries:/i.test(stdoutFirstLine) ? stdoutFirstLine : null) ??
     stderrFailureLine ??

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -238,6 +238,14 @@ interface TransientProviderFailure {
   errorMessage: string;
 }
 
+function containsOnlyHermesSessionMetadata(output: string): boolean {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.every((line) => /^(?:session_id|Session ID):\s*[A-Za-z0-9_-]+$/i.test(line));
+}
+
 function classifyTransientProviderFailure(
   stdout: string,
   stderr: string,
@@ -255,9 +263,11 @@ function classifyTransientProviderFailure(
     ? stderrOutput
     : null;
   const failureEnvelope =
-    stdoutFailureLine ??
-    stderrFailureLine ??
-    null;
+    stdoutFailureLine && containsOnlyHermesSessionMetadata(stderrOutput)
+      ? stdoutFailureLine
+      : stderrFailureLine && containsOnlyHermesSessionMetadata(stdoutOutput)
+        ? stderrFailureLine
+        : null;
   if (!failureEnvelope) return null;
 
   const hasGatewayFailure = /\bHTTP(?:\/\d(?:\.\d)?)?\s+(?:502|503|504)\b/i.test(failureEnvelope);

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -242,15 +242,20 @@ function classifyTransientProviderFailure(
   stdout: string,
   stderr: string,
 ): TransientProviderFailure | null {
-  const stdoutFirstLine = stdout.trim().split(/\r?\n/, 1)[0]?.trim() ?? "";
+  const stdoutOutput = stdout.trim();
   const stderrOutput = stderr.trim();
+  const stdoutFailureLine = /^(?:Error:\s*)?API call failed after \d+ retries:[^\r\n]+$/i.test(
+    stdoutOutput,
+  )
+    ? stdoutOutput
+    : null;
   const stderrFailureLine = /^(?:Error:\s*)?API call failed after \d+ retries:[^\r\n]+$/i.test(
     stderrOutput,
   )
     ? stderrOutput
     : null;
   const failureEnvelope =
-    (/^API call failed after \d+ retries:/i.test(stdoutFirstLine) ? stdoutFirstLine : null) ??
+    stdoutFailureLine ??
     stderrFailureLine ??
     null;
   if (!failureEnvelope) return null;

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -36,6 +36,8 @@ import {
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
+const HERMES_TRANSIENT_TEST_ADAPTER = "hermes_transient_test";
+const UNCLASSIFIED_FAILURE_TEST_ADAPTER = "unclassified_failure_test";
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -89,6 +91,40 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         testedAt: new Date().toISOString(),
       }),
     });
+    registerServerAdapter({
+      type: HERMES_TRANSIENT_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage:
+          "API call failed after 3 retries: HTTP 429: The engine is currently overloaded, please try again later",
+        errorCode: "hermes_transient_upstream",
+        resultJson: {},
+      }),
+      testEnvironment: async () => ({
+        adapterType: HERMES_TRANSIENT_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
+    registerServerAdapter({
+      type: UNCLASSIFIED_FAILURE_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "Hermes exited with code 1",
+        resultJson: {},
+      }),
+      testEnvironment: async () => ({
+        adapterType: UNCLASSIFIED_FAILURE_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
   }, 20_000);
 
   afterEach(async () => {
@@ -104,6 +140,8 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
   afterAll(async () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
+    unregisterServerAdapter(HERMES_TRANSIENT_TEST_ADAPTER);
+    unregisterServerAdapter(UNCLASSIFIED_FAILURE_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
 
@@ -212,6 +250,78 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       createdAt: input.now,
     });
   }
+
+  async function invokeFailureAdapter(adapterType: string) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Hermes Test",
+      role: "engineer",
+      status: "idle",
+      adapterType,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const run = await heartbeat.invoke(agentId, "on_demand", {}, "manual");
+    expect(run).not.toBeNull();
+    const failedRun = await waitForRunToFinish(heartbeat, run!.id);
+    expect(failedRun?.status).toBe("failed");
+    return { agentId, runId: run!.id };
+  }
+
+  it("automatically schedules a bounded retry for Hermes transient upstream failures", async () => {
+    const { runId } = await invokeFailureAdapter(HERMES_TRANSIENT_TEST_ADAPTER);
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.retryOfRunId, runId))
+            .then((rows) => rows.length),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(1);
+  });
+
+  it("does not automatically retry an unclassified nonzero exit", async () => {
+    const { agentId, runId } = await invokeFailureAdapter(UNCLASSIFIED_FAILURE_TEST_ADAPTER);
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ status: agents.status })
+            .from(agents)
+            .where(eq(agents.id, agentId))
+            .then((rows) => rows[0]?.status ?? null),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe("error");
+
+    const retries = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId));
+    expect(retries).toHaveLength(0);
+  });
 
   it("records provider quota failures, schedules the reset-time retry, and leaves the agent idle", async () => {
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -37,6 +37,7 @@ const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
 const HERMES_TRANSIENT_TEST_ADAPTER = "hermes_transient_test";
+const HERMES_TRANSIENT_CODE_FALLBACK_TEST_ADAPTER = "hermes_transient_code_fallback_test";
 const UNCLASSIFIED_FAILURE_TEST_ADAPTER = "unclassified_failure_test";
 
 if (!embeddedPostgresSupport.supported) {
@@ -100,10 +101,29 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         errorMessage:
           "API call failed after 3 retries: HTTP 429: The engine is currently overloaded, please try again later",
         errorCode: "hermes_transient_upstream",
-        resultJson: {},
+        errorFamily: "transient_upstream",
+        resultJson: { errorFamily: "transient_upstream" },
       }),
       testEnvironment: async () => ({
         adapterType: HERMES_TRANSIENT_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
+    registerServerAdapter({
+      type: HERMES_TRANSIENT_CODE_FALLBACK_TEST_ADAPTER,
+      execute: async () => ({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage:
+          "API call failed after 3 retries: HTTP 429: The engine is currently overloaded, please try again later",
+        errorCode: "hermes_transient_upstream",
+        resultJson: {},
+      }),
+      testEnvironment: async () => ({
+        adapterType: HERMES_TRANSIENT_CODE_FALLBACK_TEST_ADAPTER,
         status: "pass",
         checks: [],
         testedAt: new Date().toISOString(),
@@ -141,6 +161,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
   afterAll(async () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
     unregisterServerAdapter(HERMES_TRANSIENT_TEST_ADAPTER);
+    unregisterServerAdapter(HERMES_TRANSIENT_CODE_FALLBACK_TEST_ADAPTER);
     unregisterServerAdapter(UNCLASSIFIED_FAILURE_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
@@ -282,12 +303,33 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect(run).not.toBeNull();
     const failedRun = await waitForRunToFinish(heartbeat, run!.id);
     expect(failedRun?.status).toBe("failed");
-    return { agentId, runId: run!.id };
+    return { agentId, runId: run!.id, failedRun };
   }
 
   it("automatically schedules a bounded retry for Hermes transient upstream failures", async () => {
-    const { runId } = await invokeFailureAdapter(HERMES_TRANSIENT_TEST_ADAPTER);
+    const { runId, failedRun } = await invokeFailureAdapter(HERMES_TRANSIENT_TEST_ADAPTER);
 
+    expect(failedRun?.errorCode).toBe("hermes_transient_upstream");
+    expect(failedRun?.resultJson).toMatchObject({ errorFamily: "transient_upstream" });
+
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.retryOfRunId, runId))
+            .then((rows) => rows.length),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe(1);
+  });
+
+  it("keeps the Hermes transient error-code compatibility fallback retryable", async () => {
+    const { runId, failedRun } = await invokeFailureAdapter(HERMES_TRANSIENT_CODE_FALLBACK_TEST_ADAPTER);
+
+    expect(failedRun?.errorCode).toBe("hermes_transient_upstream");
+    expect(failedRun?.resultJson).not.toMatchObject({ errorFamily: "transient_upstream" });
     await expect
       .poll(
         () =>

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -620,6 +620,7 @@ function readHeartbeatRunErrorFamily(
   if (
     run.errorCode === "codex_transient_upstream" ||
     run.errorCode === "claude_transient_upstream" ||
+    run.errorCode === "hermes_transient_upstream" ||
     run.errorCode === "codex_harness_crash"
   ) {
     return "transient_upstream";


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates AI-agent execution and already has bounded recovery for transient upstream failures.
> - The heartbeat scheduler can make that retry decision only when an adapter persists a recognized error code or family.
> - Hermes may exhaust its internal provider retries and exit nonzero with an explicit overload, gateway, or transport signature.
> - The Hermes adapter currently collapses that outcome into an unclassified exit, so Paperclip terminates work that is safe to retry.
> - Broadly retrying every exit code 1 would be unsafe because configuration and task failures can use the same exit code.
> - This pull request classifies only explicit transient signatures and maps them into the existing bounded scheduler path.
> - The benefit is automatic recovery from temporary provider outages without changing retry limits or retrying ordinary failures.

## Linked Issues or Issue Description

- Fixes: #10422

## What Changed

- Detect terminal Hermes failure envelopes containing explicit HTTP 502/503/504, overloaded HTTP 429, `ECONNRESET`, `ETIMEDOUT`, connection-reset, or socket-hang-up signatures on nonzero exits; one stream must be the complete single failure envelope and the other must be empty or contain only Hermes session metadata.
- Return `errorCode: "hermes_transient_upstream"`, `errorFamily: "transient_upstream"`, a human-readable error, and the same family in `resultJson`.
- Teach the heartbeat scheduler's existing compatibility mapping to recognize the Hermes code.
- Keep plain nonzero exits and non-transient 429 output unclassified and non-retryable.
- Add adapter-result and embedded-Postgres scheduler regressions for classification, automatic bounded scheduling, and fail-closed ordinary failures.
- No user-facing documentation change is required; this is an internal adapter/recovery correctness fix.

## Verification

- `pnpm test` in `packages/adapters/hermes` — **74/74 passed**.
- `pnpm typecheck` in `packages/adapters/hermes` — passed.
- `pnpm exec vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts --testTimeout=30000` — **33/33 passed**.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.
- GitHub current-head build, test, typecheck, e2e, security, and Greptile checks passed. The Canary Dry Run was canceled by its 20-minute job limit after dependency installation took 14m43s; the release build was still progressing through unchanged plugin packages and emitted no source failure. The contributor token cannot rerun upstream jobs.
- Regression coverage includes the captured 429 overload plus session metadata, HTTP 502/503/504, transport resets/timeouts, persisted result metadata, normal-contract and error-code-only compatibility scheduler auto-retry, quoted stdout/stderr diagnostics, conflicting mixed streams in both directions, deterministic quota 429, and plain exit code 1.

## Risks

- Low behavioral risk: only explicit signatures on nonzero exits receive the new classification.
- False-positive retries are bounded by the existing scheduler policy; this PR does not increase retry counts or create a retry loop.
- Bare HTTP 429 output without explicit overload evidence remains unclassified to avoid treating quota/configuration failures as transient.
- Hermes session-continuity behavior is unchanged; the existing fresh-session fallback remains Codex-specific.
- No schema migration or production backport is included.
- `ROADMAP.md` was checked. This is a narrow correctness fix within the completed self-healing/automatic-recovery direction, not a duplicate planned subsystem.

## Model Used

- OpenAI `gpt-5.6-sol` through Codex/Hermes tool use and code execution.
- The change used focused Vitest and embedded-Postgres execution plus independent diff review; no hidden chain-of-thought is included.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation or confirmed no user-facing documentation change is required
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — Canary rerun required after runner timeout
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


