### PR TITLE
fix: treat scheduled monitors as live blocker paths

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -99,7 +99,10 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originKind?: string | null;
     originId?: string | null;
     originFingerprint?: string | null;
+    executionPolicy?: Record<string, unknown> | null;
     executionState?: Record<string, unknown> | null;
+    monitorNextCheckAt?: Date | null;
+    monitorAttemptCount?: number | null;
     description?: string | null;
   }) {
     const id = input.id ?? randomUUID();
@@ -116,7 +119,10 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       originKind: input.originKind ?? "manual",
       originId: input.originId ?? null,
       originFingerprint: input.originFingerprint ?? "default",
+      executionPolicy: input.executionPolicy ?? null,
       executionState: input.executionState ?? null,
+      monitorNextCheckAt: input.monitorNextCheckAt ?? null,
+      monitorAttemptCount: input.monitorAttemptCount ?? 0,
       description: input.description ?? null,
     });
     return id;
@@ -170,6 +176,177 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       attentionBlockerCount: 0,
       sampleBlockerIdentifier: "PBC-2",
     });
+  });
+
+  it("classifies a future bounded monitor on an active blocker as a covered waiting path", async () => {
+    const { companyId, agentId } = await createCompany("PBMF");
+    const now = Date.now();
+    const nextCheckAt = new Date(now + 60 * 60 * 1000);
+    const parentId = await insertIssue({ companyId, identifier: "PBMF-1", title: "Parent", status: "blocked" });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBMF-2",
+      title: "Monitored dependency",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      executionPolicy: {
+        monitor: {
+          nextCheckAt: nextCheckAt.toISOString(),
+          timeoutAt: new Date(now + 2 * 60 * 60 * 1000).toISOString(),
+          maxAttempts: 2,
+        },
+      },
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 0,
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_dependency",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBMF-2",
+    });
+  });
+
+  it("lets a valid future monitor cover an in-review blocker without classifying it as stalled", async () => {
+    const { companyId, agentId } = await createCompany("PBMR");
+    const nextCheckAt = new Date(Date.now() + 60 * 60 * 1000);
+    const parentId = await insertIssue({ companyId, identifier: "PBMR-1", title: "Parent", status: "blocked" });
+    const blockerId = await insertIssue({
+      companyId,
+      identifier: "PBMR-2",
+      title: "Review awaiting monitored check",
+      status: "in_review",
+      assigneeAgentId: agentId,
+      executionPolicy: { monitor: { nextCheckAt: nextCheckAt.toISOString(), maxAttempts: 2 } },
+      monitorNextCheckAt: nextCheckAt,
+      monitorAttemptCount: 1,
+    });
+    await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBMR-2",
+    });
+  });
+
+  it("keeps absent, overdue, timed-out, exhausted, malformed, and invalid monitors attention-required", async () => {
+    const { companyId, agentId, pausedAgentId } = await createCompany("PBMX");
+    const now = Date.now();
+    const future = new Date(now + 60 * 60 * 1000);
+    const past = new Date(now - 60 * 60 * 1000);
+    const cases = [
+      {
+        suffix: "missing",
+        issue: { status: "in_progress", assigneeAgentId: agentId },
+      },
+      {
+        suffix: "overdue",
+        issue: { status: "in_progress", assigneeAgentId: agentId, monitorNextCheckAt: past },
+      },
+      {
+        suffix: "timed-out",
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: agentId,
+          executionPolicy: {
+            monitor: {
+              nextCheckAt: future.toISOString(),
+              timeoutAt: past.toISOString(),
+              maxAttempts: 2,
+            },
+          },
+          monitorNextCheckAt: future,
+          monitorAttemptCount: 0,
+        },
+      },
+      {
+        suffix: "exhausted",
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: agentId,
+          executionPolicy: { monitor: { nextCheckAt: future.toISOString(), maxAttempts: 1 } },
+          monitorNextCheckAt: future,
+          monitorAttemptCount: 1,
+        },
+      },
+      {
+        suffix: "malformed-timeout",
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: agentId,
+          executionPolicy: {
+            monitor: {
+              nextCheckAt: future.toISOString(),
+              timeoutAt: "not-a-date",
+              maxAttempts: 2,
+            },
+          },
+          monitorNextCheckAt: future,
+          monitorAttemptCount: 0,
+        },
+      },
+      {
+        suffix: "paused-assignee",
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: pausedAgentId,
+          executionPolicy: { monitor: { nextCheckAt: future.toISOString(), maxAttempts: 2 } },
+          monitorNextCheckAt: future,
+          monitorAttemptCount: 0,
+        },
+      },
+      {
+        suffix: "invalid-assignee",
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: null,
+          executionPolicy: { monitor: { nextCheckAt: future.toISOString(), maxAttempts: 2 } },
+          monitorNextCheckAt: future,
+          monitorAttemptCount: 0,
+        },
+      },
+    ] as const;
+
+    for (const [index, testCase] of cases.entries()) {
+      const parentIdentifier = `PBMX-${index * 2 + 1}`;
+      const blockerIdentifier = `PBMX-${index * 2 + 2}`;
+      const parentId = await insertIssue({
+        companyId,
+        identifier: parentIdentifier,
+        title: `Parent ${testCase.suffix}`,
+        status: "blocked",
+      });
+      const blockerId = await insertIssue({
+        companyId,
+        identifier: blockerIdentifier,
+        title: `Blocker ${testCase.suffix}`,
+        ...testCase.issue,
+      });
+      await block({ companyId, blockerIssueId: blockerId, blockedIssueId: parentId });
+
+      const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+      expect(parent?.blockerAttention, testCase.suffix).toMatchObject({
+        state: "needs_attention",
+        reason: "attention_required",
+        unresolvedBlockerCount: 1,
+        coveredBlockerCount: 0,
+        stalledBlockerCount: 0,
+        attentionBlockerCount: 1,
+        sampleBlockerIdentifier: blockerIdentifier,
+      });
+    }
   });
 
   it("classifies an assigned backlog blocker leaf without a waiting path as attention-needed", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -111,7 +111,11 @@ import {
   parseIssueGraphLivenessIncidentKey,
   RECOVERY_ORIGIN_KINDS,
 } from "./recovery/origins.js";
-import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
+import {
+  classifyIssueGraphLiveness,
+  hasScheduledIssueMonitor,
+  type IssueLivenessFinding,
+} from "./recovery/issue-graph-liveness.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
 import { finalizeStatusCardsForStalledGeneration } from "./status-card-finalization.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
@@ -1815,6 +1819,10 @@ type IssueBlockerAttentionNode = {
   executionRunId?: string | null;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  executionPolicy?: Record<string, unknown> | null;
+  executionState?: Record<string, unknown> | null;
+  monitorNextCheckAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
 };
 type IssueBlockerAttentionInputNode =
   Pick<
@@ -2248,6 +2256,10 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.issueId, issues.id))
@@ -2272,6 +2284,10 @@ async function listIssueBlockerAttentionMap(
           executionRunId: issues.executionRunId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
+          executionPolicy: issues.executionPolicy,
+          executionState: issues.executionState,
+          monitorNextCheckAt: issues.monitorNextCheckAt,
+          monitorAttemptCount: issues.monitorAttemptCount,
         })
         .from(issues)
         .where(
@@ -2310,6 +2326,10 @@ async function listIssueBlockerAttentionMap(
           executionRunId: row.executionRunId,
           assigneeAgentId: row.assigneeAgentId,
           assigneeUserId: row.assigneeUserId,
+          executionPolicy: row.executionPolicy,
+          executionState: row.executionState,
+          monitorNextCheckAt: row.monitorNextCheckAt,
+          monitorAttemptCount: row.monitorAttemptCount,
         });
         nextFrontier.add(row.blockerIssueId);
       }
@@ -2450,6 +2470,7 @@ async function listIssueBlockerAttentionMap(
         .where(and(eq(agents.companyId, companyId), inArray(agents.id, [...agentIds])))
     : [];
   const agentsById = new Map(agentRows.map((agent) => [agent.id, agent]));
+  const blockerAttentionNowMs = Date.now();
 
   type PathClassification = {
     covered: boolean;
@@ -2477,6 +2498,17 @@ async function listIssueBlockerAttentionMap(
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.assigneeUserId && node.status !== "cancelled") {
+      return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
+    }
+    const monitorAssignee = node.assigneeAgentId ? agentsById.get(node.assigneeAgentId) : null;
+    const hasValidScheduledMonitor =
+      Boolean(node.assigneeAgentId) &&
+      !node.assigneeUserId &&
+      (node.status === "in_progress" || node.status === "in_review") &&
+      monitorAssignee?.companyId === companyId &&
+      BLOCKER_ATTENTION_INVOKABLE_AGENT_STATUSES.has(monitorAssignee.status) &&
+      hasScheduledIssueMonitor(node, blockerAttentionNowMs);
+    if (hasValidScheduledMonitor) {
       return { covered: true, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
     if (node.status === "in_review") {

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -164,22 +164,46 @@ function readDateMs(value: unknown): number | null {
 }
 
 function monitorFromIssue(issue: IssueLivenessIssueInput) {
-  const policyMonitor = readRecord(readRecord(issue.executionPolicy)?.monitor);
-  const stateMonitor = readRecord(readRecord(issue.executionState)?.monitor);
-  return { policyMonitor, stateMonitor };
+  const policy = readRecord(issue.executionPolicy);
+  const state = readRecord(issue.executionState);
+  const rawPolicyMonitor = policy?.monitor;
+  const rawStateMonitor = state?.monitor;
+  const policyMonitor = readRecord(rawPolicyMonitor);
+  const stateMonitor = readRecord(rawStateMonitor);
+  const invalidMetadata =
+    (issue.executionPolicy != null && !policy) ||
+    (issue.executionState != null && !state) ||
+    (rawPolicyMonitor != null && !policyMonitor) ||
+    (rawStateMonitor != null && !stateMonitor);
+  return { policyMonitor, stateMonitor, invalidMetadata };
 }
 
-function hasScheduledMonitor(issue: IssueLivenessIssueInput, nowMs: number) {
+export function hasScheduledIssueMonitor(issue: IssueLivenessIssueInput, nowMs: number) {
   const nextCheckAtMs = readDateMs(issue.monitorNextCheckAt);
   if (nextCheckAtMs === null || nextCheckAtMs <= nowMs) return false;
 
-  const { policyMonitor, stateMonitor } = monitorFromIssue(issue);
-  const timeoutAtMs = readDateMs(policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt);
+  const { policyMonitor, stateMonitor, invalidMetadata } = monitorFromIssue(issue);
+  if (invalidMetadata) return false;
+
+  const timeoutAt = policyMonitor?.timeoutAt ?? stateMonitor?.timeoutAt;
+  const timeoutAtMs = readDateMs(timeoutAt);
+  if (timeoutAt != null && timeoutAtMs === null) return false;
   if (timeoutAtMs !== null && timeoutAtMs <= nowMs) return false;
 
-  const maxAttempts = readPositiveInteger(policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts);
-  const stateAttemptCount = readPositiveInteger(stateMonitor?.attemptCount) ?? 0;
+  const rawMaxAttempts = policyMonitor?.maxAttempts ?? stateMonitor?.maxAttempts;
+  const maxAttempts = readPositiveInteger(rawMaxAttempts);
+  if (rawMaxAttempts != null && maxAttempts === null) return false;
+
+  const rawStateAttemptCount = stateMonitor?.attemptCount;
+  if (
+    rawStateAttemptCount != null &&
+    (typeof rawStateAttemptCount !== "number" || !Number.isInteger(rawStateAttemptCount) || rawStateAttemptCount < 0)
+  ) {
+    return false;
+  }
+  const stateAttemptCount = typeof rawStateAttemptCount === "number" ? rawStateAttemptCount : 0;
   const attemptCount = issue.monitorAttemptCount ?? stateAttemptCount;
+  if (typeof attemptCount !== "number" || !Number.isInteger(attemptCount) || attemptCount < 0) return false;
   if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
 
   return true;
@@ -401,7 +425,7 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
 
   function hasExplicitWaitingPath(issue: IssueLivenessIssueInput) {
     return Boolean(issue.assigneeUserId) ||
-      hasScheduledMonitor(issue, nowMs) ||
+      hasScheduledIssueMonitor(issue, nowMs) ||
       hasActiveExecutionPath(issue.companyId, issue.id, activeRuns, queuedWakeRequests) ||
       hasWaitingPath(issue.companyId, issue.id, pendingInteractions) ||
       hasWaitingPath(issue.companyId, issue.id, pendingApprovals) ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Blocker attention tells a board member which dependency paths have stopped.
> - A future scheduled monitor is an explicit wake path for an issue.
> - Recovery liveness already recognizes that path.
> - Blocker attention did not apply the same complete validation.
> - Healthy monitored work could therefore appear stalled and trigger noisy recovery work.
> - This pull request shares one fail-closed monitor validator across both classifiers.
> - The benefit is a quieter blocked inbox without hiding invalid waits.

## Linked Issues or Issue Description

No exact public issue exists. This section describes the bug.

**What happened?**

A blocked issue with a valid future monitor could be reported as stalled when it had no active run. The false alert could then trigger redundant recovery work.

**Expected behavior**

A valid scheduled monitor must count as a live waiting path. An overdue, expired, exhausted, malformed, paused-owner, or unassigned monitor must still fail closed.

**Steps to reproduce**

1. Create an in-progress issue that blocks another issue.
2. Set a future monitor with a valid policy and an invokable assignee.
3. Query blocker attention.
4. Observe that the old classifier reports a stalled path even though recovery will wake it later.

**Paperclip version or commit**

Reproduced on master before commit 2ce758d49ff91d89e41f405ca0bdc420f76fa3da.

**Deployment mode**

Self-hosted server built from source.

Related work found during dedup search: #10398, #10502, and #8759. Those pull requests cover related scheduled-monitor attention cases. This change also reuses one strict validator for attention and recovery and tests malformed metadata, timeout, attempt exhaustion, paused ownership, and missing ownership.

## What Changed

- Export the scheduled-monitor liveness validator from recovery.
- Load monitor metadata for blocker-attention graph nodes.
- Count only valid future monitors as covered blocker paths.
- Add positive and fail-closed regression cases.

## Verification

- pnpm exec vitest run server/src/__tests__/issue-blocker-attention.test.ts: 27 passed.
- pnpm --filter @paperclipai/server typecheck: passed.
- Full upstream test, build, typecheck, and e2e jobs passed on the current head.

## Risks

- A permissive validator could hide a real stalled path. The shared validator fails closed for malformed, expired, exhausted, paused-owner, and unassigned states.
- The query reads monitor fields for graph nodes. Existing graph bounds still limit the read.
- There is no schema migration and no API shape change.
- This overlaps related open pull requests. Maintainers should select one implementation or combine the stronger coverage.

## Model Used

OpenAI GPT-5 Codex with high reasoning, tool use, repository inspection, and code execution. The runtime does not expose an exact context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an issue or described the issue using the bug template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal tracker id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No user-facing documentation change is required for this internal classifier correction
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open changed-code finding
- [x] I will address all reviewer comments before requesting merge