### PR TITLE
feat(ui): add inbox sort attention boundaries

### DIFF
--- a/ui/src/hooks/useInboxSortAttention.test.tsx
+++ b/ui/src/hooks/useInboxSortAttention.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { useEffect } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  INBOX_SORT_HIDDEN_COMMIT_MS,
+  INBOX_SORT_IDLE_COMMIT_MS,
+  type InboxSortAttention,
+  type InboxSortCommitReason,
+  useInboxSortAttention,
+} from "./useInboxSortAttention";
+
+type HarnessProps = {
+  viewIdentity: string;
+  onCommit: (reason: InboxSortCommitReason) => void;
+  onReady: (attention: InboxSortAttention) => void;
+};
+
+function Harness({ viewIdentity, onCommit, onReady }: HarnessProps) {
+  const attention = useInboxSortAttention({ viewIdentity, onCommit });
+  useEffect(() => onReady(attention), [attention, onReady]);
+  return null;
+}
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+function mountHook(viewIdentity = "mine:all:none") {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const onCommit = vi.fn<(reason: InboxSortCommitReason) => void>();
+  let attention: InboxSortAttention | null = null;
+  const onReady = (value: InboxSortAttention) => {
+    attention = value;
+  };
+
+  const render = (nextViewIdentity = viewIdentity) => {
+    flushSync(() => {
+      root.render(
+        <Harness
+          viewIdentity={nextViewIdentity}
+          onCommit={onCommit}
+          onReady={onReady}
+        />,
+      );
+    });
+  };
+
+  render();
+  return {
+    onCommit,
+    render,
+    attention: () => {
+      if (!attention) throw new Error("Hook did not mount");
+      return attention;
+    },
+    unmount: () => flushSync(() => root.unmount()),
+  };
+}
+
+describe("useInboxSortAttention", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    setVisibility("visible");
+  });
+
+  it("commits after the visible inbox is idle for the threshold", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    vi.advanceTimersByTime(INBOX_SORT_IDLE_COMMIT_MS - 1);
+    expect(hook.onCommit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(hook.onCommit).toHaveBeenCalledWith("idle");
+    hook.unmount();
+  });
+
+  it("resets the idle threshold on inbox interaction", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    vi.advanceTimersByTime(INBOX_SORT_IDLE_COMMIT_MS - 1_000);
+    hook.attention().noteInteraction();
+    vi.advanceTimersByTime(1_000);
+    expect(hook.onCommit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(INBOX_SORT_IDLE_COMMIT_MS - 1_000);
+    expect(hook.onCommit).toHaveBeenCalledWith("idle");
+    hook.unmount();
+  });
+
+  it("commits after a long hide but not after a brief hide", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(INBOX_SORT_HIDDEN_COMMIT_MS - 1);
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(hook.onCommit).not.toHaveBeenCalled();
+
+    setVisibility("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(INBOX_SORT_HIDDEN_COMMIT_MS);
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(hook.onCommit).toHaveBeenCalledTimes(1);
+    expect(hook.onCommit).toHaveBeenCalledWith("visibility");
+    hook.unmount();
+  });
+
+  it("always commits when remounted", () => {
+    const first = mountHook();
+    expect(first.onCommit).toHaveBeenCalledWith("mount");
+    first.unmount();
+
+    const second = mountHook();
+    expect(second.onCommit).toHaveBeenCalledWith("mount");
+    second.unmount();
+  });
+
+  it("commits for tab, filter, and group-by identity changes", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    hook.render("assigned:open:project");
+    hook.render("assigned:closed:project");
+    hook.render("assigned:closed:assignee");
+    expect(hook.onCommit).toHaveBeenCalledTimes(3);
+    expect(hook.onCommit).toHaveBeenNthCalledWith(1, "view-identity-change");
+    expect(hook.onCommit).toHaveBeenNthCalledWith(2, "view-identity-change");
+    expect(hook.onCommit).toHaveBeenNthCalledWith(3, "view-identity-change");
+    hook.unmount();
+  });
+
+  it("always commits on manual refresh", () => {
+    const hook = mountHook();
+    hook.onCommit.mockClear();
+
+    hook.attention().commitManualRefresh();
+    hook.attention().commitManualRefresh();
+    expect(hook.onCommit).toHaveBeenCalledTimes(2);
+    expect(hook.onCommit).toHaveBeenNthCalledWith(1, "manual-refresh");
+    expect(hook.onCommit).toHaveBeenNthCalledWith(2, "manual-refresh");
+    hook.unmount();
+  });
+});

--- a/ui/src/hooks/useInboxSortAttention.ts
+++ b/ui/src/hooks/useInboxSortAttention.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export const INBOX_SORT_IDLE_COMMIT_MS = 150_000;
+export const INBOX_SORT_HIDDEN_COMMIT_MS = 30_000;
+
+export type InboxSortCommitReason =
+  | "mount"
+  | "idle"
+  | "visibility"
+  | "view-identity-change"
+  | "manual-refresh";
+
+type UseInboxSortAttentionOptions = {
+  viewIdentity: string;
+  onCommit: (reason: InboxSortCommitReason) => void;
+  idleCommitMs?: number;
+  hiddenCommitMs?: number;
+};
+
+export type InboxSortAttention = {
+  /** Call for pointer, keyboard, hover, archive, expand/collapse, or scroll activity. */
+  noteInteraction: () => void;
+  /** Commit immediately at an explicit refresh boundary. */
+  commitManualRefresh: () => void;
+};
+
+function isDocumentVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
+}
+
+/**
+ * Owns the attention boundaries at which the inbox may safely adopt a newly
+ * computed sort order. The caller owns order reconciliation and calls
+ * `noteInteraction` for activity scoped to the inbox list.
+ */
+export function useInboxSortAttention({
+  viewIdentity,
+  onCommit,
+  idleCommitMs = INBOX_SORT_IDLE_COMMIT_MS,
+  hiddenCommitMs = INBOX_SORT_HIDDEN_COMMIT_MS,
+}: UseInboxSortAttentionOptions): InboxSortAttention {
+  const onCommitRef = useRef(onCommit);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hiddenAtRef = useRef<number | null>(null);
+  const committedInitialViewRef = useRef(false);
+  const previousViewIdentityRef = useRef(viewIdentity);
+
+  useEffect(() => {
+    onCommitRef.current = onCommit;
+  }, [onCommit]);
+
+  const clearIdleTimer = useCallback(() => {
+    if (idleTimerRef.current !== null) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+  }, []);
+
+  const restartIdleTimer = useCallback(() => {
+    clearIdleTimer();
+    if (!isDocumentVisible()) return;
+
+    idleTimerRef.current = setTimeout(() => {
+      idleTimerRef.current = null;
+      if (isDocumentVisible()) onCommitRef.current("idle");
+    }, idleCommitMs);
+  }, [clearIdleTimer, idleCommitMs]);
+
+  const noteInteraction = useCallback(() => {
+    restartIdleTimer();
+  }, [restartIdleTimer]);
+
+  const commitManualRefresh = useCallback(() => {
+    onCommitRef.current("manual-refresh");
+    restartIdleTimer();
+  }, [restartIdleTimer]);
+
+  useEffect(() => {
+    if (!committedInitialViewRef.current) {
+      committedInitialViewRef.current = true;
+      onCommitRef.current("mount");
+    } else if (previousViewIdentityRef.current !== viewIdentity) {
+      onCommitRef.current("view-identity-change");
+    }
+
+    previousViewIdentityRef.current = viewIdentity;
+    restartIdleTimer();
+    return clearIdleTimer;
+  }, [clearIdleTimer, restartIdleTimer, viewIdentity]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    if (document.visibilityState !== "visible") {
+      hiddenAtRef.current = Date.now();
+      clearIdleTimer();
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        hiddenAtRef.current = Date.now();
+        clearIdleTimer();
+        return;
+      }
+
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+      if (hiddenAt !== null && Date.now() - hiddenAt >= hiddenCommitMs) {
+        onCommitRef.current("visibility");
+      }
+      restartIdleTimer();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [clearIdleTimer, hiddenCommitMs, restartIdleTimer]);
+
+  return { noteInteraction, commitManualRefresh };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The inbox helps operators process active work without losing their place.
> - Inbox data can change while an operator archives several rows.
> - The inbox needs explicit attention boundaries before it adopts a new computed order.
> - This pull request adds the hook that emits those boundaries.
> - The benefit is a small and tested API that later inbox wiring can use without changing the sort algorithm.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The board inbox currently has no shared definition of when it is safe to commit a new computed sort order.

**Subsystem affected**

`ui/` — React and Vite board UI.

**Current behavior**

Inbox code must react directly to data changes. It cannot distinguish active list use from a natural refresh boundary.

**Proposed behavior**

Use one hook to commit on mount, a view identity change, a manual refresh, 150 seconds of visible idle time, or a return after at least 30 seconds hidden. Reset the idle timer after inbox list interaction.

**Reason and benefit**

These boundaries let later inbox integration preserve spatial order during archive bursts and still refresh after the operator loses attention.

**Breaking changes**

None. This pull request adds a hook and tests. It does not wire the hook into the inbox or change the sort algorithm.

## What Changed

- Added named 150-second idle and 30-second hidden thresholds.
- Added commit reasons for mount, idle, visibility return, view identity changes, and manual refresh.
- Added an interaction callback that restarts the visible idle timer.
- Added fake-timer tests for all commit points and timer reset behavior.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/hooks/useInboxSortAttention.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`
- `pnpm check:token-gates`

## Risks

- Low risk. The new hook is not connected to the inbox in this pull request.
- The integration must call `noteInteraction` for list activity and `commitManualRefresh` for explicit refresh actions.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5. The exact serving snapshot and context-window size are not exposed to this session. The model used reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
