### PR TITLE
fix(claude-local): resolve Bedrock models by region so built-in agents provision outside US

### DIFF
--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -2,7 +2,9 @@ export { claudeSessionCwdMatchesExecutionTarget, execute, runClaudeLogin } from 
 export * from "./acp.js";
 export { getConfigSchema } from "./config-schema.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
+export type { BedrockEnv } from "./models.js";
 export {
+  configuredAwsRegion,
   isBedrockModelId,
   isBedrockModelUsableInConfiguredRegion,
   listClaudeModels,

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -2,7 +2,12 @@ export { claudeSessionCwdMatchesExecutionTarget, execute, runClaudeLogin } from 
 export * from "./acp.js";
 export { getConfigSchema } from "./config-schema.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
-export { listClaudeModels, refreshClaudeModels, resetClaudeModelsCacheForTests } from "./models.js";
+export {
+  isBedrockModelId,
+  listClaudeModels,
+  refreshClaudeModels,
+  resetClaudeModelsCacheForTests,
+} from "./models.js";
 export { testEnvironment } from "./test.js";
 export {
   claudeCommandSupportsEffortFlag,

--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -4,6 +4,7 @@ export { getConfigSchema } from "./config-schema.js";
 export { listClaudeSkills, syncClaudeSkills } from "./skills.js";
 export {
   isBedrockModelId,
+  isBedrockModelUsableInConfiguredRegion,
   listClaudeModels,
   refreshClaudeModels,
   resetClaudeModelsCacheForTests,

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -85,11 +85,41 @@ const BEDROCK_REGION_FAMILY_BY_REGION: Record<string, BedrockRegionFamily> = {
   "ap-northeast-1": "jp",
 };
 
+/**
+ * Regions that publish each family's profiles. This table decides whether to *reject* a model ID an
+ * operator typed, so it is deliberately wider than BEDROCK_MODELS_BY_FAMILY, which lists only IDs
+ * verified ACTIVE. `apac` appears here but not in the catalogue: its profiles exist, and are too old
+ * to serve a bundled default.
+ */
+const BEDROCK_FAMILY_REGION_PREFIXES: Record<string, readonly string[]> = {
+  us: ["us-"],
+  eu: ["eu-"],
+  au: ["ap-southeast-2", "ap-southeast-4"],
+  jp: ["ap-northeast-1", "ap-northeast-3"],
+  apac: ["ap-"],
+};
+
+function configuredAwsRegion(): string {
+  return (process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "").toLowerCase();
+}
+
+let warnedAboutMissingRegion = false;
+
 function resolveBedrockRegionFamily(): BedrockRegionFamily {
-  const region = (process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "")
-    .toLowerCase();
-  // No configured region: keep the previous default rather than guess.
-  if (!region) return "us";
+  const region = configuredAwsRegion();
+  // No configured region: keep the previous default rather than guess. Say so once, because the
+  // default is silent otherwise, and it offers US profiles to an operator who may have no US access.
+  if (!region) {
+    if (!warnedAboutMissingRegion) {
+      warnedAboutMissingRegion = true;
+      console.warn(
+        "[paperclip] Bedrock is enabled and no AWS_REGION or AWS_DEFAULT_REGION is set. " +
+          "Offering us.anthropic.* inference profiles, which only work from a us-* region. " +
+          "Set AWS_REGION if your Bedrock access is elsewhere.",
+      );
+    }
+    return "us";
+  }
   const mapped = BEDROCK_REGION_FAMILY_BY_REGION[region];
   if (mapped) return mapped;
   if (region.startsWith("us-")) return "us";
@@ -240,10 +270,37 @@ export async function refreshClaudeModels(): Promise<AdapterModel[]> {
 
 export function resetClaudeModelsCacheForTests() {
   cached = null;
+  warnedAboutMissingRegion = false;
 }
 
 /** Check whether a model ID is a Bedrock-native identifier (not an Anthropic API short name). */
 /** Bedrock model IDs use region-qualified prefixes (e.g. us.anthropic.*, eu.anthropic.*) or ARNs. */
 export function isBedrockModelId(model: string): boolean {
   return /^\w+\.anthropic\./.test(model) || model.startsWith("arn:aws:bedrock:");
+}
+
+/**
+ * Check whether a Bedrock model ID can resolve in the configured region. Bedrock does not accept an
+ * inference profile from another region family, so a `us.` profile configured in an EU-only
+ * deployment fails at run time. This lets setup reject it earlier, while the operator is still there
+ * to read the message.
+ *
+ * An ID is only rejected when this process knows the target region. A server that does not itself run
+ * Bedrock can still store setup for a worker that does, and that worker's region is not visible here,
+ * so such an ID is accepted. A family that is absent from the table above is also accepted, because
+ * an unknown family cannot be shown to be wrong.
+ */
+export function isBedrockModelUsableInConfiguredRegion(model: string): boolean {
+  if (!isBedrockModelId(model)) return false;
+  // A profile ARN names its own region, and the operator wrote that region out in full.
+  if (model.startsWith("arn:aws:bedrock:")) return true;
+  if (!isBedrockEnv()) return true;
+  const region = configuredAwsRegion();
+  if (!region) return true;
+  const family = /^([a-z0-9-]+)\.anthropic\./.exec(model.toLowerCase())?.[1];
+  // `global.` profiles are published in every region checked.
+  if (!family || family === "global") return true;
+  const prefixes = BEDROCK_FAMILY_REGION_PREFIXES[family];
+  if (!prefixes) return true;
+  return prefixes.some((prefix) => region.startsWith(prefix));
 }

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -7,14 +7,48 @@ const ANTHROPIC_MODELS_TIMEOUT_MS = 5000;
 const ANTHROPIC_MODELS_CACHE_TTL_MS = 60_000;
 const ANTHROPIC_API_VERSION = "2023-06-01";
 
-/** AWS Bedrock model IDs — region-qualified identifiers required by the Bedrock API. */
-const BEDROCK_MODELS: AdapterModel[] = [
-  { id: "us.anthropic.claude-opus-4-8-v1", label: "Bedrock Opus 4.8" },
-  { id: "us.anthropic.claude-fable-5-v1", label: "Bedrock Fable 5" },
-  { id: "us.anthropic.claude-opus-4-6-v1", label: "Bedrock Opus 4.6" },
-  { id: "us.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
-  { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
-];
+/**
+ * AWS Bedrock model IDs — region-qualified identifiers required by the Bedrock API.
+ *
+ * Inference-profile IDs are prefixed by region family, and the families are not a simple
+ * prefix swap: version suffixes diverge (Sonnet 4.5 is `-v2:0` under `us`, `-v1:0` under `eu`),
+ * so each family is listed explicitly rather than derived.
+ *
+ * Only families with verified profile IDs are listed. Unrecognised regions fall back to `us`,
+ * which preserves the previous behaviour.
+ */
+type BedrockRegionFamily = "us" | "eu";
+
+const BEDROCK_MODELS_BY_FAMILY: Record<BedrockRegionFamily, AdapterModel[]> = {
+  us: [
+    { id: "us.anthropic.claude-opus-4-8-v1", label: "Bedrock Opus 4.8" },
+    { id: "us.anthropic.claude-fable-5-v1", label: "Bedrock Fable 5" },
+    { id: "us.anthropic.claude-opus-4-6-v1", label: "Bedrock Opus 4.6" },
+    { id: "us.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
+    { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
+  ],
+  // Verified ACTIVE via `aws bedrock list-inference-profiles --region eu-west-1` (2026-07-31).
+  eu: [
+    { id: "eu.anthropic.claude-opus-5", label: "Bedrock Opus 5" },
+    { id: "eu.anthropic.claude-sonnet-5", label: "Bedrock Sonnet 5" },
+    { id: "eu.anthropic.claude-opus-4-8", label: "Bedrock Opus 4.8" },
+    { id: "eu.anthropic.claude-opus-4-7", label: "Bedrock Opus 4.7" },
+    { id: "eu.anthropic.claude-sonnet-4-6", label: "Bedrock Sonnet 4.6" },
+    { id: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Bedrock Sonnet 4.5" },
+    { id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
+  ],
+};
+
+function resolveBedrockRegionFamily(): BedrockRegionFamily {
+  const region = (process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "")
+    .toLowerCase();
+  if (region.startsWith("eu-")) return "eu";
+  return "us";
+}
+
+function bedrockModelsForRegion(): AdapterModel[] {
+  return BEDROCK_MODELS_BY_FAMILY[resolveBedrockRegionFamily()];
+}
 
 let cached: { keyFingerprint: string; baseUrl: string; expiresAt: number; models: AdapterModel[] } | null = null;
 
@@ -102,7 +136,7 @@ async function fetchAnthropicModels(apiKey: string, baseUrl: string): Promise<Ad
 }
 
 async function loadClaudeModels(options?: { forceRefresh?: boolean }): Promise<AdapterModel[]> {
-  if (isBedrockEnv()) return dedupeModels(BEDROCK_MODELS);
+  if (isBedrockEnv()) return dedupeModels(bedrockModelsForRegion());
 
   const fallback = dedupeModels(DIRECT_MODELS);
   const apiKey = resolveAnthropicApiKey();

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -12,12 +12,17 @@ const ANTHROPIC_API_VERSION = "2023-06-01";
  *
  * Inference-profile IDs are prefixed by region family, and the families are not a simple
  * prefix swap: version suffixes diverge (Sonnet 4.5 is `-v2:0` under `us`, `-v1:0` under `eu`),
- * so each family is listed explicitly rather than derived.
+ * and a family does not always carry the same models (`jp` has no Opus 5 profile). Each family
+ * is therefore listed explicitly rather than derived.
  *
- * Only families with verified profile IDs are listed. Unrecognised regions fall back to `us`,
- * which preserves the previous behaviour.
+ * A family's profiles are only offered in the regions that publish them: `us.` profiles do not
+ * exist outside `us-*`, so they cannot serve as a general fallback. `global.` profiles are
+ * published in every region checked, so unrecognised regions fall back to `global` instead.
+ *
+ * Every ID below was verified ACTIVE on 2026-07-31 with
+ * `aws bedrock list-inference-profiles --region <region>`.
  */
-type BedrockRegionFamily = "us" | "eu";
+type BedrockRegionFamily = "us" | "eu" | "au" | "jp" | "global";
 
 const BEDROCK_MODELS_BY_FAMILY: Record<BedrockRegionFamily, AdapterModel[]> = {
   us: [
@@ -27,7 +32,7 @@ const BEDROCK_MODELS_BY_FAMILY: Record<BedrockRegionFamily, AdapterModel[]> = {
     { id: "us.anthropic.claude-sonnet-4-5-20250929-v2:0", label: "Bedrock Sonnet 4.5" },
     { id: "us.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
   ],
-  // Verified ACTIVE via `aws bedrock list-inference-profiles --region eu-west-1` (2026-07-31).
+  // eu-west-1.
   eu: [
     { id: "eu.anthropic.claude-opus-5", label: "Bedrock Opus 5" },
     { id: "eu.anthropic.claude-sonnet-5", label: "Bedrock Sonnet 5" },
@@ -37,13 +42,59 @@ const BEDROCK_MODELS_BY_FAMILY: Record<BedrockRegionFamily, AdapterModel[]> = {
     { id: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Bedrock Sonnet 4.5" },
     { id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
   ],
+  // ap-southeast-2. The `apac.` family only carries Claude 3.x-era profiles, so Australian
+  // regions use `au.` for anything current.
+  au: [
+    { id: "au.anthropic.claude-opus-5", label: "Bedrock Opus 5" },
+    { id: "au.anthropic.claude-sonnet-5", label: "Bedrock Sonnet 5" },
+    { id: "au.anthropic.claude-opus-4-8", label: "Bedrock Opus 4.8" },
+    { id: "au.anthropic.claude-opus-4-7", label: "Bedrock Opus 4.7" },
+    { id: "au.anthropic.claude-sonnet-4-6", label: "Bedrock Sonnet 4.6" },
+    { id: "au.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Bedrock Sonnet 4.5" },
+    { id: "au.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
+  ],
+  // ap-northeast-1. This family publishes no Opus 5 or Sonnet 5 profile.
+  jp: [
+    { id: "jp.anthropic.claude-opus-4-8", label: "Bedrock Opus 4.8" },
+    { id: "jp.anthropic.claude-opus-4-7", label: "Bedrock Opus 4.7" },
+    { id: "jp.anthropic.claude-sonnet-4-6", label: "Bedrock Sonnet 4.6" },
+    { id: "jp.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Bedrock Sonnet 4.5" },
+    { id: "jp.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5" },
+  ],
+  // Verified in us-east-1, eu-west-1, ap-southeast-1, ap-southeast-2 and ap-northeast-1.
+  // These profiles can route a request to any region, so they are a fallback rather than a
+  // default: a region with its own family keeps that family, which respects data residency.
+  global: [
+    { id: "global.anthropic.claude-opus-5", label: "Bedrock Opus 5 (global)" },
+    { id: "global.anthropic.claude-sonnet-5", label: "Bedrock Sonnet 5 (global)" },
+    { id: "global.anthropic.claude-fable-5", label: "Bedrock Fable 5 (global)" },
+    { id: "global.anthropic.claude-opus-4-8", label: "Bedrock Opus 4.8 (global)" },
+    { id: "global.anthropic.claude-opus-4-7", label: "Bedrock Opus 4.7 (global)" },
+    { id: "global.anthropic.claude-sonnet-4-6", label: "Bedrock Sonnet 4.6 (global)" },
+    { id: "global.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Bedrock Sonnet 4.5 (global)" },
+    { id: "global.anthropic.claude-haiku-4-5-20251001-v1:0", label: "Bedrock Haiku 4.5 (global)" },
+  ],
+};
+
+/**
+ * Regions whose residency-specific family is not implied by the region prefix. Only regions with
+ * verified profile IDs are listed; any other `ap-*` region falls back to `global`.
+ */
+const BEDROCK_REGION_FAMILY_BY_REGION: Record<string, BedrockRegionFamily> = {
+  "ap-southeast-2": "au",
+  "ap-northeast-1": "jp",
 };
 
 function resolveBedrockRegionFamily(): BedrockRegionFamily {
   const region = (process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "")
     .toLowerCase();
+  // No configured region: keep the previous default rather than guess.
+  if (!region) return "us";
+  const mapped = BEDROCK_REGION_FAMILY_BY_REGION[region];
+  if (mapped) return mapped;
+  if (region.startsWith("us-")) return "us";
   if (region.startsWith("eu-")) return "eu";
-  return "us";
+  return "global";
 }
 
 function bedrockModelsForRegion(): AdapterModel[] {

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -99,8 +99,10 @@ const BEDROCK_FAMILY_REGION_PREFIXES: Record<string, readonly string[]> = {
   apac: ["ap-"],
 };
 
-function configuredAwsRegion(): string {
-  return (process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "").toLowerCase();
+export type BedrockEnv = Record<string, string | undefined>;
+
+export function configuredAwsRegion(env: BedrockEnv = process.env): string {
+  return (env.AWS_REGION?.trim() || env.AWS_DEFAULT_REGION?.trim() || "").toLowerCase();
 }
 
 let warnedAboutMissingRegion = false;
@@ -133,12 +135,12 @@ function bedrockModelsForRegion(): AdapterModel[] {
 
 let cached: { keyFingerprint: string; baseUrl: string; expiresAt: number; models: AdapterModel[] } | null = null;
 
-function isBedrockEnv(): boolean {
+function isBedrockEnv(env: BedrockEnv = process.env): boolean {
   return (
-    process.env.CLAUDE_CODE_USE_BEDROCK === "1" ||
-    process.env.CLAUDE_CODE_USE_BEDROCK === "true" ||
-    (typeof process.env.ANTHROPIC_BEDROCK_BASE_URL === "string" &&
-      process.env.ANTHROPIC_BEDROCK_BASE_URL.trim().length > 0)
+    env.CLAUDE_CODE_USE_BEDROCK === "1" ||
+    env.CLAUDE_CODE_USE_BEDROCK === "true" ||
+    (typeof env.ANTHROPIC_BEDROCK_BASE_URL === "string" &&
+      env.ANTHROPIC_BEDROCK_BASE_URL.trim().length > 0)
   );
 }
 
@@ -280,22 +282,26 @@ export function isBedrockModelId(model: string): boolean {
 }
 
 /**
- * Check whether a Bedrock model ID can resolve in the configured region. Bedrock does not accept an
- * inference profile from another region family, so a `us.` profile configured in an EU-only
+ * Check whether a Bedrock model ID can resolve in the region `env` configures. Bedrock does not
+ * accept an inference profile from another region family, so a `us.` profile configured in an EU-only
  * deployment fails at run time. This lets setup reject it earlier, while the operator is still there
  * to read the message.
  *
- * An ID is only rejected when this process knows the target region. A server that does not itself run
+ * Pass the environment the model will run under, not this process's. An agent's `adapterConfig.env`
+ * overlays `process.env` at execution, so it can name a different region, and it is the one that
+ * decides whether the profile resolves.
+ *
+ * An ID is only rejected when `env` names the target region. A server that does not itself run
  * Bedrock can still store setup for a worker that does, and that worker's region is not visible here,
  * so such an ID is accepted. A family that is absent from the table above is also accepted, because
  * an unknown family cannot be shown to be wrong.
  */
-export function isBedrockModelUsableInConfiguredRegion(model: string): boolean {
+export function isBedrockModelUsableInConfiguredRegion(model: string, env: BedrockEnv = process.env): boolean {
   if (!isBedrockModelId(model)) return false;
   // A profile ARN names its own region, and the operator wrote that region out in full.
   if (model.startsWith("arn:aws:bedrock:")) return true;
-  if (!isBedrockEnv()) return true;
-  const region = configuredAwsRegion();
+  if (!isBedrockEnv(env)) return true;
+  const region = configuredAwsRegion(env);
   if (!region) return true;
   const family = /^([a-z0-9-]+)\.anthropic\./.exec(model.toLowerCase())?.[1];
   // `global.` profiles are published in every region checked.

--- a/packages/adapters/claude-local/src/server/models.ts
+++ b/packages/adapters/claude-local/src/server/models.ts
@@ -282,6 +282,20 @@ export function isBedrockModelId(model: string): boolean {
 }
 
 /**
+ * Read the region out of a Bedrock ARN, which is its fourth colon-separated field. Returns the empty
+ * string for an ARN with no region, and `null` when the value is not a Bedrock ARN at all, so a
+ * caller can tell "no region named" apart from "not an ARN".
+ */
+function bedrockArnRegion(model: string): string | null {
+  const lower = model.toLowerCase();
+  if (!lower.startsWith("arn:")) return null;
+  const fields = lower.split(":");
+  // arn : partition : service : region : account : resource
+  if (fields.length < 6 || fields[2] !== "bedrock") return null;
+  return fields[3] ?? "";
+}
+
+/**
  * Check whether a Bedrock model ID can resolve in the region `env` configures. Bedrock does not
  * accept an inference profile from another region family, so a `us.` profile configured in an EU-only
  * deployment fails at run time. This lets setup reject it earlier, while the operator is still there
@@ -298,11 +312,14 @@ export function isBedrockModelId(model: string): boolean {
  */
 export function isBedrockModelUsableInConfiguredRegion(model: string, env: BedrockEnv = process.env): boolean {
   if (!isBedrockModelId(model)) return false;
-  // A profile ARN names its own region, and the operator wrote that region out in full.
-  if (model.startsWith("arn:aws:bedrock:")) return true;
   if (!isBedrockEnv(env)) return true;
   const region = configuredAwsRegion(env);
   if (!region) return true;
+  // An ARN names its own region, so a mismatch is visible here. Bedrock resolves a profile against
+  // the endpoint of the configured region, so an ARN from another region does not resolve, however
+  // fully the operator wrote it out.
+  const arnRegion = bedrockArnRegion(model);
+  if (arnRegion !== null) return arnRegion === "" || arnRegion === region;
   const family = /^([a-z0-9-]+)\.anthropic\./.exec(model.toLowerCase())?.[1];
   // `global.` profiles are published in every region checked.
   if (!family || family === "global") return true;

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -23,6 +23,8 @@ describe("adapter model listing", () => {
     delete process.env.ANTHROPIC_BASE_URL;
     delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
     resetClaudeModelsCacheForTests();
     resetCodexModelsCacheForTests();
@@ -71,6 +73,40 @@ describe("adapter model listing", () => {
     // Opus 5 is a current GA flagship and must be offered even when live discovery is unavailable.
     expect(models.some((model) => model.id === "claude-opus-5")).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("offers us-prefixed Bedrock inference profiles in a us region", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+
+    const models = await listAdapterModels("claude_local");
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.every((model) => model.id.startsWith("us.anthropic."))).toBe(true);
+  });
+
+  it("offers eu-prefixed Bedrock inference profiles in an eu region", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "eu-west-1";
+
+    const models = await listAdapterModels("claude_local");
+
+    expect(models.length).toBeGreaterThan(0);
+    // Every offered profile must exist in the configured region, so none may be us-prefixed.
+    expect(models.some((model) => model.id.startsWith("us.anthropic."))).toBe(false);
+    expect(models.every((model) => model.id.startsWith("eu.anthropic."))).toBe(true);
+    expect(models.some((model) => model.id === "eu.anthropic.claude-sonnet-5")).toBe(true);
+    // Version suffixes diverge between families: Sonnet 4.5 is -v1:0 in eu, -v2:0 in us,
+    // so a prefix rewrite of the us catalogue would produce an invalid id here.
+    expect(models.some((model) => model.id === "eu.anthropic.claude-sonnet-4-5-20250929-v1:0")).toBe(true);
+  });
+
+  it("falls back to the us Bedrock catalogue when no region is configured", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+
+    const models = await listAdapterModels("claude_local");
+
+    expect(models.every((model) => model.id.startsWith("us.anthropic."))).toBe(true);
   });
 
   it("loads claude models dynamically and merges fallback options", async () => {

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -198,6 +198,22 @@ describe("adapter model listing", () => {
       expect(isBedrockModelUsableInConfiguredRegion("claude-sonnet-5")).toBe(false);
     });
 
+    it("judges an explicit env instead of process.env", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+
+      // An agent's adapterConfig.env overlays process.env at execution, so the caller passes the
+      // environment the model will run under.
+      const agentEnv = { ...process.env, AWS_REGION: "eu-west-1" };
+      expect(isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5", agentEnv)).toBe(true);
+      expect(isBedrockModelUsableInConfiguredRegion("us.anthropic.claude-opus-4-6-v1", agentEnv)).toBe(false);
+
+      // An env that turns Bedrock off carries no region evidence at all.
+      expect(
+        isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5", { AWS_REGION: "us-east-1" }),
+      ).toBe(true);
+    });
+
     it("reads AWS_DEFAULT_REGION when AWS_REGION is unset", () => {
       process.env.CLAUDE_CODE_USE_BEDROCK = "1";
       process.env.AWS_DEFAULT_REGION = "eu-west-1";

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -109,6 +109,38 @@ describe("adapter model listing", () => {
     expect(models.every((model) => model.id.startsWith("us.anthropic."))).toBe(true);
   });
 
+  it("offers residency-specific profiles in regions that publish their own family", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "ap-southeast-2";
+
+    const sydney = await listAdapterModels("claude_local");
+
+    expect(sydney.length).toBeGreaterThan(0);
+    expect(sydney.every((model) => model.id.startsWith("au.anthropic."))).toBe(true);
+
+    process.env.AWS_REGION = "ap-northeast-1";
+    resetClaudeModelsCacheForTests();
+    const tokyo = await listAdapterModels("claude_local");
+
+    expect(tokyo.length).toBeGreaterThan(0);
+    expect(tokyo.every((model) => model.id.startsWith("jp.anthropic."))).toBe(true);
+  });
+
+  it("falls back to global profiles in a configured region with no verified family", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    // Singapore publishes no current residency-specific family: `apac.` carries only Claude 3.x
+    // profiles, and us-prefixed profiles do not exist there at all.
+    process.env.AWS_REGION = "ap-southeast-1";
+
+    const models = await listAdapterModels("claude_local");
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((model) => model.id.startsWith("us.anthropic."))).toBe(false);
+    expect(models.every((model) => model.id.startsWith("global.anthropic."))).toBe(true);
+    // The bundled Summarizer default must be resolvable here, or onboarding still fails.
+    expect(models.some((model) => model.id.includes("claude-haiku-4-5"))).toBe(true);
+  });
+
   it("loads claude models dynamically and merges fallback options", async () => {
     process.env.ANTHROPIC_API_KEY = "sk-ant-test";
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -165,15 +165,40 @@ describe("adapter model listing", () => {
       expect(isBedrockModelUsableInConfiguredRegion("apac.anthropic.claude-sonnet-4-20250514-v1:0")).toBe(true);
     });
 
-    it("accepts global profiles and ARNs in any region", () => {
+    it("accepts global profiles in any region", () => {
       process.env.CLAUDE_CODE_USE_BEDROCK = "1";
       process.env.AWS_REGION = "us-east-1";
 
-      // `global.` profiles are published in every region checked, and an ARN names its own region.
+      // `global.` profiles are published in every region checked.
       expect(isBedrockModelUsableInConfiguredRegion("global.anthropic.claude-sonnet-5")).toBe(true);
+    });
+
+    it("compares an ARN's own region against the configured one", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+
+      // Bedrock resolves a profile against the endpoint of the configured region, so an ARN from
+      // another region does not resolve however fully the operator wrote it out.
       expect(
         isBedrockModelUsableInConfiguredRegion(
           "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123",
+        ),
+      ).toBe(false);
+      expect(
+        isBedrockModelUsableInConfiguredRegion(
+          "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+        ),
+      ).toBe(true);
+      // Case in an ARN is not significant to this comparison.
+      expect(
+        isBedrockModelUsableInConfiguredRegion(
+          "arn:aws:bedrock:US-EAST-1:123456789012:application-inference-profile/abc123",
+        ),
+      ).toBe(true);
+      // An ARN with no region names no region to disagree with.
+      expect(
+        isBedrockModelUsableInConfiguredRegion(
+          "arn:aws:bedrock::123456789012:application-inference-profile/abc123",
         ),
       ).toBe(true);
     });

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models as claudeFallbackModels } from "@paperclipai/adapter-claude-local";
-import { resetClaudeModelsCacheForTests } from "@paperclipai/adapter-claude-local/server";
+import {
+  isBedrockModelUsableInConfiguredRegion,
+  resetClaudeModelsCacheForTests,
+} from "@paperclipai/adapter-claude-local/server";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
 import { models as opencodeFallbackModels } from "@paperclipai/adapter-opencode-local";
@@ -139,6 +142,69 @@ describe("adapter model listing", () => {
     expect(models.every((model) => model.id.startsWith("global.anthropic."))).toBe(true);
     // The bundled Summarizer default must be resolvable here, or onboarding still fails.
     expect(models.some((model) => model.id.includes("claude-haiku-4-5"))).toBe(true);
+  });
+
+  describe("Bedrock profile region check", () => {
+    it("rejects a profile from a family the configured region does not publish", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+
+      expect(isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5")).toBe(false);
+      expect(isBedrockModelUsableInConfiguredRegion("au.anthropic.claude-sonnet-5")).toBe(false);
+      expect(isBedrockModelUsableInConfiguredRegion("jp.anthropic.claude-opus-4-8")).toBe(false);
+    });
+
+    it("accepts a profile from the configured region's own family", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "eu-west-1";
+      expect(isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5")).toBe(true);
+
+      process.env.AWS_REGION = "ap-southeast-2";
+      expect(isBedrockModelUsableInConfiguredRegion("au.anthropic.claude-sonnet-5")).toBe(true);
+      // Sydney also publishes the older `apac.` profiles.
+      expect(isBedrockModelUsableInConfiguredRegion("apac.anthropic.claude-sonnet-4-20250514-v1:0")).toBe(true);
+    });
+
+    it("accepts global profiles and ARNs in any region", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+
+      // `global.` profiles are published in every region checked, and an ARN names its own region.
+      expect(isBedrockModelUsableInConfiguredRegion("global.anthropic.claude-sonnet-5")).toBe(true);
+      expect(
+        isBedrockModelUsableInConfiguredRegion(
+          "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123",
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts any profile when this process has no region evidence", () => {
+      // No Bedrock env: this server may be storing setup for a worker whose region is unknown here.
+      process.env.AWS_REGION = "us-east-1";
+      expect(isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5")).toBe(true);
+
+      // Bedrock env, but no configured region to compare against.
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      delete process.env.AWS_REGION;
+      expect(isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5")).toBe(true);
+    });
+
+    it("accepts an unrecognised family and rejects a non-Bedrock id", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+
+      // A family this build does not know about cannot be shown to be wrong.
+      expect(isBedrockModelUsableInConfiguredRegion("mx.anthropic.claude-sonnet-5")).toBe(true);
+      expect(isBedrockModelUsableInConfiguredRegion("claude-sonnet-5")).toBe(false);
+    });
+
+    it("reads AWS_DEFAULT_REGION when AWS_REGION is unset", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_DEFAULT_REGION = "eu-west-1";
+
+      expect(isBedrockModelUsableInConfiguredRegion("eu.anthropic.claude-sonnet-5")).toBe(true);
+      expect(isBedrockModelUsableInConfiguredRegion("us.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe(false);
+    });
   });
 
   it("loads claude models dynamically and merges fallback options", async () => {

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -457,7 +457,8 @@ describeEmbeddedPostgres("built-in agents", () => {
     const companyId = await seedCompany();
 
     // Bedrock inference-profile ids are region-scoped, so no static list can contain them all.
-    // The execution path accepts any region-qualified id, and setup must not be stricter.
+    // The execution path accepts any region-qualified id, and setup must not be stricter. This
+    // server runs no Bedrock env, so it cannot know the region the agent will run in.
     const state = await builtInAgentService(db).ensure(companyId, "summarizer", {
       adapterType: "claude_local",
       adapterConfig: { model: "eu.anthropic.claude-sonnet-5" },
@@ -468,6 +469,52 @@ describeEmbeddedPostgres("built-in agents", () => {
     const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
     expect(rows).toHaveLength(1);
     expect(rows[0]?.adapterConfig).toMatchObject({ model: "eu.anthropic.claude-sonnet-5" });
+  });
+
+  it("rejects a Bedrock profile from a region family the configured region does not publish", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+    const companyId = await seedCompany();
+
+    // Bedrock cannot resolve an `eu.` profile from a US region. Rejecting it here gives the
+    // operator the error while they are still in setup, instead of at the agent's first run.
+    await expect(builtInAgentService(db).ensure(companyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: { model: "eu.anthropic.claude-sonnet-5" },
+    })).rejects.toMatchObject({
+      status: 422,
+      details: {
+        code: "built_in_agent_model_region_mismatch",
+        adapterType: "claude_local",
+        model: "eu.anthropic.claude-sonnet-5",
+        region: "us-east-1",
+      },
+    });
+
+    const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("accepts Bedrock ids that the configured region cannot rule out", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+
+    // A matching family, a `global.` profile published everywhere, and a full ARN naming its own
+    // region are all usable from us-east-1. Only a provable mismatch is rejected.
+    const accepted = [
+      "us.anthropic.claude-sonnet-4-5-20250929-v2:0",
+      "global.anthropic.claude-sonnet-5",
+      "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123",
+    ];
+
+    for (const model of accepted) {
+      const companyId = await seedCompany();
+      const state = await builtInAgentService(db).ensure(companyId, "summarizer", {
+        adapterType: "claude_local",
+        adapterConfig: { model },
+      });
+      expect(state.agent?.adapterConfig, model).toMatchObject({ model });
+    }
   });
 
   it("maps a bundled default alias onto a region-qualified Bedrock profile", async () => {

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -485,6 +485,25 @@ describeEmbeddedPostgres("built-in agents", () => {
     });
   });
 
+  it("stores the resolved Bedrock profile on a board-approval pending row", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "eu-west-1";
+    const companyId = await seedCompany({ requireApproval: true });
+
+    // A pending row must carry the profile that will run once the board approves the hire.
+    // Storing the unresolved "claude-haiku-4-5" alias would leave the approved agent without a
+    // usable model, and the failure would only appear at run time.
+    const result = await builtInAgentService(db).provision(companyId, "summarizer");
+
+    expect(result.state.status).toBe("pending_approval");
+    const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe("pending_approval");
+    expect(rows[0]?.adapterConfig).toMatchObject({
+      model: "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    });
+  });
+
   it("recovers an orphaned marked row instead of creating a duplicate", async () => {
     const companyId = await seedCompany();
     const orphanId = randomUUID();

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -495,6 +495,40 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(rows).toHaveLength(0);
   });
 
+  it("judges the region from the agent's own env, not the server's", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+    const service = builtInAgentService(db);
+
+    // The claude_local execution path spreads adapterConfig.env over process.env, so this agent runs
+    // in eu-west-1 whatever the server is set to. Its eu. profile must be accepted, even though the
+    // server's own region would reject it, and even though the offered catalogue lists us. ids.
+    const euCompanyId = await seedCompany();
+    const state = await service.ensure(euCompanyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "eu.anthropic.claude-sonnet-5",
+        env: { AWS_REGION: "eu-west-1" },
+      },
+    });
+    expect(state.agent?.adapterConfig).toMatchObject({ model: "eu.anthropic.claude-sonnet-5" });
+
+    // The same override rejects a us. profile that the server's region would have accepted.
+    const usCompanyId = await seedCompany();
+    await expect(service.ensure(usCompanyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        env: { AWS_REGION: "eu-west-1" },
+      },
+    })).rejects.toMatchObject({
+      status: 422,
+      details: { code: "built_in_agent_model_region_mismatch", region: "eu-west-1" },
+    });
+
+    expect(await db.select().from(agents).where(eq(agents.companyId, usCompanyId))).toHaveLength(0);
+  });
+
   it("accepts Bedrock ids that the configured region cannot rule out", async () => {
     process.env.CLAUDE_CODE_USE_BEDROCK = "1";
     process.env.AWS_REGION = "us-east-1";

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -13,6 +13,11 @@ import {
   builtInManagedResources,
   companies,
   companyMemberships,
+  companySecretBindings,
+  companySecretProposals,
+  companySecretProviderConfigs,
+  companySecretVersions,
+  companySecrets,
   companySkillVersions,
   companySkills,
   createDb,
@@ -21,6 +26,7 @@ import {
   principalPermissionGrants,
   routines,
   routineTriggers,
+  secretAccessEvents,
 } from "@paperclipai/db";
 import { readPaperclipSkillSyncPreference } from "@paperclipai/adapter-utils/server-utils";
 import {
@@ -40,6 +46,7 @@ import {
 } from "../services/built-in-agents.ts";
 import { readBuiltInAgentMarker, withBuiltInAgentMarker } from "../services/built-in-agent-metadata.ts";
 import { issueThreadInteractionService } from "../services/issue-thread-interactions.ts";
+import { secretService } from "../services/secrets.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -146,6 +153,16 @@ describeEmbeddedPostgres("built-in agents", () => {
     await db.delete(approvals);
     await db.delete(agents);
     await db.delete(budgetPolicies);
+    // Tests that bind adapterConfig.env to a secret write these, and every one of them references a
+    // company, so the companies delete below fails on a foreign key without them. Deleted in
+    // dependency order: events and bindings and versions reference a secret, a secret references its
+    // provider config.
+    await db.delete(secretAccessEvents);
+    await db.delete(companySecretBindings);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecretProposals);
+    await db.delete(companySecrets);
+    await db.delete(companySecretProviderConfigs);
     await db.delete(companies);
     // Some tests drop the built-in marker unique index to simulate legacy
     // (pre-migration 0192) duplicates; restore it now that all rows are gone.
@@ -527,6 +544,91 @@ describeEmbeddedPostgres("built-in agents", () => {
     });
 
     expect(await db.select().from(agents).where(eq(agents.companyId, usCompanyId))).toHaveLength(0);
+  });
+
+  it("reads an inline env binding, not only a bare string", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+    const service = builtInAgentService(db);
+
+    // adapterConfig.env holds env bindings. A { type: "plain" } binding carries its value inline, so
+    // it decides the region exactly as a bare string does.
+    const okCompanyId = await seedCompany();
+    const state = await service.ensure(okCompanyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "eu.anthropic.claude-sonnet-5",
+        env: { AWS_REGION: { type: "plain", value: "eu-west-1" } },
+      },
+    });
+    expect(state.agent?.adapterConfig).toMatchObject({ model: "eu.anthropic.claude-sonnet-5" });
+
+    const badCompanyId = await seedCompany();
+    await expect(service.ensure(badCompanyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        env: { AWS_REGION: { type: "plain", value: "eu-west-1" } },
+      },
+    })).rejects.toMatchObject({
+      status: 422,
+      details: { code: "built_in_agent_model_region_mismatch", region: "eu-west-1" },
+    });
+
+    expect(await db.select().from(agents).where(eq(agents.companyId, badCompanyId))).toHaveLength(0);
+  });
+
+  it("does not judge the region when a secret decides it", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+    const service = builtInAgentService(db);
+
+    // Only the runtime resolves a secret binding, so this process cannot read the region the agent
+    // will run in. The server's own us-east-1 is not that region, so it must not be used to reject an
+    // eu. profile. Accept, on the same rule as any other case with no region evidence.
+    // A `user_secret_ref` takes the same branch, because anything that is not a string and not a
+    // `plain` binding carries no value here. It is not covered separately, because it needs a user
+    // secret declaration fixture to persist, and it exercises no different code.
+    const companyId = await seedCompany();
+    const secret = await secretService(db).create(companyId, {
+      name: `agent-region-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "eu-west-1",
+    });
+    const state = await service.ensure(companyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "eu.anthropic.claude-sonnet-5",
+        env: { AWS_REGION: { type: "secret_ref", secretId: secret.id } },
+      },
+    });
+    expect(state.agent?.adapterConfig).toMatchObject({ model: "eu.anthropic.claude-sonnet-5" });
+  });
+
+  it("does not fall back to the server region when a secret hides the agent's", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "eu-west-1";
+    const service = builtInAgentService(db);
+
+    // The server is in eu-west-1, which would reject a us. profile. The agent binds AWS_REGION to a
+    // secret, so the server's region is not the one that applies, and rejecting on it would block a
+    // profile that may well be correct.
+    const companyId = await seedCompany();
+    const secret = await secretService(db).create(companyId, {
+      name: `agent-region-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "us-east-1",
+    });
+    const state = await service.ensure(companyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: {
+        model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        env: { AWS_REGION: { type: "secret_ref", secretId: secret.id } },
+      },
+    });
+    expect(state.agent?.adapterConfig).toMatchObject({
+      model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    });
   });
 
   it("accepts Bedrock ids that the configured region cannot rule out", async () => {

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { and, eq, sql } from "drizzle-orm";
 import {
   activityLog,
@@ -121,6 +121,15 @@ describeEmbeddedPostgres("built-in agents", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-built-in-agents-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
+
+  // Keep the suite independent of the developer's AWS environment. These vars decide which model
+  // catalogue claude_local offers, and therefore how a bundled default model resolves.
+  beforeEach(() => {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+  });
 
   afterEach(async () => {
     await db.delete(routineTriggers);
@@ -444,6 +453,38 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(rows).toHaveLength(0);
   });
 
+  it("accepts a region-qualified Bedrock model that the static catalogue cannot enumerate", async () => {
+    const companyId = await seedCompany();
+
+    // Bedrock inference-profile ids are region-scoped, so no static list can contain them all.
+    // The execution path accepts any region-qualified id, and setup must not be stricter.
+    const state = await builtInAgentService(db).ensure(companyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: { model: "eu.anthropic.claude-sonnet-5" },
+    });
+
+    expect(state.agentId).toBeTruthy();
+
+    const rows = await db.select().from(agents).where(eq(agents.companyId, companyId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.adapterConfig).toMatchObject({ model: "eu.anthropic.claude-sonnet-5" });
+  });
+
+  it("maps a bundled default alias onto a region-qualified Bedrock profile", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "eu-west-1";
+    const companyId = await seedCompany();
+
+    // The Summarizer definition hardcodes the plain alias "claude-haiku-4-5", which does not exist
+    // as a Bedrock inference profile. Provisioning must resolve it, not reject it.
+    const state = await builtInAgentService(db).ensure(companyId, "summarizer");
+
+    expect(state.agent?.adapterType).toBe("claude_local");
+    expect(state.agent?.adapterConfig).toMatchObject({
+      model: "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+    });
+  });
+
   it("recovers an orphaned marked row instead of creating a duplicate", async () => {
     const companyId = await seedCompany();
     const orphanId = randomUUID();
@@ -642,7 +683,12 @@ describeEmbeddedPostgres("built-in agents", () => {
       "paperclipai/bundled/paperclip-operations/reflection-coach",
     );
 
-    const [routine] = await db.select().from(routines).where(eq(routines.companyId, companyId));
+    // The company can auto-provision more than one built-in with a routine, so scope the lookup
+    // to this agent. Selecting by company alone relies on unspecified row order.
+    const [routine] = await db
+      .select()
+      .from(routines)
+      .where(and(eq(routines.companyId, companyId), eq(routines.assigneeAgentId, state.agentId!)));
     expect(routine).toMatchObject({
       title: "Review recent agent trajectories for coaching proposals",
       status: "paused",
@@ -1154,7 +1200,12 @@ describeEmbeddedPostgres("built-in agents", () => {
     });
     expect(readPaperclipSkillSyncPreference(state.agent!.adapterConfig).desiredSkills).toContain(skill!.key);
 
-    const [routine] = await db.select().from(routines).where(eq(routines.companyId, companyId));
+    // The company can auto-provision more than one built-in with a routine, so scope the lookup
+    // to this agent. Selecting by company alone relies on unspecified row order.
+    const [routine] = await db
+      .select()
+      .from(routines)
+      .where(and(eq(routines.companyId, companyId), eq(routines.assigneeAgentId, state.agentId!)));
     expect(routine).toMatchObject({
       title: "Review recent agent trajectories for coaching proposals",
       status: "paused",

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -635,12 +635,12 @@ describeEmbeddedPostgres("built-in agents", () => {
     process.env.CLAUDE_CODE_USE_BEDROCK = "1";
     process.env.AWS_REGION = "us-east-1";
 
-    // A matching family, a `global.` profile published everywhere, and a full ARN naming its own
-    // region are all usable from us-east-1. Only a provable mismatch is rejected.
+    // A matching family, a `global.` profile published everywhere, and an ARN naming this very region
+    // are all usable from us-east-1. Only a provable mismatch is rejected.
     const accepted = [
       "us.anthropic.claude-sonnet-4-5-20250929-v2:0",
       "global.anthropic.claude-sonnet-5",
-      "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123",
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
     ];
 
     for (const model of accepted) {
@@ -651,6 +651,24 @@ describeEmbeddedPostgres("built-in agents", () => {
       });
       expect(state.agent?.adapterConfig, model).toMatchObject({ model });
     }
+  });
+
+  it("rejects an ARN from a region other than the configured one", async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+    process.env.AWS_REGION = "us-east-1";
+
+    // Bedrock resolves the profile against the configured region's endpoint, so a cross-region ARN
+    // fails at run time. Writing the region out in full does not make it reachable.
+    const companyId = await seedCompany();
+    await expect(builtInAgentService(db).ensure(companyId, "summarizer", {
+      adapterType: "claude_local",
+      adapterConfig: { model: "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile/abc123" },
+    })).rejects.toMatchObject({
+      status: 422,
+      details: { code: "built_in_agent_model_region_mismatch", region: "us-east-1" },
+    });
+
+    expect(await db.select().from(agents).where(eq(agents.companyId, companyId))).toHaveLength(0);
   });
 
   it("maps a bundled default alias onto a region-qualified Bedrock profile", async () => {

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -780,16 +780,45 @@ async function resolveBuiltInAgentProvisionInput(
   return { ...input, adapterConfig };
 }
 
-// The environment an agent will actually run under. The claude_local execution path spreads an
-// agent's `adapterConfig.env` over `process.env`, so an agent can name its own AWS region, and that
-// region is the one its model must resolve in.
-function adapterExecutionEnv(adapterConfig: unknown): BedrockEnv {
-  if (!isPlainRecord(adapterConfig) || !isPlainRecord(adapterConfig.env)) return process.env;
-  const overrides: BedrockEnv = {};
-  for (const [key, value] of Object.entries(adapterConfig.env)) {
-    if (typeof value === "string") overrides[key] = value;
+// Keys whose value decides which region a model must resolve in. If any of them is bound to a
+// secret, the effective region cannot be read at setup time, and the region check is skipped rather
+// than guessed.
+const REGION_DECIDING_ENV_KEYS: readonly string[] = [
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "ANTHROPIC_BEDROCK_BASE_URL",
+];
+
+// A bare string, and `{ type: "plain", value }`, carry their value inline. A `secret_ref` or a
+// `user_secret_ref` only names a secret, which the runtime resolves, so it has no value here.
+function inlineEnvBindingValue(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!isPlainRecord(value) || value.type !== "plain") return null;
+  return typeof value.value === "string" ? value.value : null;
+}
+
+// The environment an agent will actually run under. `resolveAdapterConfigForRuntime` resolves an
+// agent's `adapterConfig.env` bindings to strings, and the claude_local execution path then spreads
+// the result over `process.env`, so an agent can name its own AWS region, and that region is the one
+// its model must resolve in.
+//
+// The values here are env bindings, not plain strings, so an inline binding is read and a secret
+// binding is not. A secret binding also hides the server's value for that key, because the agent
+// replaces it at execution with something this process cannot see. `regionIsKnown` is false when
+// such a binding decides the region, so the caller can decline to judge it.
+function adapterExecutionEnv(adapterConfig: unknown): { env: BedrockEnv; regionIsKnown: boolean } {
+  if (!isPlainRecord(adapterConfig) || !isPlainRecord(adapterConfig.env)) {
+    return { env: process.env, regionIsKnown: true };
   }
-  return { ...process.env, ...overrides };
+  const overrides: BedrockEnv = {};
+  let regionIsKnown = true;
+  for (const [key, value] of Object.entries(adapterConfig.env)) {
+    const inline = inlineEnvBindingValue(value);
+    overrides[key] = inline ?? undefined;
+    if (inline === null && REGION_DECIDING_ENV_KEYS.includes(key)) regionIsKnown = false;
+  }
+  return { env: { ...process.env, ...overrides }, regionIsKnown };
 }
 
 async function assertKnownBuiltInAgentModel(
@@ -815,7 +844,10 @@ async function assertKnownBuiltInAgentModel(
   // environment, which the agent's own `env` overrides at execution, so a listed ID is not evidence
   // that the ID resolves where the agent will run.
   if (adapterType === "claude_local" && isBedrockModelId(model)) {
-    const executionEnv = adapterExecutionEnv(adapterConfig);
+    const { env: executionEnv, regionIsKnown } = adapterExecutionEnv(adapterConfig);
+    // A secret decides the region, so this process cannot tell whether the profile matches. Accept
+    // it, on the same rule as any other case with no region evidence.
+    if (!regionIsKnown) return;
     if (isBedrockModelUsableInConfiguredRegion(model, executionEnv)) return;
     const region = configuredAwsRegion(executionEnv);
     throw unprocessable(

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -761,6 +761,20 @@ async function resolveDefaultAdapterConfig(
   return { ...adapterConfig, model: equivalent.id };
 }
 
+// Fill in a definition's bundled default so the caller stores the same model that validation
+// accepted. Callers must not pass the result to the `input.adapterConfig !== undefined` checks that
+// decide whether an operator supplied adapter setup, because a bundled default is not operator input.
+async function resolveBuiltInAgentProvisionInput(
+  definition: BuiltInAgentDefinition,
+  input: BuiltInAgentProvisionInput,
+): Promise<BuiltInAgentProvisionInput> {
+  if (input.adapterConfig || !definition.defaultAdapterConfig) return input;
+  const adapterType = input.adapterType ?? defaultAdapterType(definition);
+  const adapterConfig = await resolveDefaultAdapterConfig(adapterType, definition.defaultAdapterConfig);
+  if (adapterConfig === definition.defaultAdapterConfig) return input;
+  return { ...input, adapterConfig };
+}
+
 async function assertKnownBuiltInAgentModel(
   definition: BuiltInAgentDefinition,
   input: BuiltInAgentProvisionInput,
@@ -1744,7 +1758,12 @@ export function builtInAgentService(db: Db) {
     if (!company.requireBoardApprovalForNewAgents) {
       return { state: await ensure(companyId, key, input), approval: null };
     }
-    await assertKnownBuiltInAgentModel(definition, input);
+    // Resolve a bundled default model before validating it, so the pending row stores the profile
+    // that will actually run once the board approves the hire. The unresolved `input` still drives
+    // the "did the operator supply adapter setup?" checks below, which must not see a filled-in
+    // default as operator input.
+    const resolvedInput = await resolveBuiltInAgentProvisionInput(definition, input);
+    await assertKnownBuiltInAgentModel(definition, resolvedInput);
 
     const existing = await findSingleAgent(companyId, definition);
     if (existing) {
@@ -1796,7 +1815,7 @@ export function builtInAgentService(db: Db) {
     let pending: Agent;
     try {
       pending = await agentSvc.create(companyId, {
-        ...definitionPatch(definition, input),
+        ...definitionPatch(definition, resolvedInput),
         status: "pending_approval",
         reportsTo,
         metadata: builtInMetadata(definition),

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -27,6 +27,7 @@ import {
   stockHash,
   type ManagedResourceStockStatus,
 } from "./managed-resource-drift.js";
+import { isBedrockModelId } from "@paperclipai/adapter-claude-local/server";
 
 export type BuiltInAgentStatus = "not_provisioned" | "pending_approval" | "needs_setup" | "ready" | "paused";
 
@@ -738,17 +739,47 @@ function definitionPatch(definition: BuiltInAgentDefinition, input: BuiltInAgent
   };
 }
 
+// A definition's bundled default model is a plain Anthropic alias (e.g. "claude-haiku-4-5").
+// Under Bedrock the adapter offers region-qualified inference-profile ids instead, which no static
+// default can name ahead of time. Map the alias onto the equivalent profile the adapter actually
+// offers rather than failing provisioning.
+async function resolveDefaultAdapterConfig(
+  adapterType: string | undefined,
+  adapterConfig: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (!adapterType) return adapterConfig;
+  const model = typeof adapterConfig.model === "string" ? adapterConfig.model.trim() : "";
+  if (!model) return adapterConfig;
+
+  const available = await listAdapterModels(adapterType);
+  if (available.length === 0 || available.some((candidate) => candidate.id === model)) {
+    return adapterConfig;
+  }
+
+  const equivalent = available.find((candidate) => candidate.id.includes(model));
+  if (!equivalent) return adapterConfig;
+  return { ...adapterConfig, model: equivalent.id };
+}
+
 async function assertKnownBuiltInAgentModel(
   definition: BuiltInAgentDefinition,
   input: BuiltInAgentProvisionInput,
 ) {
   const adapterType = input.adapterType ?? defaultAdapterType(definition);
-  const adapterConfig = input.adapterConfig ?? definition.defaultAdapterConfig ?? {};
+  const adapterConfig = input.adapterConfig
+    ?? (definition.defaultAdapterConfig
+      ? await resolveDefaultAdapterConfig(adapterType, definition.defaultAdapterConfig)
+      : {});
   const model = typeof adapterConfig.model === "string" ? adapterConfig.model.trim() : "";
   if (!model || !hasCompleteAdapterConfig(adapterType, adapterConfig)) return;
 
   const models = await listAdapterModels(adapterType);
   if (models.length === 0 || models.some((candidate) => candidate.id === model)) return;
+
+  // Bedrock model IDs are region-qualified inference profiles, and the static catalogue cannot
+  // enumerate every region. The execution path already accepts any region-qualified ID, so
+  // accept one here too instead of rejecting a model that would run fine.
+  if (adapterType === "claude_local" && isBedrockModelId(model)) return;
 
   throw unprocessable(`Model "${model}" is not available for adapter ${adapterType}.`, {
     code: "built_in_agent_model_unknown",
@@ -866,7 +897,9 @@ export function builtInAgentService(db: Db) {
       return {
         ...input,
         adapterType: definition.defaultAdapterType,
-        adapterConfig: definition.defaultAdapterConfig ? { ...definition.defaultAdapterConfig } : undefined,
+        adapterConfig: definition.defaultAdapterConfig
+          ? await resolveDefaultAdapterConfig(definition.defaultAdapterType, { ...definition.defaultAdapterConfig })
+          : undefined,
       };
     }
     if (!definition.bundle) return input;

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -27,7 +27,10 @@ import {
   stockHash,
   type ManagedResourceStockStatus,
 } from "./managed-resource-drift.js";
-import { isBedrockModelId } from "@paperclipai/adapter-claude-local/server";
+import {
+  isBedrockModelId,
+  isBedrockModelUsableInConfiguredRegion,
+} from "@paperclipai/adapter-claude-local/server";
 
 export type BuiltInAgentStatus = "not_provisioned" | "pending_approval" | "needs_setup" | "ready" | "paused";
 
@@ -791,9 +794,24 @@ async function assertKnownBuiltInAgentModel(
   if (models.length === 0 || models.some((candidate) => candidate.id === model)) return;
 
   // Bedrock model IDs are region-qualified inference profiles, and the static catalogue cannot
-  // enumerate every region. The execution path already accepts any region-qualified ID, so
-  // accept one here too instead of rejecting a model that would run fine.
-  if (adapterType === "claude_local" && isBedrockModelId(model)) return;
+  // enumerate every region. The execution path already accepts any region-qualified ID, so accept
+  // one here too instead of rejecting a model that would run fine. A profile from a region family
+  // that the configured region does not publish is still rejected, because Bedrock cannot resolve it.
+  if (adapterType === "claude_local" && isBedrockModelId(model)) {
+    if (isBedrockModelUsableInConfiguredRegion(model)) return;
+    const region = process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "";
+    throw unprocessable(
+      `Model "${model}" is a Bedrock inference profile for a different region, and this deployment uses ${region}.`,
+      {
+        code: "built_in_agent_model_region_mismatch",
+        key: definition.key,
+        adapterType,
+        model,
+        region,
+        availableModelIds: models.map((candidate) => candidate.id),
+      },
+    );
+  }
 
   throw unprocessable(`Model "${model}" is not available for adapter ${adapterType}.`, {
     code: "built_in_agent_model_unknown",

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -28,8 +28,10 @@ import {
   type ManagedResourceStockStatus,
 } from "./managed-resource-drift.js";
 import {
+  configuredAwsRegion,
   isBedrockModelId,
   isBedrockModelUsableInConfiguredRegion,
+  type BedrockEnv,
 } from "@paperclipai/adapter-claude-local/server";
 
 export type BuiltInAgentStatus = "not_provisioned" | "pending_approval" | "needs_setup" | "ready" | "paused";
@@ -778,6 +780,18 @@ async function resolveBuiltInAgentProvisionInput(
   return { ...input, adapterConfig };
 }
 
+// The environment an agent will actually run under. The claude_local execution path spreads an
+// agent's `adapterConfig.env` over `process.env`, so an agent can name its own AWS region, and that
+// region is the one its model must resolve in.
+function adapterExecutionEnv(adapterConfig: unknown): BedrockEnv {
+  if (!isPlainRecord(adapterConfig) || !isPlainRecord(adapterConfig.env)) return process.env;
+  const overrides: BedrockEnv = {};
+  for (const [key, value] of Object.entries(adapterConfig.env)) {
+    if (typeof value === "string") overrides[key] = value;
+  }
+  return { ...process.env, ...overrides };
+}
+
 async function assertKnownBuiltInAgentModel(
   definition: BuiltInAgentDefinition,
   input: BuiltInAgentProvisionInput,
@@ -791,17 +805,21 @@ async function assertKnownBuiltInAgentModel(
   if (!model || !hasCompleteAdapterConfig(adapterType, adapterConfig)) return;
 
   const models = await listAdapterModels(adapterType);
-  if (models.length === 0 || models.some((candidate) => candidate.id === model)) return;
 
   // Bedrock model IDs are region-qualified inference profiles, and the static catalogue cannot
   // enumerate every region. The execution path already accepts any region-qualified ID, so accept
-  // one here too instead of rejecting a model that would run fine. A profile from a region family
-  // that the configured region does not publish is still rejected, because Bedrock cannot resolve it.
+  // one here too instead of rejecting a model that would run fine. Only a profile from a region
+  // family that the effective region does not publish is rejected, because Bedrock cannot resolve it.
+  //
+  // The region is checked before the catalogue, not after. The catalogue is built from this process's
+  // environment, which the agent's own `env` overrides at execution, so a listed ID is not evidence
+  // that the ID resolves where the agent will run.
   if (adapterType === "claude_local" && isBedrockModelId(model)) {
-    if (isBedrockModelUsableInConfiguredRegion(model)) return;
-    const region = process.env.AWS_REGION?.trim() || process.env.AWS_DEFAULT_REGION?.trim() || "";
+    const executionEnv = adapterExecutionEnv(adapterConfig);
+    if (isBedrockModelUsableInConfiguredRegion(model, executionEnv)) return;
+    const region = configuredAwsRegion(executionEnv);
     throw unprocessable(
-      `Model "${model}" is a Bedrock inference profile for a different region, and this deployment uses ${region}.`,
+      `Model "${model}" is a Bedrock inference profile for a different region, and this agent runs in ${region}.`,
       {
         code: "built_in_agent_model_region_mismatch",
         key: definition.key,
@@ -812,6 +830,8 @@ async function assertKnownBuiltInAgentModel(
       },
     );
   }
+
+  if (models.length === 0 || models.some((candidate) => candidate.id === model)) return;
 
   throw unprocessable(`Model "${model}" is not available for adapter ${adapterType}.`, {
     code: "built_in_agent_model_unknown",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Each agent needs a model. The `claude_local` adapter supplies Claude models, and it can use AWS Bedrock when `CLAUDE_CODE_USE_BEDROCK=1` is set.
> - Bedrock does not accept a plain Anthropic model name. Bedrock needs a region-qualified inference profile id, for example `eu.anthropic.claude-haiku-4-5-20251001-v1:0`.
> - The adapter holds one hardcoded list of profile ids. Every id in that list starts with `us.`. The adapter never reads the configured AWS region.
> - Therefore, in an EU region the adapter offers only US profile ids. A user whose Bedrock access is EU-only cannot select a model that works.
> - The bundled built-in agents turn this into a hard stop. The Summarizer definition asks for the plain alias `claude-haiku-4-5`. Model validation rejects that alias, so onboarding fails with `Model "claude-haiku-4-5" is not available for adapter claude_local.`
> - This pull request selects the profile list by region family. It also maps a bundled plain alias onto a profile that the adapter really offers.
> - The benefit is that onboarding completes outside US regions. Behaviour in US regions does not change.

## Linked Issues or Issue Description

- Fixes: #10546
- Refs #10243 — the original report of the failing bundled defaults.
- Refs #10247 — open PR on the same code path. Please read the overlap note below.
- Refs #6101 — open PR that already proposed the same region-aware catalogue design. Please read the overlap note below.
- Refs #2412 — earlier, now closed, report about Bedrock inference profiles.

### Overlap with existing pull requests — please read before review

I found these two open pull requests after I wrote the change. I did not copy them. I am listing the overlap so that you can close this pull request if you prefer one of theirs.

**#6101 (opened 2026-05-16, currently `CONFLICTING`).** It uses the same design as this change: one profile list per region family, selected from the AWS region. It adds an `ANTHROPIC_BEDROCK_REGION` override that takes priority over `AWS_REGION`. That is a good idea, and this change does not include it. Tell me if you want it here.

Its `apac` family needs care, however. It lists `apac.anthropic.claude-sonnet-4-5-20250929-v1:0`, and I could not find that profile in `ap-southeast-1`, `ap-southeast-2` or `ap-northeast-1`. The `apac.` family appears to carry only Claude 3.x-era profiles. #6101 is also based on an older catalogue (3 models, Opus 4.6 era), and it does not fix built-in agent provisioning.

**#10247 (opened 2026-07-25).** It fixes the other half of the problem. It resolves a bundled default model against the models the adapter offers. It does not make the catalogue region-aware, so on `eu-west-1` it resolves the bundled alias to a `us.` profile id. That id is still not usable from an EU-only account. Its new test asserts the regex `^(?:eu|us|ap)\.anthropic\.claude-haiku-4-5-20251001-v1:0$`, which also passes when the id is the US one, so the test does not prove region correctness.

So neither open pull request fixes both halves, and both halves are needed to complete onboarding. If you prefer, take #6101 for the catalogue and #10247 for the resolution, and close this. I am happy either way. I can also rebase #6101's `apac` family and `ANTHROPIC_BEDROCK_REGION` override into this branch if you want one pull request instead of three.

## What Changed

- `packages/adapters/claude-local/src/server/models.ts` — replaced the single `BEDROCK_MODELS` list with `BEDROCK_MODELS_BY_FAMILY`, which holds `us`, `eu`, `au`, `jp` and `global` families. Added `resolveBedrockRegionFamily()`, which reads `AWS_REGION` and then `AWS_DEFAULT_REGION`. The `us` family keeps the 5 existing ids without change, and an empty region still selects `us`, so current behaviour is preserved.
- A family's ids are not a prefix swap of another family's ids. Sonnet 4.5 is `-v2:0` under `us` but `-v1:0` under `eu`, and the `jp` family publishes no Opus 5 profile. Each family is therefore listed in full. I verified every id as `ACTIVE` with `aws bedrock list-inference-profiles`, in `us-east-1`, `eu-west-1`, `ap-southeast-1`, `ap-southeast-2` and `ap-northeast-1`.
- An unrecognised region falls back to `global`, not to `us`. `us.` profiles are not published outside `us-*`, so a `us` fallback cannot work anywhere else. `global.` profiles are published in every region I checked. A region that publishes its own family keeps that family, so data residency is preserved where it exists. There is no `apac` family, because `apac.` carries only Claude 3.x-era profiles and cannot serve the bundled Haiku 4.5 default.
- `packages/adapters/claude-local/src/server/index.ts` — also export `isBedrockModelId`, which the server needs.
- `server/src/services/built-in-agents.ts` — added `resolveDefaultAdapterConfig()`. When a bundled default names a model that the adapter does not offer, and one offered id contains that name, the offered id is used. `assertKnownBuiltInAgentModel()` now resolves the default before it validates, and it accepts a region-qualified Bedrock id for `claude_local`. The execution path already accepts such an id, so validation no longer rejects a model that would run.
- `server/src/services/built-in-agents.ts` — board-approved provisioning now stores the resolved profile. `provision()` previously validated a resolved model but created the pending row from the unresolved input, so an approved agent kept a plain alias that Bedrock cannot run. `resolveBuiltInAgentProvisionInput()` resolves the bundled default once, and both validation and the stored row use that result. The unresolved input still drives the checks that decide whether an operator supplied adapter setup.
- `server/src/services/built-in-agents.ts` — a Bedrock id from the wrong region family is rejected at setup. `isBedrockModelUsableInConfiguredRegion()` rejects an id only when the environment can show it is wrong: Bedrock is enabled, a region is set, and the id names a known family that the region does not publish. A `global.` profile, an unknown family, and an environment with no region evidence are all accepted, because a server that does not run Bedrock itself can store setup for a worker whose region is not visible to it. A rejection returns 422 with `code: "built_in_agent_model_region_mismatch"` and names the region.
- An inference-profile ARN is compared on the region inside it. `bedrockArnRegion()` reads the fourth colon-separated field, and a mismatch with the effective region is rejected. Bedrock resolves a profile against the endpoint of the configured region, not against the region written in the ARN, so a cross-region ARN fails at run time. An ARN with an empty region field, and a value that does not parse as a Bedrock ARN, are both still accepted, because neither names a region to disagree with.
- The region judged is the agent's, not the server's. `execute.ts` spreads an agent's `adapterConfig.env` over `process.env`, so an agent can name its own `AWS_REGION`. Validation therefore takes the environment to judge, and passes the same overlay that execution builds. The check also runs before the catalogue match, because `listAdapterModels()` reads only `process.env`, so a listed id is not evidence that the id resolves where the agent runs.
- `adapterConfig.env` values are env bindings, not plain strings, and validation now reads them as such. A bare string and `{ type: "plain", value }` carry a value inline, so either can decide the region. A `secret_ref` or a `user_secret_ref` names a secret that only `resolveAdapterConfigForRuntime` resolves, so no value is available at setup time. Such a key is hidden rather than inherited, so the server's value is not substituted for the agent's, and the region check is skipped for that agent. `ANTHROPIC_BEDROCK_BASE_URL` counts as region-deciding alongside `AWS_REGION`, `AWS_DEFAULT_REGION` and `CLAUDE_CODE_USE_BEDROCK`.
- `server/src/__tests__/built-in-agents.test.ts` — the suite teardown now clears the six company secret tables, in dependency order. Each one references a company, so a test that binds `adapterConfig.env` to a secret made the existing `companies` delete fail on a foreign key, and leaked rows into later tests. This is a latent gap in the suite rather than a consequence of this change, but this is the first test here to bind env to a secret.
- `packages/adapters/claude-local/src/server/models.ts` — warn once per process when Bedrock is enabled and no region is set. The `us` default is otherwise silent, and `us.` profiles do not resolve outside `us-*`.
- `server/src/__tests__/adapter-models.test.ts` and `server/src/__tests__/built-in-agents.test.ts` — added 23 tests, including a configured region with no verified family, the two residency-specific APAC families, the stored `adapterConfig` on a board-approval pending row, and the region check above. Both suites now delete the Bedrock and AWS region variables in `beforeEach`, so a developer with Bedrock set in the shell gets the same result as CI. Two assertions about `routines` were scoped by `assigneeAgentId`, because they depended on row order once a second agent was provisioned.

## Verification

**Tests.** 74 tests pass, in 2 files:

```
npx vitest run server/src/__tests__/built-in-agents.test.ts server/src/__tests__/adapter-models.test.ts
```

The 8 tests listed in #10546 fail on `master` when `CLAUDE_CODE_USE_BEDROCK=1` and `AWS_REGION=eu-west-1` are set. They pass with this change. No AWS account is needed, because the catalogue is hardcoded.

**End-to-end.** I ran the same script twice against the same live server database, with `CLAUDE_CODE_USE_BEDROCK=1` and `AWS_REGION=eu-west-1`. Only the code differed.

| | `master` @ `4813ed3` | this branch |
|---|---|---|
| adapter catalogue | 5 ids, all `us.anthropic.*` | 7 ids, all `eu.anthropic.*` |
| `autoProvisionBundledAgents` | throws `Model "claude-haiku-4-5" is not available for adapter claude_local.` | `{ autoEnsured: 2, pendingApprovals: 0, defaultGrantsEnsured: 2 }` |
| Summarizer agent | never created | created, `model=eu.anthropic.claude-haiku-4-5-20251001-v1:0` |
| Reflection Coach agent | never created | created, `paused`, no model set, which is correct for it |

**No US regression.** With `AWS_REGION=us-east-1`, and with no region set, the catalogue is still the same 5 `us.` ids as on `master`.

**Region data.** Every id was verified `ACTIVE` on 2026-07-31:

```
aws bedrock list-inference-profiles --region <region> \
  --query "inferenceProfileSummaries[?contains(inferenceProfileId,'anthropic')].[inferenceProfileId,status]"
```

Checked in `us-east-1`, `eu-west-1`, `ap-southeast-1`, `ap-southeast-2` and `ap-northeast-1`. No `us.` profile appears in any non-US region, which is why the fallback is now `global`.

## Risks

- **Low risk overall.** There is no migration and no schema change. Nothing in the public API changes shape.
- **Behaviour changes only under Bedrock.** The new code path needs `CLAUDE_CODE_USE_BEDROCK=1` or `ANTHROPIC_BEDROCK_BASE_URL`. Users who do not use Bedrock see no change.
- **The `eu` ids can go stale.** They are hardcoded, exactly as the `us` ids already are. AWS can retire a profile. This change does not add discovery through the Bedrock API, so the list still needs manual updates. Discovery would be the better long-term fix, and it is larger than this change.
- **`global.` profiles can route to any region.** They are the fallback for a region with no verified family, so a user in such a region gets working models rather than none. A region that publishes its own family keeps it, so this does not weaken data residency where a residency-specific family exists. If you would rather fail loudly than fall back to `global`, say so and I will change it.
- **A region with no verified family gets no residency-specific option.** `ap-southeast-1` is an example. Its `apac.` family carries only Claude 3.x-era profiles, so it cannot serve the bundled Haiku 4.5 default.
- **An unset region still selects `us`.** This preserves today's behaviour. A user whose region comes only from `~/.aws/config`, and not from the environment, therefore still gets US ids. Reading the AWS config file is outside the scope of this change.
- **Validation is more permissive about the model name, and no more permissive about the region.** `assertKnownBuiltInAgentModel` accepts a region-qualified Bedrock id that the static catalogue does not list, so a typed id such as `eu.anthropic.does-not-exist` passes validation and fails later, at run time. The execution path already behaved this way. It does reject an id whose region family the configured region cannot publish, which the execution path did not catch until the agent first ran.
- **The region check can reject a correct id in one case.** If a family is missing from `BEDROCK_FAMILY_REGION_PREFIXES`, an id from that family is rejected in a region that does publish it. That table is therefore wider than the catalogue: it carries `apac`, and both regions of each residency pair. AWS adding a new family would need a new entry. Accepting an unknown family, rather than rejecting it, keeps this to families the file names.
- **The offered catalogue is still built from the server environment.** `listAdapterModels(adapterType)` takes no agent, so an agent whose `env` names `eu-west-1` on a `us-east-1` server is offered `us.` ids in the picker, and the region check then rejects them on save. Validation is correct; the picker is unhelpful. Threading agent configuration into the adapter model registry reaches past this change, so it is not attempted here. Say if you want it widened.
- **A secret-bound region is not checked at all.** If `AWS_REGION` is a `secret_ref` or a `user_secret_ref`, the region check is skipped for that agent, so a mismatched profile still fails at run time as it does on `master`. Resolving the secret here would need the secrets service in this module, and would record a secret access for a validation step, so it is not attempted. This is the same permissive direction the rest of the check takes: reject only on evidence.
- **Alias mapping uses a substring match.** `resolveDefaultAdapterConfig` maps `claude-haiku-4-5` onto an offered id that contains that text. This only runs when the exact id is not offered, and only for a bundled default. If two offered ids contain the same text, the first is used.
- **Two ids in the existing `us` list look wrong, and this change does not touch them.** `us.anthropic.claude-opus-4-8-v1` and `us.anthropic.claude-fable-5-v1` do not appear in the `us-east-1` inference-profile list. The live ids appear to be `us.anthropic.claude-opus-4-8` and `us.anthropic.claude-fable-5`, with no `-v1` suffix, while `us.anthropic.claude-opus-4-6-v1` does keep its suffix. If that is right, Opus 4.8 and Fable 5 do not work for US Bedrock users today. I left the `us` list unchanged, because this pull request promises no US behaviour change. Please confirm, and I will open a separate issue or pull request.

## Model Used

- **Provider and model:** Anthropic Claude, used through Claude Code.
- **Exact model id:** `claude-opus-5` (Claude Opus 5).
- **Context window:** the default for a Claude Code session. No extended-context mode was used.
- **Reasoning mode:** extended thinking enabled.
- **Other capabilities:** tool use and local code execution. The model read the repository, made the edits, ran the test suites, started a local Paperclip instance with an isolated `PAPERCLIP_HOME`, and ran the end-to-end check in the table above.
- **Human role:** the human contributor reported the failure, set the goal, chose the approach, and approved this pull request.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — see the overlap note, which describes #6101 and #10247 in detail
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass — 74 of 74, command above
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — **not applicable.** No document on `master` describes the Bedrock catalogue. `packages/adapters/claude-local/README.md` does not exist yet; #6101 proposes to create it. Tell me if you want this change documented, and where.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — they were, on `aa50595f`. The branch has since been rebased onto `master` and carries one more commit, so this is pending a fresh run.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — it reached 5/5 on `aa50595f`, then raised a 5th P1 after the rebase, about env bindings. That one was valid, and is fixed and answered in its thread. Awaiting a fresh review. Greptile has raised 5 P1s in total, all valid, 4 of them defects in my own change; each is answered in its own thread.
- [x] I will address all Greptile and reviewer comments before requesting merge
