### PR TITLE
fix(codex): do not inject a duplicate --skip-git-repo-check for sandbox runs

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -156,4 +156,45 @@ describe("buildCodexExecArgs", () => {
       "-",
     ]);
   });
+
+  it("does not add a second --skip-git-repo-check when extraArgs already carry it", () => {
+    const result = buildCodexExecArgs(
+      {
+        model: "gpt-5.5",
+        extraArgs: ["--skip-git-repo-check"],
+      },
+      { skipGitRepoCheck: true },
+    );
+
+    expect(result.args.filter((arg) => arg === "--skip-git-repo-check")).toHaveLength(1);
+    expect(result.args).toEqual([
+      "exec",
+      "--json",
+      "--model",
+      "gpt-5.5",
+      "--skip-git-repo-check",
+      "-",
+    ]);
+  });
+
+  it("does not add a second --skip-git-repo-check when the legacy args field carries it", () => {
+    const result = buildCodexExecArgs(
+      {
+        model: "gpt-5.5",
+        args: ["--skip-git-repo-check"],
+      },
+      { skipGitRepoCheck: true },
+    );
+
+    expect(result.args.filter((arg) => arg === "--skip-git-repo-check")).toHaveLength(1);
+  });
+
+  it("keeps the operator's --skip-git-repo-check when the sandbox injection is not requested", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.5",
+      extraArgs: ["--skip-git-repo-check"],
+    });
+
+    expect(result.args.filter((arg) => arg === "--skip-git-repo-check")).toHaveLength(1);
+  });
 });

--- a/packages/adapters/codex-local/src/server/codex-args.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.ts
@@ -5,6 +5,8 @@ import {
   normalizeCodexModel,
 } from "../index.js";
 
+const SKIP_GIT_REPO_CHECK_FLAG = "--skip-git-repo-check";
+
 export type BuildCodexExecArgsResult = {
   args: string[];
   model: string;
@@ -52,7 +54,14 @@ export function buildCodexExecArgs(
   const extraArgs = readExtraArgs(record);
 
   const args = ["exec", "--json"];
-  if (options.skipGitRepoCheck) args.push("--skip-git-repo-check");
+  // Codex rejects a repeated `--skip-git-repo-check` ("cannot be used multiple
+  // times"). The adapter injects this flag for sandbox execution, so when an
+  // operator's extraArgs already carry it the injection would abort the run
+  // with exit code 2. Skip the injection in that case and let the operator's
+  // copy stand.
+  if (options.skipGitRepoCheck && !extraArgs.includes(SKIP_GIT_REPO_CHECK_FLAG)) {
+    args.push(SKIP_GIT_REPO_CHECK_FLAG);
+  }
   if (search) args.unshift("--search");
   if (bypass) args.push("--dangerously-bypass-approvals-and-sandbox");
   if (model) args.push("--model", model);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A Codex agent runs `codex exec`, and the adapter assembles its argument vector from the agent's config plus execution-context options
> - For sandbox execution the adapter injects `--skip-git-repo-check`, because a headless remote workspace has no git trust prompt to answer
> - The adapter also appends the operator's `extraArgs` verbatim, so an agent that already lists `--skip-git-repo-check` in its config gets the flag twice on a sandbox run
> - `codex exec` rejects a repeated `--skip-git-repo-check` and exits with code 2, which the adapter surfaces as `adapter_failed` before any work runs
> - This pull request skips the sandbox injection when the operator's args already carry the flag
> - The benefit is that a common, harmless-looking config no longer crashes every sandbox run

## Linked Issues or Issue Description

**What happened?**

A `codex_local` agent configured with `extraArgs: ["--skip-git-repo-check"]` fails on every sandbox run:

```
error: the argument '--skip-git-repo-check' cannot be used multiple times

Usage: codex exec [OPTIONS] [PROMPT]
```

The adapter reports `stopReason: "adapter_failed"` (Codex exited with code 2). The flag appears twice in the argv: once injected by the adapter for sandbox execution, once from the operator's `extraArgs`.

**Steps to reproduce**

1. Configure a `codex_local` agent with `extraArgs: ["--skip-git-repo-check"]` (or the legacy `args` field).
2. Point it at a sandbox environment.
3. Start a run — `codex exec` aborts immediately on the duplicate flag.

**Expected behavior**

The run launches with a single `--skip-git-repo-check`. An operator listing the flag the adapter already injects should be a no-op, not a hard failure.

**Paperclip version**

Current `master`.

**Deployment mode**

Any deployment running Codex agents in sandbox environments.

## What Changed

- `buildCodexExecArgs` no longer pushes the sandbox `--skip-git-repo-check` when the resolved args (`extraArgs`, or the legacy `args` fallback) already contain it. The operator's copy stands; the argv carries the flag exactly once. Non-sandbox runs and configs without the flag are unchanged.

## Verification

- `cd packages/adapters/codex-local && pnpm vitest run src/server/codex-args.test.ts` — new cases: `extraArgs` already carrying the flag (single occurrence), the legacy `args` field carrying it (single occurrence), and the operator's flag preserved when the sandbox injection is not requested. Existing "adds --skip-git-repo-check when requested" case unchanged.
- `cd packages/adapters/codex-local && pnpm vitest run` — full package suite (218 tests).
- `pnpm run typecheck` in the package.

## Risks

- Low. The change only suppresses a duplicate of a single, idempotent flag; it never removes an operator-supplied argument and never adds one that was not already going to be present.

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic) via Claude Code — extended thinking, agentic tool use (file edits, vitest/tsc runs). No other models involved.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge