### PR TITLE
fix(api): reject unknown issue patch fields

### DIFF
--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -34,6 +34,8 @@ The response also includes:
 - `planDocument`: the full text of the issue document with key `plan`, when present
 - `documentSummaries`: metadata for all linked issue documents
 - `legacyPlanDocument`: a read-only fallback when the description still contains an old `<plan>` block
+- `blockedBy`: summaries of issues that block this issue
+- `blocks`: summaries of issues this issue blocks
 
 ## Create Issue
 
@@ -64,7 +66,9 @@ Headers: X-Paperclip-Run-Id: {runId}
 
 The optional `comment` field adds a comment in the same call.
 
-Updatable fields: `title`, `description`, `status`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`.
+Updatable fields include `title`, `description`, `status`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, and `blockedByIssueIds`.
+
+`blockedByIssueIds` replaces the issue's blocker set. Relation summaries are read back as `blockedBy` and `blocks`; those response fields are read-only and are not accepted as PATCH keys. Unknown or read-only PATCH fields return `400 Validation error` instead of being silently ignored.
 
 For `PATCH /api/issues/{issueId}`, `assigneeAgentId` may be either the agent UUID or the agent shortname/urlKey within the same company.
 

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -105,7 +105,7 @@ describe("issue validators", () => {
       createdByUserId: "spoofed-creator",
       responsibleUserId: "spoofed-responsible",
     });
-    const updated = updateIssueSchema.parse({
+    const updated = updateIssueSchema.safeParse({
       title: "Do not update attribution",
       createdByUserId: "spoofed-creator",
       responsibleUserId: "spoofed-responsible",
@@ -113,8 +113,14 @@ describe("issue validators", () => {
 
     expect(created.createdByUserId).toBe("spoofed-creator");
     expect(created.responsibleUserId).toBe("spoofed-responsible");
-    expect(updated).not.toHaveProperty("createdByUserId");
-    expect(updated).not.toHaveProperty("responsibleUserId");
+    expect(updated.success).toBe(false);
+  });
+
+  it("rejects read-only issue relation fields on update", () => {
+    const blockerId = "00000000-0000-4000-8000-000000000001";
+
+    expect(updateIssueSchema.safeParse({ blockedByIssueIds: [blockerId] }).success).toBe(true);
+    expect(updateIssueSchema.safeParse({ blockedBy: [{ id: blockerId }] }).success).toBe(false);
   });
 
   it("allows false-positive recovery resolutions to atomically restore the source issue status", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -541,7 +541,7 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),
   hiddenAt: z.string().datetime().nullable().optional(),
-});
+}).strict();
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
 export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorkspaceSettingsSchema>;

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1466,6 +1466,19 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalled();
   });
 
+  it("rejects read-only blocker relations instead of silently accepting them", async () => {
+    const res = await request(await createApp(boardActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedBy: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+    expect(res.body.details).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "unrecognized_keys", keys: ["blockedBy"] }),
+    ]));
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("allows agents with the active-checkout management grant to mutate active checkouts", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: input.action === "issue:mutate" || input.action === "tasks:manage_active_checkouts",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3626,6 +3626,49 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     expect(child.blocks).toEqual([]);
   });
 
+  it("persists blocked-by relations when updating an existing child issue", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const parentId = randomUUID();
+    const blockerId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Parent",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocker",
+        status: "todo",
+        priority: "high",
+      },
+    ]);
+    const { issue: child } = await svc.createChild(parentId, {
+      title: "Child issue",
+      status: "blocked",
+      priority: "medium",
+    });
+
+    await svc.update(child.id, { blockedByIssueIds: [blockerId] });
+
+    const updatedChild = await svc.getById(child.id);
+    const childRelations = await svc.getRelationSummaries(child.id);
+    const blockerRelations = await svc.getRelationSummaries(blockerId);
+    expect(updatedChild?.parentId).toBe(parentId);
+    expect(childRelations.blockedBy.map((relation) => relation.id)).toEqual([blockerId]);
+    expect(blockerRelations.blocks.map((relation) => relation.id)).toEqual([child.id]);
+  });
+
   it("returns blocks summaries when child creation blocks the parent", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -202,7 +202,7 @@ import { deliverAgentUnblockNotification } from "../services/routable-blocked.js
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
-});
+}).strict();
 const refreshExternalObjectsSchema = z.object({
   objectIds: z.array(z.string().uuid()).max(50).optional(),
 }).strict();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane people use to coordinate AI agents and their work
> - Issue dependencies are first-class relations that drive blocked-state visibility and automatic wakeups
> - The issue PATCH validator currently strips unknown keys, so a response-only relation key can return success without changing the dependency graph
> - That silent-success behavior makes malformed blocker writes indistinguishable from a persistence defect
> - Existing-child blocker updates also need an explicit regression so hierarchy cannot accidentally change relation persistence
> - This pull request makes issue PATCH fail closed, locks in child-update persistence, and documents the asymmetric write/read contract
> - The benefit is that callers either persist the requested blocker edge or receive an actionable 400 response

## Linked Issues or Issue Description

Bug report:

- **What happened:** `PATCH /api/issues/{issueId}` accepted unknown or response-only fields such as `blockedBy`, returned 200, and silently discarded them.
- **Expected behavior:** callers must use `blockedByIssueIds`; unsupported PATCH keys should return 400, and correct blocker updates must persist when the target issue is itself a child.
- **Impact:** a caller can believe it created a dependency while the issue remains blocked without a first-class blocker edge.

## What Changed

- Made the shared issue-update schema and HTTP route reject unknown PATCH keys.
- Added an HTTP regression proving `blockedBy` returns `400 Validation error` before the mutation service runs.
- Added an embedded-database regression proving `blockedByIssueIds` persists bidirectionally on an existing child issue without changing its parent.
- Documented `blockedByIssueIds` as the write field and `blockedBy` / `blocks` as read-only response fields.

## Verification

- `vitest run packages/shared/src/validators/issue.test.ts` - 28 passed.
- Focused issue-route regression - 1 passed (71 unrelated tests skipped by filter).
- `tsc -p packages/shared/tsconfig.json --noEmit` - passed.
- `tsc -p server/tsconfig.json --noEmit` - passed.
- The embedded-Postgres regression is included for Linux CI; this Windows host skipped that suite because its native embedded-Postgres data bundle is unavailable.

## Risks

- **Intentional compatibility change:** clients that relied on unsupported fields being silently ignored will now receive HTTP 400 and must correct their payload.
- Correctly shaped PATCH requests are unchanged. There is no database migration and no change to blocker persistence logic.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, max reasoning, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge