### PR TITLE
fix(interactions): let agents retract own prompts

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -1156,7 +1156,7 @@ export interface RequestItemVerdictsPayload {
 
 export interface RequestConfirmationResult {
   version: 1;
-  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target";
+  outcome: "accepted" | "rejected" | "cancelled" | "superseded_by_comment" | "stale_target";
   reason?: string | null;
   commentId?: string | null;
   staleTarget?: RequestConfirmationTarget | null;
@@ -1191,6 +1191,7 @@ export interface RequestItemVerdictsResult {
   outcome: "resolved" | "superseded_by_comment" | "stale_target" | "cancelled";
   complete: boolean;
   items: RequestItemVerdictsResultItem[];
+  reason?: string | null;
   commentId?: string | null;
   staleTarget?: RequestConfirmationTarget | null;
 }

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -908,7 +908,7 @@ export const requestConfirmationToolActionResultSchema = z.object({
 
 export const requestConfirmationResultSchema = z.object({
   version: z.literal(1),
-  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target"]),
+  outcome: z.enum(["accepted", "rejected", "cancelled", "superseded_by_comment", "stale_target"]),
   reason: z.string().trim().max(4000).nullable().optional(),
   commentId: z.string().uuid().nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),
@@ -1034,6 +1034,7 @@ export const requestItemVerdictsResultSchema = z.object({
   complete: z.boolean(),
   items: z.array(requestItemVerdictsResultItemSchema)
     .max(REQUEST_ITEM_VERDICTS_ITEM_LIMIT),
+  reason: z.string().trim().max(4000).nullable().optional(),
   commentId: z.string().uuid().nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),
 }).superRefine((value, ctx) => {

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -11,6 +11,7 @@ const mockIssueService = vi.hoisted(() => ({
 
 const mockInteractionService = vi.hoisted(() => ({
   listForIssue: vi.fn(),
+  getById: vi.fn(),
   create: vi.fn(),
   acceptInteraction: vi.fn(),
   acceptSuggestedTasks: vi.fn(),
@@ -19,7 +20,7 @@ const mockInteractionService = vi.hoisted(() => ({
   expireRequestConfirmationsSupersededByHistoricalComments: vi.fn(),
   answerQuestions: vi.fn(),
   submitItemVerdicts: vi.fn(),
-  cancelQuestions: vi.fn(),
+  cancelInteraction: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -327,7 +328,15 @@ describe.sequential("issue thread interaction routes", () => {
       },
       newlyResolvedItemIds: ["docs"],
     });
-    mockInteractionService.cancelQuestions.mockResolvedValue({
+    mockInteractionService.getById.mockResolvedValue({
+      id: "interaction-2",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "ask_user_questions",
+      status: "pending",
+      createdByAgentId: CREATED_AGENT_ID,
+    });
+    mockInteractionService.cancelInteraction.mockResolvedValue({
       id: "interaction-2",
       companyId: "company-1",
       issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
@@ -337,6 +346,7 @@ describe.sequential("issue thread interaction routes", () => {
       idempotencyKey: null,
       sourceCommentId: "comment-2",
       sourceRunId: "run-2",
+      createdByAgentId: CREATED_AGENT_ID,
       payload: {
         version: 1,
         questions: [{
@@ -583,7 +593,7 @@ describe.sequential("issue thread interaction routes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("cancelled");
-    expect(mockInteractionService.cancelQuestions).toHaveBeenCalledWith(
+    expect(mockInteractionService.cancelInteraction).toHaveBeenCalledWith(
       expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
       "interaction-2",
       {},
@@ -608,6 +618,95 @@ describe.sequential("issue thread interaction routes", () => {
         action: "issue.thread_interaction_cancelled",
       }),
     );
+  });
+
+  it("allows an agent to cancel only a pending interaction it authored and audits the run", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "33333333-3333-4333-8333-333333333333",
+      keyScope: { kind: "standard" },
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send({ reason: "Superseded by the current issue state" });
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.cancelInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+      "interaction-2",
+      { reason: "Superseded by the current issue state" },
+      { agentId: CREATED_AGENT_ID, userId: null },
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorType: "agent",
+        agentId: CREATED_AGENT_ID,
+        runId: "33333333-3333-4333-8333-333333333333",
+        action: "issue.thread_interaction_cancelled",
+        details: expect.objectContaining({
+          cancellationReason: "Superseded by the current issue state",
+          authoredByAgentId: CREATED_AGENT_ID,
+        }),
+      }),
+    );
+  });
+
+  it("forbids an agent from cancelling another actor's interaction", async () => {
+    mockInteractionService.getById.mockResolvedValueOnce({
+      id: "interaction-2",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "ask_user_questions",
+      status: "pending",
+      createdByAgentId: ASSIGNEE_AGENT_ID,
+    });
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "33333333-3333-4333-8333-333333333333",
+      keyScope: { kind: "standard" },
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send({ reason: "Stale" });
+
+    expect(res.status).toBe(403);
+    expect(mockInteractionService.cancelInteraction).not.toHaveBeenCalled();
+  });
+
+  it("forbids an agent from cancelling a board-authored interaction", async () => {
+    mockInteractionService.getById.mockResolvedValueOnce({
+      id: "interaction-2",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "ask_user_questions",
+      status: "pending",
+      createdByAgentId: null,
+      createdByUserId: "local-board",
+    });
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "33333333-3333-4333-8333-333333333333",
+      keyScope: { kind: "standard" },
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send({ reason: "Stale" });
+
+    expect(res.status).toBe(403);
+    expect(mockInteractionService.cancelInteraction).not.toHaveBeenCalled();
   });
 
   it("accepts request confirmations and wakes the current assignee when configured for accept-only wakeups", async () => {

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -547,7 +547,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       userId: "local-board",
     });
 
-    const cancelled = await interactionsSvc.cancelQuestions({
+    const cancelled = await interactionsSvc.cancelInteraction({
       id: issueId,
       companyId,
     }, created.id, {
@@ -573,6 +573,73 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     }, {
       userId: "local-board",
     })).rejects.toThrow("Interaction has already been resolved");
+  });
+
+  it("retracts three stale agent-authored prompts while leaving the live prompt pending", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Four-prompt queue hygiene");
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Queue hygiene agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const created = [];
+    for (const prompt of ["Stale one?", "Stale two?", "Stale three?", "Live decision?"]) {
+      created.push(await interactionsSvc.create({
+        id: issueId,
+        companyId,
+      }, {
+        kind: "ask_user_questions",
+        continuationPolicy: "wake_assignee",
+        payload: {
+          version: 1,
+          questions: [{
+            id: "decision",
+            prompt,
+            selectionMode: "single",
+            options: [{ id: "continue", label: "Continue" }],
+          }],
+        },
+      }, {
+        agentId,
+      }));
+    }
+
+    for (const interaction of created.slice(0, 3)) {
+      await interactionsSvc.cancelInteraction({
+        id: issueId,
+        companyId,
+      }, interaction.id, {
+        reason: "Superseded by current issue state",
+      }, {
+        agentId,
+      });
+    }
+
+    const interactions = await interactionsSvc.listForIssue(issueId);
+    const pending = interactions.filter((interaction) => interaction.status === "pending");
+    const cancelled = interactions.filter((interaction) => interaction.status === "cancelled");
+
+    expect(pending.map((interaction) => interaction.id)).toEqual([created[3]!.id]);
+    expect(cancelled.map((interaction) => interaction.id)).toEqual(
+      created.slice(0, 3).map((interaction) => interaction.id),
+    );
+    expect(cancelled).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        createdByAgentId: agentId,
+        resolvedByAgentId: agentId,
+        result: expect.objectContaining({
+          cancellationReason: "Superseded by current issue state",
+        }),
+      }),
+    ]));
   });
 
   it("expires ask_user_questions interactions by default when a user comments after creation", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9390,11 +9390,37 @@ export function issueRoutes(
       const interactionId = req.params.interactionId as string;
       const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
       if (!issue) return;
-      if (await rejectAgentIssueThreadInteractionResolution(req, res, issue)) return;
-      assertBoard(req);
 
       const actor = getActorInfo(req);
-      const interaction = await issueThreadInteractionService(db).cancelQuestions(issue, interactionId, req.body, {
+      const interactionSvc = issueThreadInteractionService(db);
+      if (req.actor.type === "agent") {
+        const agentRunId = requireAgentRunId(req, res);
+        if (!agentRunId) return;
+        if (
+          !(await assertTaskWatchdogIssueMutationAllowed(req, res, issue, { allowWatchdogIssue: false }))
+        ) {
+          return;
+        }
+        const current = await interactionSvc.getById(interactionId);
+        if (
+          !current
+          || current.companyId !== issue.companyId
+          || current.issueId !== issue.id
+        ) {
+          res.status(404).json({ error: "Interaction not found" });
+          return;
+        }
+        if (!actor.agentId || current.createdByAgentId !== actor.agentId) {
+          res.status(403).json({
+            error: "Agent actors can only cancel pending issue-thread interactions they authored",
+          });
+          return;
+        }
+      } else {
+        assertBoard(req);
+      }
+
+      const interaction = await interactionSvc.cancelInteraction(issue, interactionId, req.body, {
         agentId: actor.agentId,
         userId: actor.actorType === "user" ? actor.actorId : null,
       });
@@ -9413,10 +9439,8 @@ export function issueRoutes(
           interactionId: interaction.id,
           interactionKind: interaction.kind,
           interactionStatus: interaction.status,
-          cancellationReason:
-            interaction.kind === "ask_user_questions"
-              ? (interaction.result?.cancellationReason ?? null)
-              : null,
+          cancellationReason: req.body.reason?.trim() || null,
+          authoredByAgentId: interaction.createdByAgentId,
         },
       });
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -5839,7 +5839,7 @@ registerCurrentRoute({
   method: "post",
   path: "/api/issues/{id}/interactions/{interactionId}/cancel",
   tags: ["issues"],
-  summary: "Cancel an issue question interaction",
+  summary: "Cancel a pending issue interaction",
   body: cancelIssueThreadInteractionSchema,
 });
 

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1905,7 +1905,7 @@ export function issueThreadInteractionService(db: Db) {
       return answered;
     },
 
-    cancelQuestions: async (
+    cancelInteraction: async (
       issue: { id: string; companyId: string },
       interactionId: string,
       input: CancelIssueThreadInteraction,
@@ -1922,25 +1922,51 @@ export function issueThreadInteractionService(db: Db) {
       if (current.companyId !== issue.companyId || current.issueId !== issue.id) {
         throw notFound("Interaction not found");
       }
-      if (current.kind !== "ask_user_questions") {
-        throw unprocessable("Only ask_user_questions interactions can be cancelled");
-      }
       if (current.status !== "pending") {
         throw conflict("Interaction has already been resolved");
       }
 
       const reason = data.reason?.trim() || null;
+      const result = current.kind === "ask_user_questions"
+        ? {
+            version: 1 as const,
+            answers: [],
+            cancelled: true as const,
+            cancellationReason: reason,
+            summaryMarkdown: null,
+          }
+        : current.kind === "suggest_tasks"
+          ? {
+              version: 1 as const,
+              createdTasks: [],
+              skippedClientKeys: current.payload && typeof current.payload === "object" && "tasks" in current.payload
+                && Array.isArray(current.payload.tasks)
+                ? current.payload.tasks.flatMap((task) => (
+                    task && typeof task === "object" && "clientKey" in task && typeof task.clientKey === "string"
+                      ? [task.clientKey]
+                      : []
+                  ))
+                : [],
+              rejectionReason: reason,
+            }
+          : current.kind === "request_item_verdicts"
+            ? {
+                version: 1 as const,
+                outcome: "cancelled" as const,
+                complete: false,
+                items: [],
+                reason,
+              }
+            : {
+                version: 1 as const,
+                outcome: "cancelled" as const,
+                reason,
+              };
       const [updated] = await db
         .update(issueThreadInteractions)
         .set({
           status: "cancelled",
-          result: {
-            version: 1,
-            answers: [],
-            cancelled: true,
-            cancellationReason: reason,
-            summaryMarkdown: null,
-          },
+          result,
           resolvedByAgentId: actor.agentId ?? null,
           resolvedByUserId: actor.userId ?? null,
           resolvedAt: new Date(),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane people use to coordinate autonomous agents and human governance.
> - Issue-thread interactions are typed prompts that let agents request structured human decisions while preserving an audit trail.
> - Agents can create those prompts, but the cancellation route previously rejected every agent before checking who authored the interaction.
> - Stale agent-authored prompts could therefore remain ahead of a live decision in pending-only thread and attention queues.
> - The safe authority boundary is creator ownership: an agent may retract only a still-pending interaction whose `createdByAgentId` matches that agent.
> - This pull request enforces that boundary, records the resolver/run/reason, and preserves board and other-agent prompts as forbidden.
> - The benefit is clean decision queues without granting agents any authority over human-authored governance prompts.

## Linked Issues or Issue Description

### What happened?

An agent could create multiple issue-thread interactions as work evolved, but could not retract obsolete ones. `POST /api/issues/:id/interactions/:interactionId/cancel` returned the board-only denial before loading the interaction or checking its creator. Pending-only queue surfaces therefore continued to treat stale prompts as live human decisions.

### Expected behavior

An authenticated agent running in an audited heartbeat may cancel any pending interaction it authored. The same call must remain forbidden for a board/user-authored interaction or an interaction created by another agent. Cancelled interactions remain in history with actor, run, resolver, timestamp, and reason evidence, but no longer count as pending prompts.

### Steps to reproduce

1. As an agent, create four pending issue-thread interactions on one issue.
2. Let the first three become obsolete while the fourth remains the live decision.
3. Attempt to cancel the first three with the creating agent.
4. Before this change, all three requests return `403` and all four prompts remain pending.

### Related work

This is broader than #10297, which permits creator cancellation only for `request_confirmation` and explicitly keeps agent-authored questions uncancellable. It also builds on the terminal/withdrawal lifecycle work in #10251.

## What Changed

- Generalized pending interaction cancellation across all interaction kinds with kind-valid cancellation results.
- Allowed agent actors through the cancel route only when `createdByAgentId` matches the authenticated agent and a run ID is present.
- Kept board/user-authored and other-agent interactions forbidden, with company/issue scope checked before ownership.
- Recorded cancellation reason, creator, resolving agent, and run attribution while retaining the terminal interaction in history.
- Updated the shared result contracts and OpenAPI summary.
- Added route authorization/audit tests and a four-prompt regression proving three stale prompts can be cancelled while one live prompt remains pending.

## Verification

- `pnpm vitest run server/src/__tests__/issue-thread-interaction-routes.test.ts server/src/__tests__/issue-thread-interactions-service.test.ts` — 57 passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `pnpm test:run` — server group passed (2,826 passed, 1 skipped); the UI group had two pre-existing timezone-sensitive failures under `Europe/Warsaw`.
- `TZ=UTC pnpm vitest run ui/src/components/IssueProperties.test.tsx ui/src/lib/attention.test.ts` — both affected files passed (90 tests), confirming CI-timezone parity.
- `git diff --check` — passed.

## Risks

- The cancel endpoint now applies to every pending interaction kind, so downstream consumers must rely on the already-canonical terminal `status: "cancelled"` rather than assuming cancellation is question-only. Shared validators/types were updated accordingly.
- Creator ownership is checked before mutation and the service uses a pending-status compare-and-set, limiting races and preventing cross-actor cancellation.
- No database migration is required; existing interaction status, resolver, result, and activity fields carry the history.

> ROADMAP.md was checked. Its conversational-leadership direction still anchors decisions in real work objects and does not duplicate this queue-hygiene fix.

## Model Used

- OpenAI GPT-5 via Codex, agentic coding mode with repository inspection, code execution, tests, and GitHub tooling. Context-window size was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and documented the timezone-sensitive baseline failures
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
