### PR TITLE
Show durable progress and error state for large company imports

### DIFF
--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -346,6 +346,12 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("Uploading and analyzing your package");
     expect(container.textContent).toContain("Keep this page open.");
 
+    // Config edits while the request is in flight must not detach it from
+    // the UI: the progress panel keeps reporting it until it settles.
+    await enterGithubUrl("https://github.com/acme/starter-b/tree/main/company");
+
+    expect(container.textContent).toContain("Uploading and analyzing your package");
+
     await act(async () => {
       rejectPreview(new Error("stream disconnected"));
     });
@@ -378,6 +384,21 @@ describe("CompanyImport", () => {
 
     expect(container.textContent).toContain("Uploading and importing");
     expect(container.textContent).toContain("Keep this page open.");
+
+    // Config edits while the import is in flight must not detach it from
+    // the UI: the progress panel keeps reporting it until it settles.
+    const midFlightNameInput = container.querySelector<HTMLInputElement>(
+      'input[placeholder="Imported Company"]',
+    );
+    expect(midFlightNameInput).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+      setter.call(midFlightNameInput!, "Mid Flight");
+      midFlightNameInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Uploading and importing");
 
     await act(async () => {
       rejectImport(new Error("connection reset"));

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -396,10 +396,22 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("Uploading and importing");
     expect(container.textContent).toContain("Keep this page open.");
 
-    // While the import runs, previewing is locked (and explained) so a
-    // concurrent preview cannot replace the plan the import started from.
+    // While the import runs, previewing and the structural package/settings
+    // controls are locked (and explained), so nothing can replace or unmount
+    // the plan the import started from.
     expect(findButton((text) => text === "Preview import")?.disabled).toBe(true);
-    expect(container.textContent).toContain("Import in progress — previewing unlocks when it finishes.");
+    expect(container.textContent).toContain(
+      "Import in progress — the package and settings unlock when it finishes.",
+    );
+    const lockedUrlInput = container.querySelector<HTMLInputElement>(
+      'input[placeholder="https://github.com/owner/repo/tree/main/company"]',
+    );
+    expect(lockedUrlInput?.disabled).toBe(true);
+    const lockedSelects = Array.from(container.querySelectorAll("select")).filter(
+      (select) => select.value === "new" || select.value === "rename",
+    );
+    expect(lockedSelects).toHaveLength(2);
+    expect(lockedSelects.every((select) => select.disabled)).toBe(true);
 
     // Config edits while the import is in flight must not detach it from
     // the UI: the progress panel keeps reporting it until it settles.
@@ -440,6 +452,11 @@ describe("CompanyImport", () => {
     expect(container.textContent).not.toContain("Import failed:");
     expect(findButton((text) => text.startsWith("Import 3 file"))).toBeTruthy();
     expect(findButton((text) => text === "Preview import")?.disabled).toBe(false);
+    expect(
+      container.querySelector<HTMLInputElement>(
+        'input[placeholder="https://github.com/owner/repo/tree/main/company"]',
+      )?.disabled,
+    ).toBe(false);
 
     // The pause toggle feeds the request payload too: after another failed
     // attempt, toggling it also supersedes the request and clears the panel.

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -389,6 +389,20 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("check the target company before retrying.");
     expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ tone: "error" }));
 
+    // The new-company name feeds the request payload too: editing it clears
+    // the stale error panel without discarding the rendered preview.
+    const nameInput = container.querySelector<HTMLInputElement>('input[placeholder="Imported Company"]');
+    expect(nameInput).toBeTruthy();
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+      setter.call(nameInput!, "Renamed Import");
+      nameInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Import failed:");
+    expect(findButton((text) => text.startsWith("Import 3 file"))).toBeTruthy();
+
     // Changing the package supersedes the failed import: previewing a fresh
     // package must not resurface the stale import error panel.
     await enterGithubUrl("https://github.com/acme/other-starter/tree/main/company");

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -206,14 +206,14 @@ describe("CompanyImport", () => {
     await flushReact();
   }
 
-  async function enterGithubUrl() {
+  async function enterGithubUrl(url = "https://github.com/acme/starter/tree/main/company") {
     const urlInput = container.querySelector<HTMLInputElement>(
       'input[placeholder="https://github.com/owner/repo/tree/main/company"]',
     );
     expect(urlInput).toBeTruthy();
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
-      setter.call(urlInput!, "https://github.com/acme/starter/tree/main/company");
+      setter.call(urlInput!, url);
       urlInput!.dispatchEvent(new Event("input", { bubbles: true }));
     });
     await flushReact();
@@ -355,6 +355,11 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("Preview failed: stream disconnected");
     expect(container.textContent).toContain("Retry, or use the CLI folder import");
     expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ tone: "error" }));
+
+    // Changing the package supersedes the failed request: the error panel resets.
+    await enterGithubUrl("https://github.com/acme/other-starter/tree/main/company");
+
+    expect(container.textContent).not.toContain("Preview failed:");
   });
 
   it("shows a progress panel while the import runs and a durable error panel when it fails", async () => {
@@ -383,5 +388,13 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("Import failed: connection reset");
     expect(container.textContent).toContain("check the target company before retrying.");
     expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ tone: "error" }));
+
+    // Changing the package supersedes the failed import: previewing a fresh
+    // package must not resurface the stale import error panel.
+    await enterGithubUrl("https://github.com/acme/other-starter/tree/main/company");
+    await clickButton((text) => text === "Preview import");
+
+    expect(findButton((text) => text.startsWith("Import 3 file"))).toBeTruthy();
+    expect(container.textContent).not.toContain("Import failed:");
   });
 });

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -346,8 +346,9 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("Uploading and analyzing your package");
     expect(container.textContent).toContain("Keep this page open.");
 
-    // Config edits while the request is in flight must not detach it from
-    // the UI: the progress panel keeps reporting it until it settles.
+    // A mid-flight config edit keeps the progress panel visible (the request
+    // really is still running) but supersedes the request, so its failure
+    // settles silently instead of describing a package no longer selected.
     await enterGithubUrl("https://github.com/acme/starter-b/tree/main/company");
 
     expect(container.textContent).toContain("Uploading and analyzing your package");
@@ -358,6 +359,16 @@ describe("CompanyImport", () => {
     await flushReact();
 
     expect(container.textContent).not.toContain("Uploading and analyzing your package");
+    expect(container.textContent).not.toContain("Preview failed:");
+    expect(mockPushToast).not.toHaveBeenCalled();
+
+    // A failure of the currently configured request renders a durable panel.
+    await clickButton((text) => text === "Preview import");
+    await act(async () => {
+      rejectPreview(new Error("stream disconnected"));
+    });
+    await flushReact();
+
     expect(container.textContent).toContain("Preview failed: stream disconnected");
     expect(container.textContent).toContain("Retry, or use the CLI folder import");
     expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ tone: "error" }));

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -479,6 +479,26 @@ describe("CompanyImport", () => {
 
     expect(container.textContent).not.toContain("Import failed:");
 
+    // File-selection edits feed the payload too and supersede a failure.
+    await clickButton((text) => text.startsWith("Import 3 file"));
+    await act(async () => {
+      rejectImport(new Error("third failure"));
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Import failed: third failure");
+
+    const fileCheckbox = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) => !input.closest("label")?.textContent?.includes("Start imported agents"));
+    expect(fileCheckbox).toBeTruthy();
+    await act(async () => {
+      fileCheckbox!.click();
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Import failed:");
+
     // Changing the package supersedes the failed import: previewing a fresh
     // package must not resurface the stale import error panel.
     await enterGithubUrl("https://github.com/acme/other-starter/tree/main/company");

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -396,6 +396,11 @@ describe("CompanyImport", () => {
     expect(container.textContent).toContain("Uploading and importing");
     expect(container.textContent).toContain("Keep this page open.");
 
+    // While the import runs, previewing is locked (and explained) so a
+    // concurrent preview cannot replace the plan the import started from.
+    expect(findButton((text) => text === "Preview import")?.disabled).toBe(true);
+    expect(container.textContent).toContain("Import in progress — previewing unlocks when it finishes.");
+
     // Config edits while the import is in flight must not detach it from
     // the UI: the progress panel keeps reporting it until it settles.
     const midFlightNameInput = container.querySelector<HTMLInputElement>(
@@ -434,6 +439,28 @@ describe("CompanyImport", () => {
 
     expect(container.textContent).not.toContain("Import failed:");
     expect(findButton((text) => text.startsWith("Import 3 file"))).toBeTruthy();
+    expect(findButton((text) => text === "Preview import")?.disabled).toBe(false);
+
+    // The pause toggle feeds the request payload too: after another failed
+    // attempt, toggling it also supersedes the request and clears the panel.
+    await clickButton((text) => text.startsWith("Import 3 file"));
+    await act(async () => {
+      rejectImport(new Error("second failure"));
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Import failed: second failure");
+
+    const pauseInput = Array.from(container.querySelectorAll("label"))
+      .find((label) => label.textContent?.includes("Start imported agents and routines paused"))
+      ?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(pauseInput).toBeTruthy();
+    await act(async () => {
+      pauseInput!.click();
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Import failed:");
 
     // Changing the package supersedes the failed import: previewing a fresh
     // package must not resurface the stale import error panel.

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -191,7 +191,7 @@ describe("CompanyImport", () => {
     await flushReact();
   }
 
-  async function renderPageAndImport() {
+  async function renderPage() {
     root = createRoot(container);
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const currentRoot = root;
@@ -204,7 +204,9 @@ describe("CompanyImport", () => {
       );
     });
     await flushReact();
+  }
 
+  async function enterGithubUrl() {
     const urlInput = container.querySelector<HTMLInputElement>(
       'input[placeholder="https://github.com/owner/repo/tree/main/company"]',
     );
@@ -215,6 +217,11 @@ describe("CompanyImport", () => {
       urlInput!.dispatchEvent(new Event("input", { bubbles: true }));
     });
     await flushReact();
+  }
+
+  async function renderPageAndImport() {
+    await renderPage();
+    await enterGithubUrl();
 
     await clickButton((text) => text === "Preview import");
 
@@ -276,17 +283,7 @@ describe("CompanyImport", () => {
       },
     });
 
-    root = createRoot(container);
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const currentRoot = root;
-    await act(async () => {
-      currentRoot.render(
-        <QueryClientProvider client={queryClient}>
-          <CompanyImport />
-        </QueryClientProvider>,
-      );
-    });
-    await flushReact();
+    await renderPage();
 
     await clickButton((text) => text.includes("Local zip"));
 
@@ -301,11 +298,13 @@ describe("CompanyImport", () => {
     await flushReact();
 
     expect(container.textContent).toContain("CLI folder import");
+    expect(container.textContent).toContain("Package too large for browser import");
     expect(findButton((text) => text === "Preview import")?.disabled).toBe(true);
 
     await clickButton((text) => text === "Continue without attachments");
 
     expect(container.textContent).not.toContain("CLI folder import");
+    expect(container.textContent).not.toContain("Package too large for browser import");
     expect(findButton((text) => text === "Preview import")?.disabled).toBe(false);
 
     await clickButton((text) => text === "Preview import");
@@ -317,5 +316,72 @@ describe("CompanyImport", () => {
     };
     expect(request.source.type).toBe("inline");
     expect(Object.keys(request.source.files).sort()).toEqual([".paperclip.yaml", "COMPANY.md"]);
+  });
+
+  it("explains the disabled preview button until a package is chosen", async () => {
+    await renderPage();
+
+    expect(findButton((text) => text === "Preview import")?.disabled).toBe(true);
+    expect(container.textContent).toContain("Choose a package above to enable the preview.");
+
+    await enterGithubUrl();
+
+    expect(findButton((text) => text === "Preview import")?.disabled).toBe(false);
+    expect(container.textContent).not.toContain("Choose a package above to enable the preview.");
+  });
+
+  it("shows a progress panel while the preview runs and a durable error panel when it fails", async () => {
+    let rejectPreview!: (err: Error) => void;
+    mockCompaniesApi.importPreview.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPreview = reject;
+        }),
+    );
+    await renderPage();
+    await enterGithubUrl();
+
+    await clickButton((text) => text === "Preview import");
+
+    expect(container.textContent).toContain("Uploading and analyzing your package");
+    expect(container.textContent).toContain("Keep this page open.");
+
+    await act(async () => {
+      rejectPreview(new Error("stream disconnected"));
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Uploading and analyzing your package");
+    expect(container.textContent).toContain("Preview failed: stream disconnected");
+    expect(container.textContent).toContain("Retry, or use the CLI folder import");
+    expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ tone: "error" }));
+  });
+
+  it("shows a progress panel while the import runs and a durable error panel when it fails", async () => {
+    let rejectImport!: (err: Error) => void;
+    mockCompaniesApi.importBundle.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectImport = reject;
+        }),
+    );
+    await renderPage();
+    await enterGithubUrl();
+    await clickButton((text) => text === "Preview import");
+
+    await clickButton((text) => text.startsWith("Import 3 file"));
+
+    expect(container.textContent).toContain("Uploading and importing");
+    expect(container.textContent).toContain("Keep this page open.");
+
+    await act(async () => {
+      rejectImport(new Error("connection reset"));
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Uploading and importing");
+    expect(container.textContent).toContain("Import failed: connection reset");
+    expect(container.textContent).toContain("check the target company before retrying.");
+    expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ tone: "error" }));
   });
 });

--- a/ui/src/pages/CompanyImport.test.tsx
+++ b/ui/src/pages/CompanyImport.test.tsx
@@ -506,5 +506,38 @@ describe("CompanyImport", () => {
 
     expect(findButton((text) => text.startsWith("Import 3 file"))).toBeTruthy();
     expect(container.textContent).not.toContain("Import failed:");
+
+    // The outcome reports the submitted pause option, not the live checkbox:
+    // a mid-flight toggle must not change what the completed import did.
+    let resolveImport!: (value: CompanyPortabilityImportResult) => void;
+    mockCompaniesApi.importBundle.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveImport = resolve;
+        }),
+    );
+    await clickButton((text) => text.startsWith("Import 3 file"));
+
+    expect(mockCompaniesApi.importBundle).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pauseAutomations: false }),
+    );
+
+    const midFlightPauseInput = Array.from(container.querySelectorAll("label"))
+      .find((label) => label.textContent?.includes("Start imported agents and routines paused"))
+      ?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(midFlightPauseInput).toBeTruthy();
+    await act(async () => {
+      midFlightPauseInput!.click();
+    });
+    await flushReact();
+
+    await act(async () => {
+      resolveImport(buildImportResult());
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Import complete");
+    expect(container.textContent).not.toContain("Activate imported agents and routines");
   });
 });

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -927,13 +927,18 @@ export function CompanyImport() {
     },
   });
 
-  // Any change to the package or import configuration supersedes the last
-  // preview and any settled mutation state, so the persistent progress/error
-  // panels never keep describing a request that no longer applies.
-  function resetImportFlowState() {
-    setImportPreview(null);
+  // Any change to the import configuration supersedes the request the last
+  // progress/error panel describes, so it resets both mutations. The
+  // new-company name is typed against a rendered preview, so it resets only
+  // the panels; structural changes also discard the preview itself.
+  function resetMutationState() {
     previewMutation.reset();
     importMutation.reset();
+  }
+
+  function resetImportFlowState() {
+    setImportPreview(null);
+    resetMutationState();
   }
 
   async function handleChooseLocalPackage(e: ChangeEvent<HTMLInputElement>) {
@@ -1419,7 +1424,10 @@ export function CompanyImport() {
               className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
               type="text"
               value={newCompanyName}
-              onChange={(e) => setNewCompanyName(e.target.value)}
+              onChange={(e) => {
+                setNewCompanyName(e.target.value);
+                resetMutationState();
+              }}
               placeholder="Imported Company"
             />
           </Field>

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -883,9 +883,11 @@ export function CompanyImport() {
     return selected.length > 0 ? selected : undefined;
   }
 
-  // Apply mutation
+  // Apply mutation. The preview the import was started from rides along as
+  // the mutation variable so the success callback never reads state that a
+  // later preview or configuration change may have replaced.
   const importMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: (_previewForImport: CompanyPortabilityPreviewResult | null) => {
       const source = buildSource();
       if (!source) throw new Error("No source configured.");
       return companiesApi.importBundle({
@@ -902,7 +904,7 @@ export function CompanyImport() {
         pauseAutomations,
       });
     },
-    onSuccess: async (result) => {
+    onSuccess: async (result, previewForImport) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       const importedCompany = await companiesApi.get(result.company.id);
       const refreshedSession = currentUserId
@@ -916,7 +918,7 @@ export function CompanyImport() {
         ?? refreshedSession?.user?.id
         ?? refreshedSession?.session?.userId
         ?? null;
-      await applyImportedSidebarOrder(importPreview, result, sidebarOrderUserId);
+      await applyImportedSidebarOrder(previewForImport, result, sidebarOrderUserId);
       setSelectedCompanyId(importedCompany.id);
       setActivationChecked(new Set(buildActivationItems(result).map((item) => item.key)));
       setActivatedKeys(new Set());
@@ -939,9 +941,9 @@ export function CompanyImport() {
   // Any change to the import configuration supersedes the request a settled
   // progress/error panel describes, so it clears settled mutation state. A
   // pending request is never detached: its panel keeps reporting it (and the
-  // action buttons stay disabled) until it settles. The new-company name is
-  // typed against a rendered preview, so it resets only the panels;
-  // structural changes also discard the preview itself.
+  // action buttons stay disabled) until it settles. The new-company name and
+  // pause toggle are set against a rendered preview, so they reset only the
+  // panels; structural changes also discard the preview itself.
   function resetMutationState() {
     if (!previewMutation.isPending) previewMutation.reset();
     if (!importMutation.isPending) importMutation.reset();
@@ -1468,13 +1470,20 @@ export function CompanyImport() {
             size="sm"
             variant="outline"
             onClick={() => previewMutation.mutate(previewGenerationRef.current)}
-            disabled={previewMutation.isPending || !hasSource || inlineImportBlocked}
+            disabled={
+              previewMutation.isPending || importMutation.isPending || !hasSource || inlineImportBlocked
+            }
           >
             {previewMutation.isPending ? "Previewing..." : "Preview import"}
           </Button>
           {!hasSource && !previewMutation.isPending && (
             <span className="text-xs text-muted-foreground">
               Choose a package above to enable the preview.
+            </span>
+          )}
+          {importMutation.isPending && (
+            <span className="text-xs text-muted-foreground">
+              Import in progress — previewing unlocks when it finishes.
             </span>
           )}
           {inlineImportBlocked && (
@@ -1561,14 +1570,17 @@ export function CompanyImport() {
               <input
                 type="checkbox"
                 checked={pauseAutomations}
-                onChange={(e) => setPauseAutomations(e.target.checked)}
+                onChange={(e) => {
+                  setPauseAutomations(e.target.checked);
+                  resetMutationState();
+                }}
                 className="accent-foreground"
               />
               Start imported agents and routines paused
             </label>
             <Button
               size="sm"
-              onClick={() => importMutation.mutate()}
+              onClick={() => importMutation.mutate(importPreview)}
               disabled={importMutation.isPending || hasErrors || selectedCount === 0 || inlineImportBlocked}
             >
               <Download className="mr-1.5 h-3.5 w-3.5" />

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -927,13 +927,22 @@ export function CompanyImport() {
     },
   });
 
+  // Any change to the package or import configuration supersedes the last
+  // preview and any settled mutation state, so the persistent progress/error
+  // panels never keep describing a request that no longer applies.
+  function resetImportFlowState() {
+    setImportPreview(null);
+    previewMutation.reset();
+    importMutation.reset();
+  }
+
   async function handleChooseLocalPackage(e: ChangeEvent<HTMLInputElement>) {
     const fileList = e.target.files;
     if (!fileList || fileList.length === 0) return;
     try {
       const pkg = await readLocalPackageZip(fileList[0]!);
       setLocalPackage(pkg);
-      setImportPreview(null);
+      resetImportFlowState();
     } catch (err) {
       pushToast({
         tone: "error",
@@ -1311,7 +1320,7 @@ export function CompanyImport() {
               )}
               onClick={() => {
                 setSourceMode(key);
-                setImportPreview(null);
+                resetImportFlowState();
               }}
             >
               <div className="flex items-center gap-2">
@@ -1379,7 +1388,7 @@ export function CompanyImport() {
               placeholder="https://github.com/owner/repo/tree/main/company"
               onChange={(e) => {
                 setImportUrl(e.target.value);
-                setImportPreview(null);
+                resetImportFlowState();
               }}
             />
           </Field>
@@ -1391,7 +1400,7 @@ export function CompanyImport() {
             value={targetMode}
             onChange={(e) => {
               setTargetMode(e.target.value as "existing" | "new");
-              setImportPreview(null);
+              resetImportFlowState();
             }}
           >
             <option value="new">Create new company</option>
@@ -1425,7 +1434,7 @@ export function CompanyImport() {
             value={collisionStrategy}
             onChange={(e) => {
               setCollisionStrategy(e.target.value as CompanyPortabilityCollisionStrategy);
-              setImportPreview(null);
+              resetImportFlowState();
             }}
           >
             <option value="rename">Rename on conflict</option>

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -927,13 +927,15 @@ export function CompanyImport() {
     },
   });
 
-  // Any change to the import configuration supersedes the request the last
-  // progress/error panel describes, so it resets both mutations. The
-  // new-company name is typed against a rendered preview, so it resets only
-  // the panels; structural changes also discard the preview itself.
+  // Any change to the import configuration supersedes the request a settled
+  // progress/error panel describes, so it clears settled mutation state. A
+  // pending request is never detached: its panel keeps reporting it (and the
+  // action buttons stay disabled) until it settles. The new-company name is
+  // typed against a rendered preview, so it resets only the panels;
+  // structural changes also discard the preview itself.
   function resetMutationState() {
-    previewMutation.reset();
-    importMutation.reset();
+    if (!previewMutation.isPending) previewMutation.reset();
+    if (!importMutation.isPending) importMutation.reset();
   }
 
   function resetImportFlowState() {

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -29,6 +29,7 @@ import {
   ChevronRight,
   Download,
   Github,
+  Loader2,
   Package,
   Upload,
 } from "lucide-react";
@@ -1442,7 +1443,38 @@ export function CompanyImport() {
           >
             {previewMutation.isPending ? "Previewing..." : "Preview import"}
           </Button>
+          {!hasSource && !previewMutation.isPending && (
+            <span className="text-xs text-muted-foreground">
+              Choose a package above to enable the preview.
+            </span>
+          )}
+          {inlineImportBlocked && (
+            <span className="text-xs text-amber-500">
+              Package too large for browser import — see the notice above.
+            </span>
+          )}
         </div>
+        {previewMutation.isPending && (
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-border bg-muted/30 px-3 py-2.5">
+            <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+            <p className="text-xs text-muted-foreground">
+              Uploading and analyzing your package
+              {inlinePreflight ? ` (about ${formatMegabytes(inlinePreflight.estimatedBytes)})` : ""} — large
+              packages can take a few minutes. Keep this page open.
+            </p>
+          </div>
+        )}
+        {previewMutation.isError && !previewMutation.isPending && (
+          <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5">
+            <p className="text-xs text-destructive">
+              Preview failed:{" "}
+              {previewMutation.error instanceof Error
+                ? previewMutation.error.message
+                : "the request did not complete."}{" "}
+              Retry, or use the CLI folder import for very large packages.
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Preview results */}
@@ -1514,6 +1546,26 @@ export function CompanyImport() {
                 : `Import ${selectedCount} file${selectedCount === 1 ? "" : "s"}`}
             </Button>
           </div>
+          {importMutation.isPending && (
+            <div className="mx-5 mt-3 flex items-start gap-2 rounded-md border border-border bg-muted/30 px-3 py-2.5">
+              <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+              <p className="text-xs text-muted-foreground">
+                Uploading and importing — large packages can take several minutes. Keep this page open.
+              </p>
+            </div>
+          )}
+          {importMutation.isError && !importMutation.isPending && (
+            <div className="mx-5 mt-3 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5">
+              <p className="text-xs text-destructive">
+                Import failed:{" "}
+                {importMutation.error instanceof Error
+                  ? importMutation.error.message
+                  : "the request did not complete."}{" "}
+                Nothing may have been created, or the import stopped partway — check the target company
+                before retrying.
+              </p>
+            </div>
+          )}
 
           {/* Warnings */}
           {importPreview.warnings.length > 0 && (

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -770,9 +770,16 @@ export function CompanyImport() {
     return { type: "github", url };
   }
 
+  // Monotonic id for preview requests. Structural configuration changes bump
+  // it, so an in-flight preview they supersede settles silently instead of
+  // publishing a result or error for a package that is no longer selected.
+  // Imports are not gated this way: they mutate the server, so their outcome
+  // is always published.
+  const previewGenerationRef = useRef(0);
+
   // Preview mutation
   const previewMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: (_generation: number) => {
       const source = buildSource();
       if (!source) throw new Error("No source configured.");
       return companiesApi.importPreview({
@@ -785,7 +792,8 @@ export function CompanyImport() {
         collisionStrategy,
       });
     },
-    onSuccess: (result) => {
+    onSuccess: (result, generation) => {
+      if (generation !== previewGenerationRef.current) return;
       setImportPreview(result);
 
       // Build conflicts and set default name overrides with prefix
@@ -848,7 +856,8 @@ export function CompanyImport() {
       const firstFile = Object.keys(result.files)[0];
       if (firstFile) setSelectedFile(firstFile);
     },
-    onError: (err) => {
+    onError: (err, generation) => {
+      if (generation !== previewGenerationRef.current) return;
       pushToast({
         tone: "error",
         title: "Preview failed",
@@ -939,6 +948,7 @@ export function CompanyImport() {
   }
 
   function resetImportFlowState() {
+    previewGenerationRef.current += 1;
     setImportPreview(null);
     resetMutationState();
   }
@@ -1457,7 +1467,7 @@ export function CompanyImport() {
           <Button
             size="sm"
             variant="outline"
-            onClick={() => previewMutation.mutate()}
+            onClick={() => previewMutation.mutate(previewGenerationRef.current)}
             disabled={previewMutation.isPending || !hasSource || inlineImportBlocked}
           >
             {previewMutation.isPending ? "Previewing..." : "Preview import"}
@@ -1483,7 +1493,9 @@ export function CompanyImport() {
             </p>
           </div>
         )}
-        {previewMutation.isError && !previewMutation.isPending && (
+        {previewMutation.isError &&
+          !previewMutation.isPending &&
+          previewMutation.variables === previewGenerationRef.current && (
           <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2.5">
             <p className="text-xs text-destructive">
               Preview failed:{" "}

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -943,7 +943,9 @@ export function CompanyImport() {
   // pending request is never detached: its panel keeps reporting it (and the
   // action buttons stay disabled) until it settles. The new-company name and
   // pause toggle are set against a rendered preview, so they reset only the
-  // panels; structural changes also discard the preview itself.
+  // panels; structural changes also discard the preview itself. Structural
+  // controls are locked while an import runs, so this can never unmount the
+  // preview section that hosts a running import's status panels.
   function resetMutationState() {
     if (!previewMutation.isPending) previewMutation.reset();
     if (!importMutation.isPending) importMutation.reset();
@@ -1336,7 +1338,9 @@ export function CompanyImport() {
                 sourceMode === key
                   ? "border-foreground bg-accent"
                   : "border-border hover:bg-accent/50",
+                importMutation.isPending && "cursor-not-allowed opacity-50",
               )}
+              disabled={importMutation.isPending}
               onClick={() => {
                 setSourceMode(key);
                 resetImportFlowState();
@@ -1364,6 +1368,7 @@ export function CompanyImport() {
                 size="sm"
                 variant="outline"
                 onClick={() => packageInputRef.current?.click()}
+                disabled={importMutation.isPending}
               >
                 Choose zip
               </Button>
@@ -1405,6 +1410,7 @@ export function CompanyImport() {
               type="text"
               value={importUrl}
               placeholder="https://github.com/owner/repo/tree/main/company"
+              disabled={importMutation.isPending}
               onChange={(e) => {
                 setImportUrl(e.target.value);
                 resetImportFlowState();
@@ -1417,6 +1423,7 @@ export function CompanyImport() {
           <select
             className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
             value={targetMode}
+            disabled={importMutation.isPending}
             onChange={(e) => {
               setTargetMode(e.target.value as "existing" | "new");
               resetImportFlowState();
@@ -1454,6 +1461,7 @@ export function CompanyImport() {
           <select
             className="w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none"
             value={collisionStrategy}
+            disabled={importMutation.isPending}
             onChange={(e) => {
               setCollisionStrategy(e.target.value as CompanyPortabilityCollisionStrategy);
               resetImportFlowState();
@@ -1483,7 +1491,7 @@ export function CompanyImport() {
           )}
           {importMutation.isPending && (
             <span className="text-xs text-muted-foreground">
-              Import in progress — previewing unlocks when it finishes.
+              Import in progress — the package and settings unlock when it finishes.
             </span>
           )}
           {inlineImportBlocked && (

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -941,11 +941,13 @@ export function CompanyImport() {
   // Any change to the import configuration supersedes the request a settled
   // progress/error panel describes, so it clears settled mutation state. A
   // pending request is never detached: its panel keeps reporting it (and the
-  // action buttons stay disabled) until it settles. The new-company name and
-  // pause toggle are set against a rendered preview, so they reset only the
-  // panels; structural changes also discard the preview itself. Structural
-  // controls are locked while an import runs, so this can never unmount the
-  // preview section that hosts a running import's status panels.
+  // action buttons stay disabled) until it settles. Payload edits made
+  // against a rendered preview (new-company name, pause toggle, file
+  // selection, conflict choices, adapter overrides, dropping attachments)
+  // reset only the panels; structural changes also discard the preview
+  // itself. Structural controls are locked while an import runs, so this can
+  // never unmount the preview section that hosts a running import's status
+  // panels.
   function resetMutationState() {
     if (!previewMutation.isPending) previewMutation.reset();
     if (!importMutation.isPending) importMutation.reset();
@@ -1022,6 +1024,7 @@ export function CompanyImport() {
 
   function handleToggleCheck(path: string, kind: "file" | "dir") {
     if (!importPreview) return;
+    resetMutationState();
     setCheckedFiles((prev) => {
       const next = new Set(prev);
       if (kind === "file") {
@@ -1054,6 +1057,7 @@ export function CompanyImport() {
   }
 
   function handleConflictRename(slug: string, newName: string) {
+    resetMutationState();
     setNameOverrides((prev) => ({ ...prev, [slug]: newName }));
     // Editing the name un-confirms
     setConfirmedSlugs((prev) => {
@@ -1065,6 +1069,7 @@ export function CompanyImport() {
   }
 
   function handleConflictToggleConfirm(slug: string) {
+    resetMutationState();
     setConfirmedSlugs((prev) => {
       const next = new Set(prev);
       if (next.has(slug)) next.delete(slug);
@@ -1074,6 +1079,7 @@ export function CompanyImport() {
   }
 
   function handleConflictToggleSkip(slug: string, filePath: string | null) {
+    resetMutationState();
     setSkippedSlugs((prev) => {
       const next = new Set(prev);
       const wasSkipped = next.has(slug);
@@ -1101,6 +1107,7 @@ export function CompanyImport() {
   }
 
   function handleAdapterChange(slug: string, adapterType: string) {
+    resetMutationState();
     setAdapterOverrides((prev) => ({ ...prev, [slug]: adapterType }));
     // Reset config values when adapter type changes
     setAdapterConfigValues((prev) => {
@@ -1120,6 +1127,7 @@ export function CompanyImport() {
   }
 
   function handleAdapterConfigChange(slug: string, patch: Partial<CreateConfigValues>) {
+    resetMutationState();
     setAdapterConfigValues((prev) => ({
       ...prev,
       [slug]: { ...(prev[slug] ?? { ...defaultCreateValues, adapterType: adapterOverrides[slug] ?? "claude_local" }), ...patch },
@@ -1207,6 +1215,7 @@ export function CompanyImport() {
 
   function handleContinueWithoutAttachments() {
     if (!localPackage) return;
+    resetMutationState();
     setLocalPackage({ ...localPackage, files: stripBlobFiles(localPackage.files) });
     setCheckedFiles((prev) => new Set([...prev].filter((filePath) => !isBlobStoreFilePath(filePath))));
   }

--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -883,11 +883,14 @@ export function CompanyImport() {
     return selected.length > 0 ? selected : undefined;
   }
 
-  // Apply mutation. The preview the import was started from rides along as
-  // the mutation variable so the success callback never reads state that a
-  // later preview or configuration change may have replaced.
+  // Apply mutation. The preview the import was started from and the
+  // submitted pause option ride along as the mutation variables so the
+  // request and its callbacks never read state that a later edit replaced.
   const importMutation = useMutation({
-    mutationFn: (_previewForImport: CompanyPortabilityPreviewResult | null) => {
+    mutationFn: (variables: {
+      previewForImport: CompanyPortabilityPreviewResult | null;
+      pauseAutomations: boolean;
+    }) => {
       const source = buildSource();
       if (!source) throw new Error("No source configured.");
       return companiesApi.importBundle({
@@ -901,10 +904,10 @@ export function CompanyImport() {
         nameOverrides: buildFinalNameOverrides(),
         selectedFiles: buildSelectedFiles(),
         adapterOverrides: buildFinalAdapterOverrides(),
-        pauseAutomations,
+        pauseAutomations: variables.pauseAutomations,
       });
     },
-    onSuccess: async (result, previewForImport) => {
+    onSuccess: async (result, { previewForImport, pauseAutomations: submittedPauseAutomations }) => {
       await queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
       const importedCompany = await companiesApi.get(result.company.id);
       const refreshedSession = currentUserId
@@ -926,7 +929,7 @@ export function CompanyImport() {
       setImportOutcome({
         result,
         dashboardPath: `/${importedCompany.issuePrefix}/dashboard`,
-        pausedAutomations: pauseAutomations,
+        pausedAutomations: submittedPauseAutomations,
       });
     },
     onError: (err) => {
@@ -1597,7 +1600,7 @@ export function CompanyImport() {
             </label>
             <Button
               size="sm"
-              onClick={() => importMutation.mutate(importPreview)}
+              onClick={() => importMutation.mutate({ previewForImport: importPreview, pauseAutomations })}
               disabled={importMutation.isPending || hasErrors || selectedCount === 0 || inlineImportBlocked}
             >
               <Download className="mr-1.5 h-3.5 w-3.5" />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Company Import/Export (#10507) moves whole companies as zip bundles; big companies mean the browser stringifies and uploads tens of megabytes and the server walks thousands of files
> - Previewing or applying such an import can take minutes, but the only feedback was the action button's label quietly flipping, and failures surfaced only as an auto-dismissing toast
> - Real-world use immediately hit this: clicking "Preview import" on a ~45 MB package looked like nothing happened
> - This pull request adds persistent progress panels with size-aware copy while preview/import run, persistent inline error panels with retry guidance, and inline explanations whenever the preview button is disabled
> - The benefit is that long-running imports are legible: users can tell working from stuck from failed without watching for a toast

## Linked Issues or Issue Description

- Refs #10507 (the Import/Export feature this hardens). No open issue; problem description above (bug-report shape: large-package preview appears unresponsive; expected visible progress/error state; actual none beyond a button label and transient toast).

## What Changed

- Preview and import buttons keep their pending labels, and both actions now render a persistent bordered progress panel (spinner + "large packages can take a few minutes, keep this page open"; preview includes the estimated inline size)
- Failures render a persistent error panel next to the action (kept alongside the existing toast); the import one warns the target may hold partial state and to check before retrying
- A disabled preview button explains itself inline: no package selected, or package over the inline import limit (pointing at the existing size notice)
- Changing the package URL, source mode, chosen zip, target, or collision strategy resets the preview and any settled mutation state, so a stale progress or error panel never describes a superseded request; editing the new-company name resets the panels too, without discarding the rendered preview it is typed against
- Every request-shaping edit (file selection, conflict choices, adapter overrides, pause toggle, dropping attachments) likewise supersedes a settled failure; pending requests are never detached from their panels
- While an import runs, the preview action and structural package/settings controls lock with an inline explanation, and the import pins the preview and pause option it was submitted with, so completion reporting always matches the request the server ran; a preview superseded mid-flight settles silently instead of publishing a stale result

## Verification

- `pnpm --filter @paperclipai/ui typecheck`; `pnpm exec vitest run ui/src/pages/CompanyImport.test.tsx` (6 tests pass)
- Component tests cover every new state: the disabled-preview hint, the too-large hint, both in-flight progress panels (via deferred mutation promises), both persistent failure panels, and the reset of stale error panels when the configuration changes
- No request or import semantics touched beyond resetting client-side mutation state on configuration changes

## Risks

- Low: presentation and client-side state only, no API or import semantics changed.

## Model Used

- Claude Fable 5 (`claude-fable-5`), Claude Code CLI, extended thinking + tool use

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

