### PR TITLE
fix(server): enforce issue ancestor tenant boundary

### DIFF
--- a/server/src/__tests__/issue-ancestor-tenancy.test.ts
+++ b/server/src/__tests__/issue-ancestor-tenancy.test.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  companies,
+  createDb,
+  goals,
+  issues,
+  projectWorkspaces,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("issueService ancestor tenant boundary", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-ancestor-tenancy-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createCompany(name: string) {
+    const id = randomUUID();
+    await db.insert(companies).values({
+      id,
+      name,
+      issuePrefix: name.slice(0, 3).toUpperCase(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    return id;
+  }
+
+  it("stops corrupt ancestor walks and hydration at the child company boundary", async () => {
+    const foreignCompanyId = await createCompany("Foreign");
+    const childCompanyId = await createCompany("Child");
+    const foreignGoalId = randomUUID();
+    const foreignProjectId = randomUUID();
+    const foreignWorkspaceId = randomUUID();
+    const foreignAncestorId = randomUUID();
+    const localParentId = randomUUID();
+    const localChildId = randomUUID();
+
+    await db.insert(goals).values({
+      id: foreignGoalId,
+      companyId: foreignCompanyId,
+      title: "Foreign confidential goal",
+      level: "company",
+      status: "active",
+    });
+    await db.insert(projects).values({
+      id: foreignProjectId,
+      companyId: foreignCompanyId,
+      goalId: foreignGoalId,
+      name: "Foreign confidential project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: foreignWorkspaceId,
+      companyId: foreignCompanyId,
+      projectId: foreignProjectId,
+      name: "Foreign confidential workspace",
+      isPrimary: true,
+      sharedWorkspaceKey: "foreign-confidential-workspace",
+    });
+    await db.insert(issues).values([
+      {
+        id: foreignAncestorId,
+        companyId: foreignCompanyId,
+        title: "Foreign confidential ancestor",
+        description: "Must never cross the tenant boundary",
+        status: "in_progress",
+        priority: "critical",
+      },
+      {
+        id: localParentId,
+        companyId: childCompanyId,
+        parentId: foreignAncestorId,
+        projectId: foreignProjectId,
+        goalId: foreignGoalId,
+        title: "Local parent with corrupt foreign references",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: localChildId,
+        companyId: childCompanyId,
+        parentId: localParentId,
+        title: "Readable local child",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    const ancestors = await svc.getAncestors(localChildId);
+
+    expect(ancestors).toHaveLength(1);
+    expect(ancestors[0]).toMatchObject({
+      id: localParentId,
+      title: "Local parent with corrupt foreign references",
+      project: null,
+      goal: null,
+    });
+    expect(JSON.stringify(ancestors)).not.toContain("Foreign confidential");
+  });
+
+  it("rejects a cross-company parent on create even when workspace inheritance is skipped", async () => {
+    const foreignCompanyId = await createCompany("Foreign");
+    const childCompanyId = await createCompany("Child");
+    const foreignParentId = randomUUID();
+    await db.insert(issues).values({
+      id: foreignParentId,
+      companyId: foreignCompanyId,
+      title: "Foreign parent",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(svc.create(childCompanyId, {
+      parentId: foreignParentId,
+      title: "Invalid child",
+      skipExecutionWorkspaceInheritance: true,
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Parent issue not found in company",
+    });
+  });
+
+  it("rejects a cross-company parent on update without changing the issue", async () => {
+    const foreignCompanyId = await createCompany("Foreign");
+    const childCompanyId = await createCompany("Child");
+    const foreignParentId = randomUUID();
+    const localIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: foreignParentId,
+        companyId: foreignCompanyId,
+        title: "Foreign parent",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: localIssueId,
+        companyId: childCompanyId,
+        title: "Local issue",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    await expect(svc.update(localIssueId, { parentId: foreignParentId })).rejects.toMatchObject({
+      status: 422,
+      message: "Parent issue not found in company",
+    });
+    await expect(svc.getById(localIssueId)).resolves.toMatchObject({ parentId: null });
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1258,6 +1258,21 @@ async function getProjectDefaultGoalId(
   return row?.goalId ?? null;
 }
 
+async function assertIssueParentInCompany(
+  db: DbReader,
+  companyId: string,
+  parentId: string,
+) {
+  const parent = await db
+    .select({ id: issues.id })
+    .from(issues)
+    .where(and(eq(issues.id, parentId), eq(issues.companyId, companyId)))
+    .then((rows) => rows[0] ?? null);
+  if (!parent) {
+    throw unprocessable("Parent issue not found in company");
+  }
+}
+
 async function getWorkspaceInheritanceIssue(
   db: DbReader,
   companyId: string,
@@ -6309,6 +6324,9 @@ export function issueService(db: Db) {
         throw unprocessable("in_progress issues require an assignee");
       }
       return db.transaction(async (tx) => {
+        if (issueData.parentId) {
+          await assertIssueParentInCompany(tx, companyId, issueData.parentId);
+        }
         const idempotencyKey = rawIdempotencyKey?.trim() || null;
         const normalizedTitle = normalizeCreateIssueTitle(issueData.title);
         if (allowDuplicate === false) {
@@ -6874,6 +6892,9 @@ export function issueService(db: Db) {
 
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
+      }
+      if (issueData.parentId) {
+        await assertIssueParentInCompany(dbOrTx, existing.companyId, issueData.parentId);
       }
 
       const patch: Partial<typeof issues.$inferInsert> = {
@@ -8140,8 +8161,14 @@ export function issueService(db: Db) {
         assigneeAgentId: string | null; projectId: string | null; goalId: string | null;
       }> = [];
       const visited = new Set<string>([issueId]);
-      const start = await db.select().from(issues).where(eq(issues.id, issueId)).then(r => r[0] ?? null);
-      let currentId = start?.parentId ?? null;
+      const start = await db
+        .select({ companyId: issues.companyId, parentId: issues.parentId })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then(r => r[0] ?? null);
+      if (!start) return [];
+      const companyId = start.companyId;
+      let currentId = start.parentId ?? null;
       while (currentId && !visited.has(currentId) && raw.length < 50) {
         visited.add(currentId);
         const parent = await db.select({
@@ -8149,7 +8176,9 @@ export function issueService(db: Db) {
           status: issues.status, priority: issues.priority,
           assigneeAgentId: issues.assigneeAgentId, projectId: issues.projectId,
           goalId: issues.goalId, parentId: issues.parentId,
-        }).from(issues).where(eq(issues.id, currentId)).then(r => r[0] ?? null);
+        }).from(issues).where(
+          and(eq(issues.id, currentId), eq(issues.companyId, companyId)),
+        ).then(r => r[0] ?? null);
         if (!parent) break;
         raw.push({
           id: parent.id, identifier: parent.identifier ?? null, title: parent.title, description: parent.description ?? null,
@@ -8203,7 +8232,10 @@ export function issueService(db: Db) {
         const workspaceRows = await db
           .select()
           .from(projectWorkspaces)
-          .where(inArray(projectWorkspaces.projectId, projectIds))
+          .where(and(
+            eq(projectWorkspaces.companyId, companyId),
+            inArray(projectWorkspaces.projectId, projectIds),
+          ))
           .orderBy(desc(projectWorkspaces.isPrimary), asc(projectWorkspaces.createdAt), asc(projectWorkspaces.id));
         const workspaceMap = new Map<string, Array<(typeof workspaceRows)[number]>>();
         for (const workspace of workspaceRows) {
@@ -8215,7 +8247,10 @@ export function issueService(db: Db) {
         const rows = await db.select({
           id: projects.id, name: projects.name, description: projects.description,
           status: projects.status, goalId: projects.goalId,
-        }).from(projects).where(inArray(projects.id, projectIds));
+        }).from(projects).where(and(
+          eq(projects.companyId, companyId),
+          inArray(projects.id, projectIds),
+        ));
         for (const r of rows) {
           const projectWorkspaceRows = workspaceMap.get(r.id) ?? [];
           const workspaces = projectWorkspaceRows.map((workspace) => ({
@@ -8246,7 +8281,10 @@ export function issueService(db: Db) {
         const rows = await db.select({
           id: goals.id, title: goals.title, description: goals.description,
           level: goals.level, status: goals.status,
-        }).from(goals).where(inArray(goals.id, goalIds));
+        }).from(goals).where(and(
+          eq(goals.companyId, companyId),
+          inArray(goals.id, goalIds),
+        ));
         for (const r of rows) goalMap.set(r.id, r);
       }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - One server can store work for more than one company.
> - Each issue read must stay inside the issue company.
> - The ancestor service used global IDs when it walked parents and loaded related data.
> - A corrupt parent link could therefore return issue, project, goal, and workspace data from another company.
> - This pull request scopes all ancestor reads and rejects invalid parent writes.
> - The benefit is a strict company boundary for both old corrupt data and new writes.

## Linked Issues or Issue Description

**What happened?**

`getAncestors` followed `parentId` values without a company predicate. It also loaded projects, goals, and workspaces without a company predicate. A readable issue with a corrupt cross-company parent link could return data from another company.

**Expected behavior**

An ancestor walk must stop at the issue company boundary. Create and update operations must reject a parent that is not in the same company.

**Steps to reproduce**

1. Create two companies.
2. Insert an issue in the first company.
3. Insert an issue in the second company with the first issue as its parent.
4. Call `getAncestors` for the second issue.
5. Observe that the service returns the first issue before this fix.

**Paperclip version or commit**

`54e2031e8`

**Deployment mode**

Built from source. The defect is in the core server service and is not deployment-specific.

## What Changed

- Validate that `parentId` belongs to the target company during issue create and update.
- Stop ancestor traversal when a parent is outside the starting issue company.
- Scope project, goal, and project-workspace hydration to the same company.
- Add regression tests for corrupt reads and cross-company create and update attempts.

## Verification

- `corepack pnpm exec vitest run server/src/__tests__/issues-service.test.ts server/src/__tests__/issue-ancestor-tenancy.test.ts`
- Result: 113 tests passed.
- `corepack pnpm --filter @paperclipai/server typecheck` with a run-local `pnpm` Corepack shim on the harness PATH.
- Result: typecheck passed.

## Risks

- Risk is low and limited to invalid hierarchy data.
- Existing cross-company parent chains now stop at the company boundary.
- Create and update calls with a missing or foreign parent now return the same generic `422` error.
- The generic error does not reveal whether an issue exists in another company.
- No schema migration is required.
- Rollback is one commit revert.

## Model Used

- OpenAI GPT-5.6, exact harness model ID `gpt-5.6-sol`.
- The model used reasoning, file tools, shell execution, and local test execution.
- The harness did not report a context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
