### PR TITLE
feat(sdk): detach long-lived plugin callbacks from invocations

### DIFF
--- a/packages/plugins/sdk/README.md
+++ b/packages/plugins/sdk/README.md
@@ -1261,6 +1261,12 @@ await plugin.definition.setup(harness.ctx);
 await harness.emit("issue.created", { issueId: "iss_1" }, { entityId: "iss_1", entityType: "issue" });
 ```
 
+```ts
+ctx.runtime.runProactively(() => {
+  startBackgroundListener();
+});
+```
+
 ## Bundler presets
 
 ```ts

--- a/packages/plugins/sdk/src/index.ts
+++ b/packages/plugins/sdk/src/index.ts
@@ -220,6 +220,7 @@ export type {
 // Plugin context and all client interfaces
 export type {
   PluginContext,
+  PluginRuntimeClient,
   PluginConfigClient,
   PluginLocalFolderProblem,
   PluginLocalFolderStatus,

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -736,6 +736,11 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
 
   const ctx: PluginContext = {
     manifest,
+    runtime: {
+      runProactively<T>(callback: () => T): T {
+        return callback();
+      },
+    },
     config: {
       async get() {
         return { ...currentConfig };

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -1963,9 +1963,17 @@ export interface PluginStreamsClient {
  *
  * @see PLUGIN_SPEC.md §14 — SDK Surface
  */
+export interface PluginRuntimeClient {
+  /** Run long-lived callbacks outside the current host invocation scope. */
+  runProactively<T>(callback: () => T): T;
+}
+
 export interface PluginContext {
   /** The plugin's manifest as validated at install time. */
   manifest: PaperclipPluginManifestV1;
+
+  /** Helpers for work that outlives the current host invocation. */
+  runtime: PluginRuntimeClient;
 
   /** Read resolved operator configuration. */
   config: PluginConfigClient;

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -57,6 +57,7 @@ import type {
 } from "./define-plugin.js";
 import type {
   PluginContext,
+  PluginRuntimeClient,
   PluginEvent,
   PluginJobContext,
   PluginLauncherRegistration,
@@ -325,7 +326,7 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
   // distinct company's config. `null` until the first company-scoped delivery.
   let configCompanyId: string | null = null;
   let databaseNamespace: string | null = null;
-  const invocationContextStorage = new AsyncLocalStorage<PluginInvocationContext>();
+  const invocationContextStorage = new AsyncLocalStorage<PluginInvocationContext | undefined>();
 
   // Plugin handler registrations (populated during setup())
   const eventHandlers: EventRegistration[] = [];
@@ -452,6 +453,12 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
         if (!manifest) throw new Error("Plugin context accessed before initialization");
         return manifest;
       },
+
+      runtime: {
+        runProactively<T>(callback: () => T): T {
+          return invocationContextStorage.run(undefined, callback);
+        },
+      } satisfies PluginRuntimeClient,
 
       config: {
         async get(companyId?: string) {

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -203,102 +203,6 @@ describe("worker invocation scope propagation", () => {
           }
           resolve((response as { result?: unknown }).result);
         });
-
-        it("allows proactive callbacks to call the host without retaining the current invocation id", async () => {
-          const hostToWorker = new PassThrough();
-          const workerToHost = new PassThrough();
-          const hostReadline = createInterface({ input: workerToHost });
-          const pending = new Map<string, (response: JsonRpcResponse) => void>();
-          const seenInvocationIds: Array<string | null> = [];
-          let nextRequestId = 1;
-
-          const plugin = definePlugin({
-            async setup(ctx) {
-              ctx.data.register("probe", async () => {
-                const scoped = await ctx.companies.get("company-scoped");
-                const proactive = await ctx.runtime.runProactively(() => ctx.companies.get("company-proactive"));
-                return { scoped, proactive };
-              });
-            },
-          });
-
-          const worker = startWorkerRpcHost({
-            plugin,
-            stdin: hostToWorker,
-            stdout: workerToHost,
-          });
-
-          function callWorker(method: string, params: unknown, invocation?: PluginInvocationContext) {
-            const id = `host-${nextRequestId++}`;
-            const request = {
-              ...createRequest(method, params, id),
-              ...(invocation ? { paperclipInvocation: invocation } : {}),
-            };
-            const result = new Promise<unknown>((resolve, reject) => {
-              pending.set(id, (response) => {
-                if ("error" in response && response.error) {
-                  reject(new Error(response.error.message));
-                  return;
-                }
-                resolve((response as { result?: unknown }).result);
-              });
-            });
-            hostToWorker.write(serializeMessage(request));
-            return result;
-          }
-
-          hostReadline.on("line", (line) => {
-            const message = parseMessage(line);
-            if (isJsonRpcResponse(message)) {
-              pending.get(String(message.id))?.(message);
-              pending.delete(String(message.id));
-              return;
-            }
-
-            if (!isJsonRpcRequest(message)) return;
-            if (message.method !== "companies.get") return;
-
-            seenInvocationIds.push((message as { paperclipInvocationId?: string }).paperclipInvocationId ?? null);
-            hostToWorker.write(serializeMessage(createSuccessResponse(message.id, {
-              id: (message.params as { companyId?: string }).companyId,
-            })));
-          });
-
-          try {
-            await callWorker("initialize", {
-              manifest: {
-                id: "paperclip.proactive-scope-test",
-                apiVersion: 1,
-                version: "1.0.0",
-                displayName: "Proactive Scope Test",
-                description: "Scope test",
-                author: "Paperclip",
-                categories: ["automation"],
-                capabilities: ["companies.read"],
-                entrypoints: { worker: "dist/worker.js" },
-              },
-              config: {},
-              instanceInfo: { instanceId: "test", hostVersion: "0.0.0" },
-              apiVersion: 1,
-            });
-
-            await expect(callWorker(
-              "getData",
-              { key: "probe", companyId: "company-a", params: {} },
-              { id: "invocation-a", scope: { companyId: "company-a" } },
-            )).resolves.toEqual({
-              scoped: { id: "company-scoped" },
-              proactive: { id: "company-proactive" },
-            });
-
-            expect(seenInvocationIds).toEqual(["invocation-a", null]);
-          } finally {
-            worker.stop();
-            hostReadline.close();
-            hostToWorker.destroy();
-            workerToHost.destroy();
-          }
-        });
       });
       hostToWorker.write(serializeMessage(request));
       return result;
@@ -384,6 +288,102 @@ describe("worker invocation scope propagation", () => {
       await companyAExpectation;
 
       expect(nestedInvocationIds).toEqual(["invocation-b", "invocation-a"]);
+    } finally {
+      worker.stop();
+      hostReadline.close();
+      hostToWorker.destroy();
+      workerToHost.destroy();
+    }
+  });
+
+  it("allows proactive callbacks to call the host without retaining the current invocation id", async () => {
+    const hostToWorker = new PassThrough();
+    const workerToHost = new PassThrough();
+    const hostReadline = createInterface({ input: workerToHost });
+    const pending = new Map<string, (response: JsonRpcResponse) => void>();
+    const seenInvocationIds: Array<string | null> = [];
+    let nextRequestId = 1;
+
+    const plugin = definePlugin({
+      async setup(ctx) {
+        ctx.data.register("probe", async () => {
+          const scoped = await ctx.companies.get("company-scoped");
+          const proactive = await ctx.runtime.runProactively(() => ctx.companies.get("company-proactive"));
+          return { scoped, proactive };
+        });
+      },
+    });
+
+    const worker = startWorkerRpcHost({
+      plugin,
+      stdin: hostToWorker,
+      stdout: workerToHost,
+    });
+
+    function callWorker(method: string, params: unknown, invocation?: PluginInvocationContext) {
+      const id = `host-${nextRequestId++}`;
+      const request = {
+        ...createRequest(method, params, id),
+        ...(invocation ? { paperclipInvocation: invocation } : {}),
+      };
+      const result = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, (response) => {
+          if ("error" in response && response.error) {
+            reject(new Error(response.error.message));
+            return;
+          }
+          resolve((response as { result?: unknown }).result);
+        });
+      });
+      hostToWorker.write(serializeMessage(request));
+      return result;
+    }
+
+    hostReadline.on("line", (line) => {
+      const message = parseMessage(line);
+      if (isJsonRpcResponse(message)) {
+        pending.get(String(message.id))?.(message);
+        pending.delete(String(message.id));
+        return;
+      }
+
+      if (!isJsonRpcRequest(message)) return;
+      if (message.method !== "companies.get") return;
+
+      seenInvocationIds.push((message as { paperclipInvocationId?: string }).paperclipInvocationId ?? null);
+      hostToWorker.write(serializeMessage(createSuccessResponse(message.id, {
+        id: (message.params as { companyId?: string }).companyId,
+      })));
+    });
+
+    try {
+      await callWorker("initialize", {
+        manifest: {
+          id: "paperclip.proactive-scope-test",
+          apiVersion: 1,
+          version: "1.0.0",
+          displayName: "Proactive Scope Test",
+          description: "Scope test",
+          author: "Paperclip",
+          categories: ["automation"],
+          capabilities: ["companies.read"],
+          entrypoints: { worker: "dist/worker.js" },
+        },
+        config: {},
+        instanceInfo: { instanceId: "test", hostVersion: "0.0.0" },
+        apiVersion: 1,
+      });
+
+      await expect(callWorker(
+        "getData",
+        { key: "probe", companyId: "company-a", params: {} },
+        { id: "invocation-a", scope: { companyId: "company-a" } },
+      )).resolves.toEqual({
+        scoped: { id: "company-scoped" },
+        proactive: { id: "company-proactive" },
+      });
+
+      expect(seenInvocationIds).toEqual(["invocation-a", null]);
     } finally {
       worker.stop();
       hostReadline.close();

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -203,6 +203,102 @@ describe("worker invocation scope propagation", () => {
           }
           resolve((response as { result?: unknown }).result);
         });
+
+        it("allows proactive callbacks to call the host without retaining the current invocation id", async () => {
+          const hostToWorker = new PassThrough();
+          const workerToHost = new PassThrough();
+          const hostReadline = createInterface({ input: workerToHost });
+          const pending = new Map<string, (response: JsonRpcResponse) => void>();
+          const seenInvocationIds: Array<string | null> = [];
+          let nextRequestId = 1;
+
+          const plugin = definePlugin({
+            async setup(ctx) {
+              ctx.data.register("probe", async () => {
+                const scoped = await ctx.companies.get("company-scoped");
+                const proactive = await ctx.runtime.runProactively(() => ctx.companies.get("company-proactive"));
+                return { scoped, proactive };
+              });
+            },
+          });
+
+          const worker = startWorkerRpcHost({
+            plugin,
+            stdin: hostToWorker,
+            stdout: workerToHost,
+          });
+
+          function callWorker(method: string, params: unknown, invocation?: PluginInvocationContext) {
+            const id = `host-${nextRequestId++}`;
+            const request = {
+              ...createRequest(method, params, id),
+              ...(invocation ? { paperclipInvocation: invocation } : {}),
+            };
+            const result = new Promise<unknown>((resolve, reject) => {
+              pending.set(id, (response) => {
+                if ("error" in response && response.error) {
+                  reject(new Error(response.error.message));
+                  return;
+                }
+                resolve((response as { result?: unknown }).result);
+              });
+            });
+            hostToWorker.write(serializeMessage(request));
+            return result;
+          }
+
+          hostReadline.on("line", (line) => {
+            const message = parseMessage(line);
+            if (isJsonRpcResponse(message)) {
+              pending.get(String(message.id))?.(message);
+              pending.delete(String(message.id));
+              return;
+            }
+
+            if (!isJsonRpcRequest(message)) return;
+            if (message.method !== "companies.get") return;
+
+            seenInvocationIds.push((message as { paperclipInvocationId?: string }).paperclipInvocationId ?? null);
+            hostToWorker.write(serializeMessage(createSuccessResponse(message.id, {
+              id: (message.params as { companyId?: string }).companyId,
+            })));
+          });
+
+          try {
+            await callWorker("initialize", {
+              manifest: {
+                id: "paperclip.proactive-scope-test",
+                apiVersion: 1,
+                version: "1.0.0",
+                displayName: "Proactive Scope Test",
+                description: "Scope test",
+                author: "Paperclip",
+                categories: ["automation"],
+                capabilities: ["companies.read"],
+                entrypoints: { worker: "dist/worker.js" },
+              },
+              config: {},
+              instanceInfo: { instanceId: "test", hostVersion: "0.0.0" },
+              apiVersion: 1,
+            });
+
+            await expect(callWorker(
+              "getData",
+              { key: "probe", companyId: "company-a", params: {} },
+              { id: "invocation-a", scope: { companyId: "company-a" } },
+            )).resolves.toEqual({
+              scoped: { id: "company-scoped" },
+              proactive: { id: "company-proactive" },
+            });
+
+            expect(seenInvocationIds).toEqual(["invocation-a", null]);
+          } finally {
+            worker.stop();
+            hostReadline.close();
+            hostToWorker.destroy();
+            workerToHost.destroy();
+          }
+        });
       });
       hostToWorker.write(serializeMessage(request));
       return result;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
 
 patchedDependencies:
   acpx@0.12.0:
-    hash: tb5cdbd7kiiblhylbkroxfdcha
+    hash: x3fethhotv43zektyl5prdwf54
     path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
@@ -124,7 +124,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=tb5cdbd7kiiblhylbkroxfdcha)
+        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -13278,7 +13278,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  acpx@0.12.0(patch_hash=tb5cdbd7kiiblhylbkroxfdcha):
+  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
 
 patchedDependencies:
   acpx@0.12.0:
-    hash: x3fethhotv43zektyl5prdwf54
+    hash: tb5cdbd7kiiblhylbkroxfdcha
     path: patches/acpx@0.12.0.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
@@ -124,7 +124,7 @@ importers:
     dependencies:
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
+        version: 0.12.0(patch_hash=tb5cdbd7kiiblhylbkroxfdcha)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -13278,7 +13278,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
+  acpx@0.12.0(patch_hash=tb5cdbd7kiiblhylbkroxfdcha):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip runs plugin code in separate worker processes
> - The plugin SDK sends requests from plugin workers to the Paperclip host
> - The SDK uses AsyncLocalStorage to pass the current host invocation ID
> - A long-lived callback can keep this ID after the host invocation ends
> - The host rejects later requests that contain the old invocation ID
> - This pull request adds an explicit scope boundary for long-lived callbacks
> - The benefit is reliable event-driven plugin work without a change to normal SDK calls

## Linked Issues or Issue Description

Refs #8633

## What Changed

- Add the `PluginRuntimeClient` interface to the plugin SDK.
- Add `ctx.runtime.runProactively(callback)` to `PluginContext`.
- Run the callback without the current AsyncLocalStorage invocation context.
- Add the runtime API to the plugin test harness.
- Keep the current invocation scope for normal SDK calls.

## Verification

- Run `pnpm --filter @paperclipai/plugin-sdk typecheck`.
- Run `pnpm --filter @paperclipai/plugin-sdk build`.
- Register a long-lived event handler inside `ctx.runtime.runProactively()`.
- Wait until the host invocation that registered the handler has ended.
- Use the event handler to create or update an issue.
- Confirm that the worker does not send the old `paperclipInvocationId`.
- Confirm that the host uses the configured proactive company scope.
- Call the SDK from a normal host invocation.
- Confirm that this call still sends the current invocation ID.

## Risks

- Existing plugins keep their current behavior because the new API is opt-in.
- A plugin can remove a required invocation scope if it uses this API incorrectly.
- A proactive request can fail when no proactive company scope is available.
- The test harness calls the callback directly.
- The test harness does not simulate AsyncLocalStorage behavior.
- This change has no migration requirements.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5.6 Luna (`openai/gpt-5.6-luna`). The model used repository inspection, code tools, and extended reasoning. The context window size was not recorded.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

