### PR TITLE
fix(ui): recover blockquotes the markdown editor escaped as \>

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -48,6 +48,7 @@ import { MentionAwareLinkNode, mentionAwareLinkNodeReplacement } from "../lib/me
 import { mentionDeletionPlugin } from "../lib/mention-deletion";
 import { looksLikeMarkdownPaste } from "../lib/markdownPaste";
 import { normalizeMarkdown } from "../lib/normalize-markdown";
+import { unescapeBlockquoteMarkers } from "../lib/blockquote-markdown";
 import { pasteNormalizationPlugin } from "../lib/paste-normalization";
 import { cn } from "../lib/utils";
 import { useEditorAutocomplete, type SlashCommandOption } from "../context/EditorAutocompleteContext";
@@ -141,7 +142,10 @@ function convertHtmlImagesToMarkdown(text: string): string {
 
 function prepareMarkdownForEditor(value: string): string {
   const normalizedLineEndings = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  return convertHtmlImagesToMarkdown(normalizedLineEndings);
+  // Recover escaped blockquotes (`\>`) so `>`-prefixed content renders as a real
+  // blockquote in the editor as well as on display (keeps import/export in sync).
+  const withBlockquotes = unescapeBlockquoteMarkers(normalizedLineEndings);
+  return convertHtmlImagesToMarkdown(withBlockquotes);
 }
 
 function escapeRegExp(value: string): string {
@@ -1324,8 +1328,13 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           suppressHtmlProcessing
           placeholder={placeholder}
           readOnly={readOnly}
-          onChange={(next) => {
+          onChange={(rawNext) => {
             if (readOnly) return;
+            // Recover blockquotes the exporter escaped as `\>` (see
+            // unescapeBlockquoteMarkers) so a `>`-prefixed line the user typed
+            // always survives as a real blockquote, even when the WYSIWYG
+            // shortcut didn't fire.
+            const next = unescapeBlockquoteMarkers(rawNext);
             const echo = echoIgnoreMarkdownRef.current;
             if (echo !== null && next === echo) {
               echoIgnoreMarkdownRef.current = null;

--- a/ui/src/lib/blockquote-markdown.test.ts
+++ b/ui/src/lib/blockquote-markdown.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { unescapeBlockquoteMarkers } from "./blockquote-markdown";
+
+describe("unescapeBlockquoteMarkers", () => {
+  it("leaves markdown without escaped markers untouched", () => {
+    expect(unescapeBlockquoteMarkers("> quoted")).toBe("> quoted");
+    expect(unescapeBlockquoteMarkers("plain text")).toBe("plain text");
+    expect(unescapeBlockquoteMarkers("")).toBe("");
+  });
+
+  it("unescapes a single escaped blockquote line", () => {
+    expect(unescapeBlockquoteMarkers("\\> see")).toBe("> see");
+  });
+
+  it("unescapes multiple escaped blockquote lines", () => {
+    expect(unescapeBlockquoteMarkers("\\> line one\n\\> line two")).toBe("> line one\n> line two");
+  });
+
+  it("unescapes escaped blockquotes interleaved with normal text", () => {
+    expect(unescapeBlockquoteMarkers("hello\n\n\\> quoted\n\nbye")).toBe("hello\n\n> quoted\n\nbye");
+  });
+
+  it("preserves leading indentation before the marker", () => {
+    expect(unescapeBlockquoteMarkers("  \\> indented")).toBe("  > indented");
+  });
+
+  it("does not touch escaped markers inside fenced code blocks", () => {
+    const input = "```\n\\> not a quote\n```\n\\> real quote";
+    expect(unescapeBlockquoteMarkers(input)).toBe("```\n\\> not a quote\n```\n> real quote");
+  });
+
+  it("handles tilde fences", () => {
+    const input = "~~~\n\\> literal\n~~~";
+    expect(unescapeBlockquoteMarkers(input)).toBe("~~~\n\\> literal\n~~~");
+  });
+
+  it("only rewrites the leading marker, not later text", () => {
+    expect(unescapeBlockquoteMarkers("\\> a \\> b")).toBe("> a \\> b");
+  });
+
+  it("leaves a mid-line escaped marker alone", () => {
+    expect(unescapeBlockquoteMarkers("text \\> not a quote")).toBe("text \\> not a quote");
+  });
+});

--- a/ui/src/lib/blockquote-markdown.ts
+++ b/ui/src/lib/blockquote-markdown.ts
@@ -1,0 +1,53 @@
+/**
+ * When the WYSIWYG blockquote shortcut does not fire (e.g. the `> ` prefix is
+ * assembled by an edit that Lexical's markdown-shortcut transform doesn't catch,
+ * which happens on some browsers/IMEs), MDXEditor exports the paragraph as an
+ * *escaped* blockquote — `\> text`. `mdast-util-to-markdown` escapes a leading
+ * `>` so a literal paragraph round-trips as text rather than a blockquote.
+ *
+ * In this product `>` at the start of a line always means "blockquote" (there is
+ * no separate literal-`>` affordance and the composer has no blockquote toolbar
+ * button), so an escaped `\>` is never the user's intent — it is a silently
+ * dropped blockquote. This helper rewrites a leading `\>` back to `>` so the
+ * stored markdown renders as the blockquote the user typed.
+ *
+ * Fenced code blocks are left untouched: their contents are never `\`-escaped by
+ * the exporter, and a `\>` inside a code fence is meaningful literal text.
+ */
+
+const FENCE_RE = /^(\s{0,3})(`{3,}|~{3,})/;
+// A line whose first non-space content is an escaped blockquote marker: `\>`.
+// Optional leading whitespace mirrors how the exporter indents nested content.
+const ESCAPED_BLOCKQUOTE_RE = /^(\s*)\\>/;
+
+export function unescapeBlockquoteMarkers(markdown: string): string {
+  if (!markdown.includes("\\>")) return markdown;
+
+  const lines = markdown.split("\n");
+  let inFence = false;
+  let fenceMarker = "";
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const fenceMatch = FENCE_RE.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[2][0]; // ` or ~
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = marker;
+      } else if (marker === fenceMarker) {
+        inFence = false;
+        fenceMarker = "";
+      }
+      continue;
+    }
+
+    if (inFence) continue;
+
+    if (ESCAPED_BLOCKQUOTE_RE.test(line)) {
+      lines[i] = line.replace(ESCAPED_BLOCKQUOTE_RE, "$1>");
+    }
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Typing `>` to insert a blockquote (PAP-15769) can silently produce a **plain paragraph** instead of a blockquote in the markdown editor used by comments, descriptions, and documents.

Root cause: the MDXEditor markdown exporter escapes a leading `>` to `\>` whenever a `>`-prefixed line is a plain paragraph rather than a live blockquote node. That happens when the WYSIWYG blockquote shortcut does not fire — e.g. on browsers/IMEs where Lexical's markdown-shortcut input handling behaves differently (WebKit/Safari, soft keyboards), or after an edit that assembles the `> ` prefix without triggering the transform. The escaped `\> text` then renders as literal text on display, dropping the blockquote the user typed.

In Paperclip `>` at the start of a line always means "blockquote" — there is no literal-`>` affordance and the composer has no blockquote toolbar button — so an escaped `\>` is never the user's intent.

## Change

- New `ui/src/lib/blockquote-markdown.ts` — `unescapeBlockquoteMarkers()` rewrites a leading `\>` back to `>` (line-aware, leaves fenced code blocks untouched).
- Wired into `MarkdownEditor` on both **import** (`prepareMarkdownForEditor`) and **export** (`onChange`), so a `>`-prefixed line survives as a real blockquote regardless of whether the live shortcut fired, and legacy content already stored as `\>` renders correctly when re-opened.
- Unit tests for the helper (9 cases incl. multi-line, indentation, fenced-code protection, mid-line markers).

Strictly additive for the common path: content without `\>` is a no-op (early `includes` guard), so the normal `> text` → blockquote flow is unchanged.

## Testing

- `vitest` — `blockquote-markdown.test.ts` (9) + `MarkdownEditor.test.tsx` (37) pass; `tsc -b` clean.
- Isolated browser harness (real `MarkdownEditor` + the real `IssueChatThread` composer, driven with Playwright): verified `> text` still produces a `<blockquote>` and exports `> text` across empty/second-block/prefix-edit sequences, and confirmed the escaped `\>see` case now exports `>see` instead of `\>see`.

## Verification note

I could not reproduce the *exact* reported failure in headless Chromium — the WYSIWYG shortcut fired reliably there. The escape-based failure mode above is the plausible root cause on other browsers (Safari especially). Requesting QA verify blockquote insertion in a task-page comment on Safari/the live app.
