### PR TITLE
fix(auth): reject unsupported auth headers instead of silent local-board fallback

### DIFF
--- a/server/src/__tests__/auth-unsupported-header.test.ts
+++ b/server/src/__tests__/auth-unsupported-header.test.ts
@@ -1,0 +1,141 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import { agentApiKeys, agents, authUsers, companyMemberships } from "@paperclipai/db";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/error-handler.js";
+
+/**
+ * Resolves the Bearer agent-key path: the board-key lookup misses, the agent key
+ * hits, the agent record is active and the key carries a responsible user.
+ * Routed by table rather than by call order so unrelated query changes on that
+ * path do not silently shift which stub row a lookup gets.
+ */
+function createAgentKeyDb() {
+  const rowsByTable = new Map<unknown, unknown[]>([
+    [
+      agentApiKeys,
+      [
+        {
+          id: "key-1",
+          agentId: "agent-1",
+          companyId: "company-1",
+          responsibleUserId: "user-1",
+          scopeConfig: null,
+        },
+      ],
+    ],
+    [agents, [{ id: "agent-1", companyId: "company-1", status: "active" }]],
+    [authUsers, [{ id: "user-1" }]],
+    [
+      companyMemberships,
+      [{ companyId: "company-1", membershipRole: "member", status: "active" }],
+    ],
+  ]);
+
+  return {
+    select: vi.fn(() => ({
+      from(table: unknown) {
+        return {
+          where() {
+            return Promise.resolve(rowsByTable.get(table) ?? []);
+          },
+        };
+      },
+    })),
+    update: vi.fn(() => ({
+      set() {
+        return {
+          where() {
+            return Promise.resolve();
+          },
+        };
+      },
+    })),
+  } as any;
+}
+
+function createApp(db: any, deploymentMode: "local_trusted" | "authenticated" = "local_trusted") {
+  const app = express();
+  app.use(actorMiddleware(db, { deploymentMode }));
+  app.get("/actor", (req, res) => {
+    res.json(req.actor);
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe("actorMiddleware unsupported auth headers", () => {
+  it.each(["x-api-key", "api-key", "x-auth-token"])(
+    "rejects a request authenticated with %s instead of Authorization: Bearer",
+    async (header) => {
+      const res = await request(createApp({ select: vi.fn() }))
+        .get("/actor")
+        .set(header, "pcp_agent_secret");
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toContain(header);
+    },
+  );
+
+  it("rejects on authenticated deployments too", async () => {
+    const app = express();
+    app.use(
+      actorMiddleware({ select: vi.fn() } as any, {
+        deploymentMode: "authenticated",
+        resolveSession: async () => {
+          throw new Error("session must not be resolved for a rejected request");
+        },
+      }),
+    );
+    app.get("/actor", (req, res) => res.json(req.actor));
+    app.use(errorHandler);
+
+    const res = await request(app).get("/actor").set("x-api-key", "pcp_agent_secret");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("ignores an empty unsupported header", async () => {
+    const res = await request(createApp({ select: vi.fn() })).get("/actor").set("x-api-key", "");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ source: "local_implicit" });
+  });
+
+  it("keeps the implicit local board actor when no auth header is sent", async () => {
+    const res = await request(createApp({ select: vi.fn() })).get("/actor");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "board",
+      userId: "local-board",
+      isInstanceAdmin: true,
+      source: "local_implicit",
+    });
+  });
+
+  it("still authenticates a valid Authorization: Bearer token", async () => {
+    const res = await request(createApp(createAgentKeyDb()))
+      .get("/actor")
+      .set("authorization", "Bearer pcp_agent_secret");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
+    });
+  });
+
+  it("lets Authorization: Bearer win when an unsupported header is also present", async () => {
+    const res = await request(createApp(createAgentKeyDb()))
+      .get("/actor")
+      .set("authorization", "Bearer pcp_agent_secret")
+      .set("x-api-key", "ignored");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ type: "agent", agentId: "agent-1", source: "agent_key" });
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -19,10 +19,19 @@ import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
-import { forbidden, unprocessable } from "../errors.js";
+import { forbidden, unauthorized, unprocessable } from "../errors.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
+}
+
+const UNSUPPORTED_AUTH_HEADERS = ["x-api-key", "api-key", "x-auth-token"] as const;
+
+function findUnsupportedAuthHeader(req: Request): string | null {
+  for (const name of UNSUPPORTED_AUTH_HEADERS) {
+    if (req.header(name)?.trim()) return name;
+  }
+  return null;
 }
 
 function normalizeOptionalString(value: string | null | undefined) {
@@ -157,6 +166,24 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
+      // A caller that sends an auth-shaped header we do not support meant to authenticate.
+      // Falling through would silently downgrade them to the implicit local board actor
+      // (instance admin on local_trusted), so fail loudly instead.
+      const unsupportedHeader = findUnsupportedAuthHeader(req);
+      if (unsupportedHeader) {
+        req.actor = { type: "none", source: "none" };
+        logger.warn(
+          { header: unsupportedHeader, method: req.method, url: req.originalUrl },
+          "Rejected request carrying an unsupported authentication header",
+        );
+        next(
+          unauthorized(
+            `Unsupported authentication header "${unsupportedHeader}". Use "Authorization: Bearer <token>".`,
+          ),
+        );
+        return;
+      }
+
       if (opts.deploymentMode === "authenticated" && opts.resolveSession) {
         const cloudTenantActor = await resolveCloudTenantActor(db, req);
         if (cloudTenantActor) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip lets agents and humans drive the same board through one HTTP API, so *which* actor a request resolves to is the whole of its authority.
> - `actorMiddleware` (`server/src/middleware/auth.ts`) is the single place that turns a request into an actor, and it is mounted app-wide in `server/src/app.ts` before every route.
> - On `local_trusted` it assigns the implicit local-board actor (`userId: "local-board"`, `isInstanceAdmin: true`) *before* inspecting any header, and the only header it ever reads for credentials is `authorization`.
> - So a caller that authenticates with a misnamed header — `x-api-key` instead of `Authorization: Bearer` — is never rejected. It silently becomes the human board user with instance-admin rights and gets a 2xx.
> - That is invisible on the success path, and it is not cosmetic: the request runs as a board actor, so `authorAgentId` stays empty on anything it writes, agent self-wake suppression stops matching, and the agent-scoped guards that key off `actor.type === "agent"` do not apply.
> - `x-api-key` in particular is the header the Anthropic API uses, and this repo's own outbound callers (`cli/src/checks/llm-check.ts`, `packages/adapters/claude-local/src/server/models.ts`) send it — so it is exactly the name a caller reaches for by mistake.
> - This PR treats an auth-shaped header we do not support as *intent to authenticate*, and fails it loudly with a 401 instead of downgrading the caller to the default actor.

## Linked Issues or Issue Description

No public issue — inline bug report:

### What happened?

On a `local_trusted` instance, a request that sends its credential in `x-api-key`
(or `api-key` / `x-auth-token`) instead of `Authorization: Bearer` is not rejected.
`actorMiddleware` has already assigned the implicit local-board actor
(`isInstanceAdmin: true`) by the time it looks at `authorization`, finds no Bearer
prefix, and falls through. The request succeeds as the human board user.

### Expected behavior

A request that carries an auth-shaped header the server does not support should
fail with `401` naming the offending header, not silently run with instance-admin
rights under a different identity.

### Steps to reproduce

1. Start an instance in `local_trusted` mode.
2. `curl -s -o /dev/null -w '%{http_code}\n' -H 'x-api-key: <any agent key>' http://127.0.0.1:3100/api/companies`
3. Observe `200`. The request was served as `{ type: "board", userId: "local-board", isInstanceAdmin: true, source: "local_implicit" }`, not as the agent whose key was sent.

### Paperclip version

Reproduced on master at `ca92f727c` (2026-07-28). This branch is based on
`4eace88f6`; the only difference between the two is `.github/workflows/docker.yml`
and one unrelated test file, so the defect and the fix are identical on both.

### Deployment mode

`local_trusted` (the silent downgrade). On `authenticated` the same fall-through
reaches the cookie-session resolver instead, which is equally wrong for a caller
that plainly meant to present a token — so the guard is deployment-mode independent.

### Related, not duplicate

The dedup search surfaced two adjacent PRs; naming them so a reviewer does not
have to find them. **#5078** ("Fix local_trusted auth fallback handling", open)
stops a request that *does* carry an `Authorization` header from inheriting
implicit local-board authority. This PR is the complementary half: a request that
carries an auth-shaped header which is **not** `Authorization`, and therefore never
reaches that check at all. The two touch the same function and do not overlap in
behaviour; if #5078 lands first this change still applies cleanly, since it sits
inside the `!bearer` branch rather than around it. **#7763** (closed) proposed
rejecting *all* unauthenticated writes in `local_trusted` — a far broader policy
change, and deliberately not what this is.

## What Changed

- `server/src/middleware/auth.ts`: when a request carries `x-api-key`, `api-key` or `x-auth-token` with a non-empty value **and** no `Authorization: Bearer` header, respond `401` through the existing `unauthorized()` / `errorHandler` path instead of falling through to the default actor. The message names the offending header and points at the supported form.
- The actor is explicitly reset to `{ type: "none" }` on that path, so no downstream logging or error-reporting can still attribute the rejected request to the instance admin.
- A `logger.warn` records the rejected header, method and URL.
- `server/src/__tests__/auth-unsupported-header.test.ts`: new regression tests covering both the rejected and the unchanged paths.

`Authorization: Bearer` always wins: the guard only runs inside the existing
`if (!authHeader?.toLowerCase().startsWith("bearer "))` branch, so a request with
both headers authenticates normally.

## Verification

```bash
npx vitest run server/src/__tests__/auth-unsupported-header.test.ts
# 1 file, 8 tests passed
```

Red-before / green-after, measured against this branch's base (`ca92f727c`): with
`server/src/middleware/auth.ts` reverted to master and the new test file in place,
**4 of 8 fail** — each of the three rejection cases and the `authenticated`-mode
case return `200` where `401` is expected. With the change, 8/8 pass. The 4 that
pass either way are the unchanged-path guards, which is what they are for.

| Case | Expected |
|---|---|
| `x-api-key` / `api-key` / `x-auth-token`, no `Authorization` | `401`, body names the header |
| same, on `deploymentMode: "authenticated"` | `401`, session resolver never called |
| unsupported header present but empty | `200`, unchanged |
| no auth header at all (board UI) | `200`, `source: "local_implicit"`, unchanged |
| valid `Authorization: Bearer` | `200`, `source: "agent_key"`, unchanged |
| valid `Authorization: Bearer` **plus** `x-api-key` | `200`, Bearer wins, unchanged |

Measured at the tree, not assumed: `grep -rn 'x-api-key|"api-key"|x-auth-token'`
over `--include=*.ts,*.tsx,*.mjs,*.js` excluding `node_modules`/`dist` returns
**no inbound caller** that sends any of the three to the Paperclip server. Every
`x-api-key` hit is an *outbound* call to `api.anthropic.com`
(`cli/src/commands/onboard.ts:515`, `cli/src/checks/llm-check.ts:26`,
`packages/adapters/claude-local/src/server/models.ts:71`) plus the app-definition
seed and the existing `http-log-redaction.ts` entry. None of those pass through
`actorMiddleware`.

Typecheck: `npx tsc --noEmit -p server/tsconfig.json` reports **3** errors, all
pre-existing `noProfile` errors in `services/environment-execution-target.ts` and
`services/environment-runtime.ts`, present identically with and without this
change. **Zero** in the two touched files.

## Risks

Low, but there is one behavioural shift worth naming rather than leaving to be found:

`actorMiddleware` is mounted app-wide (`server/src/app.ts`), not just under `/api`.
So a reverse proxy or third-party script that injects one of these three headers on
*every* request — for its own unrelated purposes — and relies on the implicit
`local_trusted` fallback would now receive a `401` where it used to get a silent
`2xx`, including on non-API routes. That is the intended correction: such a caller
is currently writing as the human board user without knowing it. But it is visible,
and it is the one way this change can surprise someone.

The header list is deliberately narrow — three well-known auth header names, no
prefix or wildcard matching — to keep that surface as small as the defect allows.
The board UI sends none of them, and both the implicit-actor path and the
`Authorization: Bearer` path are covered by the regression tests above.

Deliberately **out of scope**, filed separately rather than bundled here:
`HTTP_LOG_REDACT_PATHS` (`server/src/middleware/http-log-redaction.ts`) redacts
`req.headers["x-api-key"]` but not `api-key` or `x-auth-token`, so a credential
sent in either of those is still written to the request log in plaintext — on the
`401` this PR now produces as much as before it. That is a logging concern, not an
auth-resolution one, and it belongs in its own PR.

## Model Used

- Provider/model: Anthropic Claude — Opus 4.8 (`claude-opus-4-8[1m]`, 1M context) authored the original change; Opus 5 (`claude-opus-5[1m]`, 1M context) rebased it onto current master, repaired the stale test fixture and re-measured everything above.
- Mode: extended reasoning with tool use (file editing, shell, test execution). Every claim above was confirmed by running the command, not inferred from reading.

## Checklist

- [x] I searched the GitHub PR list (open and recently closed) for similar PRs and confirmed this is not a duplicate
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — n/a, no UI surface
- [x] I have updated relevant documentation to reflect my changes — n/a, no documented behaviour changes; the 401 message is self-describing
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
