### PR TITLE
fix(claude-local): stop prompt overflow retry loops

### DIFF
--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -36,6 +36,18 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
   maxSessionAgeHours: 0,
 };
 
+// claude_local uses the standard 200K context window. AUR-4476 measured the
+// first prompt-overflow failures at 16 runs / 13.0h, so rotate materially
+// earlier: 12 runs leaves 25% depth headroom and 8h leaves 38% age headroom.
+// Keep the raw-input guard as a secondary signal if the adapter starts
+// reporting a session-relevant input metric in the future.
+const CLAUDE_LOCAL_SESSION_POLICY: SessionCompactionPolicy = {
+  enabled: true,
+  maxSessionRuns: 12,
+  maxRawInputTokens: 150_000,
+  maxSessionAgeHours: 8,
+};
+
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
   "claude_local",
   "codex_local",
@@ -51,7 +63,7 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
   claude_local: {
     supportsSessionResume: true,
     nativeContextManagement: "confirmed",
-    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+    defaultSessionCompaction: CLAUDE_LOCAL_SESSION_POLICY,
   },
   codex_local: {
     supportsSessionResume: true,

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -56,11 +56,13 @@ import {
   type LocalProcessSandboxOptions,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
 import {
+  CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
   claudeModelUsageTotals,
   parseClaudeStreamJson,
   describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
+  isClaudeContextOverflowError,
   isClaudeMaxTurnsResult,
   isClaudeProviderQuotaError,
   isClaudeRefusalResult,
@@ -982,9 +984,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stderr: proc.stderr,
           errorMessage: fallbackErrorMessage,
         });
+      const contextOverflow =
+        !loginMeta.requiresLogin &&
+        !providerQuota &&
+        (proc.exitCode ?? 0) !== 0 &&
+        isClaudeContextOverflowError({
+          parsed: null,
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+          errorMessage: fallbackErrorMessage,
+        });
       const transientUpstream =
         !loginMeta.requiresLogin &&
         !providerQuota &&
+        !contextOverflow &&
         (proc.exitCode ?? 0) !== 0 &&
         isClaudeTransientUpstreamError({
           parsed: null,
@@ -1009,6 +1022,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           errorMessage: fallbackErrorMessage,
         })
         ? "model_not_found"
+        : contextOverflow
+        ? CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE
         : providerQuota
         ? "provider_quota"
         : transientUpstream
@@ -1113,12 +1128,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderr: proc.stderr,
         errorMessage,
       });
+    const contextOverflow =
+      failed &&
+      !loginMeta.requiresLogin &&
+      !clearSessionForMaxTurns &&
+      !poisonedPreviousMessageId &&
+      !providerQuota &&
+      isClaudeContextOverflowError({
+        parsed,
+        stdout: proc.stdout,
+        stderr: proc.stderr,
+        errorMessage,
+      });
     const transientUpstream =
       failed &&
       !loginMeta.requiresLogin &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
       !providerQuota &&
+      !contextOverflow &&
       isClaudeTransientUpstreamError({
         parsed,
         stdout: proc.stdout,
@@ -1146,6 +1174,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? "max_turns_exhausted"
       : failed && poisonedPreviousMessageId
       ? "claude_poisoned_previous_message_id"
+      : contextOverflow
+      ? CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE
       : providerQuota
       ? "provider_quota"
       : transientUpstream

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -9,8 +9,10 @@ export {
   resetClaudeCliCapabilitiesCacheForTests,
 } from "./cli-capabilities.js";
 export {
+  CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
   parseClaudeStreamJson,
   describeClaudeFailure,
+  isClaudeContextOverflowError,
   isClaudeMaxTurnsResult,
   isClaudeProviderQuotaError,
   isClaudeRefusalResult,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
   claudeModelUsageTotals,
   parseClaudeStreamJson,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
+  isClaudeContextOverflowError,
   isClaudeProviderQuotaError,
   isClaudeTransientUpstreamError,
   isClaudePoisonedPreviousMessageIdError,
@@ -159,6 +161,21 @@ describe("isClaudeTransientUpstreamError", () => {
         errorMessage: "Invalid request_error: Unknown parameter 'foo'.",
       }),
     ).toBe(false);
+  });
+
+  it("does not classify prompt-size overflow as transient", () => {
+    const errorMessage = "Claude run failed: subtype=success: Prompt is too long";
+    expect(
+      isClaudeTransientUpstreamError({
+        errorMessage,
+      }),
+    ).toBe(false);
+    expect(
+      isClaudeContextOverflowError({
+        errorMessage,
+      }),
+    ).toBe(true);
+    expect(CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE).toBe("claude_context_overflow");
   });
 
   it("does not classify poisoned previous_message_id errors as transient", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -15,8 +15,11 @@ const CLAUDE_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
+const CLAUDE_CONTEXT_OVERFLOW_RE = /\bprompt is too long\b/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+
+export const CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE = "claude_context_overflow";
 
 /**
  * Sum the per-model usage ledger from a Claude CLI result event. The result
@@ -460,6 +463,17 @@ export function extractClaudeRetryNotBefore(
   return parseClaudeResetClockTime(match[1] ?? "", now, match[2]);
 }
 
+export function isClaudeContextOverflowError(input: {
+  parsed?: Record<string, unknown> | null;
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const haystack = buildClaudeTransientHaystack(input);
+  if (!haystack) return false;
+  return CLAUDE_CONTEXT_OVERFLOW_RE.test(haystack);
+}
+
 export function isClaudeTransientUpstreamError(input: {
   parsed?: Record<string, unknown> | null;
   stdout?: string | null;
@@ -480,6 +494,7 @@ export function isClaudeTransientUpstreamError(input: {
 
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;
+  if (isClaudeContextOverflowError(input)) return false;
   if (isClaudeProviderQuotaError(input)) return false;
   return CLAUDE_TRANSIENT_UPSTREAM_RE.test(haystack);
 }

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { AdapterRuntimeMcpServer } from "@paperclipai/adapter-utils";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
 import {
+  CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
   claudeCommandSupportsEffortFlag,
   claudeSessionCwdMatchesExecutionTarget,
   execute,
@@ -1580,6 +1581,63 @@ describe("claude execute", () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.errorCode).not.toBe("claude_transient_upstream");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies prompt-size overflow with its own deterministic error code", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-overflow-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(commandPath, {
+      resultEvent: {
+        type: "result",
+        subtype: "success",
+        session_id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        is_error: true,
+        result: "Prompt is too long",
+      },
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-overflow",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe(CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE);
+      expect(result.errorFamily ?? null).toBeNull();
+      expect(result.retryNotBefore ?? null).toBeNull();
+      expect(result.resultJson?.retryNotBefore ?? null).toBeNull();
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE } from "@paperclipai/adapter-claude-local/server";
 import {
   agents,
   agentRuntimeState,
@@ -422,6 +423,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       status: "failed",
       error: "upstream overload",
       errorCode: "adapter_failed",
+      resultJson: { errorFamily: "transient_upstream" },
       finishedAt: now,
       contextSnapshot: {
         issueId: randomUUID(),
@@ -1577,6 +1579,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       status: "failed",
       error: "upstream overload",
       errorCode: "adapter_failed",
+      resultJson: { errorFamily: "transient_upstream" },
       finishedAt: now,
       contextSnapshot: {
         issueId,
@@ -1732,6 +1735,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       status: "failed",
       error: "upstream overload",
       errorCode: "adapter_failed",
+      resultJson: { errorFamily: "transient_upstream" },
       finishedAt: now,
       contextSnapshot: {
         issueId,
@@ -1833,6 +1837,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       status: "failed",
       error: "upstream overload",
       errorCode: "adapter_failed",
+      resultJson: { errorFamily: "transient_upstream" },
       finishedAt: now,
       contextSnapshot: {
         issueId,
@@ -1943,6 +1948,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       status: "failed",
       error: "upstream overload",
       errorCode: "adapter_failed",
+      resultJson: { errorFamily: "transient_upstream" },
       finishedAt: now,
       contextSnapshot: {
         issueId,
@@ -2042,6 +2048,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       status: "failed",
       error: "still transient",
       errorCode: "adapter_failed",
+      resultJson: { errorFamily: "transient_upstream" },
       finishedAt: now,
       scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
       scheduledRetryReason: "transient_failure",
@@ -2305,5 +2312,39 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
       retryNotBefore.toISOString(),
     );
+  });
+
+  it("does not schedule bounded retries for deterministic Claude prompt overflow failures", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-07-29T12:00:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
+      errorFamily: null,
+      adapterType: "claude_local",
+      resultJson: {},
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("not_retryable");
+    if (scheduled.outcome !== "not_retryable") return;
+    expect(scheduled.errorCode).toBe(CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE);
+
+    const retryCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(retryCount).toBe(0);
   });
 });

--- a/server/src/__tests__/heartbeat-session-compaction.test.ts
+++ b/server/src/__tests__/heartbeat-session-compaction.test.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE } from "@paperclipai/adapter-claude-local/server";
+import {
+  agentRuntimeState,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { drainHeartbeatRunsToQuiescence } from "./helpers/drain-heartbeat-runs.js";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    sessionParams: { sessionId: "session-1" },
+    sessionDisplayId: "session-1",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      type: "claude_local",
+      execute: mockAdapterExecute,
+      supportsLocalAgentJwt: false,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres session-compaction tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("evaluateSessionCompaction runtime wiring (AUR-4513)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-session-compaction-wiring-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockClear();
+    await drainHeartbeatRunsToQuiescence(db, heartbeat);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  }, 20_000);
+
+  it("forces a fresh session when the latest persisted run for the active session overflowed", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const overflowSessionId = "session-overflow";
+    const overflowRunId = randomUUID();
+    const overflowAt = new Date("2026-07-29T12:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      status: "active",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(agentRuntimeState).values({
+      agentId,
+      companyId,
+      adapterType: "claude_local",
+      sessionId: overflowSessionId,
+      stateJson: {},
+      createdAt: overflowAt,
+      updatedAt: overflowAt,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: overflowRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      error: "Claude run failed: subtype=success: Prompt is too long",
+      errorCode: CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
+      resultJson: {},
+      sessionIdBefore: overflowSessionId,
+      sessionIdAfter: overflowSessionId,
+      createdAt: overflowAt,
+      updatedAt: overflowAt,
+      finishedAt: overflowAt,
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      contextSnapshot: {},
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 5_000 });
+
+    const latest = await heartbeat.getRun(run!.id);
+    const contextSnapshot = latest?.contextSnapshot as Record<string, unknown> | null;
+    const adapterInput = mockAdapterExecute.mock.calls[0]?.[0] as
+      | { runtime?: { sessionId?: string | null; sessionDisplayId?: string | null } }
+      | undefined;
+
+    expect(contextSnapshot?.paperclipPreviousSessionId).toBe(overflowSessionId);
+    expect(String(contextSnapshot?.paperclipSessionRotationReason ?? "")).toContain("prompt-size limit");
+    expect(String(contextSnapshot?.paperclipSessionHandoffMarkdown ?? "")).toContain("Paperclip session handoff:");
+    expect(latest?.sessionIdBefore).toBeNull();
+    expect(latest?.sessionIdAfter).toBe("session-1");
+    expect(adapterInput?.runtime).toMatchObject({
+      sessionId: null,
+      sessionDisplayId: null,
+    });
+  }, 15_000);
+});

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it, vi } from "vitest";
+import { CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE } from "@paperclipai/adapter-claude-local/server";
 import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
@@ -21,6 +22,7 @@ import {
   formatRuntimeWorkspaceWarningLog,
   mergeExecutionWorkspaceMetadataForPersistence,
   mergeCoalescedContextSnapshot,
+  decideSessionCompactionForRuns,
   preflightLowTrustWorkspaceIsolation,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
@@ -2540,7 +2542,7 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
 });
 
 describe("parseSessionCompactionPolicy", () => {
-  it("disables Paperclip-managed rotation by default for codex and claude local", () => {
+  it("keeps codex adapter-managed and applies the measured claude_local defaults", () => {
     expect(parseSessionCompactionPolicy(buildAgent("codex_local"))).toEqual({
       enabled: true,
       maxSessionRuns: 0,
@@ -2549,9 +2551,9 @@ describe("parseSessionCompactionPolicy", () => {
     });
     expect(parseSessionCompactionPolicy(buildAgent("claude_local"))).toEqual({
       enabled: true,
-      maxSessionRuns: 0,
-      maxRawInputTokens: 0,
-      maxSessionAgeHours: 0,
+      maxSessionRuns: 12,
+      maxRawInputTokens: 150_000,
+      maxSessionAgeHours: 8,
     });
   });
 
@@ -2587,6 +2589,105 @@ describe("parseSessionCompactionPolicy", () => {
       maxSessionRuns: 25,
       maxRawInputTokens: 500_000,
       maxSessionAgeHours: 0,
+    });
+  });
+});
+
+describe("decideSessionCompactionForRuns", () => {
+  it("forces rotation when the latest Claude run hit prompt-size overflow even with thresholds disabled", () => {
+    const decision = decideSessionCompactionForRuns({
+      policy: {
+        enabled: true,
+        maxSessionRuns: 0,
+        maxRawInputTokens: 0,
+        maxSessionAgeHours: 0,
+      },
+      sessionId: "session-overflow",
+      issueId: "issue-1",
+      continuationSummaryBody: "Continue the current fix after rotating the session.",
+      runs: [
+        {
+          id: "run-overflow",
+          createdAt: new Date("2026-07-29T12:00:00.000Z"),
+          usageJson: null,
+          error: "Claude run failed: subtype=success: Prompt is too long",
+          errorCode: CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
+          resultSummary: null,
+          resultResult: null,
+          resultMessage: null,
+          resultError: null,
+          resultTotalCostUsd: null,
+          resultCostUsd: null,
+          resultCostUsdCamel: null,
+        },
+      ],
+    });
+
+    expect(decision.rotate).toBe(true);
+    expect(decision.reason).toContain("prompt-size limit");
+    expect(decision.previousRunId).toBe("run-overflow");
+    expect(decision.handoffMarkdown).toContain("Paperclip session handoff:");
+    expect(decision.handoffMarkdown).toContain("Issue continuation summary");
+  });
+
+  it("does not rotate a healthy Claude session under the recalibrated thresholds", () => {
+    const decision = decideSessionCompactionForRuns({
+      policy: {
+        enabled: true,
+        maxSessionRuns: 12,
+        maxRawInputTokens: 150_000,
+        maxSessionAgeHours: 8,
+      },
+      sessionId: "session-healthy",
+      issueId: "issue-2",
+      runs: [
+        {
+          id: "run-2",
+          createdAt: new Date("2026-07-29T12:00:00.000Z"),
+          usageJson: {
+            rawInputTokens: 1_200,
+            rawCachedInputTokens: 0,
+            rawOutputTokens: 300,
+          },
+          error: null,
+          errorCode: null,
+          resultSummary: "Kept working.",
+          resultResult: null,
+          resultMessage: null,
+          resultError: null,
+          resultTotalCostUsd: null,
+          resultCostUsd: null,
+          resultCostUsdCamel: null,
+        },
+        {
+          id: "run-1",
+          createdAt: new Date("2026-07-29T11:15:00.000Z"),
+          usageJson: {
+            rawInputTokens: 900,
+            rawCachedInputTokens: 0,
+            rawOutputTokens: 200,
+          },
+          error: null,
+          errorCode: null,
+          resultSummary: "Earlier progress.",
+          resultResult: null,
+          resultMessage: null,
+          resultError: null,
+          resultTotalCostUsd: null,
+          resultCostUsd: null,
+          resultCostUsdCamel: null,
+        },
+      ],
+      oldestRun: {
+        createdAt: new Date("2026-07-29T11:15:00.000Z"),
+      },
+    });
+
+    expect(decision).toEqual({
+      rotate: false,
+      reason: null,
+      handoffMarkdown: null,
+      previousRunId: "run-2",
     });
   });
 });

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE } from "@paperclipai/adapter-claude-local/server";
 import {
   activityLog,
   agents,
@@ -120,22 +121,30 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    startIndex?: number;
+    status?: string;
+    errorCode?: string | null;
+    error?: string | null;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
-    for (let index = 0; index < input.count; index += 1) {
+    const startIndex = input.startIndex ?? 0;
+    for (let offset = 0; offset < input.count; offset += 1) {
+      const index = startIndex + offset;
       const runId = randomUUID();
       const createdAt = new Date(input.now.getTime() - index * 60_000);
       runs.push({
         id: runId,
         companyId: input.companyId,
         agentId: input.agentId,
-        status: "succeeded",
+        status: input.status ?? "succeeded",
         invocationSource: "assignment",
         triggerDetail: "system",
         startedAt: createdAt,
         finishedAt: new Date(createdAt.getTime() + 30_000),
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
-        livenessState: "advanced",
+        livenessState: input.status && input.status !== "succeeded" ? "failed" : "advanced",
+        errorCode: input.errorCode ?? null,
+        error: input.error ?? null,
         nextAction: "Continue processing the next batch.",
         createdAt,
         updatedAt: createdAt,
@@ -709,6 +718,59 @@ describeEmbeddedPostgres("productivity review service", () => {
       .where(eq(activityLog.action, "issue.productivity_review_continuation_held"));
     expect(activities).toHaveLength(1);
     expect(activities[0]?.entityId).toBe(seeded.issueId);
+  });
+
+  it("counts the AUR-4212 prompt-overflow run mix as attributable work failure, not infra noise", async () => {
+    const now = new Date("2026-07-26T06:43:53.341Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date("2026-07-25T22:55:00.000Z"),
+    });
+    const overflowMessage = "Claude run failed: subtype=success: Prompt is too long";
+
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 8,
+      now: new Date("2026-07-25T23:20:00.000Z"),
+      status: "failed",
+      errorCode: CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
+      error: overflowMessage,
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 1,
+      now: new Date("2026-07-26T01:15:00.000Z"),
+      status: "failed",
+      errorCode: CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE,
+      error: overflowMessage,
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 1,
+      now,
+      status: "scheduled_retry",
+      errorCode: null,
+      error: null,
+      startIndex: 0,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+    expect(review?.description).toContain("Terminal sampled runs: 9");
+    expect(review?.description).toContain("No-comment completed-run streak: 9");
+    expect(review?.description).toContain("Active queued/running/scheduled runs: 1");
   });
 
   it("clamps poisoned requestDepth metadata instead of aborting productivity reconciliation", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -238,6 +238,7 @@ import {
   type RuntimeStatusUpdate,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
+import { CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE } from "@paperclipai/adapter-claude-local/server";
 import {
   readPaperclipSkillSyncPreference,
   UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
@@ -478,6 +479,127 @@ function readTransientRecoveryContractFromRun(
         retryNotBefore: readTransientRetryNotBeforeFromRun(run),
       }
     : null;
+}
+
+function isClaudeContextOverflowRun(
+  run: Pick<SessionCompactionRunSummary, "errorCode"> | null | undefined,
+) {
+  return run?.errorCode === CLAUDE_CONTEXT_OVERFLOW_ERROR_CODE;
+}
+
+function buildSessionCompactionHandoffMarkdown(input: {
+  sessionId: string;
+  issueId: string | null;
+  reason: string;
+  continuationSummaryBody?: string | null;
+  latestRun: SessionCompactionRunSummary;
+}) {
+  const latestSummary = summarizeHeartbeatRunListResultJson({
+    summary: input.latestRun.resultSummary,
+    result: input.latestRun.resultResult,
+    message: input.latestRun.resultMessage,
+    error: input.latestRun.resultError,
+    totalCostUsd: input.latestRun.resultTotalCostUsd,
+    costUsd: input.latestRun.resultCostUsd,
+    costUsdCamel: input.latestRun.resultCostUsdCamel,
+  });
+  const latestTextSummary =
+    readNonEmptyString(latestSummary?.summary) ??
+    readNonEmptyString(latestSummary?.result) ??
+    readNonEmptyString(latestSummary?.message) ??
+    readNonEmptyString(input.latestRun.error);
+
+  return [
+    "Paperclip session handoff:",
+    `- Previous session: ${input.sessionId}`,
+    input.issueId ? `- Issue: ${input.issueId}` : "",
+    `- Rotation reason: ${input.reason}`,
+    latestTextSummary ? `- Last run summary: ${latestTextSummary}` : "",
+    input.continuationSummaryBody
+      ? `- Issue continuation summary: ${input.continuationSummaryBody.slice(0, 1_500)}`
+      : "",
+    "Continue from the current task state. Rebuild only the minimum context you need.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function decideSessionCompactionForRuns(input: {
+  policy: SessionCompactionPolicy;
+  sessionId: string;
+  issueId: string | null;
+  continuationSummaryBody?: string | null;
+  runs: SessionCompactionRunSummary[];
+  oldestRun?: Pick<SessionCompactionRunSummary, "createdAt"> | null;
+}): SessionCompactionDecision {
+  const latestRun = input.runs[0] ?? null;
+  if (!latestRun) {
+    return {
+      rotate: false,
+      reason: null,
+      handoffMarkdown: null,
+      previousRunId: null,
+    };
+  }
+
+  const buildRotationDecision = (reason: string): SessionCompactionDecision => ({
+    rotate: true,
+    reason,
+    handoffMarkdown: buildSessionCompactionHandoffMarkdown({
+      sessionId: input.sessionId,
+      issueId: input.issueId,
+      reason,
+      continuationSummaryBody: input.continuationSummaryBody,
+      latestRun,
+    }),
+    previousRunId: latestRun.id,
+  });
+
+  if (isClaudeContextOverflowRun(latestRun)) {
+    return buildRotationDecision("previous Claude run hit the prompt-size limit");
+  }
+
+  if (!input.policy.enabled || !hasSessionCompactionThresholds(input.policy)) {
+    return {
+      rotate: false,
+      reason: null,
+      handoffMarkdown: null,
+      previousRunId: latestRun.id,
+    };
+  }
+
+  const oldestRun = input.oldestRun ?? input.runs[input.runs.length - 1] ?? latestRun;
+  const latestRawUsage = readRawUsageTotals(latestRun.usageJson);
+  const sessionAgeHours = Math.max(
+    0,
+    (new Date(latestRun.createdAt).getTime() - new Date(oldestRun.createdAt).getTime()) / (1000 * 60 * 60),
+  );
+
+  let reason: string | null = null;
+  if (input.policy.maxSessionRuns > 0 && input.runs.length > input.policy.maxSessionRuns) {
+    reason = `session exceeded ${input.policy.maxSessionRuns} runs`;
+  } else if (
+    input.policy.maxRawInputTokens > 0 &&
+    latestRawUsage &&
+    latestRawUsage.inputTokens >= input.policy.maxRawInputTokens
+  ) {
+    reason =
+      `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
+      `(threshold ${formatCount(input.policy.maxRawInputTokens)})`;
+  } else if (input.policy.maxSessionAgeHours > 0 && sessionAgeHours >= input.policy.maxSessionAgeHours) {
+    reason = `session age reached ${Math.floor(sessionAgeHours)} hours`;
+  }
+
+  if (!reason) {
+    return {
+      rotate: false,
+      reason: null,
+      handoffMarkdown: null,
+      previousRunId: latestRun.id,
+    };
+  }
+
+  return buildRotationDecision(reason);
 }
 
 function isResolvedInteractionContinuationWakeContext(contextSnapshot: unknown) {
@@ -2218,6 +2340,21 @@ type SessionCompactionDecision = {
   reason: string | null;
   handoffMarkdown: string | null;
   previousRunId: string | null;
+};
+
+type SessionCompactionRunSummary = {
+  id: string;
+  createdAt: Date | string;
+  usageJson: unknown;
+  error: string | null;
+  errorCode: string | null;
+  resultSummary: string | null;
+  resultResult: string | null;
+  resultMessage: string | null;
+  resultError: string | null;
+  resultTotalCostUsd: string | null;
+  resultCostUsd: string | null;
+  resultCostUsdCamel: string | null;
 };
 
 interface ParsedIssueAssigneeAdapterOverrides {
@@ -7636,15 +7773,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     const policy = parseSessionCompactionPolicy(agent);
-    if (!policy.enabled || !hasSessionCompactionThresholds(policy)) {
-      return {
-        rotate: false,
-        reason: null,
-        handoffMarkdown: null,
-        previousRunId: null,
-      };
-    }
-
     const fetchLimit = Math.max(policy.maxSessionRuns > 0 ? policy.maxSessionRuns + 1 : 0, 4);
     const runs = await db
       .select({
@@ -7652,6 +7780,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         createdAt: heartbeatRuns.createdAt,
         usageJson: heartbeatRuns.usageJson,
         error: heartbeatRuns.error,
+        errorCode: heartbeatRuns.errorCode,
         ...heartbeatRunListResultColumns,
       })
       .from(heartbeatRuns)
@@ -7668,79 +7797,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    const latestRun = runs[0] ?? null;
     const oldestRun =
       policy.maxSessionAgeHours > 0
         ? await getOldestRunForSession(agent.id, sessionId)
-        : runs[runs.length - 1] ?? latestRun;
-    const latestRawUsage = readRawUsageTotals(latestRun?.usageJson);
-    const sessionAgeHours =
-      latestRun && oldestRun
-        ? Math.max(
-            0,
-            (new Date(latestRun.createdAt).getTime() - new Date(oldestRun.createdAt).getTime()) / (1000 * 60 * 60),
-          )
-        : 0;
-
-    let reason: string | null = null;
-    if (policy.maxSessionRuns > 0 && runs.length > policy.maxSessionRuns) {
-      reason = `session exceeded ${policy.maxSessionRuns} runs`;
-    } else if (
-      policy.maxRawInputTokens > 0 &&
-      latestRawUsage &&
-      latestRawUsage.inputTokens >= policy.maxRawInputTokens
-    ) {
-      reason =
-        `session raw input reached ${formatCount(latestRawUsage.inputTokens)} tokens ` +
-        `(threshold ${formatCount(policy.maxRawInputTokens)})`;
-    } else if (policy.maxSessionAgeHours > 0 && sessionAgeHours >= policy.maxSessionAgeHours) {
-      reason = `session age reached ${Math.floor(sessionAgeHours)} hours`;
-    }
-
-    if (!reason || !latestRun) {
-      return {
-        rotate: false,
-        reason: null,
-        handoffMarkdown: null,
-        previousRunId: latestRun?.id ?? null,
-      };
-    }
-
-    const latestSummary = summarizeHeartbeatRunListResultJson({
-      summary: latestRun?.resultSummary,
-      result: latestRun?.resultResult,
-      message: latestRun?.resultMessage,
-      error: latestRun?.resultError,
-      totalCostUsd: latestRun?.resultTotalCostUsd,
-      costUsd: latestRun?.resultCostUsd,
-      costUsdCamel: latestRun?.resultCostUsdCamel,
+        : runs[runs.length - 1] ?? null;
+    return decideSessionCompactionForRuns({
+      policy,
+      sessionId,
+      issueId,
+      continuationSummaryBody: input.continuationSummaryBody,
+      runs,
+      oldestRun,
     });
-    const latestTextSummary =
-      readNonEmptyString(latestSummary?.summary) ??
-      readNonEmptyString(latestSummary?.result) ??
-      readNonEmptyString(latestSummary?.message) ??
-      readNonEmptyString(latestRun.error);
-
-    const handoffMarkdown = [
-      "Paperclip session handoff:",
-      `- Previous session: ${sessionId}`,
-      issueId ? `- Issue: ${issueId}` : "",
-      `- Rotation reason: ${reason}`,
-      latestTextSummary ? `- Last run summary: ${latestTextSummary}` : "",
-      input.continuationSummaryBody
-        ? `- Issue continuation summary: ${input.continuationSummaryBody.slice(0, 1_500)}`
-        : "",
-      "Continue from the current task state. Rebuild only the minimum context you need.",
-    ]
-      .filter(Boolean)
-      .join("\n");
-
-    return {
-      rotate: true,
-      reason,
-      handoffMarkdown,
-      previousRunId: latestRun.id,
-    };
   }
 
   async function resolveSessionBeforeForWakeup(
@@ -10208,13 +10276,31 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON
         ? readTransientRecoveryContractFromRun(run)
         : null;
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (retryReason === BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON && !transientRecovery) {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Bounded retry skipped because the failed run is not marked as a retryable transient failure",
+        payload: {
+          retryReason,
+          errorCode: run.errorCode ?? null,
+        },
+      });
+      return {
+        outcome: "not_retryable" as const,
+        reason: "Run is not eligible for bounded transient retry",
+        errorCode: run.errorCode ?? null,
+        issueId,
+      };
+    }
     const codexTransientFallbackMode =
       agent.adapterType === "codex_local" && transientRecovery?.errorFamily === "transient_upstream"
         ? resolveCodexTransientFallbackMode(nextAttempt)
         : null;
     const transientRetryNotBefore = transientRecovery?.retryNotBefore ?? null;
-    const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
 
     if (!baseSchedule) {
       await appendRunEvent(run, await nextRunEventSeq(run.id), {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Claude Local agents reuse sessions across many heartbeat runs.
> - Some long sessions hit Claude's prompt-size wall.
> - The old code marked that deterministic failure as transient.
> - The old code also did not force a fresh session after the overflow.
> - This pull request gives overflow its own error code, blocks plain retries, and rotates the next run onto a fresh session.
> - The benefit is that agents stop burning runs in a dead retry loop.

## Linked Issues or Issue Description

Fixes #7733.

## What Changed

- Classify Claude `Prompt is too long` failures as deterministic `claude_context_overflow`.
- Keep prompt overflow off the bounded transient retry path.
- Recalibrate the default `claude_local` session policy to `12` runs and `8` hours.
- Force session rotation when the latest persisted run for the active session overflowed.
- Select `heartbeatRuns.errorCode` inside `evaluateSessionCompaction()` so the force-rotate path is live on the production data path.
- Add an embedded-Postgres regression test that seeds a real overflow row and proves the fresh-session handoff end to end.
- Keep repeated prompt-overflow streaks attributable in productivity review output.

## Verification

- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps`
- `cd server && NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit`
  - No `heartbeat.ts` errors remain.
  - The only diagnostics are the pre-existing `TS2307` and plugin-host typing errors already present on `master`.
- `pnpm run preflight:workspace-links && pnpm exec vitest run packages/adapters/claude-local/src/server/parse.test.ts server/src/__tests__/claude-local-execute.test.ts server/src/__tests__/heartbeat-retry-scheduling.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts server/src/__tests__/heartbeat-session-compaction.test.ts server/src/__tests__/productivity-review-service.test.ts --reporter=dot`
  - Result: `6` files passed and `234` tests passed.

## Risks

- This PR changes retry and session-rotation behavior for `claude_local` runs. Regressions would show up as unexpected fresh-session starts or skipped retries.
- Historical runs keep their old error codes. Only new runs get the deterministic overflow classification.
- CI is still pending. Merge should wait for the required checks.

## Model Used

- OpenAI Codex via the local `codex_local` adapter.
- Tool use enabled.
- Shell execution enabled.
- Exact public model version string is not exposed in this runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
