### PR TITLE
feat(INS-646): restore SEO document governance DoD

### DIFF
--- a/packages/db/src/migrations/0146_seo_doc_registry_entries.sql
+++ b/packages/db/src/migrations/0146_seo_doc_registry_entries.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "seo_doc_registry_entries" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "company_id" uuid NOT NULL,
+  "doc_key" text NOT NULL,
+  "issue_id" uuid NOT NULL,
+  "issue_document_key" text NOT NULL,
+  "title" text NOT NULL,
+  "issue_link" text NOT NULL,
+  "owner" text NOT NULL,
+  "last_updated" timestamp with time zone NOT NULL,
+  "update_cadence" text NOT NULL,
+  "status" text DEFAULT 'active' NOT NULL,
+  "dependencies" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "document_class" text NOT NULL,
+  "criticality" text DEFAULT 'normal' NOT NULL,
+  "last_audited_at" timestamp with time zone,
+  "last_escalated_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "seo_doc_registry_entries" ADD CONSTRAINT "seo_doc_registry_entries_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "seo_doc_registry_entries" ADD CONSTRAINT "seo_doc_registry_entries_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "seo_doc_registry_entries_company_doc_key_uq" ON "seo_doc_registry_entries" USING btree ("company_id","doc_key");
+--> statement-breakpoint
+CREATE INDEX "seo_doc_registry_entries_company_status_idx" ON "seo_doc_registry_entries" USING btree ("company_id","status");
+--> statement-breakpoint
+CREATE INDEX "seo_doc_registry_entries_company_issue_idx" ON "seo_doc_registry_entries" USING btree ("company_id","issue_id");
+--> statement-breakpoint
+CREATE INDEX "seo_doc_registry_entries_company_last_updated_idx" ON "seo_doc_registry_entries" USING btree ("company_id","last_updated");

--- a/packages/db/src/migrations/0147_seo_doc_registry_entries_checks.sql
+++ b/packages/db/src/migrations/0147_seo_doc_registry_entries_checks.sql
@@ -1,0 +1,20 @@
+DO $$ BEGIN
+ ALTER TABLE "seo_doc_registry_entries" ADD CONSTRAINT "seo_doc_registry_entries_update_cadence_check" CHECK ("update_cadence" IN ('weekly', 'biweekly', 'monthly'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "seo_doc_registry_entries" ADD CONSTRAINT "seo_doc_registry_entries_status_check" CHECK ("status" IN ('active', 'stale', 'deprecated'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "seo_doc_registry_entries" ADD CONSTRAINT "seo_doc_registry_entries_document_class_check" CHECK ("document_class" IN ('strategy', 'implementation', 'runbook', 'incident', 'experimentation', 'architecture', 'governance'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "seo_doc_registry_entries" ADD CONSTRAINT "seo_doc_registry_entries_criticality_check" CHECK ("criticality" IN ('normal', 'critical'));
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1013,8 +1013,15 @@
     {
       "idx": 146,
       "version": "7",
-      "when": 1783822632557,
-      "tag": "0146_routine_activity_gate",
+      "when": 1783792400000,
+      "tag": "0146_seo_doc_registry_entries",
+      "breakpoints": true
+    },
+    {
+      "idx": 147,
+      "version": "7",
+      "when": 1783922400000,
+      "tag": "0147_seo_doc_registry_entries_checks",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -118,3 +118,4 @@ export { pluginDatabaseNamespaces, pluginMigrations } from "./plugin_database.js
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { seoDocRegistryEntries } from "./seo_doc_registry_entries.js";

--- a/packages/db/src/schema/seo_doc_registry_entries.ts
+++ b/packages/db/src/schema/seo_doc_registry_entries.ts
@@ -1,0 +1,72 @@
+import { sql } from "drizzle-orm";
+import { check, index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { issues } from "./issues.js";
+
+export type SeoDocCadence = "weekly" | "biweekly" | "monthly";
+export type SeoDocStatus = "active" | "stale" | "deprecated";
+export type SeoDocClass =
+  | "strategy"
+  | "implementation"
+  | "runbook"
+  | "incident"
+  | "experimentation"
+  | "architecture"
+  | "governance";
+
+export type SeoDocCriticality = "normal" | "critical";
+
+export interface SeoDocDependencyRef {
+  type: "issue_document" | "issue";
+  target: string;
+  role: "source_strategy" | "implementation_handoff" | "related";
+}
+
+export const seoDocRegistryEntries = pgTable(
+  "seo_doc_registry_entries",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    docKey: text("doc_key").notNull(),
+    issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
+    issueDocumentKey: text("issue_document_key").notNull(),
+    title: text("title").notNull(),
+    issueLink: text("issue_link").notNull(),
+    owner: text("owner").notNull(),
+    lastUpdated: timestamp("last_updated", { withTimezone: true }).notNull(),
+    updateCadence: text("update_cadence").$type<SeoDocCadence>().notNull(),
+    status: text("status").$type<SeoDocStatus>().notNull().default("active"),
+    dependencies: jsonb("dependencies").$type<SeoDocDependencyRef[]>().notNull().default([]),
+    documentClass: text("document_class").$type<SeoDocClass>().notNull(),
+    criticality: text("criticality").$type<SeoDocCriticality>().notNull().default("normal"),
+    lastAuditedAt: timestamp("last_audited_at", { withTimezone: true }),
+    lastEscalatedAt: timestamp("last_escalated_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyDocKeyUq: uniqueIndex("seo_doc_registry_entries_company_doc_key_uq").on(table.companyId, table.docKey),
+    companyStatusIdx: index("seo_doc_registry_entries_company_status_idx").on(table.companyId, table.status),
+    companyIssueIdx: index("seo_doc_registry_entries_company_issue_idx").on(table.companyId, table.issueId),
+    companyLastUpdatedIdx: index("seo_doc_registry_entries_company_last_updated_idx").on(
+      table.companyId,
+      table.lastUpdated,
+    ),
+    cadenceCheck: check(
+      "seo_doc_registry_entries_update_cadence_check",
+      sql`${table.updateCadence} in ('weekly', 'biweekly', 'monthly')`,
+    ),
+    statusCheck: check(
+      "seo_doc_registry_entries_status_check",
+      sql`${table.status} in ('active', 'stale', 'deprecated')`,
+    ),
+    documentClassCheck: check(
+      "seo_doc_registry_entries_document_class_check",
+      sql`${table.documentClass} in ('strategy', 'implementation', 'runbook', 'incident', 'experimentation', 'architecture', 'governance')`,
+    ),
+    criticalityCheck: check(
+      "seo_doc_registry_entries_criticality_check",
+      sql`${table.criticality} in ('normal', 'critical')`,
+    ),
+  }),
+);

--- a/server/scripts/seed-seo-doc-registry.ts
+++ b/server/scripts/seed-seo-doc-registry.ts
@@ -1,0 +1,19 @@
+import { createDb } from "@paperclipai/db";
+import { seoDocGovernanceService } from "../src/services/seo-doc-governance.js";
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  const companyId = process.env.PAPERCLIP_COMPANY_ID;
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  if (!companyId) throw new Error("PAPERCLIP_COMPANY_ID is required");
+
+  const db = createDb(databaseUrl);
+  const governance = seoDocGovernanceService(db);
+  const result = await governance.seedFromIssueIdentifiers(companyId, ["INS-312", "INS-85"]);
+  process.stdout.write(`Seeded seo doc registry entries: ${result.synced}\n`);
+}
+
+void main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -58,6 +58,7 @@ import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
 import { createPluginWorkerManager, type PluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createPluginJobScheduler } from "./services/plugin-job-scheduler.js";
+import { createSeoDocGovernanceScheduler } from "./services/seo-doc-governance-scheduler.js";
 import { pluginJobStore } from "./services/plugin-job-store.js";
 import { createPluginToolDispatcher } from "./services/plugin-tool-dispatcher.js";
 import { pluginLifecycleManager } from "./services/plugin-lifecycle.js";
@@ -68,6 +69,7 @@ import { setPluginEventBus } from "./services/activity-log.js";
 import { createPluginDevWatcher } from "./services/plugin-dev-watcher.js";
 import { createPluginHostServiceCleanup } from "./services/plugin-host-service-cleanup.js";
 import { pluginRegistryService } from "./services/plugin-registry.js";
+import { heartbeatService } from "./services/heartbeat.js";
 import { createHostClientHandlers } from "@paperclipai/plugin-sdk";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 import { createCachedViteHtmlRenderer } from "./vite-html-renderer.js";
@@ -274,6 +276,8 @@ export async function createApp(
     jobStore,
     workerManager,
   });
+  const heartbeat = heartbeatService(db, { pluginWorkerManager: workerManager });
+  const seoDocGovernanceScheduler = createSeoDocGovernanceScheduler({ db, enqueueWakeup: heartbeat.wakeup });
   const toolDispatcher = createPluginToolDispatcher({
     workerManager,
     lifecycleManager: lifecycle,
@@ -454,6 +458,7 @@ export async function createApp(
 
   jobCoordinator.start();
   scheduler.start();
+  seoDocGovernanceScheduler.start();
   let feedbackExportShuttingDown = false;
   let feedbackExportTimer: ReturnType<typeof setInterval> | null = null;
   const disableFeedbackExportFlushes = () => {
@@ -570,6 +575,7 @@ export async function createApp(
     disableFeedbackExportFlushes();
     devWatcher?.close();
     viteHtmlRenderer?.dispose();
+    seoDocGovernanceScheduler.stop();
     hostServiceCleanup.disposeAll();
     hostServiceCleanup.teardown();
   };

--- a/server/src/routes/issues.seo-doc-governance.test.ts
+++ b/server/src/routes/issues.seo-doc-governance.test.ts
@@ -1,0 +1,130 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../errors.js";
+import { errorHandler } from "../middleware/error-handler.js";
+import { issueRoutes } from "./issues.js";
+
+const issueId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockDocumentsService = vi.hoisted(() => ({
+  upsertIssueDocument: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockIssueReferenceService = vi.hoisted(() => ({
+  listIssueReferenceSummary: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  companySearchService: () => ({}),
+  companySkillService: () => ({}),
+  companyService: () => ({}),
+  documentService: () => mockDocumentsService,
+  documentAnnotationService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({}),
+  goalService: () => ({}),
+  heartbeatService: () => ({ wakeup: vi.fn(async () => undefined), reportRunActivity: vi.fn(async () => undefined) }),
+  instanceSettingsService: () => ({
+    getExperimental: vi.fn(async () => ({})),
+    getGeneral: vi.fn(async () => ({ feedbackDataSharingPreference: "prompt" })),
+  }),
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => ({}),
+  issueReferenceService: () => mockIssueReferenceService,
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => ({}),
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+  workProductService: () => ({}),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as {
+      actor: {
+        type: string;
+        userId: string;
+        companyIds: string[];
+        source: string;
+        isInstanceAdmin: boolean;
+      };
+    }).actor = {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as never, {} as never));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issues route seo governance validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueReferenceService.listIssueReferenceSummary.mockResolvedValue({
+      directReferencedIssues: [],
+      transitiveReferencedIssues: [],
+      documentSourceCount: 0,
+      commentSourceCount: 0,
+      lastComputedAt: null,
+    });
+    mockIssueService.getById.mockResolvedValue({
+      id: issueId,
+      companyId,
+      identifier: "INS-316",
+      title: "Governed doc",
+      status: "in_progress",
+    });
+  });
+
+  it("returns actionable 422 details for seo governance validation failures", async () => {
+    mockDocumentsService.upsertIssueDocument.mockRejectedValue(
+      new HttpError(422, "Invalid seo_governance metadata", {
+        code: "missing_update_cadence",
+        fields: [{ field: "seo_governance.update_cadence", message: "update_cadence is required" }],
+      }),
+    );
+
+    const res = await request(createApp())
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .send({
+        title: "Plan",
+        format: "markdown",
+        body: "---\nseo_governance:\n  owner: cto\n---\n",
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({
+      error: "Invalid seo_governance metadata",
+      code: "missing_update_cadence",
+      details: {
+        code: "missing_update_cadence",
+        fields: [{ field: "seo_governance.update_cadence", message: "update_cadence is required" }],
+      },
+    });
+  });
+});

--- a/server/src/services/__tests__/seo-doc-governance-scheduler.test.ts
+++ b/server/src/services/__tests__/seo-doc-governance-scheduler.test.ts
@@ -1,0 +1,352 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentRuntimeState,
+  agentWakeupRequests,
+  agents,
+  companies,
+  companySkills,
+  createDb,
+  documentRevisions,
+  documents,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issues,
+  seoDocRegistryEntries,
+} from "@paperclipai/db";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "../../__tests__/helpers/embedded-postgres.js";
+import { documentService } from "../documents.js";
+import { heartbeatService } from "../heartbeat.js";
+import { createSeoDocGovernanceScheduler } from "../seo-doc-governance-scheduler.js";
+import { runningProcesses } from "../../adapters/index.js";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "CMO wakeup integration test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../../adapters/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../../adapters/index.js")>("../../adapters/index.js");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
+function governedBody(lastUpdated: string, criticality: "normal" | "critical" = "normal") {
+  return [
+    "---",
+    "seo_governance:",
+    "  owner: cto",
+    `  last_updated: ${lastUpdated}`,
+    "  update_cadence: weekly",
+    "  status: active",
+    "  document_class: architecture",
+    `  criticality: ${criticality}`,
+    "  dependencies:",
+    "---",
+    "",
+    "# Body",
+  ].join("\n");
+}
+
+describeEmbeddedPostgres("createSeoDocGovernanceScheduler", () => {
+  let db!: ReturnType<typeof createDb>;
+  let docsSvc!: ReturnType<typeof documentService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-seo-governance-scheduler-");
+    db = createDb(tempDb.connectionString);
+    docsSvc = documentService(db);
+  }, 30_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockClear();
+    // Real dispatch keeps writing (events, activity log) briefly after the run
+    // leaves queued/running; wait for 3 consecutive clean polls before tearing
+    // down, mirroring heartbeat-dependency-scheduling.test.ts's proven pattern.
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db.select({ status: heartbeatRuns.status }).from(heartbeatRuns);
+      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
+      if (!hasActiveRun) {
+        idlePolls += 1;
+        if (idlePolls >= 3) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    runningProcesses.clear();
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(issueComments);
+    await db.delete(agents);
+    await db.delete(seoDocRegistryEntries);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issues);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createIssue(identifier: string) {
+    const companyId = randomUUID();
+    const cmoAgentId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `I${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: cmoAgentId,
+      companyId,
+      name: "CMO",
+      role: "cmo",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier,
+      issueNumber: Number(identifier.split("-")[1] ?? "1"),
+      title: identifier,
+      status: "todo",
+      priority: "high",
+      createdByUserId: "user-1",
+    });
+    return { companyId, issueId, cmoAgentId };
+  }
+
+  it("emits one escalation for critical stale docs until last_updated changes", async () => {
+    const { issueId, cmoAgentId } = await createIssue("INS-321");
+    const enqueueWakeup = vi.fn(async () => null);
+
+    const created = await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody("2026-03-01", "critical"),
+    });
+
+    const scheduler = createSeoDocGovernanceScheduler({
+      db,
+      enqueueWakeup,
+      intervalMs: 60_000,
+      now: () => new Date("2026-04-21T00:00:00.000Z"),
+    });
+    expect((await scheduler.runOnce(new Date("2026-04-21T00:00:00.000Z"))).escalatedDocKeys).toContain("INS-321#document-plan");
+    expect((await scheduler.runOnce(new Date("2026-04-21T00:00:00.000Z"))).escalatedDocKeys).toEqual([]);
+
+    expect(await db.select().from(issueComments).where(eq(issueComments.issueId, issueId))).toHaveLength(1);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+    expect(enqueueWakeup).toHaveBeenNthCalledWith(
+      1,
+      cmoAgentId,
+      expect.objectContaining({
+        reason: "issue_comment_mentioned",
+        payload: expect.objectContaining({ issueId }),
+      }),
+    );
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      baseRevisionId: created.document.latestRevisionId,
+      body: governedBody("2026-04-22", "critical"),
+    });
+
+    expect((await scheduler.runOnce(new Date("2026-05-10T00:00:00.000Z"))).escalatedDocKeys).toContain("INS-321#document-plan");
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(2);
+    expect(comments[0]?.body).toContain(`[@CMO](agent://${cmoAgentId})`);
+    expect(enqueueWakeup).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not duplicate escalation comments when wake enqueue fails transiently", async () => {
+    const { companyId, issueId } = await createIssue("INS-324");
+    const enqueueWakeup = vi.fn()
+      .mockRejectedValueOnce(new Error("transient wake failure"))
+      .mockResolvedValue(null);
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody("2026-03-01", "critical"),
+    });
+
+    const scheduler = createSeoDocGovernanceScheduler({
+      db,
+      enqueueWakeup,
+      intervalMs: 60_000,
+      now: () => new Date("2026-04-21T00:00:00.000Z"),
+    });
+
+    await expect(scheduler.runOnce(new Date("2026-04-21T00:00:00.000Z"))).resolves.toMatchObject({
+      escalatedDocKeys: ["INS-324#document-plan"],
+    });
+    await expect(scheduler.runOnce(new Date("2026-04-21T00:00:00.000Z"))).resolves.toMatchObject({
+      escalatedDocKeys: [],
+    });
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    const registryEntry = await db
+      .select({
+        lastEscalatedAt: seoDocRegistryEntries.lastEscalatedAt,
+      })
+      .from(seoDocRegistryEntries)
+      .where(and(eq(seoDocRegistryEntries.companyId, companyId), eq(seoDocRegistryEntries.issueId, issueId)))
+      .then((rows) => rows[0] ?? null);
+    expect(registryEntry?.lastEscalatedAt?.toISOString()).toBe("2026-04-21T00:00:00.000Z");
+    expect(enqueueWakeup).toHaveBeenCalledTimes(1);
+  });
+
+  it("wakes the real CMO agent via heartbeatService.wakeup, not just a mocked call (INS-2954)", async () => {
+    const { issueId, cmoAgentId } = await createIssue("INS-330");
+    const heartbeat = heartbeatService(db, { runtimeEnv: {} });
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody("2026-03-01", "critical"),
+    });
+
+    const scheduler = createSeoDocGovernanceScheduler({
+      db,
+      enqueueWakeup: heartbeat.wakeup,
+      intervalMs: 60_000,
+      now: () => new Date("2026-04-21T00:00:00.000Z"),
+    });
+
+    const result = await scheduler.runOnce(new Date("2026-04-21T00:00:00.000Z"));
+    expect(result.escalatedDocKeys).toContain("INS-330#document-plan");
+
+    const comment = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .then((rows) => rows[0]);
+    expect(comment?.body).toContain(`[@CMO](agent://${cmoAgentId})`);
+
+    // Real heartbeatService.wakeup persistence, not a vi.fn() mock: assert the
+    // actual agent_wakeup_requests row it wrote, per INS-2954's addendum to
+    // INS-317 (INS-2936 closed the gap where only the comment text was checked).
+    const wakeRequest = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, cmoAgentId))
+      .then((rows) => rows[0]);
+
+    expect(wakeRequest).toBeTruthy();
+    expect(wakeRequest?.reason).toBe("issue_comment_mentioned");
+    expect(wakeRequest?.status).not.toBe("skipped");
+    expect(wakeRequest?.payload).toMatchObject({
+      issueId,
+      commentId: comment.id,
+    });
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.wakeupRequestId, wakeRequest.id))
+      .then((rows) => rows[0]);
+    expect(run).toBeTruthy();
+    expect(run?.agentId).toBe(cmoAgentId);
+
+    await waitForCondition(async () => {
+      const settled = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id));
+      return settled[0]?.status !== "queued" && settled[0]?.status !== "running";
+    });
+  });
+
+  it("continues auditing other docs when one governed document is malformed", async () => {
+    const malformed = await createIssue("INS-322");
+    const healthy = await createIssue("INS-323");
+
+    await docsSvc.upsertIssueDocument({
+      issueId: malformed.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody("2026-04-20", "normal"),
+    });
+    const healthyDoc = await docsSvc.upsertIssueDocument({
+      issueId: healthy.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody("2026-03-01", "normal"),
+    });
+
+    const malformedDocumentId = await db
+      .select({ documentId: issueDocuments.documentId })
+      .from(issueDocuments)
+      .where(and(eq(issueDocuments.issueId, malformed.issueId), eq(issueDocuments.key, "plan")))
+      .then((rows) => rows[0]?.documentId ?? null);
+    if (malformedDocumentId) {
+      await db.update(documents).set({ latestBody: "# malformed frontmatter removed" }).where(eq(documents.id, malformedDocumentId));
+    }
+
+    const scheduler = createSeoDocGovernanceScheduler({ db, now: () => new Date("2026-04-21T00:00:00.000Z") });
+    const result = await scheduler.runOnce(new Date("2026-04-21T00:00:00.000Z"));
+
+    expect(result.scanned).toBe(2);
+    expect(result.staleDocKeys).toContain("INS-323#document-plan");
+    expect(result.violations.some((v) => v.code === "missing_frontmatter" && v.docKey === "INS-322#document-plan")).toBe(true);
+
+    await docsSvc.upsertIssueDocument({
+      issueId: healthy.issueId,
+      key: "plan",
+      format: "markdown",
+      baseRevisionId: healthyDoc.document.latestRevisionId,
+      body: governedBody("2026-04-21", "normal"),
+    });
+  });
+});

--- a/server/src/services/__tests__/seo-doc-governance.test.ts
+++ b/server/src/services/__tests__/seo-doc-governance.test.ts
@@ -1,0 +1,500 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  createDb,
+  documentRevisions,
+  documents,
+  issueComments,
+  issueDocuments,
+  issues,
+  seoDocRegistryEntries,
+} from "@paperclipai/db";
+import { HttpError } from "../../errors.js";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "../../__tests__/helpers/embedded-postgres.js";
+import { documentService } from "../documents.js";
+import { seoDocGovernanceService } from "../seo-doc-governance.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function governedBody(input: {
+  owner?: string;
+  lastUpdated?: string;
+  updateCadence?: "weekly" | "biweekly" | "monthly";
+  status?: "active" | "stale" | "deprecated";
+  documentClass?: "strategy" | "implementation" | "runbook" | "incident" | "experimentation" | "architecture" | "governance";
+  criticality?: "normal" | "critical";
+  dependencies?: Array<{
+    type: "issue_document" | "issue";
+    role: "source_strategy" | "implementation_handoff" | "related";
+    target: string;
+  }>;
+}) {
+  const deps = input.dependencies ?? [];
+  return [
+    "---",
+    "seo_governance:",
+    ...(input.owner !== undefined ? [`  owner: ${input.owner}`] : []),
+    `  last_updated: ${input.lastUpdated ?? "2026-04-20"}`,
+    ...(input.updateCadence !== undefined ? [`  update_cadence: ${input.updateCadence}`] : []),
+    `  status: ${input.status ?? "active"}`,
+    `  document_class: ${input.documentClass ?? "architecture"}`,
+    `  criticality: ${input.criticality ?? "normal"}`,
+    "  dependencies:",
+    ...deps.flatMap((dep) => [
+      "    - type: " + dep.type,
+      "      role: " + dep.role,
+      "      target: " + dep.target,
+    ]),
+    "---",
+    "",
+    "# Body",
+  ].join("\n");
+}
+
+describeEmbeddedPostgres("seoDocGovernanceService", () => {
+  let db!: ReturnType<typeof createDb>;
+  let docsSvc!: ReturnType<typeof documentService>;
+  let governance!: ReturnType<typeof seoDocGovernanceService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-seo-doc-governance-");
+    db = createDb(tempDb.connectionString);
+    docsSvc = documentService(db);
+    governance = seoDocGovernanceService(db);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(seoDocRegistryEntries);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createCompanyAndIssue(identifier = "INS-312") {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `I${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier,
+      issueNumber: Number(identifier.split("-")[1] ?? "1"),
+      title: `Issue ${identifier}`,
+      status: "todo",
+      priority: "high",
+      createdByUserId: "user-1",
+    });
+    return { companyId, issueId };
+  }
+
+  it("inserts registry rows on valid governed document create", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-312");
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan-eng-review",
+      title: "Plan",
+      format: "markdown",
+      body: governedBody({
+        owner: "cto",
+        updateCadence: "monthly",
+        documentClass: "architecture",
+        dependencies: [{ type: "issue_document", role: "source_strategy", target: "INS-85#document-plan" }],
+      }),
+    });
+
+    const row = await db
+      .select()
+      .from(seoDocRegistryEntries)
+      .where(and(eq(seoDocRegistryEntries.companyId, companyId), eq(seoDocRegistryEntries.issueId, issueId)))
+      .then((rows) => rows[0]);
+
+    expect(row.docKey).toBe("INS-312#document-plan-eng-review");
+    expect(row.updateCadence).toBe("monthly");
+    expect(row.documentClass).toBe("architecture");
+    expect((row.dependencies ?? [])[0]).toMatchObject({ target: "INS-85#document-plan" });
+  });
+
+  it("returns 422 and does not persist registry when owner is missing", async () => {
+    const { issueId } = await createCompanyAndIssue("INS-313");
+
+    await expect(() =>
+      docsSvc.upsertIssueDocument({
+        issueId,
+        key: "plan",
+        format: "markdown",
+        body: governedBody({ owner: undefined, updateCadence: "monthly" }),
+      }))
+      .rejects
+      .toMatchObject({ status: 422, details: { code: "missing_owner" } } as Partial<HttpError>);
+
+    expect(await db.select().from(seoDocRegistryEntries)).toHaveLength(0);
+  });
+
+  it("restoring an older revision rewrites registry metadata", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-314");
+
+    const first = await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "monthly", status: "active", lastUpdated: "2026-04-01" }),
+    });
+    const second = await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      baseRevisionId: first.document.latestRevisionId,
+      body: governedBody({ owner: "cmo", updateCadence: "weekly", status: "deprecated", lastUpdated: "2026-04-20" }),
+    });
+
+    const revisions = await docsSvc.listIssueDocumentRevisions(issueId, "plan");
+    const originalRevision = revisions.find((r) => r.revisionNumber === 1);
+    expect(originalRevision).toBeTruthy();
+
+    await docsSvc.restoreIssueDocumentRevision({
+      issueId,
+      key: "plan",
+      revisionId: originalRevision!.id,
+      createdByUserId: "user-2",
+    });
+
+    const row = await db
+      .select()
+      .from(seoDocRegistryEntries)
+      .where(and(eq(seoDocRegistryEntries.companyId, companyId), eq(seoDocRegistryEntries.docKey, "INS-314#document-plan")))
+      .then((rows) => rows[0]);
+
+    expect(second.document.latestRevisionNumber).toBe(2);
+    expect(row.owner).toBe("cto");
+    expect(row.status).toBe("active");
+    expect(row.updateCadence).toBe("monthly");
+  });
+
+  it("flags implementation docs without source_strategy dependency", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-315");
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "weekly", documentClass: "implementation", dependencies: [] }),
+    });
+
+    const violations = await governance.validateRegistryEntry(companyId, "INS-315#document-plan");
+    expect(violations.some((v) => v.code === "implementation_missing_source_strategy")).toBe(true);
+  });
+
+  it("flags implementation docs when source_strategy points at an issue instead of an issue document", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-3151");
+    const { issueId: strategyIssueId } = await createCompanyAndIssue("INS-3152");
+
+    await docsSvc.upsertIssueDocument({
+      issueId: strategyIssueId,
+      key: "strategy",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "weekly", documentClass: "strategy" }),
+    });
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({
+        owner: "cto",
+        updateCadence: "weekly",
+        documentClass: "implementation",
+        dependencies: [{ type: "issue", role: "source_strategy", target: "INS-315B" }],
+      }),
+    });
+
+    const violations = await governance.validateRegistryEntry(companyId, "INS-3151#document-plan");
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "invalid_dependency_target",
+          message: expect.stringContaining("source_strategy requires target type issue_document"),
+        }),
+        expect.objectContaining({ code: "implementation_missing_source_strategy" }),
+      ]),
+    );
+  });
+
+  it("flags strategy docs without implementation_handoff dependency", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-316");
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "weekly", documentClass: "strategy", dependencies: [] }),
+    });
+
+    const violations = await governance.validateRegistryEntry(companyId, "INS-316#document-plan");
+    expect(violations.some((v) => v.code === "strategy_missing_handoff_issue")).toBe(true);
+  });
+
+  it("flags strategy docs when implementation_handoff points at an issue document instead of an issue", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-3161");
+    const { issueId: handoffIssueId } = await createCompanyAndIssue("INS-3162");
+
+    await docsSvc.upsertIssueDocument({
+      issueId: handoffIssueId,
+      key: "handoff",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "weekly", documentClass: "implementation" }),
+    });
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({
+        owner: "cto",
+        updateCadence: "weekly",
+        documentClass: "strategy",
+        dependencies: [{ type: "issue_document", role: "implementation_handoff", target: "INS-316B#document-handoff" }],
+      }),
+    });
+
+    const violations = await governance.validateRegistryEntry(companyId, "INS-3161#document-plan");
+    expect(violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "invalid_dependency_target",
+          message: expect.stringContaining("implementation_handoff requires target type issue"),
+        }),
+        expect.objectContaining({ code: "strategy_missing_handoff_issue" }),
+      ]),
+    );
+  });
+
+  it("marks weekly/biweekly/monthly docs stale at the expected thresholds", async () => {
+    const now = new Date("2026-04-21T00:00:00.000Z");
+    const weekly = await createCompanyAndIssue("INS-317");
+    const biweekly = await createCompanyAndIssue("INS-318");
+    const monthly = await createCompanyAndIssue("INS-319");
+
+    await docsSvc.upsertIssueDocument({
+      issueId: weekly.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "weekly", lastUpdated: "2026-04-13T23:58:00.000Z" }),
+    });
+    await docsSvc.upsertIssueDocument({
+      issueId: biweekly.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "biweekly", lastUpdated: "2026-04-06T23:58:00.000Z" }),
+    });
+    await docsSvc.upsertIssueDocument({
+      issueId: monthly.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "monthly", lastUpdated: "2026-03-20T23:58:00.000Z" }),
+    });
+
+    expect((await governance.auditCompany(weekly.companyId, now)).staleDocKeys).toContain("INS-317#document-plan");
+    expect((await governance.auditCompany(biweekly.companyId, now)).staleDocKeys).toContain("INS-318#document-plan");
+    expect((await governance.auditCompany(monthly.companyId, now)).staleDocKeys).toContain("INS-319#document-plan");
+  });
+
+  it("scopes validation to the requested company when doc keys overlap across tenants", async () => {
+    const companyA = await createCompanyAndIssue("INS-400");
+    const companyB = await createCompanyAndIssue("INS-500");
+    const companyBStrategyIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: companyBStrategyIssueId,
+      companyId: companyB.companyId,
+      identifier: "INS-401",
+      issueNumber: 401,
+      title: "Issue INS-401",
+      status: "todo",
+      priority: "high",
+      createdByUserId: "user-1",
+    });
+
+    await docsSvc.upsertIssueDocument({
+      issueId: companyBStrategyIssueId,
+      key: "strategy",
+      format: "markdown",
+      body: governedBody({ owner: "cto", updateCadence: "weekly", documentClass: "strategy" }),
+    });
+
+    await docsSvc.upsertIssueDocument({
+      issueId: companyA.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({
+        owner: "cto",
+        updateCadence: "weekly",
+        documentClass: "implementation",
+        dependencies: [{ type: "issue_document", role: "source_strategy", target: "INS-401#document-strategy" }],
+      }),
+    });
+
+    await docsSvc.upsertIssueDocument({
+      issueId: companyB.issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({
+        owner: "cto",
+        updateCadence: "weekly",
+        documentClass: "implementation",
+        dependencies: [{ type: "issue_document", role: "source_strategy", target: "INS-401#document-strategy" }],
+      }),
+    });
+
+    await db
+      .update(seoDocRegistryEntries)
+      .set({ docKey: "INS-400#document-plan" })
+      .where(and(eq(seoDocRegistryEntries.companyId, companyB.companyId), eq(seoDocRegistryEntries.issueId, companyB.issueId)));
+
+    const companyAViolations = await governance.validateRegistryEntry(companyA.companyId, "INS-400#document-plan");
+    const companyBViolations = await governance.validateRegistryEntry(companyB.companyId, "INS-400#document-plan");
+
+    expect(companyAViolations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "invalid_dependency_target",
+          message: expect.stringContaining("Dependency target issue document does not exist: INS-401#document-strategy"),
+        }),
+      ]),
+    );
+    expect(companyBViolations).toEqual([]);
+  });
+
+  it("keeps deprecated docs queryable and excludes them from escalation", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-320");
+
+    await docsSvc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      format: "markdown",
+      body: governedBody({
+        owner: "cto",
+        updateCadence: "weekly",
+        status: "deprecated",
+        criticality: "critical",
+        lastUpdated: "2026-01-01",
+      }),
+    });
+
+    const result = await governance.auditCompany(companyId, new Date("2026-04-21T00:00:00.000Z"));
+    expect(result.escalatedDocKeys).toEqual([]);
+
+    const row = await db
+      .select()
+      .from(seoDocRegistryEntries)
+      .where(eq(seoDocRegistryEntries.docKey, "INS-320#document-plan"))
+      .then((rows) => rows[0] ?? null);
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe("deprecated");
+  });
+
+  it("seedFromIssueIdentifiers backfills INS-312 and INS-85 without duplicates", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `I${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    for (const identifier of ["INS-312", "INS-85"]) {
+      const issueId = randomUUID();
+      const documentId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        identifier,
+        issueNumber: Number(identifier.split("-")[1] ?? "1"),
+        title: `Issue ${identifier}`,
+        status: "todo",
+        priority: "high",
+        createdByUserId: "user-1",
+      });
+      await db.insert(documents).values({
+        id: documentId,
+        companyId,
+        title: "Plan",
+        format: "markdown",
+        latestBody: governedBody({ owner: "cto", updateCadence: "monthly" }),
+        latestRevisionNumber: 1,
+      });
+      await db.insert(issueDocuments).values({
+        companyId,
+        issueId,
+        documentId,
+        key: "plan",
+      });
+    }
+
+    expect(await governance.seedFromIssueIdentifiers(companyId, ["INS-312", "INS-85"])).toEqual({ synced: 2 });
+    expect(await governance.seedFromIssueIdentifiers(companyId, ["INS-312", "INS-85"])).toEqual({ synced: 0 });
+  });
+
+  it("enforces DB-level enum constraints for governance registry columns", async () => {
+    const { companyId, issueId } = await createCompanyAndIssue("INS-321");
+
+    await expect(
+      db.execute(sql`
+        insert into seo_doc_registry_entries (
+          id,
+          company_id,
+          doc_key,
+          issue_id,
+          issue_document_key,
+          title,
+          issue_link,
+          owner,
+          last_updated,
+          update_cadence,
+          status,
+          dependencies,
+          document_class,
+          criticality,
+          created_at,
+          updated_at
+        ) values (
+          ${randomUUID()},
+          ${companyId},
+          ${"INS-321#document-plan"},
+          ${issueId},
+          ${"plan"},
+          ${"Plan"},
+          ${"/INS/issues/INS-321"},
+          ${"cto"},
+          ${"2026-04-20T00:00:00.000Z"},
+          ${"quarterly"},
+          ${"active"},
+          ${JSON.stringify([])}::jsonb,
+          ${"architecture"},
+          ${"normal"},
+          ${"2026-04-20T00:00:00.000Z"},
+          ${"2026-04-20T00:00:00.000Z"}
+        )
+      `),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        message: expect.stringContaining("seo_doc_registry_entries_update_cadence_check"),
+      }),
+    });
+  });
+});

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -1,8 +1,9 @@
 import { and, asc, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
+import { documentRevisions, documents, issueDocuments, issues, seoDocRegistryEntries } from "@paperclipai/db";
 import { isSystemIssueDocumentKey, issueDocumentKeySchema } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { seoDocGovernanceService } from "./seo-doc-governance.js";
 
 function normalizeDocumentKey(key: string) {
   const normalized = key.trim().toLowerCase();
@@ -109,8 +110,24 @@ export const issueDocumentSelect = {
 };
 
 export function documentService(db: Db) {
+  const seoGovernance = seoDocGovernanceService(db);
   const filterSystemDocuments = <T extends { key: string }>(rows: T[], includeSystem: boolean) =>
     includeSystem ? rows : rows.filter((row) => !isSystemIssueDocumentKey(row.key));
+
+  function maybeRethrowGovernanceValidation(err: unknown): never {
+    if (err && typeof err === "object" && "details" in err) {
+      const details = (err as { details?: unknown }).details;
+      if (
+        details &&
+        typeof details === "object" &&
+        "code" in (details as Record<string, unknown>) &&
+        typeof (details as Record<string, unknown>).code === "string"
+      ) {
+        throw unprocessable("Invalid seo_governance metadata", details);
+      }
+    }
+    throw err;
+  }
 
   return {
     getIssueDocumentPayload: async (
@@ -210,11 +227,12 @@ export function documentService(db: Db) {
     }) => {
       const key = normalizeDocumentKey(input.key);
       const issue = await db
-        .select({ id: issues.id, companyId: issues.companyId })
+        .select({ id: issues.id, companyId: issues.companyId, identifier: issues.identifier })
         .from(issues)
         .where(eq(issues.id, input.issueId))
         .then((rows) => rows[0] ?? null);
       if (!issue) throw notFound("Issue not found");
+      const issueIdentifier = issue.identifier ?? issue.id;
 
       const maxAttempts = input.lockedDocumentStrategy === "create_new_document" ? 3 : 1;
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
@@ -396,6 +414,21 @@ export function documentService(db: Db) {
               .set({ updatedAt: now })
               .where(eq(issueDocuments.documentId, existing.id));
 
+            if (input.format === "markdown") {
+              try {
+                await seoDocGovernanceService(tx as unknown as Db).syncRegistryEntryFromIssueDocument({
+                  issueId: issue.id,
+                  issueIdentifier,
+                  issueDocumentKey: key,
+                  title: input.title ?? null,
+                  body: input.body,
+                  now,
+                });
+              } catch (error) {
+                maybeRethrowGovernanceValidation(error);
+              }
+            }
+
             return {
               created: false as const,
               document: {
@@ -473,6 +506,21 @@ export function documentService(db: Db) {
             updatedAt: now,
           });
 
+          if (input.format === "markdown") {
+            try {
+              await seoDocGovernanceService(tx as unknown as Db).syncRegistryEntryFromIssueDocument({
+                issueId: issue.id,
+                issueIdentifier,
+                issueDocumentKey: key,
+                title: input.title ?? null,
+                body: input.body,
+                now,
+              });
+            } catch (error) {
+              maybeRethrowGovernanceValidation(error);
+            }
+          }
+
           return {
             created: true as const,
             document: {
@@ -521,6 +569,13 @@ export function documentService(db: Db) {
     }) => {
       const key = normalizeDocumentKey(input.key);
       return db.transaction(async (tx) => {
+        const issueIdentifierRow = await tx
+          .select({ identifier: issues.identifier })
+          .from(issues)
+          .where(eq(issues.id, input.issueId))
+          .then((rows) => rows[0] ?? null);
+        if (!issueIdentifierRow) throw notFound("Issue not found");
+
         const existing = await tx
           .select(issueDocumentSelect)
           .from(issueDocuments)
@@ -594,6 +649,21 @@ export function documentService(db: Db) {
           .update(issueDocuments)
           .set({ updatedAt: now })
           .where(eq(issueDocuments.documentId, existing.id));
+
+        if (revision.format === "markdown") {
+          try {
+            await seoDocGovernanceService(tx as unknown as Db).syncRegistryEntryFromIssueDocument({
+              issueId: input.issueId,
+              issueIdentifier: issueIdentifierRow.identifier ?? input.issueId,
+              issueDocumentKey: key,
+              title: revision.title ?? null,
+              body: revision.body,
+              now,
+            });
+          } catch (error) {
+            maybeRethrowGovernanceValidation(error);
+          }
+        }
 
         return {
           restoredFromRevisionId: revision.id,
@@ -715,6 +785,13 @@ export function documentService(db: Db) {
     deleteIssueDocument: async (issueId: string, rawKey: string) => {
       const key = normalizeDocumentKey(rawKey);
       return db.transaction(async (tx) => {
+        const issueRow = await tx
+          .select({ id: issues.id, companyId: issues.companyId, identifier: issues.identifier })
+          .from(issues)
+          .where(eq(issues.id, issueId))
+          .then((rows) => rows[0] ?? null);
+        if (!issueRow) throw notFound("Issue not found");
+
         const existing = await tx
           .select(issueDocumentSelect)
           .from(issueDocuments)
@@ -731,8 +808,31 @@ export function documentService(db: Db) {
           });
         }
 
+        const docKey = seoGovernance.buildDocKey(issueRow.identifier ?? issueRow.id, key);
+        const registryEntry = await tx
+          .select({
+            id: seoDocRegistryEntries.id,
+            status: seoDocRegistryEntries.status,
+          })
+          .from(seoDocRegistryEntries)
+          .where(and(eq(seoDocRegistryEntries.companyId, issueRow.companyId), eq(seoDocRegistryEntries.docKey, docKey)))
+          .then((rows) => rows[0] ?? null);
+
+        if (registryEntry && registryEntry.status !== "deprecated") {
+          throw unprocessable("Governed documents must be superseded before deletion", {
+            code: "governed_document_delete_requires_deprecated",
+            fields: [{
+              field: "seo_governance.status",
+              message: "Set `seo_governance.status: deprecated` before deleting this document.",
+            }],
+          });
+        }
+
         await tx.delete(issueDocuments).where(eq(issueDocuments.documentId, existing.id));
         await tx.delete(documents).where(eq(documents.id, existing.id));
+        if (registryEntry) {
+          await tx.delete(seoDocRegistryEntries).where(eq(seoDocRegistryEntries.id, registryEntry.id));
+        }
 
         return {
           ...existing,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,6 +1,8 @@
 export { companyService } from "./companies.js";
 export { companyArtifactsService } from "./company-artifacts.js";
 export { companySearchService } from "./company-search.js";
+export { seoDocGovernanceService } from "./seo-doc-governance.js";
+export { createSeoDocGovernanceScheduler } from "./seo-doc-governance-scheduler.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";

--- a/server/src/services/seo-doc-governance-scheduler.ts
+++ b/server/src/services/seo-doc-governance-scheduler.ts
@@ -1,0 +1,82 @@
+import type { Db } from "@paperclipai/db";
+import { seoDocRegistryEntries } from "@paperclipai/db";
+import type { SeoDocAuditResult } from "./seo-doc-governance.js";
+import { seoDocGovernanceService } from "./seo-doc-governance.js";
+import { logger } from "../middleware/logger.js";
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1_000;
+
+export function createSeoDocGovernanceScheduler(opts: {
+  db: Db;
+  intervalMs?: number;
+  now?: () => Date;
+  enqueueWakeup?: NonNullable<Parameters<typeof seoDocGovernanceService>[1]>["enqueueWakeup"];
+}): {
+  start(): void;
+  stop(): void;
+  runOnce(now?: Date): Promise<SeoDocAuditResult>;
+} {
+  const governance = seoDocGovernanceService(opts.db, { enqueueWakeup: opts.enqueueWakeup });
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const nowFn = opts.now ?? (() => new Date());
+  const log = logger.child({ service: "seo-doc-governance-scheduler" });
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let running = false;
+
+  const runOnce = async (auditNow?: Date): Promise<SeoDocAuditResult> => {
+    const now = auditNow ?? nowFn();
+    const companyRows = await opts.db
+      .select({ companyId: seoDocRegistryEntries.companyId })
+      .from(seoDocRegistryEntries)
+      .groupBy(seoDocRegistryEntries.companyId);
+
+    const aggregate: SeoDocAuditResult = {
+      scanned: 0,
+      staleDocKeys: [],
+      escalatedDocKeys: [],
+      violations: [],
+    };
+
+    for (const row of companyRows) {
+      const result = await governance.auditCompany(row.companyId, now);
+      aggregate.scanned += result.scanned;
+      aggregate.staleDocKeys.push(...result.staleDocKeys);
+      aggregate.escalatedDocKeys.push(...result.escalatedDocKeys);
+      aggregate.violations.push(...result.violations);
+    }
+
+    return aggregate;
+  };
+
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      await runOnce();
+    } catch (error) {
+      log.warn({ err: error }, "seo governance scheduler run failed");
+    } finally {
+      running = false;
+    }
+  };
+
+  return {
+    start() {
+      if (timer) return;
+      timer = setInterval(() => {
+        void tick();
+      }, intervalMs);
+      timer.unref?.();
+      void tick();
+    },
+    stop() {
+      if (!timer) return;
+      clearInterval(timer);
+      timer = null;
+    },
+    async runOnce(now?: Date) {
+      return runOnce(now);
+    },
+  };
+}

--- a/server/src/services/seo-doc-governance.ts
+++ b/server/src/services/seo-doc-governance.ts
@@ -1,0 +1,606 @@
+import { and, asc, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, documents, issueComments, issueDocuments, issues, seoDocRegistryEntries } from "@paperclipai/db";
+import { asString, buildAgentMentionHref, isFrontmatterPlainRecord, parseFrontmatterMarkdown } from "@paperclipai/shared";
+import { logger } from "../middleware/logger.js";
+
+export type SeoDocCadence = "weekly" | "biweekly" | "monthly";
+export type SeoDocStatus = "active" | "stale" | "deprecated";
+export type SeoDocClass =
+  | "strategy"
+  | "implementation"
+  | "runbook"
+  | "incident"
+  | "experimentation"
+  | "architecture"
+  | "governance";
+
+export interface SeoDocDependencyRef {
+  type: "issue_document" | "issue";
+  target: string;
+  role: "source_strategy" | "implementation_handoff" | "related";
+}
+
+export interface ParsedSeoDocGovernanceMeta {
+  owner: string;
+  lastUpdated: Date;
+  updateCadence: SeoDocCadence;
+  status: SeoDocStatus;
+  dependencies: SeoDocDependencyRef[];
+  documentClass: SeoDocClass;
+  criticality: "normal" | "critical";
+}
+
+export interface SeoDocViolation {
+  code:
+    | "missing_frontmatter"
+    | "missing_owner"
+    | "missing_update_cadence"
+    | "invalid_dependency_target"
+    | "implementation_missing_source_strategy"
+    | "strategy_missing_handoff_issue";
+  docKey: string;
+  message: string;
+}
+
+export interface SeoDocAuditResult {
+  scanned: number;
+  staleDocKeys: string[];
+  escalatedDocKeys: string[];
+  violations: SeoDocViolation[];
+}
+
+type SeoDocGovernanceWakeup = {
+  source: "automation";
+  triggerDetail: "system";
+  reason: "issue_comment_mentioned";
+  payload: {
+    issueId: string;
+    commentId: string;
+  };
+  requestedByActorType: "system";
+  contextSnapshot: {
+    issueId: string;
+    taskId: string;
+    commentId: string;
+    wakeCommentId: string;
+    wakeReason: "issue_comment_mentioned";
+    source: "comment.mention";
+    responsibleUserId?: string;
+  };
+};
+
+type SeoDocGovernanceDeps = {
+  enqueueWakeup?: (agentId: string, wakeup: SeoDocGovernanceWakeup) => Promise<unknown> | unknown;
+};
+
+type ValidationErrorCode = "missing_owner" | "missing_update_cadence" | "missing_frontmatter";
+
+const CADENCE_TO_MS: Record<SeoDocCadence, number> = {
+  weekly: 7 * 24 * 60 * 60 * 1_000,
+  biweekly: 14 * 24 * 60 * 60 * 1_000,
+  monthly: 31 * 24 * 60 * 60 * 1_000,
+};
+
+function normalizeIssueIdentifier(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function normalizeDocumentKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function issuePathFromIdentifier(identifier: string): string {
+  const normalized = normalizeIssueIdentifier(identifier);
+  const prefix = normalized.split("-")[0] ?? normalized;
+  return `/${prefix}/issues/${normalized}`;
+}
+
+function isCadence(value: string): value is SeoDocCadence {
+  return value === "weekly" || value === "biweekly" || value === "monthly";
+}
+
+function isDocStatus(value: string): value is SeoDocStatus {
+  return value === "active" || value === "stale" || value === "deprecated";
+}
+
+function isDocClass(value: string): value is SeoDocClass {
+  return (
+    value === "strategy" ||
+    value === "implementation" ||
+    value === "runbook" ||
+    value === "incident" ||
+    value === "experimentation" ||
+    value === "architecture" ||
+    value === "governance"
+  );
+}
+
+function isDependencyType(value: string): value is SeoDocDependencyRef["type"] {
+  return value === "issue_document" || value === "issue";
+}
+
+function isDependencyRole(value: string): value is SeoDocDependencyRef["role"] {
+  return value === "source_strategy" || value === "implementation_handoff" || value === "related";
+}
+
+function expectedDependencyTypeForRole(role: SeoDocDependencyRef["role"]): SeoDocDependencyRef["type"] | null {
+  if (role === "source_strategy") return "issue_document";
+  if (role === "implementation_handoff") return "issue";
+  return null;
+}
+
+function parseGovernanceDate(value: string): Date | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
+function normalizeDependencies(value: unknown): SeoDocDependencyRef[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => {
+      if (!isFrontmatterPlainRecord(entry)) return null;
+      const type = asString(entry.type);
+      const target = asString(entry.target);
+      const role = asString(entry.role);
+      if (!type || !target || !role) return null;
+      if (!isDependencyType(type) || !isDependencyRole(role)) return null;
+      return { type, target, role };
+    })
+    .filter((entry): entry is SeoDocDependencyRef => entry !== null);
+}
+
+function parseGovernanceRecord(body: string): Record<string, unknown> | null {
+  const parsed = parseFrontmatterMarkdown(body);
+  if (!parsed.hasFrontmatter) return null;
+  const raw = parsed.frontmatter["seo_governance"];
+  return isFrontmatterPlainRecord(raw) ? raw : null;
+}
+
+function isStale(entry: { updateCadence: SeoDocCadence; lastUpdated: Date }, now: Date): boolean {
+  const thresholdMs = CADENCE_TO_MS[entry.updateCadence] + 60_000;
+  return now.getTime() - entry.lastUpdated.getTime() > thresholdMs;
+}
+
+function escalationBody(docKey: string, cmoMention: string): string {
+  return [
+    "SEO governance escalation: critical document is stale.",
+    "",
+    `- Document: ${docKey}`,
+    "- Action required: update governance metadata/body and refresh `last_updated`.",
+    `- Escalation: ${cmoMention}`,
+  ].join("\n");
+}
+
+function buildValidationError(code: ValidationErrorCode, docKey: string): Error & { details: unknown } {
+  const field = code === "missing_owner"
+    ? "seo_governance.owner"
+    : code === "missing_update_cadence"
+      ? "seo_governance.update_cadence"
+      : "seo_governance";
+  const message = code === "missing_owner"
+    ? "owner is required"
+    : code === "missing_update_cadence"
+      ? "update_cadence is required"
+      : "invalid or incomplete seo_governance frontmatter";
+  const error = new Error(code) as Error & { details: unknown };
+  error.details = {
+    code,
+    docKey,
+    fields: [{ field, message }],
+  };
+  return error;
+}
+
+export function seoDocGovernanceService(db: Db, deps: SeoDocGovernanceDeps = {}) {
+  const log = logger.child({ service: "seo-doc-governance" });
+
+  async function findCompanyCmo(companyId: string) {
+    return db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(and(eq(agents.companyId, companyId), eq(agents.role, "cmo")))
+      .orderBy(asc(agents.createdAt), asc(agents.id))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function validateDependencies(
+    companyId: string,
+    docKey: string,
+    dependencies: SeoDocDependencyRef[],
+  ): Promise<SeoDocViolation[]> {
+    const violations: SeoDocViolation[] = [];
+
+    for (const dep of dependencies) {
+      const expectedType = expectedDependencyTypeForRole(dep.role);
+      if (expectedType && dep.type !== expectedType) {
+        violations.push({
+          code: "invalid_dependency_target",
+          docKey,
+          message: `Dependency role ${dep.role} requires target type ${expectedType}, received ${dep.type}: ${dep.target}`,
+        });
+        continue;
+      }
+
+      if (dep.type === "issue") {
+        const targetIdentifier = normalizeIssueIdentifier(dep.target);
+        const targetIssue = await db
+          .select({ id: issues.id })
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.identifier, targetIdentifier)))
+          .then((rows) => rows[0] ?? null);
+        if (!targetIssue) {
+          violations.push({
+            code: "invalid_dependency_target",
+            docKey,
+            message: `Dependency target issue does not exist: ${dep.target}`,
+          });
+        }
+        continue;
+      }
+
+      const match = dep.target.match(/^([A-Z]+-\d+)#document-([a-z0-9][a-z0-9\-_]*)$/i);
+      if (!match) {
+        violations.push({
+          code: "invalid_dependency_target",
+          docKey,
+          message: `Dependency target is not a valid issue document reference: ${dep.target}`,
+        });
+        continue;
+      }
+
+      const issueIdentifier = normalizeIssueIdentifier(match[1] ?? "");
+      const documentKey = normalizeDocumentKey(match[2] ?? "");
+      const issueDocument = await db
+        .select({ id: issueDocuments.id })
+        .from(issueDocuments)
+        .innerJoin(issues, eq(issueDocuments.issueId, issues.id))
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.identifier, issueIdentifier),
+            eq(issueDocuments.key, documentKey),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      if (!issueDocument) {
+        violations.push({
+          code: "invalid_dependency_target",
+          docKey,
+          message: `Dependency target issue document does not exist: ${dep.target}`,
+        });
+      }
+    }
+
+    return violations;
+  }
+
+  return {
+    parseGovernanceFrontmatter(body: string): ParsedSeoDocGovernanceMeta | null {
+      const record = parseGovernanceRecord(body);
+      if (!record) return null;
+
+      const owner = asString(record.owner);
+      const updateCadence = asString(record.update_cadence);
+      const lastUpdatedRaw = asString(record.last_updated);
+      const status = asString(record.status);
+      const documentClass = asString(record.document_class);
+      const criticality = asString(record.criticality);
+
+      if (!owner || !updateCadence || !lastUpdatedRaw || !status || !documentClass || !criticality) return null;
+      if (!isCadence(updateCadence) || !isDocStatus(status) || !isDocClass(documentClass)) return null;
+      if (criticality !== "normal" && criticality !== "critical") return null;
+      const lastUpdated = parseGovernanceDate(lastUpdatedRaw);
+      if (!lastUpdated) return null;
+
+      return {
+        owner,
+        lastUpdated,
+        updateCadence,
+        status,
+        dependencies: normalizeDependencies(record.dependencies),
+        documentClass,
+        criticality,
+      };
+    },
+
+    buildDocKey(issueIdentifier: string, issueDocumentKey: string): string {
+      return `${normalizeIssueIdentifier(issueIdentifier)}#document-${normalizeDocumentKey(issueDocumentKey)}`;
+    },
+
+    async syncRegistryEntryFromIssueDocument(input: {
+      issueId: string;
+      issueIdentifier: string;
+      issueDocumentKey: string;
+      title: string | null;
+      body: string;
+      now?: Date;
+    }): Promise<void> {
+      const record = parseGovernanceRecord(input.body);
+      if (!record) return;
+
+      const docKey = this.buildDocKey(input.issueIdentifier, input.issueDocumentKey);
+      if (!asString(record.owner)) throw buildValidationError("missing_owner", docKey);
+      if (!asString(record.update_cadence)) throw buildValidationError("missing_update_cadence", docKey);
+
+      const parsed = this.parseGovernanceFrontmatter(input.body);
+      if (!parsed) throw buildValidationError("missing_frontmatter", docKey);
+
+      const issueRow = await db
+        .select({ companyId: issues.companyId })
+        .from(issues)
+        .where(eq(issues.id, input.issueId))
+        .then((rows) => rows[0] ?? null);
+      if (!issueRow) return;
+
+      const now = input.now ?? new Date();
+      const issueLink = issuePathFromIdentifier(input.issueIdentifier);
+      const existing = await db
+        .select({ id: seoDocRegistryEntries.id, lastUpdated: seoDocRegistryEntries.lastUpdated })
+        .from(seoDocRegistryEntries)
+        .where(and(eq(seoDocRegistryEntries.companyId, issueRow.companyId), eq(seoDocRegistryEntries.docKey, docKey)))
+        .then((rows) => rows[0] ?? null);
+
+      if (existing) {
+        const shouldResetEscalation = parsed.lastUpdated.getTime() > existing.lastUpdated.getTime();
+        await db
+          .update(seoDocRegistryEntries)
+          .set({
+            issueId: input.issueId,
+            issueDocumentKey: normalizeDocumentKey(input.issueDocumentKey),
+            title: input.title ?? docKey,
+            issueLink,
+            owner: parsed.owner,
+            lastUpdated: parsed.lastUpdated,
+            updateCadence: parsed.updateCadence,
+            status: parsed.status,
+            dependencies: parsed.dependencies,
+            documentClass: parsed.documentClass,
+            criticality: parsed.criticality,
+            ...(shouldResetEscalation ? { lastEscalatedAt: null } : {}),
+            updatedAt: now,
+          })
+          .where(eq(seoDocRegistryEntries.id, existing.id));
+        return;
+      }
+
+      await db.insert(seoDocRegistryEntries).values({
+        companyId: issueRow.companyId,
+        docKey,
+        issueId: input.issueId,
+        issueDocumentKey: normalizeDocumentKey(input.issueDocumentKey),
+        title: input.title ?? docKey,
+        issueLink,
+        owner: parsed.owner,
+        lastUpdated: parsed.lastUpdated,
+        updateCadence: parsed.updateCadence,
+        status: parsed.status,
+        dependencies: parsed.dependencies,
+        documentClass: parsed.documentClass,
+        criticality: parsed.criticality,
+        lastAuditedAt: null,
+        lastEscalatedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    },
+
+    async validateRegistryEntry(companyId: string, docKey: string): Promise<SeoDocViolation[]> {
+      const entry = await db
+        .select()
+        .from(seoDocRegistryEntries)
+        .where(and(eq(seoDocRegistryEntries.companyId, companyId), eq(seoDocRegistryEntries.docKey, docKey)))
+        .then((rows) => rows[0] ?? null);
+      if (!entry) return [];
+
+      const violations: SeoDocViolation[] = [];
+      const linkedDocument = await db
+        .select({ body: documents.latestBody, format: documents.format })
+        .from(issueDocuments)
+        .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+        .where(and(eq(issueDocuments.issueId, entry.issueId), eq(issueDocuments.key, entry.issueDocumentKey)))
+        .then((rows) => rows[0] ?? null);
+
+      if (!linkedDocument || linkedDocument.format !== "markdown" || !parseGovernanceRecord(linkedDocument.body)) {
+        violations.push({
+          code: "missing_frontmatter",
+          docKey,
+          message: "Governed document is missing seo_governance frontmatter",
+        });
+      }
+
+      const dependencies = (entry.dependencies ?? []) as SeoDocDependencyRef[];
+      violations.push(...(await validateDependencies(companyId, docKey, dependencies)));
+
+      if (
+        entry.documentClass === "implementation" &&
+        !dependencies.some((dep) => dep.role === "source_strategy" && dep.type === "issue_document")
+      ) {
+        violations.push({
+          code: "implementation_missing_source_strategy",
+          docKey,
+          message: "Implementation document must include a source_strategy dependency",
+        });
+      }
+
+      if (
+        entry.documentClass === "strategy" &&
+        !dependencies.some((dep) => dep.role === "implementation_handoff" && dep.type === "issue")
+      ) {
+        violations.push({
+          code: "strategy_missing_handoff_issue",
+          docKey,
+          message: "Strategy document must include an implementation_handoff dependency",
+        });
+      }
+
+      return violations;
+    },
+
+    async auditCompany(companyId: string, now?: Date): Promise<SeoDocAuditResult> {
+      const auditNow = now ?? new Date();
+      const rows = await db
+        .select()
+        .from(seoDocRegistryEntries)
+        .where(eq(seoDocRegistryEntries.companyId, companyId));
+
+      const result: SeoDocAuditResult = {
+        scanned: rows.length,
+        staleDocKeys: [],
+        escalatedDocKeys: [],
+        violations: [],
+      };
+
+      for (const row of rows) {
+        const nextStatus: SeoDocStatus = row.status === "deprecated"
+          ? "deprecated"
+          : isStale({ updateCadence: row.updateCadence as SeoDocCadence, lastUpdated: row.lastUpdated }, auditNow)
+            ? "stale"
+            : "active";
+
+        result.violations.push(...(await this.validateRegistryEntry(companyId, row.docKey)));
+        if (nextStatus === "stale") result.staleDocKeys.push(row.docKey);
+
+        await db
+          .update(seoDocRegistryEntries)
+          .set({
+            status: nextStatus,
+            lastAuditedAt: auditNow,
+            updatedAt: auditNow,
+          })
+          .where(eq(seoDocRegistryEntries.id, row.id));
+
+        const shouldEscalate =
+          nextStatus === "stale" &&
+          row.criticality === "critical" &&
+          row.status !== "deprecated" &&
+          (!row.lastEscalatedAt || row.lastEscalatedAt.getTime() < row.lastUpdated.getTime());
+
+        if (!shouldEscalate) continue;
+
+        try {
+          const cmoAgent = await findCompanyCmo(companyId);
+          if (!cmoAgent) {
+            log.warn({ companyId, docKey: row.docKey }, "failed to emit seo governance escalation comment: no CMO agent found");
+            continue;
+          }
+
+          const [comment] = await db.insert(issueComments).values({
+            companyId,
+            issueId: row.issueId,
+            authorType: "system",
+            body: escalationBody(row.docKey, `[@CMO](${buildAgentMentionHref(cmoAgent.id)})`),
+          }).returning({ id: issueComments.id });
+          await db.update(issues).set({ updatedAt: auditNow }).where(eq(issues.id, row.issueId));
+          await db
+            .update(seoDocRegistryEntries)
+            .set({
+              lastEscalatedAt: auditNow,
+              updatedAt: auditNow,
+            })
+            .where(eq(seoDocRegistryEntries.id, row.id));
+          result.escalatedDocKeys.push(row.docKey);
+          if (deps.enqueueWakeup) {
+            try {
+              const issueOwner = await db
+                .select({
+                  responsibleUserId: issues.responsibleUserId,
+                  createdByUserId: issues.createdByUserId,
+                })
+                .from(issues)
+                .where(eq(issues.id, row.issueId))
+                .then((issueRows) => issueRows[0] ?? null);
+              const responsibleUserId = issueOwner?.responsibleUserId ?? issueOwner?.createdByUserId ?? undefined;
+              await deps.enqueueWakeup(cmoAgent.id, {
+                source: "automation",
+                triggerDetail: "system",
+                reason: "issue_comment_mentioned",
+                payload: {
+                  issueId: row.issueId,
+                  commentId: comment.id,
+                },
+                requestedByActorType: "system",
+                contextSnapshot: {
+                  issueId: row.issueId,
+                  taskId: row.issueId,
+                  commentId: comment.id,
+                  wakeCommentId: comment.id,
+                  wakeReason: "issue_comment_mentioned",
+                  source: "comment.mention",
+                  ...(responsibleUserId ? { responsibleUserId } : {}),
+                },
+              });
+            } catch (error) {
+              log.warn(
+                { err: error, docKey: row.docKey, issueId: row.issueId },
+                "failed to enqueue seo governance escalation wakeup",
+              );
+            }
+          }
+        } catch (error) {
+          log.warn({ err: error, docKey: row.docKey }, "failed to emit seo governance escalation comment");
+        }
+      }
+
+      return result;
+    },
+
+    async seedFromIssueIdentifiers(companyId: string, identifiers: string[]): Promise<{ synced: number }> {
+      let synced = 0;
+
+      for (const rawIdentifier of identifiers) {
+        const identifier = normalizeIssueIdentifier(rawIdentifier);
+        const issue = await db
+          .select({ id: issues.id, identifier: issues.identifier })
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), eq(issues.identifier, identifier)))
+          .then((rows) => rows[0] ?? null);
+        if (!issue) continue;
+
+        const docs = await db
+          .select({
+            key: issueDocuments.key,
+            title: documents.title,
+            body: documents.latestBody,
+            format: documents.format,
+          })
+          .from(issueDocuments)
+          .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+          .where(eq(issueDocuments.issueId, issue.id));
+
+        for (const doc of docs) {
+          if (doc.format !== "markdown") continue;
+          const docKey = this.buildDocKey(identifier, doc.key);
+          const before = await db
+            .select({ id: seoDocRegistryEntries.id })
+            .from(seoDocRegistryEntries)
+            .where(and(eq(seoDocRegistryEntries.companyId, companyId), eq(seoDocRegistryEntries.docKey, docKey)))
+            .then((rows) => rows[0] ?? null);
+
+          try {
+            await this.syncRegistryEntryFromIssueDocument({
+              issueId: issue.id,
+              issueIdentifier: issue.identifier ?? identifier,
+              issueDocumentKey: doc.key,
+              title: doc.title,
+              body: doc.body,
+            });
+          } catch {
+            continue;
+          }
+
+          const after = await db
+            .select({ id: seoDocRegistryEntries.id })
+            .from(seoDocRegistryEntries)
+            .where(and(eq(seoDocRegistryEntries.companyId, companyId), eq(seoDocRegistryEntries.docKey, docKey)))
+            .then((rows) => rows[0] ?? null);
+
+          if (!before && after) synced += 1;
+        }
+      }
+
+      return { synced };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- restore the locked SEO document registry and lifecycle metadata flow
- add staleness/dependency validation, CMO escalation, scheduler wiring, and migrations
- include service, scheduler, and route coverage

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- route suite: 1 passed
- embedded-Postgres suites skipped because this environment reports embedded Postgres unsupported

Refs INS-646