### PR TITLE
feat(ui): add inbox sort attention boundaries

### DIFF
--- a/ui/src/hooks/useInboxSortAttention.test.tsx
+++ b/ui/src/hooks/useInboxSortAttention.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { useEffect } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  INBOX_SORT_HIDDEN_COMMIT_MS,
+  INBOX_SORT_IDLE_COMMIT_MS,
+  type InboxSortAttention,
+  type InboxSortCommitReason,
+  useInboxSortAttention,
+} from "./useInboxSortAttention";
+
+type HarnessProps = {
+  viewIdentity: string;
+  onCommit: (reason: InboxSortCommitReason) => void;
+  onReady: (attention: InboxSortAttention) => void;
+};
+
+function Harness({ viewIdentity, onCommit, onReady }: HarnessProps) {
+  const attention = useInboxSortAttention({ viewIdentity, onCommit });
+  useEffect(() => onReady(attention), [attention, onReady]);
+  return null;
+}
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+function mountHook(viewIdentity = "mine:all:none") {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const onCommit = vi.fn<(reason: InboxSortCommitReason) => void>();
+  let attention: InboxSortAttention | null = null;
+  const onReady = (value: InboxSortAttention) => {
+    attention = value;
+  };
+
+  const render = (nextViewIdentity = viewIdentity) => {
+    flushSync(() => {
+      root.render(
+        <Harness
+          viewIdentity={nextViewIdentity}
+          onCommit={onCommit}
+          onReady={onReady}
+        />,
+      );
+    });
+  };
+
+  render();
+  return {
+    onCommit,
+    render,
+    attention: () => {
+      if (!attention) throw new Error("Hook did not mount");
+      return attention;
+    },
+    unmount: () => flushSync(() => root.unmount()),
+  };
+}
+
+describe("useInboxSortAttention", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    setVisibility("visible");
+  });
+
+  it("commits after the visible inbox is idle for the threshold", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    vi.advanceTimersByTime(INBOX_SORT_IDLE_COMMIT_MS - 1);
+    expect(hook.onCommit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(hook.onCommit).toHaveBeenCalledWith("idle");
+    hook.unmount();
+  });
+
+  it("resets the idle threshold on inbox interaction", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    vi.advanceTimersByTime(INBOX_SORT_IDLE_COMMIT_MS - 1_000);
+    hook.attention().noteInteraction();
+    vi.advanceTimersByTime(1_000);
+    expect(hook.onCommit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(INBOX_SORT_IDLE_COMMIT_MS - 1_000);
+    expect(hook.onCommit).toHaveBeenCalledWith("idle");
+    hook.unmount();
+  });
+
+  it("commits after a long hide but not after a brief hide", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(INBOX_SORT_HIDDEN_COMMIT_MS - 1);
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(hook.onCommit).not.toHaveBeenCalled();
+
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(INBOX_SORT_HIDDEN_COMMIT_MS);
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(hook.onCommit).toHaveBeenCalledTimes(1);
+    expect(hook.onCommit).toHaveBeenCalledWith("visibility");
+    hook.unmount();
+  });
+
+  it("always commits when remounted", () => {
+    const first = mountHook();
+    expect(first.onCommit).toHaveBeenCalledWith("mount");
+    first.unmount();
+
+    const second = mountHook();
+    expect(second.onCommit).toHaveBeenCalledWith("mount");
+    second.unmount();
+  });
+
+  it("commits for tab, filter, and group-by identity changes", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    hook.render("assigned:open:project");
+    hook.render("assigned:closed:project");
+    hook.render("assigned:closed:assignee");
+    expect(hook.onCommit).toHaveBeenCalledTimes(3);
+    expect(hook.onCommit).toHaveBeenNthCalledWith(1, "view-identity-change");
+    expect(hook.onCommit).toHaveBeenNthCalledWith(2, "view-identity-change");
+    expect(hook.onCommit).toHaveBeenNthCalledWith(3, "view-identity-change");
+    hook.unmount();
+  });
+
+  it("always commits on manual refresh", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    hook.attention().commitManualRefresh();
+    hook.attention().commitManualRefresh();
+    expect(hook.onCommit).toHaveBeenCalledTimes(2);
+    expect(hook.onCommit).toHaveBeenNthCalledWith(1, "manual-refresh");
+    expect(hook.onCommit).toHaveBeenNthCalledWith(2, "manual-refresh");
+    hook.unmount();
+  });
+});

--- a/ui/src/hooks/useInboxSortAttention.ts
+++ b/ui/src/hooks/useInboxSortAttention.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export const INBOX_SORT_IDLE_COMMIT_MS = 150_000;
+export const INBOX_SORT_HIDDEN_COMMIT_MS = 30_000;
+
+export type InboxSortCommitReason =
+  | "mount"
+  | "idle"
+  | "visibility"
+  | "view-identity-change"
+  | "manual-refresh";
+
+type UseInboxSortAttentionOptions = {
+  viewIdentity: string;
+  onCommit: (reason: InboxSortCommitReason) => void;
+  idleCommitMs?: number;
+  hiddenCommitMs?: number;
+};
+
+export type InboxSortAttention = {
+  /** Call for pointer, keyboard, hover, archive, expand/collapse, or scroll activity. */
+  noteInteraction: () => void;
+  /** Commit immediately at an explicit refresh boundary. */
+  commitManualRefresh: () => void;
+};
+
+function isDocumentVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
+}
+
+/**
+ * Owns the attention boundaries at which the inbox may safely adopt a newly
+ * computed sort order. The caller owns order reconciliation and calls
+ * `noteInteraction` for activity scoped to the inbox list.
+ */
+export function useInboxSortAttention({
+  viewIdentity,
+  onCommit,
+  idleCommitMs = INBOX_SORT_IDLE_COMMIT_MS,
+  hiddenCommitMs = INBOX_SORT_HIDDEN_COMMIT_MS,
+}: UseInboxSortAttentionOptions): InboxSortAttention {
+  const onCommitRef = useRef(onCommit);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hiddenAtRef = useRef<number | null>(null);
+  const committedInitialViewRef = useRef(false);
+  const previousViewIdentityRef = useRef(viewIdentity);
+
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  }, [onCommit]);
+
+  const clearIdleTimer = useCallback(() => {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+  }, []);
+
+  const restartIdleTimer = useCallback(() => {
+    clearIdleTimer();
+    if (!isDocumentVisible()) return;
+
+    idleTimerRef.current = setTimeout(() => {
+      idleTimerRef.current = null;
+      if (isDocumentVisible()) onCommitRef.current("idle");
+    }, idleCommitMs);
+  }, [clearIdleTimer, idleCommitMs]);
+
+  const noteInteraction = useCallback(() => {
+    restartIdleTimer();
+  }, [restartIdleTimer]);
+
+  const commitManualRefresh = useCallback(() => {
+    onCommitRef.current("manual-refresh");
+    restartIdleTimer();
+  }, [restartIdleTimer]);
+
+  useEffect(() => {
+    if (!committedInitialViewRef.current) {
+      committedInitialViewRef.current = true;
+      onCommitRef.current("mount");
+    } else if (previousViewIdentityRef.current !== viewIdentity) {
+      onCommitRef.current("view-identity-change");
+    }
+
+    previousViewIdentityRef.current = viewIdentity;
+    restartIdleTimer();
+    return clearIdleTimer;
+  }, [clearIdleTimer, restartIdleTimer, viewIdentity]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    if (document.visibilityState !== "visible") {
+      hiddenAtRef.current = Date.now();
+      clearIdleTimer();
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        hiddenAtRef.current = Date.now();
+        clearIdleTimer();
+        return;
+      }
+
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (hiddenAt !== null && Date.now() - hiddenAt >= hiddenCommitMs) {
+        onCommitRef.current("visibility");
+      }
+      restartIdleTimer();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [clearIdleTimer, hiddenCommitMs, restartIdleTimer]);
+
+  return { noteInteraction, commitManualRefresh };
+}

--- a/ui/src/lib/inboxArchiveCache.ts
+++ b/ui/src/lib/inboxArchiveCache.ts
@@ -5,7 +5,7 @@ import { queryKeys } from "./queryKeys";
 
 export type InboxIssueCacheSnapshot = Array<readonly [QueryKey, Issue[] | undefined]>;
 
-const INBOX_ARCHIVE_CONFIRMATION_GRACE_MS = 5_000;
+export const INBOX_ARCHIVE_CONFIRMATION_GRACE_MS = 5_000;
 const INBOX_ARCHIVE_MAX_GUARD_MS = 30_000;
 const EMPTY_ARCHIVED_ISSUE_IDS: ReadonlySet<string> = new Set();
 

--- a/ui/src/lib/inboxOrderPin.test.ts
+++ b/ui/src/lib/inboxOrderPin.test.ts
@@ -1,0 +1,171 @@
+import type { Issue } from "@paperclipai/shared";
+import { describe, expect, it } from "vitest";
+import type { InboxGroupedSection, InboxWorkItem } from "./inbox";
+import { INBOX_ARCHIVE_CONFIRMATION_GRACE_MS } from "./inboxArchiveCache";
+import {
+  captureInboxOrderPin,
+  reconcileInboxOrderPin,
+} from "./inboxOrderPin";
+
+function issue(id: string, title = id): Issue {
+  return {
+    id,
+    title,
+    status: "todo",
+  } as Issue;
+}
+
+function issueItem(value: Issue, timestamp = 0): InboxWorkItem {
+  return { kind: "issue", issue: value, timestamp };
+}
+
+function section(
+  key: string,
+  items: Issue[],
+  childrenByIssueId: ReadonlyArray<readonly [string, Issue[]]> = [],
+): InboxGroupedSection {
+  return {
+    key,
+    label: key,
+    displayItems: items.map((item) => issueItem(item)),
+    childrenByIssueId: new Map(childrenByIssueId),
+    searchSection: "none",
+  };
+}
+
+function sectionKeys(sections: readonly InboxGroupedSection[]): string[] {
+  return sections.map((value) => value.key);
+}
+
+function rowIds(value: InboxGroupedSection): string[] {
+  return value.displayItems.map((item) => item.kind === "issue" ? item.issue.id : "non-issue");
+}
+
+describe("inboxOrderPin", () => {
+  it("keeps a parent, its group, and neighboring groups in place when a child is archived", () => {
+    const parent = issue("parent");
+    const child = issue("child");
+    const neighbor = issue("neighbor");
+    const committed = [
+      section("parent-group", [parent], [[parent.id, [child]]]),
+      section("neighbor-group", [neighbor]),
+    ];
+    const pin = captureInboxOrderPin(committed);
+
+    const fresh = [
+      section("neighbor-group", [neighbor]),
+      section("parent-group", [parent], [[parent.id, []]]),
+    ];
+    const result = reconcileInboxOrderPin(pin, fresh, 100);
+
+    expect(sectionKeys(result.sections)).toEqual(["parent-group", "neighbor-group"]);
+    expect(rowIds(result.sections[0]!)).toEqual([parent.id]);
+    expect(result.sections[0]!.childrenByIssueId.get(parent.id)).toEqual([]);
+  });
+
+  it("removes a group in place when its last row is archived", () => {
+    const archived = issue("archived");
+    const neighbor = issue("neighbor");
+    const pin = captureInboxOrderPin([
+      section("archived-group", [archived]),
+      section("neighbor-group", [neighbor]),
+    ]);
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [section("neighbor-group", [neighbor])],
+      200,
+    );
+
+    expect(sectionKeys(result.sections)).toEqual(["neighbor-group"]);
+    expect(rowIds(result.sections[0]!)).toEqual([neighbor.id]);
+    expect(result.pin.sections.map((value) => [value.key, value.missingSince])).toEqual([
+      ["archived-group", 200],
+      ["neighbor-group", null],
+    ]);
+  });
+
+  it("restores an archived row to its original position within the tombstone grace window", () => {
+    const first = issue("first");
+    const restored = issue("restored");
+    const last = issue("last");
+    const pin = captureInboxOrderPin([section("group", [first, restored, last])]);
+    const archived = reconcileInboxOrderPin(pin, [section("group", [last, first])], 1_000);
+
+    expect(rowIds(archived.sections[0]!)).toEqual([first.id, last.id]);
+
+    const undone = reconcileInboxOrderPin(
+      archived.pin,
+      [section("group", [last, restored, first])],
+      1_000 + INBOX_ARCHIVE_CONFIRMATION_GRACE_MS - 1,
+    );
+
+    expect(rowIds(undone.sections[0]!)).toEqual([first.id, restored.id, last.id]);
+    expect(undone.pin.sections[0]!.rows.every((entry) => entry.missingSince === null)).toBe(true);
+  });
+
+  it("treats a row restored after the grace window as a new algorithmic insertion", () => {
+    const first = issue("first");
+    const expired = issue("expired");
+    const last = issue("last");
+    const pin = captureInboxOrderPin([section("group", [first, expired, last])]);
+    const archived = reconcileInboxOrderPin(pin, [section("group", [last, first])], 1_000);
+
+    const restored = reconcileInboxOrderPin(
+      archived.pin,
+      [section("group", [last, first, expired])],
+      1_000 + INBOX_ARCHIVE_CONFIRMATION_GRACE_MS,
+    );
+
+    expect(rowIds(restored.sections[0]!)).toEqual([first.id, last.id, expired.id]);
+  });
+
+  it("inserts new rows and groups algorithmically without reordering existing entries", () => {
+    const first = issue("first");
+    const last = issue("last");
+    const inserted = issue("inserted");
+    const neighbor = issue("neighbor");
+    const newGroupItem = issue("new-group-item");
+    const pin = captureInboxOrderPin([
+      section("existing", [first, last]),
+      section("neighbor", [neighbor]),
+    ]);
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [
+        section("neighbor", [neighbor]),
+        section("new-group", [newGroupItem]),
+        section("existing", [last, inserted, first]),
+      ],
+      300,
+    );
+
+    expect(sectionKeys(result.sections)).toEqual(["existing", "new-group", "neighbor"]);
+    expect(rowIds(result.sections[0]!)).toEqual([first.id, inserted.id, last.id]);
+  });
+
+  it("uses fresh row content while retaining the pinned order", () => {
+    const first = issue("first", "Old first");
+    const last = issue("last", "Old last");
+    const pin = captureInboxOrderPin([section("group", [first, last])]);
+    const freshLast = { ...last, title: "Updated last", status: "in_progress" } as Issue;
+    const freshFirst = { ...first, title: "Updated first", status: "blocked" } as Issue;
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [section("group", [freshLast, freshFirst])],
+      400,
+    );
+
+    expect(rowIds(result.sections[0]!)).toEqual([first.id, last.id]);
+    expect(result.sections[0]!.displayItems[0]).toBeDefined();
+    expect(result.sections[0]!.displayItems[0]!.kind).toBe("issue");
+    expect(result.sections[0]!.displayItems[0]).toMatchObject({
+      issue: { title: "Updated first", status: "blocked" },
+    });
+    expect(result.sections[0]!.displayItems[1]).toMatchObject({
+      issue: { title: "Updated last", status: "in_progress" },
+    });
+  });
+});

--- a/ui/src/lib/inboxOrderPin.ts
+++ b/ui/src/lib/inboxOrderPin.ts
@@ -1,0 +1,242 @@
+import type { Issue } from "@paperclipai/shared";
+import {
+  getInboxWorkItemKey,
+  type InboxGroupedSection,
+  type InboxWorkItem,
+} from "./inbox";
+import { INBOX_ARCHIVE_CONFIRMATION_GRACE_MS } from "./inboxArchiveCache";
+
+export interface InboxPinnedKey {
+  key: string;
+  missingSince: number | null;
+}
+
+export interface InboxPinnedSectionOrder extends InboxPinnedKey {
+  rows: readonly InboxPinnedKey[];
+  childrenByIssueId: ReadonlyMap<string, readonly InboxPinnedKey[]>;
+}
+
+export interface InboxOrderPin {
+  sections: readonly InboxPinnedSectionOrder[];
+}
+
+export interface InboxOrderPinReconcileResult {
+  sections: InboxGroupedSection[];
+  pin: InboxOrderPin;
+}
+
+interface ReconciledKeys {
+  entries: InboxPinnedKey[];
+  retainedPinnedKeys: ReadonlySet<string>;
+  visibleKeys: string[];
+}
+
+function inboxOrderRowKey(item: InboxWorkItem): string {
+  return item.kind === "issue" ? item.issue.id : getInboxWorkItemKey(item);
+}
+
+function captureKeys(keys: Iterable<string>): InboxPinnedKey[] {
+  return Array.from(keys, (key) => ({ key, missingSince: null }));
+}
+
+function captureSection(section: InboxGroupedSection): InboxPinnedSectionOrder {
+  return {
+    key: section.key,
+    missingSince: null,
+    rows: captureKeys(section.displayItems.map(inboxOrderRowKey)),
+    childrenByIssueId: new Map(
+      Array.from(section.childrenByIssueId, ([issueId, children]) => [
+        issueId,
+        captureKeys(children.map((child) => child.id)),
+      ]),
+    ),
+  };
+}
+
+export function captureInboxOrderPin(
+  sections: readonly InboxGroupedSection[],
+): InboxOrderPin {
+  return { sections: sections.map(captureSection) };
+}
+
+function insertionIndexForVisiblePosition(
+  entries: readonly InboxPinnedKey[],
+  visibleKeys: ReadonlySet<string>,
+  visibleIndex: number,
+): number {
+  let seenVisible = 0;
+  for (let index = 0; index < entries.length; index += 1) {
+    if (seenVisible === visibleIndex) return index;
+    if (visibleKeys.has(entries[index]!.key)) seenVisible += 1;
+  }
+  return entries.length;
+}
+
+function reconcileKeys(
+  pinned: readonly InboxPinnedKey[],
+  freshKeys: readonly string[],
+  nowMs: number,
+): ReconciledKeys {
+  const freshKeySet = new Set(freshKeys);
+  const entries = pinned.flatMap((entry): InboxPinnedKey[] => {
+    if (freshKeySet.has(entry.key)) {
+      return entry.missingSince === null
+        || nowMs - entry.missingSince < INBOX_ARCHIVE_CONFIRMATION_GRACE_MS
+        ? [{ key: entry.key, missingSince: null }]
+        : [];
+    }
+
+    const missingSince = entry.missingSince ?? nowMs;
+    return nowMs - missingSince < INBOX_ARCHIVE_CONFIRMATION_GRACE_MS
+      ? [{ key: entry.key, missingSince }]
+      : [];
+  });
+  const retainedPinnedKeys = new Set(entries.map((entry) => entry.key));
+
+  const visibleKeys = new Set(
+    entries
+      .filter((entry) => entry.missingSince === null)
+      .map((entry) => entry.key),
+  );
+
+  freshKeys.forEach((key, freshIndex) => {
+    if (retainedPinnedKeys.has(key)) return;
+    const insertionIndex = insertionIndexForVisiblePosition(entries, visibleKeys, freshIndex);
+    entries.splice(insertionIndex, 0, { key, missingSince: null });
+    visibleKeys.add(key);
+  });
+
+  return {
+    entries,
+    retainedPinnedKeys,
+    visibleKeys: entries
+      .filter((entry) => entry.missingSince === null)
+      .map((entry) => entry.key),
+  };
+}
+
+function reconcileChildren(
+  pinned: ReadonlyMap<string, readonly InboxPinnedKey[]>,
+  fresh: ReadonlyMap<string, Issue[]>,
+  nowMs: number,
+): {
+  pin: ReadonlyMap<string, readonly InboxPinnedKey[]>;
+  display: Map<string, Issue[]>;
+} {
+  const parentIssueIds = new Set([...pinned.keys(), ...fresh.keys()]);
+  const nextPin = new Map<string, readonly InboxPinnedKey[]>();
+  const display = new Map<string, Issue[]>();
+
+  for (const parentIssueId of parentIssueIds) {
+    const freshChildren = fresh.get(parentIssueId) ?? [];
+    const freshChildById = new Map(freshChildren.map((child) => [child.id, child]));
+    const reconciled = reconcileKeys(
+      pinned.get(parentIssueId) ?? [],
+      freshChildren.map((child) => child.id),
+      nowMs,
+    );
+
+    if (reconciled.entries.length > 0) {
+      nextPin.set(parentIssueId, reconciled.entries);
+    }
+    if (fresh.has(parentIssueId)) {
+      display.set(
+        parentIssueId,
+        reconciled.visibleKeys.flatMap((key) => {
+          const child = freshChildById.get(key);
+          return child ? [child] : [];
+        }),
+      );
+    }
+  }
+
+  return { pin: nextPin, display };
+}
+
+function reconcileSection(
+  pinned: InboxPinnedSectionOrder | undefined,
+  fresh: InboxGroupedSection,
+  nowMs: number,
+): { pin: InboxPinnedSectionOrder; display: InboxGroupedSection } {
+  if (!pinned) {
+    return { pin: captureSection(fresh), display: fresh };
+  }
+
+  const freshItemByKey = new Map(
+    fresh.displayItems.map((item) => [inboxOrderRowKey(item), item]),
+  );
+  const rows = reconcileKeys(
+    pinned.rows,
+    fresh.displayItems.map(inboxOrderRowKey),
+    nowMs,
+  );
+  const children = reconcileChildren(pinned.childrenByIssueId, fresh.childrenByIssueId, nowMs);
+
+  return {
+    pin: {
+      key: fresh.key,
+      missingSince: null,
+      rows: rows.entries,
+      childrenByIssueId: children.pin,
+    },
+    display: {
+      ...fresh,
+      displayItems: rows.visibleKeys.flatMap((key) => {
+        const item = freshItemByKey.get(key);
+        return item ? [item] : [];
+      }),
+      childrenByIssueId: children.display,
+    },
+  };
+}
+
+/**
+ * Applies a previously committed Inbox order to freshly computed sections.
+ *
+ * `nowMs` is explicit so reconciliation remains pure. Callers should retain the
+ * returned pin between reconciliations and replace it with `captureInboxOrderPin`
+ * at an attention/refresh commit point.
+ */
+export function reconcileInboxOrderPin(
+  pinned: InboxOrderPin,
+  freshSections: readonly InboxGroupedSection[],
+  nowMs: number,
+): InboxOrderPinReconcileResult {
+  const freshSectionByKey = new Map(freshSections.map((section) => [section.key, section]));
+  const sections = reconcileKeys(
+    pinned.sections,
+    freshSections.map((section) => section.key),
+    nowMs,
+  );
+  const pinnedSectionByKey = new Map(pinned.sections.map((section) => [section.key, section]));
+  const reconciledByKey = new Map<string, ReturnType<typeof reconcileSection>>();
+
+  for (const freshSection of freshSections) {
+    reconciledByKey.set(
+      freshSection.key,
+      reconcileSection(
+        sections.retainedPinnedKeys.has(freshSection.key)
+          ? pinnedSectionByKey.get(freshSection.key)
+          : undefined,
+        freshSection,
+        nowMs,
+      ),
+    );
+  }
+
+  const nextPinnedSections = sections.entries.flatMap((entry): InboxPinnedSectionOrder[] => {
+    const reconciled = reconciledByKey.get(entry.key);
+    if (reconciled) return [{ ...reconciled.pin, missingSince: entry.missingSince }];
+    const previous = pinnedSectionByKey.get(entry.key);
+    return previous ? [{ ...previous, missingSince: entry.missingSince }] : [];
+  });
+
+  return {
+    sections: sections.visibleKeys.flatMap((key) => {
+      const freshSection = freshSectionByKey.get(key);
+      if (!freshSection) return [];
+      return [reconciledByKey.get(key)?.display ?? freshSection];
+    }),
+    pin: { sections: nextPinnedSections },
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The inbox helps operators process active work without losing their place.
> - Inbox data can change while an operator archives several rows.
> - The inbox needs explicit attention boundaries before it adopts a new computed order.
> - This pull request adds the hook that emits those boundaries.
> - The benefit is a small and tested API that later inbox wiring can use without changing the sort algorithm.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The board inbox currently has no shared definition of when it is safe to commit a new computed sort order.

**Subsystem affected**

`ui/` — React and Vite board UI.

**Current behavior**

Inbox code must react directly to data changes. It cannot distinguish active list use from a natural refresh boundary.

**Proposed behavior**

Use one hook to commit on mount, a view identity change, a manual refresh, 150 seconds of visible idle time, or a return after at least 30 seconds hidden. Reset the idle timer after inbox list interaction.

**Reason and benefit**

These boundaries let later inbox integration preserve spatial order during archive bursts and still refresh after the operator loses attention.

**Breaking changes**

None. This pull request adds a hook and tests. It does not wire the hook into the inbox or change the sort algorithm.

## What Changed

- Added named 150-second idle and 30-second hidden thresholds.
- Added commit reasons for mount, idle, visibility return, view identity changes, and manual refresh.
- Added an interaction callback that restarts the visible idle timer.
- Added fake-timer tests for all commit points and timer reset behavior.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/hooks/useInboxSortAttention.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`
- `pnpm check:token-gates`

## Risks

- Low risk. The new hook is not connected to the inbox in this pull request.
- The integration must call `noteInteraction` for list activity and `commitManualRefresh` for explicit refresh actions.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5. The exact serving snapshot and context-window size are not exposed to this session. The model used reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
