### PR TITLE
fix(adapter-codex-local): add gpt-5.5 to model list

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -33,6 +33,7 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 }
 
 export const models = [
+  { id: "gpt-5.5", label: "gpt-5.5" },
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
   { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -7,7 +7,7 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @openai/codex";
 
 export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.3-codex";
 export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = true;
-export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = ["gpt-5.4"] as const;
+export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = ["gpt-5.4", "gpt-5.5"] as const;
 
 function normalizeModelId(model: string | null | undefined): string {
   return typeof model === "string" ? model.trim() : "";
@@ -70,7 +70,7 @@ Core fields:
 - modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...
 - promptTemplate (string, optional): run prompt template
 - search (boolean, optional): run codex with --search
-- fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and passed through for manual model IDs
+- fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and GPT-5.5 and passed through for manual model IDs
 - dangerouslyBypassApprovalsAndSandbox (boolean, optional): run with bypass flag
 - command (string, optional): defaults to "codex"
 - extraArgs (string[], optional): additional CLI args

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -26,6 +26,28 @@ describe("buildCodexExecArgs", () => {
     ]);
   });
 
+  it("enables Codex fast mode overrides for GPT-5.5", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.5",
+      fastMode: true,
+    });
+
+    expect(result.fastModeRequested).toBe(true);
+    expect(result.fastModeApplied).toBe(true);
+    expect(result.fastModeIgnoredReason).toBeNull();
+    expect(result.args).toEqual([
+      "exec",
+      "--json",
+      "--model",
+      "gpt-5.5",
+      "-c",
+      'service_tier="fast"',
+      "-c",
+      "features.fast_mode=true",
+      "-",
+    ]);
+  });
+
   it("enables Codex fast mode overrides for manual models", () => {
     const result = buildCodexExecArgs({
       model: "manual-test-model",
@@ -57,7 +79,7 @@ describe("buildCodexExecArgs", () => {
     expect(result.fastModeRequested).toBe(true);
     expect(result.fastModeApplied).toBe(false);
     expect(result.fastModeIgnoredReason).toContain(
-      "currently only supported on gpt-5.4 or manually configured model IDs",
+      "currently only supported on gpt-5.4, gpt-5.5 or manually configured model IDs",
     );
     expect(result.args).toEqual([
       "exec",

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -28,7 +28,7 @@ describe("buildCodexExecArgs", () => {
 
   it("enables Codex fast mode overrides for manual models", () => {
     const result = buildCodexExecArgs({
-      model: "gpt-5.5",
+      model: "manual-test-model",
       fastMode: true,
     });
 
@@ -39,7 +39,7 @@ describe("buildCodexExecArgs", () => {
       "exec",
       "--json",
       "--model",
-      "gpt-5.5",
+      "manual-test-model",
       "-c",
       'service_tier="fast"',
       "-c",


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Codex local adapter lets a Codex CLI agent pick a local model for its work.
> - The adapter's model picker uses a static list. The list did not include `gpt-5.5`.
> - A user could already select `gpt-5.5` in the Codex CLI, but not in the Codex plugin's local model picker. That is a gap.
> - Earlier work (PR #8396) added `gpt-5.5` to the fast-mode-supported list for messaging purposes, but did not add it to the selectable `models` array itself.
> - This pull request adds `gpt-5.5` to the selectable `models` array and to `CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS`, so the model is both pickable and gets correct fast-mode behavior instead of falling back to manual-model handling.
> - The benefit is that users can select `gpt-5.5` in the Codex plugin local model picker, with fast mode working correctly.

## Linked Issues or Issue Description

No public GitHub issue exists for this. Describing the problem here, per the bug report template:

- **Bug**: Codex plugin local model picker did not list `gpt-5.5` as a selectable model, even though the Codex CLI already supports it.
- **Expected behavior**: `gpt-5.5` appears in the Codex plugin's local model picker and can be selected.
- **Actual behavior**: `gpt-5.5` was missing from the static `models` array in `packages/adapters/codex-local/src/index.ts`, so it could not be selected.
- **Related, not duplicate**: PR #8396 ("Prevent gpt-5.5 fallback for codex_local") touches the same file and already added `gpt-5.5` to `CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS` for fallback-warning messaging, but does not add `gpt-5.5` to the selectable `models` array. Searched open PRs for `gpt-5.5 codex` before opening this one; no other PR adds the model-list entry.

## What Changed

- Add `{ id: "gpt-5.5", label: "gpt-5.5" }` to the top of the `models` array in `packages/adapters/codex-local/src/index.ts`, so it is selectable in the Codex plugin's local model picker.
- Add `gpt-5.5` to `CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS`, so the supported-model list (not the manual-model fallback) drives fast-mode behavior for it.
- Update `agentConfigurationDoc` to mention GPT-5.5 alongside GPT-5.4.
- Add a Vitest case covering `gpt-5.5` fast mode, and update the unsupported-model `fastModeIgnoredReason` expectation to use an unregistered model id.

## Verification

- `pnpm --filter @paperclip/adapter-codex-local test` — includes the new and updated Vitest cases in `packages/adapters/codex-local/src/server/codex-args.test.ts`.
- Manual: select `gpt-5.5` in the Codex plugin local model picker and confirm the selection round-trips through to the Codex CLI invocation.

## Risks

Low risk. This is an additive change to a static list and a supported-models set; it does not remove or rename any existing entries, and does not change behavior for any model other than `gpt-5.5`.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), extended thinking off, agent/tool-use mode, standard context window. PR opened and CI driven by the same agent. The underlying code change was originally authored with Claude Opus 4.7 per the branch's commit trailer.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
