### PR TITLE
feat(mcp): auto-wire @paperclipai/mcp-server into claude-local heartbeat runs

### DIFF
--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -55,10 +55,12 @@
   "dependencies": {
     "@agentclientprotocol/claude-agent-acp": "^0.63.0",
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/mcp-server": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",
+    "tsx": "^4.23.1",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/adapters/claude-local/src/server/claude-config.test.ts
+++ b/packages/adapters/claude-local/src/server/claude-config.test.ts
@@ -2,7 +2,12 @@ import * as fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { prepareClaudeConfigSeed } from "./claude-config.js";
+import {
+  prepareClaudeConfigSeed,
+  resolvePaperclipMcpServerStdioEntry,
+  resolveTsxLoaderEntry,
+  writePaperclipClaudeMcpConfig,
+} from "./claude-config.js";
 
 describe("prepareClaudeConfigSeed", () => {
   const cleanupDirs: string[] = [];
@@ -107,5 +112,102 @@ describe("prepareClaudeConfigSeed", () => {
       .rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.readFile(path.join(seedDir, "CLAUDE.md"), "utf8"))
       .resolves.toBe("local instructions");
+  });
+});
+
+describe("resolvePaperclipMcpServerStdioEntry", () => {
+  it("resolves the built @paperclipai/mcp-server stdio bin from this workspace", async () => {
+    const resolved = resolvePaperclipMcpServerStdioEntry();
+    expect(resolved).not.toBeNull();
+    expect(resolved?.entryPath.endsWith(path.join("mcp-server", "dist", "stdio.js"))).toBe(true);
+    await expect(fs.access(resolved!.entryPath)).resolves.toBeUndefined();
+    expect(resolved?.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("resolveTsxLoaderEntry", () => {
+  it("resolves tsx's ESM loader from this workspace", async () => {
+    const resolved = resolveTsxLoaderEntry();
+    expect(resolved).not.toBeNull();
+    expect(resolved?.loaderPath.endsWith(path.join("tsx", "dist", "loader.mjs"))).toBe(true);
+    await expect(fs.access(resolved!.loaderPath)).resolves.toBeUndefined();
+  });
+});
+
+describe("writePaperclipClaudeMcpConfig", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("writes an empty mcpServers object when there are no gateway servers and no paperclip tool", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-mcp-config-"));
+    cleanupDirs.push(stateDir);
+
+    const configPath = await writePaperclipClaudeMcpConfig({
+      stateDir,
+      runId: "run-1",
+      servers: [],
+    });
+
+    const written = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(written).toEqual({ mcpServers: {} });
+  });
+
+  it("adds a stdio entry for the paperclip mcp tool alongside http gateway servers", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-mcp-config-"));
+    cleanupDirs.push(stateDir);
+
+    const configPath = await writePaperclipClaudeMcpConfig({
+      stateDir,
+      runId: "run-2",
+      servers: [{ name: "gateway", url: "https://gw.example/mcp", connectionId: "conn-12345678", token: "tok" }],
+      paperclipMcpTool: {
+        args: ["--import", "/fake/path/tsx/dist/loader.mjs", "/fake/path/dist/stdio.js"],
+        env: { PAPERCLIP_API_URL: "http://localhost:3100", PAPERCLIP_API_KEY: "jwt" },
+      },
+    });
+
+    const written = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(written.mcpServers.gateway).toEqual({
+      type: "http",
+      url: "https://gw.example/mcp",
+      headers: { Authorization: "Bearer tok" },
+    });
+    expect(written.mcpServers.paperclip).toEqual({
+      type: "stdio",
+      command: "node",
+      args: ["--import", "/fake/path/tsx/dist/loader.mjs", "/fake/path/dist/stdio.js"],
+      env: { PAPERCLIP_API_URL: "http://localhost:3100", PAPERCLIP_API_KEY: "jwt" },
+    });
+  });
+
+  it("suffixes the paperclip tool name if a gateway server is already named 'paperclip'", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-mcp-config-"));
+    cleanupDirs.push(stateDir);
+
+    const configPath = await writePaperclipClaudeMcpConfig({
+      stateDir,
+      runId: "run-3",
+      servers: [{ name: "paperclip", url: "https://gw.example/mcp", connectionId: "conn-abcdefgh", token: "tok" }],
+      paperclipMcpTool: {
+        args: ["/fake/path/dist/stdio.js"],
+        env: {},
+      },
+    });
+
+    const written = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(written.mcpServers.paperclip.type).toBe("http");
+    expect(written.mcpServers["paperclip-2"]).toEqual({
+      type: "stdio",
+      command: "node",
+      args: ["/fake/path/dist/stdio.js"],
+      env: {},
+    });
   });
 });

--- a/packages/adapters/claude-local/src/server/claude-config.ts
+++ b/packages/adapters/claude-local/src/server/claude-config.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import type { AdapterExecutionContext, AdapterRuntimeMcpServer } from "@paperclipai/adapter-utils";
@@ -146,10 +148,81 @@ export function resolveManagedClaudeRuntimeStateDir(
   return path.join(instanceRoot, "companies", companyId, "agents", agentId, "claude-runtime");
 }
 
+/**
+ * Locates a file inside a workspace package without going through require()/import()
+ * module resolution — several workspace packages' "exports" maps only expose "."
+ * (pointed at their own TS source for in-repo hot-reload), so a subpath require.resolve
+ * of e.g. "package/dist/foo.js" throws ERR_PACKAGE_PATH_NOT_EXPORTED. Walking the plain
+ * node_modules search paths and reading the file directly sidesteps that.
+ */
+function resolveWorkspacePackageFile(
+  packageName: string,
+  relativeFilePath: string,
+): { filePath: string; packageRoot: string } | null {
+  const require = createRequire(import.meta.url);
+  const searchPaths = require.resolve.paths(packageName) ?? [];
+  for (const base of searchPaths) {
+    const packageRoot = path.join(base, ...packageName.split("/"));
+    const filePath = path.join(packageRoot, relativeFilePath);
+    if (!existsSync(filePath)) continue;
+    return { filePath, packageRoot };
+  }
+  return null;
+}
+
+/** Broadest real (symlink-resolved) directory a spawned process needs read access to under sandboxing — the pnpm store root when pnpm-managed, else the package directory itself. */
+function resolveSandboxReadDir(packageRoot: string): string {
+  try {
+    const realPackageRoot = realpathSync(packageRoot);
+    const pnpmStoreIndex = realPackageRoot.split(path.sep).indexOf(".pnpm");
+    return pnpmStoreIndex >= 0
+      ? realPackageRoot.split(path.sep).slice(0, pnpmStoreIndex + 1).join(path.sep)
+      : realPackageRoot;
+  } catch {
+    return packageRoot;
+  }
+}
+
+export function resolvePaperclipMcpServerStdioEntry(): {
+  entryPath: string;
+  version: string;
+  sandboxReadDir: string;
+} | null {
+  const resolved = resolveWorkspacePackageFile("@paperclipai/mcp-server", path.join("dist", "stdio.js"));
+  if (!resolved) return null;
+  let version = "0.0.0";
+  try {
+    const pkg = JSON.parse(readFileSync(path.join(resolved.packageRoot, "package.json"), "utf8"));
+    if (typeof pkg.version === "string" && pkg.version.trim().length > 0) version = pkg.version;
+  } catch {
+    // Missing/unreadable package.json shouldn't block attach; fall back to "0.0.0".
+  }
+  return {
+    entryPath: resolved.filePath,
+    version,
+    sandboxReadDir: resolveSandboxReadDir(resolved.packageRoot),
+  };
+}
+
+/**
+ * This monorepo's own packages resolve workspace deps via package.json "exports"
+ * fields pointed at TS source (for in-repo hot-reload), so plain `node dist/stdio.js`
+ * cannot resolve @paperclipai/mcp-server's own `@paperclipai/shared` import — the
+ * same reason this repo's Dockerfile CMD and dev scripts run `server/dist/index.js`
+ * through the tsx ESM loader rather than plain node. Do the same for the spawned
+ * paperclip-mcp-server stdio process.
+ */
+export function resolveTsxLoaderEntry(): { loaderPath: string; sandboxReadDir: string } | null {
+  const resolved = resolveWorkspacePackageFile("tsx", path.join("dist", "loader.mjs"));
+  if (!resolved) return null;
+  return { loaderPath: resolved.filePath, sandboxReadDir: resolveSandboxReadDir(resolved.packageRoot) };
+}
+
 export async function writePaperclipClaudeMcpConfig(input: {
   stateDir: string;
   runId: string;
   servers: AdapterRuntimeMcpServer[];
+  paperclipMcpTool?: { args: string[]; env: Record<string, string> } | null;
 }): Promise<string> {
   const configDir = path.join(input.stateDir, "runs", input.runId, "mcp");
   const configPath = path.join(configDir, "mcp-config.json");
@@ -168,6 +241,21 @@ export async function writePaperclipClaudeMcpConfig(input: {
       type: "http",
       url: server.url,
       headers: { Authorization: `Bearer ${server.token}` },
+    };
+  }
+  if (input.paperclipMcpTool) {
+    let name = "paperclip";
+    let suffix = 2;
+    while (usedNames.has(name)) {
+      name = `paperclip-${suffix}`;
+      suffix += 1;
+    }
+    usedNames.add(name);
+    mcpServers[name] = {
+      type: "stdio",
+      command: "node",
+      args: input.paperclipMcpTool.args,
+      env: input.paperclipMcpTool.env,
     };
   }
   await fs.mkdir(configDir, { recursive: true });

--- a/packages/adapters/claude-local/src/server/config-schema.ts
+++ b/packages/adapters/claude-local/src/server/config-schema.ts
@@ -68,6 +68,13 @@ export function getConfigSchema(): AdapterConfigSchema {
         hint: "Defaults to 0, which closes the ACP process after each run while retaining persistent session state.",
         meta: acpVisible,
       },
+      {
+        key: "paperclipMcpTools",
+        label: "Attach Paperclip MCP tools",
+        type: "toggle",
+        default: false,
+        hint: "Attaches @paperclipai/mcp-server as a native stdio MCP tool (checkout, comment, status update, approvals, interactions) using the run's existing credentials. Local execution targets only; off by default (AMC-4028 phase 1 opt-in).",
+      },
     ],
   };
 }

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -74,7 +74,9 @@ import {
   materializeRemoteClaudeConfig,
   prepareClaudeConfigSeed,
   resolveManagedClaudeRuntimeStateDir,
+  resolvePaperclipMcpServerStdioEntry,
   resolveSharedClaudeConfigDir,
+  resolveTsxLoaderEntry,
   writePaperclipClaudeMcpConfig,
 } from "./claude-config.js";
 import { claudeCommandSupportsEffortFlag } from "./cli-capabilities.js";
@@ -511,9 +513,45 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     onLog,
   });
   const runtimeMcpServers = ctx.runtimeMcp?.getServers() ?? [];
-  const runtimeMcpIdentity = JSON.stringify(
-    runtimeMcpServers.map(({ name, url, connectionId }) => ({ name, url, connectionId })),
-  );
+  // v1 is local execution targets only — the mcp-server package isn't shipped
+  // to remote/sandbox hosts yet (see AMC-4028 Decision 1, "G3").
+  const paperclipMcpToolsRequested = asBoolean(config.paperclipMcpTools, false) && !executionTargetIsRemote;
+  let paperclipMcpTool: { args: string[]; sandboxReadDirs: string[]; env: Record<string, string> } | null = null;
+  if (paperclipMcpToolsRequested) {
+    const resolvedEntry = resolvePaperclipMcpServerStdioEntry();
+    // This monorepo's own packages resolve each other via package.json "exports"
+    // pointed at TS source (in-repo hot-reload), so plain `node dist/stdio.js`
+    // can't resolve @paperclipai/mcp-server's own @paperclipai/shared import.
+    // Run it through tsx's ESM loader, exactly like this repo's Dockerfile CMD
+    // and dev scripts already do for server/dist/index.js.
+    const resolvedTsxLoader = resolvedEntry ? resolveTsxLoaderEntry() : null;
+    if (resolvedEntry && resolvedTsxLoader) {
+      paperclipMcpTool = {
+        args: ["--import", resolvedTsxLoader.loaderPath, resolvedEntry.entryPath],
+        sandboxReadDirs: [resolvedEntry.sandboxReadDir, resolvedTsxLoader.sandboxReadDir],
+        env: {
+          PAPERCLIP_API_URL: env.PAPERCLIP_API_URL ?? "",
+          PAPERCLIP_API_KEY: env.PAPERCLIP_API_KEY ?? "",
+          PAPERCLIP_COMPANY_ID: env.PAPERCLIP_COMPANY_ID ?? "",
+          PAPERCLIP_AGENT_ID: env.PAPERCLIP_AGENT_ID ?? "",
+          PAPERCLIP_RUN_ID: env.PAPERCLIP_RUN_ID ?? runId,
+        },
+      };
+      await onLog(
+        "stdout",
+        `[paperclip] Attached paperclip MCP tools (stdio, v${resolvedEntry.version}).\n`,
+      );
+    } else {
+      await onLog(
+        "stderr",
+        "[paperclip] paperclipMcpTools is enabled but the @paperclipai/mcp-server stdio entry point or its tsx loader could not be resolved; skipping MCP tool attach.\n",
+      );
+    }
+  }
+  const runtimeMcpIdentity = JSON.stringify({
+    gateway: runtimeMcpServers.map(({ name, url, connectionId }) => ({ name, url, connectionId })),
+    paperclipTool: paperclipMcpTool ? { args: paperclipMcpTool.args } : null,
+  });
   const claudeRuntimeStateDir = resolveManagedClaudeRuntimeStateDir(
     process.env,
     agent.companyId,
@@ -523,6 +561,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     stateDir: claudeRuntimeStateDir,
     runId,
     servers: runtimeMcpServers,
+    paperclipMcpTool,
   });
   const localMcpConfigDir = path.dirname(localMcpConfigPath);
   const sharedClaudeConfigDir = resolveSharedClaudeConfigDir(process.env);
@@ -538,6 +577,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             { path: path.join(path.dirname(sharedClaudeConfigDir), ".claude.json"), access: "rw" },
             { path: promptBundle.addDir, access: "ro" },
             { path: localMcpConfigDir, access: "ro" },
+            ...(paperclipMcpTool
+              ? paperclipMcpTool.sandboxReadDirs.map((dir) => ({ path: dir, access: "ro" as const }))
+              : []),
           ],
           extraPaths: parseLocalProcessSandboxExtraPaths(config.filesystemExtraPaths),
           homeDir: filesystemScope ? path.dirname(sharedClaudeConfigDir) : null,
@@ -730,7 +772,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
   const hasMatchingMcpServers =
     runtimeMcpServerIdentity.length === 0
-      ? runtimeMcpServers.length === 0
+      ? runtimeMcpServers.length === 0 && !paperclipMcpTool
       : runtimeMcpServerIdentity === runtimeMcpIdentity;
   const isValidUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(runtimeSessionId);
   const canResumeSession =
@@ -856,7 +898,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (attemptInstructionsFilePath && !resumeSessionId) {
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
-    if (runtimeMcpServers.length > 0) {
+    if (runtimeMcpServers.length > 0 || paperclipMcpTool) {
       args.push("--mcp-config", effectiveMcpConfigPath, "--strict-mcp-config");
     }
     args.push("--add-dir", effectivePromptBundleAddDir);

--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,4 +1,7 @@
+import { createRequire } from "node:module";
 import type { PaperclipMcpConfig } from "./config.js";
+
+const packageVersion = (createRequire(import.meta.url)("../package.json") as { version: string }).version;
 
 export class PaperclipApiError extends Error {
   readonly status: number;
@@ -84,6 +87,7 @@ export class PaperclipApiClient {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.config.apiKey}`,
       Accept: "application/json",
+      "X-Paperclip-Client": `paperclip-mcp-server/${packageVersion}`,
     };
     if (options.body !== undefined) {
       headers["Content-Type"] = "application/json";

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -50,6 +50,9 @@ describe("paperclip MCP tools", () => {
     expect((init.headers as Record<string, string>)["X-Paperclip-Run-Id"]).toBe(
       "33333333-3333-3333-3333-333333333333",
     );
+    expect((init.headers as Record<string, string>)["X-Paperclip-Client"]).toMatch(
+      /^paperclip-mcp-server\/\d+\.\d+\.\d+/,
+    );
   });
 
   it("uses default company id for company-scoped list tools", async () => {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -463,14 +463,14 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipUpdateIssue",
-      "Patch an issue, optionally including a comment; include resume=true when intentionally requesting follow-up on resumable closed work",
+      "Patch an issue, optionally including a comment; include resume=true when intentionally requesting follow-up on resumable closed work. This is also the execution-policy review/approval stage decision route: submit {status: \"done\", comment} to approve or {status: \"in_progress\", comment} to request changes on an issue whose currentParticipant matches you — the server enforces currentStageType/currentParticipant/returnAssignee semantics and returns 422 for non-participants. For standalone board-approval records instead, use paperclipApprovalDecision.",
       updateIssueToolSchema,
       async ({ issueId, ...body }) =>
         client.requestJson("PATCH", `/issues/${encodeURIComponent(issueId)}`, { body }),
     ),
     makeTool(
       "paperclipCheckoutIssue",
-      "Checkout an issue for an agent",
+      "Checkout an issue for an agent. The harness normally checks out the wake issue already before this tool is available — you usually don't need to call this for the issue you were woken for. Default expectedStatuses ([\"todo\",\"backlog\",\"blocked\"]) already prevents stealing in_progress work from another agent; keep it unless you have a specific reason to override.",
       checkoutIssueToolSchema,
       async ({ issueId, agentId, expectedStatuses }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/checkout`, {
@@ -588,7 +588,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipApprovalDecision",
-      "Approve, reject, request revision, or resubmit an approval",
+      "Approve, reject, request revision, or resubmit a standalone board-approval record (POST /approvals/{id}/...). This does NOT drive execution-policy review stages on an issue — for a currentStageType/currentParticipant review-stage decision, use paperclipUpdateIssue with {status, comment} instead.",
       approvalDecisionSchema,
       async ({ approvalId, action, decisionNote, payloadJson }) => {
         const path =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
+      '@paperclipai/mcp-server':
+        specifier: workspace:*
+        version: link:../../mcp-server
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -151,6 +154,9 @@ importers:
       '@types/node':
         specifier: ^22.20.1
         version: 22.20.1
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -1848,11 +1854,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -25,6 +25,16 @@ Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli
 
 **Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
 
+## Native Paperclip MCP Tools (preferred over curl, when attached)
+
+Some claude-local runs have `@paperclipai/mcp-server` attached as a native stdio MCP server (opt-in per agent via adapter config, AMC-4028/AMC-4029). Check your available tools for names starting with `paperclip` (e.g. `paperclipCheckoutIssue`, `paperclipUpdateIssue`, `paperclipAddComment`, `paperclipApprovalDecision`, `paperclipSuggestTasks`, `paperclipAskUserQuestions`, `paperclipRequestConfirmation`, `paperclipRequestCheckboxConfirmation`). If present, **prefer them over hand-formulating curl** for the same actions — they run under the same run-scoped credentials as curl (no new trust surface), can't drift from the API's own validation schemas, and automatically attach `X-Paperclip-Run-Id` for you.
+
+- `paperclipUpdateIssue` is both the general issue-patch tool and the execution-policy review/approval stage decision route — submit `{status: "done", comment}` to approve or `{status: "in_progress", comment}` to request changes on a stage where `currentParticipant` matches you. It is **not** the same as `paperclipApprovalDecision`, which drives only standalone board-approval records (`/approvals/{id}/approve|reject|...`).
+- `paperclipCheckoutIssue` is rarely needed directly: the harness already checks out the wake issue for you before your tools are available.
+- These native tools execute immediately against the API — they are unrelated to the separate gateway-routed **MCP Tool Approval Gates** mechanism described later in this doc (connected third-party apps that may require human approval before executing).
+
+If the native tools are not attached to your run, or don't cover an action you need (e.g. document upsert edge cases, generic escape-hatch requests), fall back to the curl recipes throughout this skill and its `references/api-reference.md` — they remain fully supported and are not being removed.
+
 ## The Heartbeat Procedure
 
 Follow these steps every time you wake up:


### PR DESCRIPTION
## Summary
- Attaches the existing `@paperclipai/mcp-server` tool surface (checkout, issue update/comment, approval decisions, interaction creation) to claude-local heartbeat runs as a native stdio MCP server, per the accepted AMC-4028 architecture decision.
- Feature-flagged per agent (`config.paperclipMcpTools`, default off), local execution targets only in v1. Zero new credential surface — the stdio process env reuses the run's existing `PAPERCLIP_API_KEY`/`PAPERCLIP_API_URL`/`PAPERCLIP_COMPANY_ID`/`PAPERCLIP_AGENT_ID`/`PAPERCLIP_RUN_ID`.
- Fixes 3 tool description strings (`paperclipUpdateIssue`, `paperclipCheckoutIssue`, `paperclipApprovalDecision`) to correct the execution-policy-vs-board-approval routing distinction, and adds an `X-Paperclip-Client` header to the MCP server's API client for tool-vs-curl triage separability.
- Updates `skills/paperclip/SKILL.md` to document the native tools as the preferred path, keeping curl fully documented as a fallback.
- **Deviation from the AMC-4028 doc, evidence-based (its own G1 gate):** the doc assumed spawning `node <dist/stdio.js>` directly. Live testing found that fails in this monorepo — `@paperclipai/mcp-server`'s own `@paperclipai/shared` import resolves through workspace `exports` pointed at TS source, which plain `node` can't follow. This repo's own Dockerfile CMD and dev scripts already solve this by running through tsx's ESM loader (`node --import tsx/dist/loader.mjs ...`) — the stdio entry now does the same.

## Test plan
- [x] `pnpm --filter @paperclipai/adapter-claude-local typecheck` — clean
- [x] `pnpm --filter @paperclipai/adapter-claude-local build` — clean
- [x] `vitest run src/server/claude-config.test.ts` (claude-local) — 8/8 passing, including new coverage for `resolvePaperclipMcpServerStdioEntry`, `resolveTsxLoaderEntry`, and `writePaperclipClaudeMcpConfig` (flag-off empty config, stdio entry alongside gateway servers, name-collision suffixing)
- [x] `pnpm --filter @paperclipai/mcp-server typecheck` — clean
- [x] `vitest run src/tools.test.ts` (mcp-server) — extended the existing header-assertion test to cover `X-Paperclip-Client`; passes (one pre-existing unrelated failure on `master`/this branch alike — `allowDuplicate` default drift in `paperclipCreateIssue`, confirmed present before this change via `git stash`)
- [x] **Live end-to-end verification** (not just typecheck): built the real workspace packages, generated a real `mcp-config.json` via the actual `writePaperclipClaudeMcpConfig`/`resolvePaperclipMcpServerStdioEntry` code path with this run's live credentials, then connected an MCP SDK client over stdio to the spawned `paperclip-mcp-server` subprocess (tsx-loader fix applied) — it listed all 41 tools including `paperclipAddComment`, and a live `paperclipAddComment` call posted a real comment on [AMC-4029](https://github.com/paperclipai/paperclip) (visible in the issue thread, correct agent actor, real UUID).

## Follow-ups (not blocking this PR, called out in the AMC-4028 doc)
- G2: ≥7 days of opt-in cohort before phase-2 default-on (CTO call).
- G3: remote/sandbox target enablement — separate ticket, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)