### PR TITLE
fix(server): fail deleted-issue wakeups before preparation

### DIFF
--- a/server/src/__tests__/heartbeat-missing-issue-execution.test.ts
+++ b/server/src/__tests__/heartbeat-missing-issue-execution.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getMissingIssueExecutionFailure } from "../services/heartbeat.ts";
+
+describe("heartbeat missing issue execution guard", () => {
+  it("returns a safe failure for a wakeup whose issue disappeared before execution", () => {
+    expect(getMissingIssueExecutionFailure("issue-1", null)).toEqual({
+      error: "Issue not found at execution time",
+      errorCode: "issue_not_found",
+    });
+  });
+
+  it("does not reject issue-less or resolvable execution contexts", () => {
+    expect(getMissingIssueExecutionFailure(null, null)).toBeNull();
+    expect(getMissingIssueExecutionFailure("issue-1", { id: "issue-1" })).toBeNull();
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2770,6 +2770,14 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+export function getMissingIssueExecutionFailure(issueId: string | null, issueContext: unknown) {
+  if (!issueId || issueContext) return null;
+  return {
+    error: "Issue not found at execution time",
+    errorCode: "issue_not_found" as const,
+  };
+}
+
 function sanitizeAgentSessionMessageText(value: unknown): string | null {
   const text = readNonEmptyString(value);
   if (!text) return null;
@@ -12628,6 +12636,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
+    const missingIssueExecutionFailure = getMissingIssueExecutionFailure(issueId, issueContext);
+    if (missingIssueExecutionFailure) {
+      await setRunStatus(run.id, "failed", {
+        error: missingIssueExecutionFailure.error,
+        errorCode: missingIssueExecutionFailure.errorCode,
+        finishedAt: new Date(),
+      });
+      await setWakeupStatus(run.wakeupRequestId, "failed", {
+        finishedAt: new Date(),
+        error: missingIssueExecutionFailure.error,
+      });
+      const failedRun = await getRun(run.id);
+      if (failedRun) {
+        await appendRunEvent(failedRun, await nextRunEventSeq(failedRun.id), {
+          eventType: "error",
+          stream: "system",
+          level: "error",
+          message: missingIssueExecutionFailure.error,
+        });
+        await releaseIssueExecutionAndPromote(failedRun);
+      }
+      await finalizeAgentStatus(agent.id, "failed");
+      return;
+    }
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
       : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service creates and executes agent runs for assigned tasks.
> - The queue checks that a task exists before it creates an executable run.
> - A task can still be deleted after queueing and before run execution.
> - The executor must stop before it prepares task sessions, workspaces, or environment leases.
> - This pull request adds the missing execution-time check and a focused regression test.
> - The benefit is that deleted tasks cannot create orphaned execution resources.

## Linked Issues or Issue Description

- Bug: An issue can exist when Paperclip queues a heartbeat and disappear before `executeRun` resolves its execution context.
- Expected behavior: Paperclip must fail the run with `issue_not_found`, fail its wake request, release the issue execution lock, and return before task-scoped preparation.
- Reproduction: Queue a run for an issue. Delete the issue before `executeRun` loads the issue context. Run the queued heartbeat.
- Version: Current `master` at `a6436126c`.
- Deployment mode: All deployment modes that execute queued heartbeat runs.

## What Changed

- Added an execution-time missing-issue guard immediately after issue context resolution.
- Failed the heartbeat run and wake request with a stable `issue_not_found` result.
- Added a system error event and released issue execution before returning.
- Added focused tests for missing, issue-less, and valid issue contexts.

## Verification

- `pnpm exec vitest run server/src/__tests__/heartbeat-missing-issue-execution.test.ts` passed with 2 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- The fork pre-push gate completed the monorepo typecheck.
- The full test gate found unrelated failures in `workspace-runtime.test.ts` and `heartbeat-workspace-branch-containment.test.ts` on current `master`. The changed files do not touch workspace-runtime code.
- `git diff --check` passed before the commit.

## Risks

- Low risk. The new branch runs only when an issue ID exists but its execution context does not.
- The guard changes that race from continued preparation to an explicit failed run.
- The existing producer-side transactional guard remains unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with `gpt-5`, reasoning and tool use enabled. The runtime did not expose a context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/no-internal-issue-references`, `fix/sandbox-secret-resolution`, `feat/adapter-retry-backoff`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
