### PR TITLE
fix: allow issue identifiers with digit-starting company prefixes

### DIFF
--- a/packages/shared/src/issue-references.test.ts
+++ b/packages/shared/src/issue-references.test.ts
@@ -14,6 +14,11 @@ describe("issue references", () => {
     expect(normalizeIssueIdentifier("not-an-issue")).toBeNull();
   });
 
+  it("accepts identifiers with digit-starting company prefixes", () => {
+    expect(normalizeIssueIdentifier("2co-4")).toBe("2CO-4");
+    expect(normalizeIssueIdentifier("3M-1")).toBe("3M-1");
+  });
+
   it("parses relative and absolute issue hrefs", () => {
     expect(parseIssueReferenceHref("/issues/PAP-123")).toEqual({ identifier: "PAP-123" });
     expect(parseIssueReferenceHref("/PAP/issues/pap-456")).toEqual({ identifier: "PAP-456" });
@@ -37,6 +42,13 @@ describe("issue references", () => {
         identifier: "PC1A2-3",
         matchedText: "https://x.test/PAP/issues/pc1a2-3",
       },
+    ]);
+  });
+
+  it("finds identifiers with digit-starting prefixes in text", () => {
+    expect(findIssueReferenceMatches("See 2CO-4 and /issues/3M-1 for details.")).toEqual([
+      { index: 4, length: 5, identifier: "2CO-4", matchedText: "2CO-4" },
+      { index: 14, length: 13, identifier: "3M-1", matchedText: "/issues/3M-1" },
     ]);
   });
 

--- a/packages/shared/src/issue-references.ts
+++ b/packages/shared/src/issue-references.ts
@@ -7,7 +7,7 @@ export interface IssueReferenceMatch {
   matchedText: string;
 }
 
-const ISSUE_REFERENCE_TOKEN_RE = /https?:\/\/[^\s<>()]+|\/[^\s<>()]+|[A-Z][A-Z0-9]*-\d+/gi;
+const ISSUE_REFERENCE_TOKEN_RE = /https?:\/\/[^\s<>()]+|\/[^\s<>()]+|[A-Z0-9][A-Z0-9]*-\d+/gi;
 
 function preserveNewlinesAsWhitespace(value: string) {
   return value.replace(/[^\n]/g, " ");

--- a/packages/shared/src/issue-references.ts
+++ b/packages/shared/src/issue-references.ts
@@ -1,4 +1,4 @@
-export const ISSUE_REFERENCE_IDENTIFIER_RE = /^[A-Z][A-Z0-9]*-\d+$/;
+export const ISSUE_REFERENCE_IDENTIFIER_RE = /^[A-Z0-9][A-Z0-9]*-\d+$/;
 
 export interface IssueReferenceMatch {
   index: number;

--- a/ui/src/lib/issue-reference.ts
+++ b/ui/src/lib/issue-reference.ts
@@ -5,9 +5,9 @@ type MarkdownNode = {
   children?: MarkdownNode[];
 };
 
-const BARE_ISSUE_IDENTIFIER_RE = /^[A-Z][A-Z0-9]*-\d+$/i;
+const BARE_ISSUE_IDENTIFIER_RE = /^[A-Z0-9][A-Z0-9]*-\d+$/i;
 const ISSUE_SCHEME_RE = /^issue:\/\/:?([^?#\s]+)(?:[?#].*)?$/i;
-const ISSUE_REFERENCE_TOKEN_RE = /issue:\/\/:?[^\s<>()]+|https?:\/\/[^\s<>()]+|\/(?:[^\s<>()/]+\/)*issues\/[A-Z][A-Z0-9]*-\d+(?=$|[\s<>)\],.;!?:])|\b[A-Z][A-Z0-9]*-\d+\b/gi;
+const ISSUE_REFERENCE_TOKEN_RE = /issue:\/\/:?[^\s<>()]+|https?:\/\/[^\s<>()]+|\/(?:[^\s<>()/]+\/)*issues\/[A-Z0-9][A-Z0-9]*-\d+(?=$|[\s<>)\],.;!?:])|\b[A-Z0-9][A-Z0-9]*-\d+\b/gi;
 
 export function parseIssuePathIdFromPath(pathOrUrl: string | null | undefined): string | null {
   if (!pathOrUrl) return null;


### PR DESCRIPTION
Closes #10077

## Thinking Path

The issue reported that issue identifiers with digit-starting company prefixes (e.g. `2CO-4`) return "Issue not found" on every lookup. Reading the code, I found `ISSUE_REFERENCE_IDENTIFIER_RE` in `packages/shared/src/issue-references.ts` — it required the prefix to start with `[A-Z]`. Greptile also pointed out that the token-extraction regex and UI-side regexes have the same constraint, so I fixed those too.

## What Changed

Three files, all one-character regex changes:

- `packages/shared/src/issue-references.ts`: `ISSUE_REFERENCE_IDENTIFIER_RE` (`/^[A-Z]... → /^[A-Z0-9]...`) — validates identifiers in API/server lookups. Also `ISSUE_REFERENCE_TOKEN_RE` — matches identifiers in free text (comments, markdown).

- `ui/src/lib/issue-reference.ts`: `BARE_ISSUE_IDENTIFIER_RE` and `ISSUE_REFERENCE_TOKEN_RE` — same fix for the UI rendering side (linkification and path parsing).

- `packages/shared/src/issue-references.test.ts`: Added test cases for digit-starting prefixes on both `normalizeIssueIdentifier` and `findIssueReferenceMatches`.

## Risks

Low. The change broadens the character class from `[A-Z]` to `[A-Z0-9]` — any prefix that was valid before remains valid. The only new matches are identifiers whose prefix starts with a digit, which the system already allows creating (the bug was that they couldn't be looked up). Non-identifier strings like `123-456` would also match in theory, but in practice the system controls prefix generation and would never produce a purely numeric one that could collide.

## Model Used

Claude (no change from original PR).

---

- [x] I have searched existing open PRs for similar changes before submitting this PR.