### PR TITLE
docs(cli): document workspace archive command

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -959,9 +959,12 @@ npx paperclipai workspace get <execution-workspace-id>
 npx paperclipai workspace close-readiness <execution-workspace-id>
 npx paperclipai workspace operations <execution-workspace-id>
 npx paperclipai workspace update <execution-workspace-id> --payload-json '{...}'
+npx paperclipai workspace update <execution-workspace-id> --payload-json '{"status":"archived"}'
 npx paperclipai workspace runtime-service <execution-workspace-id> start --payload-json '{...}'
 npx paperclipai workspace runtime-command <execution-workspace-id> run --payload-json '{...}'
 ```
+
+Before archiving an execution workspace, run `workspace close-readiness`. Archive it only when `state` is `ready` or `ready_with_warnings`; a `blocked` state makes the update return `409`. Archiving is the supported manual lifecycle close. It stops runtime services and performs allowed workspace cleanup.
 
 ```sh
 npx paperclipai environment list --company-id <company-id>

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -964,7 +964,7 @@ npx paperclipai workspace runtime-service <execution-workspace-id> start --paylo
 npx paperclipai workspace runtime-command <execution-workspace-id> run --payload-json '{...}'
 ```
 
-Before archiving an execution workspace, run `workspace close-readiness`. Archive it only when `state` is `ready` or `ready_with_warnings`; a `blocked` state makes the update return `409`. Archiving is the supported manual lifecycle close. It stops runtime services and performs allowed workspace cleanup.
+Before archiving an execution workspace, run `workspace close-readiness`. Archive it only when `state` is `ready` or `ready_with_warnings`; a `blocked` state makes the update return `409`. Archiving is the supported manual lifecycle close. It stops runtime services and performs allowed workspace cleanup. If cleanup reports an unsuccessful result while the workspace remains closed, the workspace gets status `cleanup_failed` and the update can still return successfully. If cleanup throws, the update returns `500`.
 
 ```sh
 npx paperclipai environment list --company-id <company-id>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Execution workspaces are durable resources that operators may need to close manually
> - Paperclip already provides a readiness check and an archive transition through the generic workspace update command
> - The CLI guide lists both commands but does not show the archive payload or explain the required order
> - This pull request documents the existing manual archive workflow and its blocked-state response
> - The benefit is that operators can close stale or completed workspaces without reading server route source

## Linked Issues or Issue Description

Fixes #10509.

Related but not duplicate: #7790, #5620, and #6965 cover automatic workspace closure or reaping. This pull request only documents the existing manual CLI workflow.

Duplicate search found no open pull request for #10509 or the workspace archive CLI documentation gap.

## What Changed

- Added the exact `workspace update` payload that archives an execution workspace.
- Documented the `close-readiness` states and the `409` response for blocked workspaces.
- Clarified that cleanup failures return `500` after the workspace is closed with status `cleanup_failed`.

## Verification

- `CI=true corepack pnpm --filter paperclipai exec vitest run src/__tests__/operations-parity.test.ts -t 'wraps org, execution workspace, environment, and project workspace endpoints' --reporter verbose`
- `git diff --check origin/master...HEAD`
- Confirmed that `workspace update` sends `PATCH /api/execution-workspaces/:id`, `archived` is a valid workspace status, and the route rejects blocked readiness with `409`.

## Risks

Low risk. This change updates one CLI documentation file. It does not change CLI or server behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex (GPT-5 Codex), operating in Codex desktop with repository file access, shell validation, and GitHub CLI workflow. The exact backend model ID, context window size, and reasoning mode are not surfaced by this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
