### PR TITLE
fix: hide Windows consoles for background agent runs

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3234,6 +3234,7 @@ export async function runChildProcess(
           cwd: target.cwd ?? opts.cwd,
           env: childEnv,
           detached: process.platform !== "win32",
+          windowsHide: true,
           shell: false,
           stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
         }) as ChildProcessWithEvents;

--- a/server/src/__tests__/windows-background-spawn-options.test.ts
+++ b/server/src/__tests__/windows-background-spawn-options.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+function spawnWindowsHideOptions(relativePath: string): boolean[] {
+  const sourcePath = path.join(repoRoot, relativePath);
+  const source = ts.createSourceFile(
+    sourcePath,
+    fs.readFileSync(sourcePath, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const results: boolean[] = [];
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "spawn"
+    ) {
+      const options = node.arguments[2];
+      const windowsHide = options && ts.isObjectLiteralExpression(options)
+        ? options.properties.find((property) =>
+          ts.isPropertyAssignment(property) &&
+          ts.isIdentifier(property.name) &&
+          property.name.text === "windowsHide"
+        )
+        : undefined;
+      results.push(
+        Boolean(
+          windowsHide &&
+          ts.isPropertyAssignment(windowsHide) &&
+          windowsHide.initializer.kind === ts.SyntaxKind.TrueKeyword,
+        ),
+      );
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+  return results;
+}
+
+describe("Windows background process spawn options", () => {
+  it.each([
+    ["packages/adapter-utils/src/server-utils.ts", 1],
+    ["server/src/routes/board-chat.ts", 1],
+    ["server/src/services/workspace-runtime.ts", 2],
+  ])("hides every console-capable spawn in %s", (relativePath, expectedSpawnCount) => {
+    const options = spawnWindowsHideOptions(relativePath);
+
+    expect(options).toHaveLength(expectedSpawnCount);
+    expect(options).not.toContain(false);
+  });
+});

--- a/server/src/routes/board-chat.ts
+++ b/server/src/routes/board-chat.ts
@@ -249,6 +249,7 @@ export function boardChatRoutes(
 
     const proc = spawn("claude", args, {
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
       cwd: "/tmp",
       env: {
         ...process.env,

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -525,6 +525,7 @@ async function executeProcess(input: {
     const child = spawn(input.command, input.args, {
       cwd: input.cwd,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
       env: input.env ?? process.env,
     });
     const stdout = createProcessOutputCapture(input.maxStdoutBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
@@ -4043,6 +4044,7 @@ async function spawnLocalRuntimeService(input: StartLocalRuntimeServiceInput): P
     cwd: serviceCwd,
     env,
     detached: process.platform !== "win32",
+    windowsHide: true,
     stdio: ["ignore", "pipe", "pipe"],
   });
   const spawnErrorPromise = new Promise<never>((_, reject) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Local adapters start background command-line processes for each agent run.
> - Windows can give these processes a visible console when the parent has no console.
> - Board Concierge and workspace runtime services use equivalent process launch paths.
> - The launch paths did not set the Node.js `windowsHide` option.
> - This pull request sets that option on the four audited spawn paths.
> - The benefit is quiet background work with no command, shell, stdio, or Unix process-group change.

## Linked Issues or Issue Description

Fixes #8182

Refs #10549

Related prior work: #8162, #8084, and #10286.

**What happened?**

Windows background agent runs can open visible `cmd.exe` and `conhost.exe` windows. The same omission exists in Board Concierge and workspace runtime process launches.

**Expected behavior**

Paperclip background processes must not show an interactive Windows console. Their command, arguments, environment, shell mode, process-group behavior, and stdio capture must stay the same.

**Steps to reproduce**

1. Start Paperclip on Windows from a parent process that has no console.
2. Run a local CLI adapter whose executable resolves through a `.cmd` wrapper.
3. Observe a new console host and visible console window for the background run.

**Paperclip version or commit**

Reproduced from `master` before commit `11c91380c`.

**Deployment mode**

Self-hosted Windows server.

## What Changed

- Set `windowsHide: true` on the shared local adapter process launch.
- Set `windowsHide: true` on the Board Concierge CLI launch.
- Set `windowsHide: true` on workspace command and runtime-service launches.
- Add a TypeScript AST regression that requires all audited spawn calls to keep this option.

## Verification

- `pnpm exec vitest run server/src/__tests__/windows-background-spawn-options.test.ts` (3 passed).
- `pnpm --filter @paperclipai/adapter-utils typecheck`.
- `pnpm --filter @paperclipai/server typecheck`.
- `pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts` (81 passed, 6 platform skips).
- `pnpm exec vitest run server/src/__tests__/board-chat-route-feature-flag.test.ts` (5 passed).
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t "starts only the selected workspace-controlled runtime service"`.

## Risks

- Low risk. Node.js ignores `windowsHide` on non-Windows systems.
- The change does not alter commands, arguments, environments, shell behavior, stdio, or Unix process groups.
- The contract test is intentional. A new spawn in an audited file must make its Windows window policy explicit.

> ROADMAP.md has one general bring-your-own-agent goal. It has no planned item for this Windows console defect.

## Model Used

- OpenAI Codex with GPT-5, reasoning, tool use, and code execution. The environment did not expose a more specific model build or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
