### PR TITLE
fix(ui): make task header status and priority controls interactive

### DIFF
--- a/ui/src/components/BlockedInboxView.test.tsx
+++ b/ui/src/components/BlockedInboxView.test.tsx
@@ -263,7 +263,7 @@ describe("BlockedInboxView", () => {
     );
     await waitFor(() => container.querySelector("a") !== null);
 
-    const rowText = container.querySelector("a")?.textContent ?? "";
+    const rowText = container.querySelector("a")?.parentElement?.textContent ?? "";
     expect(rowText.indexOf("Pending board decision")).toBeGreaterThanOrEqual(0);
     expect(rowText.indexOf("Needs decision")).toBeGreaterThan(rowText.indexOf("Pending board decision"));
     expect(rowText.indexOf("Board")).toBeGreaterThan(rowText.indexOf("Needs decision"));

--- a/ui/src/components/IssueRow.test.tsx
+++ b/ui/src/components/IssueRow.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 import type { Issue } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IssueRow } from "./IssueRow";
+import { StatusIcon } from "./StatusIcon";
 
 vi.mock("@/lib/router", () => ({
   Link: ({
@@ -108,6 +109,33 @@ describe("IssueRow", () => {
       expect(glyph.getAttribute("width")).toBe("16");
       expect(glyph.getAttribute("height")).toBe("16");
     });
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("keeps editable row controls keyboard-accessible and outside the navigation link", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueRow
+          issue={createIssue()}
+          desktopMetaLeading={<StatusIcon status="todo" onChange={() => undefined} />}
+        />,
+      );
+    });
+
+    const link = container.querySelector<HTMLAnchorElement>("[data-inbox-issue-link]");
+    const statusButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Change status (current: Todo)"]',
+    );
+
+    expect(link).not.toBeNull();
+    expect(statusButton).not.toBeNull();
+    expect(statusButton?.tabIndex).toBe(0);
+    expect(link?.contains(statusButton)).toBe(false);
 
     act(() => {
       root.unmount();
@@ -296,8 +324,7 @@ describe("IssueRow", () => {
       );
     });
 
-    const link = container.querySelector("[data-inbox-issue-link]") as HTMLAnchorElement | null;
-    const metaRow = Array.from(link?.querySelectorAll("span.flex.items-center.gap-2") ?? [])
+    const metaRow = Array.from(container.querySelectorAll("span.flex.items-center.gap-2"))
       .find((element) => element.textContent?.includes("PAP-42"));
 
     expect(metaRow).not.toBeUndefined();

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -162,27 +162,36 @@ export function IssueRow({
   ) : null;
 
   return (
-    <Link
-      to={createIssueDetailPath(issuePathId)}
-      state={detailState}
-      disableIssueQuicklook
-      issuePrefetch={issue}
-      data-inbox-issue-link
-      id={checklistRowId}
-      aria-current={checklistCurrentStep ? "step" : undefined}
-      onClickCapture={() => rememberIssueDetailLocationState(issuePathId, detailState)}
+    <div
       onMouseEnter={onMouseEnter}
       className={cn(
         // No color transition on the row band: hover/selection must snap
         // instantly. A fade (transition-colors) leaves a trail of fading bands
         // when scrubbing the mouse fast across the list.
         "group relative flex items-start gap-2 rounded-lg py-2.5 pl-2 pr-3 text-sm no-underline text-inherit sm:items-center sm:py-2 sm:pl-1",
-        !hideDivider && "border-b border-border last:border-b-0",
-        selected ? "hover:bg-transparent" : "hover:bg-accent/50",
-        checklistCurrentStep ? "bg-primary/5" : null,
+        "[&_button]:relative [&_button]:z-10",
         className,
       )}
     >
+      <Link
+        to={createIssueDetailPath(issuePathId)}
+        state={detailState}
+        disableIssueQuicklook
+        issuePrefetch={issue}
+        data-inbox-issue-link
+        id={checklistRowId}
+        aria-current={checklistCurrentStep ? "step" : undefined}
+        onClickCapture={() => rememberIssueDetailLocationState(issuePathId, detailState)}
+        className={cn(
+          "absolute inset-0 rounded-lg no-underline text-inherit focus-visible:z-10 focus-visible:outline-none focus-visible:ring-(length:--rad-3) focus-visible:ring-ring",
+          !hideDivider && "border-b border-border last:border-b-0",
+          selected ? "hover:bg-transparent" : "hover:bg-accent/50",
+          checklistCurrentStep ? "bg-primary/5" : null,
+          className,
+        )}
+      >
+        <span className="sr-only">Open {identifier}: {issue.title}</span>
+      </Link>
       <span className="flex shrink-0 items-center gap-1 pt-px sm:hidden">
         {mobileLeading ?? <StatusIcon status={issue.status} blockerAttention={issue.blockerAttention} size="md" className={selectedStatusClass} />}
         {productivityReviewIndicator}
@@ -316,7 +325,7 @@ export function IssueRow({
           {unreadDotButton}
         </span>
       ) : null}
-    </Link>
+    </div>
   );
 }
 

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -2147,7 +2147,13 @@ export function IssuesList({
                             </button>
                           ) : (
                             <span className="inline-flex items-center" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-                              <StatusIcon status={issue.status} size="md" blockerAttention={issue.blockerAttention} onChange={(s) => onUpdateIssue(issue.id, { status: s })} />
+                              <StatusIcon
+                                status={issue.status}
+                                size="md"
+                                blockerAttention={issue.blockerAttention}
+                                onChange={(s) => onUpdateIssue(issue.id, { status: s })}
+                                useNativeButtonTrigger={false}
+                              />
                             </span>
                           )
                         }
@@ -2174,7 +2180,13 @@ export function IssuesList({
                               checklistStepNumber={checklistStepNumber}
                               statusSlot={(
                                 <span className="inline-flex items-center" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-                                  <StatusIcon status={issue.status} size="md" blockerAttention={issue.blockerAttention} onChange={(s) => onUpdateIssue(issue.id, { status: s })} />
+                                  <StatusIcon
+                                    status={issue.status}
+                                    size="md"
+                                    blockerAttention={issue.blockerAttention}
+                                    onChange={(s) => onUpdateIssue(issue.id, { status: s })}
+                                    useNativeButtonTrigger={false}
+                                  />
                                 </span>
                               )}
                             />

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -1375,7 +1375,7 @@ export function IssuesList({
     const row = rootRef.current?.querySelector(
       `[data-issue-row-id="${escapeAttrValue(navKey.slice("issue:".length))}"]`,
     );
-    const link = row?.querySelector(":scope > [data-inbox-issue-link]");
+    const link = row?.querySelector("[data-inbox-issue-link]");
     return link instanceof HTMLElement ? link : null;
   }, []);
 
@@ -2147,13 +2147,7 @@ export function IssuesList({
                             </button>
                           ) : (
                             <span className="inline-flex items-center" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-                              <StatusIcon
-                                status={issue.status}
-                                size="md"
-                                blockerAttention={issue.blockerAttention}
-                                onChange={(s) => onUpdateIssue(issue.id, { status: s })}
-                                useNativeButtonTrigger={false}
-                              />
+                              <StatusIcon status={issue.status} size="md" blockerAttention={issue.blockerAttention} onChange={(s) => onUpdateIssue(issue.id, { status: s })} />
                             </span>
                           )
                         }
@@ -2180,13 +2174,7 @@ export function IssuesList({
                               checklistStepNumber={checklistStepNumber}
                               statusSlot={(
                                 <span className="inline-flex items-center" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-                                  <StatusIcon
-                                    status={issue.status}
-                                    size="md"
-                                    blockerAttention={issue.blockerAttention}
-                                    onChange={(s) => onUpdateIssue(issue.id, { status: s })}
-                                    useNativeButtonTrigger={false}
-                                  />
+                                  <StatusIcon status={issue.status} size="md" blockerAttention={issue.blockerAttention} onChange={(s) => onUpdateIssue(issue.id, { status: s })} />
                                 </span>
                               )}
                             />

--- a/ui/src/components/PriorityIcon.interaction.test.tsx
+++ b/ui/src/components/PriorityIcon.interaction.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PriorityIcon } from "./PriorityIcon";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+describe("PriorityIcon picker", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container.remove();
+    document.body.innerHTML = "";
+  });
+
+  it("opens the real popover and selects a priority", async () => {
+    const onChange = vi.fn();
+    await act(async () => root?.render(<PriorityIcon priority="medium" onChange={onChange} />));
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Change priority (current: Medium)"]',
+    );
+    expect(trigger).not.toBeNull();
+
+    await act(async () => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const highOption = [...document.body.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent?.trim() === "High");
+    expect(highOption).not.toBeUndefined();
+
+    await act(async () => highOption?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("high");
+  });
+});

--- a/ui/src/components/PriorityIcon.interaction.test.tsx
+++ b/ui/src/components/PriorityIcon.interaction.test.tsx
@@ -41,13 +41,17 @@ describe("PriorityIcon picker", () => {
     );
     expect(trigger).not.toBeNull();
 
-    await act(async () => trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
 
     const highOption = [...document.body.querySelectorAll<HTMLButtonElement>("button")]
       .find((button) => button.textContent?.trim() === "High");
     expect(highOption).not.toBeUndefined();
 
-    await act(async () => highOption?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    await act(async () => {
+      highOption?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
     expect(onChange).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith("high");
   });

--- a/ui/src/components/PriorityIcon.test.tsx
+++ b/ui/src/components/PriorityIcon.test.tsx
@@ -1,0 +1,14 @@
+// @vitest-environment node
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PriorityIcon } from "./PriorityIcon";
+
+describe("PriorityIcon", () => {
+  it("uses an accessible native button for the icon-only picker trigger", () => {
+    const html = renderToStaticMarkup(<PriorityIcon priority="medium" onChange={() => {}} />);
+
+    expect(html).toContain('<button type="button"');
+    expect(html).toContain('aria-label="Change priority (current: Medium)"');
+  });
+});

--- a/ui/src/components/PriorityIcon.tsx
+++ b/ui/src/components/PriorityIcon.tsx
@@ -42,11 +42,24 @@ export function PriorityIcon({ priority, onChange, className, showLabel }: Prior
   if (!onChange) return showLabel ? <span className="inline-flex items-center gap-1.5">{icon}<span className="text-sm">{config.label}</span></span> : icon;
 
   const trigger = showLabel ? (
-    <button className="inline-flex min-h-5 items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors">
+    <button
+      type="button"
+      aria-label={`Change priority (current: ${config.label})`}
+      className="inline-flex min-h-5 items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+    >
       {icon}
       <span className="text-sm">{config.label}</span>
     </button>
-  ) : icon;
+  ) : (
+    <button
+      type="button"
+      data-slot="icon-button"
+      aria-label={`Change priority (current: ${config.label})`}
+      className="inline-flex cursor-pointer items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-(length:--rad-3) focus-visible:ring-ring"
+    >
+      {icon}
+    </button>
+  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/ui/src/components/StatusIcon.test.tsx
+++ b/ui/src/components/StatusIcon.test.tsx
@@ -92,6 +92,15 @@ describe("StatusIcon", () => {
     expect(html).toContain('<button type="button"');
     expect(html).toContain('aria-label="Change status (current: Todo)"');
   });
+
+  it("avoids a nested native button when rendered inside an issue-row link", () => {
+    const html = renderToStaticMarkup(
+      <StatusIcon status="todo" onChange={() => {}} useNativeButtonTrigger={false} />,
+    );
+
+    expect(html).toContain('viewBox="0 0 24 24"');
+    expect(html).not.toContain("<button");
+  });
 });
 
 describe("StatusIcon — glyph size (PAP-243a)", () => {

--- a/ui/src/components/StatusIcon.test.tsx
+++ b/ui/src/components/StatusIcon.test.tsx
@@ -93,14 +93,6 @@ describe("StatusIcon", () => {
     expect(html).toContain('aria-label="Change status (current: Todo)"');
   });
 
-  it("avoids a nested native button when rendered inside an issue-row link", () => {
-    const html = renderToStaticMarkup(
-      <StatusIcon status="todo" onChange={() => {}} useNativeButtonTrigger={false} />,
-    );
-
-    expect(html).toContain('viewBox="0 0 24 24"');
-    expect(html).not.toContain("<button");
-  });
 });
 
 describe("StatusIcon — glyph size (PAP-243a)", () => {

--- a/ui/src/components/StatusIcon.test.tsx
+++ b/ui/src/components/StatusIcon.test.tsx
@@ -86,9 +86,11 @@ describe("StatusIcon", () => {
     expect(html).toContain("Blocked · review stalled on PAP-2279");
   });
 
-  it("keeps the onChange picker working with the glyph", () => {
+  it("uses an accessible native button for the icon-only picker trigger", () => {
     const html = renderToStaticMarkup(<StatusIcon status="todo" onChange={() => {}} />);
     expect(html).toContain('viewBox="0 0 24 24"');
+    expect(html).toContain('<button type="button"');
+    expect(html).toContain('aria-label="Change status (current: Todo)"');
   });
 });
 

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -102,12 +102,23 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
   }
 
   const trigger = showLabel ? (
-    <button className="inline-flex min-h-5 items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors">
+    <button
+      type="button"
+      aria-label={`Change status (current: ${ariaLabel})`}
+      className="inline-flex min-h-5 items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors"
+    >
       {glyph}
       <span className="text-sm">{statusLabel(status)}</span>
     </button>
   ) : (
-    glyph
+    <button
+      type="button"
+      data-slot="icon-button"
+      aria-label={`Change status (current: ${ariaLabel})`}
+      className="inline-flex cursor-pointer items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-(length:--rad-3) focus-visible:ring-ring"
+    >
+      {glyph}
+    </button>
   );
 
   return (

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -17,11 +17,6 @@ interface StatusIconProps {
   onChange?: (status: string) => void;
   className?: string;
   showLabel?: boolean;
-  /**
-   * Use a native button for an editable icon. Disable only when the picker is
-   * already inside another interactive element, such as an issue-row link.
-   */
-  useNativeButtonTrigger?: boolean;
   /** Glyph size (PAP-243a). Default `md` (16px); lists/detail/mentions use `lg` (20px). */
   size?: StatusGlyphSize;
 }
@@ -80,15 +75,7 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
  * glyph — the blocked shape recoloured blue — while the full blocked reason
  * still rides on the accessible label.
  */
-export function StatusIcon({
-  status,
-  blockerAttention,
-  onChange,
-  className,
-  showLabel,
-  useNativeButtonTrigger = true,
-  size = "md",
-}: StatusIconProps) {
+export function StatusIcon({ status, blockerAttention, onChange, className, showLabel, size = "md" }: StatusIconProps) {
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
   const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status);
@@ -123,7 +110,7 @@ export function StatusIcon({
       {glyph}
       <span className="text-sm">{statusLabel(status)}</span>
     </button>
-  ) : useNativeButtonTrigger ? (
+  ) : (
     <button
       type="button"
       data-slot="icon-button"
@@ -132,7 +119,7 @@ export function StatusIcon({
     >
       {glyph}
     </button>
-  ) : glyph;
+  );
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -17,6 +17,11 @@ interface StatusIconProps {
   onChange?: (status: string) => void;
   className?: string;
   showLabel?: boolean;
+  /**
+   * Use a native button for an editable icon. Disable only when the picker is
+   * already inside another interactive element, such as an issue-row link.
+   */
+  useNativeButtonTrigger?: boolean;
   /** Glyph size (PAP-243a). Default `md` (16px); lists/detail/mentions use `lg` (20px). */
   size?: StatusGlyphSize;
 }
@@ -75,7 +80,15 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
  * glyph — the blocked shape recoloured blue — while the full blocked reason
  * still rides on the accessible label.
  */
-export function StatusIcon({ status, blockerAttention, onChange, className, showLabel, size = "md" }: StatusIconProps) {
+export function StatusIcon({
+  status,
+  blockerAttention,
+  onChange,
+  className,
+  showLabel,
+  useNativeButtonTrigger = true,
+  size = "md",
+}: StatusIconProps) {
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
   const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status);
@@ -110,7 +123,7 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
       {glyph}
       <span className="text-sm">{statusLabel(status)}</span>
     </button>
-  ) : (
+  ) : useNativeButtonTrigger ? (
     <button
       type="button"
       data-slot="icon-button"
@@ -119,7 +132,7 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
     >
       {glyph}
     </button>
-  );
+  ) : glyph;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/ui/src/pages/Inbox.test.tsx
+++ b/ui/src/pages/Inbox.test.tsx
@@ -528,16 +528,15 @@ describe("Inbox toolbar", () => {
 
     const rows = Array.from(container.querySelectorAll("[data-inbox-item]"));
     const rowFor = (text: string) => rows.find((row) => row.textContent?.includes(text));
-    const linkOf = (row: Element) => row.querySelector<HTMLAnchorElement>("a[data-inbox-issue-link]");
     const markReadButton = (row: Element) => row.querySelector('button[aria-label="Mark as read"]');
     // The empty spacer that reserves the chevron column on every leaf row.
     // Excludes the tree-guide span (`.self-stretch`), which only renders on
     // nested rows.
     const hasLeadingSpacer = (row: Element) =>
-      !!linkOf(row)?.querySelector("span.hidden.w-4.shrink-0.sm\\:block:not(.self-stretch)");
+      !!row.querySelector("span.hidden.w-4.shrink-0.sm\\:block:not(.self-stretch)");
     // The reserved leading dot slot, present on read AND unread rows.
     const dotSlot = (row: Element) =>
-      linkOf(row)?.querySelector('[data-testid="issue-row-unread-slot"]') ?? null;
+      row.querySelector('[data-testid="issue-row-unread-slot"]');
 
     const unreadRow = rowFor("Unread inbox row")!;
     const readRow = rowFor("Read inbox row")!;

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -331,13 +331,36 @@ vi.mock("../components/ScrollToBottom", () => ({
 }));
 
 vi.mock("../components/StatusIcon", () => ({
-  StatusIcon: ({ status, blockerAttention }: { status: string; blockerAttention?: Issue["blockerAttention"] }) => (
-    <span data-status-icon-state={blockerAttention?.state}>{status}</span>
-  ),
+  StatusIcon: ({
+    status,
+    blockerAttention,
+    onChange,
+  }: {
+    status: string;
+    blockerAttention?: Issue["blockerAttention"];
+    onChange?: (status: string) => void;
+  }) => onChange ? (
+    <button
+      type="button"
+      aria-label={`Change status (current: ${status})`}
+      data-status-icon-state={blockerAttention?.state}
+      onClick={() => onChange("done")}
+    >
+      {status}
+    </button>
+  ) : <span data-status-icon-state={blockerAttention?.state}>{status}</span>,
 }));
 
 vi.mock("../components/PriorityIcon", () => ({
-  PriorityIcon: ({ priority }: { priority: string }) => <span>{priority}</span>,
+  PriorityIcon: ({ priority, onChange }: { priority: string; onChange?: (priority: string) => void }) => onChange ? (
+    <button
+      type="button"
+      aria-label={`Change priority (current: ${priority})`}
+      onClick={() => onChange("high")}
+    >
+      {priority}
+    </button>
+  ) : <span>{priority}</span>,
 }));
 
 vi.mock("../components/ApprovalCard", () => ({
@@ -1034,6 +1057,50 @@ describe("IssueDetail", () => {
         String(call[0]).includes("React has detected a change in the order of Hooks"),
       ),
     ).toBe(false);
+  });
+
+  it("updates status and priority from the task header controls", async () => {
+    const issue = createIssue({ status: "todo", priority: "medium" });
+    mockIssuesApi.get.mockResolvedValue(issue);
+    mockIssuesApi.update.mockImplementation(async (_issueId: string, data: Record<string, unknown>) => ({
+      ...issue,
+      ...data,
+    }));
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const statusButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Change status (current: todo)"]',
+    );
+    const priorityButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Change priority (current: medium)"]',
+    );
+    expect(statusButton).not.toBeNull();
+    expect(priorityButton).not.toBeNull();
+
+    await act(async () => {
+      statusButton!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await waitForAssertion(() => {
+      expect(mockIssuesApi.update).toHaveBeenCalledWith(issue.identifier, { status: "done" });
+    });
+
+    await act(async () => {
+      priorityButton!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await waitForAssertion(() => {
+      expect(mockIssuesApi.update).toHaveBeenCalledWith(issue.identifier, { priority: "high" });
+    });
+
+    mockIssuesApi.update.mockReset();
   });
 
   it("removes an inbox-origin archived issue from cached inbox variants before navigating back", async () => {


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators use the task page header to read and change task state
> - The status and priority icons already had picker logic, but the compact triggers were not semantic controls
> - This made pointer and keyboard interaction unreliable in the task header
> - This pull request makes both compact icon triggers real buttons and keeps the existing picker behavior
> - The benefit is that operators can change status and priority directly from the header with pointer or keyboard input

## Linked Issues or Issue Description

### Subsystem affected

`ui/` — React + Vite board UI.

### Problem or motivation

The compact status and priority icons can receive change handlers, but their popover triggers are plain icon elements. They do not provide a reliable click target, keyboard focus, or control label. Operators need to change both values directly from the task header.

### Proposed solution

Use semantic button triggers in the shared status and priority components. Keep the existing API update wiring and picker options. Keep task-row navigation links separate from editable row controls. An operator can select either icon, open its picker, and choose a new task status or priority.

### Alternatives considered

A task-page-only wrapper would duplicate control behavior. Moving the controls would also change the page layout. The shared components already own the picker behavior, so a shared trigger fix is smaller and more consistent.

### Roadmap alignment

This is a focused board UI usability and accessibility fix. It does not duplicate a planned roadmap feature.

### Additional context

The task page already passes change handlers to these shared components. This change makes that existing path interactive and accessible.

## What Changed

- Added semantic button triggers for compact and labeled status controls.
- Added semantic button triggers for compact and labeled priority controls.
- Added accessible current-state labels and keyboard focus styles.
- Separated issue-row navigation links from row controls to avoid nested interactive elements.
- Added real popover interaction coverage and row semantics regressions.
- Added task-page regression tests for update requests.

## Verification

- Focused task-header and row suites passed with 131 tests.
- The final row, inbox, and picker regression suites passed with 83 tests.
- `pnpm --filter @paperclipai/ui exec tsc -b --force` passed.
- `pnpm run typecheck:build-gaps` reproduced the CI typecheck before the fix. The forced UI build passed after the fix.
- `pnpm check:token-gates` passed.
- `pnpm -r typecheck` passed.
- `pnpm build` passed.
- `pnpm test:run` completed the server and UI partitions. One unrelated CLI AWS doctor assertion saw injected static AWS credentials and returned `warn` instead of `pass`. The exact test passed after those two environment variables were removed.
- `git diff --check origin/master...HEAD` passed.
- All latest-head GitHub checks passed, including both e2e shards.
- Greptile passed at the required threshold with zero open review threads.

## Risks

- The shared issue-row DOM now uses a full-area navigation link beside native action buttons.
- Existing visual layout, pointer navigation, keyboard navigation, and action behavior remain covered by row, inbox, and list tests.
- Read-only status and priority icon uses are unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with the `gpt-5` model. The runtime did not expose its context window size. The agent used reasoning, repository tools, code execution, and GitHub CLI integration.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
