### PR TITLE
feat(claude-local): OpenRouter fallback on Anthropic 529 Overloaded

### DIFF
--- a/packages/adapters/claude-local/src/server/config-schema.ts
+++ b/packages/adapters/claude-local/src/server/config-schema.ts
@@ -68,6 +68,19 @@ export function getConfigSchema(): AdapterConfigSchema {
         hint: "Defaults to 0, which closes the ACP process after each run while retaining persistent session state.",
         meta: acpVisible,
       },
+      {
+        key: "openrouterApiKey",
+        label: "OpenRouter API key (529 fallback)",
+        type: "text",
+        hint: "When set, an Anthropic 529 Overloaded automatically retries the turn against OpenRouter's Anthropic-compatible endpoint. Falls back to the OPENROUTER_API_KEY environment variable when blank.",
+      },
+      {
+        key: "openrouterFallbackActive",
+        label: "OpenRouter fallback active",
+        type: "toggle",
+        default: false,
+        hint: "Runtime flag set automatically after a 529 fallback fires, so subsequent heartbeats start on OpenRouter. Cleared manually once Anthropic capacity recovers.",
+      },
     ],
   };
 }

--- a/packages/adapters/claude-local/src/server/execute.openrouter-fallback.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.openrouter-fallback.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+function successProcess(sessionId = "claude-session-1") {
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({ type: "system", subtype: "init", session_id: sessionId, model: "claude-sonnet" }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: sessionId,
+        message: { content: [{ type: "text", text: "hello" }] },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: sessionId,
+        result: "hello",
+        usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+function overloadedProcess() {
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    stdout: "",
+    stderr:
+      "API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment.",
+    pid: 124,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+  procQueue,
+  envSnapshots,
+} = vi.hoisted(() => {
+  const procQueue: Array<Record<string, unknown>> = [];
+  const envSnapshots: Array<{ baseUrl?: string; apiKey?: string }> = [];
+  const runAdapterExecutionTargetProcess = vi.fn(
+    async (
+      _runId: string,
+      _target: unknown,
+      _command: string,
+      _args: string[],
+      opts: { env?: Record<string, string> },
+    ) => {
+      envSnapshots.push({
+        baseUrl: opts?.env?.ANTHROPIC_BASE_URL,
+        apiKey: opts?.env?.ANTHROPIC_API_KEY,
+      });
+      const next = procQueue.shift();
+      if (!next) throw new Error("execute.openrouter-fallback.test: no queued process result");
+      return next;
+    },
+  );
+  return {
+    ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+    ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+    resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "claude"),
+    runAdapterExecutionTargetProcess,
+    procQueue,
+    envSnapshots,
+  };
+});
+
+vi.mock("./acp.js", () => ({
+  createClaudeAcpExecutor: () => vi.fn(async () => {
+    throw new Error("acp should not be used in these tests");
+  }),
+  formatClaudeAcpFallbackMessage: (reason: string) => `[paperclip] ${reason}\n`,
+  // Force the CLI engine so these tests exercise runAttempt directly.
+  resolveClaudeExecutionEngineForRun: async () => ({ engine: "cli", explicit: true }),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function buildContext(config: Record<string, unknown> = {}, context: Record<string, unknown> = {}) {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: { engine: "cli", ...config },
+    context,
+    authToken: "pc-test-key",
+    onLog: vi.fn(async (_stream: "stdout" | "stderr", _chunk: string) => {}),
+  };
+}
+
+function loggedWith(ctx: ReturnType<typeof buildContext>, needle: string): boolean {
+  return ctx.onLog.mock.calls.some(([, chunk]) => typeof chunk === "string" && chunk.includes(needle));
+}
+
+describe("claude_local OpenRouter 529 fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    procQueue.length = 0;
+    envSnapshots.length = 0;
+    vi.stubEnv("PAPERCLIP_RUNTIME_API_URL", "http://127.0.0.1:4310");
+    vi.stubEnv("PAPERCLIP_API_URL", "http://127.0.0.1:4310");
+    vi.stubEnv("OPENROUTER_API_KEY", "");
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200 }) as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("retries on OpenRouter after a 529, completes, alerts the Founder, and persists the flag", async () => {
+    procQueue.push(overloadedProcess(), successProcess());
+    const ctx = buildContext({ openrouterApiKey: "or-test-key" }, { taskId: "issue-xyz" });
+
+    const result = await execute(ctx as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.errorFamily ?? null).toBeNull();
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(2);
+    // First attempt on Anthropic, retry on OpenRouter.
+    expect(envSnapshots[0].baseUrl).toBeUndefined();
+    expect(envSnapshots[1].baseUrl).toBe(OPENROUTER_BASE_URL);
+    expect(envSnapshots[1].apiKey).toBe("or-test-key");
+    expect(loggedWith(ctx, "Anthropic 529 detected; retrying via OpenRouter fallback")).toBe(true);
+
+    // Founder alert comment + config persistence.
+    const urls = fetchMock.mock.calls.map(([url]) => url);
+    expect(urls).toContain("http://127.0.0.1:4310/api/issues/issue-xyz/comments");
+    expect(urls).toContain("http://127.0.0.1:4310/api/agents/agent-1");
+    const patchCall = fetchMock.mock.calls.find(([url]) => url === "http://127.0.0.1:4310/api/agents/agent-1");
+    expect(patchCall?.[1]?.method).toBe("PATCH");
+    expect(JSON.parse(patchCall?.[1]?.body as string)).toEqual({
+      adapterConfig: { openrouterFallbackActive: true },
+    });
+  });
+
+  it("leaves transient_upstream unchanged when no OpenRouter key is available", async () => {
+    procQueue.push(overloadedProcess());
+    const ctx = buildContext({}, { taskId: "issue-xyz" });
+
+    const result = await execute(ctx as never);
+
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.errorCode).toBe("claude_transient_upstream");
+    expect(loggedWith(ctx, "retrying via OpenRouter fallback")).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("starts on OpenRouter from the first attempt when openrouterFallbackActive is set", async () => {
+    procQueue.push(successProcess());
+    const ctx = buildContext({ openrouterApiKey: "or-test-key", openrouterFallbackActive: true });
+
+    const result = await execute(ctx as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+    expect(envSnapshots[0].baseUrl).toBe(OPENROUTER_BASE_URL);
+    expect(envSnapshots[0].apiKey).toBe("or-test-key");
+    expect(loggedWith(ctx, "starting this turn on the OpenRouter endpoint")).toBe(true);
+    // No fallback event on a clean OpenRouter start → no Founder alert.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not loop when a 529 recurs while already on OpenRouter", async () => {
+    procQueue.push(overloadedProcess());
+    const ctx = buildContext(
+      { openrouterApiKey: "or-test-key", openrouterFallbackActive: true },
+      { taskId: "issue-xyz" },
+    );
+
+    const result = await execute(ctx as never);
+
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(loggedWith(ctx, "retrying via OpenRouter fallback")).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.openrouter-fallback.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.openrouter-fallback.test.ts
@@ -202,6 +202,22 @@ describe("claude_local OpenRouter 529 fallback", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("does not persist the flag or claim completion when the OpenRouter retry also fails", async () => {
+    // 529 on Anthropic, then the OpenRouter retry itself fails (e.g. bad model id).
+    procQueue.push(overloadedProcess(), overloadedProcess());
+    const ctx = buildContext({ openrouterApiKey: "or-test-key" }, { taskId: "issue-xyz" });
+
+    const result = await execute(ctx as never);
+
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(2);
+    // The retry was attempted on OpenRouter...
+    expect(envSnapshots[1].baseUrl).toBe(OPENROUTER_BASE_URL);
+    // ...but it failed, so we return the failed result and do NOT alert/persist.
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(loggedWith(ctx, "did not succeed")).toBe(true);
+  });
+
   it("does not loop when a 529 recurs while already on OpenRouter", async () => {
     procQueue.push(overloadedProcess());
     const ctx = buildContext(

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1333,7 +1333,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     openRouterFallbackActive = true;
     const retryAttempt = await runAttempt(resumeSessionId);
     const retryResult = toAdapterResult(retryAttempt, opts);
-    await notifyOpenRouterFallback();
+    // Only claim completion + persist the flag when the OpenRouter retry
+    // actually succeeded. If it also failed (e.g. OpenRouter is down or the
+    // Claude model id is not accepted by OpenRouter), returning the failed
+    // result is correct — but persisting openrouterFallbackActive would lock
+    // later heartbeats onto a provider that just failed, and the "no Founder
+    // action needed" alert would be untrue.
+    const retrySucceeded =
+      (retryResult.exitCode ?? 1) === 0 && !retryResult.timedOut && !retryResult.errorCode;
+    if (retrySucceeded) {
+      await notifyOpenRouterFallback();
+    } else {
+      await onLog(
+        "stderr",
+        "[paperclip] OpenRouter fallback retry did not succeed; leaving openrouterFallbackActive unset and not posting a completion alert.\n",
+      );
+    }
     return retryResult;
   };
 

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -69,6 +69,7 @@ import {
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  isClaudeOverloadedError,
 } from "./parse.js";
 import {
   materializeRemoteClaudeConfig,
@@ -91,6 +92,11 @@ import {
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const executeClaudeAcp = createClaudeAcpExecutor();
+
+// OpenRouter exposes an Anthropic-compatible Messages API at this base URL. When
+// the 529 fallback fires we repoint the Claude CLI here by overriding
+// ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY for the retry (and subsequent turns).
+const OPENROUTER_ANTHROPIC_BASE_URL = "https://openrouter.ai/api/v1";
 
 interface ClaudeExecutionInput {
   runId: string;
@@ -422,6 +428,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   );
   const model = asString(config.model, "");
+  const openrouterApiKeyConfig = asString(config.openrouterApiKey, "").trim();
+  const openrouterFallbackActiveConfig = asBoolean(config.openrouterFallbackActive, false);
+  const resolveOpenRouterApiKey = (): string | null => {
+    if (openrouterApiKeyConfig) return openrouterApiKeyConfig;
+    const envKey = asString(process.env.OPENROUTER_API_KEY, "").trim();
+    return envKey.length > 0 ? envKey : null;
+  };
+  // Tracks whether this run is already routed to OpenRouter — either because a
+  // prior heartbeat persisted the flag (startup injection below) or because a
+  // 529 fallback fired mid-run. Guards against a fallback loop.
+  let openRouterFallbackActive = false;
   const effort = asString(config.effort, "");
   const chrome = asBoolean(config.chrome, false);
   const maxTurns = asNumber(config.maxTurnsPerRun, 0);
@@ -470,6 +487,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     extraArgs,
   } = runtimeConfig;
   let loggedEnv = initialLoggedEnv;
+  // Startup injection: if a prior heartbeat activated the OpenRouter fallback,
+  // start this turn on OpenRouter so we don't re-incur the Anthropic 529 first.
+  // Done before effectiveEnv/billingType are derived so billing reflects the
+  // API-key auth path.
+  if (openrouterFallbackActiveConfig) {
+    const key = resolveOpenRouterApiKey();
+    if (key) {
+      env.ANTHROPIC_API_KEY = key;
+      env.ANTHROPIC_BASE_URL = OPENROUTER_ANTHROPIC_BASE_URL;
+      openRouterFallbackActive = true;
+      await onLog(
+        "stdout",
+        "[paperclip] openrouterFallbackActive is set; starting this turn on the OpenRouter endpoint.\n",
+      );
+    } else {
+      await onLog(
+        "stderr",
+        "[paperclip] openrouterFallbackActive is set but no OpenRouter API key is available; using Anthropic.\n",
+      );
+    }
+  }
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   const terminalResultCleanupGraceMs = Math.max(
     0,
@@ -1203,6 +1241,102 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  // Best-effort side effects that run exactly once, when a 529 fallback fires:
+  // alert the Founder on the active task and persist the runtime flag so the
+  // next heartbeat starts on OpenRouter. Neither failure blocks the completed
+  // OpenRouter retry from being returned.
+  const notifyOpenRouterFallback = async () => {
+    const apiBaseRaw = asString(env.PAPERCLIP_API_URL, "").trim();
+    const apiKey = asString(env.PAPERCLIP_API_KEY, "").trim();
+    const taskId = asString(env.PAPERCLIP_TASK_ID, "").trim();
+    if (!apiBaseRaw || !apiKey) {
+      await onLog(
+        "stderr",
+        "[paperclip] OpenRouter fallback: cannot reach Paperclip API to alert the Founder (missing PAPERCLIP_API_URL or PAPERCLIP_API_KEY).\n",
+      );
+      return;
+    }
+    const apiBase = apiBaseRaw.replace(/\/+$/, "").replace(/\/api$/, "");
+    if (taskId) {
+      try {
+        const res = await fetch(`${apiBase}/api/issues/${taskId}/comments`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${apiKey}`,
+            "x-paperclip-run-id": runId,
+          },
+          body: JSON.stringify({
+            body: "Anthropic returned 529 Overloaded — switched to OpenRouter fallback to complete this task. No Founder action needed.",
+          }),
+        });
+        if (!res.ok) {
+          await onLog(
+            "stderr",
+            `[paperclip] OpenRouter fallback: Founder alert comment failed (HTTP ${res.status}).\n`,
+          );
+        }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        await onLog("stderr", `[paperclip] OpenRouter fallback: Founder alert comment errored: ${reason}\n`);
+      }
+    }
+    try {
+      const res = await fetch(`${apiBase}/api/agents/${agent.id}`, {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${apiKey}`,
+        },
+        // Merge patch (replaceAdapterConfig defaults false) — only flips this key.
+        body: JSON.stringify({ adapterConfig: { openrouterFallbackActive: true } }),
+      });
+      if (!res.ok) {
+        await onLog(
+          "stderr",
+          `[paperclip] OpenRouter fallback: failed to persist openrouterFallbackActive (HTTP ${res.status}); the next heartbeat may re-detect the 529.\n`,
+        );
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stderr",
+        `[paperclip] OpenRouter fallback: failed to persist openrouterFallbackActive: ${reason}\n`,
+      );
+    }
+  };
+
+  const finalizeAttempt = async (
+    attempt: Awaited<ReturnType<typeof runAttempt>>,
+    resumeSessionId: string | null,
+    opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
+  ): Promise<AdapterExecutionResult> => {
+    const result = toAdapterResult(attempt, opts);
+    // Only an Anthropic 529 Overloaded is recoverable via OpenRouter, and only
+    // when we are not already on OpenRouter (guards against a fallback loop).
+    if (openRouterFallbackActive || result.errorFamily !== "transient_upstream") {
+      return result;
+    }
+    const overloaded = isClaudeOverloadedError({
+      parsed: attempt.parsed,
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+      errorMessage: result.errorMessage,
+    });
+    if (!overloaded) return result;
+    const key = resolveOpenRouterApiKey();
+    // No key: leave the unchanged transient_upstream result in place (AC #2).
+    if (!key) return result;
+    await onLog("stdout", "[paperclip] Anthropic 529 detected; retrying via OpenRouter fallback.\n");
+    env.ANTHROPIC_API_KEY = key;
+    env.ANTHROPIC_BASE_URL = OPENROUTER_ANTHROPIC_BASE_URL;
+    openRouterFallbackActive = true;
+    const retryAttempt = await runAttempt(resumeSessionId);
+    const retryResult = toAdapterResult(retryAttempt, opts);
+    await notifyOpenRouterFallback();
+    return retryResult;
+  };
+
   try {
     const initial = await runAttempt(sessionId ?? null);
     const sessionErrorKind =
@@ -1251,10 +1385,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         }
       }
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      return await finalizeAttempt(retry, null, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return await finalizeAttempt(initial, sessionId ?? null, {
+      fallbackSessionId: runtimeSessionId || runtime.sessionId,
+    });
   } finally {
     if (paperclipBridge) {
       await paperclipBridge.stop();

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -13,6 +13,11 @@ const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+// Narrow subset of the transient-upstream family: specifically an Anthropic 529
+// "Overloaded" response. This is the trigger for the OpenRouter fallback path,
+// distinct from the broader rate-limit/503/quota signals in
+// CLAUDE_TRANSIENT_UPSTREAM_RE which OpenRouter cannot recover.
+const CLAUDE_OVERLOADED_RE = /(?:\b529\b|overloaded(?:_error)?|server\s+overloaded)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
@@ -504,4 +509,22 @@ export function isClaudeProviderQuotaError(input: {
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;
   return CLAUDE_PROVIDER_QUOTA_RE.test(haystack);
+}
+
+/**
+ * True when the failure is specifically an Anthropic 529 "Overloaded" response.
+ * This is a strict subset of {@link isClaudeTransientUpstreamError}; callers gate
+ * the OpenRouter fallback on this so they only re-route the one failure class an
+ * Anthropic-compatible alternate endpoint can actually clear (a 529 from
+ * Anthropic's own fleet), never a provider quota or a broad rate limit.
+ */
+export function isClaudeOverloadedError(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const haystack = buildClaudeTransientHaystack(input);
+  if (!haystack) return false;
+  return CLAUDE_OVERLOADED_RE.test(haystack);
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The `claude-local` adapter runs each agent turn through the Claude CLI against Anthropic.
> - Anthropic sometimes returns a `529 Overloaded` response. Today the adapter classifies this as `transient_upstream` and fails the turn. The run stalls until Anthropic capacity recovers or a human intervenes.
> - Anthropic capacity can stay degraded for many minutes. A stalled agent needs no code fix, only a different upstream endpoint for the same models.
> - OpenRouter exposes an Anthropic-compatible Messages API that serves the same Claude models from separate capacity.
> - This pull request makes the adapter retry the turn on OpenRouter when it gets a `529`, complete the work, alert the owner on the active task, and keep later turns on OpenRouter until the flag is cleared.
> - The benefit is that a transient Anthropic overload no longer stalls an agent, and the owner is told when the fallback fired.

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the problem in-PR (adapter reliability):

**Adapter:** `claude-local`.
**Problem:** an Anthropic `529 Overloaded` is a server-side capacity signal, not a client error. The adapter currently returns `transient_upstream` and the agent turn fails. When Anthropic stays overloaded, the agent cannot make progress without human help, even though the same Claude models are reachable through an Anthropic-compatible alternate endpoint.
**Desired behaviour:** on a `529`, automatically retry the same turn against OpenRouter's Anthropic-compatible endpoint, finish the work, tell the task owner that the fallback activated, and start subsequent turns on OpenRouter so the `529` is not re-incurred each time. When no OpenRouter key is configured, keep the existing `transient_upstream` behaviour unchanged.

Related PRs (found while searching for duplicates; none implement this exact provider-swap fallback for `claude-local`):
- Refs #8472 — `claude-local --fallback-model`: a different approach to the same `529`/overload problem (bump the model, same provider) rather than switching provider.
- Refs #3357 — first-class OpenRouter API key support (config surface for OpenRouter keys).
- Refs #2408 — a standalone `openrouter_local` adapter (a separate adapter, not a fallback path for `claude-local`).

## What Changed

- `parse.ts`: add `isClaudeOverloadedError`. This matches only `529` / `Overloaded`. It is a strict subset of the `transient_upstream` family, so the fallback re-routes only the one failure class an Anthropic-compatible endpoint can clear. It never re-routes a provider quota or a broad rate limit.
- `execute.ts` (startup): when the `openrouterFallbackActive` config flag is set, inject `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` for OpenRouter before the first attempt. This runs before `billingType` is derived so billing reflects the API-key path.
- `execute.ts` (on `529`): when the result is `transient_upstream`, the error is a `529`, the run is not already on OpenRouter, and a key is available, swap the environment to OpenRouter and retry the turn. Then post an owner-facing comment to the active task and PATCH the agent `adapterConfig.openrouterFallbackActive = true` (merge patch, only that key). The comment and the PATCH are best-effort and never block the completed retry. A guard prevents a `529` on OpenRouter from re-triggering the fallback.
- `execute.ts` (key resolution): use `config.openrouterApiKey`, else the `OPENROUTER_API_KEY` environment variable.
- `config-schema.ts`: expose `openrouterApiKey` (text) and `openrouterFallbackActive` (toggle).
- tests: add `execute.openrouter-fallback.test.ts`.

## Verification

- New tests: `pnpm exec vitest run packages/adapters/claude-local/src/server/execute.openrouter-fallback.test.ts` → **4 passed**. They cover: (1) `529` triggers an OpenRouter retry that succeeds, posts the owner comment, and PATCHes the flag; (2) no key leaves `transient_upstream` unchanged; (3) `openrouterFallbackActive` starts the first attempt on OpenRouter; (4) a `529` while already on OpenRouter does not loop.
- `pnpm --filter @paperclipai/adapter-claude-local typecheck` and `build` → clean.
- Full `packages/adapters/claude-local` suite: 82 passed, 2 failed. Both failures (`test.probe.test.ts` overload classification, `execute.remote.test.ts` SSH sync assertion) also fail on clean `origin/master` with these changes stashed. They are pre-existing and unrelated to this PR.

## Risks

- Low-to-medium risk. The path is off by default: with no OpenRouter key and no flag set, behaviour is unchanged.
- **Not yet validated against a live `529`.** The tests mock the process boundary. The exact OpenRouter base URL (`https://openrouter.ai/api/v1`) and Claude model-id compatibility are unverified end to end. OpenRouter usually namespaces models as `anthropic/claude-*`, so a bare Claude model id may need remapping. Before relying on this in production, run one live smoke test; if the model id needs remapping, add an `openrouterModel` override.
- The owner comment and the config PATCH are best-effort. If the PATCH fails, the retry still completes, but the next turn may re-detect the `529` and fall back again (repeat alert). This is logged.

## Model Used

Claude Opus 4.8 (1M context), extended-thinking mode, with tool use and code execution (Claude Code / Anthropic).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
