### PR TITLE
fix(server): do not re-stamp execution_run_id to a stale-assignee legacy run

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -2306,4 +2306,237 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       retryNotBefore.toISOString(),
     );
   });
+
+  it("does not re-stamp execution_run_id to a stale-assignee legacy run during mid-run reassignment", async () => {
+    const companyId = randomUUID();
+    const oldAgentId = randomUUID();
+    const newAgentId = randomUUID();
+    const issueId = randomUUID();
+    const legacyRunId = randomUUID();
+    const now = new Date("2026-05-13T03:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values([
+      {
+        id: oldAgentId,
+        companyId,
+        name: "ClaudeCoder",
+        role: "engineer",
+        status: "active",
+        adapterType: "claude_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: 1,
+          },
+        },
+        permissions: {},
+      },
+      {
+        id: newAgentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: 1,
+          },
+        },
+        permissions: {},
+      },
+    ]);
+
+    // Old assignee has a still-running heartbeat run tagged with this issue.
+    await db.insert(heartbeatRuns).values({
+      id: legacyRunId,
+      companyId,
+      agentId: oldAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      startedAt: now,
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    // Issue has been reassigned to the new agent mid-run. execution_run_id was
+    // cleared by the reassignment so the legacyRun fallback path is reachable.
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned mid-run",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: newAgentId,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    // Saturate the new assignee's queue so wakeup does not actually launch.
+    await db.insert(heartbeatRuns).values(
+      Array.from({ length: 5 }, () => ({
+        id: randomUUID(),
+        companyId,
+        agentId: newAgentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "running" as const,
+        contextSnapshot: {
+          wakeReason: "test_busy_slot",
+        },
+        startedAt: now,
+        updatedAt: now,
+        createdAt: now,
+      })),
+    );
+
+    const newAssigneeRun = await heartbeat.wakeup(newAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: { issueId, source: "issue.update" },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    expect(newAssigneeRun).not.toBeNull();
+    expect(newAssigneeRun?.agentId).toBe(newAgentId);
+
+    const issueAfter = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfter?.executionRunId).not.toBe(legacyRunId);
+
+    const deferredWakeups = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.status, "deferred_issue_execution"))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(deferredWakeups).toBe(0);
+  });
+
+  it("still re-stamps execution_run_id when the legacy run belongs to the current assignee (same-agent re-entry)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const legacyRunId = randomUUID();
+    const now = new Date("2026-05-13T03:30:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: legacyRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      startedAt: now,
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Same-agent re-entry",
+      status: "in_progress",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: agentId,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      issueNumber: 1,
+      identifier: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-1`,
+    });
+
+    // Saturate the agent's queue so wakeup does not actually launch.
+    await db.insert(heartbeatRuns).values(
+      Array.from({ length: 5 }, () => ({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "running" as const,
+        contextSnapshot: {
+          wakeReason: "test_busy_slot",
+        },
+        startedAt: now,
+        updatedAt: now,
+        createdAt: now,
+      })),
+    );
+
+    await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: { issueId, source: "issue.update" },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    const issueAfter = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issueAfter?.executionRunId).toBe(legacyRunId);
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16536,6 +16536,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (legacyRun) {
             if (await cancelStaleScheduledRetry(legacyRun)) {
               activeExecutionRun = null;
+            } else if (
+              issue.assigneeAgentId &&
+              legacyRun.agentId !== issue.assigneeAgentId
+            ) {
+              // Mid-run reassignment: the legacyRun belongs to the previous
+              // assignee. Re-stamping issues.execution_run_id to that run would
+              // route the new assignee's wake into deferred_issue_execution
+              // behind a stale owner, and the early-return guard in
+              // releaseIssueExecutionAndPromote would later prevent that wake
+              // from ever being promoted. Skip the fallback so the new
+              // assignee's wake proceeds on the normal path.
+              activeExecutionRun = null;
             } else {
               activeExecutionRun = legacyRun;
               const legacyAgent = await tx


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat / execution-run subsystem owns the single-writer guarantee for an issue: at most one heartbeat run "owns" an issue at a time, and other wakes queue up as `deferred_issue_execution` rows behind that owner.
> - When ownership changes (mid-run reassignment), `enqueueWakeup` must let the *new* assignee become the owner. Today, the "legacyRun fallback" in `server/src/services/heartbeat.ts` looks up any queued/running heartbeat run tagged with the same `issueId` and re-stamps `issues.execution_run_id` onto that run regardless of who its `agentId` is — so the old assignee's run becomes owner again and the new assignee's wake gets queued behind it.
> - Because the early-return in `releaseIssueExecutionAndPromote` only promotes a deferred wake when the releasing run *is* the current owner (`issue.executionRunId === run.id`), the deferred wake never gets promoted once the old run later fails / is cancelled. The issue is left wedged with no live run.
> - This pull request narrows the legacyRun fallback to runs whose `agentId` still matches `issue.assigneeAgentId`, so cross-assignee reassignments fall through to the normal "new owner" path while same-agent recovery (e.g. retried run for the same assignee) keeps working.
> - The benefit is no more stuck-in-`in_progress` / `in_review` / `todo` issues after reassignment, without changing recovery semantics for the common case.

## Linked Issues or Issue Description

Supersedes #5876. That pull request carried the same fix, but its branch name contained an internal ticket id, which CONTRIBUTING.md does not allow. This pull request replaces it from a compliant branch. I have also corrected the tooling that generated the old name, so it will not happen again. I searched the open pull request list and found no other pull request for this bug.

No public GitHub issue exists for this bug. The description follows the bug report template.

**What happened**

Reassign an issue to a different agent while a run for that issue is queued or active. After the first agent's run ends, the issue stops. It stays in `in_progress`, `in_review`, or `todo` with no live run. The new assignee never wakes. An operator must correct the row by hand.

The cause is the legacy-run fallback in `enqueueWakeup`. It selects a queued or running heartbeat run by `issueId` only. It does not compare `legacyRun.agentId` with `issue.assigneeAgentId`. It therefore points `issues.execution_run_id` at the previous assignee's run. The new assignee's wake is then written as a `deferred_issue_execution` behind that run.

`releaseIssueExecutionAndPromote` then blocks recovery:

```ts
if (issue.executionRunId && issue.executionRunId !== run.id) return null;
```

The stale run is not the recorded owner, so the promotion path returns early. The deferred wake stays in the queue forever.

**Expected behavior**

After a mid-run reassignment, the new assignee's wake must proceed on the normal path. The issue must not be stamped to a run that belongs to a previous assignee.

**Steps to reproduce**

1. Assign an issue to agent A. Let the run reach `queued` or `running`.
2. Reassign the same issue to agent B while that run is still active.
3. Let agent A's run fail, or cancel it.
4. Look at the issue. It stays in a non-terminal status with no live run. Agent B never starts.

**Paperclip version or commit**

Reproduced on `master`. This branch is rebased onto current `master`.

**Agent adapter(s) involved**

Not adapter-specific. This is a core bug in the heartbeat service.

## What Changed

- `server/src/services/heartbeat.ts` — in the `enqueueWakeup` legacyRun fallback, skip re-stamping `issues.execution_run_id` to the legacy run when `legacyRun.agentId !== issue.assigneeAgentId`. Fall through so the new assignee's wake takes the normal "claim ownership" path.
- `server/src/__tests__/heartbeat-retry-scheduling.test.ts` — adds two regression tests:
  1. Mid-run reassignment: a new assignee's wake is **not** deferred behind the previous assignee's still-running run.
  2. Same-agent recovery: when the legacy run's agent still matches `issue.assigneeAgentId`, the legacyRun fallback continues to re-stamp (unchanged behavior).

## Verification

Rebased onto current `master`. The two regression tests were written against an older base, where heartbeat run dispatch did not yet require a resolvable responsible user. They stopped at `responsible_user_unresolved` (HTTP 422) before reaching their assertions. The fixtures now set `defaultResponsibleUserId` on the company and `responsibleUserId` on the issue, matching the other tests in the same file.

- `pnpm --filter @paperclipai/server typecheck` — passes.
- `./node_modules/.bin/vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts` — 32 tests pass.
- Reverted the guard and re-ran the suite. `does not re-stamp execution_run_id to a stale-assignee legacy run` then fails, so the test still covers the fix. The same-agent control test passes in both states, which is correct, because it asserts unchanged behavior.
- No schema or migration changes. The fix is a guard on an existing branch.

## Risks

- **Low risk, scoped guard.** The change only narrows which legacy runs are eligible for the fallback; it does not introduce a new write path.
- **Recovery for same-agent retries** (e.g. crashed run re-entry) is preserved — the `agentId` equality check is exactly the condition that distinguishes "same owner reconnecting" from "ownership has changed."
- **No-op for issues that were never reassigned.** All existing heartbeat-retry tests continue to pass.
- Edge case considered: if `issue.assigneeAgentId` is null (issue assigned to a human user only), the guard does not apply and the fallback behaves as before. The guard requires `issue.assigneeAgentId` to be set.

## Model Used

- Original fix: Claude (Anthropic) — `claude-opus-4-7`, extended-thinking mode, tool use over the repo.
- Rebase onto current `master` and test-fixture correction: Claude (Anthropic) — `claude-opus-5`, run through Claude Code with extended thinking and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation change applies
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] I will address all Greptile and reviewer comments before requesting merge
