### PR TITLE
feat(i18n): add Chinese (zh-CN/zh-TW) for sidebar, global chrome & onboarding entry

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -393,6 +393,7 @@ function legacyToolsRedirectTarget(tab?: string) {
 }
 
 function OnboardingRoutePage() {
+  const { t } = useTranslation();
   const { companies } = useCompany();
   const { openOnboarding } = useDialogActions();
   const { onboardingOpen, onboardingRouteDismissed } = useDialogState();
@@ -411,15 +412,15 @@ function OnboardingRoutePage() {
     : null;
 
   const title = matchedCompany
-    ? `Add another agent to ${matchedCompany.name}`
+    ? t("onboarding.addAgentToCompanyTitle", { name: matchedCompany.name })
     : companies.length > 0
-      ? "Create another company"
-      : "Create your first company";
+      ? t("onboarding.createAnotherCompanyTitle")
+      : t("onboarding.createFirstCompanyTitle");
   const description = matchedCompany
-    ? "Run onboarding again to add an agent and a starter task for this company."
+    ? t("onboarding.addAgentToCompanyDesc")
     : companies.length > 0
-      ? "Run onboarding again to create another company and seed its first agent."
-      : "Get started by creating a company and your first agent.";
+      ? t("onboarding.createAnotherCompanyDesc")
+      : t("onboarding.createFirstCompanyDesc");
 
   return (
     <div className="mx-auto max-w-xl py-10">
@@ -434,7 +435,7 @@ function OnboardingRoutePage() {
                 : openOnboarding()
             }
           >
-            {matchedCompany ? "Add Agent" : "Start Onboarding"}
+            {matchedCompany ? t("onboarding.addAgentButton") : t("onboarding.startOnboardingButton")}
           </Button>
         </div>
       </div>

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -46,6 +46,7 @@ import { pinDocumentScrollToZero } from "../lib/pin-document-scroll";
 import { cn } from "../lib/utils";
 import { NotFoundPage } from "../pages/NotFound";
 import { PluginSlotMount, resolveRouteSidebarSlot, usePluginSlots } from "../plugins/slots";
+import { useTranslation } from "../i18n";
 
 function getCompanyRouteSegment(pathname: string, companyPrefix: string | undefined): string | null {
   return getCompanyPathSegments(pathname, companyPrefix)[0]?.toLowerCase() ?? null;
@@ -72,6 +73,7 @@ function isSkillsStoreRoute(pathname: string, companyPrefix: string | undefined)
 }
 
 export function Layout() {
+  const { t } = useTranslation();
   const {
     sidebarOpen,
     setSidebarOpen,
@@ -548,7 +550,7 @@ export function Layout() {
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-(--z-200) focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
-        Skip to Main Content
+        {t("common.skipToMainContent")}
       </a>
       <WorktreeBanner />
       <DevRestartBanner devServer={health?.devServer} />

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -48,8 +48,10 @@ import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
 import { PluginSlotOutlet } from "@/plugins/slots";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
+import { useTranslation } from "@/i18n";
 
 export function Sidebar() {
+  const { t } = useTranslation();
   const { openNewIssue } = useDialogActions();
   // Every labeled section is collapsible (session-scoped, default open) —
   // one policy across static nav groups and the data-driven sections.
@@ -134,8 +136,8 @@ export function Sidebar() {
               variant="ghost"
               size="icon-sm"
               className="text-muted-foreground shrink-0"
-              aria-label="Open search"
-              title="Open search"
+              aria-label={t("common.openSearch")}
+              title={t("common.openSearch")}
             >
               <NavLink to="/search">
                 <Search className="h-4 w-4" />
@@ -153,8 +155,8 @@ export function Sidebar() {
                   variant="ghost"
                   size="icon-sm"
                   className="text-muted-foreground shrink-0"
-                  aria-label="Keep sidebar expanded"
-                  title="Keep sidebar expanded"
+                  aria-label={t("common.keepSidebarExpanded")}
+                  title={t("common.keepSidebarExpanded")}
                   onClick={() => setCollapsed(false)}
                 >
                   <Pin className="h-4 w-4" />
@@ -165,8 +167,8 @@ export function Sidebar() {
                   size="icon-sm"
                   className="text-muted-foreground shrink-0"
                   aria-expanded={!collapsed}
-                  aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+                  aria-label={collapsed ? t("common.expandSidebar") : t("common.collapseSidebar")}
+                  title={collapsed ? t("common.expandSidebar") : t("common.collapseSidebar")}
                   onClick={() => toggleCollapsed()}
                 >
                   {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
@@ -185,60 +187,60 @@ export function Sidebar() {
               <button
                 onClick={() => openNewIssue()}
                 data-slot="icon-button"
-                aria-label={rail ? "New Task" : undefined}
+                aria-label={rail ? t("common.newTask") : undefined}
                 className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-foreground/80 hover:bg-accent/50 hover:text-foreground transition-colors"
               >
                 <SquarePen className="h-4 w-4 shrink-0" />
-                <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "truncate"}>New Task</span>
+                <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "truncate"}>{t("common.newTask")}</span>
               </button>
             );
             return rail ? (
               <Tooltip>
                 <TooltipTrigger asChild>{newTaskButton}</TooltipTrigger>
-                <TooltipContent side="right">New Task</TooltipContent>
+                <TooltipContent side="right">{t("common.newTask")}</TooltipContent>
               </Tooltip>
             ) : (
               newTaskButton
             );
           })()}
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem to="/dashboard" label={t("sidebar.dashboard")} icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
-            label="Inbox"
+            label={t("sidebar.inbox")}
             icon={Inbox}
             badge={inboxBadge.inbox}
-            badgeLabel="unread"
+            badgeLabel={t("sidebar.unread")}
             badgeTone={inboxBadge.failedRuns > 0 ? "danger" : "default"}
             alert={inboxBadge.failedRuns > 0}
           />
           {showDecisions ? (
             <SidebarNavItem
               to="/decisions"
-              label="Decisions"
+              label={t("sidebar.decisions")}
               icon={ListChecks}
               badge={attentionCount}
-              badgeLabel="decisions"
+              badgeLabel={t("sidebar.decisionsBadge")}
             />
           ) : null}
           {showStatusCards ? (
-            <SidebarNavItem to="/status" label="Status" icon={LayoutGrid} textBadge="beta" />
+            <SidebarNavItem to="/status" label={t("sidebar.status")} icon={LayoutGrid} textBadge={t("sidebar.beta")} />
           ) : null}
           {conferenceRoomChatEnabled ? (
-            <SidebarNavItem to="/board-chat" label="Conference Room" icon={MessagesSquare} />
+            <SidebarNavItem to="/board-chat" label={t("sidebar.conferenceRoom")} icon={MessagesSquare} />
           ) : null}
         </div>
 
-        <SidebarSection label="Work" collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
-          <SidebarNavItem to="/issues" label="Tasks" icon={CircleDot} />
+        <SidebarSection label={t("sidebar.work")} collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
+          <SidebarNavItem to="/issues" label={t("sidebar.tasks")} icon={CircleDot} />
           {showCases ? (
-            <SidebarNavItem to="/cases" label="Cases" icon={Layers} textBadge="beta" />
+            <SidebarNavItem to="/cases" label={t("sidebar.cases")} icon={Layers} textBadge={t("sidebar.beta")} />
           ) : null}
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
+          <SidebarNavItem to="/routines" label={t("sidebar.routines")} icon={Repeat} />
           {showPipelines ? (
-            <SidebarNavItem to="/pipelines" label="Pipelines" icon={GitBranch} />
+            <SidebarNavItem to="/pipelines" label={t("sidebar.pipelines")} icon={GitBranch} />
           ) : null}
           {showGoalsLink ? (
-            <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+            <SidebarNavItem to="/goals" label={t("sidebar.goals")} icon={Target} />
           ) : goalsLinkPending ? (
             <div
               data-testid="sidebar-goals-placeholder"
@@ -246,14 +248,14 @@ export function Sidebar() {
               aria-hidden="true"
             />
           ) : null}
-          <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
-          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
+          <SidebarNavItem to="/artifacts" label={t("sidebar.artifacts")} icon={Package} />
+          <SidebarNavItem to="/skills" label={t("sidebar.skills")} icon={Boxes} />
           {showWorkspacesLink ? (
-            <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
+            <SidebarNavItem to="/workspaces" label={t("sidebar.workspaces")} icon={GitBranch} />
           ) : null}
           {streamlined ? (
             <>
-              <SidebarNavItem to="/projects" label="Projects" icon={FolderOpen} />
+              <SidebarNavItem to="/projects" label={t("sidebar.projects")} icon={FolderOpen} />
               <SidebarStarredProjects />
             </>
           ) : null}
@@ -277,13 +279,13 @@ export function Sidebar() {
 
         <SidebarAgents streamlined={streamlined} />
 
-        <SidebarSection label="Company" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
-          <SidebarNavItem to="/org" label="Org" icon={Network} />
-          {showApps ? <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} /> : null}
-          <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
-          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
-          <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+        <SidebarSection label={t("sidebar.company")} collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
+          <SidebarNavItem to="/org" label={t("sidebar.org")} icon={Network} />
+          {showApps ? <SidebarNavItem to="/apps" label={t("sidebar.apps")} icon={AppWindow} /> : null}
+          <SidebarNavItem to="/timeline" label={t("sidebar.timeline")} icon={GanttChartSquare} />
+          <SidebarNavItem to="/costs" label={t("sidebar.costs")} icon={DollarSign} />
+          <SidebarNavItem to="/activity" label={t("sidebar.activity")} icon={History} />
+          <SidebarNavItem to="/company/settings" label={t("sidebar.settings")} icon={Settings} />
         </SidebarSection>
 
         <PluginSlotOutlet

--- a/ui/src/i18n/locales/ar.json
+++ b/ui/src/i18n/locales/ar.json
@@ -5,5 +5,40 @@
       "description": "ابدأ بإنشاء شركة.",
       "newCompany": "شركة جديدة"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ar.json
+++ b/ui/src/i18n/locales/ar.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/bn.json
+++ b/ui/src/i18n/locales/bn.json
@@ -5,5 +5,40 @@
       "description": "একটি কোম্পানি তৈরি করে শুরু করুন।",
       "newCompany": "নতুন কোম্পানি"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/bn.json
+++ b/ui/src/i18n/locales/bn.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/cs.json
+++ b/ui/src/i18n/locales/cs.json
@@ -5,5 +5,40 @@
       "description": "Začněte vytvořením společnosti.",
       "newCompany": "Nová společnost"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/cs.json
+++ b/ui/src/i18n/locales/cs.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/da.json
+++ b/ui/src/i18n/locales/da.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/da.json
+++ b/ui/src/i18n/locales/da.json
@@ -5,5 +5,40 @@
       "description": "Kom i gang ved at oprette en virksomhed.",
       "newCompany": "Ny virksomhed"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/de.json
+++ b/ui/src/i18n/locales/de.json
@@ -5,5 +5,40 @@
       "description": "Beginnen Sie, indem Sie ein Unternehmen erstellen.",
       "newCompany": "Neues Unternehmen"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/de.json
+++ b/ui/src/i18n/locales/de.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/el.json
+++ b/ui/src/i18n/locales/el.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/el.json
+++ b/ui/src/i18n/locales/el.json
@@ -5,5 +5,40 @@
       "description": "Ξεκινήστε δημιουργώντας μια εταιρεία.",
       "newCompany": "Νέα εταιρεία"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -5,5 +5,40 @@
       "description": "Get started by creating a company.",
       "newCompany": "New Company"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/es.json
+++ b/ui/src/i18n/locales/es.json
@@ -5,5 +5,40 @@
       "description": "Comienza creando una empresa.",
       "newCompany": "Nueva empresa"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/es.json
+++ b/ui/src/i18n/locales/es.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/fa.json
+++ b/ui/src/i18n/locales/fa.json
@@ -5,5 +5,40 @@
       "description": "با ایجاد یک شرکت شروع کنید.",
       "newCompany": "شرکت جدید"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/fa.json
+++ b/ui/src/i18n/locales/fa.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/fi.json
+++ b/ui/src/i18n/locales/fi.json
@@ -5,5 +5,40 @@
       "description": "Aloita luomalla yritys.",
       "newCompany": "Uusi yritys"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/fi.json
+++ b/ui/src/i18n/locales/fi.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/fil.json
+++ b/ui/src/i18n/locales/fil.json
@@ -5,5 +5,40 @@
       "description": "Magsimula sa paggawa ng kumpanya.",
       "newCompany": "Bagong Kumpanya"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/fil.json
+++ b/ui/src/i18n/locales/fil.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -5,5 +5,40 @@
       "description": "Commencez par créer une entreprise.",
       "newCompany": "Nouvelle entreprise"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/fr.json
+++ b/ui/src/i18n/locales/fr.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/he.json
+++ b/ui/src/i18n/locales/he.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/he.json
+++ b/ui/src/i18n/locales/he.json
@@ -5,5 +5,40 @@
       "description": "התחילו ביצירת חברה.",
       "newCompany": "חברה חדשה"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/hi.json
+++ b/ui/src/i18n/locales/hi.json
@@ -5,5 +5,40 @@
       "description": "कंपनी बनाकर शुरुआत करें.",
       "newCompany": "नई कंपनी"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/hi.json
+++ b/ui/src/i18n/locales/hi.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/hu.json
+++ b/ui/src/i18n/locales/hu.json
@@ -5,5 +5,40 @@
       "description": "Kezdje egy vállalat létrehozásával.",
       "newCompany": "Új vállalat"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/hu.json
+++ b/ui/src/i18n/locales/hu.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/id.json
+++ b/ui/src/i18n/locales/id.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/id.json
+++ b/ui/src/i18n/locales/id.json
@@ -5,5 +5,40 @@
       "description": "Mulai dengan membuat perusahaan.",
       "newCompany": "Perusahaan Baru"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/it.json
+++ b/ui/src/i18n/locales/it.json
@@ -5,5 +5,40 @@
       "description": "Inizia creando un'azienda.",
       "newCompany": "Nuova azienda"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/it.json
+++ b/ui/src/i18n/locales/it.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/ja.json
+++ b/ui/src/i18n/locales/ja.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/ja.json
+++ b/ui/src/i18n/locales/ja.json
@@ -5,5 +5,40 @@
       "description": "会社を作成して始めましょう。",
       "newCompany": "新しい会社"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -5,5 +5,40 @@
       "description": "회사를 만들어 시작하세요.",
       "newCompany": "새 회사"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ko.json
+++ b/ui/src/i18n/locales/ko.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/mr.json
+++ b/ui/src/i18n/locales/mr.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/mr.json
+++ b/ui/src/i18n/locales/mr.json
@@ -5,5 +5,40 @@
       "description": "कंपनी तयार करून सुरुवात करा.",
       "newCompany": "नवीन कंपनी"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ms.json
+++ b/ui/src/i18n/locales/ms.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/ms.json
+++ b/ui/src/i18n/locales/ms.json
@@ -5,5 +5,40 @@
       "description": "Mulakan dengan mencipta syarikat.",
       "newCompany": "Syarikat Baharu"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/nb.json
+++ b/ui/src/i18n/locales/nb.json
@@ -5,5 +5,40 @@
       "description": "Kom i gang ved å opprette et selskap.",
       "newCompany": "Nytt selskap"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/nb.json
+++ b/ui/src/i18n/locales/nb.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/nl.json
+++ b/ui/src/i18n/locales/nl.json
@@ -5,5 +5,40 @@
       "description": "Begin door een bedrijf aan te maken.",
       "newCompany": "Nieuw bedrijf"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/nl.json
+++ b/ui/src/i18n/locales/nl.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/pa.json
+++ b/ui/src/i18n/locales/pa.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/pa.json
+++ b/ui/src/i18n/locales/pa.json
@@ -5,5 +5,40 @@
       "description": "ਕੰਪਨੀ ਬਣਾਕੇ ਸ਼ੁਰੂ ਕਰੋ।",
       "newCompany": "ਨਵੀਂ ਕੰਪਨੀ"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/pl.json
+++ b/ui/src/i18n/locales/pl.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/pl.json
+++ b/ui/src/i18n/locales/pl.json
@@ -5,5 +5,40 @@
       "description": "Zacznij od utworzenia firmy.",
       "newCompany": "Nowa firma"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/pt-BR.json
+++ b/ui/src/i18n/locales/pt-BR.json
@@ -5,5 +5,40 @@
       "description": "Comece criando uma empresa.",
       "newCompany": "Nova empresa"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/pt-BR.json
+++ b/ui/src/i18n/locales/pt-BR.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/pt-PT.json
+++ b/ui/src/i18n/locales/pt-PT.json
@@ -5,5 +5,40 @@
       "description": "Comece por criar uma empresa.",
       "newCompany": "Nova empresa"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/pt-PT.json
+++ b/ui/src/i18n/locales/pt-PT.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/ro.json
+++ b/ui/src/i18n/locales/ro.json
@@ -5,5 +5,40 @@
       "description": "Începeți prin crearea unei companii.",
       "newCompany": "Companie nouă"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ro.json
+++ b/ui/src/i18n/locales/ro.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/ru.json
+++ b/ui/src/i18n/locales/ru.json
@@ -5,5 +5,40 @@
       "description": "Начните с создания компании.",
       "newCompany": "Новая компания"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ru.json
+++ b/ui/src/i18n/locales/ru.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/sv.json
+++ b/ui/src/i18n/locales/sv.json
@@ -5,5 +5,40 @@
       "description": "Kom igång genom att skapa ett företag.",
       "newCompany": "Nytt företag"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/sv.json
+++ b/ui/src/i18n/locales/sv.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/sw.json
+++ b/ui/src/i18n/locales/sw.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/sw.json
+++ b/ui/src/i18n/locales/sw.json
@@ -5,5 +5,40 @@
       "description": "Anza kwa kuunda kampuni.",
       "newCompany": "Kampuni Mpya"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ta.json
+++ b/ui/src/i18n/locales/ta.json
@@ -5,5 +5,40 @@
       "description": "ஒரு நிறுவனத்தை உருவாக்கி தொடங்குங்கள்.",
       "newCompany": "புதிய நிறுவனம்"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ta.json
+++ b/ui/src/i18n/locales/ta.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/te.json
+++ b/ui/src/i18n/locales/te.json
@@ -5,5 +5,40 @@
       "description": "కంపెనీని సృష్టించడం ద్వారా ప్రారంభించండి.",
       "newCompany": "కొత్త కంపెనీ"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/te.json
+++ b/ui/src/i18n/locales/te.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/th.json
+++ b/ui/src/i18n/locales/th.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/th.json
+++ b/ui/src/i18n/locales/th.json
@@ -5,5 +5,40 @@
       "description": "เริ่มต้นด้วยการสร้างบริษัท",
       "newCompany": "บริษัทใหม่"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/tr.json
+++ b/ui/src/i18n/locales/tr.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/tr.json
+++ b/ui/src/i18n/locales/tr.json
@@ -5,5 +5,40 @@
       "description": "Bir şirket oluşturarak başlayın.",
       "newCompany": "Yeni Şirket"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/uk.json
+++ b/ui/src/i18n/locales/uk.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/uk.json
+++ b/ui/src/i18n/locales/uk.json
@@ -5,5 +5,40 @@
       "description": "Почніть зі створення компанії.",
       "newCompany": "Нова компанія"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ur.json
+++ b/ui/src/i18n/locales/ur.json
@@ -5,5 +5,40 @@
       "description": "کمپنی بنا کر شروع کریں۔",
       "newCompany": "نئی کمپنی"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/ur.json
+++ b/ui/src/i18n/locales/ur.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/vi.json
+++ b/ui/src/i18n/locales/vi.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "decisions",
     "beta": "beta",
     "company": "Company"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "Create your first company",
+    "createAnotherCompanyTitle": "Create another company",
+    "addAgentToCompanyTitle": "Add another agent to {{name}}",
+    "createFirstCompanyDesc": "Get started by creating a company and your first agent.",
+    "createAnotherCompanyDesc": "Run onboarding again to create another company and seed its first agent.",
+    "addAgentToCompanyDesc": "Run onboarding again to add an agent and a starter task for this company.",
+    "addAgentButton": "Add Agent",
+    "startOnboardingButton": "Start Onboarding"
   }
 }

--- a/ui/src/i18n/locales/vi.json
+++ b/ui/src/i18n/locales/vi.json
@@ -5,5 +5,40 @@
       "description": "Bắt đầu bằng cách tạo một công ty.",
       "newCompany": "Công ty mới"
     }
+  },
+  "common": {
+    "skipToMainContent": "Skip to Main Content",
+    "openSearch": "Open search",
+    "keepSidebarExpanded": "Keep sidebar expanded",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
+    "newTask": "New Task"
+  },
+  "sidebar": {
+    "dashboard": "Dashboard",
+    "inbox": "Inbox",
+    "decisions": "Decisions",
+    "status": "Status",
+    "conferenceRoom": "Conference Room",
+    "work": "Work",
+    "tasks": "Tasks",
+    "cases": "Cases",
+    "routines": "Routines",
+    "pipelines": "Pipelines",
+    "goals": "Goals",
+    "artifacts": "Artifacts",
+    "skills": "Skills",
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "org": "Org",
+    "apps": "Apps",
+    "timeline": "Timeline",
+    "costs": "Costs",
+    "activity": "Activity",
+    "settings": "Settings",
+    "unread": "unread",
+    "decisionsBadge": "decisions",
+    "beta": "beta",
+    "company": "Company"
   }
 }

--- a/ui/src/i18n/locales/zh-CN.json
+++ b/ui/src/i18n/locales/zh-CN.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "决策",
     "beta": "测试版",
     "company": "公司"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "创建您的第一家公司",
+    "createAnotherCompanyTitle": "创建另一家公司",
+    "addAgentToCompanyTitle": "为 {{name}} 添加另一个智能体",
+    "createFirstCompanyDesc": "通过创建公司和您的第一个智能体开始。",
+    "createAnotherCompanyDesc": "再次运行引导以创建另一家公司并生成其首个智能体。",
+    "addAgentToCompanyDesc": "再次运行引导，为此公司添加一个智能体和入门任务。",
+    "addAgentButton": "添加智能体",
+    "startOnboardingButton": "开始引导"
   }
 }

--- a/ui/src/i18n/locales/zh-CN.json
+++ b/ui/src/i18n/locales/zh-CN.json
@@ -5,5 +5,40 @@
       "description": "通过创建公司开始。",
       "newCompany": "新公司"
     }
+  },
+  "common": {
+    "skipToMainContent": "跳到主要内容",
+    "openSearch": "打开搜索",
+    "keepSidebarExpanded": "保持侧栏展开",
+    "expandSidebar": "展开侧栏",
+    "collapseSidebar": "收起侧栏",
+    "newTask": "新建任务"
+  },
+  "sidebar": {
+    "dashboard": "仪表盘",
+    "inbox": "收件箱",
+    "decisions": "决策",
+    "status": "状态",
+    "conferenceRoom": "会议室",
+    "work": "工作",
+    "tasks": "任务",
+    "cases": "案例",
+    "routines": "例行任务",
+    "pipelines": "流水线",
+    "goals": "目标",
+    "artifacts": "产物",
+    "skills": "技能",
+    "workspaces": "工作区",
+    "projects": "项目",
+    "org": "组织",
+    "apps": "应用",
+    "timeline": "时间线",
+    "costs": "成本",
+    "activity": "动态",
+    "settings": "设置",
+    "unread": "未读",
+    "decisionsBadge": "决策",
+    "beta": "测试版",
+    "company": "公司"
   }
 }

--- a/ui/src/i18n/locales/zh-TW.json
+++ b/ui/src/i18n/locales/zh-TW.json
@@ -5,5 +5,40 @@
       "description": "從建立公司開始。",
       "newCompany": "新公司"
     }
+  },
+  "common": {
+    "skipToMainContent": "跳到主要內容",
+    "openSearch": "開啟搜尋",
+    "keepSidebarExpanded": "保持側欄展開",
+    "expandSidebar": "展開側欄",
+    "collapseSidebar": "收起側欄",
+    "newTask": "新增任務"
+  },
+  "sidebar": {
+    "dashboard": "儀表板",
+    "inbox": "收件匣",
+    "decisions": "決策",
+    "status": "狀態",
+    "conferenceRoom": "會議室",
+    "work": "工作",
+    "tasks": "任務",
+    "cases": "案例",
+    "routines": "例行任務",
+    "pipelines": "管線",
+    "goals": "目標",
+    "artifacts": "產物",
+    "skills": "技能",
+    "workspaces": "工作區",
+    "projects": "專案",
+    "org": "組織",
+    "apps": "應用程式",
+    "timeline": "時間軸",
+    "costs": "成本",
+    "activity": "動態",
+    "settings": "設定",
+    "unread": "未讀",
+    "decisionsBadge": "決策",
+    "beta": "測試版",
+    "company": "公司"
   }
 }

--- a/ui/src/i18n/locales/zh-TW.json
+++ b/ui/src/i18n/locales/zh-TW.json
@@ -40,5 +40,15 @@
     "decisionsBadge": "決策",
     "beta": "測試版",
     "company": "公司"
+  },
+  "onboarding": {
+    "createFirstCompanyTitle": "建立您的第一家公司",
+    "createAnotherCompanyTitle": "建立另一家公司",
+    "addAgentToCompanyTitle": "為 {{name}} 新增另一個智能體",
+    "createFirstCompanyDesc": "透過建立公司與您的第一個智能體開始。",
+    "createAnotherCompanyDesc": "再次執行引導以建立另一家公司並建立其首個智能體。",
+    "addAgentToCompanyDesc": "再次執行引導，為此公司新增一個智能體與入門任務。",
+    "addAgentButton": "新增智能體",
+    "startOnboardingButton": "開始引導"
   }
 }


### PR DESCRIPTION
## Summary
This is the first slice of an effort to fully localize the Paperclip UI into Chinese. It translates the most-visible, repeatedly-rendered text:

- **Sidebar navigation**: all `SidebarNavItem` labels (Dashboard, Inbox, Tasks, Cases, Routines, Pipelines, Goals, Artifacts, Skills, Workspaces, Projects, Org, Apps, Timeline, Costs, Activity, Settings, Decisions, Status, Conference Room), the `Work` / `Company` section headers, the `New Task` button, and the sidebar search / expand-collapse `aria-label`s.
- **Global chrome**: the "Skip to Main Content" link in `Layout`.
- **Onboarding entry card** (`App.tsx` `OnboardingRoutePage`), including the `{{name}}` company-name interpolation.

## How it works with the existing i18n setup
- New source strings live under `common.*`, `sidebar.*`, and `onboarding.*` in `en.json`.
- `zh-CN` (Simplified) and `zh-TW` (Traditional) are fully translated.
- The other 37 registered locales receive English fallback values for the new keys, so `locale-validation` (which requires every locale to exactly match `en.json`'s key/placeholder shape) stays green.

## Test plan
- `pnpm --filter ui exec vitest run src/i18n/locale-validation.test.ts` — passes (7/7).
- `tsc --noEmit` in `ui/` — clean.

Follow-up PRs will cover the onboarding wizard, dialogs, and the remaining pages. Happy to adjust scope/key naming if the maintainers prefer a different convention.