### PR TITLE
fix(db): let activity_log reference a run that no longer exists

### DIFF
--- a/packages/db/src/migrations/0198_activity_log_run_id_no_fk.sql
+++ b/packages/db/src/migrations/0198_activity_log_run_id_no_fk.sql
@@ -1,0 +1,19 @@
+-- Drop activity_log's foreign key to heartbeat_runs. The column stays, the index
+-- stays, only the constraint goes.
+--
+-- An audit trail must be able to name an entity that has since been cleaned up.
+-- This constraint made that impossible in both directions:
+--
+--  * Writing: agent JWTs pin a run_id claim for their whole 14-day life while
+--    heartbeat runs are ephemeral. Once the run row was gone, every write by that
+--    token failed the constraint. logActivity runs after the business write has
+--    committed, so the caller saw a 500 on work that had actually succeeded — and
+--    callers that retry on 500 then created the issue twice. Six of ten agent
+--    tokens on this instance carried a dead run id and could not write at all.
+--  * Cleaning up: ON DELETE no action means audit rows pin their runs, so run
+--    retention is blocked by the log that merely mentions them.
+--
+-- Keeping the value without the constraint is the point: activity_log.run_id
+-- records which run claimed to act, whether or not that run still exists.
+-- activity_log_run_id_idx (0003) is untouched, so queries by run_id are unaffected.
+ALTER TABLE "activity_log" DROP CONSTRAINT IF EXISTS "activity_log_run_id_heartbeat_runs_id_fk";

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1373,6 +1373,13 @@
       "when": 1785175200000,
       "tag": "0197_decisions_v1",
       "breakpoints": true
+    },
+    {
+      "idx": 198,
+      "version": "7",
+      "when": 1785175201000,
+      "tag": "0198_activity_log_run_id_no_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/activity_log.ts
+++ b/packages/db/src/schema/activity_log.ts
@@ -1,7 +1,6 @@
 import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
-import { heartbeatRuns } from "./heartbeat_runs.js";
 
 export const activityLog = pgTable(
   "activity_log",
@@ -14,7 +13,10 @@ export const activityLog = pgTable(
     entityType: text("entity_type").notNull(),
     entityId: text("entity_id").notNull(),
     agentId: uuid("agent_id").references(() => agents.id),
-    runId: uuid("run_id").references(() => heartbeatRuns.id),
+    // Deliberately NOT a foreign key (see migration 0197). An audit row must be able
+    // to name a run that has since been cleaned up; constraining it broke writes from
+    // agent tokens whose pinned run had expired, and blocked run retention besides.
+    runId: uuid("run_id"),
     responsibleUserId: text("responsible_user_id"),
     details: jsonb("details").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/db/src/schema/activity_log.ts
+++ b/packages/db/src/schema/activity_log.ts
@@ -13,7 +13,7 @@ export const activityLog = pgTable(
     entityType: text("entity_type").notNull(),
     entityId: text("entity_id").notNull(),
     agentId: uuid("agent_id").references(() => agents.id),
-    // Deliberately NOT a foreign key (see migration 0197). An audit row must be able
+    // Deliberately NOT a foreign key (see migration 0198). An audit row must be able
     // to name a run that has since been cleaned up; constraining it broke writes from
     // agent tokens whose pinned run had expired, and blocked run retention besides.
     runId: uuid("run_id"),

--- a/server/src/__tests__/activity-log-responsible-user.test.ts
+++ b/server/src/__tests__/activity-log-responsible-user.test.ts
@@ -231,4 +231,105 @@ describeEmbeddedPostgres("logActivity responsible-user stamping", () => {
 
     expect(row?.responsibleUserId).toBe("key-user");
   });
+
+  it("logs the activity when the claimed run no longer exists", async () => {
+    // The regression: an agent JWT pins a run_id for 14 days, heartbeat runs are
+    // ephemeral, and once the row is gone activity_log's FK to heartbeat_runs
+    // rejected the insert. logActivity threw, the route returned 500 — on a write
+    // that had already committed. Six of ten agent tokens on the live instance
+    // carried a dead run id and could not create an issue at all.
+    // Migration 0197 drops that FK: an audit row must be able to name a run that
+    // has since been cleaned up, so the id is kept as a plain value.
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const deadRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "default-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Ripley",
+      role: "ceo",
+      status: "running",
+      adapterType: "openclaw_gateway",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // The assertion that matters is that this does not throw: with the FK in place
+    // the insert raised and the route turned a committed write into a 500.
+    await expect(logActivity(db, activityInput({
+      companyId,
+      actorId: agentId,
+      agentId,
+      entityType: "agent",
+      entityId: agentId,
+      runId: deadRunId,
+    }))).resolves.toBeDefined();
+
+    const row = await db
+      .select({ runId: activityLog.runId })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId))
+      .then((rows) => rows[0]);
+
+    expect(row).toBeDefined();
+    expect(row?.runId).toBe(deadRunId);   // provenance kept, constraint gone
+  });
+
+  it("still records a run id that does exist", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const liveRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "default-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Bishop",
+      role: "cto",
+      status: "running",
+      adapterType: "openclaw_gateway",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: liveRunId,
+      companyId,
+      agentId,
+      responsibleUserId: "run-user",
+    });
+
+    await logActivity(db, activityInput({
+      companyId,
+      actorId: agentId,
+      agentId,
+      entityType: "agent",
+      entityId: agentId,
+      runId: liveRunId,
+    }));
+
+    const row = await db
+      .select({ runId: activityLog.runId, responsibleUserId: activityLog.responsibleUserId })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId))
+      .then((rows) => rows[0]);
+
+    expect(row?.runId).toBe(liveRunId);
+    expect(row?.responsibleUserId).toBe("run-user");
+  });
 });

--- a/server/src/__tests__/activity-log-responsible-user.test.ts
+++ b/server/src/__tests__/activity-log-responsible-user.test.ts
@@ -238,7 +238,7 @@ describeEmbeddedPostgres("logActivity responsible-user stamping", () => {
     // rejected the insert. logActivity threw, the route returned 500 — on a write
     // that had already committed. Six of ten agent tokens on the live instance
     // carried a dead run id and could not create an issue at all.
-    // Migration 0197 drops that FK: an audit row must be able to name a run that
+    // Migration 0198 drops that FK: an audit row must be able to name a run that
     // has since been cleaned up, so the id is kept as a plain value.
     const companyId = randomUUID();
     const agentId = randomUUID();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The activity log records which run did each action, for audit
> - `activity_log.run_id` has a foreign key to `heartbeat_runs`, with no `onDelete` rule
> - A heartbeat run is short-lived, but an agent JWT holds its `run_id` claim for the life of the token
> - When the run row is gone, every write from that token fails the constraint
> - `logActivity()` runs after the caller's write is already committed, so the caller sees HTTP 500 for work that succeeded, and a caller that retries then creates the record two times
> - The same constraint also stops run cleanup, because an audit row holds its run
> - This pull request removes the constraint and keeps the column, the value, and the index
> - The benefit is that the audit log can name a run that was cleaned up, which is what an audit log must do

## Linked Issues or Issue Description

Refs #5454 — the same failure on a neighbour table. That issue is about `issue_comments.created_by_run_id`. This pull request repairs `activity_log.run_id`. The tables differ in one way: `issue_comments` has `onDelete: "set null"`, so deletion is safe there, but an insert with a run id that is already gone still fails. `activity_log` has no `onDelete` rule, so it fails on both paths.

I did not change `issue_comments` in this pull request. That table has other run columns and belongs in its own review.

**What happened?**

Agents could not create issues. The API returned HTTP 500, but the issue was written. On our instance six of ten agent tokens carried a `run_id` that no longer existed, so those agents could not write at all. Over three months, five of 1020 agent runs completed.

**Expected behaviour**

An audit record must be able to name an entity that was later cleaned up. A write must not fail because of the audit step that follows it.

**Steps to reproduce**

1. Give an agent a token whose `run_id` claim points to a `heartbeat_runs` row.
2. Delete that run row, or wait for retention to remove it.
3. Create an issue with that token.
4. The issue appears in the database. The API returns HTTP 500 with `insert or update on table "activity_log" violates foreign key constraint "activity_log_run_id_heartbeat_runs_id_fk"`.

## What Changed

- New migration `0198_activity_log_run_id_no_fk.sql` drops `activity_log_run_id_heartbeat_runs_id_fk`. The statement uses `IF EXISTS`.
- `schema/activity_log.ts`: `runId` is a plain `uuid` column now. A comment explains why it is not a reference.
- The column, its value, and `activity_log_run_id_idx` do not change. Queries by `run_id` work as before.
- Two tests: one shows that an activity with a run id that does not exist is still written; one shows that a run id that does exist is still recorded, with the correct responsible user.

## Verification

```
npx vitest run server/src/__tests__/activity-log-responsible-user.test.ts
pnpm -C packages/db run check:migrations
```

The new test fails on `master` with `violates foreign key constraint "activity_log_run_id_heartbeat_runs_id_fk"`. It passes with the migration applied.

We have run this on our instance since 2026-08-01. A write from a token with a stale run id now returns HTTP 201, and the audit row holds the stale run id as a plain value.

## Risks

Low risk. The migration only drops a constraint, so it does not need a lock on the data and it does not rewrite the table. Existing rows do not change.

The trade-off is that `run_id` can now hold a value with no matching run. That is the goal: the audit log states which run claimed to act, and it must keep that statement after the run is gone. Code that joins `activity_log` to `heartbeat_runs` must accept no match, which it must accept in any case, because the column is nullable today.

## Model Used

- **Claude Opus 5** (`claude-opus-5`), through Claude Code, with extended thinking, tool use and code execution. It found the root cause, wrote the migration and the tests, and wrote this description.
- **OpenAI GPT-5.5** through the Codex CLI, as an adversarial review. It rejected the first attempt, which repaired this in application code: it verified the run and dropped the id when the run was gone, then guarded the insert. Codex showed that the guard does nothing inside a transaction, because a caught Postgres error still leaves the transaction aborted, and that four call sites pass a transaction handle. It also showed that swallowing insert errors breaks the audit guarantee, and that an early return drops plugin events that have no replay. Removing the constraint answers all of those.

A human directed the work, chose the scope and approved this pull request.

- [x] I have searched GitHub for duplicate or related PRs and linked them above
