### PR TITLE
Defer Claude weekly-limit retries until reset

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -59,6 +59,7 @@ import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
   describeClaudeFailure,
+  detectClaudeOverflowHold,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeMaxTurnsResult,
@@ -971,17 +972,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       };
     }
 
+    const overflowHold = detectClaudeOverflowHold(proc.stderr);
+
     if (!parsed) {
-      const fallbackErrorMessage = parseFallbackErrorMessage(proc);
+      const fallbackErrorMessage = overflowHold?.message ?? parseFallbackErrorMessage(proc);
       const providerQuota =
         !loginMeta.requiresLogin &&
-        (proc.exitCode ?? 0) !== 0 &&
-        isClaudeProviderQuotaError({
-          parsed: null,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage: fallbackErrorMessage,
-        });
+        (overflowHold !== null ||
+          ((proc.exitCode ?? 0) !== 0 &&
+            isClaudeProviderQuotaError({
+              parsed: null,
+              stdout: proc.stdout,
+              stderr: proc.stderr,
+              errorMessage: fallbackErrorMessage,
+            })));
       const transientUpstream =
         !loginMeta.requiresLogin &&
         !providerQuota &&
@@ -992,14 +996,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stderr: proc.stderr,
           errorMessage: fallbackErrorMessage,
         });
-      const transientRetryNotBefore = providerQuota || transientUpstream
-        ? extractClaudeRetryNotBefore({
-            parsed: null,
-            stdout: proc.stdout,
-            stderr: proc.stderr,
-            errorMessage: fallbackErrorMessage,
-          })
-        : null;
+      const transientRetryNotBefore = overflowHold?.retryNotBefore ??
+        (providerQuota || transientUpstream
+          ? extractClaudeRetryNotBefore({
+              parsed: null,
+              stdout: proc.stdout,
+              stderr: proc.stderr,
+              errorMessage: fallbackErrorMessage,
+            })
+          : null);
       const errorCode = loginMeta.requiresLogin
         ? "claude_auth_required"
         : isClaudeModelNotFoundError({
@@ -1088,6 +1093,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const parsedSucceeded =
       parsedSubtype === "success" && !parsedIsError && !successfulQuotaRefusal;
     const failed =
+      overflowHold !== null ||
       successfulQuotaRefusal ||
       (!parsedSucceeded && ((proc.exitCode ?? 0) !== 0 || parsedIsError));
     // Validate-before-persist guard: never persist a sessionId whose transcript
@@ -1116,19 +1122,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       } as Record<string, unknown>)
       : null;
     const errorMessage = failed
-      ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
+      ? overflowHold?.message ?? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;
     const providerQuota =
       failed &&
       !loginMeta.requiresLogin &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
-      isClaudeProviderQuotaError({
-        parsed,
-        stdout: proc.stdout,
-        stderr: proc.stderr,
-        errorMessage,
-      });
+      (overflowHold !== null ||
+        isClaudeProviderQuotaError({
+          parsed,
+          stdout: proc.stdout,
+          stderr: proc.stderr,
+          errorMessage,
+        }));
     const transientUpstream =
       failed &&
       !loginMeta.requiresLogin &&
@@ -1141,14 +1148,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderr: proc.stderr,
         errorMessage,
       });
-    const transientRetryNotBefore = providerQuota || transientUpstream
-      ? extractClaudeRetryNotBefore({
-          parsed,
-          stdout: proc.stdout,
-          stderr: proc.stderr,
-          errorMessage,
-        })
-      : null;
+    const transientRetryNotBefore = overflowHold?.retryNotBefore ??
+      (providerQuota || transientUpstream
+        ? extractClaudeRetryNotBefore({
+            parsed,
+            stdout: proc.stdout,
+            stderr: proc.stderr,
+            errorMessage,
+          })
+        : null);
     const resolvedErrorCode = loginMeta.requiresLogin
       ? "claude_auth_required"
       : failed && isClaudeModelNotFoundError({

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1072,8 +1072,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const claudeRefusal = isClaudeRefusalResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
     const parsedSubtype = asString(parsed.subtype, "").trim().toLowerCase();
-    const parsedSucceeded = parsedSubtype === "success" && !parsedIsError;
-    const failed = !parsedSucceeded && ((proc.exitCode ?? 0) !== 0 || parsedIsError);
+    const zeroTokenResult =
+      usage.inputTokens === 0 && usage.cachedInputTokens === 0 && usage.outputTokens === 0;
+    // Claude can wrap a subscription refusal in subtype=success. Keep the guard
+    // narrow so ordinary successful output that discusses quotas remains valid.
+    const successfulQuotaRefusal =
+      parsedSubtype === "success" &&
+      !parsedIsError &&
+      zeroTokenResult &&
+      isClaudeProviderQuotaError({
+        parsed,
+        stdout: proc.stdout,
+        stderr: proc.stderr,
+      });
+    const parsedSucceeded =
+      parsedSubtype === "success" && !parsedIsError && !successfulQuotaRefusal;
+    const failed =
+      successfulQuotaRefusal ||
+      (!parsedSucceeded && ((proc.exitCode ?? 0) !== 0 || parsedIsError));
     // Validate-before-persist guard: never persist a sessionId whose transcript
     // is known-poisoned. The Claude CLI keeps an on-disk JSONL keyed by the
     // session id; if the last entry contains a non-`msg_`-prefixed

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -87,6 +87,21 @@ describe("isClaudeTransientUpstreamError", () => {
     );
   });
 
+  it("classifies a success-envelope weekly limit and extracts its calendar reset", () => {
+    const now = new Date("2026-08-01T12:00:00.000Z");
+    const parsed = {
+      subtype: "success",
+      is_error: false,
+      result: "You've hit your weekly limit - resets Aug 5, 7am (America/New_York)",
+    };
+
+    expect(isClaudeProviderQuotaError({ parsed })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ parsed })).toBe(false);
+    expect(extractClaudeRetryNotBefore({ parsed }, now)?.toISOString()).toBe(
+      "2026-08-05T11:00:00.000Z",
+    );
+  });
+
   it("classifies Anthropic API rate_limit_error and overloaded_error as transient", () => {
     expect(
       isClaudeTransientUpstreamError({
@@ -359,6 +374,17 @@ describe("extractClaudeRetryNotBefore", () => {
       now,
     );
     expect(extracted?.toISOString()).toBe("2026-04-23T03:15:00.000Z");
+  });
+
+  it("does not roll a stale calendar reset into the following year", () => {
+    const extracted = extractClaudeRetryNotBefore(
+      {
+        errorMessage:
+          "You've hit your weekly limit - resets Aug 5, 7am (America/New_York)",
+      },
+      new Date("2026-08-05T11:01:00.000Z"),
+    );
+    expect(extracted).toBeNull();
   });
 
   it("returns null when no reset hint is present", () => {

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
+  detectClaudeOverflowHold,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeProviderQuotaError,
@@ -32,6 +33,26 @@ describe("detectClaudeLoginRequired", () => {
         stderr: "Invalid API key",
       }).requiresLogin,
     ).toBe(false);
+  });
+});
+
+describe("detectClaudeOverflowHold", () => {
+  it("recognizes only the wrapper stderr sentinel and preserves its reset epoch", () => {
+    const message =
+      "[claude-overflow] HOLD: subscription session limit active; skipping launch until reset; resetEpoch=1900000000 (this run is a zero-token no-op).";
+
+    expect(detectClaudeOverflowHold(`${message}\n`)).toEqual({
+      message,
+      retryNotBefore: new Date(1_900_000_000 * 1_000),
+    });
+    expect(detectClaudeOverflowHold("Docs mention a subscription session limit.")).toBeNull();
+  });
+
+  it("still recognizes the historical sentinel when reset metadata is absent", () => {
+    const message =
+      "[claude-overflow] HOLD: subscription session limit active; skipping launch until reset (this run is a zero-token no-op).";
+
+    expect(detectClaudeOverflowHold(message)).toEqual({ message, retryNotBefore: null });
   });
 });
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -13,6 +13,9 @@ const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+(?:session|weekly|monthly)\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+const CLAUDE_OVERFLOW_HOLD_RE =
+  /(?:^|\r?\n)(\[claude-overflow\] HOLD: subscription session limit active; skipping launch until reset\b[^\r\n]*)/i;
+const CLAUDE_OVERFLOW_HOLD_RESET_EPOCH_RE = /\bresetEpoch=(\d{10})\b/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
@@ -310,6 +313,28 @@ function buildClaudeTransientHaystack(input: {
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
+}
+
+export function detectClaudeOverflowHold(stderr: string): {
+  message: string;
+  retryNotBefore: Date | null;
+} | null {
+  // Only the wrapper's anchored stderr line is authoritative. Searching stdout
+  // would let ordinary agent output that quotes the sentinel become a false HOLD.
+  const holdMatch = stderr.match(CLAUDE_OVERFLOW_HOLD_RE);
+  const message = holdMatch?.[1]?.trim();
+  if (!message) return null;
+
+  const resetEpoch = message.match(CLAUDE_OVERFLOW_HOLD_RESET_EPOCH_RE)?.[1];
+  const retryNotBefore = resetEpoch
+    ? new Date(Number.parseInt(resetEpoch, 10) * 1_000)
+    : null;
+  return {
+    message,
+    retryNotBefore: retryNotBefore && Number.isFinite(retryNotBefore.getTime())
+      ? retryNotBefore
+      : null,
+  };
 }
 
 function readTimeZoneParts(date: Date, timeZone: string) {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -12,11 +12,11 @@ const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+  /(?:you(?:'|’)ve\s+hit\s+your\s+(?:session|weekly|monthly)\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+  /(?:you(?:'|’)ve\s+hit\s+your\s+(?:session|weekly|monthly)\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
 /**
  * Sum the per-model usage ledger from a Claude CLI result event. The result
@@ -414,9 +414,24 @@ function nextClockTimeInTimeZone(input: {
   return retryAt;
 }
 
-function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: string | null): Date | null {
-  const normalized = clockText.trim().replace(/\s+/g, " ");
-  const match = normalized.match(/^(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?/i);
+const CLAUDE_RESET_MONTHS: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+};
+const CLAUDE_MAX_CALENDAR_RESET_LOOKAHEAD_MS = 32 * 24 * 60 * 60 * 1000;
+
+function parseClaudeClockTime(value: string): { hour: number; minute: number } | null {
+  const match = value.trim().match(/^(\d{1,2})(?::(\d{2}))?\s*([ap])\.?\s*m\.?/i);
   if (!match) return null;
 
   const hour12 = Number.parseInt(match[1] ?? "", 10);
@@ -424,21 +439,83 @@ function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: 
   if (!Number.isInteger(hour12) || hour12 < 1 || hour12 > 12) return null;
   if (!Number.isInteger(minute) || minute < 0 || minute > 59) return null;
 
-  let hour24 = hour12 % 12;
-  if ((match[3] ?? "").toLowerCase() === "p") hour24 += 12;
+  let hour = hour12 % 12;
+  if ((match[3] ?? "").toLowerCase() === "p") hour += 12;
+  return { hour, minute };
+}
+
+function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: string | null): Date | null {
+  const normalized = clockText.trim().replace(/\s+/g, " ");
+  const calendarMatch = normalized.match(
+    /^([a-z]{3,9})\s+(\d{1,2})(?:,\s*(\d{4}))?(?:\s*,|\s+at)\s*(.+)$/i,
+  );
+  if (calendarMatch) {
+    const month =
+      CLAUDE_RESET_MONTHS[(calendarMatch[1] ?? "").slice(0, 3).toLowerCase()];
+    const day = Number.parseInt(calendarMatch[2] ?? "", 10);
+    const explicitYear = calendarMatch[3]
+      ? Number.parseInt(calendarMatch[3], 10)
+      : null;
+    const clock = parseClaudeClockTime(calendarMatch[4] ?? "");
+    if (!month || !Number.isInteger(day) || day < 1 || day > 31 || !clock) return null;
+
+    const timeZone = normalizeResetTimeZone(timeZoneHint);
+    const nowParts = timeZone ? readTimeZoneParts(now, timeZone) : null;
+    let year = explicitYear ?? nowParts?.year ?? now.getFullYear();
+    const buildCandidate = (candidateYear: number) => {
+      if (timeZone) {
+        return dateFromTimeZoneWallClock({
+          year: candidateYear,
+          month,
+          day,
+          hour: clock.hour,
+          minute: clock.minute,
+          timeZone,
+        });
+      }
+
+      const candidate = new Date(candidateYear, month - 1, day, clock.hour, clock.minute, 0, 0);
+      if (
+        candidate.getFullYear() !== candidateYear ||
+        candidate.getMonth() !== month - 1 ||
+        candidate.getDate() !== day
+      ) {
+        return null;
+      }
+      return candidate;
+    };
+
+    let retryAt = buildCandidate(year);
+    if (!retryAt) return null;
+    if (retryAt.getTime() <= now.getTime()) {
+      if (explicitYear !== null) return null;
+      year += 1;
+      retryAt = buildCandidate(year);
+    }
+    if (
+      !retryAt ||
+      retryAt.getTime() - now.getTime() > CLAUDE_MAX_CALENDAR_RESET_LOOKAHEAD_MS
+    ) {
+      return null;
+    }
+    return retryAt;
+  }
+
+  const clock = parseClaudeClockTime(normalized);
+  if (!clock) return null;
 
   if (timeZoneHint) {
     const explicitRetryAt = nextClockTimeInTimeZone({
       now,
-      hour: hour24,
-      minute,
+      hour: clock.hour,
+      minute: clock.minute,
       timeZoneHint,
     });
     if (explicitRetryAt) return explicitRetryAt;
   }
 
   const retryAt = new Date(now);
-  retryAt.setHours(hour24, minute, 0, 0);
+  retryAt.setHours(clock.hour, clock.minute, 0, 0);
   if (retryAt.getTime() <= now.getTime()) {
     retryAt.setDate(retryAt.getDate() + 1);
   }

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -43,6 +43,19 @@ process.exit(${exit});
   await fs.chmod(commandPath, 0o755);
 }
 
+async function writePortableClaudeCommand(
+  root: string,
+  writer: (scriptPath: string) => Promise<void>,
+): Promise<string> {
+  const commandPath = path.join(root, process.platform === "win32" ? "claude.cmd" : "claude");
+  const scriptPath = process.platform === "win32" ? path.join(root, "claude.js") : commandPath;
+  await writer(scriptPath);
+  if (process.platform === "win32") {
+    await fs.writeFile(commandPath, `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`, "utf8");
+  }
+  return commandPath;
+}
+
 async function writeFakeClaudeCommand(commandPath: string): Promise<void> {
   const script = `#!/usr/bin/env node
 const fs = require("node:fs");
@@ -1416,12 +1429,11 @@ describe("claude execute", () => {
     }
   });
 
-  it("treats subtype=success results as successful even when the process exits nonzero", async () => {
+  it("keeps a PRIMARY subtype=success result successful even when the process exits nonzero", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-success-subtype-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "claude");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFailingClaudeCommand(commandPath, {
+    const commandPath = await writePortableClaudeCommand(root, (target) => writeFailingClaudeCommand(target, {
       exitCode: 1,
       resultEvent: {
         type: "result",
@@ -1431,7 +1443,7 @@ describe("claude execute", () => {
         result: "Implemented the requested change.",
         usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
       },
-    });
+    }));
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -1466,7 +1478,78 @@ describe("claude execute", () => {
       expect(result.exitCode).toBe(1);
       expect(result.errorMessage).toBeNull();
       expect(result.errorCode).toBeNull();
+      expect(result.errorFamily ?? null).toBeNull();
+      expect(result.retryNotBefore ?? null).toBeNull();
       expect(result.summary).toBe("Implemented the requested change.");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["historical empty stdout", "empty", null],
+    ["zero-token success result stdout", "result", "2030-03-17T17:46:40.000Z"],
+  ])("classifies a claude-overflow HOLD with %s as provider quota", async (_shape, stdoutShape, expectedRetry) => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-overflow-hold-"));
+    const resetMetadata = expectedRetry ? "; resetEpoch=1900000000" : "";
+    const holdNotice =
+      `[claude-overflow] HOLD: subscription session limit active; skipping launch until reset${resetMetadata} (this run is a zero-token no-op).`;
+    const stdout = stdoutShape === "result"
+      ? `${JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          duration_ms: 0,
+          duration_api_ms: 0,
+          num_turns: 0,
+          result: holdNotice,
+          total_cost_usd: 0,
+          usage: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 },
+        })}\n`
+      : "";
+    const workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    const commandPath = await writePortableClaudeCommand(root, (target) =>
+      writeTextFailingClaudeCommand(target, {
+        stdout,
+        stderr: `${holdNotice}\n`,
+        exitCode: 0,
+      }),
+    );
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: `run-claude-overflow-hold-${_shape.replaceAll(" ", "-")}`,
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorCode).toBe("provider_quota");
+      expect(result.errorCode).not.toBe("adapter_failed");
+      expect(result.errorFamily).toBe("provider_quota");
+      expect(result.errorMessage).toBe(holdNotice);
+      expect(result.retryNotBefore ?? null).toBe(expectedRetry);
+      expect(result.resultJson?.providerQuotaRetryNotBefore ?? null).toBe(expectedRetry);
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -1474,6 +1474,78 @@ describe("claude execute", () => {
     }
   });
 
+  it("treats a zero-token weekly-limit success envelope as provider quota", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-weekly-limit-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, process.platform === "win32" ? "claude.cmd" : "claude");
+    const scriptPath = process.platform === "win32" ? path.join(root, "claude.js") : commandPath;
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(scriptPath, {
+      exitCode: 1,
+      resultEvent: {
+        type: "result",
+        subtype: "success",
+        session_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        is_error: false,
+        result: "You've hit your weekly limit - resets Aug 5, 7am (America/New_York)",
+        usage: { input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 },
+      },
+    });
+    if (process.platform === "win32") {
+      await fs.writeFile(
+        commandPath,
+        `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`,
+        "utf8",
+      );
+    }
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-01T12:00:00.000Z"));
+
+    try {
+      const result = await execute({
+        runId: "run-claude-weekly-limit",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: { engine: "cli" },
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          engine: "cli",
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      const expectedRetryNotBefore = "2026-08-05T11:00:00.000Z";
+      expect(result.exitCode).toBe(1);
+      expect(result.errorCode).toBe("provider_quota");
+      expect(result.errorFamily).toBe("provider_quota");
+      expect(result.retryNotBefore).toBe(expectedRetryNotBefore);
+      expect(result.resultJson?.providerQuotaRetryNotBefore).toBe(expectedRetryNotBefore);
+      expect(result.errorMessage ?? "").toContain("weekly limit");
+    } finally {
+      vi.useRealTimers();
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("classifies rate-limit / overloaded failures without reset metadata as transient", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-rate-limit-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Claude local adapter classifies provider failures for the heartbeat scheduler
> - Claude can return a weekly-limit refusal inside a zero-token `subtype=success` result
> - The success subtype currently bypasses quota classification and creates immediate retry churn
> - The refusal also contains a dated reset that the current clock-only parser cannot use
> - This pull request classifies that envelope as `provider_quota` and carries its reset time to the scheduler
> - The benefit is one deferred retry at the quota reset instead of repeated no-work runs before the reset

## Linked Issues or Issue Description

Fixes #6499

Refs #10616. That pull request shares quota parsing with the ACP path. It does not guard the Claude CLI `subtype=success` envelope.

Refs #9548. That pull request makes structured success authoritative. This pull request defines the narrow zero-token quota-refusal exception.

Refs #9367. This change supplies the stable `provider_quota` signal that optional fallback work consumes.

## What Changed

- Match the `You've hit your weekly limit` and monthly-limit forms as provider quota failures.
- Parse dated reset text such as `Aug 5, 7am (America/New_York)` into an absolute retry time.
- Reject stale dated resets instead of rolling them into the next year. Keep valid year-boundary resets within a 32-day quota window.
- Treat a zero-token quota result as failed even when Claude reports `subtype=success` and `is_error=false`.
- Keep ordinary structured success results successful. Add parser and execution regressions for both paths.

No schema, migration, configuration, or public API change is required. No user documentation changes are required because `provider_quota` and reset-aware scheduling already exist.

## Verification

- `corepack pnpm exec vitest run packages/adapters/claude-local/src/server/parse.test.ts --reporter=dot` - 41 passed.
- `corepack pnpm exec vitest run server/src/__tests__/claude-local-execute.test.ts -t "zero-token weekly-limit" --reporter=dot` - 1 passed and 24 skipped by the name filter.
- `corepack pnpm exec tsc --noEmit -p packages/adapters/claude-local/tsconfig.json` - passed.
- `corepack pnpm exec tsc --noEmit -p server/tsconfig.json` - passed after the required plugin SDK build-dependency step.
- `git diff --check` - passed.

The existing provider-quota scheduler test already asserts one pending retry at `retryNotBefore`. A local attempt to run that embedded-Postgres test stopped before test discovery because the current dependency graph raises `ERR_REQUIRE_CYCLE_MODULE` in `drizzle-orm` on Node 22.22.0 and Node 24.13.1. This pull request does not change the scheduler or Drizzle code.

## Risks

- Low behavioral risk. The success-envelope override requires both quota wording and zero token usage.
- A parser false positive can defer a run. The phrase match stays limited to provider limit language, and the reset window is at most 32 days.
- The parser part overlaps with #10616. If #10616 lands first, this branch can use its shared helper while it keeps the unique success-envelope guard and execution test.
- Rollback is one commit. Reverting it restores the prior classifier and retry behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected - check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based runtime. The exact serving ID and context window are not exposed. The runtime used repository tools, shell execution, and code editing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
