### PR TITLE
fix(hermes): keep quiet runs live during silent work

### DIFF
--- a/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
+++ b/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
@@ -108,6 +108,63 @@ describe("hermes-local quiet-mode liveness", () => {
     )).toHaveLength(heartbeatCountAfterExit);
   });
 
+  it("serializes alive heartbeats behind in-flight child output", async () => {
+    let releaseChildLog!: () => void;
+    let resolveChild!: (result: {
+      exitCode: number;
+      signal: null;
+      timedOut: boolean;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    const { ctx, onLog } = makeCtx(true);
+    onLog.mockImplementation(async (_stream, chunk) => {
+      if (chunk === "child output\n") {
+        await new Promise<void>((resolve) => {
+          releaseChildLog = resolve;
+        });
+      }
+    });
+    runChildProcessMock.mockImplementation(async (_runId, _command, _args, options) => {
+      await options.onSpawn?.({
+        pid: 12345,
+        processGroupId: 12345,
+        startedAt: new Date().toISOString(),
+      });
+      const childLog = options.onLog("stdout", "child output\n");
+      return await new Promise((resolve) => {
+        resolveChild = (result) => {
+          void childLog.then(() => resolve(result));
+        };
+      });
+    });
+
+    const execution = execute(ctx as any);
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    try {
+      expect(onLog.mock.calls.some(([, chunk]) =>
+        typeof chunk === "string" && chunk.includes("[hermes] alive:"),
+      )).toBe(false);
+    } finally {
+      releaseChildLog();
+      resolveChild({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "Completed after child output.\nsession_id: quiet-session-ordered\n",
+        stderr: "",
+      });
+      await execution;
+    }
+
+    const orderedChunks = onLog.mock.calls
+      .map(([, chunk]) => chunk)
+      .filter((chunk) => chunk === "child output\n" || chunk.includes("[hermes] alive:"));
+    expect(orderedChunks[0]).toBe("child output\n");
+    expect(orderedChunks[1]).toContain("[hermes] alive:");
+  });
+
   it("does not start a phantom heartbeat after execution finishes before onSpawn resolves", async () => {
     let releaseOnSpawn!: () => void;
     const { ctx, onLog } = makeCtx(true);

--- a/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
+++ b/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
@@ -44,7 +44,7 @@ function makeCtx(quiet: boolean) {
       },
       onLog,
       onMeta: vi.fn(async () => undefined),
-      onSpawn: vi.fn(async () => undefined),
+      onSpawn: vi.fn(async (): Promise<void> => undefined),
     },
     onLog,
   };
@@ -105,6 +105,42 @@ describe("hermes-local quiet-mode liveness", () => {
     expect(onLog.mock.calls.filter(([, chunk]) =>
       typeof chunk === "string" && chunk.includes("[hermes] alive:"),
     )).toHaveLength(heartbeatCountAfterExit);
+  });
+
+  it("does not start a phantom heartbeat after execution finishes before onSpawn resolves", async () => {
+    let releaseOnSpawn!: () => void;
+    const { ctx, onLog } = makeCtx(true);
+    ctx.onSpawn = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseOnSpawn = resolve;
+        }),
+    );
+    runChildProcessMock.mockImplementation(async (_runId, _command, _args, options) => {
+      void options.onSpawn?.({
+        pid: 12345,
+        processGroupId: 12345,
+        startedAt: new Date().toISOString(),
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "Completed quickly.\nsession_id: quiet-session-2\n",
+        stderr: "",
+      };
+    });
+
+    const result = await execute(ctx as any);
+    expect(result.sessionParams).toEqual({ sessionId: "quiet-session-2" });
+
+    releaseOnSpawn();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(onLog.mock.calls.some(([, chunk]) =>
+      typeof chunk === "string" && chunk.includes("[hermes] alive:"),
+    )).toBe(false);
   });
 
   it("does not start alive heartbeats or change session capture in legacy mode", async () => {

--- a/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
+++ b/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runChildProcessMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: runChildProcessMock,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function makeCtx(quiet: boolean) {
+  const onLog = vi.fn(async (_stream: "stdout" | "stderr", _chunk: string) => undefined);
+  return {
+    ctx: {
+      runId: "test-run-quiet-liveness",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Hermes",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "/usr/bin/hermes",
+        provider: "openrouter",
+        timeoutSec: 120,
+        graceSec: 5,
+        quiet,
+      },
+      context: {
+        issueId: "issue-1",
+        wakeReason: "manual",
+        paperclipWake: null,
+      },
+      onLog,
+      onMeta: vi.fn(async () => undefined),
+      onSpawn: vi.fn(async () => undefined),
+    },
+    onLog,
+  };
+}
+
+describe("hermes-local quiet-mode liveness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    runChildProcessMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits post-spawn alive heartbeats without contaminating response or session capture", async () => {
+    let resolveChild!: (result: {
+      exitCode: number;
+      signal: null;
+      timedOut: boolean;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    runChildProcessMock.mockImplementation(async (_runId, _command, _args, options) => {
+      await options.onSpawn?.({
+        pid: 12345,
+        processGroupId: 12345,
+        startedAt: new Date().toISOString(),
+      });
+      return await new Promise((resolve) => {
+        resolveChild = resolve;
+      });
+    });
+
+    const { ctx, onLog } = makeCtx(true);
+    const execution = execute(ctx as any);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    resolveChild({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "[hermes] alive: 30s\nCompleted the requested action.\nsession_id: quiet-session-1\n",
+      stderr: "",
+    });
+    const result = await execution;
+
+    const aliveLogs = onLog.mock.calls.filter(([, chunk]) =>
+      typeof chunk === "string" && chunk.includes("[hermes] alive:"),
+    );
+    expect(aliveLogs.length).toBeGreaterThanOrEqual(1);
+    expect(result.summary).toBe("Completed the requested action.");
+    expect(result.summary).not.toContain("[hermes] alive:");
+    expect(result.sessionParams).toEqual({ sessionId: "quiet-session-1" });
+
+    const heartbeatCountAfterExit = aliveLogs.length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(onLog.mock.calls.filter(([, chunk]) =>
+      typeof chunk === "string" && chunk.includes("[hermes] alive:"),
+    )).toHaveLength(heartbeatCountAfterExit);
+  });
+
+  it("does not start alive heartbeats or change session capture in legacy mode", async () => {
+    runChildProcessMock.mockImplementation(async (_runId, _command, args, options) => {
+      await options.onSpawn?.({
+        pid: 12345,
+        processGroupId: 12345,
+        startedAt: new Date().toISOString(),
+      });
+      expect(args).not.toContain("-Q");
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "Completed the requested action.\nSession ID: legacy-session-1\n",
+        stderr: "",
+      };
+    });
+
+    const { ctx, onLog } = makeCtx(false);
+    const result = await execute(ctx as any);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(onLog.mock.calls.some(([, chunk]) =>
+      typeof chunk === "string" && chunk.includes("[hermes] alive:"),
+    )).toBe(false);
+    expect(result.sessionParams).toEqual({ sessionId: "legacy-session-1" });
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
+++ b/packages/adapters/hermes/src/server/execute.quiet-liveness.test.ts
@@ -57,6 +57,7 @@ describe("hermes-local quiet-mode liveness", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -141,6 +142,52 @@ describe("hermes-local quiet-mode liveness", () => {
     expect(onLog.mock.calls.some(([, chunk]) =>
       typeof chunk === "string" && chunk.includes("[hermes] alive:"),
     )).toBe(false);
+  });
+
+  it("reports heartbeat write failures without failing the child execution", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let resolveChild!: (result: {
+      exitCode: number;
+      signal: null;
+      timedOut: boolean;
+      stdout: string;
+      stderr: string;
+    }) => void;
+    runChildProcessMock.mockImplementation(async (_runId, _command, _args, options) => {
+      await options.onSpawn?.({
+        pid: 12345,
+        processGroupId: 12345,
+        startedAt: new Date().toISOString(),
+      });
+      return await new Promise((resolve) => {
+        resolveChild = resolve;
+      });
+    });
+
+    const { ctx, onLog } = makeCtx(true);
+    onLog.mockImplementation(async (_stream, chunk) => {
+      if (chunk.includes("[hermes] alive:")) throw new Error("log store unavailable");
+    });
+    const execution = execute(ctx as any);
+    await vi.advanceTimersByTimeAsync(15_000);
+    resolveChild({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "Completed.\nsession_id: quiet-session-3\n",
+      stderr: "",
+    });
+
+    const result = await execution;
+
+    expect(result.exitCode).toBe(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.any(Error),
+        runId: "test-run-quiet-liveness",
+      }),
+      "failed to append Hermes quiet heartbeat log",
+    );
   });
 
   it("does not start alive heartbeats or change session capture in legacy mode", async () => {

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -512,24 +512,30 @@ export async function execute(
   // Hermes writes non-error noise to stderr (MCP init, INFO logs, etc).
   // Paperclip renders all stderr as red/error in the UI.
   // Wrap onLog to reclassify benign stderr lines as stdout.
-  const wrappedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
-    if (stream === "stderr") {
-      const trimmed = chunk.trimEnd();
-      // Benign patterns that should NOT appear as errors:
-      // - Structured log lines: [timestamp] INFO/DEBUG/WARN: ...
-      // - MCP server registration messages
-      // - Python import/site noise
-      const isBenign = /^\[?\d{4}[-/]\d{2}[-/]\d{2}T/.test(trimmed) || // structured timestamps
-        /^[A-Z]+:\s+(INFO|DEBUG|WARN|WARNING)\b/.test(trimmed) || // log levels
-        /Successfully registered all tools/.test(trimmed) ||
-        /MCP [Ss]erver/.test(trimmed) ||
-        /tool registered successfully/.test(trimmed) ||
-        /Application initialized/.test(trimmed);
-      if (isBenign) {
-        return ctx.onLog("stdout", chunk);
+  let adapterLogWrite: Promise<void> = Promise.resolve();
+  const wrappedOnLog = (stream: "stdout" | "stderr", chunk: string) => {
+    const write = adapterLogWrite.then(async () => {
+      if (stream === "stderr") {
+        const trimmed = chunk.trimEnd();
+        // Benign patterns that should NOT appear as errors:
+        // - Structured log lines: [timestamp] INFO/DEBUG/WARN: ...
+        // - MCP server registration messages
+        // - Python import/site noise
+        const isBenign = /^\[?\d{4}[-/]\d{2}[-/]\d{2}T/.test(trimmed) || // structured timestamps
+          /^[A-Z]+:\s+(INFO|DEBUG|WARN|WARNING)\b/.test(trimmed) || // log levels
+          /Successfully registered all tools/.test(trimmed) ||
+          /MCP [Ss]erver/.test(trimmed) ||
+          /tool registered successfully/.test(trimmed) ||
+          /Application initialized/.test(trimmed);
+        if (isBenign) {
+          await ctx.onLog("stdout", chunk);
+          return;
+        }
       }
-    }
-    return ctx.onLog(stream, chunk);
+      await ctx.onLog(stream, chunk);
+    });
+    adapterLogWrite = write.catch(() => undefined);
+    return write;
   };
 
   const quietHeartbeatIntervalMs = 15_000;
@@ -571,6 +577,7 @@ export async function execute(
     quietHeartbeatClosed = true;
     if (quietHeartbeatTimer) clearInterval(quietHeartbeatTimer);
     await quietHeartbeatWrite;
+    await adapterLogWrite;
   }
 
   // ── Parse output ───────────────────────────────────────────────────────

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -532,14 +532,42 @@ export async function execute(
     return ctx.onLog(stream, chunk);
   };
 
-  const result = await runChildProcess(ctx.runId, hermesCmd, args, {
-    cwd,
-    env,
-    timeoutSec,
-    graceSec,
-    onLog: wrappedOnLog,
-    onSpawn: ctx.onSpawn,
-  });
+  const quietHeartbeatIntervalMs = 15_000;
+  let quietHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let quietHeartbeatStartedAt = 0;
+  let quietHeartbeatWrite = Promise.resolve();
+  const startQuietHeartbeat = () => {
+    if (!useQuiet || quietHeartbeatTimer) return;
+    quietHeartbeatStartedAt = Date.now();
+    quietHeartbeatTimer = setInterval(() => {
+      const elapsedSeconds = Math.max(1, Math.round((Date.now() - quietHeartbeatStartedAt) / 1000));
+      quietHeartbeatWrite = quietHeartbeatWrite
+        .then(() => wrappedOnLog("stdout", `[hermes] alive: ${elapsedSeconds}s\n`))
+        .catch(() => undefined);
+    }, quietHeartbeatIntervalMs);
+    quietHeartbeatTimer.unref?.();
+  };
+  const onSpawn = useQuiet
+    ? async (meta: { pid: number; processGroupId: number | null; startedAt: string }) => {
+        await ctx.onSpawn?.(meta);
+        startQuietHeartbeat();
+      }
+    : ctx.onSpawn;
+
+  let result: Awaited<ReturnType<typeof runChildProcess>>;
+  try {
+    result = await runChildProcess(ctx.runId, hermesCmd, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onLog: wrappedOnLog,
+      onSpawn,
+    });
+  } finally {
+    if (quietHeartbeatTimer) clearInterval(quietHeartbeatTimer);
+    await quietHeartbeatWrite;
+  }
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -534,10 +534,11 @@ export async function execute(
 
   const quietHeartbeatIntervalMs = 15_000;
   let quietHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let quietHeartbeatClosed = false;
   let quietHeartbeatStartedAt = 0;
   let quietHeartbeatWrite = Promise.resolve();
   const startQuietHeartbeat = () => {
-    if (!useQuiet || quietHeartbeatTimer) return;
+    if (quietHeartbeatClosed || quietHeartbeatTimer) return;
     quietHeartbeatStartedAt = Date.now();
     quietHeartbeatTimer = setInterval(() => {
       const elapsedSeconds = Math.max(1, Math.round((Date.now() - quietHeartbeatStartedAt) / 1000));
@@ -565,6 +566,7 @@ export async function execute(
       onSpawn,
     });
   } finally {
+    quietHeartbeatClosed = true;
     if (quietHeartbeatTimer) clearInterval(quietHeartbeatTimer);
     await quietHeartbeatWrite;
   }

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -544,7 +544,9 @@ export async function execute(
       const elapsedSeconds = Math.max(1, Math.round((Date.now() - quietHeartbeatStartedAt) / 1000));
       quietHeartbeatWrite = quietHeartbeatWrite
         .then(() => wrappedOnLog("stdout", `[hermes] alive: ${elapsedSeconds}s\n`))
-        .catch(() => undefined);
+        .catch((err) => {
+          console.warn({ err, runId: ctx.runId }, "failed to append Hermes quiet heartbeat log");
+        });
     }, quietHeartbeatIntervalMs);
     quietHeartbeatTimer.unref?.();
   };

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -128,6 +128,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     ageMs: number;
     withOutput?: boolean;
     logChunk?: string;
+    quietHermes?: boolean;
+    processPid?: number | null;
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
@@ -169,8 +171,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         role: "engineer",
         status: "running",
         reportsTo: managerId,
-        adapterType: "codex_local",
-        adapterConfig: {},
+        adapterType: opts.quietHermes ? "hermes_local" : "codex_local",
+        adapterConfig: opts.quietHermes ? { quiet: true } : {},
         runtimeConfig: {},
         permissions: {},
       },
@@ -199,6 +201,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       triggerDetail: "system",
       startedAt,
       processStartedAt: startedAt,
+      processPid: opts.processPid ?? null,
       lastOutputAt,
       lastOutputSeq: opts.withOutput ? 3 : 0,
       lastOutputStream: opts.withOutput ? "stdout" : null,
@@ -286,6 +289,42 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(evaluations[0]?.description).toContain("Decision Checklist");
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
+  });
+
+  it("treats a quiet Hermes run with a live child pid as working despite stale output", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      quietHermes: true,
+      processPid: process.pid,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const outputSilence = await heartbeat.buildRunOutputSilence(run!, now);
+
+    expect(result).toMatchObject({ created: 0, skipped: 1 });
+    expect(outputSilence).toMatchObject({ level: "ok", processAlive: true });
+  });
+
+  it("still treats a quiet Hermes run with a dead child pid as stalled", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      quietHermes: true,
+      processPid: 2_000_000_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const outputSilence = await heartbeat.buildRunOutputSilence(run!, now);
+
+    expect(result.created).toBe(1);
+    expect(outputSilence).toMatchObject({ level: "suspicious", processAlive: false });
   });
 
   it("redacts sensitive values from actual run-log evidence", async () => {

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../services/heartbeat.ts";
 import { recoveryService } from "../services/recovery/service.ts";
 import { getRunLogStore } from "../services/run-log-store.ts";
+import { runningProcesses } from "../adapters/utils.ts";
 
 const mockAdapterExecute = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -108,6 +109,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
   }, 30_000);
 
   afterEach(async () => {
+    runningProcesses.clear();
     for (let attempt = 0; attempt < 100; attempt += 1) {
       const activeRuns = await db
         .select({ id: heartbeatRuns.id })
@@ -205,7 +207,13 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       lastOutputAt,
       lastOutputSeq: opts.withOutput ? 3 : 0,
       lastOutputStream: opts.withOutput ? "stdout" : null,
-      contextSnapshot: { issueId },
+      contextSnapshot: {
+        issueId,
+        paperclipAdapterExecution: {
+          adapterType: opts.quietHermes ? "hermes_local" : "codex_local",
+          quiet: opts.quietHermes === true,
+        },
+      },
       stdoutExcerpt: "OPENAI_API_KEY=sk-test-secret-value should not leak",
       logBytes: 0,
     });
@@ -293,12 +301,21 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
   it("treats a quiet Hermes run with a live child pid as working despite stale output", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
-    const { companyId, runId } = await seedRunningRun({
+    const { companyId, coderId, runId } = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
       quietHermes: true,
       processPid: process.pid,
     });
+    runningProcesses.set(runId, {
+      child: { pid: process.pid } as never,
+      graceSec: 5,
+      processGroupId: null,
+    });
+    await db
+      .update(agents)
+      .set({ adapterType: "codex_local", adapterConfig: {} })
+      .where(eq(agents.id, coderId));
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
@@ -325,6 +342,50 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     expect(result.created).toBe(1);
     expect(outputSilence).toMatchObject({ level: "suspicious", processAlive: false });
+  });
+
+  it("does not trust a live raw pid without the identity-bound tracked child", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      quietHermes: true,
+      processPid: process.pid,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const outputSilence = await heartbeat.buildRunOutputSilence(run!, now);
+
+    expect(result.created).toBe(1);
+    expect(outputSilence).toMatchObject({ level: "suspicious", processAlive: false });
+  });
+
+  it("does not derive quiet mode from mutable current agent configuration", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      processPid: process.pid,
+    });
+    runningProcesses.set(runId, {
+      child: { pid: process.pid } as never,
+      graceSec: 5,
+      processGroupId: null,
+    });
+    await db
+      .update(agents)
+      .set({ adapterType: "hermes_local", adapterConfig: { quiet: true } })
+      .where(eq(agents.id, coderId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const outputSilence = await heartbeat.buildRunOutputSilence(run!, now);
+
+    expect(result.created).toBe(1);
+    expect(outputSilence).toMatchObject({ level: "suspicious", processAlive: null });
   });
 
   it("redacts sensitive values from actual run-log evidence", async () => {

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -39,6 +39,7 @@ const mockAdapterExecute = vi.hoisted(() =>
     model: "test-model",
   })),
 );
+const mockIsProcessGroupAlive = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("../telemetry.ts", () => ({
   getTelemetryClient: () => ({ track: vi.fn() }),
@@ -62,6 +63,16 @@ vi.mock("../adapters/index.ts", async () => {
       supportsLocalAgentJwt: false,
       execute: mockAdapterExecute,
     })),
+  };
+});
+
+vi.mock("../services/local-service-supervisor.ts", async () => {
+  const actual = await vi.importActual<typeof import("../services/local-service-supervisor.ts")>(
+    "../services/local-service-supervisor.ts",
+  );
+  return {
+    ...actual,
+    isProcessGroupAlive: mockIsProcessGroupAlive,
   };
 });
 
@@ -110,6 +121,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
   afterEach(async () => {
     runningProcesses.clear();
+    mockIsProcessGroupAlive.mockReset();
+    mockIsProcessGroupAlive.mockReturnValue(false);
     for (let attempt = 0; attempt < 100; attempt += 1) {
       const activeRuns = await db
         .select({ id: heartbeatRuns.id })
@@ -308,7 +321,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       processPid: process.pid,
     });
     runningProcesses.set(runId, {
-      child: { pid: process.pid } as never,
+      child: { pid: process.pid, exitCode: null, signalCode: null } as never,
       graceSec: 5,
       processGroupId: null,
     });
@@ -316,6 +329,63 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       .update(agents)
       .set({ adapterType: "codex_local", adapterConfig: {} })
       .where(eq(agents.id, coderId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const outputSilence = await heartbeat.buildRunOutputSilence(run!, now);
+
+    expect(result).toMatchObject({ created: 0, skipped: 1 });
+    expect(outputSilence).toMatchObject({ level: "ok", processAlive: true });
+  });
+
+  it.each([
+    ["exit code", { exitCode: 1, signalCode: null }],
+    ["signal", { exitCode: null, signalCode: "SIGTERM" }],
+  ])("creates a stale-run evaluation after a quiet Hermes direct child has terminal %s despite a live process group", async (_terminalState, childTerminalState) => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      quietHermes: true,
+      processPid: 2_000_000_000,
+    });
+    mockIsProcessGroupAlive.mockReturnValue(true);
+    runningProcesses.set(runId, {
+      child: { pid: 2_000_000_000, ...childTerminalState } as never,
+      graceSec: 5,
+      processGroupId: 424_242,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const outputSilence = await heartbeat.buildRunOutputSilence(run!, now);
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+
+    expect(result).toMatchObject({ created: 1, skipped: 0 });
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.originId).toBe(runId);
+    expect(outputSilence).toMatchObject({ level: "suspicious", processAlive: false });
+  });
+
+  it("continues to trust a live process group for a non-terminal quiet Hermes direct child", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      quietHermes: true,
+      processPid: 2_000_000_000,
+    });
+    mockIsProcessGroupAlive.mockReturnValue(true);
+    runningProcesses.set(runId, {
+      child: { pid: 2_000_000_000, exitCode: null, signalCode: null } as never,
+      graceSec: 5,
+      processGroupId: 424_242,
+    });
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.scanSilentActiveRuns({ now, companyId });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14892,6 +14892,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         : {}),
     };
+    context.paperclipAdapterExecution = {
+      adapterType: agent.adapterType,
+      quiet: agent.adapterType === "hermes_local" && runtimeConfig.quiet === true,
+    };
     await db
       .update(heartbeatRuns)
       .set({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1433,26 +1433,32 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function readQuietHermesProcessAlive(companyId: string, runId: string): Promise<boolean | null> {
     const [record] = await db
       .select({
-        adapterType: agents.adapterType,
-        adapterConfig: agents.adapterConfig,
+        status: heartbeatRuns.status,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
         processPid: heartbeatRuns.processPid,
         processGroupId: heartbeatRuns.processGroupId,
       })
       .from(heartbeatRuns)
-      .innerJoin(agents, eq(agents.id, heartbeatRuns.agentId))
       .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.companyId, companyId)))
       .limit(1);
+    const launchConfig = parseObject(parseObject(record?.contextSnapshot).paperclipAdapterExecution);
     if (
       !record ||
-      record.adapterType !== "hermes_local" ||
-      parseObject(record.adapterConfig).quiet !== true
+      record.status !== "running" ||
+      launchConfig.adapterType !== "hermes_local" ||
+      launchConfig.quiet !== true
     ) {
       return null;
     }
 
     const running = runningProcesses.get(runId);
-    const processPid = running?.child.pid ?? record.processPid;
-    const processGroupId = running?.processGroupId ?? record.processGroupId;
+    if (!running) {
+      return typeof record.processPid === "number" || typeof record.processGroupId === "number"
+        ? false
+        : null;
+    }
+    const processPid = running.child.pid;
+    const processGroupId = running.processGroupId;
     if (typeof processPid !== "number" && typeof processGroupId !== "number") return null;
     return (
       (typeof processPid === "number" && isPidAlive(processPid)) ||

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1457,6 +1457,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ? false
         : null;
     }
+    if (running.child.exitCode !== null || running.child.signalCode !== null) return false;
     const processPid = running.child.pid;
     const processGroupId = running.processGroupId;
     if (typeof processPid !== "number" && typeof processGroupId !== "number") return null;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -303,6 +303,7 @@ export type RunOutputSilenceSummary = {
   evaluationIssueId: string | null;
   evaluationIssueIdentifier: string | null;
   evaluationIssueAssigneeAgentId: string | null;
+  processAlive: boolean | null;
 };
 
 function readNonEmptyString(value: unknown): string | null {
@@ -1429,6 +1430,36 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row != null;
   }
 
+  async function readQuietHermesProcessAlive(companyId: string, runId: string): Promise<boolean | null> {
+    const [record] = await db
+      .select({
+        adapterType: agents.adapterType,
+        adapterConfig: agents.adapterConfig,
+        processPid: heartbeatRuns.processPid,
+        processGroupId: heartbeatRuns.processGroupId,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(agents.id, heartbeatRuns.agentId))
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.companyId, companyId)))
+      .limit(1);
+    if (
+      !record ||
+      record.adapterType !== "hermes_local" ||
+      parseObject(record.adapterConfig).quiet !== true
+    ) {
+      return null;
+    }
+
+    const running = runningProcesses.get(runId);
+    const processPid = running?.child.pid ?? record.processPid;
+    const processGroupId = running?.processGroupId ?? record.processGroupId;
+    if (typeof processPid !== "number" && typeof processGroupId !== "number") return null;
+    return (
+      (typeof processPid === "number" && isPidAlive(processPid)) ||
+      (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId))
+    );
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -1436,9 +1467,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     >,
     now = new Date(),
   ): Promise<RunOutputSilenceSummary> {
-    const [quietUntilDecision, evaluation] = await Promise.all([
+    const [quietUntilDecision, evaluation, processAlive] = await Promise.all([
       latestActiveOutputQuietUntilDecision(run.companyId, run.id, now),
       findOpenStaleRunEvaluation(run.companyId, run.id),
+      readQuietHermesProcessAlive(run.companyId, run.id),
     ]);
     const silenceStartedAt = silenceStartedAtForRun(run);
     const silenceAgeMs = run.status === "running" ? silenceAgeMsForRun(run, now) : null;
@@ -1446,6 +1478,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       ? "not_applicable"
       : quietUntilDecision
         ? "snoozed"
+        : processAlive
+          ? "ok"
         : (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS
           ? "critical"
           : (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS
@@ -1466,6 +1500,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       evaluationIssueId: evaluation?.id ?? null,
       evaluationIssueIdentifier: evaluation?.identifier ?? null,
       evaluationIssueAssigneeAgentId: evaluation?.assigneeAgentId ?? null,
+      processAlive,
     };
   }
 
@@ -2325,6 +2360,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const run of candidates) {
+      if (await readQuietHermesProcessAlive(run.companyId, run.id)) {
+        result.skipped += 1;
+        continue;
+      }
       if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
         result.snoozed += 1;
         continue;


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates long-running AI-agent work and monitors active runs through durable output progress plus tracked child-process metadata.
> - Hermes quiet mode intentionally suppresses normal model output, including during long tool execution.
> - Paperclip advances `lastOutputAt` through adapter `onLog`, so a healthy quiet child can appear stale despite remaining alive.
> - Output silence alone is therefore insufficient evidence of a stalled quiet Hermes run, while PID liveness alone must not suppress alerts for dead or untracked children.
> - This pull request adds a truthful post-spawn quiet heartbeat and a quiet-Hermes-only process-liveness guard in the existing output-silence monitor.
> - Session ID parsing and response summaries must remain unchanged because quiet mode is also the clean session-capture path.
> - The benefit is accurate active-run status without disabling stale-run detection when the child has actually died.

## Linked Issues or Issue Description

- Fixes: #10423

## What Changed

- Start a 15-second `[hermes] alive: ...` log timer only after a quiet Hermes child has spawned successfully.
- Stop the timer and drain any pending heartbeat write when the child exits or execution throws.
- Keep heartbeat lines out of response summaries while preserving quiet and legacy session ID capture.
- Snapshot the launch adapter type and resolved quiet mode in the run context so later agent-config edits cannot change liveness classification.
- Add `processAlive` evidence to output-silence summaries only when the identity-bound `runningProcesses` entry for that quiet Hermes run still owns a live PID/process group.
- Never trust a bare persisted PID after the tracked child closes; dead, missing, or recycled PID evidence retains existing suspicious/critical behavior.
- Report heartbeat-log write failures through the same structured warning shape used by child-process log writes without aborting healthy work.
- Leave non-quiet Hermes and every other adapter's monitoring behavior unchanged.
- Add timer, cleanup, parsing, live-PID, and dead-PID regressions.
- No user-facing documentation change is required; this corrects internal runtime observability.

## Verification

- `pnpm test` in `packages/adapters/hermes` — **64/64 passed**.
- `pnpm typecheck` in `packages/adapters/hermes` — passed.
- `pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts --testTimeout=30000` — **22/22 passed**.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.
- Regression coverage includes post-spawn heartbeat timing and cleanup, child/heartbeat log ordering, delayed `onSpawn` completion after child exit, heartbeat-write diagnostics, summary/session capture, legacy mode unchanged, launch-config stability, identity-bound live-PID classification, dead PID, and recycled raw PID fail-closed behavior.

## Risks

- Low-to-medium observability risk: quiet runs emit one small log every 15 seconds; Paperclip's existing output-progress throttling bounds persistence churn.
- PID/process-group liveness is accepted only through the run-ID-bound in-memory child registry; a bare persisted PID cannot suppress recovery after child close or PID reuse.
- A live but internally hung process is treated as alive; periodic adapter heartbeats now provide current progress evidence, while execution timeout and process supervision remain unchanged.
- Heartbeat-log write failure is isolated from child execution so observability storage cannot abort otherwise healthy work.
- No schema migration or production backport is included.
- `ROADMAP.md` was checked. This is a narrow correctness fix within shipped watchdog/self-healing behavior, not a duplicate planned subsystem.

## Model Used

- OpenAI `gpt-5.6-sol` through Codex/Hermes tool use and code execution.
- The change used fake-timer adapter tests, embedded-Postgres watchdog tests, package typechecks, and independent diff review; no hidden chain-of-thought is included.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation or confirmed no user-facing documentation change is required
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

