### PR TITLE
Redact issue-document persistence and propagation

### DIFF
--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -161,6 +161,59 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
     expect(JSON.stringify({ storedDocument, storedRevisions, fetched, revisions })).toContain("Ordinary prose: status is pending.");
   });
 
+  it("redacts legacy revision text before restoring it into current document state", async () => {
+    const { issueId } = await createIssueWithDocuments();
+    const legacyValue = "test-only-restored-sensitive-value";
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "security-notes",
+      title: "Safe title",
+      format: "markdown",
+      body: "Safe body",
+    });
+
+    // Simulate a pre-redaction revision, then ensure a restore cannot copy it
+    // into the current document or a newly-created revision in plaintext.
+    await db
+      .update(documentRevisions)
+      .set({
+        title: `PAPERCLIP_API_KEY=${legacyValue}`,
+        body: `password: ${legacyValue}`,
+      })
+      .where(eq(documentRevisions.id, created.document.latestRevisionId));
+    const updated = await svc.upsertIssueDocument({
+      issueId,
+      key: "security-notes",
+      title: "Current safe title",
+      format: "markdown",
+      body: "Current safe body",
+      baseRevisionId: created.document.latestRevisionId,
+    });
+
+    const restored = await svc.restoreIssueDocumentRevision({
+      issueId,
+      key: "security-notes",
+      revisionId: created.document.latestRevisionId!,
+    });
+    const storedDocument = await db
+      .select()
+      .from(documents)
+      .where(eq(documents.id, restored.document.id))
+      .then((rows) => rows[0]);
+    const restoredRevision = await db
+      .select()
+      .from(documentRevisions)
+      .where(eq(documentRevisions.id, restored.document.latestRevisionId!))
+      .then((rows) => rows[0]);
+
+    expect(updated.document.latestRevisionId).not.toBe(restored.document.latestRevisionId);
+    expect(JSON.stringify({ restored, storedDocument, restoredRevision })).not.toContain(legacyValue);
+    expect(restored.document).toEqual(expect.objectContaining({
+      title: "PAPERCLIP_API_KEY=***REDACTED***",
+      body: "password: ***REDACTED***",
+    }));
+  });
+
   it("redacts legacy document rows at every service output boundary", async () => {
     const { issueId } = await createIssueWithDocuments();
     const legacyValue = "test-only-legacy-sensitive-value";

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   companies,
   createDb,
@@ -111,5 +112,52 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
       key: ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
       body: "# Handoff",
     }));
+  });
+
+  it("redacts document text before persistence and returned downstream payloads", async () => {
+    const { issueId } = await createIssueWithDocuments();
+    const inputValue = "test-only-sensitive-value";
+
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "security-notes",
+      title: `Credential PAPERCLIP_API_KEY=${inputValue}`,
+      format: "markdown",
+      body: `# Notes\n\nOPENAI_API_KEY: ${inputValue}\n\nOrdinary prose: follow up with the vendor.`,
+      changeSummary: `Added secret=${inputValue}`,
+    });
+    const updated = await svc.upsertIssueDocument({
+      issueId,
+      key: "security-notes",
+      title: `Updated AUTH_TOKEN=${inputValue}`,
+      format: "markdown",
+      body: `Updated password: ${inputValue}\n\nOrdinary prose: status is pending.`,
+      changeSummary: `Updated token=${inputValue}`,
+      baseRevisionId: created.document.latestRevisionId,
+    });
+
+    const storedDocument = await db
+      .select()
+      .from(documents)
+      .where(eq(documents.id, updated.document.id))
+      .then((rows) => rows[0]);
+    const storedRevisions = await db
+      .select()
+      .from(documentRevisions)
+      .where(eq(documentRevisions.documentId, updated.document.id));
+    const fetched = await svc.getIssueDocumentByKey(issueId, "security-notes");
+    const revisions = await svc.listIssueDocumentRevisions(issueId, "security-notes");
+
+    expect(updated.document).toEqual(expect.objectContaining({
+      title: "Updated AUTH_TOKEN=***REDACTED***",
+      body: "Updated password: ***REDACTED***\n\nOrdinary prose: status is pending.",
+    }));
+    expect(fetched).toEqual(expect.objectContaining({
+      title: updated.document.title,
+      body: updated.document.body,
+      latestRevisionId: updated.document.latestRevisionId,
+    }));
+    expect(JSON.stringify({ storedDocument, storedRevisions, fetched, revisions })).not.toContain(inputValue);
+    expect(JSON.stringify({ storedDocument, storedRevisions, fetched, revisions })).toContain("Ordinary prose: status is pending.");
   });
 });

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -160,4 +160,49 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
     expect(JSON.stringify({ storedDocument, storedRevisions, fetched, revisions })).not.toContain(inputValue);
     expect(JSON.stringify({ storedDocument, storedRevisions, fetched, revisions })).toContain("Ordinary prose: status is pending.");
   });
+
+  it("redacts legacy document rows at every service output boundary", async () => {
+    const { issueId } = await createIssueWithDocuments();
+    const legacyValue = "test-only-legacy-sensitive-value";
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "security-notes",
+      title: "Safe title",
+      format: "markdown",
+      body: "Safe body",
+      changeSummary: "Safe summary",
+    });
+
+    await db
+      .update(documents)
+      .set({
+        title: `PAPERCLIP_API_KEY=${legacyValue}`,
+        latestBody: `password: ${legacyValue}`,
+      })
+      .where(eq(documents.id, created.document.id));
+    await db
+      .update(documentRevisions)
+      .set({
+        title: `AUTH_TOKEN=${legacyValue}`,
+        body: `token=${legacyValue}`,
+        changeSummary: `secret=${legacyValue}`,
+      })
+      .where(eq(documentRevisions.id, created.document.latestRevisionId));
+
+    const fetched = await svc.getIssueDocumentByKey(issueId, "security-notes");
+    const listed = await svc.listIssueDocuments(issueId);
+    const payload = await svc.getIssueDocumentPayload({ id: issueId, description: null });
+    const revisions = await svc.listIssueDocumentRevisions(issueId, "security-notes");
+
+    expect(JSON.stringify({ fetched, listed, payload, revisions })).not.toContain(legacyValue);
+    expect(fetched).toEqual(expect.objectContaining({
+      title: "PAPERCLIP_API_KEY=***REDACTED***",
+      body: "password: ***REDACTED***",
+    }));
+    expect(revisions[0]).toEqual(expect.objectContaining({
+      title: "AUTH_TOKEN=***REDACTED***",
+      body: "token=***REDACTED***",
+      changeSummary: "secret=***REDACTED***",
+    }));
+  });
 });

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -258,4 +258,27 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
       changeSummary: "secret=***REDACTED***",
     }));
   });
+
+  it("redacts a legacy document title before returning it for deletion activity", async () => {
+    const { issueId } = await createIssueWithDocuments();
+    const legacyValue = "test-only-deleted-document-secret";
+    const created = await svc.upsertIssueDocument({
+      issueId,
+      key: "security-notes",
+      title: "Safe title",
+      format: "markdown",
+      body: "Safe body",
+    });
+    await db
+      .update(documents)
+      .set({ title: `PAPERCLIP_API_KEY=${legacyValue}` })
+      .where(eq(documents.id, created.document.id));
+
+    const removed = await svc.deleteIssueDocument(issueId, "security-notes");
+
+    expect(removed).toEqual(expect.objectContaining({
+      title: "PAPERCLIP_API_KEY=***REDACTED***",
+    }));
+    expect(JSON.stringify(removed)).not.toContain(legacyValue);
+  });
 });

--- a/server/src/__tests__/feedback-service.test.ts
+++ b/server/src/__tests__/feedback-service.test.ts
@@ -508,7 +508,12 @@ describe("feedbackService.saveIssueVote", () => {
   });
 
   it("stores a trace record for document revision feedback targets", async () => {
-    const { issueId, revisionId } = await seedIssueWithAgentDocument();
+    const { companyId, issueId, revisionId } = await seedIssueWithAgentDocument();
+    const legacyValue = "test-only-legacy-document-title-value";
+    await db
+      .update(documents)
+      .set({ title: `PAPERCLIP_API_KEY=${legacyValue}` })
+      .where(eq(documents.companyId, companyId));
 
     const result = await svc.saveIssueVote({
       issueId,
@@ -537,8 +542,14 @@ describe("feedbackService.saveIssueVote", () => {
       type: "issue_document_revision",
       id: revisionId,
       documentKey: "plan",
+      documentTitle: "PAPERCLIP_API_KEY=***REDACTED***",
       revisionNumber: 1,
     });
+    const bundle = traces[0]?.payloadSnapshot?.bundle as Record<string, unknown> | null;
+    const primaryContent = bundle?.primaryContent as Record<string, unknown> | null;
+    expect(primaryContent?.documentTitle).toBe("PAPERCLIP_API_KEY=***REDACTED***");
+    expect(traces[0]?.targetSummary.documentTitle).toBe("PAPERCLIP_API_KEY=***REDACTED***");
+    expect(JSON.stringify(traces[0])).not.toContain(legacyValue);
   });
 
   it("stores a downvote reason and includes it in the trace payload", async () => {

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -266,6 +266,41 @@ describe("issue activity event routes", () => {
     });
   }, 15_000);
 
+  it("redacts updated issue text before activity details are persisted or propagated", async () => {
+    const issue = makeIssue();
+    const rawValue = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6";
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      title: "Updated PAPERCLIP_API_KEY=***REDACTED***",
+      description: "Updated secret: ***REDACTED***",
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${issue.id}`)
+      .send({
+        title: `Updated PAPERCLIP_API_KEY=${rawValue}`,
+        description: `Updated secret: ${rawValue}`,
+      });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "issue.updated",
+          details: expect.objectContaining({
+            title: "Updated PAPERCLIP_API_KEY=***REDACTED***",
+            description: "Updated secret: ***REDACTED***",
+          }),
+        }),
+      );
+    });
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain(rawValue);
+  });
+
   it("logs explicit reviewer and approver activity when execution policy participants change", async () => {
     const existingPolicy = normalizeIssueExecutionPolicy({
       stages: [

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -268,21 +268,22 @@ describe("issue activity event routes", () => {
 
   it("redacts updated issue text before activity details are persisted or propagated", async () => {
     const issue = makeIssue();
-    const rawValue = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6";
+    const bearerCredential = "A1b2C3d4E5f6G7h8I9j0K1l2";
+    const credentialUrl = "https://build-user:TestOnlyPass123@example.test/hooks";
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...issue,
       ...patch,
-      title: "Updated PAPERCLIP_API_KEY=***REDACTED***",
-      description: "Updated secret: ***REDACTED***",
+      title: "Updated Bearer ***REDACTED***",
+      description: "Updated callback https://***REDACTED***@example.test/hooks",
       updatedAt: new Date(),
     }));
 
     const res = await request(await createApp())
       .patch(`/api/issues/${issue.id}`)
       .send({
-        title: `Updated PAPERCLIP_API_KEY=${rawValue}`,
-        description: `Updated secret: ${rawValue}`,
+        title: `Updated Bearer ${bearerCredential}`,
+        description: `Updated callback ${credentialUrl}`,
       });
 
     expect(res.status).toBe(200);
@@ -292,13 +293,15 @@ describe("issue activity event routes", () => {
         expect.objectContaining({
           action: "issue.updated",
           details: expect.objectContaining({
-            title: "Updated PAPERCLIP_API_KEY=***REDACTED***",
-            description: "Updated secret: ***REDACTED***",
+            title: "Updated Bearer ***REDACTED***",
+            description: "Updated callback https://***REDACTED***@example.test/hooks",
           }),
         }),
       );
     });
-    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain(rawValue);
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain(bearerCredential);
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("build-user");
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("TestOnlyPass123");
   });
 
   it("logs explicit reviewer and approver activity when execution policy participants change", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -408,6 +408,39 @@ describe("agent issue mutation checkout ownership", () => {
     );
   });
 
+  it("redacts issue document text before handing it to persistence", async () => {
+    const inputValue = "test-only-sensitive-value";
+    mockDocumentService.upsertIssueDocument.mockResolvedValueOnce({
+      created: true,
+      document: {
+        id: "document-1",
+        key: "plan",
+        title: "PAPERCLIP_API_KEY=***REDACTED***",
+        format: "markdown",
+        body: "password: ***REDACTED***",
+        latestRevisionId: "revision-1",
+        latestRevisionNumber: 1,
+      },
+    });
+
+    const res = await request(await createApp(ownerActor()))
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .send({
+        title: `PAPERCLIP_API_KEY=${inputValue}`,
+        format: "markdown",
+        body: `password: ${inputValue}`,
+        changeSummary: `token=${inputValue}`,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalledWith(expect.objectContaining({
+      title: "PAPERCLIP_API_KEY=***REDACTED***",
+      body: "password: ***REDACTED***",
+      changeSummary: "token=***REDACTED***",
+    }));
+    expect(JSON.stringify(res.body)).not.toContain(inputValue);
+  });
+
   it("preserves board mutations on active checkouts", async () => {
     const app = await createApp(boardActor());
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -499,6 +499,8 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   it("redacts issue text before persisting creates, updates, and comments", async () => {
     const companyId = randomUUID();
     const inputValue = "test-only-sensitive-value";
+    const bearerCredential = "A1b2C3d4E5f6G7h8I9j0K1l2";
+    const credentialUrl = "https://build-user:TestOnlyPass123@example.test/hooks";
 
     await db.insert(companies).values({
       id: companyId,
@@ -508,14 +510,14 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
 
     const created = await svc.create(companyId, {
-      title: `Create PAPERCLIP_API_KEY=${inputValue}`,
-      description: `Description OPENAI_API_KEY: ${inputValue}`,
+      title: `Create Bearer ${bearerCredential}`,
+      description: `Description callback ${credentialUrl}`,
     });
     await svc.update(created.id, {
       title: `Update AUTH_TOKEN=${inputValue}`,
       description: `Updated password: ${inputValue}`,
     });
-    const comment = await svc.addComment(created.id, `Comment secret=${inputValue}`, {});
+    const comment = await svc.addComment(created.id, `Comment Bearer ${bearerCredential} ${credentialUrl}`, {});
     const [storedIssue] = await db.select().from(issues).where(eq(issues.id, created.id));
     const [storedComment] = await db.select().from(issueComments).where(eq(issueComments.id, comment.id));
 
@@ -523,8 +525,11 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       title: "Update AUTH_TOKEN=***REDACTED***",
       description: "Updated password: ***REDACTED***",
     }));
-    expect(storedComment?.body).toBe("Comment secret=***REDACTED***");
+    expect(storedComment?.body).toBe("Comment Bearer ***REDACTED*** https://***REDACTED***@example.test/hooks");
     expect(JSON.stringify({ storedIssue, storedComment })).not.toContain(inputValue);
+    expect(JSON.stringify({ storedIssue, storedComment })).not.toContain(bearerCredential);
+    expect(JSON.stringify({ storedIssue, storedComment })).not.toContain("build-user");
+    expect(JSON.stringify({ storedIssue, storedComment })).not.toContain("TestOnlyPass123");
   });
 
   it("filters issues by execution workspace id", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -495,6 +495,38 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   it("returns null instead of throwing for malformed non-uuid issue refs", async () => {
     await expect(svc.getById("not-a-uuid")).resolves.toBeNull();
   });
+
+  it("redacts issue text before persisting creates, updates, and comments", async () => {
+    const companyId = randomUUID();
+    const inputValue = "test-only-sensitive-value";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const created = await svc.create(companyId, {
+      title: `Create PAPERCLIP_API_KEY=${inputValue}`,
+      description: `Description OPENAI_API_KEY: ${inputValue}`,
+    });
+    await svc.update(created.id, {
+      title: `Update AUTH_TOKEN=${inputValue}`,
+      description: `Updated password: ${inputValue}`,
+    });
+    const comment = await svc.addComment(created.id, `Comment secret=${inputValue}`, {});
+    const [storedIssue] = await db.select().from(issues).where(eq(issues.id, created.id));
+    const [storedComment] = await db.select().from(issueComments).where(eq(issueComments.id, comment.id));
+
+    expect(storedIssue).toEqual(expect.objectContaining({
+      title: "Update AUTH_TOKEN=***REDACTED***",
+      description: "Updated password: ***REDACTED***",
+    }));
+    expect(storedComment?.body).toBe("Comment secret=***REDACTED***");
+    expect(JSON.stringify({ storedIssue, storedComment })).not.toContain(inputValue);
+  });
+
   it("filters issues by execution workspace id", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -189,6 +189,38 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     ).rejects.toThrow("Plugin may only use originKind values under plugin:paperclip.missions");
   });
 
+  it("uses persisted redacted issue text in plugin update activity", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+    const issue = await services.issues.create({
+      companyId,
+      title: "Initial issue title",
+      description: "Initial issue description",
+    });
+    const sensitiveValue = "test-only-plugin-update-sensitive-value";
+
+    await services.issues.update({
+      companyId,
+      issueId: issue.id,
+      patch: {
+        title: `PAPERCLIP_API_KEY=${sensitiveValue}`,
+        description: `PAPERCLIP_API_KEY=${sensitiveValue}`,
+      },
+    });
+
+    const [activity] = await db
+      .select({ details: activityLog.details })
+      .from(activityLog)
+      .where(and(eq(activityLog.entityType, "issue"), eq(activityLog.entityId, issue.id), eq(activityLog.action, "issue.updated")));
+    const patch = (activity?.details as Record<string, unknown> | null)?.patch as Record<string, unknown> | undefined;
+
+    expect(patch).toMatchObject({
+      title: "PAPERCLIP_API_KEY=***REDACTED***",
+      description: "PAPERCLIP_API_KEY=***REDACTED***",
+    });
+    expect(JSON.stringify(activity)).not.toContain(sensitiveValue);
+  });
+
   it("asserts checkout ownership for run-scoped plugin actions", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -85,6 +85,13 @@ describe("redaction", () => {
     expect(result).not.toContain(jwt);
   });
 
+  it("redacts secret-looking environment assignments in issue-style prose", () => {
+    const result = redactSensitiveText("Investigation notes: PAPERCLIP_API_KEY: test-only-sensitive-value");
+
+    expect(result).toContain(REDACTED_EVENT_VALUE);
+    expect(result).not.toContain("test-only-sensitive-value");
+  });
+
   it("redacts inline secrets from command metadata without hiding safe command text", () => {
     const input = {
       command: "custom-acp --token ghp_example_secret env OPENAI_API_KEY=sk-live-example custom-acp",

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -102,6 +102,27 @@ describe("redaction", () => {
     expect(secret).not.toContain(opaqueValue);
   });
 
+  it("redacts opaque bearer credentials without a header colon while preserving ordinary prose", () => {
+    const credential = "A1b2C3d4E5f6G7h8I9j0K1l2";
+    const redacted = redactSensitiveText(`Paste Bearer ${credential} into the request`);
+    const ordinary = redactSensitiveText("The bearer token flow is documented in the guide");
+
+    expect(redacted).toBe(`Paste Bearer ${REDACTED_EVENT_VALUE} into the request`);
+    expect(redacted).not.toContain(credential);
+    expect(ordinary).toBe("The bearer token flow is documented in the guide");
+  });
+
+  it("redacts URL userinfo credentials while preserving benign URLs", () => {
+    const credentialUrl = "https://build-user:TestOnlyPass123@example.test/hooks?mode=sync";
+    const redacted = redactSensitiveText(`Callback: ${credentialUrl}`);
+    const benign = "Read https://docs.example.test:8443/guides/auth?mode=public";
+
+    expect(redacted).toBe(`Callback: https://${REDACTED_EVENT_VALUE}@example.test/hooks?mode=sync`);
+    expect(redacted).not.toContain("build-user");
+    expect(redacted).not.toContain("TestOnlyPass123");
+    expect(redactSensitiveText(benign)).toBe(benign);
+  });
+
   it("redacts inline secrets from command metadata without hiding safe command text", () => {
     const input = {
       command: "custom-acp --token ghp_example_secret env OPENAI_API_KEY=sk-live-example custom-acp",

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -92,6 +92,16 @@ describe("redaction", () => {
     expect(result).not.toContain("test-only-sensitive-value");
   });
 
+  it("preserves ordinary colon prose while redacting convincingly secret-shaped values", () => {
+    const ordinary = redactSensitiveText("Investigation notes: secret: follow up with the vendor");
+    const opaqueValue = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6";
+    const secret = redactSensitiveText(`Investigation notes: secret: ${opaqueValue}`);
+
+    expect(ordinary).toBe("Investigation notes: secret: follow up with the vendor");
+    expect(secret).toContain(REDACTED_EVENT_VALUE);
+    expect(secret).not.toContain(opaqueValue);
+  });
+
   it("redacts inline secrets from command metadata without hiding safe command text", () => {
     const input = {
       command: "custom-acp --token ghp_example_secret env OPENAI_API_KEY=sk-live-example custom-acp",

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -112,6 +112,14 @@ describe("redaction", () => {
     expect(ordinary).toBe("The bearer token flow is documented in the guide");
   });
 
+  it("preserves the Authorization Bearer header shape while redacting its credential", () => {
+    const credential = "test-only-bearer-credential";
+
+    expect(redactSensitiveText(`Authorization: Bearer ${credential}`)).toBe(
+      `Authorization: Bearer ${REDACTED_EVENT_VALUE}`,
+    );
+  });
+
   it("redacts URL userinfo credentials while preserving benign URLs", () => {
     const credentialUrl = "https://build-user:TestOnlyPass123@example.test/hooks?mode=sync";
     const redacted = redactSensitiveText(`Callback: ${credentialUrl}`);

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -13,8 +13,16 @@ const JSON_SECRET_FIELD_TEXT_RE =
 const ESCAPED_JSON_SECRET_FIELD_TEXT_RE =
   /((?:\\")?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))/gi;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
-const TEXT_SECRET_ASSIGNMENT_RE =
-  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*[:=]\s*["']?)[^\s"'`]+/gi;
+// `secret: status` is common prose, so colon-form redaction is deliberately
+// narrower than equals-form redaction. Uppercase environment-style names are
+// always treated as secret assignments; other colon forms need an opaque
+// credential shape before they are redacted.
+const TEXT_ENV_SECRET_ASSIGNMENT_RE =
+  /(\b[A-Z][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION|JWT)[A-Z0-9_]*\s*[:=]\s*["']?)[^\s"'`]+/g;
+const TEXT_NAMED_SECRET_EQUALS_RE =
+  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*=\s*["']?)[^\s"'`]+/gi;
+const TEXT_NAMED_SECRET_COLON_RE =
+  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*:\s*["']?)(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?|[A-Za-z0-9+/=_-]{32,})/gi;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
@@ -99,5 +107,7 @@ export function redactSensitiveText(input: string): string {
   return redactCommandText(input, REDACTED_EVENT_VALUE)
     .replace(JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
     .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
-    .replace(TEXT_SECRET_ASSIGNMENT_RE, `$1${REDACTED_EVENT_VALUE}`);
+    .replace(TEXT_ENV_SECRET_ASSIGNMENT_RE, `$1${REDACTED_EVENT_VALUE}`)
+    .replace(TEXT_NAMED_SECRET_EQUALS_RE, `$1${REDACTED_EVENT_VALUE}`)
+    .replace(TEXT_NAMED_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`);
 }

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -21,8 +21,10 @@ const TEXT_ENV_SECRET_ASSIGNMENT_RE =
   /(\b[A-Z][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION|JWT)[A-Z0-9_]*\s*[:=]\s*["']?)[^\s"'`]+/g;
 const TEXT_NAMED_SECRET_EQUALS_RE =
   /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*=\s*["']?)[^\s"'`]+/gi;
-const TEXT_NAMED_SECRET_COLON_RE =
-  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*:\s*["']?)(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?|[A-Za-z0-9+/=_-]{32,})/gi;
+const TEXT_CLEAR_SECRET_COLON_RE =
+  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*:\s*["']?)[^\s"'`]+/gi;
+const TEXT_AMBIGUOUS_SECRET_COLON_RE =
+  /(secret\s*:\s*["']?)(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?|[A-Za-z0-9+/=_-]{32,})/gi;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
@@ -109,5 +111,6 @@ export function redactSensitiveText(input: string): string {
     .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
     .replace(TEXT_ENV_SECRET_ASSIGNMENT_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_NAMED_SECRET_EQUALS_RE, `$1${REDACTED_EVENT_VALUE}`)
-    .replace(TEXT_NAMED_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`);
+    .replace(TEXT_CLEAR_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`)
+    .replace(TEXT_AMBIGUOUS_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`);
 }

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -25,6 +25,15 @@ const TEXT_CLEAR_SECRET_COLON_RE =
   /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*:\s*["']?)[^\s"'`]+/gi;
 const TEXT_AMBIGUOUS_SECRET_COLON_RE =
   /(secret\s*:\s*["']?)(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?|[A-Za-z0-9+/=_-]{32,})/gi;
+// A bare `Bearer` prefix is common in copied headers, but ordinary prose such
+// as "bearer tokens" must stay readable. Redact only a single opaque token:
+// a known provider shape, JWT, or 24+ character URL-safe/base64-like value.
+const TEXT_BARE_BEARER_CREDENTIAL_RE =
+  /(\bbearer\s+)(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?|[A-Za-z0-9+/=_-]{24,})(?=$|[^A-Za-z0-9+/=_-])/gi;
+// Userinfo is credentials only when it includes a password (`user:password@`).
+// This deliberately leaves normal URLs, ports, and username-only URLs intact.
+const TEXT_URL_EMBEDDED_CREDENTIAL_RE =
+  /(\b[a-z][a-z0-9+.-]*:\/\/)[^\s/?#:@]+:[^\s/?#@]+@/gi;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
@@ -112,5 +121,7 @@ export function redactSensitiveText(input: string): string {
     .replace(TEXT_ENV_SECRET_ASSIGNMENT_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_NAMED_SECRET_EQUALS_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_CLEAR_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`)
-    .replace(TEXT_AMBIGUOUS_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`);
+    .replace(TEXT_AMBIGUOUS_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`)
+    .replace(TEXT_BARE_BEARER_CREDENTIAL_RE, `$1${REDACTED_EVENT_VALUE}`)
+    .replace(TEXT_URL_EMBEDDED_CREDENTIAL_RE, `$1${REDACTED_EVENT_VALUE}@`);
 }

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -13,6 +13,8 @@ const JSON_SECRET_FIELD_TEXT_RE =
 const ESCAPED_JSON_SECRET_FIELD_TEXT_RE =
   /((?:\\")?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))/gi;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
+const TEXT_SECRET_ASSIGNMENT_RE =
+  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*[:=]\s*["']?)[^\s"'`]+/gi;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
@@ -94,10 +96,8 @@ export function redactEventPayload(payload: Record<string, unknown> | null): Rec
 }
 
 export function redactSensitiveText(input: string): string {
-  return redactCommandText(
-    input
-      .replace(JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
-      .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`),
-    REDACTED_EVENT_VALUE,
-  );
+  return redactCommandText(input, REDACTED_EVENT_VALUE)
+    .replace(JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
+    .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
+    .replace(TEXT_SECRET_ASSIGNMENT_RE, `$1${REDACTED_EVENT_VALUE}`);
 }

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -22,7 +22,12 @@ const TEXT_ENV_SECRET_ASSIGNMENT_RE =
 const TEXT_NAMED_SECRET_EQUALS_RE =
   /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*=\s*["']?)[^\s"'`]+/gi;
 const TEXT_CLEAR_SECRET_COLON_RE =
-  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*:\s*["']?)[^\s"'`]+/gi;
+  /((?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization(?!\s*:\s*bearer\b)|bearer|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)\s*:\s*["']?)[^\s"'`]+/gi;
+// Handle copied Authorization headers before generic colon-form redaction.
+// Otherwise the generic matcher consumes only `Bearer`, leaving its credential
+// to a later matcher and corrupting the safe header representation.
+const TEXT_AUTHORIZATION_BEARER_HEADER_RE =
+  /(\bauthorization\s*:\s*bearer\s+)[^\s"'`]+/gi;
 const TEXT_AMBIGUOUS_SECRET_COLON_RE =
   /(secret\s*:\s*["']?)(?:sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?|[A-Za-z0-9+/=_-]{32,})/gi;
 // A bare `Bearer` prefix is common in copied headers, but ordinary prose such
@@ -120,6 +125,7 @@ export function redactSensitiveText(input: string): string {
     .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
     .replace(TEXT_ENV_SECRET_ASSIGNMENT_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_NAMED_SECRET_EQUALS_RE, `$1${REDACTED_EVENT_VALUE}`)
+    .replace(TEXT_AUTHORIZATION_BEARER_HEADER_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_CLEAR_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_AMBIGUOUS_SECRET_COLON_RE, `$1${REDACTED_EVENT_VALUE}`)
     .replace(TEXT_BARE_BEARER_CREDENTIAL_RE, `$1${REDACTED_EVENT_VALUE}`)

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -85,6 +85,7 @@ import {
   redactIssueMonitorExternalRef,
   setIssueExecutionPolicyMonitorScheduledBy,
 } from "../services/issue-execution-policy.js";
+import { redactSensitiveText } from "../redaction.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
@@ -166,6 +167,25 @@ function summarizeIssueReferenceActivityDetails(input:
     ...(input.removedReferencedIssues.length > 0 ? { removedReferencedIssues: input.removedReferencedIssues } : {}),
     ...(input.currentReferencedIssues.length > 0 ? { currentReferencedIssues: input.currentReferencedIssues } : {}),
   };
+}
+
+function redactIssueTextActivityFields(
+  fields: Record<string, unknown>,
+  persistedIssue: { title: string; description: string | null },
+) {
+  const redacted = { ...fields };
+  // Use the persisted values for changed text. This keeps the activity record
+  // on the same redaction boundary as indexing, live events, and plugins.
+  if (typeof fields.title === "string") redacted.title = persistedIssue.title;
+  if (typeof fields.description === "string") redacted.description = persistedIssue.description;
+  return redacted;
+}
+
+function redactPreviousIssueTextActivityFields(fields: Record<string, unknown>) {
+  const redacted = { ...fields };
+  if (typeof fields.title === "string") redacted.title = redactSensitiveText(fields.title);
+  if (typeof fields.description === "string") redacted.description = redactSensitiveText(fields.description);
+  return redacted;
 }
 
 function monitorPoliciesEqual(left: NormalizedExecutionPolicy | null, right: NormalizedExecutionPolicy | null) {
@@ -2395,6 +2415,8 @@ export function issueRoutes(
     }
 
     const hasFieldChanges = Object.keys(previous).length > 0;
+    const activityUpdateFields = redactIssueTextActivityFields(updateFields, issue);
+    const activityPrevious = redactPreviousIssueTextActivityFields(previous);
     const reopened =
       commentBody &&
       effectiveMoveToTodoRequested &&
@@ -2412,14 +2434,14 @@ export function issueRoutes(
       entityType: "issue",
       entityId: issue.id,
       details: {
-        ...updateFields,
+        ...activityUpdateFields,
         identifier: issue.identifier,
         ...(commentBody ? { source: "comment" } : {}),
         ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
         ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus } : {}),
         ...(interruptedRunId ? { interruptedRunId } : {}),
         ...(cancelledStatusRunId ? { cancelledStatusRunId } : {}),
-        _previous: hasFieldChanges ? previous : undefined,
+        _previous: hasFieldChanges ? activityPrevious : undefined,
         ...summarizeIssueReferenceActivityDetails(
           updateReferenceDiff
             ? {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1337,14 +1337,19 @@ export function issueRoutes(
     }
 
     const actor = getActorInfo(req);
+    const redactedDocumentInput = {
+      title: req.body.title == null ? null : redactSensitiveText(req.body.title),
+      body: redactSensitiveText(req.body.body),
+      changeSummary: req.body.changeSummary == null ? null : redactSensitiveText(req.body.changeSummary),
+    };
     const referenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
     const result = await documentsSvc.upsertIssueDocument({
       issueId: issue.id,
       key: keyParsed.data,
-      title: req.body.title ?? null,
+      title: redactedDocumentInput.title,
       format: req.body.format,
-      body: req.body.body,
-      changeSummary: req.body.changeSummary ?? null,
+      body: redactedDocumentInput.body,
+      changeSummary: redactedDocumentInput.changeSummary,
       baseRevisionId: req.body.baseRevisionId ?? null,
       createdByAgentId: actor.agentId ?? null,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
 import { isSystemIssueDocumentKey, issueDocumentKeySchema } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { redactSensitiveText } from "../redaction.js";
 
 function normalizeDocumentKey(key: string) {
   const normalized = key.trim().toLowerCase();
@@ -15,6 +16,18 @@ function normalizeDocumentKey(key: string) {
 
 function isUniqueViolation(error: unknown): boolean {
   return !!error && typeof error === "object" && "code" in error && (error as { code?: string }).code === "23505";
+}
+
+function redactIssueDocumentText(input: {
+  title?: string | null;
+  body: string;
+  changeSummary?: string | null;
+}) {
+  return {
+    title: input.title == null ? null : redactSensitiveText(input.title),
+    body: redactSensitiveText(input.body),
+    changeSummary: input.changeSummary == null ? null : redactSensitiveText(input.changeSummary),
+  };
 }
 
 export function extractLegacyPlanBody(description: string | null | undefined) {
@@ -181,6 +194,10 @@ export function documentService(db: Db) {
       createdByRunId?: string | null;
     }) => {
       const key = normalizeDocumentKey(input.key);
+      // Documents are exposed through activity, plugins, search/reference indexing,
+      // and heartbeat payloads. Redact before any revision or current-document row
+      // is written so every downstream surface receives the safe representation.
+      const redacted = redactIssueDocumentText(input);
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -233,10 +250,10 @@ export function documentService(db: Db) {
                 companyId: issue.companyId,
                 documentId: existing.id,
                 revisionNumber: nextRevisionNumber,
-                title: input.title ?? null,
+                title: redacted.title,
                 format: input.format,
-                body: input.body,
-                changeSummary: input.changeSummary ?? null,
+                body: redacted.body,
+                changeSummary: redacted.changeSummary,
                 createdByAgentId: input.createdByAgentId ?? null,
                 createdByUserId: input.createdByUserId ?? null,
                 createdByRunId: input.createdByRunId ?? null,
@@ -247,9 +264,9 @@ export function documentService(db: Db) {
             await tx
               .update(documents)
               .set({
-                title: input.title ?? null,
+                title: redacted.title,
                 format: input.format,
-                latestBody: input.body,
+                latestBody: redacted.body,
                 latestRevisionId: revision.id,
                 latestRevisionNumber: nextRevisionNumber,
                 updatedByAgentId: input.createdByAgentId ?? null,
@@ -267,9 +284,9 @@ export function documentService(db: Db) {
               created: false as const,
               document: {
                 ...existing,
-                title: input.title ?? null,
+                title: redacted.title,
                 format: input.format,
-                body: input.body,
+                body: redacted.body,
                 latestRevisionId: revision.id,
                 latestRevisionNumber: nextRevisionNumber,
                 updatedByAgentId: input.createdByAgentId ?? null,
@@ -287,9 +304,9 @@ export function documentService(db: Db) {
             .insert(documents)
             .values({
               companyId: issue.companyId,
-              title: input.title ?? null,
+              title: redacted.title,
               format: input.format,
-              latestBody: input.body,
+              latestBody: redacted.body,
               latestRevisionId: null,
               latestRevisionNumber: 1,
               createdByAgentId: input.createdByAgentId ?? null,
@@ -307,10 +324,10 @@ export function documentService(db: Db) {
               companyId: issue.companyId,
               documentId: document.id,
               revisionNumber: 1,
-              title: input.title ?? null,
+              title: redacted.title,
               format: input.format,
-              body: input.body,
-              changeSummary: input.changeSummary ?? null,
+              body: redacted.body,
+              changeSummary: redacted.changeSummary,
               createdByAgentId: input.createdByAgentId ?? null,
               createdByUserId: input.createdByUserId ?? null,
               createdByRunId: input.createdByRunId ?? null,
@@ -400,6 +417,7 @@ export function documentService(db: Db) {
           });
         }
 
+        const redacted = redactIssueDocumentText(revision);
         const now = new Date();
         const nextRevisionNumber = existing.latestRevisionNumber + 1;
         const [restoredRevision] = await tx
@@ -408,9 +426,9 @@ export function documentService(db: Db) {
             companyId: existing.companyId,
             documentId: existing.id,
             revisionNumber: nextRevisionNumber,
-            title: revision.title ?? null,
+            title: redacted.title,
             format: revision.format,
-            body: revision.body,
+            body: redacted.body,
             changeSummary: `Restored from revision ${revision.revisionNumber}`,
             createdByAgentId: input.createdByAgentId ?? null,
             createdByUserId: input.createdByUserId ?? null,
@@ -421,9 +439,9 @@ export function documentService(db: Db) {
         await tx
           .update(documents)
           .set({
-            title: revision.title ?? null,
+            title: redacted.title,
             format: revision.format,
-            latestBody: revision.body,
+            latestBody: redacted.body,
             latestRevisionId: restoredRevision.id,
             latestRevisionNumber: nextRevisionNumber,
             updatedByAgentId: input.createdByAgentId ?? null,
@@ -442,9 +460,9 @@ export function documentService(db: Db) {
           restoredFromRevisionNumber: revision.revisionNumber,
           document: {
             ...existing,
-            title: revision.title ?? null,
+            title: redacted.title,
             format: revision.format,
-            body: revision.body,
+            body: redacted.body,
             latestRevisionId: restoredRevision.id,
             latestRevisionNumber: nextRevisionNumber,
             updatedByAgentId: input.createdByAgentId ?? null,

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -63,9 +63,9 @@ function mapIssueDocumentRow(
     companyId: row.companyId,
     issueId: row.issueId,
     key: row.key,
-    title: row.title,
+    title: row.title == null ? null : redactSensitiveText(row.title),
     format: row.format,
-    ...(includeBody ? { body: row.latestBody } : {}),
+    ...(includeBody ? { body: redactSensitiveText(row.latestBody) } : {}),
     latestRevisionId: row.latestRevisionId ?? null,
     latestRevisionNumber: row.latestRevisionNumber,
     createdByAgentId: row.createdByAgentId,
@@ -128,7 +128,7 @@ export function documentService(db: Db) {
         legacyPlanDocument: legacyPlanBody
           ? {
               key: "plan" as const,
-              body: legacyPlanBody,
+              body: redactSensitiveText(legacyPlanBody),
               source: "issue_description" as const,
             }
           : null,
@@ -178,7 +178,13 @@ export function documentService(db: Db) {
         .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
         .innerJoin(documentRevisions, eq(documentRevisions.documentId, documents.id))
         .where(and(eq(issueDocuments.issueId, issueId), eq(issueDocuments.key, key)))
-        .orderBy(desc(documentRevisions.revisionNumber));
+        .orderBy(desc(documentRevisions.revisionNumber))
+        .then((rows) => rows.map((row) => ({
+          ...row,
+          title: row.title == null ? null : redactSensitiveText(row.title),
+          body: redactSensitiveText(row.body),
+          changeSummary: row.changeSummary == null ? null : redactSensitiveText(row.changeSummary),
+        })));
     },
 
     upsertIssueDocument: async (input: {

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -494,9 +494,17 @@ export function documentService(db: Db) {
         await tx.delete(issueDocuments).where(eq(issueDocuments.documentId, existing.id));
         await tx.delete(documents).where(eq(documents.id, existing.id));
 
+        // This result is used to populate the deletion activity record after
+        // the transaction. Legacy rows may predate persistence redaction, so
+        // never let their raw title cross that activity boundary.
+        const redacted = redactIssueDocumentText({
+          title: existing.title,
+          body: existing.latestBody,
+        });
         return {
           ...existing,
-          body: existing.latestBody,
+          title: redacted.title,
+          body: redacted.body,
           latestRevisionId: existing.latestRevisionId ?? null,
         };
       });

--- a/server/src/services/feedback-redaction.ts
+++ b/server/src/services/feedback-redaction.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { redactCurrentUserText } from "../log-redaction.js";
-import { sanitizeRecord } from "../redaction.js";
+import { redactSensitiveText, sanitizeRecord } from "../redaction.js";
 
 export type FeedbackRedactionState = {
   redactedFields: Set<string>;
@@ -114,6 +114,16 @@ export function sanitizeFeedbackText(
   if (output !== input) {
     recordField(state, fieldPath);
     increment(state, "current_user", 1);
+  }
+
+  // Keep feedback exports aligned with the common ingestion redactor. This
+  // covers durable text such as legacy document titles using env-style names
+  // (for example, prefixed uppercase API-key variables).
+  const commonRedacted = redactSensitiveText(output);
+  if (commonRedacted !== output) {
+    output = commonRedacted;
+    recordField(state, fieldPath);
+    increment(state, "common_text_secret", 1);
   }
 
   for (const pattern of FREE_TEXT_PATTERNS) {

--- a/server/src/services/feedback.ts
+++ b/server/src/services/feedback.ts
@@ -1025,7 +1025,14 @@ async function buildIssueContext(
       authorUserId: item.authorUserId,
       createdByRunId: item.createdByRunId,
       documentKey: item.documentKey,
-      documentTitle: item.documentTitle,
+      documentTitle: item.documentTitle
+        ? sanitizeFeedbackText(
+          item.documentTitle,
+          state,
+          `bundle.issueContext.items.${index}.documentTitle`,
+          MAX_EXCERPT_CHARS,
+        )
+        : null,
       revisionNumber: item.revisionNumber,
       targetPath: item.targetPath,
       body,
@@ -1041,7 +1048,7 @@ async function buildIssueContext(
     issue: {
       id: issue.id,
       identifier: issue.identifier,
-      title: issue.title,
+      title: sanitizeFeedbackText(issue.title, state, "bundle.issueContext.issue.title", MAX_EXCERPT_CHARS),
       projectId: issue.projectId,
       path: buildIssuePath(issue.identifier),
       descriptionExcerpt: descriptionExcerpt ? truncateExcerpt(descriptionExcerpt, MAX_DESCRIPTION_CHARS) : null,
@@ -1315,6 +1322,9 @@ async function buildPayloadArtifacts(
   },
 ) {
   const state = createFeedbackRedactionState();
+  const documentTitle = input.target.documentTitle
+    ? sanitizeFeedbackText(input.target.documentTitle, state, "bundle.primaryContent.documentTitle", MAX_EXCERPT_CHARS)
+    : null;
   const primaryBody = sanitizeFeedbackText(
     input.target.body,
     state,
@@ -1331,7 +1341,7 @@ async function buildPayloadArtifacts(
     createdByRunId: input.target.createdByRunId,
     documentId: input.target.documentId,
     documentKey: input.target.documentKey,
-    documentTitle: input.target.documentTitle,
+    documentTitle,
     revisionNumber: input.target.revisionNumber,
     targetPath: input.target.targetPath,
     body: primaryBody,
@@ -1344,7 +1354,7 @@ async function buildPayloadArtifacts(
     authorUserId: input.target.authorUserId,
     createdAt: input.target.createdAt,
     documentKey: input.target.documentKey,
-    documentTitle: input.target.documentTitle,
+    documentTitle,
     revisionNumber: input.target.revisionNumber,
   });
 
@@ -1362,7 +1372,10 @@ async function buildPayloadArtifacts(
       sharedWithLabs: input.sharedWithLabs,
       sharedAt: input.sharedWithLabs ? input.now.toISOString() : null,
     },
-    target: input.target.payloadTarget,
+    // Target metadata includes legacy document titles. Treat it as untrusted
+    // persisted text too, otherwise a pre-redaction title bypasses the body
+    // sanitizer and can be exported in the feedback envelope.
+    target: sanitizeFeedbackValue(input.target.payloadTarget, state, "target", MAX_EXCERPT_CHARS),
   } satisfies Record<string, unknown>;
 
   if (!input.sharedWithLabs) {

--- a/server/src/services/issue-continuation-summary.ts
+++ b/server/src/services/issue-continuation-summary.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
+import { redactSensitiveText } from "../redaction.js";
 import { documents, issueDocuments, issues } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
 import { documentService } from "./documents.js";
@@ -216,8 +217,8 @@ export async function getIssueContinuationSummaryDocument(
   if (!row) return null;
   return {
     key: ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
-    title: row.title,
-    body: row.body,
+    title: row.title == null ? null : redactSensitiveText(row.title),
+    body: redactSensitiveText(row.body),
     latestRevisionId: row.latestRevisionId,
     latestRevisionNumber: row.latestRevisionNumber,
     updatedAt: row.updatedAt,

--- a/server/src/services/issue-references.ts
+++ b/server/src/services/issue-references.ts
@@ -10,6 +10,7 @@ import type {
 } from "@paperclipai/shared";
 import { extractIssueReferenceMatches } from "@paperclipai/shared";
 import { notFound } from "../errors.js";
+import { redactSensitiveText } from "../redaction.js";
 
 const SOURCE_KIND_ORDER: Record<IssueReferenceSourceKind, number> = {
   title: 0,
@@ -257,7 +258,7 @@ export function issueReferenceService(db: Db) {
       sourceKind: "document",
       sourceRecordId: document.documentId,
       documentKey: document.key,
-      text: document.body,
+      text: redactSensitiveText(document.body),
     }, dbOrTx);
   }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -53,6 +53,7 @@ import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
+import { redactSensitiveText } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getDefaultCompanyGoal } from "./goals.js";
 import {
@@ -2682,6 +2683,13 @@ export function issueService(db: Db) {
         inheritExecutionWorkspaceFromIssueId,
         ...issueData
       } = data;
+      // Issue text is indexed, included in wake payloads, and copied into activity
+      // summaries. Redact before persistence so sensitive environment expansions
+      // cannot propagate through any of those surfaces.
+      issueData.title = redactSensitiveText(issueData.title);
+      if (typeof issueData.description === "string") {
+        issueData.description = redactSensitiveText(issueData.description);
+      }
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -2929,6 +2937,12 @@ export function issueService(db: Db) {
         actorUserId,
         ...issueData
       } = data;
+      if (typeof issueData.title === "string") {
+        issueData.title = redactSensitiveText(issueData.title);
+      }
+      if (typeof issueData.description === "string") {
+        issueData.description = redactSensitiveText(issueData.description);
+      }
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -3735,7 +3749,7 @@ export function issueService(db: Db) {
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
       };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+      const redactedBody = redactSensitiveText(redactCurrentUserText(body, currentUserRedactionOptions));
       const [comment] = await db
         .insert(issueComments)
         .values({

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1571,7 +1571,9 @@ export function buildHostServices(
           details: {
             identifier: issue.identifier,
             documentKey: params.key,
-            title: params.title ?? null,
+            // The document service returns the persisted, redacted title. Do
+            // not propagate the plugin's raw input into activity details.
+            title: result.document.title ?? null,
             format: params.format ?? "markdown",
           },
         });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1077,6 +1077,12 @@ export function buildHostServices(
           actorAgentId,
           actorUserId,
         })) as Issue;
+        // The issue service redacts text before persistence. Reuse those
+        // persisted values for audit activity so a plugin's raw patch cannot
+        // bypass the same boundary through the live event or plugin event.
+        const activityPatch = { ...patch };
+        if (typeof patch.title === "string") activityPatch.title = updated.title;
+        if (typeof patch.description === "string") activityPatch.description = updated.description;
         await logPluginActivity({
           companyId,
           action: "issue.updated",
@@ -1085,7 +1091,7 @@ export function buildHostServices(
           actor: { actorAgentId, actorUserId, actorRunId },
           details: {
             identifier: updated.identifier,
-            patch,
+            patch: activityPatch,
             _previous: {
               status: existing.status,
               assigneeAgentId: existing.assigneeAgentId,


### PR DESCRIPTION
Redacts secret-shaped issue-document titles, bodies, and change summaries before document/revision persistence and all downstream read, activity, plugin, indexing, and restore paths.

Adds focused persistence, route, legacy-row, revision-restore, and false-positive coverage.

Fixes #10483