### PR TITLE
fix(auth): authorize local-board agent mutations

### DIFF
--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -90,12 +90,12 @@ function createDbState(input: {
   return { db, activity };
 }
 
-function createApp(db: any) {
+function createApp(db: any, deploymentMode: "authenticated" | "local_trusted" = "authenticated") {
   const app = express();
   app.use(express.json());
   app.use(
     actorMiddleware(db, {
-      deploymentMode: "authenticated",
+      deploymentMode,
       resolveSession: async () => null,
     }),
   );
@@ -282,6 +282,68 @@ describe("agent auth middleware", () => {
       type: "agent",
       runId,
       onBehalfOfUserId: "user-legacy",
+      source: "agent_jwt",
+    });
+  });
+
+  it("binds the synthetic local board as an active owner for local-trusted agent JWTs", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: { id: runId, companyId, agentId, responsibleUserId: "local-board" },
+    });
+    const token = craftAgentJwtWithoutResponsibleClaim({
+      secret: process.env.PAPERCLIP_AGENT_JWT_SECRET!,
+      agentId,
+      companyId,
+      adapterType: "codex_local",
+      runId,
+    });
+
+    const res = await request(createApp(db, "local_trusted"))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      onBehalfOfUserId: "local-board",
+      onBehalfOfMemberships: [{
+        companyId,
+        membershipRole: "owner",
+        status: "active",
+      }],
+      source: "agent_jwt",
+    });
+  });
+
+  it("does not synthesize local-board membership in authenticated mode", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const { db } = createDbState({
+      agent: { id: agentId, companyId },
+      run: { id: runId, companyId, agentId, responsibleUserId: "local-board" },
+    });
+    const token = craftAgentJwtWithoutResponsibleClaim({
+      secret: process.env.PAPERCLIP_AGENT_JWT_SECRET!,
+      agentId,
+      companyId,
+      adapterType: "codex_local",
+      runId,
+    });
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "agent",
+      onBehalfOfUserId: "local-board",
+      onBehalfOfMemberships: [],
       source: "agent_jwt",
     });
   });

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -604,6 +604,43 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it.each(["issue:mutate", "issue:comment"] as const)(
+    "allows assigned agent %s on behalf of the synthetic local board",
+    async (action) => {
+      const company = await createCompany(db, `LocalBoard-${action}`);
+      const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+      const issue = await createIssue(db, company.id, {
+        title: "Local trusted assigned issue",
+        assigneeAgentId: actorAgent.id,
+      });
+
+      await expect(authorizationService(db).decide({
+        actor: {
+          type: "agent",
+          agentId: actorAgent.id,
+          companyId: company.id,
+          onBehalfOfUserId: "local-board",
+          onBehalfOfMemberships: [{
+            companyId: company.id,
+            membershipRole: "owner",
+            status: "active",
+          }],
+          source: "agent_jwt",
+        },
+        action,
+        resource: {
+          type: "issue",
+          companyId: company.id,
+          issueId: issue.id,
+          assigneeAgentId: actorAgent.id,
+        },
+      })).resolves.toMatchObject({
+        allowed: true,
+        reason: "allow_self",
+      });
+    },
+  );
+
   it("keeps responsible-user issue mutations denied for viewer memberships", async () => {
     const company = await createCompany(db, "ResponsibleUserIssueViewerDenied");
     const actorAgent = await createAgent(db, company.id, { role: "engineer" });

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -49,9 +49,16 @@ async function resolveLegacyRunResponsibleUserId(
 
 async function loadResponsibleUserMemberships(
   db: Db,
-  input: { companyId: string; userId: string | null },
+  input: { companyId: string; userId: string | null; deploymentMode: DeploymentMode },
 ) {
   if (!input.userId) return [];
+  if (input.deploymentMode === "local_trusted" && input.userId === "local-board") {
+    return [{
+      companyId: input.companyId,
+      membershipRole: "owner",
+      status: "active",
+    }];
+  }
   const [user, memberships] = await Promise.all([
     db
       .select({ id: authUsers.id })
@@ -308,6 +315,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       const onBehalfOfMemberships = await loadResponsibleUserMemberships(db, {
         companyId: claims.company_id,
         userId: onBehalfOfUserId,
+        deploymentMode: opts.deploymentMode,
       });
 
       req.actor = {
@@ -366,6 +374,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       onBehalfOfMemberships: await loadResponsibleUserMemberships(db, {
         companyId: key.companyId,
         userId: responsibleUserId,
+        deploymentMode: opts.deploymentMode,
       }),
       runId: runIdHeader || undefined,
       source: "agent_key",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that lets agents execute governed work on assigned issues.
> - Agent issue writes are authorized by both the agent boundary and its responsible-user context.
> - Local-trusted deployments represent the implicit full-control board with the synthetic `local-board` identity.
> - Scheduled agent JWTs correctly carry that identity, but middleware tried to load it from persisted users and memberships.
> - The empty membership snapshot caused the responsible-user intersection to reject valid assigned-issue PATCH and comment requests.
> - This pull request synthesizes the implicit owner membership only for `local_trusted` mode and keeps authenticated mode fail-closed.
> - The benefit is that scheduled agents can finish and park their own checked-out issues without weakening hosted/authenticated authorization.

## Linked Issues or Issue Description

- Bug: In a `local_trusted` instance, run an assigned agent heartbeat whose responsible user is the implicit local board. Checkout succeeds, but PATCHing or commenting on the assigned issue returns 403 `Issue is outside this actor's authorization boundary`.
- Expected: The synthetic local board should carry the same full-control owner authority through the responsible-user intersection that it has for direct board requests.
- Actual: `loadResponsibleUserMemberships` returns no memberships because `local-board` is intentionally not a persisted auth user.

## What Changed

- Bind `local-board` to a synthetic active owner membership when agent auth middleware runs in `local_trusted` mode.
- Preserve the existing persisted-user lookup in authenticated mode.
- Add middleware regression coverage for both deployment modes.
- Add authorization coverage for assigned-issue mutation and comment decisions.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-auth-middleware.test.ts src/__tests__/authorization-service.test.ts`
  - 2 files passed; 60 tests passed.
- `git diff --check`
  - Passed.
- `pnpm --filter @paperclipai/server typecheck`
  - Could not complete in the isolated worktree because workspace package dependency links are absent (`@types/node`, `zod`, and related shared-package modules unresolved). The focused suites compile and pass using the root checkout's installed dependencies.

## Risks

- Low and deployment-mode bounded. The synthetic membership is created only when `deploymentMode === "local_trusted"` and `userId === "local-board"`.
- Authenticated mode has an explicit regression test proving it does not synthesize this membership.
- No schema, migration, issue-transition, or checkout semantics change.

> This is a narrow regression fix and does not overlap a Paperclip roadmap feature.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, agentic coding with reasoning, repository inspection, code execution, and test tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no user-facing documentation change required)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
