### PR TITLE
feat(acpx): pre-computed memory recall at platform level

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -46,6 +46,8 @@ import {
   parseObject,
   readPaperclipRuntimeSkillEntries,
   readPaperclipIssueWorkModeFromContext,
+  isPaperclipRecoveryWakePayload,
+  normalizePaperclipWakePayload,
   renderPaperclipWakePrompt,
   renderTemplate,
   resolvePaperclipInstanceRootForAdapter,
@@ -1873,6 +1875,54 @@ function renderApiAccessNote(env: Record<string, string>): string {
   return lines.join("\n");
 }
 
+const PRECOMPUTED_RECALL_TIMEOUT_MS = 10_000;
+const PRECOMPUTED_RECALL_MAX_RESULTS = 5;
+
+async function precomputeMemoryRecall(input: {
+  issueTitle: string;
+  issueIdentifier: string | null;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}): Promise<string> {
+  const { issueTitle, issueIdentifier, onLog } = input;
+  const keywords = issueTitle.replace(/[^\w\sáčďéěíňóřšťúůýžÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ-]/g, " ").trim();
+  const query = [
+    `lex: ${keywords}`,
+    `vec: ${issueTitle}`,
+    `hyde: Informace relevantní k: ${issueTitle}`,
+  ].join("\n");
+  try {
+    const { stdout } = await execFileAsync("qmd", [
+      "query", query, "-c", "memory-v2",
+      "-n", String(PRECOMPUTED_RECALL_MAX_RESULTS),
+      "--no-rerank", "--no-expand", "--format", "json",
+    ], { timeout: PRECOMPUTED_RECALL_TIMEOUT_MS });
+    const results = JSON.parse(stdout);
+    if (!Array.isArray(results) || results.length === 0) return "";
+    const label = issueIdentifier ? `${issueIdentifier} ${issueTitle}` : issueTitle;
+    const lines = [
+      `Paperclip pre-computed memory recall for "${label}":`,
+      "",
+    ];
+    for (const r of results.slice(0, PRECOMPUTED_RECALL_MAX_RESULTS)) {
+      const snippet = typeof r.snippet === "string"
+        ? r.snippet.replace(/@@ .+? @@\n?/, "").trim().slice(0, 200)
+        : "";
+      lines.push(`- ${r.file ?? "(unknown)"}: ${r.title ?? "(no title)"}`);
+      if (snippet) lines.push(`  ${snippet}`);
+    }
+    lines.push(
+      "",
+      "Use these results as initial context. For deeper recall, invoke /memory-recall with a refined query.",
+      "After using recall data, include a [NOINDEX: MEMORY-RECALL-DEBUG ... /NOINDEX] block in your issue comment per the memory-recall skill Step 3.5.",
+    );
+    return lines.join("\n");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[paperclip] Pre-computed memory recall failed: ${msg}\n`);
+    return "";
+  }
+}
+
 async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean, env: Record<string, string>): Promise<{
   prompt: string;
   promptMetrics: Record<string, number>;
@@ -1921,16 +1971,30 @@ async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean
       : "";
   const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession });
   const shouldUseResumeDeltaPrompt = resumedSession && wakePrompt.length > 0;
+  const isRecoveryWake = isPaperclipRecoveryWakePayload(context.paperclipWake);
   const promptInstructionsPrefix = shouldUseResumeDeltaPrompt ? "" : instructionsPrefix;
   const renderedPrompt = shouldUseResumeDeltaPrompt ? "" : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const taskContextNote = asString(context.paperclipTaskMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
   const apiAccessNote = renderApiAccessNote(env);
+
+  let memoryRecallContext = "";
+  const normalizedWake = normalizePaperclipWakePayload(context.paperclipWake);
+  const issueTitle = normalizedWake?.issue?.title ?? null;
+  if (issueTitle && !resumedSession && !isRecoveryWake) {
+    memoryRecallContext = await precomputeMemoryRecall({
+      issueTitle,
+      issueIdentifier: normalizedWake?.issue?.identifier ?? null,
+      onLog,
+    });
+  }
+
   const prompt = joinPromptSections([
     promptInstructionsPrefix,
     renderedBootstrapPrompt,
     wakePrompt,
+    memoryRecallContext,
     sessionHandoffNote,
     taskContextNote,
     paperclipEnvNote,
@@ -1946,6 +2010,7 @@ async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean
       instructionsChars: promptInstructionsPrefix.length,
       bootstrapPromptChars: renderedBootstrapPrompt.length,
       wakePromptChars: wakePrompt.length,
+      memoryRecallContextChars: memoryRecallContext.length,
       sessionHandoffChars: sessionHandoffNote.length,
       taskContextChars: taskContextNote.length,
       runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -167,6 +167,7 @@ export const DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE = [
   "- For plan approval, update the plan document first, then create request_confirmation targeting the latest plan revision with idempotencyKey confirmation:{issueId}:plan:{revisionId}. Wait for acceptance before creating implementation subtasks, and create a fresh confirmation after superseding board/user comments if approval is still needed.",
   "- If blocked, mark the issue blocked and name the unblock owner and action.",
   "- Respect budget, pause/cancel, approval gates, and company boundaries.",
+  "- If pre-computed memory recall results are present in this prompt, use them as context for your work. After using recall data, include a [NOINDEX: MEMORY-RECALL-DEBUG ... /NOINDEX] block in your first issue comment showing the query decomposition, scores, and results used (see memory-recall skill Step 3.5 for format).",
 ].join("\n");
 
 export const WATCHDOG_DEFAULT_MANDATE = [

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,6 +1,8 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 import {
@@ -42,6 +44,7 @@ import {
   renderTemplate,
   renderPaperclipWakePrompt,
   isPaperclipRecoveryWakePayload,
+  normalizePaperclipWakePayload,
   rewriteWorkspaceCwdEnvVarsForExecution,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
@@ -155,6 +158,56 @@ function isBedrockAuth(env: Record<string, string>): boolean {
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
+}
+
+const execFileAsync = promisify(execFile);
+
+const PRECOMPUTED_RECALL_TIMEOUT_MS = 10_000;
+const PRECOMPUTED_RECALL_MAX_RESULTS = 5;
+
+async function precomputeMemoryRecall(input: {
+  issueTitle: string;
+  issueIdentifier: string | null;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}): Promise<string> {
+  const { issueTitle, issueIdentifier, onLog } = input;
+  const keywords = issueTitle.replace(/[^\w\sáčďéěíňóřšťúůýžÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ-]/g, " ").trim();
+  const query = [
+    `lex: ${keywords}`,
+    `vec: ${issueTitle}`,
+    `hyde: Informace relevantní k: ${issueTitle}`,
+  ].join("\n");
+  try {
+    const { stdout } = await execFileAsync("qmd", [
+      "query", query, "-c", "memory-v2",
+      "-n", String(PRECOMPUTED_RECALL_MAX_RESULTS),
+      "--no-rerank", "--no-expand", "--format", "json",
+    ], { timeout: PRECOMPUTED_RECALL_TIMEOUT_MS });
+    const results = JSON.parse(stdout);
+    if (!Array.isArray(results) || results.length === 0) return "";
+    const label = issueIdentifier ? `${issueIdentifier} ${issueTitle}` : issueTitle;
+    const lines = [
+      `Paperclip pre-computed memory recall for "${label}":`,
+      "",
+    ];
+    for (const r of results.slice(0, PRECOMPUTED_RECALL_MAX_RESULTS)) {
+      const snippet = typeof r.snippet === "string"
+        ? r.snippet.replace(/@@ .+? @@\n?/, "").trim().slice(0, 200)
+        : "";
+      lines.push(`- ${r.file ?? "(unknown)"}: ${r.title ?? "(no title)"}`);
+      if (snippet) lines.push(`  ${snippet}`);
+    }
+    lines.push(
+      "",
+      "Use these results as initial context. For deeper recall, invoke /memory-recall with a refined query.",
+      "After using recall data, include a [NOINDEX: MEMORY-RECALL-DEBUG ... /NOINDEX] block in your issue comment per the memory-recall skill Step 3.5.",
+    );
+    return lines.join("\n");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await onLog("stderr", `[paperclip] Pre-computed memory recall failed: ${msg}\n`);
+    return "";
+  }
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {
@@ -800,14 +853,29 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : "";
   const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
   const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
-  const renderedPrompt = shouldUseResumeDeltaPrompt || isPaperclipRecoveryWakePayload(context.paperclipWake)
+  const isRecoveryWake = isPaperclipRecoveryWakePayload(context.paperclipWake);
+  const renderedPrompt = shouldUseResumeDeltaPrompt || isRecoveryWake
     ? ""
     : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const taskContextNote = asString(context.paperclipTaskMarkdown, "").trim();
+
+  // Pre-compute memory recall for non-routine issues on fresh sessions.
+  let memoryRecallContext = "";
+  const normalizedWake = normalizePaperclipWakePayload(context.paperclipWake);
+  const issueTitle = normalizedWake?.issue?.title ?? null;
+  if (issueTitle && !sessionId && !isRecoveryWake) {
+    memoryRecallContext = await precomputeMemoryRecall({
+      issueTitle,
+      issueIdentifier: normalizedWake?.issue?.identifier ?? null,
+      onLog,
+    });
+  }
+
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
     wakePrompt,
+    memoryRecallContext,
     sessionHandoffNote,
     taskContextNote,
     renderedPrompt,
@@ -816,6 +884,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     promptChars: prompt.length,
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
+    memoryRecallContextChars: memoryRecallContext.length,
     sessionHandoffChars: sessionHandoffNote.length,
     taskContextChars: taskContextNote.length,
     heartbeatPromptChars: renderedPrompt.length,


### PR DESCRIPTION
## Summary

- **Platform enforcement** for memory recall compliance (EXE-17236): harness runs `qmd query` with issue title before agent wake and injects recall results into the prompt
- Agents no longer need to self-invoke `/memory-recall` — the platform does it on fresh, non-recovery sessions
- Prompt template updated to instruct agents to generate `[NOINDEX: MEMORY-RECALL-DEBUG]` blocks when pre-computed recall data is present

## Changes (3 files, +136 lines)

| File | Change |
|------|--------|
| `packages/adapter-utils/src/acpx-engine/execute.ts` | `precomputeMemoryRecall()` + `buildPrompt()` integration |
| `packages/adapters/claude-local/src/server/execute.ts` | Same function for CLI execution path |
| `packages/adapter-utils/src/server-utils.ts` | Prompt template directive for NOINDEX blocks |

## How it works

1. On wake, `buildPrompt()` checks: fresh session + has issue title + not recovery wake
2. Runs `qmd query` with issue title (lex + vec + hyde multi-query, 10s timeout)
3. Formats top 5 results and injects into prompt before session handoff
4. Agent sees recall data without needing to call anything
5. Prompt directive instructs agent to include NOINDEX debug block

## Verification

- ✅ TypeScript: adapter-utils + claude-local pass
- ✅ Tests: server-utils 75/75, claude-local 144/144 (12 pre-existing sandbox ioctl failures)
- ✅ `qmd query` end-to-end tested

## Test plan

- [ ] Deploy to staging/local and verify recall data appears in agent prompts
- [ ] Confirm agents generate NOINDEX blocks in issue comments
- [ ] Monitor qmd query latency stays under 10s timeout