### PR TITLE
fix(auth): secure authenticated default and LAN access

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,11 +320,13 @@ npx paperclipai onboard --yes
 > npx --registry https://registry.npmjs.org paperclipai onboard --yes
 > ```
 
-That quickstart path now defaults to trusted local loopback mode for the fastest first run. To start in authenticated/private mode instead, choose a bind preset explicitly:
+That quickstart path defaults to authenticated/private mode for hosts that run agent sandboxes. For an isolated single-user development box, choose loopback explicitly:
 
 ```bash
+npx paperclipai onboard --yes --bind loopback
+# For a private-network agent host:
 npx paperclipai onboard --yes --bind lan
-# or:
+# Or a Tailscale-only agent host:
 npx paperclipai onboard --yes --bind tailnet
 ```
 

--- a/cli/src/__tests__/onboard.test.ts
+++ b/cli/src/__tests__/onboard.test.ts
@@ -129,7 +129,7 @@ describe("onboard", () => {
     expect(fs.existsSync(path.join(path.dirname(fixture.configPath), ".env"))).toBe(true);
   });
 
-  it("keeps --yes onboarding on local trusted loopback defaults", async () => {
+  it("uses authenticated defaults for --yes onboarding", async () => {
     const configPath = createFreshConfigPath();
     process.env.HOST = "0.0.0.0";
     process.env.PAPERCLIP_BIND = "lan";
@@ -137,10 +137,10 @@ describe("onboard", () => {
     await onboard({ config: configPath, yes: true, invokedByRun: true });
 
     const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as PaperclipConfig;
-    expect(raw.server.deploymentMode).toBe("local_trusted");
+    expect(raw.server.deploymentMode).toBe("authenticated");
     expect(raw.server.exposure).toBe("private");
-    expect(raw.server.bind).toBe("loopback");
-    expect(raw.server.host).toBe("127.0.0.1");
+    expect(raw.server.bind).toBe("lan");
+    expect(raw.server.host).toBe("0.0.0.0");
   });
 
   it("creates instance-root config and data paths for a fresh PAPERCLIP_HOME", async () => {
@@ -195,16 +195,16 @@ describe("onboard", () => {
     expect(raw.server.host).toBe("127.0.0.1");
   });
 
-  it("ignores deployment env overrides during --yes quickstart", async () => {
+  it("keeps authenticated mode as the --yes quickstart default", async () => {
     const configPath = createFreshConfigPath();
     process.env.PAPERCLIP_DEPLOYMENT_MODE = "authenticated";
 
     await onboard({ config: configPath, yes: true, invokedByRun: true });
 
     const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as PaperclipConfig;
-    expect(raw.server.deploymentMode).toBe("local_trusted");
+    expect(raw.server.deploymentMode).toBe("authenticated");
     expect(raw.server.exposure).toBe("private");
-    expect(raw.server.bind).toBe("loopback");
-    expect(raw.server.host).toBe("127.0.0.1");
+    expect(raw.server.bind).toBe("lan");
+    expect(raw.server.host).toBe("0.0.0.0");
   });
 });

--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -52,7 +52,7 @@ function defaultConfig(): PaperclipConfig {
       logDir: resolveDefaultLogsDir(instanceId),
     },
     server: {
-      deploymentMode: "local_trusted",
+      deploymentMode: "authenticated",
       exposure: "private",
       bind: "loopback",
       host: "127.0.0.1",

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -127,28 +127,23 @@ function describeServerBinding(server: Pick<PaperclipConfig["server"], "bind" | 
   return `${bind}${detail ? ` (${detail})` : ""}:${server.port}`;
 }
 
-function quickstartDefaultsFromEnv(opts?: { preferTrustedLocal?: boolean }): {
+function quickstartDefaultsFromEnv(): {
   defaults: OnboardDefaults;
   usedEnvKeys: string[];
   ignoredEnvKeys: Array<{ key: string; reason: string }>;
 } {
-  const preferTrustedLocal = opts?.preferTrustedLocal ?? false;
   const instanceId = resolvePaperclipInstanceId();
   const defaultStorage = defaultStorageConfig();
   const defaultSecrets = defaultSecretsConfig();
   const databaseUrl = process.env.DATABASE_URL?.trim() || undefined;
-  const publicUrl = preferTrustedLocal
-    ? undefined
-    : (
-      process.env.PAPERCLIP_PUBLIC_URL?.trim() ||
-      process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL?.trim() ||
-      process.env.BETTER_AUTH_URL?.trim() ||
-      process.env.BETTER_AUTH_BASE_URL?.trim() ||
-      undefined
-    );
-  const deploymentMode = preferTrustedLocal
-    ? "local_trusted"
-    : (parseEnumFromEnv<DeploymentMode>(process.env.PAPERCLIP_DEPLOYMENT_MODE, DEPLOYMENT_MODES) ?? "local_trusted");
+  const publicUrl =
+    process.env.PAPERCLIP_PUBLIC_URL?.trim() ||
+    process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL?.trim() ||
+    process.env.BETTER_AUTH_URL?.trim() ||
+    process.env.BETTER_AUTH_BASE_URL?.trim() ||
+    undefined;
+  const deploymentMode =
+    parseEnumFromEnv<DeploymentMode>(process.env.PAPERCLIP_DEPLOYMENT_MODE, DEPLOYMENT_MODES) ?? "authenticated";
   const deploymentExposureFromEnv = parseEnumFromEnv<DeploymentExposure>(
     process.env.PAPERCLIP_DEPLOYMENT_EXPOSURE,
     DEPLOYMENT_EXPOSURES,
@@ -159,13 +154,9 @@ function quickstartDefaultsFromEnv(opts?: { preferTrustedLocal?: boolean }): {
   const customBindHostFromEnv = process.env.PAPERCLIP_BIND_HOST?.trim() || undefined;
   const hostFromEnv = process.env.HOST?.trim() || undefined;
   const configuredBindHost = customBindHostFromEnv ?? hostFromEnv;
-  const bind = preferTrustedLocal
+  const bind = deploymentMode === "local_trusted"
     ? "loopback"
-    : (
-      deploymentMode === "local_trusted"
-        ? "loopback"
-        : (bindFromEnv ?? (configuredBindHost ? inferBindModeFromHost(configuredBindHost) : "lan"))
-    );
+    : (bindFromEnv ?? (configuredBindHost ? inferBindModeFromHost(configuredBindHost) : "lan"));
   const resolvedBind = resolveRuntimeBind({
     bind,
     host: hostFromEnv ?? (bind === "loopback" ? "127.0.0.1" : "0.0.0.0"),
@@ -267,25 +258,6 @@ function quickstartDefaultsFromEnv(opts?: { preferTrustedLocal?: boolean }): {
     },
   };
   const ignoredEnvKeys: Array<{ key: string; reason: string }> = [];
-  if (preferTrustedLocal) {
-    const forcedLocalReason = "Ignored because --yes quickstart forces trusted local loopback defaults";
-    for (const key of [
-      "PAPERCLIP_DEPLOYMENT_MODE",
-      "PAPERCLIP_DEPLOYMENT_EXPOSURE",
-      "PAPERCLIP_BIND",
-      "PAPERCLIP_BIND_HOST",
-      "HOST",
-      "PAPERCLIP_AUTH_BASE_URL_MODE",
-      "PAPERCLIP_AUTH_PUBLIC_BASE_URL",
-      "PAPERCLIP_PUBLIC_URL",
-      "BETTER_AUTH_URL",
-      "BETTER_AUTH_BASE_URL",
-    ] as const) {
-      if (process.env[key] !== undefined) {
-        ignoredEnvKeys.push({ key, reason: forcedLocalReason });
-      }
-    }
-  }
   if (deploymentMode === "local_trusted" && process.env.PAPERCLIP_DEPLOYMENT_EXPOSURE !== undefined) {
     ignoredEnvKeys.push({
       key: "PAPERCLIP_DEPLOYMENT_EXPOSURE",
@@ -459,9 +431,7 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
   if (tc) trackInstallStarted(tc);
 
   let llm: PaperclipConfig["llm"] | undefined;
-  const { defaults: derivedDefaults, usedEnvKeys, ignoredEnvKeys } = quickstartDefaultsFromEnv({
-    preferTrustedLocal: opts.yes === true && !opts.bind,
-  });
+  const { defaults: derivedDefaults, usedEnvKeys, ignoredEnvKeys } = quickstartDefaultsFromEnv();
   let {
     database,
     logging,

--- a/cli/src/commands/worktree-lib.ts
+++ b/cli/src/commands/worktree-lib.ts
@@ -208,7 +208,7 @@ export function buildWorktreeConfig(input: {
       logDir: paths.logDir,
     },
     server: {
-      deploymentMode: source?.server.deploymentMode ?? "local_trusted",
+      deploymentMode: source?.server.deploymentMode ?? "authenticated",
       exposure: source?.server.exposure ?? "private",
       ...(source?.server.bind ? { bind: source.server.bind } : {}),
       ...(source?.server.customBindHost ? { customBindHost: source.server.customBindHost } : {}),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -70,7 +70,7 @@ program
   .option("-c, --config <path>", "Path to config file")
   .option("-d, --data-dir <path>", DATA_DIR_OPTION_HELP)
   .option("--bind <mode>", "Quickstart reachability preset (loopback, lan, tailnet)")
-  .option("-y, --yes", "Accept quickstart defaults (trusted local loopback unless --bind is set) and start immediately", false)
+  .option("-y, --yes", "Accept authenticated quickstart defaults and start immediately (use --bind loopback for isolated local trusted mode)", false)
   .option("--run", "Start Paperclip immediately after saving config", false)
   .action(onboard);
 

--- a/docs/cli/setup-commands.md
+++ b/docs/cli/setup-commands.md
@@ -37,7 +37,7 @@ If Paperclip is already configured, rerunning `onboard` keeps the existing confi
 
 First prompt:
 
-1. `Quickstart` (recommended): local defaults (embedded database, no LLM provider, local disk storage, default secrets)
+1. `Quickstart` (recommended): authenticated/private defaults for agent-hosting safety (embedded database, no LLM provider, local disk storage, default secrets)
 2. `Advanced setup`: full interactive configuration
 
 Start immediately after onboarding:
@@ -46,11 +46,13 @@ Start immediately after onboarding:
 pnpm paperclipai onboard --run
 ```
 
-Non-interactive defaults + immediate start (opens browser on server listen):
+Non-interactive authenticated defaults + immediate start (opens browser on server listen):
 
 ```sh
 pnpm paperclipai onboard --yes
 ```
+
+For an isolated single-user development box that does not run agent sandboxes, use `--bind loopback` to opt into `local_trusted`.
 
 On an existing install, `--yes` now preserves the current config and just starts Paperclip with that setup.
 

--- a/docs/deploy/deployment-modes.md
+++ b/docs/deploy/deployment-modes.md
@@ -7,7 +7,7 @@ Paperclip supports two runtime modes with different security profiles. Reachabil
 
 ## `local_trusted`
 
-The default mode. Optimized for single-operator local use.
+An explicit mode for an isolated single-operator local box that does not host agent sandboxes.
 
 - **Host binding**: loopback only (localhost)
 - **Bind**: `loopback`
@@ -24,6 +24,8 @@ pnpm paperclipai onboard
 ## `authenticated`
 
 Login required. Supports two exposure policies.
+
+Authenticated mode is the default for agent-hosting hosts, including Framework Desktop fleet members. It requires an authenticated session or scoped bearer token for API access; `/api/health` remains a limited public liveness check.
 
 ### `authenticated` + `private`
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -16,7 +16,7 @@ All environment variables that Paperclip uses for server configuration.
 | `DATABASE_URL` | (embedded) | PostgreSQL connection string |
 | `PAPERCLIP_HOME` | `~/.paperclip` | Base directory for all Paperclip data |
 | `PAPERCLIP_INSTANCE_ID` | `default` | Instance identifier (for multiple local instances) |
-| `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
+| `PAPERCLIP_DEPLOYMENT_MODE` | `authenticated` | Runtime mode override; use `local_trusted` only on an isolated single-user loopback host |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
 

--- a/docs/deploy/local-development.md
+++ b/docs/deploy/local-development.md
@@ -40,7 +40,13 @@ This does:
 
 ## Bind Presets In Dev
 
-Default `pnpm dev` stays in `local_trusted` with loopback-only binding.
+Default `pnpm dev` uses authenticated/private mode for agent-hosting safety.
+
+For an isolated single-user development box that does not run agent sandboxes, opt into trusted loopback mode:
+
+```sh
+pnpm dev --bind loopback
+```
 
 To open Paperclip to a private network with login enabled:
 

--- a/docs/deploy/overview.md
+++ b/docs/deploy/overview.md
@@ -9,18 +9,18 @@ Paperclip supports three deployment configurations, from zero-friction local to 
 
 | Mode | Auth | Best For |
 |------|------|----------|
-| `local_trusted` | No login required | Single-operator local machine |
+| `local_trusted` | No login required | Explicitly isolated single-user local machine |
 | `authenticated` + `private` | Login required | Private network (Tailscale, VPN, LAN) |
 | `authenticated` + `public` | Login required | Internet-facing cloud deployment |
 
 ## Quick Comparison
 
-### Local Trusted (Default)
+### Local Trusted (Explicit)
 
 - Loopback-only host binding (localhost)
 - No human login flow
 - Fastest local startup
-- Best for: solo development and experimentation
+- Best for: solo development and experimentation on a host that does not run agent sandboxes
 
 ### Authenticated + Private
 
@@ -38,7 +38,8 @@ Paperclip supports three deployment configurations, from zero-friction local to 
 
 ## Choosing a Mode
 
-- **Just trying Paperclip?** Use `local_trusted` (the default)
+- **Running agent sandboxes or sharing the host?** Use `authenticated` (the default)
+- **Using an isolated single-user dev box?** Use `local_trusted` with loopback binding
 - **Sharing with a team on private network?** Use `authenticated` + `private`
 - **Deploying to the cloud?** Use `authenticated` + `public` — see [AWS ECS Fargate guide](aws-ecs.md)
 

--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -46,7 +46,7 @@ export const loggingConfigSchema = z.object({
 });
 
 export const serverConfigSchema = z.object({
-  deploymentMode: z.enum(DEPLOYMENT_MODES).default("local_trusted"),
+  deploymentMode: z.enum(DEPLOYMENT_MODES).default("authenticated"),
   exposure: z.enum(DEPLOYMENT_EXPOSURES).default("private"),
   bind: z.enum(BIND_MODES).optional(),
   customBindHost: z.string().optional(),

--- a/server/src/__tests__/authenticated-mode-rollout.test.ts
+++ b/server/src/__tests__/authenticated-mode-rollout.test.ts
@@ -17,6 +17,12 @@ function withActor(actor: Request["actor"]) {
   });
   app.use(authenticatedApiGuard({ deploymentMode: "authenticated" }));
   app.get("/companies", (_req, res) => res.json({ ok: true }));
+  app.all("/invites/:token/{*path}", (_req, res) => res.json({ bootstrap: "invite" }));
+  app.get("/board-claim/:token", (_req, res) => res.json({ bootstrap: "board-claim" }));
+  app.all("/board-claim/:token/{*path}", (_req, res) => res.json({ bootstrap: "board-claim" }));
+  app.post("/cli-auth/challenges", (_req, res) => res.json({ bootstrap: "cli-auth" }));
+  app.all("/cli-auth/challenges/{*path}", (_req, res) => res.json({ bootstrap: "cli-auth" }));
+  app.post("/join-requests/:requestId/claim-api-key", (_req, res) => res.json({ bootstrap: "join-claim" }));
   app.use(errorHandler);
   return app;
 }
@@ -71,6 +77,18 @@ describe("authenticated agent-host rollout", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["get", "/invites/pcp_invite_token/onboarding"],
+    ["get", "/board-claim/claim-token"],
+    ["post", "/cli-auth/challenges"],
+    ["get", "/cli-auth/challenges/challenge-id"],
+    ["post", "/join-requests/request-id/claim-api-key"],
+  ] as const)("allows capability bootstrap endpoint %s %s to reach its route", async (method, path) => {
+    const res = await request(withActor({ type: "none", source: "none" }))[method](path);
+
+    expect(res.status).toBe(200);
   });
 
   it("defaults hosts to authenticated mode while preserving an explicit local-trusted override", () => {

--- a/server/src/__tests__/authenticated-mode-rollout.test.ts
+++ b/server/src/__tests__/authenticated-mode-rollout.test.ts
@@ -1,0 +1,111 @@
+import express, { type Request } from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { authenticatedApiGuard } from "../app.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/error-handler.js";
+import { healthRoutes } from "../routes/health.js";
+import { resolveDeploymentMode } from "../config.js";
+import type { Db } from "@paperclipai/db";
+
+function withActor(actor: Request["actor"]) {
+  const app = express();
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use(authenticatedApiGuard({ deploymentMode: "authenticated" }));
+  app.get("/companies", (_req, res) => res.json({ ok: true }));
+  app.use(errorHandler);
+  return app;
+}
+
+function withRealActorMiddleware(opts: {
+  deploymentMode: "authenticated" | "local_trusted";
+  agentRecord?: { id: string; companyId: string; status: string };
+}) {
+  const selectResults = opts.agentRecord
+    ? [[], [], [opts.agentRecord]]
+    : [[], []];
+  const db = {
+    select: () => {
+      const result = selectResults.shift() ?? [];
+      const query = {
+        from: () => query,
+        where: () => query,
+        then: (resolve: (value: unknown[]) => unknown) => Promise.resolve(result).then(resolve),
+      };
+      return query;
+    },
+  } as unknown as Db;
+  const app = express();
+  app.use(actorMiddleware(db, { deploymentMode: opts.deploymentMode }));
+  app.use("/api", authenticatedApiGuard({ deploymentMode: opts.deploymentMode }));
+  app.use("/api/health", healthRoutes(undefined, {
+    deploymentMode: opts.deploymentMode,
+    deploymentExposure: "private",
+    authReady: true,
+    companyDeletionEnabled: true,
+  }));
+  app.get("/api/companies", (_req, res) => res.json({ ok: true }));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("authenticated agent-host rollout", () => {
+  it("rejects anonymous API reads with 401", async () => {
+    const res = await request(withActor({ type: "none", source: "none" })).get("/companies");
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("passes an authenticated agent request through unchanged", async () => {
+    const res = await request(withActor({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_jwt",
+    })).get("/companies");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("defaults hosts to authenticated mode while preserving an explicit local-trusted override", () => {
+    expect(resolveDeploymentMode({})).toBe("authenticated");
+    expect(resolveDeploymentMode({ envValue: "local_trusted" })).toBe("local_trusted");
+  });
+
+  it("enforces the assembled actor-to-API boundary while preserving health and local-trusted paths", async () => {
+    const previousAgentJwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "authenticated-mode-test-secret";
+    try {
+      const agentToken = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");
+      expect(agentToken).toBeTruthy();
+
+      const authenticatedApp = withRealActorMiddleware({
+        deploymentMode: "authenticated",
+        agentRecord: { id: "agent-1", companyId: "company-1", status: "active" },
+      });
+      const anonymous = await request(authenticatedApp).get("/api/companies");
+      const agent = await request(authenticatedApp)
+        .get("/api/companies")
+        .set("Authorization", `Bearer ${agentToken}`);
+      const health = await request(authenticatedApp).get("/api/health");
+
+      expect(anonymous.status).toBe(401);
+      expect(agent.status).toBe(200);
+      expect(health.status).toBe(200);
+      expect(health.body).toMatchObject({ status: "ok", deploymentMode: "authenticated" });
+
+      const localTrusted = await request(withRealActorMiddleware({ deploymentMode: "local_trusted" }))
+        .get("/api/companies");
+      expect(localTrusted.status).toBe(200);
+    } finally {
+      if (previousAgentJwtSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+      else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousAgentJwtSecret;
+    }
+  });
+});

--- a/server/src/__tests__/private-hostname-guard.test.ts
+++ b/server/src/__tests__/private-hostname-guard.test.ts
@@ -1,17 +1,36 @@
 import { describe, expect, it, vi } from "vitest";
 import express from "express";
+import type os from "node:os";
 import request from "supertest";
 import { privateHostnameGuard } from "../middleware/private-hostname-guard.js";
 
 const unknownHostname = "blocked-host.invalid";
+const lanIp = "192.168.6.178";
+const lanHostname = "paperclip-lan.example.test";
+const lanNetworkInterfaces: NodeJS.Dict<os.NetworkInterfaceInfo[]> = {
+  en0: [{
+    address: lanIp,
+    family: "IPv4",
+    internal: false,
+    netmask: "255.255.255.0",
+    cidr: `${lanIp}/24`,
+    mac: "00:00:00:00:00:00",
+  }],
+};
 
-function createApp(opts: { enabled: boolean; allowedHostnames?: string[]; bindHost?: string }) {
+function createApp(opts: {
+  enabled: boolean;
+  allowedHostnames?: string[];
+  bindHost?: string;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+}) {
   const app = express();
   app.use(
     privateHostnameGuard({
       enabled: opts.enabled,
       allowedHostnames: opts.allowedHostnames ?? [],
       bindHost: opts.bindHost ?? "0.0.0.0",
+      networkInterfacesMap: opts.networkInterfacesMap,
     }),
   );
   app.get("/api/health", (_req, res) => {
@@ -46,6 +65,23 @@ describe("privateHostnameGuard", () => {
     const app = createApp({ enabled: true, bindHost: "0.0.0.0" });
     const res = await request(app).get("/api/health").set("Host", "0.0.0.0:3100");
     expect(res.status).toBe(200);
+  });
+
+  it("allows the actual LAN address and intended hostname for a wildcard bind", async () => {
+    const app = createApp({
+      enabled: true,
+      bindHost: "0.0.0.0",
+      allowedHostnames: [lanHostname],
+      networkInterfacesMap: lanNetworkInterfaces,
+    });
+
+    const lanIpResponse = await request(app).get("/api/health").set("Host", `${lanIp}:3100`);
+    const hostnameResponse = await request(app).get("/api/health").set("Host", `${lanHostname}:3100`);
+    const unrelatedHostResponse = await request(app).get("/api/health").set("Host", "192.168.6.179:3100");
+
+    expect(lanIpResponse.status).toBe(200);
+    expect(hostnameResponse.status).toBe(200);
+    expect(unrelatedHostResponse.status).toBe(403);
   });
 
   it("blocks unknown hostnames with remediation command", async () => {

--- a/server/src/__tests__/private-hostname-guard.test.ts
+++ b/server/src/__tests__/private-hostname-guard.test.ts
@@ -42,6 +42,12 @@ describe("privateHostnameGuard", () => {
     expect(res.status).toBe(200);
   });
 
+  it("allows the configured wildcard LAN bind hostname", async () => {
+    const app = createApp({ enabled: true, bindHost: "0.0.0.0" });
+    const res = await request(app).get("/api/health").set("Host", "0.0.0.0:3100");
+    expect(res.status).toBe(200);
+  });
+
   it("blocks unknown hostnames with remediation command", async () => {
     const app = createApp({ enabled: true, allowedHostnames: ["some-other-host"] });
     const res = await request(app).get("/api/health").set("Host", `${unknownHostname}:3100`);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -90,6 +90,7 @@ import { createCachedViteHtmlRenderer } from "./vite-html-renderer.js";
 import { DEFAULT_JSON_BODY_LIMIT, PORTABLE_JSON_BODY_LIMIT } from "./http/body-limits.js";
 import { COMPANY_IMPORT_API_PATH } from "./routes/company-import-paths.js";
 import { apiCompression } from "./middleware/api-compression.js";
+import { unauthorized } from "./errors.js";
 
 type UiMode = "none" | "static" | "vite-dev";
 const FEEDBACK_EXPORT_FLUSH_INTERVAL_MS = 5_000;
@@ -226,6 +227,23 @@ export function createManagedBundledPluginWorkerRecovery(input: {
         inFlightStarts.delete(plugin.id);
       }
     }
+  };
+}
+
+export function authenticatedApiGuard(opts: { deploymentMode: DeploymentMode }): express.RequestHandler {
+  return (req, _res, next) => {
+    // healthRoutes is mounted at /api/health below; keep its liveness response
+    // public while all other /api routes require an authenticated actor.
+    const isPublicHealthCheck = req.path === "/health" || req.path.startsWith("/health/");
+    if (
+      opts.deploymentMode === "authenticated" &&
+      !isPublicHealthCheck &&
+      (!req.actor || req.actor.type === "none")
+    ) {
+      next(unauthorized());
+      return;
+    }
+    next();
   };
 }
 
@@ -521,6 +539,7 @@ export async function createApp(
       allowedHostnames: opts.allowedHostnames,
     }),
   );
+  app.use("/api", authenticatedApiGuard({ deploymentMode: opts.deploymentMode }));
   app.use("/api", api);
   app.use("/api", (_req, res) => {
     res.status(404).json({ error: "API route not found" });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -232,12 +232,21 @@ export function createManagedBundledPluginWorkerRecovery(input: {
 
 export function authenticatedApiGuard(opts: { deploymentMode: DeploymentMode }): express.RequestHandler {
   return (req, _res, next) => {
+    // These routes establish authentication with a one-time capability instead
+    // of an existing actor. They still validate that capability in accessRoutes.
+    const isCapabilityBootstrapPath =
+      req.path.startsWith("/invites/") ||
+      req.path.startsWith("/board-claim/") ||
+      req.path === "/cli-auth/challenges" ||
+      req.path.startsWith("/cli-auth/challenges/") ||
+      (/^\/join-requests\/[^/]+\/claim-api-key$/.test(req.path));
     // healthRoutes is mounted at /api/health below; keep its liveness response
     // public while all other /api routes require an authenticated actor.
     const isPublicHealthCheck = req.path === "/health" || req.path.startsWith("/health/");
     if (
       opts.deploymentMode === "authenticated" &&
       !isPublicHealthCheck &&
+      !isCapabilityBootstrapPath &&
       (!req.actor || req.actor.type === "none")
     ) {
       next(unauthorized());

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -89,6 +89,17 @@ export interface Config {
   telemetryEnabled: boolean;
 }
 
+export function resolveDeploymentMode(input: {
+  envValue?: string;
+  fileValue?: DeploymentMode;
+}): DeploymentMode {
+  const envValue = input.envValue;
+  if (envValue && DEPLOYMENT_MODES.includes(envValue as DeploymentMode)) {
+    return envValue as DeploymentMode;
+  }
+  return input.fileValue ?? "authenticated";
+}
+
 function detectTailnetBindHost(): string | undefined {
   const explicit = process.env.PAPERCLIP_TAILNET_BIND_HOST?.trim();
   if (explicit) return explicit;
@@ -158,11 +169,10 @@ export function loadConfig(): Config {
     undefined;
 
   const deploymentModeFromEnvRaw = process.env.PAPERCLIP_DEPLOYMENT_MODE;
-  const deploymentModeFromEnv =
-    deploymentModeFromEnvRaw && DEPLOYMENT_MODES.includes(deploymentModeFromEnvRaw as DeploymentMode)
-      ? (deploymentModeFromEnvRaw as DeploymentMode)
-      : null;
-  const deploymentMode: DeploymentMode = deploymentModeFromEnv ?? fileConfig?.server.deploymentMode ?? "local_trusted";
+  const deploymentMode = resolveDeploymentMode({
+    envValue: deploymentModeFromEnvRaw,
+    fileValue: fileConfig?.server.deploymentMode,
+  });
   const strictModeFromEnv = process.env.PAPERCLIP_SECRETS_STRICT_MODE;
   const secretsStrictMode =
     strictModeFromEnv !== undefined

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -33,7 +33,7 @@ export function resolvePrivateHostnameAllowSet(opts: { allowedHostnames: string[
   const bindHost = opts.bindHost.trim().toLowerCase();
   const allowSet = new Set<string>(configuredAllow);
 
-  if (bindHost && bindHost !== "0.0.0.0") {
+  if (bindHost) {
     allowSet.add(bindHost);
   }
   allowSet.add("localhost");

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -1,4 +1,6 @@
 import type { Request, RequestHandler } from "express";
+import type os from "node:os";
+import { collectReachableInterfaceHosts } from "../runtime-api.js";
 
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.trim().toLowerCase();
@@ -28,13 +30,22 @@ function normalizeAllowedHostnames(values: string[]): string[] {
   return Array.from(unique);
 }
 
-export function resolvePrivateHostnameAllowSet(opts: { allowedHostnames: string[]; bindHost: string }): Set<string> {
+export function resolvePrivateHostnameAllowSet(opts: {
+  allowedHostnames: string[];
+  bindHost: string;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
+}): Set<string> {
   const configuredAllow = normalizeAllowedHostnames(opts.allowedHostnames);
   const bindHost = opts.bindHost.trim().toLowerCase();
   const allowSet = new Set<string>(configuredAllow);
 
   if (bindHost) {
     allowSet.add(bindHost);
+  }
+  if (bindHost === "0.0.0.0" || bindHost === "::") {
+    for (const host of collectReachableInterfaceHosts({ networkInterfacesMap: opts.networkInterfacesMap })) {
+      allowSet.add(host.toLowerCase());
+    }
   }
   allowSet.add("localhost");
   allowSet.add("127.0.0.1");
@@ -53,6 +64,7 @@ export function privateHostnameGuard(opts: {
   enabled: boolean;
   allowedHostnames: string[];
   bindHost: string;
+  networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 }): RequestHandler {
   if (!opts.enabled) {
     return (_req, _res, next) => next();
@@ -61,6 +73,7 @@ export function privateHostnameGuard(opts: {
   const allowSet = resolvePrivateHostnameAllowSet({
     allowedHostnames: opts.allowedHostnames,
     bindHost: opts.bindHost,
+    networkInterfacesMap: opts.networkInterfacesMap,
   });
 
   return (req, res, next) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane teams use to manage AI agents for work.
> - Agent-hosting machines can run semi-trusted execution sandboxes beside the control plane.
> - The legacy local-trusted default gives host-loopback requests implicit local-board trust.
> - That boundary is unsafe when a sandbox can reach the host loopback service.
> - Authenticated mode resolves board, agent, session, and tenant actors from credentials.
> - This pull request makes authenticated mode the default while retaining explicit local-trusted loopback setup.
> - The follow-up preserves one-time capability paths and valid wildcard-bind LAN access.
> - The result is a fail-closed generic API boundary without blocking valid setup, join, or configured LAN flows.

## Linked Issues or Issue Description

No public GitHub issue exists for this security hardening work.

- **Problem:** Agent-hosting machines could default to the local-trusted implicit-admin loopback boundary. The initial authenticated-mode guard blocked capability-backed setup routes. A wildcard LAN listener also rejected its actual interface address.
- **Affected deployment:** Self-hosted Paperclip instances on machines that run agent sandboxes and bind to a LAN interface.
- **Expected behavior:** Authenticated mode is the default. Generic anonymous API requests are rejected. One-time invite, claim, and CLI-auth capabilities reach route-level validation. A wildcard bind admits only the machine's usable non-loopback interface addresses and configured intended hostnames.
- **Related work:** Refs #2980 and #5498. Related PRs reviewed during duplicate search: #3344, #9429, and #10430. None duplicates this default-mode rollout.

## What Changed

- Defaulted deployment-mode resolution and shared configuration schema to authenticated, while preserving explicit local-trusted loopback setup for isolated development.
- Added an authenticated API guard so anonymous generic API requests receive 401, while health remains a narrow public liveness endpoint.
- Preserved scoped agent bearer access and the invite-token, board-claim, CLI-auth, and join-key claim paths. Each endpoint retains its token or session validation.
- Added actual non-loopback interface addresses to the private-host allow set only for wildcard binds. Configured intended hostnames remain allowed. Loopback, wildcard, link-local, and unrelated hosts remain denied.
- Added LAN-IP, intended-hostname, and unrelated-host regression coverage.
- Updated onboarding, CLI, deployment, and quickstart documentation for the secure default.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/private-hostname-guard.test.ts` - 7 passed
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/authenticated-mode-rollout.test.ts` - 9 passed
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/cli-auth-routes.test.ts` - 10 passed
- `pnpm --filter @paperclipai/server typecheck` - passed
- `git diff --check` - clean
- Repository CI and Greptile restarted for head `e1f9f9623a73b0aef343cac4947d8164f1c3ae9f`.

## Risks

Low-to-moderate behavioral change: deployments that relied on unauthenticated loopback must use scoped credentials. The capability-route exception is narrow and each listed handler retains token or session validation. The wildcard allow set is computed at process startup, so an interface change requires the same server restart as a bind configuration change. The guard does not trust arbitrary hosts.

> This change aligns with ROADMAP.md's Cloud / Sandbox agents direction and does not duplicate a planned core feature. The security change was board-approved before implementation.

## Model Used

- Implementation: OpenAI Codex `gpt-5.6-luna` via `codex_local`, with code execution and targeted test/typecheck verification.
- Publication and repair: OpenAI Codex `gpt-5.6-terra`, with code execution and targeted verification. The adapter did not expose a context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect the default-mode change
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
