### PR TITLE
fix(runtime-api): PAPERCLIP_RUNTIME_API_URL precedence + authPublicBaseUrl port preservation

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1738,8 +1738,8 @@ export async function startAdapterExecutionTargetPaperclipBridge(input: {
       : DEFAULT_SANDBOX_CALLBACK_BRIDGE_MAX_BODY_BYTES;
   const hostApiUrl =
     input.hostApiUrl?.trim() ||
-    process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ||
     process.env.PAPERCLIP_API_URL?.trim() ||
+    process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ||
     resolveDefaultPaperclipApiUrl();
   const shellCommand = adapterExecutionTargetShellCommand(target);
   const runner = adapterExecutionTargetCommandRunner(target);

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1971,8 +1971,8 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
   const apiUrl =
-    process.env.PAPERCLIP_RUNTIME_API_URL ??
     process.env.PAPERCLIP_API_URL ??
+    process.env.PAPERCLIP_RUNTIME_API_URL ??
     `http://${runtimeHost}:${runtimePort}`;
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 describe("buildPaperclipEnv", () => {
-  it("prefers an explicit PAPERCLIP_RUNTIME_API_URL", () => {
+  it("prefers an explicit PAPERCLIP_API_URL over PAPERCLIP_RUNTIME_API_URL", () => {
     process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
     process.env.PAPERCLIP_API_URL = "http://localhost:4100";
     process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
@@ -37,18 +37,18 @@ describe("buildPaperclipEnv", () => {
 
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
-    expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
+    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:4100");
   });
 
-  it("falls back to PAPERCLIP_API_URL when no runtime URL is configured", () => {
-    delete process.env.PAPERCLIP_RUNTIME_API_URL;
-    process.env.PAPERCLIP_API_URL = "http://localhost:4100";
+  it("falls back to PAPERCLIP_RUNTIME_API_URL when PAPERCLIP_API_URL is not set", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
+    delete process.env.PAPERCLIP_API_URL;
     process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
     process.env.PAPERCLIP_LISTEN_PORT = "3101";
 
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
-    expect(env.PAPERCLIP_API_URL).toBe("http://localhost:4100");
+    expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
   });
 
   it("uses runtime listen host/port when explicit URL is not set", () => {

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -470,6 +470,9 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
     expect(started.apiUrl).toBe("http://custom-api:3100");
     expect(process.env.PAPERCLIP_API_URL).toBe("http://custom-api:3100");
+    // Regression: PAPERCLIP_RUNTIME_API_URL must also respect the override,
+    // not the derived runtimeApiUrl.
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://custom-api:3100");
     expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")).toEqual(
       expect.arrayContaining(["http://custom-api:3100"]),
     );
@@ -526,5 +529,20 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+
+  it("preserves operator-set publicBaseUrl port when it differs from listen port (reverse-proxy scenario)", async () => {
+    // Regression for MMB-10776: operator sets publicBaseUrl to :8443 (reverse proxy)
+    // while Paperclip listens on :3001. The port must NOT be rewritten to 3001.
+    loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      port: 3001,
+      authBaseUrlMode: "explicit",
+      authPublicBaseUrl: "http://brainbug01.tail802293.ts.net:8443",
+    }));
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("http://brainbug01.tail802293.ts.net:8443");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://brainbug01.tail802293.ts.net:8443");
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -244,13 +244,20 @@ export async function startServer(): Promise<StartedServer> {
     }
   }
 
-  function rewriteLocalUrlPort(rawUrl: string | undefined, port: number): string | undefined {
+  function rewriteLocalUrlPort(rawUrl: string | undefined, detectedPort: number, requestedPort?: number): string | undefined {
     if (!rawUrl) return undefined;
     try {
       const parsed = new URL(rawUrl);
       // The URL API normalizes default ports like :80/:443 to "", so treat them as stable URLs.
       if (!parsed.port) return rawUrl;
-      parsed.port = String(port);
+      // Only rewrite the port if the publicBaseUrl port matches the originally requested
+      // listen port — i.e., detectPort auto-shifted it. If the operator set a deliberately
+      // different port (e.g., a reverse proxy on :8443 while Paperclip listens on :3001),
+      // the publicBaseUrl must be preserved as-is.
+      if (requestedPort !== undefined && Number(parsed.port) !== requestedPort) {
+        return rawUrl;
+      }
+      parsed.port = String(detectedPort);
       return parsed.toString();
     } catch {
       return rawUrl;
@@ -531,7 +538,7 @@ export async function startServer(): Promise<StartedServer> {
   const requestedListenPort = config.port;
   const listenPort = await detectPort(requestedListenPort);
   if (config.authBaseUrlMode === "explicit" && config.authPublicBaseUrl) {
-    config.authPublicBaseUrl = rewriteLocalUrlPort(config.authPublicBaseUrl, listenPort);
+    config.authPublicBaseUrl = rewriteLocalUrlPort(config.authPublicBaseUrl, listenPort, requestedListenPort);
   }
   
   let authReady = config.deploymentMode === "local_trusted";
@@ -767,7 +774,11 @@ export async function startServer(): Promise<StartedServer> {
   });
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
+  // PAPERCLIP_RUNTIME_API_URL must respect the operator override (PAPERCLIP_API_URL)
+  // and the authPublicBaseUrl-derived URL, NOT the raw derived runtimeApiUrl.
+  // Using configuredApiUrl ensures that env-based overrides take precedence over
+  // the derived value, preventing agents from receiving unreachable API URLs.
+  process.env.PAPERCLIP_RUNTIME_API_URL = configuredApiUrl;
   process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
   


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server injects environment variables into agent run contexts
> - PAPERCLIP_RUNTIME_API_URL was derived from the listen port (:3001) and took precedence over the correct PAPERCLIP_API_URL, causing agents to receive unreachable API URLs
> - The authPublicBaseUrl port rewrite blindly overwrote the operator-configured port (e.g., :8443 for reverse proxy) with the actual listen port (:3001)
> - This pull request fixes the precedence order and preserves the operator-configured port
> - Agents will now reliably receive the correct, reachable API URL in their run environment

## What Changed

- server/src/index.ts: Changed PAPERCLIP_RUNTIME_API_URL to use configuredApiUrl instead of runtimeApiUrl (L698)
- packages/adapter-utils/src/execution-target.ts: Swapped precedence to check PAPERCLIP_API_URL before PAPERCLIP_RUNTIME_API_URL
- packages/adapter-utils/src/server-utils.ts: Swapped precedence to check PAPERCLIP_API_URL before PAPERCLIP_RUNTIME_API_URL
- server/src/index.ts L232: Only rewrite authPublicBaseUrl port when it matches the listen port, preserving operator-configured overrides
- Added server/src/__tests__/server-startup-feedback-export.test.ts regression test

## Verification

- Regression tests pass: pnpm test:run
- Typecheck passes: pnpm -r typecheck
- The fix ensures PAPERCLIP_API_URL (set via PAPERCLIP_API_KEY override) wins over the derived PAPERCLIP_RUNTIME_API_URL
- Port preservation verified: operator-configured :8443 port in publicBaseUrl is not overwritten with :3001

## Risks

- Low. This is a bug fix that restores intended behavior. The precedence swap is well-tested.
- No breaking changes to the API surface.

## Model Used

None — human-authored.
