### PR TITLE
fix: stop provider failure wake storms

### DIFF
--- a/packages/adapters/claude-local/src/server/acp-provider-failure.test.ts
+++ b/packages/adapters/claude-local/src/server/acp-provider-failure.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { withClaudeAcpProviderFailureClassification } from "./acp.js";
+
+describe("Claude ACP provider failure classification", () => {
+  it("converts weekly-limit ACP turn failures into a quota retry contract", () => {
+    const result = withClaudeAcpProviderFailureClassification(
+      {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorCode: "acpx_turn_failed",
+        errorMessage: "Claude usage limit reached - weekly limit reached. Try again in 2 days.",
+        resultJson: { status: "failed", stopReason: "weekly limit reached" },
+      },
+      new Date("2026-08-01T12:00:00.000Z"),
+    );
+
+    expect(result).toMatchObject({
+      errorCode: "provider_quota",
+      errorFamily: "provider_quota",
+      retryNotBefore: "2026-08-03T12:00:00.000Z",
+      resultJson: {
+        providerQuotaRetryNotBefore: "2026-08-03T12:00:00.000Z",
+      },
+    });
+  });
+
+  it("opens the circuit for ACP credential failures instead of retrying them", () => {
+    const result = withClaudeAcpProviderFailureClassification({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "acpx_auth_required",
+      errorMessage: "Please log in. Run `claude login` first.",
+      resultJson: { status: "failed" },
+    });
+
+    expect(result).toMatchObject({
+      errorCode: "configuration_incomplete",
+      resultJson: { recoveryClassification: "configuration_incomplete" },
+    });
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.retryNotBefore).toBeUndefined();
+  });
+});

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -38,6 +38,11 @@ import {
   materializeRemoteClaudeConfig,
   prepareClaudeConfigSeed,
 } from "./claude-config.js";
+import {
+  detectClaudeLoginRequired,
+  extractClaudeRetryNotBefore,
+  isClaudeProviderQuotaError,
+} from "./parse.js";
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRootDir = path.resolve(moduleDir, "../..");
@@ -280,6 +285,56 @@ function withClaudeAcpDefaults(options: ClaudeAcpExecutorOptions): AcpxEngineExe
   };
 }
 
+export function withClaudeAcpProviderFailureClassification(
+  result: AdapterExecutionResult,
+  now = new Date(),
+): AdapterExecutionResult {
+  if ((result.exitCode ?? 0) === 0) return result;
+  const resultJson = parseObject(result.resultJson);
+  const stopReason = asString(resultJson.stopReason, "");
+  const failureText = [result.errorMessage ?? "", result.summary ?? "", stopReason]
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+  const classifierInput = {
+    parsed: resultJson,
+    stdout: result.summary ?? "",
+    stderr: failureText,
+    errorMessage: result.errorMessage ?? "",
+  };
+
+  if (detectClaudeLoginRequired(classifierInput).requiresLogin) {
+    return {
+      ...result,
+      errorCode: "configuration_incomplete",
+      resultJson: {
+        ...resultJson,
+        recoveryClassification: "configuration_incomplete",
+      },
+    };
+  }
+  if (!isClaudeProviderQuotaError(classifierInput)) return result;
+
+  const retryNotBefore = extractClaudeRetryNotBefore(classifierInput, now)?.toISOString() ?? null;
+  return {
+    ...result,
+    errorCode: "provider_quota",
+    errorFamily: "provider_quota",
+    retryNotBefore,
+    resultJson: {
+      ...resultJson,
+      errorFamily: "provider_quota",
+      ...(retryNotBefore
+        ? {
+            retryNotBefore,
+            transientRetryNotBefore: retryNotBefore,
+            providerQuotaRetryNotBefore: retryNotBefore,
+          }
+        : {}),
+    },
+  };
+}
+
 export function createClaudeAcpExecutor(options: ClaudeAcpExecutorOptions = {}): ClaudeAcpExecutor {
   let executor: ClaudeAcpExecutor | null = null;
   return async (ctx) => {
@@ -289,10 +344,11 @@ export function createClaudeAcpExecutor(options: ClaudeAcpExecutorOptions = {}):
       currentExecutor = createAcpxEngineExecutor(withClaudeAcpDefaults(options));
       executor = currentExecutor;
     }
-    return currentExecutor({
+    const result = await currentExecutor({
       ...ctx,
       config: buildClaudeAcpConfig(ctx.config),
     });
+    return withClaudeAcpProviderFailureClassification(result);
   };
 }
 

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -117,11 +117,16 @@ describe("isClaudeTransientUpstreamError", () => {
   });
 
   it("classifies the subscription 5-hour / weekly limit wording as provider quota", () => {
+    const now = new Date("2026-08-01T12:00:00.000Z");
+    const weeklyLimit = "Claude usage limit reached — weekly limit reached. Try again in 2 days.";
     expect(
       isClaudeProviderQuotaError({
-        errorMessage: "Claude usage limit reached — weekly limit reached. Try again in 2 days.",
+        errorMessage: weeklyLimit,
       }),
     ).toBe(true);
+    expect(extractClaudeRetryNotBefore({ errorMessage: weeklyLimit }, now)?.toISOString()).toBe(
+      "2026-08-03T12:00:00.000Z",
+    );
     expect(
       isClaudeProviderQuotaError({
         errorMessage: "5-hour limit reached.",

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -17,6 +17,8 @@ const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+const CLAUDE_EXTRA_USAGE_RELATIVE_RE =
+  /(?:try\s+again|resets?)\s+in\s+(\d+(?:\.\d+)?)\s*(minutes?|hours?|days?|weeks?)/i;
 
 /**
  * Sum the per-model usage ledger from a Claude CLI result event. The result
@@ -456,8 +458,24 @@ export function extractClaudeRetryNotBefore(
 ): Date | null {
   const haystack = buildClaudeTransientHaystack(input);
   const match = haystack.match(CLAUDE_EXTRA_USAGE_RESET_RE);
-  if (!match) return null;
-  return parseClaudeResetClockTime(match[1] ?? "", now, match[2]);
+  if (match) {
+    const clockReset = parseClaudeResetClockTime(match[1] ?? "", now, match[2]);
+    if (clockReset) return clockReset;
+  }
+
+  const relativeMatch = haystack.match(CLAUDE_EXTRA_USAGE_RELATIVE_RE);
+  if (!relativeMatch) return null;
+  const amount = Number.parseFloat(relativeMatch[1] ?? "");
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+  const unit = (relativeMatch[2] ?? "").toLowerCase();
+  const unitMs = unit.startsWith("week")
+    ? 7 * 24 * 60 * 60 * 1000
+    : unit.startsWith("day")
+      ? 24 * 60 * 60 * 1000
+      : unit.startsWith("hour")
+        ? 60 * 60 * 1000
+        : 60 * 1000;
+  return new Date(now.getTime() + amount * unitMs);
 }
 
 export function isClaudeTransientUpstreamError(input: {

--- a/packages/shared/src/agent-eligibility.test.ts
+++ b/packages/shared/src/agent-eligibility.test.ts
@@ -64,6 +64,18 @@ describe("agent work eligibility", () => {
     });
   });
 
+  it("keeps failed agents assigned but opens the invocation circuit until their error is cleared", () => {
+    const target = agent({ status: "error" });
+    const manager = agent({ id: "manager-1", name: "CTO", status: "active", reportsTo: null });
+
+    expect(getAgentWorkEligibility({ agent: target, agents: [target, manager] })).toMatchObject({
+      assignable: true,
+      invokable: false,
+      assignabilityReason: "eligible",
+      invokabilityReason: "error",
+    });
+  });
+
   it("reports unknown lifecycle statuses explicitly", () => {
     const target = agent({ status: "sabbatical" });
     const manager = agent({ id: "manager-1", name: "CTO", status: "active", reportsTo: null });

--- a/packages/shared/src/agent-eligibility.ts
+++ b/packages/shared/src/agent-eligibility.ts
@@ -5,6 +5,7 @@ export type AgentEligibilityLifecycleReason =
   | "terminated"
   | "pending_approval"
   | "paused"
+  | "error"
   | "invalid_org_chain"
   | "unknown_status";
 
@@ -56,9 +57,9 @@ export interface AgentWorkEligibility {
 }
 
 const NON_ASSIGNABLE_AGENT_STATUSES = new Set<string>(["terminated", "pending_approval"]);
-const NON_INVOKABLE_AGENT_STATUSES = new Set<string>(["terminated", "pending_approval", "paused"]);
+const NON_INVOKABLE_AGENT_STATUSES = new Set<string>(["terminated", "pending_approval", "paused", "error"]);
 const ASSIGNABLE_AGENT_STATUSES = new Set<string>(["active", "paused", "idle", "running", "error"]);
-const INVOKABLE_AGENT_STATUSES = new Set<string>(["active", "idle", "running", "error"]);
+const INVOKABLE_AGENT_STATUSES = new Set<string>(["active", "idle", "running"]);
 
 export function isAgentStatusAssignableToWork(status: AgentStatus | string): boolean {
   return ASSIGNABLE_AGENT_STATUSES.has(status) && !NON_ASSIGNABLE_AGENT_STATUSES.has(status);
@@ -216,7 +217,9 @@ export function getAgentWorkEligibility(input: {
         ? "pending_approval"
         : input.agent.status === "paused"
           ? "paused"
-          : "unknown_status"
+          : input.agent.status === "error"
+            ? "error"
+            : "unknown_status"
     : orgChainHealth.status === "invalid_org_chain"
       ? "invalid_org_chain"
       : "eligible";

--- a/server/src/__tests__/agent-invokability.test.ts
+++ b/server/src/__tests__/agent-invokability.test.ts
@@ -16,6 +16,20 @@ function agent(partial: Partial<AgentOrgRow> & Pick<AgentOrgRow, "id">): AgentOr
 }
 
 describe("agent invokability", () => {
+  it("blocks agents in error until the explicit clear-error transition", () => {
+    const rows = [agent({ id: "coder", status: "error" })];
+
+    expect(evaluateAgentInvokability(rows[0], rows)).toMatchObject({
+      invokable: false,
+      reason: "error",
+      invalidOrgChain: false,
+      details: {
+        agentId: "coder",
+        agentStatus: "error",
+      },
+    });
+  });
+
   it("blocks active descendants under a terminated manager as invalid-org-chain", () => {
     const rows = [
       agent({ id: "ceo", status: "terminated" }),

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -41,6 +41,9 @@ const mockAdapterExecute = vi.hoisted(() =>
     model: "test-model",
   })),
 );
+const invokabilityMockState = vi.hoisted(() => ({
+  rejectDirectEvaluation: false,
+}));
 
 vi.mock("../adapters/index.ts", async () => {
   const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
@@ -50,6 +53,29 @@ vi.mock("../adapters/index.ts", async () => {
       supportsLocalAgentJwt: false,
       execute: mockAdapterExecute,
     })),
+  };
+});
+
+vi.mock("../services/agent-invokability.ts", async () => {
+  const actual = await vi.importActual<typeof import("../services/agent-invokability.ts")>(
+    "../services/agent-invokability.ts",
+  );
+  return {
+    ...actual,
+    evaluateAgentInvokability: (
+      ...args: Parameters<typeof actual.evaluateAgentInvokability>
+    ): ReturnType<typeof actual.evaluateAgentInvokability> => {
+      if (invokabilityMockState.rejectDirectEvaluation) {
+        return {
+          invokable: false,
+          reason: "error",
+          message: "Agent became non-invokable before claim",
+          details: {},
+          invalidOrgChain: false,
+        };
+      }
+      return actual.evaluateAgentInvokability(...args);
+    },
   };
 });
 
@@ -100,6 +126,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
   }, 20_000);
 
   afterEach(async () => {
+    invokabilityMockState.rejectDirectEvaluation = false;
     let idlePolls = 0;
     for (let attempt = 0; attempt < 100; attempt += 1) {
       const runs = await db
@@ -683,6 +710,94 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       finishFirstRun();
     }
   }, 40_000);
+
+  it("cancels a run that becomes non-invokable during claim without reacquiring the agent start lock", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `L${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "LockRaceAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      status: "queued",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId,
+      contextSnapshot: { wakeReason: "issue_assigned" },
+      responsibleUserId: "responsible-user",
+    });
+    await db
+      .update(agentWakeupRequests)
+      .set({ runId })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+
+    // The scheduler's initial database-backed eligibility check still passes.
+    // The direct evaluation inside claimQueuedRun then models the real race in
+    // which another run moves the agent to error before this queued row claims.
+    invokabilityMockState.rejectDirectEvaluation = true;
+    await heartbeat.resumeQueuedRuns();
+    invokabilityMockState.rejectDirectEvaluation = false;
+
+    const [run, wakeup, agent] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, error: heartbeatRuns.error })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agents.status })
+        .from(agents)
+        .where(eq(agents.id, agentId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run).toMatchObject({
+      status: "cancelled",
+      error: "Cancelled because the agent is not invokable: error",
+    });
+    expect(wakeup?.status).toBe("cancelled");
+    expect(agent?.status).toBe("active");
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
 
   it("cancels stale queued runs when issue blockers are still unresolved", async () => {
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -32,6 +32,7 @@ import {
   MAX_TURN_CONTINUATION_WAKE_REASON,
   heartbeatService,
 } from "../services/heartbeat.ts";
+import { PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS } from "../services/recovery/service.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -2085,6 +2086,32 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       retryReason: "transient_failure",
       scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
       maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+    });
+  });
+
+  it("uses a conservative quota cooldown when the provider omits reset metadata", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-08-01T12:00:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "provider_quota",
+      errorFamily: "provider_quota",
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled).toMatchObject({
+      outcome: "scheduled",
+      dueAt: new Date(now.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS),
     });
   });
 

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -296,6 +296,80 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .toEqual({ status: "idle", errorReason: null });
   });
 
+  it("opens the error circuit when provider quota retry attempts are exhausted", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Exhausted Quota Test",
+      role: "engineer",
+      status: "idle",
+      adapterType: PROVIDER_QUOTA_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "queued",
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+      scheduledRetryReason: "transient_failure",
+      contextSnapshot: {
+        wakeReason: "transient_failure_retry",
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    const failedRun = await waitForRunToFinish(heartbeat, runId);
+
+    expect(failedRun).toMatchObject({
+      status: "failed",
+      errorCode: "provider_quota",
+      scheduledRetryAttempt: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length,
+    });
+    const retryCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId))
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(retryCount).toBe(0);
+    await expect
+      .poll(
+        () =>
+          db
+            .select({ status: agents.status, errorReason: agents.errorReason })
+            .from(agents)
+            .where(eq(agents.id, agentId))
+            .then((rows) => rows[0] ?? null),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toEqual({
+        status: "error",
+        errorReason: "You've hit your session limit - resets at 4pm (America/Chicago).",
+      });
+  });
+
   async function seedMaxTurnFixture(input?: {
     companyId?: string;
     agentId?: string;

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -428,6 +428,41 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
   });
 
+  it("classifies an errored ACPX agent before the invocation circuit suppresses recovery wakes", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(agents).set({ status: "error" }).where(eq(agents.id, coderId));
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: coderId,
+      invocationSource: "manual",
+      status: "failed",
+      error: "Claude usage limit reached — weekly limit reached.",
+      errorCode: "acpx_turn_failed",
+      startedAt: new Date("2026-08-01T12:00:00.000Z"),
+      finishedAt: new Date("2026-08-01T12:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+      resultJson: { stopReason: "weekly limit reached" },
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result).toMatchObject({ providerQuotaMonitored: 1, dispatchRequeued: 0 });
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: coderId,
+      monitorNextCheckAt: expect.any(Date),
+      monitorNotes: "Provider usage quota reached; retry the original assignee after the default recovery backoff.",
+    });
+    const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(updatedRun).toMatchObject({ errorCode: "provider_quota" });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
   it("schedules another provider-quota monitor after a prior quota monitor fired", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.update(issues).set({ monitorAttemptCount: 1 }).where(eq(issues.id, sourceIssueId));

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -463,6 +463,40 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
+  it("does not turn a temporary agent pause into a permanent issue blocker", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(agents).set({ status: "paused", pauseReason: "manual" }).where(eq(agents.id, coderId));
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: coderId,
+      invocationSource: "manual",
+      status: "failed",
+      error: "model_not_found: requested model does not exist",
+      errorCode: "adapter_failed",
+      startedAt: new Date("2026-08-01T12:00:00.000Z"),
+      finishedAt: new Date("2026-08-01T12:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result).toMatchObject({ escalated: 0, providerQuotaMonitored: 0, skipped: 1 });
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: coderId,
+      monitorNextCheckAt: null,
+    });
+    const [updatedRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(updatedRun?.errorCode).toBe("adapter_failed");
+    expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
   it("schedules another provider-quota monitor after a prior quota monitor fired", async () => {
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     await db.update(issues).set({ monitorAttemptCount: 1 }).where(eq(issues.id, sourceIssueId));

--- a/server/src/services/agent-invokability.ts
+++ b/server/src/services/agent-invokability.ts
@@ -13,6 +13,7 @@ export type AgentOrgRow = Pick<
 export type AgentInvokabilityBlockReason =
   | "missing"
   | "paused"
+  | "error"
   | "terminated"
   | "pending_approval"
   | "unknown_status"
@@ -34,6 +35,7 @@ export type AgentInvokability =
 
 export const DIRECT_NON_INVOKABLE_STATUSES = new Set<AgentStatus>([
   "paused",
+  "error",
   "terminated",
   "pending_approval",
 ]);
@@ -49,6 +51,7 @@ function blocked(
 
 function statusBlockReason(status: AgentStatus): AgentInvokabilityBlockReason | null {
   if (status === "paused") return "paused";
+  if (status === "error") return "error";
   if (status === "terminated") return "terminated";
   if (status === "pending_approval") return "pending_approval";
   return null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -211,7 +211,10 @@ import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
-import { recoveryService } from "./recovery/service.js";
+import {
+  PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS,
+  recoveryService,
+} from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { resolveRequiredSuccessfulRunHandoffOnValidPath } from "./successful-run-handoff-state.js";
 import { taskWatchdogService } from "./task-watchdogs.js";
@@ -10436,7 +10439,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agent.adapterType === "codex_local" && transientRecovery?.errorFamily === "transient_upstream"
         ? resolveCodexTransientFallbackMode(nextAttempt)
         : null;
-    const transientRetryNotBefore = transientRecovery?.retryNotBefore ?? null;
+    const transientRetryNotBefore = transientRecovery?.retryNotBefore ??
+      (transientRecovery?.errorFamily === "provider_quota"
+        ? new Date(now.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS)
+        : null);
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
 
@@ -14902,6 +14908,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         error: runErrorMessage,
       });
 
+      let automaticRetryScheduled = false;
       const finalizedRun = persistedRun ?? (await getRun(run.id));
       if (finalizedRun) {
         await appendRunEvent(finalizedRun, seq++, {
@@ -14954,12 +14961,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (outcome === "failed" && isMaxTurnExhaustionRun(livenessRun)) {
           const policy = parseMaxTurnContinuationPolicy(agent);
           if (policy.enabled && policy.maxAttempts > 0) {
-            await scheduleBoundedRetryForRun(livenessRun, agent, {
+            const retry = await scheduleBoundedRetryForRun(livenessRun, agent, {
               retryReason: MAX_TURN_CONTINUATION_RETRY_REASON,
               wakeReason: MAX_TURN_CONTINUATION_WAKE_REASON,
               maxAttempts: policy.maxAttempts,
               delayMs: policy.delayMs,
             });
+            automaticRetryScheduled = retry.outcome === "scheduled";
           } else {
             await appendRunEvent(livenessRun, await nextRunEventSeq(livenessRun.id), {
               eventType: "lifecycle",
@@ -14973,7 +14981,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             });
           }
         } else if (outcome === "failed" && readTransientRecoveryContractFromRun(livenessRun)) {
-          await scheduleBoundedRetryForRun(livenessRun, agent);
+          const retry = await scheduleBoundedRetryForRun(livenessRun, agent);
+          automaticRetryScheduled = retry.outcome === "scheduled";
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
         await releaseIssueExecutionAndPromote(livenessRun);
@@ -15052,7 +15061,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         {
           keepIdleOnFailure:
             outcome === "failed" &&
-            (finalizedRun ? readHeartbeatRunErrorFamily(finalizedRun) === "provider_quota" : runErrorCode === "provider_quota"),
+            (automaticRetryScheduled ||
+              (finalizedRun
+                ? readHeartbeatRunErrorFamily(finalizedRun) === "provider_quota"
+                : runErrorCode === "provider_quota")),
           wasFirstHeartbeat: timerClaimWasFirstHeartbeat(run),
         },
       );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -15061,10 +15061,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         {
           keepIdleOnFailure:
             outcome === "failed" &&
-            (automaticRetryScheduled ||
-              (finalizedRun
-                ? readHeartbeatRunErrorFamily(finalizedRun) === "provider_quota"
-                : runErrorCode === "provider_quota")),
+            automaticRetryScheduled,
           wasFirstHeartbeat: timerClaimWasFirstHeartbeat(run),
         },
       );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11560,18 +11560,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
-  async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
+  async function claimQueuedRun(
+    run: typeof heartbeatRuns.$inferSelect,
+    companyAgents?: AgentOrgRow[],
+    options: { agentStartLockHeld?: boolean } = {},
+  ) {
     if (run.status !== "queued") return run;
+
+    // startNextQueuedRunForAgent() calls this while holding the per-agent start
+    // lock. Defer queue continuation so cancelRunInternal() cannot reacquire
+    // that same lock and stall for its 30-second stale timeout.
+    const cancelBeforeClaim = (reason: string) =>
+      cancelRunInternal(run.id, reason, {
+        deferQueueDispatch: options.agentStartLockHeld === true,
+      });
+
     const agent = await getAgent(run.agentId);
     if (!agent) {
-      await cancelRunInternal(run.id, "Cancelled because the agent no longer exists");
+      await cancelBeforeClaim("Cancelled because the agent no longer exists");
       return null;
     }
     const invokability = companyAgents
       ? evaluateAgentInvokability(toAgentOrgRow(agent), companyAgents)
       : await getAgentInvokability(agent);
     if (!invokability.invokable) {
-      await cancelRunInternal(run.id, `Cancelled because the agent is not invokable: ${invokability.reason}`);
+      await cancelBeforeClaim(
+        `Cancelled because the agent is not invokable: ${invokability.reason}`,
+      );
       return null;
     }
 
@@ -11581,7 +11596,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
-      await cancelRunInternal(run.id, budgetBlock.reason);
+      await cancelBeforeClaim(budgetBlock.reason);
       return null;
     }
 
@@ -11607,7 +11622,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         contextSnapshot: context,
       });
       if (activePauseHold && !treeHoldInteractionWake) {
-        await cancelRunInternal(run.id, "Cancelled because issue is held by an active subtree pause hold");
+        await cancelBeforeClaim(
+          "Cancelled because issue is held by an active subtree pause hold",
+        );
         await logActivity(db, {
           companyId: run.companyId,
           actorType: "system",
@@ -12678,7 +12695,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
       for (const queuedRun of prioritizedRuns) {
         if (claimedRuns.length >= availableSlots) break;
-        const claimed = await claimQueuedRun(queuedRun, companyAgents);
+        const claimed = await claimQueuedRun(queuedRun, companyAgents, { agentStartLockHeld: true });
         if (claimed) claimedRuns.push(claimed);
       }
       if (claimedRuns.length === 0) return [];
@@ -15415,7 +15432,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
   async function releaseIssueExecutionAndPromote(
     run: typeof heartbeatRuns.$inferSelect,
-    options: { suppressImmediateRecovery?: boolean } = {},
+    options: {
+      suppressImmediateRecovery?: boolean;
+      suppressQueueDispatch?: boolean;
+    } = {},
   ) {
     const runContext = parseObject(run.contextSnapshot);
     const contextIssueId = readNonEmptyString(runContext.issueId);
@@ -16177,7 +16197,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       },
     });
 
-    await startNextQueuedRunForAgent(promotedRun.agentId);
+    if (!options.suppressQueueDispatch) {
+      await startNextQueuedRunForAgent(promotedRun.agentId);
+    }
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
@@ -17531,6 +17553,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     resultJson?: Record<string, unknown>;
     eventMessage?: string;
     eventPayload?: Record<string, unknown>;
+    deferQueueDispatch?: boolean;
   };
 
   async function cancelRunInternal(runId: string, reason = "Cancelled by control plane", options: CancelRunOptions = {}) {
@@ -17589,13 +17612,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         message: options.eventMessage ?? "run cancelled",
         ...(options.eventPayload ? { payload: options.eventPayload } : {}),
       });
-      await releaseIssueExecutionAndPromote(cancelled);
+      await releaseIssueExecutionAndPromote(cancelled, {
+        suppressImmediateRecovery: options.deferQueueDispatch,
+        suppressQueueDispatch: options.deferQueueDispatch,
+      });
     }
 
-    await finalizeAgentStatus(run.agentId, "cancelled", undefined, {
-      wasFirstHeartbeat: timerClaimWasFirstHeartbeat(run),
-    });
-    await startNextQueuedRunForAgent(run.agentId);
+    if (!options.deferQueueDispatch) {
+      await finalizeAgentStatus(run.agentId, "cancelled", undefined, {
+        wasFirstHeartbeat: timerClaimWasFirstHeartbeat(run),
+      });
+      await startNextQueuedRunForAgent(run.agentId);
+    }
     return cancelled;
   }
 

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -35,6 +35,21 @@ describe("classifyAdapterFailureForRecovery", () => {
     });
   });
 
+  it("recovers historical ACPX weekly-limit failures that lost their adapter family", () => {
+    const now = new Date("2026-08-01T12:00:00.000Z");
+    const classification = classifyAdapterFailureForRecovery({
+      errorCode: "acpx_turn_failed",
+      error: "Claude usage limit reached — weekly limit reached.",
+      resultJson: { stopReason: "weekly limit reached" },
+    }, now);
+
+    expect(classification).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date(now.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS),
+      parsedResetTime: false,
+    });
+  });
+
   it("treats timezone-less provider reset clocks as UTC", () => {
     const now = new Date("2026-07-15T20:00:00.000Z");
     const classification = classifyAdapterFailureForRecovery({
@@ -73,6 +88,14 @@ describe("classifyAdapterFailureForRecovery", () => {
     expect(classifyAdapterFailureForRecovery({
       errorCode: "adapter_failed",
       error,
+      resultJson: null,
+    })).toEqual({ kind: "configuration_incomplete" });
+  });
+
+  it("treats ACPX login failures as configuration-incomplete circuit breakers", () => {
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "acpx_auth_required",
+      error: "Please log in. Run `claude login` first.",
       resultJson: null,
     })).toEqual({ kind: "configuration_incomplete" });
   });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -382,9 +382,17 @@ const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
 const PROVIDER_QUOTA_ERROR_RE =
-  /(?:you(?:'|’)ve hit your usage limit|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
+  /(?:you(?:'|’)ve hit your (?:usage|session) limit|(?:usage|session|weekly|5[-\s]?hour) limit(?: reached| exceeded)?|out of extra usage|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
-  /(?:model_not_found|model [^\n]{0,120} not found|missing (?:api )?(?:key|credentials?)|credentials? (?:are |is )?missing|no (?:api )?(?:key|credentials?) (?:was |were )?(?:found|configured|provided)|api key (?:is )?(?:not set|unavailable))/i;
+  /(?:model_not_found|model [^\n]{0,120} not found|missing (?:api )?(?:key|credentials?)|credentials? (?:are |is )?missing|no (?:api )?(?:key|credentials?) (?:was |were )?(?:found|configured|provided)|api key (?:is )?(?:not set|unavailable)|auth(?:entication)? required|not logged in|please (?:log in|run `?claude login`?))/i;
+const ADAPTER_FAILURE_RECOVERY_ERROR_CODES = new Set([
+  "adapter_failed",
+  "provider_quota",
+  "configuration_incomplete",
+  "acpx_turn_failed",
+  "acpx_auth_required",
+  "claude_auth_required",
+]);
 
 export type AdapterFailureRecoveryClassification =
   | { kind: "provider_quota"; retryAt: Date; parsedResetTime: boolean }
@@ -463,11 +471,7 @@ export function classifyAdapterFailureForRecovery(
   latestRun: Pick<NonNullable<LatestIssueRun>, "error" | "errorCode" | "resultJson">,
   now = new Date(),
 ): AdapterFailureRecoveryClassification {
-  if (
-    latestRun.errorCode !== "adapter_failed" &&
-    latestRun.errorCode !== "provider_quota" &&
-    latestRun.errorCode !== "configuration_incomplete"
-  ) {
+  if (!latestRun.errorCode || !ADAPTER_FAILURE_RECOVERY_ERROR_CODES.has(latestRun.errorCode)) {
     return null;
   }
   const resultJson = parseObject(latestRun.resultJson);
@@ -3678,10 +3682,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       const agentInvokable = agent && agent.companyId === issue.companyId
         ? await isAgentInvokable(agent)
         : false;
-      if (issue.status !== "in_review" && !agentInvokable) {
-        result.skipped += 1;
-        continue;
-      }
 
       if (await hasActiveExecutionPath(
         issue.companyId,
@@ -3776,6 +3776,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           }
           continue;
         }
+      }
+
+      // A failed agent is intentionally non-invokable until clear-error. Still
+      // classify its terminal adapter failure first so quota waits become
+      // durable monitors and credential failures become explicit blockers,
+      // rather than leaving the issue to be reconsidered every recovery sweep.
+      if (issue.status !== "in_review" && !agentInvokable) {
+        result.skipped += 1;
+        continue;
       }
 
       const acceptedContinuationInteraction = await getLatestAcceptedContinuationInteraction(issue.companyId, issue.id);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3733,6 +3733,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      // Only errored agents may cross this gate so we can classify the failure
+      // that opened their invocation circuit. A paused agent is a temporary
+      // operator hold: mutating its issue to blocked here would outlive the
+      // pause and leave the work stranded after the agent is resumed.
+      if (issue.status !== "in_review" && !agentInvokable && agent?.status !== "error") {
+        result.skipped += 1;
+        continue;
+      }
+
       const adapterFailureClassification = issue.status !== "in_review" && latestRun && isUnsuccessfulTerminalIssueRun(latestRun)
         ? classifyAdapterFailureForRecovery(latestRun, recoveryNow)
         : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat and recovery services decide when an agent may run again.
> - The error lifecycle state was still invokable.
> - Claude ACP also flattened provider quota and authentication failures into a generic failure.
> - Recovery could wake the same failed agent on every sweep.
> - A scheduled quota retry must keep the agent idle only while that retry exists.
> - A temporary operator pause must not mutate assigned work into a permanent blocker.
> - This pull request opens a durable error circuit and adds bounded provider-aware recovery.
> - The benefit is that provider failures wait or stop once instead of creating wake storms.

## Linked Issues or Issue Description

No exact public issue exists. This section describes the bug.

**What happened?**

An agent in error could still be invoked. Claude quota and login failures were stored as generic ACP turn failures. Recovery then reconsidered the same work repeatedly. A temporary paused agent could also have its issue changed to blocked, and an exhausted quota retry could leave the agent idle with no future wake.

**Expected behavior**

An errored agent must remain non-invokable until clear-error. Provider quota must schedule a bounded reset-time retry. Authentication failures must become explicit configuration blockers. If retry attempts are exhausted, the agent must enter error. Pausing an agent must preserve the issue state for resume.

**Steps to reproduce**

1. Run a Claude agent until the provider returns a quota or login failure.
2. Let the heartbeat finalize the failed run.
3. Run recovery more than once.
4. Observe repeated wakes under the old behavior.
5. Exhaust the bounded retry count or pause the agent before recovery.
6. Observe the old idle-without-wake or permanent-blocked state.

**Paperclip version or commit**

Reproduced on master before commit b1a7e88607bf5a8eddf39744c9ce1fc57b7f95a3.

**Deployment mode**

Self-hosted server built from source.

**Agent adapter involved**

Claude Code local adapter and core heartbeat/recovery services.

Related work found during dedup search: #9635 covers recovery-time provider quota waits, #9546 covers successful Claude run misclassification, and #9288 covers adjacent provider-limit classification. This pull request adds the shared error invocation circuit and the full heartbeat-to-recovery lifecycle.

## What Changed

- Make error non-invokable while keeping existing assignments.
- Classify Claude ACP quota and authentication failures.
- Parse absolute and relative provider reset windows.
- Apply a conservative one-hour fallback when reset metadata is absent.
- Persist provider retry metadata on the run.
- Keep an agent idle only when a bounded retry was actually scheduled.
- Enter error when quota retries are exhausted.
- Preserve in-progress work while an agent is temporarily paused.
- Classify historical generic ACP failures before the error circuit suppresses wakes.
- Add regression coverage for pause safety and exhausted quota retries.

## Verification

- Focused validation before review: 7 files and 137 tests passed.
- Review-fix validation: issue recovery and heartbeat retry suites, 2 files and 75 tests passed.
- Shared, Claude adapter, and server typechecks passed.
- The prior upstream head passed build, general tests, serialized suites, canary, and both e2e shards.

## Risks

- Error becomes a real invocation circuit. Operators must use clear-error after fixing a persistent problem.
- Text classification is conservative. Unmatched failures keep the existing generic recovery path.
- Relative reset strings depend on provider text and time interpretation. Missing data uses a one-hour fallback.
- Existing assignments remain on errored agents. This avoids silent reassignment but requires visible recovery ownership.
- The new pause guard applies to standard assigned work. Existing review-participant recovery semantics remain unchanged.

## Model Used

OpenAI GPT-5 Codex with high reasoning, tool use, repository inspection, and code execution. The runtime does not expose an exact context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an issue or described the issue using the bug template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal tracker id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No user-facing documentation change is required for this internal runtime correction
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open findings
- [x] I will address all reviewer comments before requesting merge