### PR TITLE
fix(tool-gateway): kill orphaned local adapter process when session dies

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -39,6 +39,7 @@ import {
   issues,
   projects,
   projectWorkspaces,
+  toolGatewaySessions,
   workspaceOperations,
 } from "@paperclipai/db";
 import {
@@ -591,6 +592,77 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     return { environmentId, leaseId };
   }
+
+  async function seedToolGatewaySessionFixture(input: {
+    companyId: string;
+    agentId: string;
+    runId: string;
+    expiresAt: Date;
+    revokedAt?: Date | null;
+  }) {
+    await db.insert(toolGatewaySessions).values({
+      id: randomUUID(),
+      companyId: input.companyId,
+      agentId: input.agentId,
+      runId: input.runId,
+      tokenHash: randomUUID(),
+      expiresAt: input.expiresAt,
+      revokedAt: input.revokedAt ?? null,
+    });
+  }
+
+  it("cancels a run and kills its process once its only tool-gateway session has expired", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      includeIssue: true,
+    });
+    await seedToolGatewaySessionFixture({
+      companyId,
+      agentId,
+      runId,
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapDeadSessionRuns();
+    expect(result).toEqual({ reaped: 1, runIds: [runId] });
+
+    expect(await waitForPidExit(child.pid!)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run).toMatchObject({ status: "cancelled", errorCode: "tool_gateway_session_dead" });
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]);
+    expect(issue?.executionRunId).toBeNull();
+  });
+
+  it("leaves a run alone when its tool-gateway session is still live", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+
+    const { companyId, agentId, runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      includeIssue: false,
+    });
+    await seedToolGatewaySessionFixture({
+      companyId,
+      agentId,
+      runId,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapDeadSessionRuns();
+    expect(result).toEqual({ reaped: 0, runIds: [] });
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(isPidAlive(child.pid)).toBe(true);
+  });
 
   it("does not reap active adapter executions started by another heartbeat service instance", async () => {
     let releaseAdapter: (() => void) | null = null;

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from "node:crypto";
-import { spawn } from "node:child_process";
 import { createServer, type IncomingMessage } from "node:http";
 import express from "express";
 import { and, eq } from "drizzle-orm";
@@ -3481,54 +3480,6 @@ rl.on("line", (line) => {
       .where(eq(toolAccessAuditEvents.action, "call_denied"));
     expect(dedicatedAudits).toHaveLength(3);
     expect(dedicatedAudits.every((event) => event.outcome === "denied")).toBe(true);
-  });
-
-  it("kills the run's local adapter process when its gateway session dies with no way to renew", async () => {
-    function isPidAlive(pid: number | null | undefined) {
-      if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-    async function waitForPidExit(pid: number, timeoutMs = 2_000) {
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        if (!isPidAlive(pid)) return true;
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      }
-      return !isPidAlive(pid);
-    }
-
-    const company = await createCompany(db);
-    const agent = await createAgent(db, company.id);
-    const { run } = await createIssueAndRun(db, company.id, agent.id);
-    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-    try {
-      expect(child.pid).toBeTruthy();
-      await db.update(heartbeatRuns).set({ processPid: child.pid }).where(eq(heartbeatRuns.id, run.id));
-
-      const gateway = createTestToolGatewayService(db);
-      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
-      await db
-        .update(toolGatewaySessions)
-        .set({ expiresAt: new Date(Date.now() - 1_000), updatedAt: new Date() })
-        .where(eq(toolGatewaySessions.id, session.id));
-
-      await expect(gateway.listToolsForSession(session.token)).rejects.toMatchObject({
-        status: 401,
-        reasonCode: "session_expired",
-      });
-
-      expect(await waitForPidExit(child.pid!)).toBe(true);
-
-      const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, run.id));
-      expect(updatedRun).toMatchObject({ status: "failed", errorCode: "tool_gateway_session_dead" });
-    } finally {
-      if (isPidAlive(child.pid)) child.kill("SIGKILL");
-    }
   });
 
   it("cleans up expired durable sessions explicitly", async () => {

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import { createServer, type IncomingMessage } from "node:http";
 import express from "express";
 import { and, eq } from "drizzle-orm";
@@ -3480,6 +3481,54 @@ rl.on("line", (line) => {
       .where(eq(toolAccessAuditEvents.action, "call_denied"));
     expect(dedicatedAudits).toHaveLength(3);
     expect(dedicatedAudits.every((event) => event.outcome === "denied")).toBe(true);
+  });
+
+  it("kills the run's local adapter process when its gateway session dies with no way to renew", async () => {
+    function isPidAlive(pid: number | null | undefined) {
+      if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    async function waitForPidExit(pid: number, timeoutMs = 2_000) {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (!isPidAlive(pid)) return true;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      return !isPidAlive(pid);
+    }
+
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    try {
+      expect(child.pid).toBeTruthy();
+      await db.update(heartbeatRuns).set({ processPid: child.pid }).where(eq(heartbeatRuns.id, run.id));
+
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      await db
+        .update(toolGatewaySessions)
+        .set({ expiresAt: new Date(Date.now() - 1_000), updatedAt: new Date() })
+        .where(eq(toolGatewaySessions.id, session.id));
+
+      await expect(gateway.listToolsForSession(session.token)).rejects.toMatchObject({
+        status: 401,
+        reasonCode: "session_expired",
+      });
+
+      expect(await waitForPidExit(child.pid!)).toBe(true);
+
+      const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, run.id));
+      expect(updatedRun).toMatchObject({ status: "failed", errorCode: "tool_gateway_session_dead" });
+    } finally {
+      if (isPidAlive(child.pid)) child.kill("SIGKILL");
+    }
   });
 
   it("cleans up expired durable sessions explicitly", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1021,6 +1021,11 @@ export async function startServer(): Promise<StartedServer> {
           logger.warn({ ...scanned }, "startup active-run output watchdog created review work");
         }
 
+        const deadSessionReaped = await heartbeat.reapDeadSessionRuns();
+        if (deadSessionReaped.reaped > 0) {
+          logger.warn({ ...deadSessionReaped }, "startup reap of heartbeat runs with a dead tool-gateway session");
+        }
+
         const swept = await heartbeat.sweepStaleIssueLocks();
         if (swept.cleared > 0) {
           logger.warn({ ...swept }, "startup stale-lock sweeper cleared issue locks");
@@ -1179,6 +1184,12 @@ export async function startServer(): Promise<StartedServer> {
               const scanned = await heartbeat.scanSilentActiveRuns();
               if (scanned.created > 0 || scanned.escalated > 0) {
                 logger.warn({ ...scanned }, "periodic active-run output watchdog created review work");
+              }
+            })
+            .then(async () => {
+              const reaped = await heartbeat.reapDeadSessionRuns();
+              if (reaped.reaped > 0) {
+                logger.warn({ ...reaped }, "reaped heartbeat runs with a dead tool-gateway session");
               }
             })
             .then(async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -61,6 +61,7 @@ import {
   routineRevisions,
   routineRuns,
   routines,
+  toolGatewaySessions,
   toolMcpGateways,
   toolMcpGatewayTokens,
   toolConnections,
@@ -12316,6 +12317,52 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { reaped: reaped.length, runIds: reaped };
   }
 
+  // A tool-gateway session has no renewal path -- once it's revoked or its
+  // TTL lapses, the run behind it can never make another tool call again.
+  // Left alone, its local adapter process just keeps retrying against the
+  // dead session forever (the client can't tell "your token needs a real
+  // OAuth refresh" apart from "your run is over"), burning resources and
+  // blocking the run's concurrency slot indefinitely instead of failing
+  // loudly. Cancel any such run through the normal cancellation path (which
+  // already terminates the tracked process via the in-memory handle when
+  // available, so it can't be tricked by a stale/reused pid) the first time
+  // we notice its session has died with nothing live to replace it.
+  async function reapDeadSessionRuns() {
+    const now = new Date();
+    const candidates = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "running"),
+          sql`exists (
+            select 1 from ${toolGatewaySessions}
+            where ${toolGatewaySessions.runId} = ${heartbeatRuns.id}
+          )`,
+          sql`not exists (
+            select 1 from ${toolGatewaySessions}
+            where ${toolGatewaySessions.runId} = ${heartbeatRuns.id}
+              and ${toolGatewaySessions.revokedAt} is null
+              and ${toolGatewaySessions.expiresAt} > ${now.toISOString()}::timestamptz
+          )`,
+        ),
+      )
+      .limit(100);
+
+    const reaped: string[] = [];
+    for (const { id } of candidates) {
+      const cancelled = await cancelRunInternal(id, "Tool gateway session died with no way to renew it", {
+        errorCode: "tool_gateway_session_dead",
+      });
+      if (cancelled) reaped.push(id);
+    }
+
+    if (reaped.length > 0) {
+      logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped heartbeat runs with a dead tool-gateway session");
+    }
+    return { reaped: reaped.length, runIds: reaped };
+  }
+
   async function resumeQueuedRuns() {
     if ((await getSchedulingSuppression()).suppressed) return;
     const cutoff = await getWorktreeExecutionCutoff();
@@ -17785,6 +17832,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     prepareHotRestartShutdown,
     reconcileHotRestartAdoption,
     reapOrphanedRuns,
+    reapDeadSessionRuns,
     // Override-aware scheduling-suppression check (honors the worktree
     // run-execution experimental setting). Callers outside the service that
     // gate on suppression should prefer this over the env-only resolver.

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { and, desc, eq, inArray, isNull, lte, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { terminateLocalService } from "./local-service-supervisor.js";
 import {
   agents,
   approvals,
@@ -1249,46 +1248,6 @@ export function createToolGatewayService(
     }
   }
 
-  // A revoked/expired gateway session can never be renewed (there is no
-  // session-refresh path), so a still-"running" run behind it can never make
-  // another tool call again. Left alone, its local adapter process (opencode,
-  // claude, etc.) just keeps retrying against the dead session forever —
-  // burning resources and blocking the run's concurrency slot indefinitely
-  // instead of failing loudly. Fail the run and kill its process here, once,
-  // the first time we notice its session has died.
-  async function terminateOrphanedRunOnDeadSession(row: typeof toolGatewaySessions.$inferSelect, reasonCode: string) {
-    const [candidate] = await db
-      .select({
-        status: heartbeatRuns.status,
-        processPid: heartbeatRuns.processPid,
-        processGroupId: heartbeatRuns.processGroupId,
-      })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, row.runId))
-      .limit(1);
-    if (!candidate || candidate.status !== "running") return;
-    const pid = candidate.processPid;
-    const processGroupId = candidate.processGroupId;
-    // Nothing to clean up (e.g. a session with no local adapter process
-    // behind it) -- leave the run's status alone.
-    if (typeof pid !== "number" && typeof processGroupId !== "number") return;
-
-    const now = new Date();
-    const [run] = await db
-      .update(heartbeatRuns)
-      .set({
-        status: "failed",
-        error: `Tool gateway session died (${reasonCode}) with no way to renew it; process terminated`,
-        errorCode: "tool_gateway_session_dead",
-        finishedAt: now,
-        updatedAt: now,
-      })
-      .where(and(eq(heartbeatRuns.id, row.runId), eq(heartbeatRuns.status, "running")))
-      .returning({ processPid: heartbeatRuns.processPid, processGroupId: heartbeatRuns.processGroupId });
-    if (!run) return;
-    await terminateLocalService({ pid: pid ?? processGroupId ?? 0, processGroupId });
-  }
-
   async function getActiveSession(
     sessionToken: string,
     namedGatewayProtocol?: {
@@ -1336,13 +1295,11 @@ export function createToolGatewayService(
 
     if (row.revokedAt) {
       await writeSessionAuthFailure(row, "session_revoked");
-      await terminateOrphanedRunOnDeadSession(row, "session_revoked");
       throw new ToolGatewayHttpError(401, "Tool gateway session is expired or invalid", "session_revoked");
     }
 
     if (row.expiresAt.getTime() <= Date.now()) {
       await writeSessionAuthFailure(row, "session_expired");
-      await terminateOrphanedRunOnDeadSession(row, "session_expired");
       throw new ToolGatewayHttpError(401, "Tool gateway session is expired or invalid", "session_expired");
     }
 

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { and, desc, eq, inArray, isNull, lte, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
+import { terminateLocalService } from "./local-service-supervisor.js";
 import {
   agents,
   approvals,
@@ -75,16 +76,22 @@ import {
   verifyToolArgumentsSignature,
 } from "./tool-content-guards.js";
 
-const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000;
-const MAX_SESSION_TTL_MS = 60 * 60 * 1000;
+// Self-hosted/local model providers behind a tool call (e.g. a cold-booting
+// vLLM instance) can take much longer than a hosted API to answer the first
+// request after sleep/wake. Deployments that front such a provider can raise
+// these ceilings via env vars; defaults are unchanged for everyone else.
+const DEFAULT_SESSION_TTL_MS = Number(process.env.TOOL_GATEWAY_SESSION_TTL_DEFAULT_MS) || 15 * 60 * 1000;
+const MAX_SESSION_TTL_MS = Number(process.env.TOOL_GATEWAY_SESSION_TTL_MAX_MS) || 60 * 60 * 1000;
 const DEFAULT_TOOL_TIMEOUT_MS = 10_000;
 // When a human approves a parked write, the server carries it out on their
 // behalf with no interactive caller left to raise `timeoutMs`. Remote write
 // providers (e.g. Zapier Google Sheets `add_row`) routinely take longer than
-// the 10s interactive default, so an approved action would otherwise abort with
-// `tool_timeout` even though the approval succeeded. Give approved executions
-// the full permitted headroom instead.
-const APPROVED_EXECUTION_TIMEOUT_MS = 60_000;
+// the 10s interactive default, so an approved action would otherwise abort
+// with `tool_timeout` even though the approval succeeded. Give approved
+// executions the full permitted headroom instead. This also doubles as the
+// ceiling any caller-supplied `timeoutMs` can be clamped to (see `timeoutMs()`
+// below) — deployments fronting a slow-to-cold-start provider can raise it.
+const APPROVED_EXECUTION_TIMEOUT_MS = Number(process.env.TOOL_GATEWAY_MAX_TOOL_TIMEOUT_MS) || 60_000;
 const MAX_REMOTE_MCP_RESPONSE_BYTES = 1_000_000;
 const ACTIVE_GATEWAY_RUN_STATUSES = new Set(["running"]);
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -440,7 +447,7 @@ function gatewaySessionFromRow(row: typeof toolGatewaySessions.$inferSelect): To
 
 function timeoutMs(value: number | undefined) {
   if (!Number.isFinite(value)) return DEFAULT_TOOL_TIMEOUT_MS;
-  return Math.max(1, Math.min(60_000, Math.floor(value ?? DEFAULT_TOOL_TIMEOUT_MS)));
+  return Math.max(1, Math.min(APPROVED_EXECUTION_TIMEOUT_MS, Math.floor(value ?? DEFAULT_TOOL_TIMEOUT_MS)));
 }
 
 function sessionTtlMs(value: number | undefined) {
@@ -1242,6 +1249,46 @@ export function createToolGatewayService(
     }
   }
 
+  // A revoked/expired gateway session can never be renewed (there is no
+  // session-refresh path), so a still-"running" run behind it can never make
+  // another tool call again. Left alone, its local adapter process (opencode,
+  // claude, etc.) just keeps retrying against the dead session forever —
+  // burning resources and blocking the run's concurrency slot indefinitely
+  // instead of failing loudly. Fail the run and kill its process here, once,
+  // the first time we notice its session has died.
+  async function terminateOrphanedRunOnDeadSession(row: typeof toolGatewaySessions.$inferSelect, reasonCode: string) {
+    const [candidate] = await db
+      .select({
+        status: heartbeatRuns.status,
+        processPid: heartbeatRuns.processPid,
+        processGroupId: heartbeatRuns.processGroupId,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, row.runId))
+      .limit(1);
+    if (!candidate || candidate.status !== "running") return;
+    const pid = candidate.processPid;
+    const processGroupId = candidate.processGroupId;
+    // Nothing to clean up (e.g. a session with no local adapter process
+    // behind it) -- leave the run's status alone.
+    if (typeof pid !== "number" && typeof processGroupId !== "number") return;
+
+    const now = new Date();
+    const [run] = await db
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        error: `Tool gateway session died (${reasonCode}) with no way to renew it; process terminated`,
+        errorCode: "tool_gateway_session_dead",
+        finishedAt: now,
+        updatedAt: now,
+      })
+      .where(and(eq(heartbeatRuns.id, row.runId), eq(heartbeatRuns.status, "running")))
+      .returning({ processPid: heartbeatRuns.processPid, processGroupId: heartbeatRuns.processGroupId });
+    if (!run) return;
+    await terminateLocalService({ pid: pid ?? processGroupId ?? 0, processGroupId });
+  }
+
   async function getActiveSession(
     sessionToken: string,
     namedGatewayProtocol?: {
@@ -1289,11 +1336,13 @@ export function createToolGatewayService(
 
     if (row.revokedAt) {
       await writeSessionAuthFailure(row, "session_revoked");
+      await terminateOrphanedRunOnDeadSession(row, "session_revoked");
       throw new ToolGatewayHttpError(401, "Tool gateway session is expired or invalid", "session_revoked");
     }
 
     if (row.expiresAt.getTime() <= Date.now()) {
       await writeSessionAuthFailure(row, "session_expired");
+      await terminateOrphanedRunOnDeadSession(row, "session_expired");
       throw new ToolGatewayHttpError(401, "Tool gateway session is expired or invalid", "session_expired");
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Tool-gateway sessions are how a local adapter (opencode, claude, etc.) authenticates its tool calls back to Paperclip for the duration of a run
> - Sessions have no renewal path: a fixed TTL is set at creation and can never be extended, and once revoked/expired there is no way back
> - When a run legitimately needs more time than the TTL allows (e.g. it's waiting behind a slow self-hosted model provider), the session dies mid-run, but the run itself stays "running" forever and its local adapter process just keeps retrying against the now-dead session, since a bare 401 looks to the client like "go refresh your OAuth token," not "your run is over"
> - This wastes resources indefinitely and can permanently occupy that run's concurrency slot, since nothing ever tells the orphaned process to stop or marks the run finished
> - This pull request makes the session-TTL/tool-call-timeout ceilings configurable via env vars (so a deployment fronting a slow provider isn't stuck with fixed short defaults), and adds a periodic reconciliation step that finalizes and kills the process for any run whose only tool-gateway session(s) have died with nothing live to replace them
> - The benefit is a session dying no longer means silent, permanent resource leakage and a stuck run — it fails loudly and cleanly through the same path a human-initiated cancel uses

## Linked Issues or Issue Description

No existing public issue found (searched open/closed PRs for "tool-gateway session dead orphan" and "reapDeadSessionRuns", no duplicates).

**Bug**: A tool-gateway session has no renewal mechanism (`server/src/services/tool-gateway.ts`: sessions are created once via `createSession` with a TTL clamped between `DEFAULT_SESSION_TTL_MS` and `MAX_SESSION_TTL_MS`, and there is no refresh/renew endpoint). If a run's session dies (revoked, or TTL elapsed) while the run is still legitimately in progress, the run's `heartbeatRuns.status` stays `"running"` forever — nothing ever transitions it to a terminal state. The local adapter process behind it keeps calling the tool-gateway, gets a `401`, and (per the MCP auth spec) treats that as a signal to retry an OAuth-discovery flow rather than give up, looping indefinitely. This permanently blocks the run's concurrency slot and leaks the OS process.

**Repro**: create a run with a local adapter, let its tool-gateway session expire (short TTL, or a slow tool call that outlives it), then observe the run never leaves `"running"` and the adapter process never exits.

## What Changed

- `server/src/services/tool-gateway.ts`: `DEFAULT_SESSION_TTL_MS`, `MAX_SESSION_TTL_MS`, and the tool-call timeout ceiling (previously a hardcoded `Math.min(60_000, ...)`) are now overridable via `TOOL_GATEWAY_SESSION_TTL_DEFAULT_MS`, `TOOL_GATEWAY_SESSION_TTL_MAX_MS`, and `TOOL_GATEWAY_MAX_TOOL_TIMEOUT_MS` env vars. Defaults are unchanged.
- `server/src/services/heartbeat.ts`: new `reapDeadSessionRuns()`, run alongside `reapOrphanedRuns` in the existing periodic reconciliation loop (and once at startup). It finds runs still `"running"` that have at least one tool-gateway session and no currently-live one, and finalizes each through the existing `cancelRunInternal` path — the same one the human-facing cancel action uses, so process termination goes through the in-memory running-process handle when available (no risk of signaling a reused pid) and `releaseIssueExecutionAndPromote` runs normally (issue ownership, environment leases, queued-work promotion all handled as usual).
- `server/src/index.ts`: wires `reapDeadSessionRuns` into both the startup reconciliation and the periodic scheduler tick.
- Tests: two new cases in `heartbeat-process-recovery.test.ts` (spawns a real child process; asserts it's killed and the run cancelled with `errorCode: tool_gateway_session_dead` when its session has expired; asserts nothing happens when the session is still live).

## Verification

- `npx vitest run src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/tool-gateway.test.ts src/__tests__/tool-gateway-service.test.ts` — 159 passed.
- `tsc --noEmit` clean.

## Risks

- Low risk. The new reconciliation step only acts on runs that are already unrecoverable (no live session and no way to get one), and reuses the same cancellation path already exercised by the manual "cancel run" action, so it inherits its existing safety properties (in-memory process handle preferred over a stored pid, proper issue/environment/queue cleanup). Default timeout/TTL values are unchanged, so existing deployments see no behavior change unless they opt in via the new env vars.

## Model Used

Claude (Anthropic), Sonnet 5, agentic coding session with tool use (file edits, test execution, git) — no extended-thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge