### PR TITLE
docs: require Simplified Technical English for PR text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->
+
 ## Thinking Path
 
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,8 @@ Bugs, docs improvements, and small targeted improvements are still the easiest p
 
 ## Writing a Good PR message
 
+Write all PR text in Simplified Technical English (ASD-STE100): use short sentences, one instruction per sentence, simple approved vocabulary, and the active voice.
+
 Your PR description must follow the [PR template](.github/PULL_REQUEST_TEMPLATE.md). All sections are required. The "thinking path" at the top explains from the top of the project down to what you fixed. E.g.:
 
 ### Thinking Path Example 1:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Many contributors are AI agents, and they write the pull request text.
> - PR descriptions vary in clarity, and long or ambiguous prose slows down review.
> - Simplified Technical English (ASD-STE100) is a controlled language that makes technical text short, clear, and unambiguous.
> - This pull request adds one line to `CONTRIBUTING.md` and one line to the pull request template. Both lines instruct the author to write PR text in Simplified Technical English (ASD-STE100).
> - The benefit is clearer, faster-to-review pull request descriptions.

## Linked Issues or Issue Description

No related GitHub issue exists. This is a small documentation change. It sets a writing-style rule for pull request text: authors must use Simplified Technical English (ASD-STE100).

## What Changed

- Add one line to `CONTRIBUTING.md` (in "Writing a Good PR message") that requires Simplified Technical English (ASD-STE100).
- Add one comment line to `.github/PULL_REQUEST_TEMPLATE.md` that gives the same instruction to PR authors.

## Verification

- Read the two changed files. Confirm each new line is present and correct.
- `git diff --stat origin/master` shows only the two files, with 4 inserted lines.

## Risks

Low risk. The change is documentation only. It adds guidance text and does not change code or behavior.

## Model Used

Claude Opus 4.8 (claude-opus-4-8), 1M context window, extended thinking, tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
