### PR TITLE
fix(issues): deduplicate legacy child creates

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1714,6 +1714,7 @@ export {
   createIssueSchema,
   createIssueInputSchema,
   createChildIssueSchema,
+  createChildIssueWithDuplicateGuardSchema,
   createAcceptedPlanDecompositionSchema,
   resolveCreateIssueStatusDefault,
   createIssueLabelSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -401,6 +401,7 @@ export {
   createIssueSchema,
   createIssueInputSchema,
   createChildIssueSchema,
+  createChildIssueWithDuplicateGuardSchema,
   createAcceptedPlanDecompositionSchema,
   resolveCreateIssueStatusDefault,
   createIssueLabelSchema,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -520,7 +520,7 @@ export const upsertIssueWatchdogSchema = z.object({
 
 export type UpsertIssueWatchdog = z.infer<typeof upsertIssueWatchdogSchema>;
 
-export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBaseSchema
+const createChildIssueBaseSchema = createIssueBaseSchema
   .omit({
     parentId: true,
     inheritExecutionWorkspaceFromIssueId: true,
@@ -529,7 +529,14 @@ export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBa
   .extend({
     acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
     blockParentUntilDone: z.boolean().optional().default(false),
-  })).superRefine(requireBlockedStatusForUnblockDescriptor);
+  });
+
+export const createChildIssueSchema = withCreateIssueStatusDefault(createChildIssueBaseSchema)
+  .superRefine(requireBlockedStatusForUnblockDescriptor);
+
+export const createChildIssueWithDuplicateGuardSchema = withCreateIssueStatusDefault(
+  createChildIssueBaseSchema.extend(createIssueDuplicateGuardSchema),
+).superRefine(requireBlockedStatusForUnblockDescriptor);
 
 export type CreateChildIssue = z.infer<typeof createChildIssueSchema>;
 

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -211,6 +211,43 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     });
   });
 
+  it("deduplicates legacy child creates without replaying child side effects", async () => {
+    const companyId = await seedCompany();
+    const parent = await seedParent(companyId);
+    const app = createApp();
+
+    const first = await request(app)
+      .post(`/api/issues/${parent.id}/children`)
+      .send({ title: "Prepare child release", idempotencyKey: "run-3:child-release" })
+      .expect(201);
+    const replay = await request(app)
+      .post(`/api/issues/${parent.id}/children`)
+      .send({
+        title: "Different retry payload",
+        idempotencyKey: "run-3:child-release",
+        allowDuplicate: true,
+      })
+      .expect(200);
+    const titleDuplicate = await request(app)
+      .post(`/api/issues/${parent.id}/children`)
+      .send({ title: "  prepare CHILD release  " })
+      .expect(200);
+
+    expect(replay.body).toMatchObject({
+      id: first.body.id,
+      deduplicated: true,
+      deduplicationReason: "idempotency_key",
+    });
+    expect(titleDuplicate.body).toMatchObject({
+      id: first.body.id,
+      deduplicated: true,
+      deduplicationReason: "recent_open_title",
+    });
+    expect(await db.select().from(issues).where(eq(issues.parentId, parent.id))).toHaveLength(1);
+    expect(await db.select().from(activityLog).where(eq(activityLog.action, "issue.child_created")))
+      .toHaveLength(1);
+  });
+
   it("allows an explicit duplicate create", async () => {
     const companyId = await seedCompany();
     const parent = await seedParent(companyId);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -42,7 +42,7 @@ import {
   checkoutIssueSchema,
   createDocumentAnnotationCommentSchema,
   createDocumentAnnotationThreadSchema,
-  createChildIssueSchema,
+  createChildIssueWithDuplicateGuardSchema,
   createIssueSchema,
   resolveCreateIssueStatusDefault,
   resolveIssueRecoveryActionSchema,
@@ -8180,7 +8180,7 @@ export function issueRoutes(
     });
   });
 
-  router.post("/issues/:id/children", applyCreateIssueStatusDefault, validate(createChildIssueSchema), async (req, res) => {
+  router.post("/issues/:id/children", applyCreateIssueStatusDefault, validate(createChildIssueWithDuplicateGuardSchema), async (req, res) => {
     const parentId = req.params.id as string;
     const parent = await getAccessibleResource(req, res, svc.getById(parentId), "Parent issue not found");
     if (!parent) return;
@@ -8237,7 +8237,7 @@ export function issueRoutes(
       projectId: createBody.projectId ?? parent.projectId ?? null,
       executionPolicy,
     }, actor);
-    const { issue, parentBlockerAdded } = await svc.createChild(parent.id, {
+    const { issue, parentBlockerAdded, deduplicationReason } = await svc.createChild(parent.id, {
       ...createBody,
       ...(taskBridgeOriginForActor(req) ?? {}),
       id: issueId,
@@ -8258,6 +8258,14 @@ export function issueRoutes(
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
       watchdogActorRunId: actor.runId,
     });
+    if (deduplicationReason) {
+      res.status(200).json({
+        ...issue,
+        deduplicated: true,
+        deduplicationReason,
+      });
+      return;
+    }
     await externalObjectsSvc.syncIssueSafely(issue.id);
 
     await logActivity(db, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6548,6 +6548,30 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
       if (!parent) throw notFound("Parent issue not found");
 
+      const idempotencyKey = data.idempotencyKey?.trim() || null;
+      if (idempotencyKey) {
+        const retentionCutoff = new Date(Date.now() - ISSUE_CREATE_IDEMPOTENCY_KEY_RETENTION_MS);
+        const existingIssue = await db
+          .select({ issue: issues })
+          .from(issueCreateIdempotencyKeys)
+          .innerJoin(issues, eq(issueCreateIdempotencyKeys.issueId, issues.id))
+          .where(and(
+            eq(issueCreateIdempotencyKeys.companyId, parent.companyId),
+            eq(issueCreateIdempotencyKeys.idempotencyKey, idempotencyKey),
+            gte(issueCreateIdempotencyKeys.createdAt, retentionCutoff),
+          ))
+          .limit(1)
+          .then((rows) => rows[0]?.issue ?? null);
+        if (existingIssue) {
+          data.onDeduplicated?.("idempotency_key");
+          return {
+            issue: existingIssue,
+            parentBlockerAdded: false,
+            deduplicationReason: "idempotency_key" as const,
+          };
+        }
+      }
+
       const [{ childCount }] = await db
         .select({ childCount: sql<number>`count(*)::int` })
         .from(issues)
@@ -6573,8 +6597,14 @@ export function issueService(db: Db) {
         inheritStrategyOnly && !hasExplicitExecutionWorkspaceOverride
           ? buildPreRealizationExecutionWorkspaceSettings(parent.executionWorkspaceSettings)
           : null;
+      let deduplicationReason: "idempotency_key" | "recent_open_title" | null = null;
+      const onDeduplicated = issueData.onDeduplicated;
       let child = await issueService(db).create(parent.companyId, {
         ...issueData,
+        onDeduplicated: (reason) => {
+          deduplicationReason = reason;
+          onDeduplicated?.(reason);
+        },
         parentId: parent.id,
         projectId: issueData.projectId ?? parent.projectId,
         projectWorkspaceId: issueData.projectWorkspaceId ?? (inheritStrategyOnly ? parent.projectWorkspaceId : undefined),
@@ -6593,6 +6623,10 @@ export function issueService(db: Db) {
           : { inheritExecutionWorkspaceFromIssueId: parent.id }),
       });
 
+      if (deduplicationReason) {
+        return { issue: child, parentBlockerAdded: false, deduplicationReason };
+      }
+
       if (blockParentUntilDone) {
         const existingBlockers = await db
           .select({ blockerIssueId: issueRelations.issueId })
@@ -6610,6 +6644,7 @@ export function issueService(db: Db) {
       return {
         issue: child,
         parentBlockerAdded: Boolean(blockParentUntilDone),
+        deduplicationReason: null,
       };
     },
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and issue trees.
> - Agents can create child issues through a legacy helper route.
> - The canonical issue-create route already prevents duplicate retries.
> - The legacy child route drops those duplicate controls.
> - Fan-in and retries can therefore create duplicate cards and replay side effects.
> - This pull request applies the existing duplicate contract only to that legacy route.
> - The benefit is one canonical child and one set of side effects for one logical request.

## Linked Issues or Issue Description

- Refs #9650. That merged work protects the canonical create route.
- Refs #8356. That older overlapping pull request is stale and conflicting.
- The remaining bug is limited to `POST /api/issues/:id/children`, which does not accept or forward the canonical duplicate controls.

## What Changed

- Add a route-specific child schema with `idempotencyKey` and `allowDuplicate`.
- Keep the accepted-plan child schema unchanged.
- Forward the duplicate controls through `createChild()`.
- Replay retained idempotency keys before the maximum-child guard.
- Return the canonical issue with `200` and the duplicate reason.
- Stop before external sync, child-created activity, assignment wake, watchdog work, and parent-blocker side effects on replay.
- Add a route regression for keyed replay and normalized recent-title deduplication.
- Verify that only one child and one `issue.child_created` activity exist.

## Verification

- RED: the legacy child replay returned `201` and created a second child before the fix
- `pnpm --filter @paperclipai/shared build`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-create-deduplication-routes.test.ts` — 9/9 passed
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- A reused idempotency key returns its original company-scoped issue, matching the canonical route.
- Recent-title protection now applies by default on the legacy child route. Clients can set `allowDuplicate: true` for intentional duplicate titles.
- Accepted-plan decomposition behavior remains unchanged through a separate schema.
- The service exits before replayed side effects.

## Model Used

- OpenAI Codex `gpt-5.6-sol` through Hermes Agent, with reasoning, tool use, code execution, and an independent exact-diff review agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used
- [x] I have checked `ROADMAP.md` and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked public related PRs and described the residual bug
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation change is required for this route fix
- [x] I have considered and documented the risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open findings
- [x] I will address all Greptile and reviewer comments before requesting merge
