### PR TITLE
fix(server): recover managed plugin workers after boot races

### DIFF
--- a/server/src/__tests__/plugin-environment-driver-ready-recovery.test.ts
+++ b/server/src/__tests__/plugin-environment-driver-ready-recovery.test.ts
@@ -37,10 +37,10 @@ const manifest: PaperclipPluginManifestV1 = {
   ],
 };
 
-function createPlugin(status: string) {
+function createPlugin(status: string, options: { id?: string; pluginKey?: string } = {}) {
   return {
-    id: PLUGIN_ID,
-    pluginKey: PLUGIN_KEY,
+    id: options.id ?? PLUGIN_ID,
+    pluginKey: options.pluginKey ?? PLUGIN_KEY,
     status,
     manifestJson: manifest,
   };
@@ -212,5 +212,39 @@ describe("listReadyPluginEnvironmentDrivers worker recovery", () => {
       }),
     ]);
     expect(secondDrivers).toEqual(firstDrivers);
+  });
+
+  it("bounds slow managed bundled recovery attempts without serial waits", async () => {
+    vi.useFakeTimers();
+    try {
+      const plugins = [
+        createPlugin("ready"),
+        createPlugin("ready", {
+          id: "plugin-modal",
+          pluginKey: "paperclip.modal-sandbox-provider",
+        }),
+      ];
+      mockRegistry.list.mockResolvedValue(plugins);
+      const worker = createWorkerManager();
+      const startWorker = vi.fn(() => new Promise<boolean>(() => {}));
+
+      const driversPromise = listReadyPluginEnvironmentDrivers({
+        db: {} as never,
+        workerManager: worker.workerManager,
+        recoverMissingWorker: {
+          pluginKeys: [PLUGIN_KEY, "paperclip.modal-sandbox-provider"],
+          startWorker,
+          timeoutMs: 25,
+        },
+      });
+      await Promise.resolve();
+
+      expect(startWorker).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(driversPromise).resolves.toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/server/src/__tests__/plugin-environment-driver-ready-recovery.test.ts
+++ b/server/src/__tests__/plugin-environment-driver-ready-recovery.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { createManagedBundledPluginWorkerRecovery } from "../app.js";
+import { listReadyPluginEnvironmentDrivers } from "../services/plugin-environment-driver.js";
+import type { PluginLoader } from "../services/plugin-loader.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+
+const mockRegistry = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../services/plugin-registry.js", () => ({
+  pluginRegistryService: () => mockRegistry,
+}));
+
+const PLUGIN_ID = "plugin-daytona";
+const PLUGIN_KEY = "paperclip.daytona-sandbox-provider";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_KEY,
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Daytona Sandbox Provider",
+  description: "Provides Daytona-backed sandboxes.",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: ["environment.drivers.register"],
+  entrypoints: { worker: "dist/worker.js" },
+  environmentDrivers: [
+    {
+      driverKey: "daytona",
+      kind: "sandbox_provider",
+      displayName: "Daytona",
+      description: "Daytona sandbox provider",
+      configSchema: { type: "object", properties: {} },
+    },
+  ],
+};
+
+function createPlugin(status: string) {
+  return {
+    id: PLUGIN_ID,
+    pluginKey: PLUGIN_KEY,
+    status,
+    manifestJson: manifest,
+  };
+}
+
+function createWorkerManager(options: {
+  running?: boolean;
+  hasHandle?: boolean;
+} = {}) {
+  let running = options.running ?? false;
+  const workerManager = {
+    isRunning: vi.fn(() => running),
+    getWorker: vi.fn(() => (options.hasHandle ? { status: "backoff" } : undefined)),
+  } as unknown as PluginWorkerManager;
+  return {
+    workerManager,
+    markRunning: () => {
+      running = true;
+    },
+  };
+}
+
+function createDeferred<T = void>() {
+  let resolve!: (value?: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("listReadyPluginEnvironmentDrivers worker recovery", () => {
+  beforeEach(() => {
+    mockRegistry.list.mockReset();
+  });
+
+  it("recovers a managed bundled provider that was installed by a sibling process after this process skipped it", async () => {
+    const plugin = createPlugin("installed");
+    mockRegistry.list.mockImplementation(async () => [plugin]);
+    const worker = createWorkerManager();
+    const startWorker = vi.fn(async () => {
+      worker.markRunning();
+      return true;
+    });
+
+    await expect(
+      listReadyPluginEnvironmentDrivers({
+        db: {} as never,
+        workerManager: worker.workerManager,
+        recoverMissingWorker: {
+          pluginKeys: [PLUGIN_KEY],
+          startWorker,
+        },
+      }),
+    ).resolves.toEqual([]);
+    expect(startWorker).not.toHaveBeenCalled();
+
+    plugin.status = "ready";
+    const drivers = await listReadyPluginEnvironmentDrivers({
+      db: {} as never,
+      workerManager: worker.workerManager,
+      recoverMissingWorker: {
+        pluginKeys: [PLUGIN_KEY],
+        startWorker,
+      },
+    });
+
+    expect(startWorker).toHaveBeenCalledWith({
+      id: PLUGIN_ID,
+      pluginKey: PLUGIN_KEY,
+    });
+    expect(drivers).toEqual([
+      expect.objectContaining({
+        pluginId: PLUGIN_ID,
+        pluginKey: PLUGIN_KEY,
+        driverKey: "daytona",
+        displayName: "Daytona",
+      }),
+    ]);
+  });
+
+  it("does not lazy-start ready plugins outside the managed bundled allowlist", async () => {
+    const plugin = createPlugin("ready");
+    mockRegistry.list.mockResolvedValue([plugin]);
+    const worker = createWorkerManager();
+    const startWorker = vi.fn(async () => {
+      worker.markRunning();
+      return true;
+    });
+
+    const drivers = await listReadyPluginEnvironmentDrivers({
+      db: {} as never,
+      workerManager: worker.workerManager,
+      recoverMissingWorker: {
+        pluginKeys: ["paperclip.kubernetes-sandbox-provider"],
+        startWorker,
+      },
+    });
+
+    expect(startWorker).not.toHaveBeenCalled();
+    expect(drivers).toEqual([]);
+  });
+
+  it("leaves existing worker-manager recovery handles alone", async () => {
+    const plugin = createPlugin("ready");
+    mockRegistry.list.mockResolvedValue([plugin]);
+    const worker = createWorkerManager({ hasHandle: true });
+    const startWorker = vi.fn(async () => true);
+
+    const drivers = await listReadyPluginEnvironmentDrivers({
+      db: {} as never,
+      workerManager: worker.workerManager,
+      recoverMissingWorker: {
+        pluginKeys: [PLUGIN_KEY],
+        startWorker,
+      },
+    });
+
+    expect(startWorker).not.toHaveBeenCalled();
+    expect(drivers).toEqual([]);
+  });
+
+  it("single-flights concurrent managed bundled recovery starts", async () => {
+    const plugin = createPlugin("ready");
+    mockRegistry.list.mockResolvedValue([plugin]);
+    const worker = createWorkerManager();
+    const loadStarted = createDeferred();
+    const releaseLoad = createDeferred();
+    const loadSingle = vi.fn(async () => {
+      loadStarted.resolve();
+      await releaseLoad.promise;
+      worker.markRunning();
+      return { success: true };
+    });
+    const startWorker = createManagedBundledPluginWorkerRecovery({
+      managedBundledPluginKeys: [PLUGIN_KEY],
+      workerManager: worker.workerManager,
+      getLoader: () => ({ loadSingle }) as Pick<PluginLoader, "loadSingle">,
+    });
+
+    const first = listReadyPluginEnvironmentDrivers({
+      db: {} as never,
+      workerManager: worker.workerManager,
+      recoverMissingWorker: {
+        pluginKeys: [PLUGIN_KEY],
+        startWorker,
+      },
+    });
+    await loadStarted.promise;
+    const second = listReadyPluginEnvironmentDrivers({
+      db: {} as never,
+      workerManager: worker.workerManager,
+      recoverMissingWorker: {
+        pluginKeys: [PLUGIN_KEY],
+        startWorker,
+      },
+    });
+
+    releaseLoad.resolve();
+    const [firstDrivers, secondDrivers] = await Promise.all([first, second]);
+
+    expect(loadSingle).toHaveBeenCalledTimes(1);
+    expect(loadSingle).toHaveBeenCalledWith(PLUGIN_ID);
+    expect(firstDrivers).toEqual([
+      expect.objectContaining({
+        pluginId: PLUGIN_ID,
+        driverKey: "daytona",
+      }),
+    ]);
+    expect(secondDrivers).toEqual(firstDrivers);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -64,7 +64,7 @@ import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { readBrandedStaticIndexHtml } from "./static-index-html.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
-import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
+import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader, type PluginLoader } from "./services/plugin-loader.js";
 import {
   SELF_HOSTED_AUTO_INSTALL_KEYS,
   ensureBundledPlugins,
@@ -146,6 +146,55 @@ export function shouldEnablePrivateHostnameGuard(opts: {
     opts.deploymentExposure === "private" &&
     (opts.deploymentMode === "local_trusted" || opts.deploymentMode === "authenticated")
   );
+}
+
+export function createManagedBundledPluginWorkerRecovery(input: {
+  managedBundledPluginKeys: readonly string[];
+  workerManager: Pick<PluginWorkerManager, "getWorker" | "isRunning">;
+  getLoader: () => Pick<PluginLoader, "loadSingle"> | null;
+}): (plugin: { id: string; pluginKey: string }) => Promise<boolean> {
+  const recoverablePluginKeys = new Set(input.managedBundledPluginKeys);
+  const inFlightStarts = new Map<string, Promise<boolean>>();
+
+  return async (plugin) => {
+    if (!recoverablePluginKeys.has(plugin.pluginKey)) return false;
+
+    const inFlight = inFlightStarts.get(plugin.id);
+    if (inFlight) return inFlight;
+
+    const startPromise = (async () => {
+      if (input.workerManager.getWorker(plugin.id)) {
+        return input.workerManager.isRunning(plugin.id);
+      }
+
+      const loader = input.getLoader();
+      if (!loader) return false;
+
+      try {
+        const result = await loader.loadSingle(plugin.id);
+        return result.success === true || input.workerManager.isRunning(plugin.id);
+      } catch (err) {
+        logger.warn(
+          {
+            pluginId: plugin.id,
+            pluginKey: plugin.pluginKey,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "managed bundled plugin lazy worker recovery failed",
+        );
+        throw err;
+      }
+    })();
+
+    inFlightStarts.set(plugin.id, startPromise);
+    try {
+      return await startPromise;
+    } finally {
+      if (inFlightStarts.get(plugin.id) === startPromise) {
+        inFlightStarts.delete(plugin.id);
+      }
+    }
+  };
 }
 
 export async function createApp(
@@ -238,6 +287,34 @@ export async function createApp(
 
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = opts.pluginWorkerManager ?? createPluginWorkerManager();
+  const managedAutoInstallKeys = opts.managedPluginAutoInstall ?? null;
+  const bundledCatalogRoot =
+    opts.bundledPluginCatalogRoot ?? resolveBundledCatalogRoot(process.env);
+  const bundledPluginInstalls = resolveBundledPluginInstalls(
+    managedAutoInstallKeys ?? SELF_HOSTED_AUTO_INSTALL_KEYS,
+    {
+      catalogRoot: bundledCatalogRoot,
+      env: process.env,
+      enforceCatalogRoot: managedAutoInstallKeys !== null,
+    },
+  );
+  const managedBundledPluginKeys =
+    managedAutoInstallKeys !== null
+      ? bundledPluginInstalls.map((install) => install.pluginKey)
+      : [];
+  let runtimePluginLoader: Pick<PluginLoader, "loadSingle"> | null = null;
+  // A sibling process can install a managed bundled plugin while this process
+  // skips the mid-install row, then finish the row after this process's
+  // loadAll() pass. The capabilities route may recover only those managed
+  // bundles by starting their ready-but-unstarted worker lazily.
+  const recoverManagedBundledPluginWorker =
+    managedAutoInstallKeys !== null
+      ? createManagedBundledPluginWorkerRecovery({
+          managedBundledPluginKeys,
+          workerManager,
+          getLoader: () => runtimePluginLoader,
+        })
+      : undefined;
 
   // Mount API routes
   const api = Router();
@@ -271,7 +348,15 @@ export async function createApp(
   api.use(fileResourceRoutes(db));
   api.use(routineRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(pipelineRoutes(db));
-  api.use(environmentRoutes(db, { pluginWorkerManager: workerManager }));
+  api.use(environmentRoutes(db, {
+    pluginWorkerManager: workerManager,
+    recoverMissingPluginWorker: recoverManagedBundledPluginWorker
+      ? {
+        pluginKeys: managedBundledPluginKeys,
+        startWorker: recoverManagedBundledPluginWorker,
+      }
+      : undefined,
+  }));
   api.use(executionWorkspaceRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(goalRoutes(db));
   api.use(boardChatRoutes(db, { deploymentMode: opts.deploymentMode }));
@@ -380,6 +465,7 @@ export async function createApp(
       },
     },
   );
+  runtimePluginLoader = loader;
   api.use(
     toolGatewayRoutes(db, toolGateway),
   );
@@ -570,21 +656,10 @@ export async function createApp(
   // drive the key list from the control plane; self-hosted instances keep
   // the pre-existing behavior of ensuring only the kubernetes bundle.
   //
-  // Resolution below is deliberately synchronous and NOT fail-safe: an
+  // Resolution is deliberately synchronous and NOT fail-safe: an
   // unknown key or a path escaping the bundled catalog root throws out of
   // createApp so a managed instance refuses to start (positive allowlist,
   // fail closed).
-  const managedAutoInstallKeys = opts.managedPluginAutoInstall ?? null;
-  const bundledCatalogRoot =
-    opts.bundledPluginCatalogRoot ?? resolveBundledCatalogRoot(process.env);
-  const bundledPluginInstalls = resolveBundledPluginInstalls(
-    managedAutoInstallKeys ?? SELF_HOSTED_AUTO_INSTALL_KEYS,
-    {
-      catalogRoot: bundledCatalogRoot,
-      env: process.env,
-      enforceCatalogRoot: managedAutoInstallKeys !== null,
-    },
-  );
   // SAFETY: installation is fully fail-safe. Any failure
   // (missing bundle, install error, load error) is caught, logged, and
   // swallowed per plugin so the server ALWAYS finishes booting. A degraded

--- a/server/src/routes/environments.ts
+++ b/server/src/routes/environments.ts
@@ -47,7 +47,10 @@ import {
 } from "../services/environment-config.js";
 import { probeEnvironment } from "../services/environment-probe.js";
 import { secretService } from "../services/secrets.js";
-import { listReadyPluginEnvironmentDrivers } from "../services/plugin-environment-driver.js";
+import {
+  listReadyPluginEnvironmentDrivers,
+  type ReadyPluginWorkerRecovery,
+} from "../services/plugin-environment-driver.js";
 import { getConfiguredSecretProvider } from "../secrets/configured-provider.js";
 import { assertBoardOrgAccess, getActorInfo } from "./authz.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
@@ -261,7 +264,10 @@ function assertNoClientPlatformProvisionedMarkers(metadata: unknown): void {
 
 export function environmentRoutes(
   db: Db,
-  options: { pluginWorkerManager?: PluginWorkerManager } = {},
+  options: {
+    pluginWorkerManager?: PluginWorkerManager;
+    recoverMissingPluginWorker?: ReadyPluginWorkerRecovery;
+  } = {},
 ) {
   const router = Router();
   const svc = environmentService(db);
@@ -602,6 +608,7 @@ export function environmentRoutes(
     const pluginDrivers = await listReadyPluginEnvironmentDrivers({
       db,
       workerManager: options.pluginWorkerManager,
+      recoverMissingWorker: options.recoverMissingPluginWorker,
     });
     res.json(getEnvironmentCapabilities(
       AGENT_ADAPTER_TYPES,

--- a/server/src/services/plugin-environment-driver.ts
+++ b/server/src/services/plugin-environment-driver.ts
@@ -30,6 +30,27 @@ import {
 import { pluginRegistryService } from "./plugin-registry.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 
+export interface ReadyPluginWorkerRecovery {
+  pluginKeys: readonly string[];
+  startWorker(plugin: { id: string; pluginKey: string }): Promise<boolean>;
+}
+
+export interface ReadyPluginEnvironmentDriver {
+  pluginId: string;
+  pluginKey: string;
+  driverKey: string;
+  displayName: string;
+  description?: string;
+  configSchema: PluginEnvironmentDriverDeclaration["configSchema"];
+  supportsReusableLeases?: PluginEnvironmentDriverDeclaration["supportsReusableLeases"];
+  supportsInteractiveSetup?: PluginEnvironmentDriverDeclaration["supportsInteractiveSetup"];
+  interactiveSetupConnectionTypes?: PluginEnvironmentDriverDeclaration["interactiveSetupConnectionTypes"];
+  supportsTemplateCapture?: PluginEnvironmentDriverDeclaration["supportsTemplateCapture"];
+  templateRefKind?: PluginEnvironmentDriverDeclaration["templateRefKind"];
+  templateConfigBinding?: PluginEnvironmentDriverDeclaration["templateConfigBinding"];
+  supportsTemplateDelete?: PluginEnvironmentDriverDeclaration["supportsTemplateDelete"];
+}
+
 export function pluginDriverProviderKey(config: Pick<PluginEnvironmentConfig, "pluginKey" | "driverKey">): string {
   return `${config.pluginKey}:${config.driverKey}`;
 }
@@ -94,30 +115,48 @@ export async function resolvePluginSandboxProviderDriverByKey(input: {
 export async function listReadyPluginEnvironmentDrivers(input: {
   db: Db;
   workerManager?: PluginWorkerManager;
+  recoverMissingWorker?: ReadyPluginWorkerRecovery;
 }) {
   if (!input.workerManager) return [];
   const pluginRegistry = pluginRegistryService(input.db);
   const plugins = await pluginRegistry.list();
-  return plugins.flatMap((plugin) => {
-    if (plugin.status !== "ready" || !input.workerManager?.isRunning(plugin.id)) return [];
-    return (plugin.manifestJson.environmentDrivers ?? [])
-      .filter((driver) => driver.kind === "sandbox_provider")
-      .map((driver) => ({
-        pluginId: plugin.id,
-        pluginKey: plugin.pluginKey,
-        driverKey: driver.driverKey,
-        displayName: driver.displayName,
-        description: driver.description,
-        configSchema: driver.configSchema,
-        supportsReusableLeases: driver.supportsReusableLeases,
-        supportsInteractiveSetup: driver.supportsInteractiveSetup,
-        interactiveSetupConnectionTypes: driver.interactiveSetupConnectionTypes,
-        supportsTemplateCapture: driver.supportsTemplateCapture,
-        templateRefKind: driver.templateRefKind,
-        templateConfigBinding: driver.templateConfigBinding,
-        supportsTemplateDelete: driver.supportsTemplateDelete,
-      }));
-  });
+  const recoverablePluginKeys = new Set(input.recoverMissingWorker?.pluginKeys ?? []);
+  const rows: ReadyPluginEnvironmentDriver[] = [];
+  for (const plugin of plugins) {
+    if (plugin.status !== "ready") continue;
+    if (!input.workerManager.isRunning(plugin.id)) {
+      const canRecover =
+        recoverablePluginKeys.has(plugin.pluginKey)
+        && !input.workerManager.getWorker(plugin.id);
+      if (canRecover) {
+        await input.recoverMissingWorker?.startWorker({
+          id: plugin.id,
+          pluginKey: plugin.pluginKey,
+        }).catch(() => false);
+      }
+      if (!input.workerManager.isRunning(plugin.id)) continue;
+    }
+    rows.push(
+      ...(plugin.manifestJson.environmentDrivers ?? [])
+        .filter((driver) => driver.kind === "sandbox_provider")
+        .map((driver) => ({
+          pluginId: plugin.id,
+          pluginKey: plugin.pluginKey,
+          driverKey: driver.driverKey,
+          displayName: driver.displayName,
+          description: driver.description,
+          configSchema: driver.configSchema,
+          supportsReusableLeases: driver.supportsReusableLeases,
+          supportsInteractiveSetup: driver.supportsInteractiveSetup,
+          interactiveSetupConnectionTypes: driver.interactiveSetupConnectionTypes,
+          supportsTemplateCapture: driver.supportsTemplateCapture,
+          templateRefKind: driver.templateRefKind,
+          templateConfigBinding: driver.templateConfigBinding,
+          supportsTemplateDelete: driver.supportsTemplateDelete,
+        })),
+    );
+  }
+  return rows;
 }
 
 export async function validatePluginSandboxProviderConfig(input: {

--- a/server/src/services/plugin-environment-driver.ts
+++ b/server/src/services/plugin-environment-driver.ts
@@ -33,6 +33,7 @@ import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 export interface ReadyPluginWorkerRecovery {
   pluginKeys: readonly string[];
   startWorker(plugin: { id: string; pluginKey: string }): Promise<boolean>;
+  timeoutMs?: number;
 }
 
 export interface ReadyPluginEnvironmentDriver {
@@ -53,6 +54,23 @@ export interface ReadyPluginEnvironmentDriver {
 
 export function pluginDriverProviderKey(config: Pick<PluginEnvironmentConfig, "pluginKey" | "driverKey">): string {
   return `${config.pluginKey}:${config.driverKey}`;
+}
+
+const DEFAULT_READY_PLUGIN_WORKER_RECOVERY_TIMEOUT_MS = 2_000;
+
+async function resolveWithTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutValue: T): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return await promise;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(timeoutValue), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export async function resolvePluginEnvironmentDriver(input: {
@@ -121,20 +139,35 @@ export async function listReadyPluginEnvironmentDrivers(input: {
   const pluginRegistry = pluginRegistryService(input.db);
   const plugins = await pluginRegistry.list();
   const recoverablePluginKeys = new Set(input.recoverMissingWorker?.pluginKeys ?? []);
+  const readyPlugins = plugins.filter((plugin) => plugin.status === "ready");
+  const recoveryAttempts: Promise<boolean>[] = [];
+
+  for (const plugin of readyPlugins) {
+    const canRecover =
+      !input.workerManager.isRunning(plugin.id)
+      && recoverablePluginKeys.has(plugin.pluginKey)
+      && !input.workerManager.getWorker(plugin.id);
+    if (!canRecover || !input.recoverMissingWorker) continue;
+    const timeoutMs =
+      input.recoverMissingWorker.timeoutMs ?? DEFAULT_READY_PLUGIN_WORKER_RECOVERY_TIMEOUT_MS;
+    recoveryAttempts.push(resolveWithTimeout(
+      input.recoverMissingWorker.startWorker({
+        id: plugin.id,
+        pluginKey: plugin.pluginKey,
+      }).catch(() => false),
+      timeoutMs,
+      false,
+    ));
+  }
+
+  if (recoveryAttempts.length > 0) {
+    await Promise.all(recoveryAttempts);
+  }
+
   const rows: ReadyPluginEnvironmentDriver[] = [];
-  for (const plugin of plugins) {
-    if (plugin.status !== "ready") continue;
+  for (const plugin of readyPlugins) {
     if (!input.workerManager.isRunning(plugin.id)) {
-      const canRecover =
-        recoverablePluginKeys.has(plugin.pluginKey)
-        && !input.workerManager.getWorker(plugin.id);
-      if (canRecover) {
-        await input.recoverMissingWorker?.startWorker({
-          id: plugin.id,
-          pluginKey: plugin.pluginKey,
-        }).catch(() => false);
-      }
-      if (!input.workerManager.isRunning(plugin.id)) continue;
+      continue;
     }
     rows.push(
       ...(plugin.manifestJson.environmentDrivers ?? [])


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Managed deployments can run web, worker, and runtime-worker processes against the same database.
> - Bundled sandbox provider plugins are installed at boot from managed config and then loaded by each process that needs to serve plugin-backed capabilities.
> - A sibling process can win the install race while the web process observes only the intermediate `installed` row and then loads zero ready plugins.
> - After the sibling finishes the row to `ready`, the web process still has no local plugin worker, so the environments capabilities route filters the driver out forever.
> - This pull request makes managed bundled sandbox providers recover lazily when a ready plugin exists but this process missed the worker start.
> - The benefit is that multi-service boot order no longer decides whether managed sandbox providers appear in the environments UI.

## Linked Issues or Issue Description

No public GitHub issue tracks this exact race yet.

Related public work:

- Refs #10063
- Refs #10157
- Refs #10158
- Refs #10324

Bug description:

- What happened: in a managed multi-process deployment, the web process could skip an auto-installed bundled plugin while another process was still installing it. Once the row became `ready`, the API process still had no local plugin worker, so the sandbox provider stayed absent from environment capabilities until the web process restarted.
- Expected behavior: after the plugin row reaches `ready`, the environments capabilities route should be able to list the sandbox provider without requiring a process restart.
- Deployment mode: managed deployment with multiple server processes sharing one database and booting concurrently.

## What Changed

- Added a managed bundled plugin worker recovery helper with per-plugin single-flight protection.
- Wired the environments capabilities route to recover only managed auto-install plugin keys when a ready plugin has no running worker in the current process.
- Kept existing worker-manager handles untouched so plugins already in backoff/recovery are not double-started.
- Added a regression suite covering installed-to-ready recovery, allowlist scoping, existing handles, and concurrent request single-flight behavior.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps`
- `corepack pnpm exec vitest run server/src/__tests__/plugin-environment-driver-ready-recovery.test.ts` — 5 tests passed
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && cd server && ../node_modules/.bin/tsc --noEmit`

## Risks

Low to medium risk. The recovery path is intentionally scoped to managed `plugins.autoInstall` keys, so self-hosted single-process behavior is unchanged. The main risk is starting a plugin worker from a read-style capabilities request, but the implementation avoids double starts with a single-flight guard and does not interfere with existing worker handles.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 coding agent with shell and GitHub CLI tool use. Context window details were not exposed by the execution environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

