### PR TITLE
Redact agent configuration response values

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -360,7 +360,9 @@ Invariants:
 
 Operational policy:
 
-- Config read APIs redact sensitive plain values.
+- Agent identity and detail APIs never return adapter or runtime configuration.
+- Authorized configuration reads expose environment binding metadata only; scalar environment values are write-only.
+- Strict secret mode rejects sensitive plain bindings, including token, PAT, database URL, and scoped credential keys.
 - Activity and approval payloads must not persist raw sensitive values.
 - Config revisions may include redacted placeholders; such revisions are non-restorable for redacted fields.
 

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -555,15 +555,19 @@ describe("agent instructions bundle routes", () => {
         adapterConfig: {
           command: "codex --profile engineer",
         },
-      }));
+    }));
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
-    expect(res.body.adapterConfig).toMatchObject({
-      command: "codex --profile engineer",
-    });
-    expect(res.body.adapterConfig.instructionsBundleMode).toBeUndefined();
-    expect(res.body.adapterConfig.instructionsRootPath).toBeUndefined();
-    expect(res.body.adapterConfig.instructionsEntryFile).toBeUndefined();
-    expect(res.body.adapterConfig.instructionsFilePath).toBeUndefined();
+    expect(res.body.adapterConfig).toEqual({});
+    expect(res.body.runtimeConfig).toEqual({});
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          command: "codex --profile engineer",
+        }),
+      }),
+      expect.any(Object),
+    );
   });
 });

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -435,7 +435,7 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.runtimeConfig).toEqual({});
   }, 20_000);
 
-  it("keeps board agent detail unredacted for low-trust agents", async () => {
+  it("never returns adapter or runtime config from board agent detail", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...baseAgent,
       permissions: {
@@ -464,16 +464,53 @@ describe.sequential("agent permission routes", () => {
     const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
 
     expect(res.status).toBe(200);
-    expect(res.body.adapterConfig).toMatchObject({
-      command: "pnpm agent:run",
-      env: { PAPERCLIP_API_KEY: "secret-test-key" },
-    });
-    expect(res.body.runtimeConfig).toMatchObject({
-      modelProfiles: {
-        default: { enabled: true, adapterConfig: { model: "openai/gpt-5.4-mini" } },
+    expect(res.body.adapterConfig).toEqual({});
+    expect(res.body.runtimeConfig).toEqual({});
+    expect(JSON.stringify(res.body)).not.toContain("secret-test-key");
+    expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
+  }, 20_000);
+
+  it("returns only binding metadata from the authorized configuration endpoint", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        command: "pnpm agent:run",
+        env: {
+          CUSTOM_NAME: { type: "plain", value: "credential-with-an-innocent-key" },
+          SECRET_NAME: {
+            type: "secret_ref",
+            secretId: "33333333-3333-4333-8333-333333333333",
+            version: "latest",
+          },
+        },
       },
     });
-    expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/configuration`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig).toMatchObject({
+      command: "pnpm agent:run",
+      env: {
+        CUSTOM_NAME: { type: "plain" },
+        SECRET_NAME: {
+          type: "secret_ref",
+          secretId: "33333333-3333-4333-8333-333333333333",
+          version: "latest",
+        },
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain("credential-with-an-innocent-key");
   }, 20_000);
 
   it("redacts company agent list for authenticated company members without agent admin permission", async () => {
@@ -502,6 +539,51 @@ describe.sequential("agent permission routes", () => {
         runtimeConfig: {},
       }),
     ]);
+  });
+
+  it("preserves only the built-in marker in authorized company agent lists", async () => {
+    mockAgentService.list.mockResolvedValue([
+      {
+        ...baseAgent,
+        adapterConfig: {
+          env: {
+            GITHUBAUTH: {
+              type: "plain",
+              value: "fixture-github-auth",
+            },
+          },
+        },
+        metadata: {
+          paperclipBuiltInAgent: {
+            key: "briefs",
+            featureKeys: ["briefs"],
+          },
+          privateNote: "fixture-private-metadata",
+        },
+      },
+    ]);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/${companyId}/agents`),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].metadata).toEqual({
+      paperclipBuiltInAgent: {
+        key: "briefs",
+        featureKeys: ["briefs"],
+      },
+    });
+    expect(JSON.stringify(res.body)).not.toContain("fixture-github-auth");
+    expect(JSON.stringify(res.body)).not.toContain("fixture-private-metadata");
   });
 
   it("blocks agent updates for authenticated company members without agent admin permission", async () => {

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -2929,17 +2929,21 @@ describe("company portability", () => {
         adapterConfig: {
           promptTemplate: "You are ClaudeCoder.",
           env: {
+            AUTHORITY_URL: {
+              type: "plain",
+              value: "https://identity.example.test",
+            },
             APIKEY: {
               type: "plain",
-              value: "sk-plain-api",
+              value: "fixture-api-key",
             },
             GITHUBAUTH: {
               type: "plain",
-              value: "gh-auth-token",
+              value: "fixture-github-auth",
             },
             PRIVATEKEY: {
               type: "plain",
-              value: "private-key-value",
+              value: "fixture-private-key",
             },
           },
         },
@@ -2963,10 +2967,24 @@ describe("company portability", () => {
     expect(extension).toContain("APIKEY:");
     expect(extension).toContain("GITHUBAUTH:");
     expect(extension).toContain("PRIVATEKEY:");
-    expect(extension).not.toContain("sk-plain-api");
-    expect(extension).not.toContain("gh-auth-token");
-    expect(extension).not.toContain("private-key-value");
+    expect(extension).not.toContain("fixture-api-key");
+    expect(extension).not.toContain("fixture-github-auth");
+    expect(extension).not.toContain("fixture-private-key");
     expect(extension).toContain('kind: "secret"');
+    expect(exported.manifest.envInputs).toContainEqual(
+      expect.objectContaining({
+        key: "GITHUBAUTH",
+        kind: "secret",
+        defaultValue: "",
+      }),
+    );
+    expect(exported.manifest.envInputs).toContainEqual(
+      expect.objectContaining({
+        key: "AUTHORITY_URL",
+        kind: "plain",
+        defaultValue: "https://identity.example.test",
+      }),
+    );
   });
 
   it("imports packaged skills and restores desired skill refs on agents", async () => {

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -401,6 +401,51 @@ describe("resolveExecutionRunAdapterConfig", () => {
     });
   });
 
+  it("allows non-credential auth mode selectors for low-trust runs", async () => {
+    const resolveAdapterConfigForRuntime = vi.fn().mockResolvedValue({
+      config: {
+        env: {
+          AUTH_MODE: "device",
+          GITHUB_AUTH_MODE: "app",
+        },
+      },
+      secretKeys: new Set<string>(),
+      manifest: [],
+    });
+
+    const result = await resolveExecutionRunAdapterConfig({
+      companyId: "company-1",
+      agentId: "agent-1",
+      issueId: "issue-1",
+      executionRunConfig: {
+        env: {
+          AUTH_MODE: "device",
+          GITHUB_AUTH_MODE: "app",
+        },
+      },
+      projectEnv: null,
+      trustPreset: {
+        kind: "low_trust_review",
+        preset: LOW_TRUST_REVIEW_PRESET,
+        boundary: {
+          mode: LOW_TRUST_REVIEW_PRESET,
+          companyId: "company-1",
+          issueIds: ["issue-1"],
+        },
+        sourcePresets: {},
+      },
+      secretsSvc: {
+        resolveAdapterConfigForRuntime,
+        resolveEnvBindings: vi.fn(),
+      } as any,
+    });
+
+    expect(result.resolvedConfig.env).toEqual({
+      AUTH_MODE: "device",
+      GITHUB_AUTH_MODE: "app",
+    });
+  });
+
   it("fails push-capability preflight when no GitHub write credential is bound at agent or project scope", async () => {
     await expect(resolveExecutionRunAdapterConfig({
       companyId: "company-1",

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -1060,7 +1060,9 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     const standardActor = agentActor(fixture, fixture.agents.standard.id);
     const standardRes = await request(createApp(db, { ...standardActor, runId: null })).get("/api/agents/me");
     expect(standardRes.status, JSON.stringify(standardRes.body)).toBe(200);
-    expect(JSON.stringify(standardRes.body)).toContain(fixture.canaries.agentConfig);
+    expect(standardRes.body.adapterConfig).toEqual({});
+    expect(standardRes.body.runtimeConfig).toEqual({});
+    expectNoCanary(standardRes.body, fixture.canaries.agentConfig);
 
     const issueScopedLowTrustRes = await request(createApp(db, standardActor)).get("/api/agents/me");
     expect(issueScopedLowTrustRes.status, JSON.stringify(issueScopedLowTrustRes.body)).toBe(200);

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactConfigMetadata,
+  redactEventPayload,
+  redactSensitiveText,
+  sanitizeRecord,
+} from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -61,6 +67,52 @@ describe("redaction", () => {
     expect(redactEventPayload({ password: "hunter2", safe: "value" })).toEqual({
       password: REDACTED_EVENT_VALUE,
       safe: "value",
+    });
+  });
+
+  it("returns configuration metadata without scalar environment values", () => {
+    expect(redactConfigMetadata({
+      command: "pnpm agent:run",
+      env: {
+        CUSTOM_NAME: { type: "plain", value: "credential-with-an-innocent-key" },
+        LEGACY_NAME: "legacy-credential",
+        SECRET_NAME: {
+          type: "secret_ref",
+          secretId: "11111111-1111-1111-1111-111111111111",
+          version: "latest",
+        },
+        USER_NAME: {
+          type: "user_secret_ref",
+          key: "provider_key",
+          version: 2,
+        },
+      },
+      nested: {
+        env: {
+          ANOTHER_NAME: { type: "plain", value: "nested-credential" },
+        },
+      },
+    })).toEqual({
+      command: "pnpm agent:run",
+      env: {
+        CUSTOM_NAME: { type: "plain" },
+        LEGACY_NAME: { type: "plain" },
+        SECRET_NAME: {
+          type: "secret_ref",
+          secretId: "11111111-1111-1111-1111-111111111111",
+          version: "latest",
+        },
+        USER_NAME: {
+          type: "user_secret_ref",
+          key: "provider_key",
+          version: 2,
+        },
+      },
+      nested: {
+        env: {
+          ANOTHER_NAME: { type: "plain" },
+        },
+      },
     });
   });
 

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -148,6 +148,36 @@ describeEmbeddedPostgres("secretService", () => {
     ).rejects.toThrow(/same company/i);
   });
 
+  it("enforces strict mode for token, PAT, database URL, and scoped credential keys", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+
+    for (const key of [
+      "READINESS_READ_TOKEN",
+      "SYNTHETIC_CREDENTIAL_DELTA",
+      "QA_DATABASE_URL",
+      "SYNTHETIC_CREDENTIAL_ALPHA",
+    ]) {
+      await expect(
+        svc.normalizeEnvBindingsForPersistence(
+          companyId,
+          { [key]: "synthetic-value" },
+          { strictMode: true },
+        ),
+      ).rejects.toThrow(`Strict secret mode requires secret references for sensitive key: ${key}`);
+    }
+
+    await expect(
+      svc.normalizeEnvBindingsForPersistence(
+        companyId,
+        { PATH: "/usr/local/bin" },
+        { strictMode: true },
+      ),
+    ).resolves.toEqual({
+      PATH: { type: "plain", value: "/usr/local/bin" },
+    });
+  });
+
   it("prevents duplicate bindings for a target config path", async () => {
     const companyId = await seedCompany();
     const svc = secretService(db);

--- a/server/src/__tests__/sensitive-env.test.ts
+++ b/server/src/__tests__/sensitive-env.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isSensitiveEnvKey } from "../services/sensitive-env.js";
+
+describe("isSensitiveEnvKey", () => {
+  it.each([
+    "AUTH",
+    "AUTH-HEADER",
+    "AUTHHEADER",
+    "AUTH_HEADER",
+    "AUTHTOKEN",
+    "SYNTHETIC_CREDENTIAL_ZETA",
+    "SYNTHETIC_CREDENTIAL_BETA",
+    "ACCESSTOKEN",
+    "GITHUB-AUTH",
+    "GITHUBAUTH",
+    "GITHUB_AUTH",
+    "OPENAI_API_KEY_ENGINEER",
+    "PAPERCLIP_POSTHOG_API_KEY",
+    "QA_DATABASE_URL",
+    "READINESS_READ_TOKEN",
+    "SYNTHETIC_CREDENTIAL_DELTA",
+    "VERCEL_AUTOMATION_BYPASS_SECRET",
+    "SYNTHETIC_CREDENTIAL_EPSILON",
+    "buffer_api_key",
+    "SYNTHETIC_CREDENTIAL_GAMMA",
+    "SYNTHETIC_CREDENTIAL_GAMMA_2",
+    "SYNTHETIC_CREDENTIAL_ALPHA",
+  ])("classifies %s as sensitive", (key) => {
+    expect(isSensitiveEnvKey(key)).toBe(true);
+  });
+
+  it.each([
+    "AUTHOR_NAME",
+    "AUTH_MODE",
+    "AUTHORITY_URL",
+    "AUTHENTICATION_MODE",
+    "AUTHORIZED_USERS",
+    "OAUTH_MODE",
+    "PATH",
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_WORKSPACE_ROOT",
+    "COMPATIBILITY_MODE",
+    "GITHUB_AUTH_MODE",
+    "TOKENIZATION_MODE",
+  ])("does not classify %s as sensitive", (key) => {
+    expect(isSensitiveEnvKey(key)).toBe(false);
+  });
+});

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -75,6 +75,48 @@ function isPlainBinding(value: unknown): value is { type: "plain"; value: unknow
   return value.type === "plain" && "value" in value;
 }
 
+function redactEnvBindingMetadata(value: unknown): Record<string, unknown> {
+  if (isSecretRefBinding(value)) {
+    return {
+      type: "secret_ref",
+      secretId: value.secretId,
+      ...(value.version !== undefined ? { version: value.version } : {}),
+    };
+  }
+  if (isUserSecretRefBinding(value)) {
+    return {
+      type: "user_secret_ref",
+      key: value.key,
+      ...(value.version !== undefined ? { version: value.version } : {}),
+    };
+  }
+  if (isPlainBinding(value) || typeof value === "string") {
+    return { type: "plain" };
+  }
+  return { type: "unknown" };
+}
+
+function redactConfigValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(redactConfigValue);
+  if (!isPlainObject(value)) return value;
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "env" && isPlainObject(entry)) {
+      redacted[key] = Object.fromEntries(
+        Object.entries(entry).map(([envKey, binding]) => [
+          envKey,
+          redactEnvBindingMetadata(binding),
+        ]),
+      );
+      continue;
+    }
+    redacted[key] = redactConfigValue(entry);
+  }
+  return sanitizeRecord(redacted);
+}
+
 function sanitizeCommandArgs(args: unknown[]): unknown[] {
   let redactNext = false;
   return args.map((arg) => {
@@ -131,6 +173,14 @@ export function redactEventPayload(payload: Record<string, unknown> | null): Rec
   if (!payload) return null;
   if (!isPlainObject(payload)) return payload;
   return sanitizeRecord(payload);
+}
+
+export function redactConfigMetadata(
+  config: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  if (!config) return null;
+  if (!isPlainObject(config)) return config;
+  return redactConfigValue(config) as Record<string, unknown>;
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -81,7 +81,7 @@ import {
   refreshAdapterModels,
   requireServerAdapter,
 } from "../adapters/index.js";
-import { redactEventPayload } from "../redaction.js";
+import { redactConfigMetadata, redactEventPayload } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import { renderOrgChartSvg, renderOrgChartPng, type OrgNode, type OrgChartStyle, ORG_CHART_STYLES } from "./org-chart-svg.js";
 import {
@@ -105,6 +105,10 @@ import { recoveryService } from "../services/recovery/service.js";
 import { resolveCoreTrustPreset } from "../services/trust-preset-resolver.js";
 import { readObject } from "../lib/objects.js";
 import { listInvalidOrgChainDescendantIds } from "../services/agent-invokability.js";
+import {
+  BUILT_IN_AGENT_METADATA_KEY,
+  readBuiltInAgentMarker,
+} from "../services/built-in-agent-metadata.js";
 import { logger } from "../middleware/logger.js";
 import {
   AGENT_PROFILE_CHANGE_CONSENT_FIELDS,
@@ -656,7 +660,6 @@ export function agentRoutes(
 
   async function buildAgentDetail(
     agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>,
-    options?: { restricted?: boolean },
   ) {
     const [chainOfCommand, accessState] = await Promise.all([
       svc.getChainOfCommand(agent.id),
@@ -664,7 +667,7 @@ export function agentRoutes(
     ]);
 
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...redactForRestrictedAgentView(agent),
       chainOfCommand,
       access: accessState,
     };
@@ -1674,11 +1677,13 @@ export function agentRoutes(
       ...agent,
       adapterConfig: {},
       runtimeConfig: {},
+      metadata: null,
     };
   }
 
   function redactAgentConfiguration(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
+    const builtInAgentMarker = readBuiltInAgentMarker(agent.metadata);
     return {
       id: agent.id,
       companyId: agent.companyId,
@@ -1688,9 +1693,12 @@ export function agentRoutes(
       status: agent.status,
       reportsTo: agent.reportsTo,
       adapterType: agent.adapterType,
-      adapterConfig: redactEventPayload(agent.adapterConfig),
-      runtimeConfig: redactEventPayload(agent.runtimeConfig),
+      adapterConfig: redactConfigMetadata(agent.adapterConfig),
+      runtimeConfig: redactConfigMetadata(agent.runtimeConfig),
       permissions: agent.permissions,
+      metadata: builtInAgentMarker
+        ? { [BUILT_IN_AGENT_METADATA_KEY]: builtInAgentMarker }
+        : null,
       updatedAt: agent.updatedAt,
     };
   }
@@ -1700,12 +1708,12 @@ export function agentRoutes(
     const record = snapshot as Record<string, unknown>;
     return {
       ...record,
-      adapterConfig: redactEventPayload(
+      adapterConfig: redactConfigMetadata(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
       ),
-      runtimeConfig: redactEventPayload(
+      runtimeConfig: redactConfigMetadata(
         typeof record.runtimeConfig === "object" && record.runtimeConfig !== null
           ? (record.runtimeConfig as Record<string, unknown>)
           : {},
@@ -2028,7 +2036,7 @@ export function agentRoutes(
     const result = await filterAgentsForActor(req, await svc.list(companyId));
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(result.map((agent) => redactAgentConfiguration(agent)));
       return;
     }
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
@@ -2253,13 +2261,6 @@ export function agentRoutes(
         res.json(buildLowTrustSelfView(agent));
         return;
       }
-    }
-    const canReadSensitiveDetail = isSelf
-      ? true
-      : await actorCanReadConfigurationsForCompany(req, agent.companyId);
-    if (!canReadSensitiveDetail) {
-      res.json(await buildAgentDetail(agent, { restricted: true }));
-      return;
     }
     res.json(await buildAgentDetail(agent));
   });
@@ -3131,7 +3132,7 @@ export function agentRoutes(
       details: summarizeAgentUpdateDetails(patchData),
     });
 
-    res.json(agent);
+    res.json(redactForRestrictedAgentView(agent));
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
@@ -3157,7 +3158,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactForRestrictedAgentView(agent));
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
@@ -3188,7 +3189,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactForRestrictedAgentView(agent));
   });
 
   router.post("/agents/:id/clear-error", async (req, res) => {
@@ -3220,7 +3221,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactForRestrictedAgentView(agent));
   });
 
   router.post("/agents/:id/approve", async (req, res) => {
@@ -3274,7 +3275,7 @@ export function agentRoutes(
       details: { source: "agent_detail", approvalId: openApproval?.id ?? null },
     });
 
-    res.json(agent);
+    res.json(redactForRestrictedAgentView(agent));
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
@@ -3344,7 +3345,7 @@ export function agentRoutes(
       },
     });
 
-    res.json(agent);
+    res.json(redactForRestrictedAgentView(agent));
   });
 
   router.delete("/agents/:id", async (req, res) => {

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -97,6 +97,7 @@ import {
 } from "./catalog-provenance.js";
 import { readBuiltInAgentMarker } from "./built-in-agent-metadata.js";
 import { normalizePortablePath } from "./portable-path.js";
+import { isSensitiveEnvKey } from "./sensitive-env.js";
 import type {
   ImportIssueRow,
   ImportIssueCommentRow,
@@ -497,35 +498,6 @@ function buildSkillExportDirMap(skills: CompanySkill[], companyIssuePrefix: stri
   }
 
   return keyToDir;
-}
-
-function isSensitiveEnvKey(key: string) {
-  const normalized = key.trim().toLowerCase();
-  return (
-    normalized === "token" ||
-    normalized.endsWith("_token") ||
-    normalized.endsWith("-token") ||
-    normalized.includes("apikey") ||
-    normalized.includes("api_key") ||
-    normalized.includes("api-key") ||
-    normalized.includes("access_token") ||
-    normalized.includes("access-token") ||
-    normalized.includes("auth") ||
-    normalized.includes("auth_token") ||
-    normalized.includes("auth-token") ||
-    normalized.includes("authorization") ||
-    normalized.includes("bearer") ||
-    normalized.includes("secret") ||
-    normalized.includes("passwd") ||
-    normalized.includes("password") ||
-    normalized.includes("credential") ||
-    normalized.includes("jwt") ||
-    normalized.includes("privatekey") ||
-    normalized.includes("private_key") ||
-    normalized.includes("private-key") ||
-    normalized.includes("cookie") ||
-    normalized.includes("connectionstring")
-  );
 }
 
 function normalizePortableProjectEnv(value: unknown): AgentEnvConfig | null {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -91,6 +91,7 @@ import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService, type MissingRuntimeBinding } from "./secrets.js";
+import { isSensitiveEnvKey } from "./sensitive-env.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import {
   buildHeartbeatRunIssueComment,
@@ -644,9 +645,6 @@ export function requiresPushCapabilityPreflight(input: {
     && hasGithubPrWorkflowSkill(input.explicitRunScopedSkillKeys);
 }
 
-const LOW_TRUST_SENSITIVE_ENV_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
-
 // PAPERCLIP_* env binding policy:
 // 1. PAPERCLIP_API_KEY is never accepted from user/adapter/project/routine
 //    config — the harness-minted run token is the only source.
@@ -683,7 +681,7 @@ function assertLowTrustEnvConfigAllowed(envValue: unknown, source: string) {
     const isPlainBinding =
       typeof binding === "string" ||
       (typeof binding === "object" && binding !== null && binding.type === "plain");
-    if (isPlainBinding && LOW_TRUST_SENSITIVE_ENV_KEY_RE.test(key)) {
+    if (isPlainBinding && isSensitiveEnvKey(key)) {
       throw new HttpError(422, `Low-trust execution cannot use inline sensitive env value ${source}.${key}`, {
         code: "low_trust_inline_sensitive_env_denied",
       });

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -64,11 +64,10 @@ import { isSecretProviderClientError } from "../secrets/types.js";
 import { authorizationDeniedDetails, authorizationService } from "./authorization.js";
 import { findActiveServerAdapter } from "../adapters/index.js";
 import { logActivity } from "./activity-log.js";
+import { isSensitiveEnvKey } from "./sensitive-env.js";
 
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const AGENT_ACCESS_CONFIG_PATH_PREFIX = "access.";
-const SENSITIVE_ENV_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
 const REDACTED_SENTINEL = "***REDACTED***";
 const COMING_SOON_SECRET_PROVIDERS: ReadonlySet<SecretProvider> = new Set([
   "gcp_secret_manager",
@@ -524,10 +523,6 @@ type SecretResolutionErrorCode =
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
-}
-
-function isSensitiveEnvKey(key: string) {
-  return SENSITIVE_ENV_KEY_RE.test(key);
 }
 
 function normalizeSecretKey(input: string) {

--- a/server/src/services/sensitive-env.ts
+++ b/server/src/services/sensitive-env.ts
@@ -1,0 +1,42 @@
+const SENSITIVE_ENV_KEY_PARTS = [
+  "apikey",
+  "api_key",
+  "api-key",
+  "access_token",
+  "access-token",
+  "authheader",
+  "auth_header",
+  "auth-header",
+  "auth_token",
+  "auth-token",
+  "authorization",
+  "bearer",
+  "secret",
+  "passwd",
+  "password",
+  "credential",
+  "jwt",
+  "privatekey",
+  "private_key",
+  "private-key",
+  "cookie",
+  "connectionstring",
+  "connection_string",
+  "connection-string",
+] as const;
+
+export function isSensitiveEnvKey(key: string) {
+  const normalized = key.trim().toLowerCase();
+  return (
+    normalized.endsWith("token") ||
+    normalized === "pat" ||
+    normalized.endsWith("_pat") ||
+    normalized.endsWith("-pat") ||
+    normalized.endsWith("auth") ||
+    normalized === "database_url" ||
+    normalized.endsWith("_database_url") ||
+    normalized.endsWith("-database-url") ||
+    (normalized.includes("posthog") && normalized.endsWith("_scope")) ||
+    SENSITIVE_ENV_KEY_PARTS.some((part) => normalized.includes(part))
+  );
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents use adapter configuration and runtime bindings to start work
> - Agent read routes returned more configuration data than callers needed
> - Some returned fields can contain credentials or other sensitive values
> - This pull request limits these responses to safe identity and binding metadata
> - The benefit is a smaller and consistent credential exposure boundary

## Linked Issues or Issue Description

No public GitHub issue exists for this bug.

### What happened?

Agent detail and self-identity routes could return adapter configuration and runtime binding values.

### Expected behavior

These routes return only safe identity data. Authorized configuration inventory returns only key, binding type, secret identifier, and version metadata.

### Steps to reproduce

1. Configure an agent with runtime bindings.
2. Read the agent detail, self-identity, or authorized configuration route.
3. Inspect the response fields.

### Paperclip version or commit

916c135091967490198d94428d118edeb66b5429

### Deployment mode

Self-hosted Paperclip server.

### Installation method

Built from source with pnpm.

## What Changed

- Added one sensitive runtime-binding detector.
- Redacted agent detail and self-identity responses.
- Limited authorized configuration inventory to metadata.
- Reused the detector in heartbeat, secrets, and company portability services.
- Added focused tests for response redaction and sensitive binding detection.
- Updated the implementation specification.

## Verification

- Ran seven focused server security test files. All 267 tests passed.
- Ran pnpm --filter @paperclipai/server typecheck.
- Ran pnpm --filter @paperclipai/server build.
- Ran git diff --check origin/master...HEAD.

## Risks

- Clients that read raw adapter configuration from agent detail routes must use the authorized metadata inventory instead.
- The central detector can classify more credential-like keys as sensitive. Tests cover the shared classifications.
- Strict mode stays disabled in this change. Runtime restart and strict-mode activation are not part of this pull request.

This bug fix aligns with the Secrets Manager roadmap item. It does not add a new core feature.

## Model Used

- OpenAI gpt-5.6-sol. The runtime managed the context size and reasoning mode. Tool use and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes: # / Closes # / Refs # OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub #NNN / github.com/paperclipai/paperclip URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge