### PR TITLE
fix(claude-local): always pass --max-turns with 200-turn floor default

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -849,7 +849,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--model", model);
     }
     if (effectiveEffort) args.push("--effort", effectiveEffort);
-    if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
+    // Always pass --max-turns to avoid relying on the CLI default (which can be as low as 8).
+    // When the agent config omits maxTurnsPerRun (value 0), use 200 as a safe fleet-wide floor.
+    args.push("--max-turns", String(maxTurns > 0 ? maxTurns : 200));
     // On resumed sessions the instructions are already in the session cache;
     // re-injecting them via --append-system-prompt-file wastes 5-10K tokens
     // per heartbeat and the Claude CLI may reject the combination outright.


### PR DESCRIPTION
## Summary
- Fleet-wide runs were aborting with `error_max_turns: Reached maximum number of turns (8)` for agents without an explicit `maxTurnsPerRun` set.
- `execute.ts` only added `--max-turns` to the Claude CLI args when `maxTurnsPerRun > 0`; when omitted (0), no flag was passed at all, so the CLI fell back to its own internal default, which resolves to 8 on affected CLI versions.
- Now the adapter always passes `--max-turns`, using the configured value or a 200-turn floor when unset.

## Test plan
- [ ] Restart affected agents and confirm no new `max_turns_exhausted` failures appear in `heartbeat_runs` after this deploys.
- [ ] Spot-check an agent without `maxTurnsPerRun` configured to verify `--max-turns 200` is now passed.

Ref: RENA-52919