### PR TITLE
fix(acpx): tolerate unsupported effort control

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AcpRuntimeOptions } from "acpx/runtime";
+import { AcpRuntimeError, type AcpRuntimeOptions } from "acpx/runtime";
 import type { AdapterRuntimeMcpAccess } from "@paperclipai/adapter-utils";
 import {
   DEFAULT_REMOTE_SANDBOX_ADAPTER_TIMEOUT_SEC,
@@ -134,6 +134,7 @@ function createLocalSandboxRunner(
 function buildRuntime(
   onSetConfigOption?: (input: { key: string; value: string }) => void,
   onEnsureSession?: (input: Record<string, unknown>) => void,
+  setConfigOptionError?: (input: { key: string; value: string }) => Error | undefined,
 ) {
   return {
     ensureSession: async (input: Record<string, unknown>) => {
@@ -152,6 +153,8 @@ function buildRuntime(
       cancel: async () => {},
     }),
     setConfigOption: async (input: { key: string; value: string }) => {
+      const error = setConfigOptionError?.(input);
+      if (error) throw error;
       onSetConfigOption?.(input);
     },
     close: async () => {},
@@ -167,6 +170,7 @@ async function runExecutor(
     executionTarget?: Record<string, unknown>;
     runtimeMcp?: AdapterRuntimeMcpAccess;
     prepareRemoteManagedHome?: AcpxEngineExecutorOptions["prepareRemoteManagedHome"];
+    setConfigOptionError?: (input: { key: string; value: string }) => Error | undefined;
   } = {},
 ) {
   const runtimeOptions: Record<string, unknown>[] = [];
@@ -179,11 +183,12 @@ async function runExecutor(
     ...(options.prepareRemoteManagedHome
       ? { prepareRemoteManagedHome: options.prepareRemoteManagedHome }
       : {}),
-    createRuntime: (options) => {
-      runtimeOptions.push(options as unknown as Record<string, unknown>);
+    createRuntime: (runtimeCreateOptions) => {
+      runtimeOptions.push(runtimeCreateOptions as unknown as Record<string, unknown>);
       return buildRuntime(
         ({ key, value }) => configOptions.push({ key, value }),
         (input) => sessionInputs.push(input),
+        options.setConfigOptionError,
       ) as never;
     },
   });
@@ -308,6 +313,58 @@ describe("shared ACPX engine runtime behavior", () => {
       { key: "model", value: "gemini-2.5-pro" },
       { key: "effort", value: "high" },
     ]);
+  });
+
+  it("continues with a warning when ACP rejects optional effort config", async () => {
+    const result = await runExecutor(
+      { agent: "gemini", thinkingEffort: "low" },
+      {
+        setConfigOptionError: ({ key }) =>
+          key === "effort"
+            ? new AcpRuntimeError(
+                "ACP_BACKEND_UNSUPPORTED_CONTROL",
+                "ACP session does not advertise config option 'effort'.",
+              )
+            : undefined,
+      },
+    );
+
+    expect(result.configOptions).toEqual([]);
+    expect(result.logs).toContainEqual({
+      stream: "stderr",
+      text: "[paperclip] ACPX gemini does not support the optional effort config; continuing without effort=low.\n",
+    });
+  });
+
+  it("keeps non-effort session config failures fatal", async () => {
+    const execute = createAcpxEngineExecutor({
+      createRuntime: () =>
+        buildRuntime(
+          undefined,
+          undefined,
+          () =>
+            new AcpRuntimeError(
+              "ACP_BACKEND_UNSUPPORTED_CONTROL",
+              "ACP session does not advertise config option 'model'.",
+            ),
+        ) as never,
+    });
+
+    const result = await execute({
+      runId: "run-1",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: { agent: "gemini", model: "gemini-2.5-pro" },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      errorCode: "acpx_session_config_failed",
+      errorMeta: { acpCode: "ACP_BACKEND_UNSUPPORTED_CONTROL" },
+    });
   });
 
   it("does not inject CODEX_CONFIG or session config when Codex overrides are absent", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1944,11 +1944,26 @@ async function applySessionConfigOptions(input: {
     throw new Error(message);
   }
   for (const option of options) {
-    await input.runtime.setConfigOption({
-      handle: input.handle,
-      key: option.key,
-      value: option.value,
-    });
+    try {
+      await input.runtime.setConfigOption({
+        handle: input.handle,
+        key: option.key,
+        value: option.value,
+      });
+    } catch (error) {
+      if (
+        option.key === "effort" &&
+        isAcpRuntimeError(error) &&
+        error.code === "ACP_BACKEND_UNSUPPORTED_CONTROL"
+      ) {
+        await input.onLog(
+          "stderr",
+          `[paperclip] ACPX ${input.prepared.acpxAgent} does not support the optional effort config; continuing without effort=${option.value}.\n`,
+        );
+        continue;
+      }
+      throw error;
+    }
     await input.onLog(
       "stdout",
       `[paperclip] Applied ACPX ${input.prepared.acpxAgent} config ${option.key}=${option.value}\n`,


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent runs across adapters and execution backends
> - The shared ACPX engine applies optional runtime controls before starting a turn
> - Some ACP backends do not advertise the optional `effort` control
> - ACPX reports that capability mismatch with `ACP_BACKEND_UNSUPPORTED_CONTROL`
> - Treating that one optional mismatch as fatal prevents otherwise valid runs, including cheap recovery heartbeats
> - This pull request warns and continues only when `effort` is unsupported
> - The benefit is compatibility with narrower ACP backends without weakening failures for required or unrelated controls

## Linked Issues or Issue Description

- Fixes: #10175

## What Changed

- Catch ACPX's unsupported-control error when applying the optional `effort` session config.
- Emit a visible stderr warning and continue the run without the rejected effort override.
- Preserve successful effort configuration and existing fatal handling for all other session-control failures.
- Add regressions for both the tolerated effort rejection and a fatal non-effort rejection.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts` (87 tests passed)
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `git diff --check`

## Risks

- Low risk. The fallback is limited to the `effort` key and the exact `ACP_BACKEND_UNSUPPORTED_CONTROL` code. Authentication, transport, initialization, and other session-control errors remain fatal.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 family, tool-enabled agentic coding with repository inspection, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
