### PR TITLE
fix(logging): restore dead noisy-endpoint silencing, bound 4xx/5xx log bodies, widen Cloudflare Access header redaction, add dated timestamps

### DIFF
--- a/server/src/__tests__/http-log-redaction.test.ts
+++ b/server/src/__tests__/http-log-redaction.test.ts
@@ -15,6 +15,8 @@ describe("HTTP logger redaction", () => {
     expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-csrf-token"]');
     expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-xsrf-token"]');
     expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-api-key"]');
+    expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["cf-access-jwt-assertion"]');
+    expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["cf-access-authenticated-user-email"]');
   });
 
   it("redacts request and response header secrets from pino-http output", async () => {
@@ -53,6 +55,8 @@ describe("HTTP logger redaction", () => {
               authorization: "Bearer auth-secret",
               cookie: "sid=request-secret",
               "set-cookie": "proxy-secret",
+              "cf-access-jwt-assertion": "cf-jwt-secret",
+              "cf-access-authenticated-user-email": "cf-user-secret@example.com",
             },
           },
           (res) => {
@@ -72,7 +76,7 @@ describe("HTTP logger redaction", () => {
     }
 
     const output = chunks.join("");
-    expect(output).not.toMatch(/auth-secret|request-secret|proxy-secret|response-secret/);
+    expect(output).not.toMatch(/auth-secret|request-secret|proxy-secret|response-secret|cf-jwt-secret|cf-user-secret/);
 
     const log = JSON.parse(output.trim()) as {
       req: { headers: Record<string, string> };
@@ -82,5 +86,7 @@ describe("HTTP logger redaction", () => {
     expect(log.req.headers.cookie).toBe("[Redacted]");
     expect(log.req.headers["set-cookie"]).toBe("[Redacted]");
     expect(log.res.headers["set-cookie"]).toBe("[Redacted]");
+    expect(log.req.headers["cf-access-jwt-assertion"]).toBe("[Redacted]");
+    expect(log.req.headers["cf-access-authenticated-user-email"]).toBe("[Redacted]");
   });
 });

--- a/server/src/__tests__/logger-stable-request-path.test.ts
+++ b/server/src/__tests__/logger-stable-request-path.test.ts
@@ -1,0 +1,83 @@
+import express from "express";
+import { createServer } from "node:http";
+import { request } from "node:http";
+import { describe, expect, it } from "vitest";
+import { stableRequestPath } from "../middleware/logger.js";
+import { shouldSilenceHttpSuccessLog } from "../middleware/http-log-policy.js";
+
+// Regression test for a bug where noisy-endpoint silencing (health checks,
+// dashboard/issues polling, etc.) never actually fired.
+//
+// Express mounts middleware/routers via `app.use(prefix, router)` by
+// temporarily rewriting `req.url` to strip `prefix` for the duration of that
+// router's dispatch, restoring it only when a handler calls `next()` to
+// unwind back out of the router. A terminal handler that responds directly
+// (`res.json()`, the normal case for API routes) never calls `next()`, so
+// `req.url` is *never restored* — it stays stripped for the rest of the
+// request's lifetime, including inside a `res.on("finish", ...)` listener
+// registered before the router ran (exactly how pino-http observes a
+// request). `req.originalUrl` is set once and is never touched by router
+// mounting, so it's the only field that reliably reflects the full path at
+// finish time.
+describe("stableRequestPath", () => {
+  it("returns originalUrl (not the router-stripped url) once a request handled by a mounted sub-router finishes", async () => {
+    const app = express();
+    const api = express.Router();
+    let observedAtFinish: { url?: string; originalUrl?: string } | undefined;
+
+    api.get("/companies/:id/heartbeat-runs", (req, res) => {
+      res.on("finish", () => {
+        observedAtFinish = { url: req.url, originalUrl: req.originalUrl };
+      });
+      res.json({ ok: true });
+    });
+    app.use("/api", api);
+
+    const server = createServer(app);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected server to listen on an ephemeral TCP port");
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const client = request(
+          { hostname: "127.0.0.1", port: address.port, path: "/api/companies/abc/heartbeat-runs" },
+          (res) => {
+            res.resume();
+            res.on("end", resolve);
+          },
+        );
+        client.on("error", reject);
+        client.end();
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+
+    expect(observedAtFinish).toBeDefined();
+    // The bug, pinned: by finish time, req.url has lost the /api mount prefix.
+    expect(observedAtFinish?.url).toBe("/companies/abc/heartbeat-runs");
+    expect(observedAtFinish?.originalUrl).toBe("/api/companies/abc/heartbeat-runs");
+
+    // Using the raw (stripped) url, the silencing pattern (which requires a
+    // leading /api/) never matches — this was the live bug.
+    expect(shouldSilenceHttpSuccessLog("GET", observedAtFinish?.url, 200)).toBe(false);
+
+    // stableRequestPath prefers originalUrl, so silencing works correctly.
+    expect(stableRequestPath(observedAtFinish!)).toBe("/api/companies/abc/heartbeat-runs");
+    expect(shouldSilenceHttpSuccessLog("GET", stableRequestPath(observedAtFinish!), 200)).toBe(true);
+  });
+
+  it("falls back to url when originalUrl is absent", () => {
+    expect(stableRequestPath({ url: "/api/health" })).toBe("/api/health");
+  });
+});

--- a/server/src/__tests__/logger-tz.test.ts
+++ b/server/src/__tests__/logger-tz.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
  * zones see correct wall-clock times in their logs.
  *
  * We verify that:
- * 1. The logger module initialises pino-pretty with "SYS:HH:MM:ss".
+ * 1. The logger module initialises pino-pretty with "SYS:yyyy-mm-dd HH:MM:ss".
  * 2. The pino-pretty SYS: prefix resolves to a timezone-sensitive format
  *    string — confirmed via pino-pretty's own asynchronous formatter, which
  *    applies translateTime to a known epoch under different TZ values.
@@ -53,7 +53,7 @@ describe("logger translateTime respects TZ environment variable", () => {
     vi.clearAllMocks();
   });
 
-  it("configures pino-pretty with SYS:HH:MM:ss so timestamps honour the TZ env var", async () => {
+  it("configures pino-pretty with a SYS:-prefixed, date-inclusive format so timestamps honour the TZ env var", async () => {
     await import("../middleware/logger.js");
 
     expect(mockTransport).toHaveBeenCalledOnce();
@@ -61,7 +61,7 @@ describe("logger translateTime respects TZ environment variable", () => {
       targets: Array<{ options: Record<string, unknown> }>;
     };
     for (const target of targets) {
-      expect(target.options.translateTime).toBe("SYS:HH:MM:ss");
+      expect(target.options.translateTime).toBe("SYS:yyyy-mm-dd HH:MM:ss");
     }
   });
 

--- a/server/src/__tests__/redact-sensitive.test.ts
+++ b/server/src/__tests__/redact-sensitive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { redactSensitive } from "../middleware/redact-sensitive.js";
+import { redactSensitive, truncateForLog } from "../middleware/redact-sensitive.js";
 
 describe("redactSensitive", () => {
   it("redacts a plaintext password field on a sign-in body", () => {
@@ -96,5 +96,32 @@ describe("redactSensitive", () => {
     const json = JSON.stringify(out);
     expect(json).not.toContain("null");
     expect(json).not.toContain("[1,2,3]");
+  });
+});
+
+describe("truncateForLog", () => {
+  it("passes small payloads through unchanged (after redaction)", () => {
+    const body = { status: "in_review", comment: "short comment", password: "x" };
+
+    expect(truncateForLog(body)).toEqual({
+      status: "in_review",
+      comment: "short comment",
+      password: "[REDACTED]",
+    });
+  });
+
+  it("bounds an oversized payload to a preview instead of writing it in full", () => {
+    const body = { comment: "a".repeat(10_000) };
+
+    const out = truncateForLog(body) as { truncated: true; originalLength: number; preview: string };
+
+    expect(out.truncated).toBe(true);
+    expect(out.originalLength).toBeGreaterThan(10_000);
+    expect(out.preview.length).toBeLessThan(out.originalLength);
+    expect(JSON.stringify(out).length).toBeLessThan(JSON.stringify(body).length);
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(truncateForLog(undefined)).toBe(undefined);
   });
 });

--- a/server/src/middleware/http-log-redaction.ts
+++ b/server/src/middleware/http-log-redaction.ts
@@ -10,4 +10,9 @@ export const HTTP_LOG_REDACT_PATHS = [
   'req.headers["x-csrf-token"]',
   'req.headers["x-xsrf-token"]',
   'req.headers["x-api-key"]',
+  // Cloudflare Access: the JWT assertion is a bearer credential, and the
+  // authenticated-user-email identifies the requester — both belong beside
+  // `authorization` rather than in a plaintext, long-retained log.
+  'req.headers["cf-access-jwt-assertion"]',
+  'req.headers["cf-access-authenticated-user-email"]',
 ] as const;

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -6,7 +6,19 @@ import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { HTTP_LOG_REDACT_PATHS } from "./http-log-redaction.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
-import { redactSensitive } from "./redact-sensitive.js";
+import { redactSensitive, truncateForLog } from "./redact-sensitive.js";
+
+// Express rewrites `req.url` to strip a mounted router's prefix (e.g. `/api`)
+// for the duration of that router's dispatch, and only restores it when a
+// handler calls `next()` to unwind back out. Terminal handlers that respond
+// directly (the common case — `res.json()` etc.) never call `next()`, so by
+// the time these pino-http callbacks run on `res.on("finish")`, `req.url` is
+// stuck with the prefix stripped. `req.originalUrl` is set once per request
+// and is never mutated by router mounting, so it's the only stable path to
+// match against here.
+export function stableRequestPath(req: { url?: string; originalUrl?: string }): string | undefined {
+  return req.originalUrl ?? req.url;
+}
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -24,7 +36,7 @@ fs.mkdirSync(logDir, { recursive: true });
 const logFile = path.join(logDir, "server.log");
 
 const sharedOpts = {
-  translateTime: "SYS:HH:MM:ss",
+  translateTime: "SYS:yyyy-mm-dd HH:MM:ss",
   ignore: "pid,hostname",
   singleLine: true,
 };
@@ -50,7 +62,7 @@ export const logger = pino({
 export const httpLogger = pinoHttp({
   logger,
   customLogLevel(_req, res, err) {
-    if (shouldSilenceHttpSuccessLog(_req.method, _req.url, res.statusCode)) {
+    if (shouldSilenceHttpSuccessLog(_req.method, stableRequestPath(_req), res.statusCode)) {
       return "silent";
     }
     if (err || res.statusCode >= 500) return "error";
@@ -58,12 +70,12 @@ export const httpLogger = pinoHttp({
     return "info";
   },
   customSuccessMessage(req, res) {
-    return `${req.method} ${req.url} ${res.statusCode}`;
+    return `${req.method} ${stableRequestPath(req)} ${res.statusCode}`;
   },
   customErrorMessage(req, res, err) {
     const ctx = (res as any).__errorContext;
     const errMsg = ctx?.error?.message || err?.message || (res as any).err?.message || "unknown error";
-    return `${req.method} ${req.url} ${res.statusCode} — ${errMsg}`;
+    return `${req.method} ${stableRequestPath(req)} ${res.statusCode} — ${errMsg}`;
   },
   customProps(req, res) {
     if (res.statusCode >= 400) {
@@ -71,21 +83,21 @@ export const httpLogger = pinoHttp({
       if (ctx) {
         return {
           errorContext: ctx.error,
-          reqBody: redactSensitive(ctx.reqBody),
-          reqParams: redactSensitive(ctx.reqParams),
-          reqQuery: redactSensitive(ctx.reqQuery),
+          reqBody: truncateForLog(ctx.reqBody),
+          reqParams: truncateForLog(ctx.reqParams),
+          reqQuery: truncateForLog(ctx.reqQuery),
         };
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
       if (body && typeof body === "object" && Object.keys(body).length > 0) {
-        props.reqBody = redactSensitive(body);
+        props.reqBody = truncateForLog(body);
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {
-        props.reqParams = redactSensitive(params);
+        props.reqParams = truncateForLog(params);
       }
       if (query && typeof query === "object" && Object.keys(query).length > 0) {
-        props.reqQuery = redactSensitive(query);
+        props.reqQuery = truncateForLog(query);
       }
       if ((req as any).route?.path) {
         props.routePath = (req as any).route.path;

--- a/server/src/middleware/redact-sensitive.ts
+++ b/server/src/middleware/redact-sensitive.ts
@@ -1,10 +1,11 @@
 // Redaction for HTTP log payloads.
 //
 // `customProps` in logger.ts copies `req.body` / `req.params` / `req.query`
-// verbatim into the 4xx/5xx log lines so operators can diagnose. That means
-// Better Auth's `POST /api/auth/sign-in/email` body (which has the user's
-// plaintext password) and similar payloads (sign-up, reset-password, API
-// keys via Authorization header equivalents) end up on disk.
+// (via `truncateForLog` below) into the 4xx/5xx log lines so operators can
+// diagnose. That means Better Auth's `POST /api/auth/sign-in/email` body
+// (which has the user's plaintext password) and similar payloads (sign-up,
+// reset-password, API keys via Authorization header equivalents) end up on
+// disk unless redacted first.
 //
 // This walker returns a shallow copy of the input with values for sensitive
 // keys replaced with the literal string "[REDACTED]". Recurses into nested
@@ -75,6 +76,25 @@ function stripSecretBearingUrlParts(value: string): string {
   } catch {
     return value;
   }
+}
+
+// Bound for `reqBody`/`reqParams`/`reqQuery` on 4xx/5xx log lines. Issue
+// descriptions, comments, and other business content can be arbitrarily
+// large; a bounded prefix keeps enough to diagnose the error without letting
+// a single retried request (or a retry loop against one endpoint) blow up
+// server.log.
+const MAX_LOGGED_JSON_CHARS = 4096;
+
+export function truncateForLog(value: unknown): unknown {
+  const redacted = redactSensitive(value);
+  if (redacted === undefined) return redacted;
+  const json = JSON.stringify(redacted);
+  if (json === undefined || json.length <= MAX_LOGGED_JSON_CHARS) return redacted;
+  return {
+    truncated: true,
+    originalLength: json.length,
+    preview: json.slice(0, MAX_LOGGED_JSON_CHARS),
+  };
 }
 
 export function redactSensitive(value: unknown, depth = 0): unknown {


### PR DESCRIPTION
**Summary**
Four related fixes to the HTTP request logger, found while diagnosing rapid, unexplained server.log growth on a busy self-hosted instance:

shouldSilenceHttpSuccessLog() never actually silences anything. It's called with req.url, but Express strips a mounted router's prefix (e.g. the leading /api) from req.url for any terminal handler that responds without calling next() — which is the normal case for virtually every route (res.json() and friends). By the time customLogLevel/customSuccessMessage run on res.on("finish"), req.url has already lost that prefix, so none of the configured noisy-endpoint patterns (e.g. /api/issues, /api/dashboard, /api/heartbeat-runs) ever match. The silencing feature is effectively dead code — every one of those high-frequency polling endpoints logs in full at info regardless of the configured allowlist. Confirmed empirically: on one instance, traffic matching the "should be silenced" patterns accounted for roughly a third of all INFO lines in a multi-hour window. Fix: use req.originalUrl, which Express sets once and never mutates during router dispatch.
Unbounded reqBody/reqParams/reqQuery on 4xx/5xx lines. These are already redacted for known-sensitive keys (password, token, etc. — see the existing redactSensitive), but an arbitrarily large payload (a big JSON body, a retried request, a retry loop hammering one endpoint) can still write megabytes into a single log line. This PR adds a bounded-length preview (truncateForLog, default 4096 chars) as defense-in-depth on top of the existing key-based redaction, independent of what the field names happen to be.
Cloudflare Access headers aren't redacted. The existing header redaction list stops at x-api-key / authorization. Any deployment sitting behind Cloudflare Access forwards cf-access-jwt-assertion (a bearer-grade credential — the signed Access JWT for the request) and cf-access-authenticated-user-email (the authenticated user's email) on every request. Neither is currently redacted, so both land in plaintext in a long-retained log. This PR adds both to the redaction list alongside authorization.
Log timestamps have no date component. The default pino-pretty translateTime is SYS:HH:MM:ss — time only. Once a log spans more than 24 hours (the default rotation is size-based, not time-based, so this is common on a quiet instance or one with maxLogSize set high), correlating a log line to an actual date requires cross-referencing another data source. This PR changes the format to SYS:yyyy-mm-dd HH:MM:ss.
None of these are behavior changes to what gets logged at a semantic level for a healthy, correctly-behaving client — they only affect volume (fix 1), a hard length ceiling on already-redacted error-path fields (fix 2), which headers are masked (fix 3), and timestamp formatting (fix 4).

**Relationship to existing issues/PRs**
I searched before opening this (duplicate search per CONTRIBUTING.md):

#4398 ("Core logging is too noisy...") reports the same class of symptom as fix 1 (noisy successful traffic) and also touches retention, which this PR does not attempt — this PR is a narrower, root-cause fix for the specific silencing bug, not a general noise/retention overhaul.
#4759 ("HTTP logger leaks plaintext passwords... in reqBody on 4xx responses") is about the same code path as fix 2, but describes the absence of body redaction; the codebase already had key-based redaction (redactSensitive) by the time I looked, so the gap I found is specifically the unbounded size of an already-redacted payload, not missing redaction. This PR doesn't fully resolve #4759 if the underlying concern is "no redaction at all" on a version predating that existing redaction — worth the maintainers double-checking against the version #4759 was filed against.
#836 (open PR, "Harden HTTP request logging redaction") takes a different, complementary approach to logged bodies: it recurses through reqBody/reqParams/reqQuery and masks specific key names (password, apiKey, etc.) and headers matching /token/i. It does not bound total payload size, and its header regex would not catch cf-access-jwt-assertion or cf-access-authenticated-user-email (neither contains "token"). This PR's fix 2 is a size-bound safety net on top of whatever key-based redaction exists (this repo's own redactSensitive, or #836's sanitizeHttpLogObject if that lands first) — not a replacement for it. If #836 lands before this PR, fix 2 here will need a small rebase to call whatever redaction function is current; happy to do that. Fixes 1, 3, and 4 don't overlap with #836 at all.

**Test plan**
Added/updated unit tests covering: the req.originalUrl vs req.url behavior against a real mounted sub-router (regression test pinning the exact bug), the truncation boundary, the widened redaction list, and the new timestamp format.
vitest run on the affected test files: 19/19 passing.
tsc --noEmit: no new errors introduced by this change (pre-existing unrelated errors only, in unrelated files).