### PR TITLE
fix: redact Pi transcripts and isolate signing secrets

### DIFF
--- a/docs/deploy/secrets.md
+++ b/docs/deploy/secrets.md
@@ -27,6 +27,31 @@ you bind to an agent as exposed to that agent. Limit blast radius with bindings
 provider supports them, and rotation when an agent transcript or downstream
 system might have captured a value.
 
+### Rotate A Leaked Agent JWT Signing Secret
+
+Treat a transcript containing `PAPERCLIP_AGENT_JWT_SECRET` as a signing-key
+compromise. An attacker with this value can mint agent run tokens; deleting the
+transcript alone does not revoke that capability.
+
+1. Stop or drain agent runs. Rotation invalidates every outstanding local-agent
+   JWT, so in-flight agents can lose API access.
+2. Generate a new high-entropy value, for example with
+   `openssl rand -base64 48`.
+3. Replace `PAPERCLIP_AGENT_JWT_SECRET` in the deployment secret store or in the
+   instance `.env` beside `config.json`. Never paste the old or new value into
+   an issue, command output, transcript, or activity record.
+4. Restart every Paperclip server process using that instance and verify
+   `paperclipai doctor` plus a controlled agent wake.
+5. Remove or access-restrict affected transcript and log copies after retaining
+   only the value-free incident evidence required by policy.
+
+Rotation takes effect on restart and makes tokens signed with the old key fail
+verification. If `BETTER_AUTH_SECRET` is unset, authenticated deployments also
+use `PAPERCLIP_AGENT_JWT_SECRET` as the board-session secret; expect existing
+board sessions to require authentication again. Configure a separate
+`BETTER_AUTH_SECRET` if agent-token and board-session rotations need independent
+lifecycles.
+
 ## Using Secrets In Runs
 
 Creating a company secret does not automatically create an environment variable.

--- a/packages/adapter-utils/src/server-utils-env.test.ts
+++ b/packages/adapter-utils/src/server-utils-env.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import { sanitizeInheritedPaperclipEnv } from "./server-utils.js";
 
 describe("sanitizeInheritedPaperclipEnv", () => {
-  it("drops the host-only Paperclip CLI command pointer", () => {
+  it("drops host-only Paperclip and authentication secrets", () => {
     expect(sanitizeInheritedPaperclipEnv({
       PAPERCLIPAI_CMD: "node /missing/paperclipai/dist/index.js",
+      PAPERCLIP_AGENT_JWT_SECRET: "paperclip-signing-canary",
+      BETTER_AUTH_SECRET: "better-auth-signing-canary",
       PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
       PATH: "/usr/bin",
     })).toEqual({

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2197,6 +2197,8 @@ export function refreshPaperclipWorkspaceEnvForExecution(input: {
 export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   delete env.PAPERCLIPAI_CMD;
+  // Better Auth is also the fallback agent-JWT signer and is never agent runtime input.
+  delete env.BETTER_AUTH_SECRET;
   for (const key of Object.keys(env)) {
     if (!key.startsWith("PAPERCLIP_")) continue;
     if (key === "PAPERCLIP_RUNTIME_API_URL") continue;

--- a/packages/adapters/pi-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/pi-local/src/server/execute.remote.test.ts
@@ -179,10 +179,13 @@ describe("pi remote execution", () => {
     });
     expect(String(result.sessionId)).toContain(`${managedRemoteWorkspace}/.paperclip-runtime/pi/sessions/`);
     expect(prepareWorkspaceForSshExecution).toHaveBeenCalledTimes(1);
-    expect(syncDirectoryToSsh).toHaveBeenCalledTimes(1);
+    expect(syncDirectoryToSsh).toHaveBeenCalledTimes(2);
     expect(syncDirectoryToSsh).toHaveBeenCalledWith(expect.objectContaining({
       remoteDir: `${managedRemoteWorkspace}/.paperclip-runtime/pi/skills`,
       followSymlinks: true,
+    }));
+    expect(syncDirectoryToSsh).toHaveBeenCalledWith(expect.objectContaining({
+      remoteDir: `${managedRemoteWorkspace}/.paperclip-runtime/pi/extensions`,
     }));
     expect(runSshCommand).toHaveBeenCalledWith(
       expect.anything(),
@@ -195,6 +198,10 @@ describe("pi remote execution", () => {
     expect(call?.[2]).toContain("--session");
     expect(call?.[2]).toContain("--skill");
     expect(call?.[2]).toContain(`${managedRemoteWorkspace}/.paperclip-runtime/pi/skills`);
+    expect(call?.[2]).toContain("--extension");
+    expect(call?.[2]).toContain(
+      `${managedRemoteWorkspace}/.paperclip-runtime/pi/extensions/transcript-redaction-extension.ts`,
+    );
     expect(call?.[3].env.PAPERCLIP_WORKSPACE_CWD).toBe(managedRemoteWorkspace);
     expect(JSON.parse(call?.[3].env.PAPERCLIP_WORKSPACES_JSON ?? "[]")).toEqual([
       {

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -49,6 +49,10 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { shellQuote } from "@paperclipai/adapter-utils/ssh";
 import { isPiUnknownSessionError, parsePiJsonl } from "./parse.js";
+import {
+  collectTranscriptSecretValues,
+  redactTranscriptValue,
+} from "./transcript-redaction-extension.js";
 import { ensurePiModelConfiguredAndAvailable } from "./models.js";
 import { preparePiRuntimeConfig } from "./runtime-config.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
@@ -798,6 +802,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       },
       clearSessionOnMissingSession = false,
     ): AdapterExecutionResult => {
+      const secretValues = collectTranscriptSecretValues(
+        executionTargetIsRemote ? env : runtimeEnv,
+      );
+      const redactResultValue = <T>(value: T): T => redactTranscriptValue(value, secretValues);
+
       if (attempt.proc.timedOut) {
         return {
           exitCode: attempt.proc.exitCode,
@@ -834,7 +843,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         exitCode: effectiveExitCode,
         signal: attempt.proc.signal,
         timedOut: false,
-        errorMessage: (effectiveExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+        errorMessage:
+          (effectiveExitCode ?? 0) === 0 ? null : redactResultValue(fallbackErrorMessage),
         usage: {
           inputTokens: attempt.parsed.usage.inputTokens,
           outputTokens: attempt.parsed.usage.outputTokens,
@@ -848,11 +858,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         model: model,
         billingType: "unknown",
         costUsd: attempt.parsed.usage.costUsd,
-        resultJson: {
+        resultJson: redactResultValue({
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
-        },
-        summary: attempt.parsed.finalMessage ?? attempt.parsed.messages.join("\n\n").trim(),
+        }),
+        summary: redactResultValue(
+          attempt.parsed.finalMessage ?? attempt.parsed.messages.join("\n\n").trim(),
+        ),
         clearSession: Boolean(clearSessionOnMissingSession),
       };
     };

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -39,6 +39,7 @@ import {
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
   removeMaintainerOnlySkillSymlinks,
+  sanitizeInheritedPaperclipEnv,
   renderTemplate,
   renderPaperclipWakePrompt,
   isPaperclipRecoveryWakePayload,
@@ -130,6 +131,46 @@ async function buildPiSkillsDir(config: Record<string, unknown>): Promise<string
     await fs.symlink(entry.source, path.join(target, entry.runtimeName));
   }
   return target;
+}
+
+async function buildPiTranscriptRedactionExtension(): Promise<{
+  dir: string;
+  fileName: string;
+  filePath: string;
+}> {
+  const sourceCandidates = [
+    path.join(__moduleDir, "transcript-redaction-extension.js"),
+    path.join(__moduleDir, "transcript-redaction-extension.ts"),
+  ];
+  let sourcePath: string | null = null;
+  for (const candidate of sourceCandidates) {
+    try {
+      await fs.access(candidate);
+      sourcePath = candidate;
+      break;
+    } catch {
+      // Try the source-tree fallback when running through tsx.
+    }
+  }
+  if (!sourcePath) throw new Error("Pi transcript redaction extension is missing");
+
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-extension-"));
+  const fileName = path.basename(sourcePath);
+  const filePath = path.join(dir, fileName);
+  await fs.copyFile(sourcePath, filePath);
+  return { dir, fileName, filePath };
+}
+
+function resolveTranscriptSecretEnvKeys(context: Record<string, unknown>): string[] {
+  const secrets = parseObject(context.paperclipSecrets);
+  const manifest = Array.isArray(secrets.manifest) ? secrets.manifest : [];
+  const keys = new Set<string>(["PAPERCLIP_API_KEY"]);
+  for (const rawEntry of manifest) {
+    const entry = parseObject(rawEntry);
+    const envKey = asString(entry.envKey, "").trim();
+    if (envKey) keys.add(envKey);
+  }
+  return [...keys];
 }
 
 function resolvePiBiller(env: Record<string, string>, provider: string | null): string {
@@ -317,6 +358,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }
+  env.PAPERCLIP_TRANSCRIPT_SECRET_ENV_KEYS = JSON.stringify(
+    resolveTranscriptSecretEnvKeys(context),
+  );
   // Materialize custom Pi providers (PAPERCLIP_PI_PROVIDERS) into a managed
   // PI_CODING_AGENT_DIR before runtimeEnv is computed, so both local validation
   // and the spawned Pi process resolve models against the managed models.json.
@@ -336,7 +380,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const skillBinDirs = piSkillEntries
       .filter((entry) => injectedSkillKeys.has(entry.key) && entry.source.length > 0)
       .map((entry) => path.join(entry.source, "bin"));
-    const mergedEnv = ensurePathInEnv({ ...process.env, ...env });
+    const mergedEnv = ensurePathInEnv({
+      ...sanitizeInheritedPaperclipEnv(process.env),
+      ...env,
+    });
     const pathKey =
       typeof mergedEnv.Path === "string" && mergedEnv.Path.length > 0 && !mergedEnv.PATH
         ? "Path"
@@ -399,6 +446,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     let remoteRuntimeRootDir: string | null = null;
     let localSkillsDir: string | null = null;
     let remoteSkillsDir: string | null = null;
+    let remoteExtensionFile: string | null = null;
+    const localExtension = await buildPiTranscriptRedactionExtension();
     let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
 
     if (executionTargetIsRemote) {
@@ -423,6 +472,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
               key: "skills",
               localDir: localSkillsDir,
               followSymlinks: true,
+            },
+            {
+              key: "extensions",
+              localDir: localExtension.dir,
             },
             ...(localAgentConfigDir
               ? [{
@@ -453,6 +506,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         }
         remoteRuntimeRootDir = preparedRemoteRuntime.runtimeRootDir;
         remoteSkillsDir = preparedRemoteRuntime.assetDirs.skills ?? null;
+        const remoteExtensionDir = preparedRemoteRuntime.assetDirs.extensions;
+        remoteExtensionFile = remoteExtensionDir
+          ? path.posix.join(remoteExtensionDir, localExtension.fileName)
+          : null;
         if (localAgentConfigDir && preparedRemoteRuntime.assetDirs.agentConfig) {
           env.PI_CODING_AGENT_DIR = preparedRemoteRuntime.assetDirs.agentConfig;
         }
@@ -460,6 +517,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         await Promise.allSettled([
           restoreRemoteWorkspace?.(),
           localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+          fs.rm(localExtension.dir, { recursive: true, force: true }).catch(() => undefined),
         ]);
         throw error;
       }
@@ -479,7 +537,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         Object.assign(env, paperclipBridge.env);
         loggedEnv = buildInvocationEnvForLogs(env, {
           runtimeEnv: Object.fromEntries(
-            Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
+            Object.entries(ensurePathInEnv({
+              ...sanitizeInheritedPaperclipEnv(process.env),
+              ...env,
+            })).filter(
               (entry): entry is [string, string] => typeof entry[1] === "string",
             ),
           ),
@@ -657,6 +718,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--tools", "read,bash,edit,write,grep,find,ls");
       args.push("--session", sessionFile);
       args.push("--skill", remoteSkillsDir ?? PI_AGENT_SKILLS_DIR);
+      args.push("--extension", remoteExtensionFile ?? localExtension.filePath);
 
       if (extraArgs.length > 0) args.push(...extraArgs);
 
@@ -839,6 +901,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         paperclipBridge?.stop(),
         restoreRemoteWorkspace?.(),
         localSkillsDir ? fs.rm(path.dirname(localSkillsDir), { recursive: true, force: true }).catch(() => undefined) : Promise.resolve(),
+        fs.rm(localExtension.dir, { recursive: true, force: true }).catch(() => undefined),
       ]);
     }
   } finally {

--- a/packages/adapters/pi-local/src/server/models.ts
+++ b/packages/adapters/pi-local/src/server/models.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 import type { AdapterModel } from "@paperclipai/adapter-utils";
-import { asString, runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import {
+  asString,
+  runChildProcess,
+  sanitizeInheritedPaperclipEnv,
+} from "@paperclipai/adapter-utils/server-utils";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 
@@ -108,7 +112,10 @@ export async function discoverPiModels(input: {
   const command = resolvePiCommand(input.command);
   const cwd = asString(input.cwd, process.cwd());
   const env = normalizeEnv(input.env);
-  const runtimeEnv = normalizeEnv({ ...process.env, ...env });
+  const runtimeEnv = normalizeEnv({
+    ...sanitizeInheritedPaperclipEnv(process.env),
+    ...env,
+  });
 
   const result = await runChildProcess(
     `pi-models-${Date.now()}-${Math.random().toString(16).slice(2)}`,

--- a/packages/adapters/pi-local/src/server/test.ts
+++ b/packages/adapters/pi-local/src/server/test.ts
@@ -7,6 +7,7 @@ import {
   asString,
   parseObject,
   ensurePathInEnv,
+  sanitizeInheritedPaperclipEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   asStringArray,
@@ -125,7 +126,10 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...env }));
+  const runtimeEnv = normalizeEnv(ensurePathInEnv({
+    ...sanitizeInheritedPaperclipEnv(process.env),
+    ...env,
+  }));
 
   const cwdInvalid = checks.some((check) => check.code === "pi_cwd_invalid");
   if (cwdInvalid) {

--- a/packages/adapters/pi-local/src/server/transcript-redaction-extension.test.ts
+++ b/packages/adapters/pi-local/src/server/transcript-redaction-extension.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import transcriptRedactionExtension, {
+  collectTranscriptSecretValues,
+} from "./transcript-redaction-extension.js";
+
+const originalEnv = process.env;
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("Pi transcript redaction extension", () => {
+  it("redacts runtime and granted secrets before a tool result is persisted", () => {
+    const apiCanary = "canary-paperclip-api-key-value";
+    const signingCanary = "canary-paperclip-signing-secret-value";
+    const grantedCanary = "canary-granted-secret-value";
+    process.env = {
+      ...originalEnv,
+      PAPERCLIP_API_KEY: apiCanary,
+      PAPERCLIP_AGENT_JWT_SECRET: signingCanary,
+      GRANTED_VALUE: grantedCanary,
+      PAPERCLIP_TRANSCRIPT_SECRET_ENV_KEYS: JSON.stringify([
+        "PAPERCLIP_API_KEY",
+        "GRANTED_VALUE",
+      ]),
+    };
+
+    let toolResultHandler:
+      | ((event: { content: unknown; details?: unknown }) => { content: unknown; details?: unknown })
+      | undefined;
+    transcriptRedactionExtension({
+      on: (_event, handler) => {
+        toolResultHandler = handler;
+      },
+    });
+
+    const controlledEnvOutput = [
+      `PAPERCLIP_API_KEY=${apiCanary}`,
+      `PAPERCLIP_AGENT_JWT_SECRET=${signingCanary}`,
+      `GRANTED_VALUE=${grantedCanary}`,
+      "SAFE_VALUE=visible",
+    ].join("\n");
+    const redacted = toolResultHandler?.({
+      content: [{ type: "text", text: controlledEnvOutput }],
+      details: { rawOutput: controlledEnvOutput },
+    });
+    const persistedSessionJsonl = `${JSON.stringify({
+      type: "message",
+      message: { role: "toolResult", ...redacted },
+    })}\n`;
+
+    expect(persistedSessionJsonl).toContain("***REDACTED***");
+    expect(persistedSessionJsonl).toContain("SAFE_VALUE=visible");
+    expect(persistedSessionJsonl).not.toContain(apiCanary);
+    expect(persistedSessionJsonl).not.toContain(signingCanary);
+    expect(persistedSessionJsonl).not.toContain(grantedCanary);
+  });
+
+  it("ignores empty and very short sensitive values", () => {
+    const values = collectTranscriptSecretValues({
+      EMPTY_TOKEN: "",
+      SHORT_TOKEN: "abc",
+      LONG_TOKEN: "long-canary-value",
+    });
+
+    expect(values).toEqual(["long-canary-value"]);
+  });
+});

--- a/packages/adapters/pi-local/src/server/transcript-redaction-extension.ts
+++ b/packages/adapters/pi-local/src/server/transcript-redaction-extension.ts
@@ -1,0 +1,78 @@
+const REDACTED_VALUE = "***REDACTED***";
+const EXTRA_SECRET_ENV_KEYS = "PAPERCLIP_TRANSCRIPT_SECRET_ENV_KEYS";
+const SENSITIVE_ENV_KEY_RE =
+  /(api_?key|access_?token|auth(?:_?token)?|token|authorization|bearer|secret|passwd|password|credential|jwt|private_?key|cookie|connectionstring)/i;
+
+type ToolResultEvent = {
+  content: unknown;
+  details?: unknown;
+};
+
+type PiExtensionApi = {
+  on(event: "tool_result", handler: (event: ToolResultEvent) => { content: unknown; details?: unknown }): void;
+};
+
+function parseExtraSecretEnvKeys(env: NodeJS.ProcessEnv): string[] {
+  const raw = env[EXTRA_SECRET_ENV_KEYS];
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((value): value is string => typeof value === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function collectTranscriptSecretValues(env: NodeJS.ProcessEnv): string[] {
+  const secretKeys = new Set([
+    ...Object.keys(env).filter((key) => SENSITIVE_ENV_KEY_RE.test(key)),
+    ...parseExtraSecretEnvKeys(env),
+  ]);
+
+  return [...secretKeys]
+    .map((key) => env[key])
+    .filter((value): value is string => typeof value === "string" && value.length >= 4)
+    .sort((left, right) => right.length - left.length);
+}
+
+function redactString(value: string, secretValues: string[]): string {
+  let redacted = value;
+  for (const secret of secretValues) {
+    redacted = redacted.split(secret).join(REDACTED_VALUE);
+  }
+  return redacted;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function redactTranscriptValue<T>(value: T, secretValues: string[]): T {
+  if (typeof value === "string") return redactString(value, secretValues) as T;
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactTranscriptValue(entry, secretValues)) as T;
+  }
+  if (!isPlainObject(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, redactTranscriptValue(entry, secretValues)]),
+  ) as T;
+}
+
+export default function transcriptRedactionExtension(pi: PiExtensionApi): void {
+  const secretValues = collectTranscriptSecretValues(process.env);
+  if (secretValues.length === 0) return;
+
+  // Pi applies tool_result patches before emitting and persisting the final tool message.
+  pi.on("tool_result", (event) => ({
+    content: redactTranscriptValue(event.content, secretValues),
+    ...(event.details === undefined
+      ? {}
+      : { details: redactTranscriptValue(event.details, secretValues) }),
+  }));
+}

--- a/releases/v2026.729.0.md
+++ b/releases/v2026.729.0.md
@@ -1,0 +1,37 @@
+# Paperclip v2026.729.0
+
+> Released: 2026-07-29
+
+## Highlights
+
+- **Secret-safe Pi transcripts and run results** — Runtime and granted secret literals are now redacted before Pi persists tool results, before adapter results and errors enter heartbeat persistence, and before summaries reach run logs. The Better Auth signing secret is no longer inherited by agent child processes, and the deployment guide now includes a bounded signing-secret rotation procedure.
+- **Faster, more observable managed sandboxes** — Remote ACP sessions now stage workspaces once, reuse compatible sessions, route file transfers through provider-native sync hooks, and report per-step round-trip and provider latency. Daytona and Kubernetes providers gain faster setup paths and ordered post-upload commands. ([#10070](https://github.com/paperclipai/paperclip/pull/10070), [#10073](https://github.com/paperclipai/paperclip/pull/10073), [#10089](https://github.com/paperclipai/paperclip/pull/10089), [#10222](https://github.com/paperclipai/paperclip/pull/10222), [#10340](https://github.com/paperclipai/paperclip/pull/10340), [#10347](https://github.com/paperclipai/paperclip/pull/10347), [#10354](https://github.com/paperclipai/paperclip/pull/10354), @nickyleach)
+- **Richer operator workflows** — Activity-gated routine policies, experimental status-card generation and updates, document stars, interaction withdrawal, terminal-issue expiry, and explicit unblock ownership make recurring and governed work easier to operate. ([#9952](https://github.com/paperclipai/paperclip/pull/9952), [#10094](https://github.com/paperclipai/paperclip/pull/10094), [#10101](https://github.com/paperclipai/paperclip/pull/10101), [#10112](https://github.com/paperclipai/paperclip/pull/10112), [#10202](https://github.com/paperclipai/paperclip/pull/10202), [#10225](https://github.com/paperclipai/paperclip/pull/10225), [#10251](https://github.com/paperclipai/paperclip/pull/10251))
+
+## Improvements
+
+- **Managed runtime provisioning** — Managed instances can provision sandbox environments from managed configuration, enforce platform-owned settings, and ship a cloud image with bundled plugins. ([#10058](https://github.com/paperclipai/paperclip/pull/10058), [#10061](https://github.com/paperclipai/paperclip/pull/10061), [#10063](https://github.com/paperclipai/paperclip/pull/10063), [#10157](https://github.com/paperclipai/paperclip/pull/10157), [#10324](https://github.com/paperclipai/paperclip/pull/10324), [#10343](https://github.com/paperclipai/paperclip/pull/10343))
+- **Plugin and chat-gateway capabilities** — Plugins can respond to interactions and approvals, read attachments, attribute issue comments correctly, receive stored configuration on startup, and fail closed across company boundaries. ([#10050](https://github.com/paperclipai/paperclip/pull/10050), [#10066](https://github.com/paperclipai/paperclip/pull/10066), [#10092](https://github.com/paperclipai/paperclip/pull/10092), [#10096](https://github.com/paperclipai/paperclip/pull/10096), [#10103](https://github.com/paperclipai/paperclip/pull/10103), [#10113](https://github.com/paperclipai/paperclip/pull/10113), [#10137](https://github.com/paperclipai/paperclip/pull/10137), @nguyenm7)
+- **Secrets and audit improvements** — External secret values now write through correctly, secret detail pages deep-link cleanly, and user-scoped secret resolution carries the acting audit principal. ([#10115](https://github.com/paperclipai/paperclip/pull/10115), [#10124](https://github.com/paperclipai/paperclip/pull/10124), [#10196](https://github.com/paperclipai/paperclip/pull/10196), @nickyleach)
+- **Agent and model support** — Claude Opus 5 is available in the static fallback list, Codex resolves GPT-5.6 metadata at the adapter source, OpenCode registers configured models, and newly created agents no longer default to cheap model profiles. ([#10019](https://github.com/paperclipai/paperclip/pull/10019), [#10178](https://github.com/paperclipai/paperclip/pull/10178), [#9780](https://github.com/paperclipai/paperclip/pull/9780), [#10327](https://github.com/paperclipai/paperclip/pull/10327), @nguyenm7)
+- **Core skill beta releases** — Paperclip can publish and track beta releases of the built-in skill catalog, and the summarize-status skill now leads with decisions and actions. ([#10117](https://github.com/paperclipai/paperclip/pull/10117), [#10228](https://github.com/paperclipai/paperclip/pull/10228))
+
+## Fixes
+
+- **Duplicate built-in agents self-heal** — Reconciliation prevents duplicate built-in agents and repairs existing duplicates safely. ([#10223](https://github.com/paperclipai/paperclip/pull/10223))
+- **More reliable execution recovery** — Structured wake payloads retain issue descriptions without duplication, task watchdogs avoid unchanged stopped-state wakes, ambiguous successful runs resume on the normal model, and Codex harness crashes are classified as retriable infrastructure failures. ([#10151](https://github.com/paperclipai/paperclip/pull/10151), [#10184](https://github.com/paperclipai/paperclip/pull/10184), [#10207](https://github.com/paperclipai/paperclip/pull/10207), [#10210](https://github.com/paperclipai/paperclip/pull/10210), [#10216](https://github.com/paperclipai/paperclip/pull/10216))
+- **Safer sandbox access and staging** — Task-scoped egress grants preserve control-plane access, proxy sockets stay within Linux path limits, and in-place workspace realization is supported. ([#10152](https://github.com/paperclipai/paperclip/pull/10152), [#10155](https://github.com/paperclipai/paperclip/pull/10155), [#10221](https://github.com/paperclipai/paperclip/pull/10221), [#10230](https://github.com/paperclipai/paperclip/pull/10230))
+- **Stable interactions and plugin workers** — Legacy interaction outcomes no longer break listings, terminal confirmation acceptance no longer wedges, and proactive plugin calls resolve their company scope before worker setup. ([#10099](https://github.com/paperclipai/paperclip/pull/10099), [#10103](https://github.com/paperclipai/paperclip/pull/10103), [#10113](https://github.com/paperclipai/paperclip/pull/10113), [#10119](https://github.com/paperclipai/paperclip/pull/10119), @nguyenm7)
+- **Calendar-correct backup retention** — Monthly backup retention now uses calendar months rather than fixed day counts. ([#3718](https://github.com/paperclipai/paperclip/pull/3718), @LeonSGP43)
+- **Cleaner board state** — Archived projects are excluded from default project lists, inbox external-object summaries stay hidden, decision training remains under Decisions, and routines are grouped by folder name. ([#10020](https://github.com/paperclipai/paperclip/pull/10020), [#10146](https://github.com/paperclipai/paperclip/pull/10146), [#10181](https://github.com/paperclipai/paperclip/pull/10181), [#10201](https://github.com/paperclipai/paperclip/pull/10201), @nickyleach)
+
+## Upgrade Guide
+
+- Upgrade normally with the `paperclipai@2026.729.0` package; startup applies the included database migrations.
+- If an agent could have printed credentials into Pi tool output before this release, rotate those credentials after upgrading. Operators whose historical transcripts exposed `PAPERCLIP_AGENT_JWT_SECRET` should follow `docs/deploy/secrets.md`; rotating it invalidates outstanding agent run JWTs and should be coordinated with a restart.
+
+## Contributors
+
+Thank you to everyone who contributed to this release!
+
+@joachimBrindeau, @LeonSGP43, @nguyenm7, @nickyleach

--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { compactRunLogChunk } from "../services/heartbeat.js";
+import {
+  compactRunLogChunk,
+  redactAdapterExecutionResultSecrets,
+} from "../services/heartbeat.js";
 
 describe("compactRunLogChunk", () => {
   it("redacts inline base64 image data from structured log chunks", () => {
@@ -32,6 +35,35 @@ describe("compactRunLogChunk", () => {
 
     expect(compacted).toBe("GRANTED_VALUE=***REDACTED***");
     expect(compacted).not.toContain(canary);
+  });
+
+  it("redacts partial tool output from every persisted adapter result field", () => {
+    const runJwtCanary = "canary-run-jwt-value";
+    const grantedCanary = "canary-granted-secret-value";
+    const partialUpdate = JSON.stringify({
+      type: "tool_execution_update",
+      partialResult: {
+        content: `PAPERCLIP_API_KEY=${runJwtCanary}\nGRANTED_VALUE=${grantedCanary}`,
+      },
+    });
+
+    const redacted = redactAdapterExecutionResultSecrets(
+      {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `adapter failed: ${runJwtCanary}`,
+        errorMeta: { partialUpdate },
+        resultJson: { stdout: partialUpdate, nested: { grantedCanary } },
+        summary: `summary: ${grantedCanary}`,
+      },
+      [runJwtCanary, grantedCanary],
+    );
+    const persisted = JSON.stringify(redacted);
+
+    expect(persisted).toContain("***REDACTED***");
+    expect(persisted).not.toContain(runJwtCanary);
+    expect(persisted).not.toContain(grantedCanary);
   });
 
   it("redacts Paperclip credential shapes before persisting run-log chunks", () => {

--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -22,10 +22,23 @@ describe("compactRunLogChunk", () => {
     expect(compacted.endsWith("tail")).toBe(true);
   });
 
+  it("redacts resolved secret literals even when their env key is not sensitive", () => {
+    const canary = "canary-granted-runtime-value";
+    const compacted = compactRunLogChunk(
+      `GRANTED_VALUE=${canary}`,
+      16_384,
+      [canary],
+    );
+
+    expect(compacted).toBe("GRANTED_VALUE=***REDACTED***");
+    expect(compacted).not.toContain(canary);
+  });
+
   it("redacts Paperclip credential shapes before persisting run-log chunks", () => {
     const chunk = [
       "Authorization: Bearer live-bearer-token-value",
       `export PAPERCLIP_API_KEY='paperclip-shell-secret'`,
+      `PAPERCLIP_AGENT_JWT_SECRET=paperclip-signing-canary`,
       `auth {"refresh_token":"refresh-token-fixture-secret"}`,
       `payload {"PAPERCLIP_API_KEY":"paperclip-json-secret"}`,
       "--paperclip-api-key=paperclip-flag-secret",
@@ -36,6 +49,7 @@ describe("compactRunLogChunk", () => {
     expect(compacted).toContain("***REDACTED***");
     expect(compacted).not.toContain("live-bearer-token-value");
     expect(compacted).not.toContain("paperclip-shell-secret");
+    expect(compacted).not.toContain("paperclip-signing-canary");
     expect(compacted).not.toContain("refresh-token-fixture-secret");
     expect(compacted).not.toContain("paperclip-json-secret");
     expect(compacted).not.toContain("paperclip-flag-secret");

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -134,8 +134,10 @@ describe("pi_local execute", () => {
 
     const previousHome = process.env.HOME;
     const previousSigningSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    const previousBetterAuthSecret = process.env.BETTER_AUTH_SECRET;
     process.env.HOME = root;
     process.env.PAPERCLIP_AGENT_JWT_SECRET = "canary-host-signing-secret";
+    process.env.BETTER_AUTH_SECRET = "canary-better-auth-signing-secret";
 
     try {
       const result = await execute({
@@ -174,6 +176,7 @@ describe("pi_local execute", () => {
         argv: string[];
       };
       expect(capture.env.PAPERCLIP_AGENT_JWT_SECRET).toBeUndefined();
+      expect(capture.env.BETTER_AUTH_SECRET).toBeUndefined();
       expect(capture.env.PAPERCLIP_API_KEY).toBe("canary-run-api-token");
       const persistedResult = JSON.stringify({
         resultJson: result.resultJson,
@@ -195,6 +198,8 @@ describe("pi_local execute", () => {
       else process.env.HOME = previousHome;
       if (previousSigningSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
       else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousSigningSecret;
+      if (previousBetterAuthSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = previousBetterAuthSecret;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -57,7 +57,19 @@ if (process.argv.includes("--list-models")) {
 fs.writeFileSync(${JSON.stringify(dumpPath)}, JSON.stringify({ env: process.env, argv: process.argv.slice(2) }));
 console.log(JSON.stringify({ type: "agent_start" }));
 console.log(JSON.stringify({ type: "turn_start" }));
-console.log(JSON.stringify({ type: "turn_end", message: { role: "assistant", content: "done", usage: {} }, toolResults: [] }));
+console.log(JSON.stringify({
+  type: "tool_execution_update",
+  toolCallId: "tool-env",
+  toolName: "bash",
+  partialResult: {
+    content: "GRANTED_VALUE=" + process.env.GRANTED_VALUE + "\\nPAPERCLIP_API_KEY=" + process.env.PAPERCLIP_API_KEY,
+  },
+}));
+console.log(JSON.stringify({
+  type: "turn_end",
+  message: { role: "assistant", content: "done " + process.env.GRANTED_VALUE, usage: {} },
+  toolResults: [],
+}));
 console.log(JSON.stringify({ type: "agent_end", messages: [] }));
 process.exit(0);
 `;
@@ -126,7 +138,7 @@ describe("pi_local execute", () => {
     process.env.PAPERCLIP_AGENT_JWT_SECRET = "canary-host-signing-secret";
 
     try {
-      await execute({
+      const result = await execute({
         runId: "run-pi-redaction",
         agent: {
           id: "agent-redaction",
@@ -163,6 +175,14 @@ describe("pi_local execute", () => {
       };
       expect(capture.env.PAPERCLIP_AGENT_JWT_SECRET).toBeUndefined();
       expect(capture.env.PAPERCLIP_API_KEY).toBe("canary-run-api-token");
+      const persistedResult = JSON.stringify({
+        resultJson: result.resultJson,
+        errorMessage: result.errorMessage,
+        summary: result.summary,
+      });
+      expect(persistedResult).toContain("***REDACTED***");
+      expect(persistedResult).not.toContain("canary-run-api-token");
+      expect(persistedResult).not.toContain("canary-granted-value");
       expect(JSON.parse(capture.env.PAPERCLIP_TRANSCRIPT_SECRET_ENV_KEYS)).toEqual([
         "PAPERCLIP_API_KEY",
         "GRANTED_VALUE",

--- a/server/src/__tests__/pi-local-execute.test.ts
+++ b/server/src/__tests__/pi-local-execute.test.ts
@@ -46,6 +46,25 @@ process.exit(0);
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writeInvocationDumpPiCommand(commandPath: string, dumpPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+if (process.argv.includes("--list-models")) {
+  console.log("provider  model");
+  console.log("google    gemini-3-flash-preview");
+  process.exit(0);
+}
+fs.writeFileSync(${JSON.stringify(dumpPath)}, JSON.stringify({ env: process.env, argv: process.argv.slice(2) }));
+console.log(JSON.stringify({ type: "agent_start" }));
+console.log(JSON.stringify({ type: "turn_start" }));
+console.log(JSON.stringify({ type: "turn_end", message: { role: "assistant", content: "done", usage: {} }, toolResults: [] }));
+console.log(JSON.stringify({ type: "agent_end", messages: [] }));
+process.exit(0);
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
 describe("pi_local execute", () => {
   it("fails the run when Pi exhausts automatic retries despite exiting 0", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-execute-"));
@@ -89,6 +108,73 @@ describe("pi_local execute", () => {
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps host signing secrets out of Pi and installs transcript redaction", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-pi-redaction-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "pi");
+    const dumpPath = path.join(root, "invocation.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeInvocationDumpPiCommand(commandPath, dumpPath);
+
+    const previousHome = process.env.HOME;
+    const previousSigningSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    process.env.HOME = root;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "canary-host-signing-secret";
+
+    try {
+      await execute({
+        runId: "run-pi-redaction",
+        agent: {
+          id: "agent-redaction",
+          companyId: "company-redaction",
+          name: "Pi Agent",
+          adapterType: "pi_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "google/gemini-3-flash-preview",
+          promptTemplate: "Keep working.",
+          env: { GRANTED_VALUE: "canary-granted-value" },
+        },
+        context: {
+          paperclipSecrets: {
+            manifest: [{ envKey: "GRANTED_VALUE" }],
+          },
+        },
+        authToken: "canary-run-api-token",
+        onLog: async () => {},
+      });
+
+      const capture = JSON.parse(await fs.readFile(dumpPath, "utf8")) as {
+        env: Record<string, string>;
+        argv: string[];
+      };
+      expect(capture.env.PAPERCLIP_AGENT_JWT_SECRET).toBeUndefined();
+      expect(capture.env.PAPERCLIP_API_KEY).toBe("canary-run-api-token");
+      expect(JSON.parse(capture.env.PAPERCLIP_TRANSCRIPT_SECRET_ENV_KEYS)).toEqual([
+        "PAPERCLIP_API_KEY",
+        "GRANTED_VALUE",
+      ]);
+      const extensionIndex = capture.argv.indexOf("--extension");
+      expect(extensionIndex).toBeGreaterThanOrEqual(0);
+      expect(capture.argv[extensionIndex + 1]).toMatch(/transcript-redaction-extension\.(?:js|ts)$/);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousSigningSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+      else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousSigningSecret;
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2031,15 +2031,56 @@ function redactInlineBase64ImageData(chunk: string) {
   );
 }
 
-function redactLiteralSecretValues(chunk: string, secretValues: Iterable<string>): string {
-  const sortedValues = [...secretValues]
+function normalizeLiteralSecretValues(secretValues: Iterable<string>): string[] {
+  return [...new Set(secretValues)]
     .filter((value) => value.length >= 4)
     .sort((left, right) => right.length - left.length);
+}
+
+function redactLiteralSecretValues(chunk: string, secretValues: Iterable<string>): string {
   let redacted = chunk;
-  for (const value of sortedValues) {
+  for (const value of normalizeLiteralSecretValues(secretValues)) {
     redacted = redacted.split(value).join("***REDACTED***");
   }
   return redacted;
+}
+
+function redactRunSecretValue<T>(value: T, secretValues: Iterable<string>): T {
+  const normalizedSecretValues = normalizeLiteralSecretValues(secretValues);
+  const redactValue = (entry: unknown): unknown => {
+    if (typeof entry === "string") {
+      return redactSensitiveText(redactLiteralSecretValues(entry, normalizedSecretValues));
+    }
+    if (Array.isArray(entry)) return entry.map(redactValue);
+    if (!entry || typeof entry !== "object") return entry;
+    const prototype = Object.getPrototypeOf(entry);
+    if (prototype !== Object.prototype && prototype !== null) return entry;
+    return Object.fromEntries(
+      Object.entries(entry as Record<string, unknown>).map(([key, nested]) => [key, redactValue(nested)]),
+    );
+  };
+  return redactValue(value) as T;
+}
+
+export function redactAdapterExecutionResultSecrets(
+  result: AdapterExecutionResult,
+  secretValues: Iterable<string>,
+): AdapterExecutionResult {
+  return {
+    ...result,
+    ...(result.errorMessage === undefined
+      ? {}
+      : { errorMessage: redactRunSecretValue(result.errorMessage, secretValues) }),
+    ...(result.errorMeta === undefined
+      ? {}
+      : { errorMeta: redactRunSecretValue(result.errorMeta, secretValues) }),
+    ...(result.resultJson === undefined
+      ? {}
+      : { resultJson: redactRunSecretValue(result.resultJson, secretValues) }),
+    ...(result.summary === undefined
+      ? {}
+      : { summary: redactRunSecretValue(result.summary, secretValues) }),
+  };
 }
 
 export function compactRunLogChunk(
@@ -11902,6 +11943,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     activeRunExecutions.add(run.id);
     let runScratch: HeartbeatRunScratch | null = null;
+    const literalRunSecretValues = new Set<string>();
+    for (const value of [
+      process.env.PAPERCLIP_API_KEY,
+      process.env.PAPERCLIP_AGENT_JWT_SECRET,
+    ]) {
+      if (typeof value === "string") literalRunSecretValues.add(value);
+    }
 
     try {
     const agent = await getAgent(run.agentId);
@@ -12441,6 +12489,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ...effectiveResolvedConfig,
       paperclipRuntimeSkills: runtimeSkillEntries,
     };
+    const initiallyResolvedRuntimeEnv = parseObject(runtimeConfig.env);
+    for (const key of secretKeys) {
+      const value = initiallyResolvedRuntimeEnv[key];
+      if (typeof value === "string") literalRunSecretValues.add(value);
+    }
     const latestAgentConfigRevision = await getLatestAgentConfigRevision(agent.companyId, agent.id);
     const sessionConfigMetadata = await buildEffectiveRunSessionConfigMetadata({
       adapterType: agent.adapterType,
@@ -13298,7 +13351,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(eq(heartbeatRuns.id, runId));
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
-      const literalRunSecretValues = new Set<string>();
       const resolvedRuntimeEnv = parseObject(runtimeConfig.env);
       for (const key of secretKeys) {
         const value = resolvedRuntimeEnv[key];
@@ -13751,6 +13803,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           },
           authToken: authToken ?? undefined,
         });
+        adapterResult = redactAdapterExecutionResultSecrets(
+          adapterResult,
+          literalRunSecretValues,
+        );
         // Adapter returned cleanly, which means its workspace-restore finally
         // block also ran without throwing. Record the workspace_finalize
         // barrier so dependents that share this executionWorkspace can wake.
@@ -14153,9 +14209,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       );
     } catch (err) {
-      const message = redactCurrentUserText(
-        err instanceof Error ? err.message : "Unknown adapter failure",
-        await getCurrentUserRedactionOptions(),
+      const message = redactRunSecretValue(
+        redactCurrentUserText(
+          err instanceof Error ? err.message : "Unknown adapter failure",
+          await getCurrentUserRedactionOptions(),
+        ),
+        literalRunSecretValues,
       );
       const workspaceValidationFailure = isWorkspaceValidationFailure(err) ? err : null;
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
@@ -14191,7 +14250,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
           errorCode: failureErrorCode,
           errorMessage: message,
-          resultJson: workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
+          resultJson: redactRunSecretValue(
+            workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
+            literalRunSecretValues,
+          ),
         }),
         stdoutExcerpt,
         stderrExcerpt,
@@ -14278,9 +14340,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } catch (outerErr) {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
           // The inner catch did not fire, so we must record the failure here.
-          const message = redactCurrentUserText(
-            outerErr instanceof Error ? outerErr.message : "Unknown setup failure",
-            await getCurrentUserRedactionOptions(),
+          const message = redactRunSecretValue(
+            redactCurrentUserText(
+              outerErr instanceof Error ? outerErr.message : "Unknown setup failure",
+              await getCurrentUserRedactionOptions(),
+            ),
+            literalRunSecretValues,
           );
           // A missing secret/env binding is a known pre-dispatch configuration gap,
           // not an opaque setup crash. Surface it with its own errorCode so the
@@ -14304,8 +14369,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               resultJson: mergeRunStopMetadataForAgent(setupFailureAgent, "failed", {
                 errorCode: setupFailureErrorCode,
                 errorMessage: message,
-                resultJson:
+                resultJson: redactRunSecretValue(
                   workspaceValidationSetupFailure?.resultJson ?? configurationIncompleteSetupFailure?.resultJson ?? null,
+                  literalRunSecretValues,
+                ),
               }),
             } : {}),
           }).catch(() => ({ run: null, updated: false as const }));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2031,8 +2031,25 @@ function redactInlineBase64ImageData(chunk: string) {
   );
 }
 
-export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_CHUNK_CHARS) {
-  const normalized = redactSensitiveText(redactInlineBase64ImageData(chunk));
+function redactLiteralSecretValues(chunk: string, secretValues: Iterable<string>): string {
+  const sortedValues = [...secretValues]
+    .filter((value) => value.length >= 4)
+    .sort((left, right) => right.length - left.length);
+  let redacted = chunk;
+  for (const value of sortedValues) {
+    redacted = redacted.split(value).join("***REDACTED***");
+  }
+  return redacted;
+}
+
+export function compactRunLogChunk(
+  chunk: string,
+  maxChars = MAX_PERSISTED_LOG_CHUNK_CHARS,
+  literalSecretValues: Iterable<string> = [],
+) {
+  const normalized = redactSensitiveText(
+    redactLiteralSecretValues(redactInlineBase64ImageData(chunk), literalSecretValues),
+  );
   if (normalized.length <= maxChars) return normalized;
 
   const headChars = Math.max(0, Math.floor(maxChars * 0.6));
@@ -13281,9 +13298,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(eq(heartbeatRuns.id, runId));
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
+      const literalRunSecretValues = new Set<string>();
+      const resolvedRuntimeEnv = parseObject(runtimeConfig.env);
+      for (const key of secretKeys) {
+        const value = resolvedRuntimeEnv[key];
+        if (typeof value === "string") literalRunSecretValues.add(value);
+      }
+      let authToken: string | null = null;
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
         const sanitizedChunk = compactRunLogChunk(
           redactCurrentUserText(chunk, currentUserRedactionOptions),
+          MAX_PERSISTED_LOG_CHUNK_CHARS,
+          literalRunSecretValues,
         );
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
@@ -13475,7 +13501,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         issueRef?.workMode === "skill_test"
           ? { kind: "skill_test" as const, issueId: issueRef.id }
           : { kind: "standard" as const };
-      const authToken = adapter.supportsLocalAgentJwt
+      authToken = adapter.supportsLocalAgentJwt
         ? createLocalAgentJwt(
           agent.id,
           agent.companyId,
@@ -13485,6 +13511,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           localAgentJwtScope,
         )
         : null;
+      if (authToken) literalRunSecretValues.add(authToken);
       if (adapter.supportsLocalAgentJwt && !authToken) {
         logger.warn(
           {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11947,6 +11947,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     for (const value of [
       process.env.PAPERCLIP_API_KEY,
       process.env.PAPERCLIP_AGENT_JWT_SECRET,
+      process.env.BETTER_AUTH_SECRET,
     ]) {
       if (typeof value === "string") literalRunSecretValues.add(value);
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane operators use to run and govern AI-agent companies
> - Agent runtimes and persisted transcripts cross a sensitive trust boundary because they can receive runtime credentials and emit arbitrary tool output
> - Pi execution could persist secrets from runtime environment values and partial tool output into transcripts and run summaries
> - The Better Auth signing secret could also be inherited by agent subprocesses even though agents do not need that control-plane credential
> - The reviewed GST-21 patch redacts runtime secrets before Pi transcript persistence, redacts partial tool output before run-result persistence, and strips the signing secret from inherited agent environments
> - This pull request also documents the already-completed signing-key rotation procedure and adds the stable release notes needed to publish the complete fixed package set
> - The benefit is a smaller credential blast radius without changing normal agent execution or operator workflows

## Linked Issues or Issue Description

### What happened?

Pi tool output and runtime environment values could reach persisted transcripts/run results without credential redaction, and agent subprocesses could inherit the Better Auth signing secret.

### Expected behavior

Runtime credentials and signing keys remain outside persisted agent output and outside agent subprocess environments.

### Steps to reproduce

Run a Pi agent whose runtime environment contains a sentinel secret and whose tool emits the same value in partial output; inspect the transcript, run result, and inherited environment.

### Paperclip version or commit

Reproduces before reviewed tip `e987de21a`; fixed by the commits in this PR.

### Deployment mode

Self-hosted server, npm package.

### Adapter

Pi plus core local-process runtime environment handling.

### Database and access context

Not database-specific; agent execution context.

### Environment

Node.js 24 on Linux.

### Privacy

No live credentials or sensitive transcript content are included in this report.

## What Changed

- Redact runtime secrets before Pi transcript persistence, including remote execution paths.
- Redact partial Pi tool output before storing run results and heartbeat logs.
- Remove `PAPERCLIP_AGENT_JWT_SECRET` and `BETTER_AUTH_SECRET` from inherited agent environments.
- Add focused regression coverage for transcript, run-result, heartbeat-log, and environment sanitization behavior.
- Document the signing-secret rotation runbook without rotating the already-replaced production secret.
- Add `releases/v2026.729.0.md` for the complete stable promotion.

## Verification

- Focused changed-test gate: 5 files / 18 tests passed.
- Stable patch IDs for all four reviewed commits exactly match reviewed branch tip `e987de21a` after replay onto current `master`.
- `git diff --check` passes and the working tree is clean.
- The previous broad `pnpm test:run` completed with seven pre-existing runtime-environment failures limited to `server-startup-feedback-export.test.ts` and `workspace-runtime.test.ts`; focused changed tests passed, and CI will rerun the authoritative release gate.

## Risks

- Redaction is intentionally conservative and could mask output equal to a configured runtime secret; this is preferable to persisting credentials.
- Signing-secret removal could expose an undocumented adapter dependency on control-plane credentials; focused environment tests cover the intended contract.
- Stable publication remains gated on all upstream CI checks and Greptile review.
- No database schema change is introduced by this PR.

> This security hardening supports the existing Secrets Manager roadmap item and does not duplicate planned core feature work.

## Model Used

- OpenAI Codex, GPT-5.6 agentic coding model, high-reasoning mode with repository, shell, GitHub CLI, and code-execution tools; context-window size is not exposed by the execution harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

