### PR TITLE
fix(server): gate sandbox/ssh execution targets by shared remote-managed adapter capability

### DIFF
--- a/server/src/__tests__/environment-execution-target.test.ts
+++ b/server/src/__tests__/environment-execution-target.test.ts
@@ -176,6 +176,106 @@ describe("resolveEnvironmentExecutionTarget", () => {
     });
   });
 
+  it("resolves sandbox targets for every remote-managed adapter, including grok_local", async () => {
+    for (const adapterType of [
+      "claude_local",
+      "codex_local",
+      "cursor",
+      "gemini_local",
+      "grok_local",
+      "opencode_local",
+      "pi_local",
+    ]) {
+      mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
+        driver: "sandbox",
+        config: {
+          provider: "fake-plugin",
+          reuseLease: false,
+          timeoutMs: 30_000,
+        },
+      });
+
+      const target = await resolveEnvironmentExecutionTarget({
+        db: {} as never,
+        companyId: "company-1",
+        adapterType,
+        environment: {
+          id: "env-1",
+          driver: "sandbox",
+          config: { provider: "fake-plugin" },
+        },
+        leaseId: "lease-1",
+        leaseMetadata: {},
+        lease: null,
+        environmentRuntime: null,
+      });
+
+      expect(target, `adapter ${adapterType}`).toMatchObject({
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fake-plugin",
+      });
+    }
+  });
+
+  it("returns null for adapters without remote-managed environment support", async () => {
+    for (const driver of ["sandbox", "ssh"] as const) {
+      const target = await resolveEnvironmentExecutionTarget({
+        db: {} as never,
+        companyId: "company-1",
+        adapterType: "process",
+        environment: {
+          id: "env-1",
+          driver,
+          config: { provider: "fake-plugin" },
+        },
+        leaseId: "lease-1",
+        leaseMetadata: {},
+        lease: null,
+        environmentRuntime: null,
+      });
+
+      expect(target, `driver ${driver}`).toBeNull();
+    }
+    expect(mockResolveEnvironmentDriverConfigForRuntime).not.toHaveBeenCalled();
+  });
+
+  it("resolves SSH execution targets for grok_local", async () => {
+    mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
+      driver: "ssh",
+      config: {
+        host: "ssh.example.test",
+        port: 22,
+        username: "paperclip",
+        remoteWorkspacePath: "/srv/paperclip",
+        privateKey: "PRIVATE KEY",
+        knownHosts: "[ssh.example.test]:22 ssh-ed25519 AAAA",
+        strictHostKeyChecking: true,
+      },
+    });
+
+    const target = await resolveEnvironmentExecutionTarget({
+      db: {} as never,
+      companyId: "company-1",
+      adapterType: "grok_local",
+      environment: {
+        id: "env-ssh-1",
+        driver: "ssh",
+        config: {},
+      },
+      leaseId: "lease-ssh-1",
+      leaseMetadata: {},
+      lease: null,
+      environmentRuntime: null,
+    });
+
+    expect(target).toMatchObject({
+      kind: "remote",
+      transport: "ssh",
+      remoteCwd: "/srv/paperclip",
+    });
+  });
+
   it("resolves SSH execution targets in bridge mode", async () => {
     mockResolveEnvironmentDriverConfigForRuntime.mockResolvedValue({
       driver: "ssh",

--- a/server/src/services/environment-execution-target.ts
+++ b/server/src/services/environment-execution-target.ts
@@ -1,5 +1,6 @@
 import type { Db } from "@paperclipai/db";
 import type { Environment, EnvironmentLease } from "@paperclipai/shared";
+import { adapterSupportsRemoteManagedEnvironments } from "@paperclipai/shared";
 import {
   adapterExecutionTargetToRemoteSpec,
   type AdapterExecutionTarget,
@@ -33,14 +34,10 @@ export async function resolveEnvironmentExecutionTarget(input: {
   }
 
   if (input.environment.driver === "sandbox") {
-    if (
-      input.adapterType !== "codex_local" &&
-      input.adapterType !== "claude_local" &&
-      input.adapterType !== "gemini_local" &&
-      input.adapterType !== "opencode_local" &&
-      input.adapterType !== "pi_local" &&
-      input.adapterType !== "cursor"
-    ) {
+    // Keep this gate in lockstep with the shared capability metadata that the
+    // environment selector and capabilities API expose; a drift here lets the
+    // UI offer environments the runtime then refuses.
+    if (!adapterSupportsRemoteManagedEnvironments(input.adapterType)) {
       return null;
     }
 
@@ -161,14 +158,7 @@ export async function resolveEnvironmentExecutionTarget(input: {
   }
 
   if (
-    (
-      input.adapterType !== "codex_local" &&
-      input.adapterType !== "claude_local" &&
-      input.adapterType !== "gemini_local" &&
-      input.adapterType !== "opencode_local" &&
-      input.adapterType !== "pi_local" &&
-      input.adapterType !== "cursor"
-    ) ||
+    !adapterSupportsRemoteManagedEnvironments(input.adapterType) ||
     input.environment.driver !== "ssh"
   ) {
     return null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip can run an agent in a remote-managed environment, such as a sandbox provider or an SSH host.
> - The server resolves an execution target for each run. The resolver kept its own hardcoded list of allowed adapters.
> - The shared capability metadata in `packages/shared/src/environment-support.ts` already defines which adapters support remote-managed environments. The environment selector and the capabilities API use it.
> - The two lists drifted. The UI offered sandbox environments to Grok Build (`grok_local`) agents, but the resolver refused them at run time.
> - This pull request makes the resolver use the shared capability check for both the sandbox gate and the SSH gate.
> - The benefit is one source of truth. The UI and the runtime now agree on which adapters can use remote-managed environments.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug. Inline description per the bug report template:

**What happened?**

A Grok Build (`grok_local`) agent was assigned a sandbox environment (a Daytona provider). The UI allowed the assignment. Every run and primary-model test then failed with the warning: `Adapter "grok_local" is not allowed in "<environment>" environments.`

**Expected behavior**

An adapter that the environment selector offers for a sandbox environment must also pass the runtime gate. The Grok Build run must start in the sandbox.

**Steps to reproduce**

1. Create a sandbox environment (for example, with a Daytona provider plugin).
2. Create an agent that uses the `grok_local` adapter.
3. Set the agent's environment to the sandbox environment. The UI accepts this.
4. Run the agent, or run the primary-model test. The run fails with the adapter-not-allowed warning.

**Paperclip version or commit**

Reproduced on `master` at `0edb742f8d`.

**Deployment mode**

Local instance with a remote sandbox provider plugin. The same gate also applies to SSH environments.

## What Changed

- `resolveEnvironmentExecutionTarget` in `server/src/services/environment-execution-target.ts` now gates the sandbox path with the shared `adapterSupportsRemoteManagedEnvironments()` helper. Before, it used a hardcoded six-adapter list that did not include `grok_local`.
- The SSH path in the same file now uses the same shared helper.
- New regression tests in `server/src/__tests__/environment-execution-target.test.ts`: sandbox target resolution for every remote-managed adapter (including `grok_local`), SSH target resolution for `grok_local`, and the null path for an adapter without remote-managed support.

## Verification

- Run `node_modules/.bin/vitest run server/src/__tests__/environment-execution-target.test.ts`. All 10 tests pass, including the 3 new ones.
- Confirm `grok_local` is in the `REMOTE_MANAGED_ADAPTERS` set in `packages/shared/src/environment-support.ts`. The resolver now reads the same set.
- On a live local instance with this fix, a `grok_local` agent assigned to a Daytona sandbox environment no longer produces the adapter-not-allowed warning.

## Risks

Low risk. The change routes two hardcoded checks through existing shared capability metadata. Behavior changes only where the lists had drifted: `grok_local`, and any future adapter added to the shared set, can now resolve sandbox and SSH execution targets. Adapters outside the shared set still return `null`.

## Model Used

Claude Fable 5 (`claude-fable-5`) by Anthropic, with extended thinking and tool use, running in Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
