### PR TITLE
fix(issues): cover monitor-backed in_review blocker lanes

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -99,7 +99,12 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originKind?: string | null;
     originId?: string | null;
     originFingerprint?: string | null;
+    executionPolicy?: Record<string, unknown> | null;
     executionState?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
+    monitorAttemptCount?: number | null;
+    monitorNotes?: string | null;
+    monitorScheduledBy?: string | null;
     description?: string | null;
   }) {
     const id = input.id ?? randomUUID();
@@ -116,7 +121,12 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       originKind: input.originKind ?? "manual",
       originId: input.originId ?? null,
       originFingerprint: input.originFingerprint ?? "default",
+      executionPolicy: input.executionPolicy ?? null,
       executionState: input.executionState ?? null,
+      monitorNextCheckAt: input.monitorNextCheckAt ?? null,
+      monitorAttemptCount: input.monitorAttemptCount ?? 0,
+      monitorNotes: input.monitorNotes ?? null,
+      monitorScheduledBy: input.monitorScheduledBy ?? null,
       description: input.description ?? null,
     });
     return id;
@@ -420,6 +430,74 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention).toMatchObject({
       state: "covered",
       stalledBlockerCount: 0,
+    });
+  });
+
+  it("treats an in_review leaf with a scheduled monitor as covered", async () => {
+    const { companyId, agentId } = await createCompany("PBY");
+    const parentId = await insertIssue({ companyId, identifier: "PBY-1", title: "Parent", status: "blocked" });
+    const nextCheckAt = "2026-07-31T14:00:00.000Z";
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBY-2",
+      title: "Monitor-backed review leaf",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      executionPolicy: {
+        mode: "normal",
+        stages: [],
+        commentRequired: true,
+        monitor: {
+          nextCheckAt,
+          notes: "Check back tomorrow",
+          scheduledBy: "assignee",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: "Check back tomorrow",
+          scheduledBy: "assignee",
+          kind: null,
+          serviceName: null,
+          externalRef: null,
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+      monitorNextCheckAt: new Date(nextCheckAt),
+      monitorAttemptCount: 0,
+      monitorNotes: "Check back tomorrow",
+      monitorScheduledBy: "assignee",
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_dependency",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBY-2",
     });
   });
 

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -436,7 +436,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
   it("treats an in_review leaf with a scheduled monitor as covered", async () => {
     const { companyId, agentId } = await createCompany("PBY");
     const parentId = await insertIssue({ companyId, identifier: "PBY-1", title: "Parent", status: "blocked" });
-    const nextCheckAt = "2026-07-31T14:00:00.000Z";
+    const nextCheckAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
     const reviewLeafId = await insertIssue({
       companyId,
       identifier: "PBY-2",

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -501,6 +501,103 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("does not treat a scheduled monitor on a paused assignee as covered", async () => {
+    const { companyId, pausedAgentId } = await createCompany("PBYP");
+    const parentId = await insertIssue({ companyId, identifier: "PBYP-1", title: "Parent", status: "blocked" });
+    const nextCheckAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBYP-2",
+      title: "Paused monitor-backed review leaf",
+      status: "in_review",
+      assigneeAgentId: pausedAgentId,
+      executionPolicy: {
+        mode: "normal",
+        stages: [],
+        commentRequired: true,
+        monitor: {
+          nextCheckAt,
+          notes: "Check back tomorrow",
+          scheduledBy: "assignee",
+        },
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          lastTriggeredAt: null,
+          attemptCount: 0,
+          notes: "Check back tomorrow",
+          scheduledBy: "assignee",
+          kind: null,
+          serviceName: null,
+          externalRef: null,
+          timeoutAt: null,
+          maxAttempts: null,
+          recoveryPolicy: null,
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+      monitorNextCheckAt: new Date(nextCheckAt),
+      monitorAttemptCount: 0,
+      monitorNotes: "Check back tomorrow",
+      monitorScheduledBy: "assignee",
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "stalled",
+      reason: "stalled_review",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 1,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBYP-2",
+      sampleStalledBlockerIdentifier: "PBYP-2",
+    });
+  });
+
+  it("does not treat raw future monitor metadata without a scheduled state as covered", async () => {
+    const { companyId, agentId } = await createCompany("PBYR");
+    const parentId = await insertIssue({ companyId, identifier: "PBYR-1", title: "Parent", status: "blocked" });
+    const reviewLeafId = await insertIssue({
+      companyId,
+      identifier: "PBYR-2",
+      title: "Raw monitor metadata review leaf",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date("2099-02-01T15:00:00.000Z"),
+      monitorAttemptCount: 0,
+    });
+    await block({ companyId, blockerIssueId: reviewLeafId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "stalled",
+      reason: "stalled_review",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 1,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBYR-2",
+      sampleStalledBlockerIdentifier: "PBYR-2",
+    });
+  });
+
   it("does not treat a future monitor on a blocked issue as covered", async () => {
     const { companyId, agentId } = await createCompany("PBYM");
     const parentId = await insertIssue({ companyId, identifier: "PBYM-1", title: "Parent", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -501,6 +501,33 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("does not treat a future monitor on a blocked issue as covered", async () => {
+    const { companyId, agentId } = await createCompany("PBYM");
+    const parentId = await insertIssue({ companyId, identifier: "PBYM-1", title: "Parent", status: "blocked" });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBYM-2",
+      title: "Blocked lane with dormant monitor metadata",
+      status: "blocked",
+      assigneeAgentId: agentId,
+      monitorNextCheckAt: new Date("2099-02-01T15:00:00.000Z"),
+      monitorAttemptCount: 0,
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 0,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 1,
+      sampleBlockerIdentifier: "PBYM-2",
+    });
+  });
+
   it("flags a deep chain whose leaf is stalled in_review through multiple layers", async () => {
     const { companyId, agentId } = await createCompany("PBZ");
     const rootId = await insertIssue({ companyId, identifier: "PBZ-1", title: "Root", status: "blocked" });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3524,6 +3524,7 @@ describeEmbeddedPostgres("issueService monitor persistence normalization", () =>
           nextCheckAt: "2026-08-03T14:00:00.000Z",
           notes: "Canonical policy update.",
           scheduledBy: "assignee",
+          externalRef: "provider-run-123",
         },
       },
     });
@@ -3531,6 +3532,11 @@ describeEmbeddedPostgres("issueService monitor persistence normalization", () =>
     expect(updated?.monitorNextCheckAt?.toISOString()).toBe("2026-08-03T14:00:00.000Z");
     expect(updated?.monitorNotes).toBe("Canonical policy update.");
     expect(updated?.monitorScheduledBy).toBe("assignee");
+    expect(updated?.executionPolicy).toMatchObject({
+      monitor: {
+        externalRef: "provider-run-123",
+      },
+    });
     expect(updated?.executionState).toMatchObject({
       monitor: {
         status: "scheduled",

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3386,6 +3386,163 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
   });
 });
 
+describeEmbeddedPostgres("issueService monitor persistence normalization", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-monitor-persistence-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(environments);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedMonitorAssignee() {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "MonitorOwner",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, assigneeAgentId };
+  }
+
+  it("materializes a real monitor contract when create receives legacy top-level monitor fields", async () => {
+    const { companyId, assigneeAgentId } = await seedMonitorAssignee();
+    const nextCheckAt = new Date("2026-08-03T14:00:00.000Z");
+
+    const created = await svc.create(companyId, {
+      title: "Legacy monitor create",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId,
+      monitorNextCheckAt: nextCheckAt,
+      monitorNotes: "Follow up on Monday.",
+      monitorScheduledBy: "assignee",
+    });
+
+    expect(created.monitorNextCheckAt?.toISOString()).toBe("2026-08-03T14:00:00.000Z");
+    expect(created.executionPolicy).toMatchObject({
+      monitor: {
+        nextCheckAt: "2026-08-03T14:00:00.000Z",
+        notes: "Follow up on Monday.",
+        scheduledBy: "assignee",
+      },
+    });
+    expect(created.executionState).toMatchObject({
+      monitor: {
+        status: "scheduled",
+        nextCheckAt: "2026-08-03T14:00:00.000Z",
+        notes: "Follow up on Monday.",
+        scheduledBy: "assignee",
+        attemptCount: 0,
+      },
+    });
+  });
+
+  it("materializes a real monitor contract when update receives legacy top-level monitor fields", async () => {
+    const { companyId, assigneeAgentId } = await seedMonitorAssignee();
+    const issue = await svc.create(companyId, {
+      title: "Legacy monitor update",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId,
+    });
+
+    const updated = await svc.update(issue.id, {
+      monitorNextCheckAt: new Date("2026-08-03T14:00:00.000Z"),
+      monitorNotes: "Repair the persisted follow-up lane.",
+      monitorScheduledBy: "assignee",
+    });
+
+    expect(updated?.monitorNextCheckAt?.toISOString()).toBe("2026-08-03T14:00:00.000Z");
+    expect(updated?.executionPolicy).toMatchObject({
+      monitor: {
+        nextCheckAt: "2026-08-03T14:00:00.000Z",
+        notes: "Repair the persisted follow-up lane.",
+        scheduledBy: "assignee",
+      },
+    });
+    expect(updated?.executionState).toMatchObject({
+      monitor: {
+        status: "scheduled",
+        nextCheckAt: "2026-08-03T14:00:00.000Z",
+        notes: "Repair the persisted follow-up lane.",
+        scheduledBy: "assignee",
+        attemptCount: 0,
+      },
+    });
+  });
+
+  it("syncs top-level monitor fields when direct service callers set executionPolicy.monitor", async () => {
+    const { companyId, assigneeAgentId } = await seedMonitorAssignee();
+    const issue = await svc.create(companyId, {
+      title: "Direct policy update",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId,
+    });
+
+    const updated = await svc.update(issue.id, {
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: "2026-08-03T14:00:00.000Z",
+          notes: "Canonical policy update.",
+          scheduledBy: "assignee",
+        },
+      },
+    });
+
+    expect(updated?.monitorNextCheckAt?.toISOString()).toBe("2026-08-03T14:00:00.000Z");
+    expect(updated?.monitorNotes).toBe("Canonical policy update.");
+    expect(updated?.monitorScheduledBy).toBe("assignee");
+    expect(updated?.executionState).toMatchObject({
+      monitor: {
+        status: "scheduled",
+        nextCheckAt: "2026-08-03T14:00:00.000Z",
+        notes: "Canonical policy update.",
+        scheduledBy: "assignee",
+        attemptCount: 0,
+      },
+    });
+  });
+});
+
 describeEmbeddedPostgres("issueService blockers and dependency wake readiness", () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: ReturnType<typeof issueService>;

--- a/server/src/__tests__/recovery-classifiers.test.ts
+++ b/server/src/__tests__/recovery-classifiers.test.ts
@@ -75,6 +75,48 @@ describe("recovery classifier boundary", () => {
   });
 
   it("treats a scheduled monitor as an explicit review action path", () => {
+    const nextCheckAt = "2026-04-30T19:00:00.000Z";
+    const findings = classifyIssueGraphLiveness({
+      now: "2026-04-30T18:00:00.000Z",
+      issues: [
+        {
+          id: issueId,
+          companyId,
+          identifier: "PAP-2945",
+          title: "Wait for external review",
+          status: "in_review",
+          assigneeAgentId: agentId,
+          assigneeUserId: null,
+          createdByAgentId: null,
+          createdByUserId: null,
+          executionPolicy: {
+            monitor: {
+              nextCheckAt,
+              notes: "Check back tomorrow",
+              scheduledBy: "assignee",
+            },
+          },
+          executionState: null,
+          monitorNextCheckAt: nextCheckAt,
+        },
+      ],
+      relations: [],
+      agents: [
+        {
+          id: agentId,
+          companyId,
+          name: "Coder",
+          role: "engineer",
+          status: "idle",
+          reportsTo: null,
+        },
+      ],
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("does not treat raw future monitor metadata without a scheduled state as an explicit review action path", () => {
     const findings = classifyIssueGraphLiveness({
       now: "2026-04-30T18:00:00.000Z",
       issues: [
@@ -105,10 +147,53 @@ describe("recovery classifier boundary", () => {
       ],
     });
 
-    expect(findings).toEqual([]);
+    expect(findings[0]?.state).toBe("in_review_without_action_path");
+  });
+
+  it("does not treat a scheduled monitor on a paused assignee as an explicit review action path", () => {
+    const nextCheckAt = "2026-04-30T19:00:00.000Z";
+    const findings = classifyIssueGraphLiveness({
+      now: "2026-04-30T18:00:00.000Z",
+      issues: [
+        {
+          id: issueId,
+          companyId,
+          identifier: "PAP-2945",
+          title: "Wait for external review",
+          status: "in_review",
+          assigneeAgentId: agentId,
+          assigneeUserId: null,
+          createdByAgentId: null,
+          createdByUserId: null,
+          executionPolicy: {
+            monitor: {
+              nextCheckAt,
+              notes: "Check back tomorrow",
+              scheduledBy: "assignee",
+            },
+          },
+          executionState: null,
+          monitorNextCheckAt: nextCheckAt,
+        },
+      ],
+      relations: [],
+      agents: [
+        {
+          id: agentId,
+          companyId,
+          name: "Coder",
+          role: "engineer",
+          status: "paused",
+          reportsTo: null,
+        },
+      ],
+    });
+
+    expect(findings[0]?.state).toBe("in_review_without_action_path");
   });
 
   it("does not treat overdue or exhausted monitors as explicit waiting paths", () => {
+    const nextCheckAt = "2026-04-30T19:00:00.000Z";
     const baseIssue = {
       id: issueId,
       companyId,
@@ -119,6 +204,8 @@ describe("recovery classifier boundary", () => {
       assigneeUserId: null,
       createdByAgentId: null,
       createdByUserId: null,
+      executionState: null,
+      monitorNextCheckAt: nextCheckAt,
     };
     const agents = [
       {
@@ -127,7 +214,7 @@ describe("recovery classifier boundary", () => {
         name: "Coder",
         role: "engineer",
         status: "idle",
-        reportsTo: managerId,
+        reportsTo: null,
       },
     ];
 
@@ -136,8 +223,6 @@ describe("recovery classifier boundary", () => {
       issues: [
         {
           ...baseIssue,
-          executionState: null,
-          monitorNextCheckAt: "2026-04-30T19:00:00.000Z",
         },
       ],
       relations: [],
@@ -151,12 +236,10 @@ describe("recovery classifier boundary", () => {
           ...baseIssue,
           executionPolicy: {
             monitor: {
-              nextCheckAt: "2026-04-30T19:00:00.000Z",
+              nextCheckAt,
               maxAttempts: 1,
             },
           },
-          executionState: null,
-          monitorNextCheckAt: "2026-04-30T19:00:00.000Z",
           monitorAttemptCount: 1,
         },
       ],

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -251,7 +251,7 @@ function buildClearedMonitorState(input: {
   };
 }
 
-function issueAllowsMonitor(status: string, assigneeAgentId: string | null, assigneeUserId: string | null) {
+export function issueAllowsMonitor(status: string, assigneeAgentId: string | null, assigneeUserId: string | null) {
   return Boolean(assigneeAgentId) && !assigneeUserId && (status === "in_progress" || status === "in_review");
 }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -105,7 +105,11 @@ import {
   parseIssueGraphLivenessIncidentKey,
   RECOVERY_ORIGIN_KINDS,
 } from "./recovery/origins.js";
-import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
+import {
+  classifyIssueGraphLiveness,
+  hasScheduledMonitorWaitingPath,
+  type IssueLivenessFinding,
+} from "./recovery/issue-graph-liveness.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { finalizeStatusCardsForStalledGeneration } from "./status-card-finalization.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
@@ -1770,13 +1774,28 @@ type IssueBlockerAttentionNode = {
   title: string;
   status: string;
   executionRunId?: string | null;
+  executionPolicy?: Record<string, unknown> | null;
+  executionState?: Record<string, unknown> | null;
+  monitorNextCheckAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
 };
 type IssueBlockerAttentionInputNode =
   Pick<
     IssueBlockerAttentionNode,
-    "id" | "companyId" | "parentId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId"
+    | "id"
+    | "companyId"
+    | "parentId"
+    | "identifier"
+    | "title"
+    | "status"
+    | "executionPolicy"
+    | "executionState"
+    | "monitorNextCheckAt"
+    | "monitorAttemptCount"
+    | "assigneeAgentId"
+    | "assigneeUserId"
   >
   & { executionRunId?: string | null };
 
@@ -2195,6 +2214,10 @@ async function listIssueBlockerAttentionMap(
           title: issues.title,
           status: issues.status,
           executionRunId: issues.executionRunId,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
         })
@@ -2220,6 +2243,10 @@ async function listIssueBlockerAttentionMap(
           title: issues.title,
           status: issues.status,
           executionRunId: issues.executionRunId,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
         })
@@ -2255,6 +2282,10 @@ async function listIssueBlockerAttentionMap(
           title: row.title,
           status: row.status,
           executionRunId: row.executionRunId,
+          executionPolicy: row.executionPolicy,
+          executionState: row.executionState,
+          monitorNextCheckAt: row.monitorNextCheckAt,
+          monitorAttemptCount: row.monitorAttemptCount,
           assigneeAgentId: row.assigneeAgentId,
           assigneeUserId: row.assigneeUserId,
         });
@@ -2397,6 +2428,7 @@ async function listIssueBlockerAttentionMap(
         .where(and(eq(agents.companyId, companyId), inArray(agents.id, [...agentIds])))
     : [];
   const agentsById = new Map(agentRows.map((agent) => [agent.id, agent]));
+  const nowMs = Date.now();
 
   type PathClassification = {
     covered: boolean;
@@ -2421,6 +2453,9 @@ async function listIssueBlockerAttentionMap(
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (explicitWaitingIssueIds.has(node.id)) {
+      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+    }
+    if (hasScheduledMonitorWaitingPath(node, nowMs)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.assigneeUserId && node.status !== "cancelled") {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6353,7 +6353,8 @@ export function issueService(db: Db) {
         onDeduplicated,
         ...issueData
       } = data;
-      const explicitExecutionPolicy = normalizeIssueExecutionPolicy(issueData.executionPolicy ?? null);
+      const explicitExecutionPolicyInput = issueData.executionPolicy;
+      const explicitExecutionPolicy = normalizeIssueExecutionPolicy(explicitExecutionPolicyInput ?? null);
       const effectiveExecutionPolicy =
         explicitExecutionPolicy?.monitor || !hasLegacyMonitorPatchFields(issueData)
           ? explicitExecutionPolicy
@@ -6364,8 +6365,8 @@ export function issueService(db: Db) {
             });
       if (effectiveExecutionPolicy !== explicitExecutionPolicy) {
         issueData.executionPolicy = effectiveExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
-      } else if (issueData.executionPolicy !== undefined) {
-        issueData.executionPolicy = explicitExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+      } else if (explicitExecutionPolicyInput !== undefined) {
+        issueData.executionPolicy = explicitExecutionPolicyInput as typeof issues.$inferInsert["executionPolicy"];
       }
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
@@ -6710,9 +6711,10 @@ export function issueService(db: Db) {
         delete issueData.executionWorkspaceSettings;
       }
       const previousExecutionPolicy = normalizeIssueExecutionPolicy(existing.executionPolicy ?? null);
+      const explicitExecutionPolicyInput = issueData.executionPolicy;
       const explicitExecutionPolicy =
-        issueData.executionPolicy !== undefined
-          ? normalizeIssueExecutionPolicy(issueData.executionPolicy ?? null)
+        explicitExecutionPolicyInput !== undefined
+          ? normalizeIssueExecutionPolicy(explicitExecutionPolicyInput ?? null)
           : undefined;
 
       if (issueData.status) {
@@ -6723,8 +6725,8 @@ export function issueService(db: Db) {
         ...issueData,
         updatedAt: new Date(),
       };
-      if (explicitExecutionPolicy !== undefined) {
-        patch.executionPolicy = explicitExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+      if (explicitExecutionPolicyInput !== undefined) {
+        patch.executionPolicy = explicitExecutionPolicyInput as typeof issues.$inferInsert["executionPolicy"];
       }
       if (existing.status !== "blocked" && issueData.status === "blocked") {
         patch.blockedTransitionAt = patch.updatedAt;
@@ -6831,7 +6833,10 @@ export function issueService(db: Db) {
               fields: issueData,
             });
       if (shouldMaterializeMonitorPolicy) {
-        patch.executionPolicy = effectiveExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+        patch.executionPolicy =
+          effectiveExecutionPolicy === explicitExecutionPolicy && explicitExecutionPolicyInput !== undefined
+            ? explicitExecutionPolicyInput as typeof issues.$inferInsert["executionPolicy"]
+            : effectiveExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
         Object.assign(
           patch,
           applyIssueMonitorPolicyTransition({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -84,7 +84,13 @@ import {
   type ParsedExecutionWorkspaceMode,
 } from "./execution-workspace-policy.js";
 import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
-import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
+import {
+  applyIssueMonitorPolicyTransition,
+  buildInitialIssueMonitorFields,
+  normalizeIssueExecutionPolicy,
+  parseIssueExecutionState,
+  stripMonitorFromExecutionPolicy,
+} from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
@@ -138,6 +144,57 @@ const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
 // users — real signups with their own ids — are never reattributed.
 const NON_HUMAN_SENTINEL_AUTHOR_USER_IDS = new Set<string>(["local-board"]);
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_MAX_LOG_BYTES = 2_000_000;
+
+function hasLegacyMonitorPatchFields(input: Partial<typeof issues.$inferInsert>) {
+  return input.monitorNextCheckAt !== undefined
+    || input.monitorNotes !== undefined
+    || input.monitorScheduledBy !== undefined;
+}
+
+function normalizeLegacyMonitorScheduledBy(value: string | null | undefined) {
+  return value === "board" || value === "assignee" ? value : null;
+}
+
+function withLegacyMonitorPolicy(input: {
+  basePolicy: ReturnType<typeof normalizeIssueExecutionPolicy>;
+  baseState: ReturnType<typeof parseIssueExecutionState>;
+  fields: Partial<typeof issues.$inferInsert>;
+}) {
+  const baseMonitor = input.basePolicy?.monitor ?? input.baseState?.monitor ?? null;
+  const nextCheckAt = input.fields.monitorNextCheckAt !== undefined
+    ? input.fields.monitorNextCheckAt instanceof Date
+      ? input.fields.monitorNextCheckAt.toISOString()
+      : input.fields.monitorNextCheckAt
+    : baseMonitor?.nextCheckAt ?? null;
+
+  if (!nextCheckAt) {
+    return stripMonitorFromExecutionPolicy(input.basePolicy);
+  }
+
+  return normalizeIssueExecutionPolicy({
+    mode: input.basePolicy?.mode ?? "normal",
+    commentRequired: input.basePolicy?.commentRequired ?? true,
+    stages: input.basePolicy?.stages ?? [],
+    ...(input.basePolicy?.reviewPreset ? { reviewPreset: input.basePolicy.reviewPreset } : {}),
+    ...(input.basePolicy?.authorizationPolicy ? { authorizationPolicy: input.basePolicy.authorizationPolicy } : {}),
+    monitor: {
+      nextCheckAt,
+      notes: input.fields.monitorNotes !== undefined
+        ? input.fields.monitorNotes
+        : baseMonitor?.notes ?? null,
+      scheduledBy:
+        normalizeLegacyMonitorScheduledBy(input.fields.monitorScheduledBy)
+        ?? baseMonitor?.scheduledBy
+        ?? "assignee",
+      kind: input.basePolicy?.monitor?.kind ?? input.baseState?.monitor?.kind ?? null,
+      serviceName: input.basePolicy?.monitor?.serviceName ?? input.baseState?.monitor?.serviceName ?? null,
+      externalRef: input.basePolicy?.monitor?.externalRef ?? input.baseState?.monitor?.externalRef ?? null,
+      timeoutAt: input.basePolicy?.monitor?.timeoutAt ?? input.baseState?.monitor?.timeoutAt ?? null,
+      maxAttempts: input.basePolicy?.monitor?.maxAttempts ?? input.baseState?.monitor?.maxAttempts ?? null,
+      recoveryPolicy: input.basePolicy?.monitor?.recoveryPolicy ?? input.baseState?.monitor?.recoveryPolicy ?? null,
+    },
+  });
+}
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_CHUNK_BYTES = 256_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS = 60_000;
 const ISSUE_COMMENT_RUN_LOG_DERIVATION_MAX_PARALLEL_READS = 8;
@@ -6296,6 +6353,20 @@ export function issueService(db: Db) {
         onDeduplicated,
         ...issueData
       } = data;
+      const explicitExecutionPolicy = normalizeIssueExecutionPolicy(issueData.executionPolicy ?? null);
+      const effectiveExecutionPolicy =
+        explicitExecutionPolicy?.monitor || !hasLegacyMonitorPatchFields(issueData)
+          ? explicitExecutionPolicy
+          : withLegacyMonitorPolicy({
+              basePolicy: explicitExecutionPolicy,
+              baseState: parseIssueExecutionState(issueData.executionState ?? null),
+              fields: issueData,
+            });
+      if (effectiveExecutionPolicy !== explicitExecutionPolicy) {
+        issueData.executionPolicy = effectiveExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+      } else if (issueData.executionPolicy !== undefined) {
+        issueData.executionPolicy = explicitExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+      }
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -6561,7 +6632,7 @@ export function issueService(db: Db) {
         Object.assign(
           values,
           buildInitialIssueMonitorFields({
-            policy: normalizeIssueExecutionPolicy(issueData.executionPolicy ?? null),
+            policy: effectiveExecutionPolicy,
             status: values.status ?? "backlog",
             assigneeAgentId: values.assigneeAgentId ?? null,
             assigneeUserId: values.assigneeUserId ?? null,
@@ -6638,6 +6709,11 @@ export function issueService(db: Db) {
         delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }
+      const previousExecutionPolicy = normalizeIssueExecutionPolicy(existing.executionPolicy ?? null);
+      const explicitExecutionPolicy =
+        issueData.executionPolicy !== undefined
+          ? normalizeIssueExecutionPolicy(issueData.executionPolicy ?? null)
+          : undefined;
 
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
@@ -6647,6 +6723,9 @@ export function issueService(db: Db) {
         ...issueData,
         updatedAt: new Date(),
       };
+      if (explicitExecutionPolicy !== undefined) {
+        patch.executionPolicy = explicitExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+      }
       if (existing.status !== "blocked" && issueData.status === "blocked") {
         patch.blockedTransitionAt = patch.updatedAt;
         patch.blockedOwnerNotifiedAt = null;
@@ -6739,6 +6818,35 @@ export function issueService(db: Db) {
           executionWorkspacePreference: nextExecutionWorkspacePreference ?? null,
           executionWorkspaceSettings: issueData.executionWorkspaceSettings,
         });
+      }
+      const shouldMaterializeMonitorPolicy =
+        explicitExecutionPolicy !== undefined || hasLegacyMonitorPatchFields(issueData);
+      const baselineExecutionPolicy = explicitExecutionPolicy ?? previousExecutionPolicy;
+      const effectiveExecutionPolicy =
+        baselineExecutionPolicy?.monitor || !hasLegacyMonitorPatchFields(issueData)
+          ? baselineExecutionPolicy
+          : withLegacyMonitorPolicy({
+              basePolicy: baselineExecutionPolicy,
+              baseState: parseIssueExecutionState(existing.executionState ?? null),
+              fields: issueData,
+            });
+      if (shouldMaterializeMonitorPolicy) {
+        patch.executionPolicy = effectiveExecutionPolicy as typeof issues.$inferInsert["executionPolicy"];
+        Object.assign(
+          patch,
+          applyIssueMonitorPolicyTransition({
+            issue: existing,
+            policy: effectiveExecutionPolicy,
+            previousPolicy: previousExecutionPolicy,
+            requestedStatus: issueData.status,
+            requestedAssigneePatch: {
+              assigneeAgentId: issueData.assigneeAgentId,
+              assigneeUserId: issueData.assigneeUserId,
+            },
+            actor: { agentId: null, userId: null },
+            monitorExplicitlyUpdated: true,
+          }).patch,
+        );
       }
 
       applyStatusSideEffects(issueData.status, patch);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1813,6 +1813,9 @@ type IssueBlockerAttentionActivePathRow = {
 type IssueBlockerAttentionAgentRow = {
   id: string;
   companyId: string;
+  name: string;
+  role: string;
+  reportsTo: string | null;
   status: string;
 };
 
@@ -2417,15 +2420,23 @@ async function listIssueBlockerAttentionMap(
     for (const row of recoveryActionRows) explicitWaitingIssueIds.add(row.sourceIssueId);
   }
 
-  const agentRows: IssueBlockerAttentionAgentRow[] = agentIds.size > 0
+  const loadAllCompanyAgents = [...nodesById.values()].some((node) => node.monitorNextCheckAt);
+  const agentRows: IssueBlockerAttentionAgentRow[] = loadAllCompanyAgents || agentIds.size > 0
     ? await dbOrTx
         .select({
           id: agents.id,
           companyId: agents.companyId,
+          name: agents.name,
+          role: agents.role,
+          reportsTo: agents.reportsTo,
           status: agents.status,
         })
         .from(agents)
-        .where(and(eq(agents.companyId, companyId), inArray(agents.id, [...agentIds])))
+        .where(
+          loadAllCompanyAgents
+            ? eq(agents.companyId, companyId)
+            : and(eq(agents.companyId, companyId), inArray(agents.id, [...agentIds])),
+        )
     : [];
   const agentsById = new Map(agentRows.map((agent) => [agent.id, agent]));
   const nowMs = Date.now();
@@ -2455,7 +2466,7 @@ async function listIssueBlockerAttentionMap(
     if (explicitWaitingIssueIds.has(node.id)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
-    if (hasScheduledMonitorWaitingPath(node, nowMs)) {
+    if (hasScheduledMonitorWaitingPath(node, nowMs, agentsById)) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.assigneeUserId && node.status !== "cancelled") {

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -169,7 +169,7 @@ function monitorFromIssue(issue: IssueLivenessIssueInput) {
   return { policyMonitor, stateMonitor };
 }
 
-function hasScheduledMonitor(issue: IssueLivenessIssueInput, nowMs: number) {
+export function hasScheduledMonitorWaitingPath(issue: IssueLivenessIssueInput, nowMs: number) {
   const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
   if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
 
@@ -401,7 +401,7 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
 
   function hasExplicitWaitingPath(issue: IssueLivenessIssueInput) {
     return Boolean(issue.assigneeUserId) ||
-      hasScheduledMonitor(issue, nowMs) ||
+      hasScheduledMonitorWaitingPath(issue, nowMs) ||
       hasActiveExecutionPath(issue.companyId, issue.id, activeRuns, queuedWakeRequests) ||
       hasWaitingPath(issue.companyId, issue.id, pendingInteractions) ||
       hasWaitingPath(issue.companyId, issue.id, pendingApprovals) ||

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -1,5 +1,6 @@
 import { getAgentWorkEligibility, isAgentInvokable } from "@paperclipai/shared";
 import { buildIssueGraphLivenessIncidentKey } from "./origins.js";
+import { issueAllowsMonitor } from "../issue-execution-policy.js";
 
 export type IssueLivenessSeverity = "warning" | "critical";
 
@@ -170,6 +171,10 @@ function monitorFromIssue(issue: IssueLivenessIssueInput) {
 }
 
 export function hasScheduledMonitorWaitingPath(issue: IssueLivenessIssueInput, nowMs: number) {
+  if (!issueAllowsMonitor(issue.status, issue.assigneeAgentId ?? null, issue.assigneeUserId ?? null)) {
+    return false;
+  }
+
   const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
   if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
 

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -1,4 +1,8 @@
-import { getAgentWorkEligibility, isAgentInvokable } from "@paperclipai/shared";
+import {
+  PROVIDER_QUOTA_MONITOR_SERVICE_NAME,
+  getAgentWorkEligibility,
+  isAgentInvokable,
+} from "@paperclipai/shared";
 import { buildIssueGraphLivenessIncidentKey } from "./origins.js";
 import { issueAllowsMonitor } from "../issue-execution-policy.js";
 
@@ -157,6 +161,10 @@ function readPositiveInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 }
 
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 function readDateMs(value: unknown): number | null {
   if (!(typeof value === "string" || value instanceof Date)) return null;
   const date = value instanceof Date ? value : new Date(value);
@@ -170,7 +178,22 @@ function monitorFromIssue(issue: IssueLivenessIssueInput) {
   return { policyMonitor, stateMonitor };
 }
 
-export function hasScheduledMonitorWaitingPath(issue: IssueLivenessIssueInput, nowMs: number) {
+function scheduledMonitorTargetAgentId(
+  issue: IssueLivenessIssueInput,
+  policyMonitor: Record<string, unknown>,
+) {
+  if (readNonEmptyString(policyMonitor.serviceName) === PROVIDER_QUOTA_MONITOR_SERVICE_NAME) {
+    const participantAgentId = readPrincipalAgentId(readRecord(issue.executionState)?.currentParticipant);
+    if (participantAgentId) return participantAgentId;
+  }
+  return issue.assigneeAgentId ?? null;
+}
+
+export function hasScheduledMonitorWaitingPath(
+  issue: IssueLivenessIssueInput,
+  nowMs: number,
+  agentsById: Map<string, IssueLivenessAgentInput>,
+) {
   if (!issueAllowsMonitor(issue.status, issue.assigneeAgentId ?? null, issue.assigneeUserId ?? null)) {
     return false;
   }
@@ -179,6 +202,19 @@ export function hasScheduledMonitorWaitingPath(issue: IssueLivenessIssueInput, n
   if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
 
   const { policyMonitor, stateMonitor } = monitorFromIssue(issue);
+  if (!policyMonitor) return false;
+
+  const policyNextCheckAtMs = readDateMs(policyMonitor.nextCheckAt);
+  if (policyNextCheckAtMs === null || policyNextCheckAtMs !== nextCheckAtMs) {
+    return false;
+  }
+
+  if (stateMonitor) {
+    if (readNonEmptyString(stateMonitor.status) !== "scheduled") return false;
+    const stateNextCheckAtMs = readDateMs(stateMonitor.nextCheckAt);
+    if (stateNextCheckAtMs === null || stateNextCheckAtMs !== nextCheckAtMs) return false;
+  }
+
   const timeoutAtMs = readDateMs(policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt);
   if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
 
@@ -186,6 +222,13 @@ export function hasScheduledMonitorWaitingPath(issue: IssueLivenessIssueInput, n
   const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
   const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
   if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  const targetAgentId = scheduledMonitorTargetAgentId(issue, policyMonitor);
+  if (!targetAgentId) return false;
+  const targetAgent = agentsById.get(targetAgentId);
+  if (!targetAgent || targetAgent.companyId !== issue.companyId || !isInvokableAgent(targetAgent, agentsById)) {
+    return false;
+  }
 
   return true;
 }
@@ -406,7 +449,7 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
 
   function hasExplicitWaitingPath(issue: IssueLivenessIssueInput) {
     return Boolean(issue.assigneeUserId) ||
-      hasScheduledMonitorWaitingPath(issue, nowMs) ||
+      hasScheduledMonitorWaitingPath(issue, nowMs, agentsById) ||
       hasActiveExecutionPath(issue.companyId, issue.id, activeRuns, queuedWakeRequests) ||
       hasWaitingPath(issue.companyId, issue.id, pendingInteractions) ||
       hasWaitingPath(issue.companyId, issue.id, pendingApprovals) ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Blocker attention tells operators if a blocked issue has a real waiting path or needs a human now
> - Review follow-up lanes often wait on a scheduled monitor instead of an active run
> - The recovery liveness code already treats that scheduled monitor as a real waiting path
> - But blocker attention did not load or reuse that monitor state for `in_review` leaves
> - So a healthy follow-up lane could be marked as stalled even though it would wake itself later
> - This pull request reuses the shared monitor waiting-path helper in blocker attention and adds a regression for the `in_review` case
> - The benefit is that monitor-backed review lanes stay covered, while truly idle review leaves still need attention

## Linked Issues or Issue Description

No exact public GitHub issue exists for this case, so this section describes the bug.

**What happened.** A blocked parent could point at an `in_review` child that already had a scheduled issue monitor. The child persisted `monitorNextCheckAt`, `executionPolicy.monitor`, and `executionState.monitor`, but blocker attention still reported the chain as stalled.

**What was expected.** A scheduled monitor is a live waiting path. The parent should report that blocker as covered until the monitor expires or is exhausted.

**Why it matters.** Blocker attention is only useful if it is strict about real dead ends. False stalled states on healthy review follow-up lanes create noise and hide the blockers that really need a person.

**Related work.** Dedup search found related upstream work: #10398, #8759, and closed predecessor #8751. This PR stays distinct because it is rebased on current `master`, it matches the live `in_review` follow-up lane shape, and it adds the missing regression for that review-state case.

## What Changed

- Exported the shared scheduled-monitor waiting-path helper from `server/src/services/recovery/issue-graph-liveness.ts`.
- Updated `server/src/services/issues.ts` so blocker-attention classification loads monitor-backed fields for graph nodes and treats a valid scheduled monitor as an explicit waiting path.
- Added a focused regression in `server/src/__tests__/issue-blocker-attention.test.ts` for an `in_review` blocker leaf with a scheduled monitor.

## Verification

- `pnpm run preflight:workspace-links`
- `pnpm exec vitest run server/src/__tests__/issue-blocker-attention.test.ts`

## Risks

- Low risk. The change only widens the covered-path check when a monitor is already scheduled and still valid.
- The main failure mode would be a helper that is too permissive. The regression keeps the `in_review` monitor case pinned to the shared waiting-path rules instead of a new local copy.

## Model Used

- OpenAI GPT-5.4 via Codex local adapter, with tool use and xhigh reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
