### PR TITLE
docs: add Impeccable design tool awareness to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,3 +214,16 @@ PR #2218 (`feat/external-adapter-phase1`) adds external adapter support. See roo
 - `createServerAdapter()` must include ALL optional fields (especially `detectModel`)
 - Built-in UI adapters can shadow external plugin parsers — remove built-in when fully externalizing
 - Reference external adapters: Hermes (`@henkey/hermes-paperclip-adapter` or `file:`) and Droid (npm)
+
+## Cross-project design tool: Impeccable
+
+`impeccable/` is available at `~/Downloads/Projects/impeccable`. It provides 23
+design commands and 59 deterministic anti-pattern detector rules for frontend
+design quality. Use it when working on Paperclip's board UI (`ui/`):
+
+- `/impeccable critique` — UX design review for the board interface
+- `/impeccable audit` — accessibility, performance, and responsive checks
+- `/impeccable polish` — final quality pass before shipping
+
+Run `npx impeccable install` from the project root to set up. See
+`impeccable/README.md` for details.


### PR DESCRIPTION
Add cross-project section pointing agents to ~/Downloads/Projects/impeccable for board UI design review (critique, audit, polish) and 59 anti-pattern detector rules.

This is from a local fork with QoL patches; the only change in this PR is the AGENTS.md addition.