### PR TITLE
feat(ui): pin inbox display order

### DIFF
--- a/ui/src/lib/inboxArchiveCache.ts
+++ b/ui/src/lib/inboxArchiveCache.ts
@@ -5,7 +5,7 @@ import { queryKeys } from "./queryKeys";
 
 export type InboxIssueCacheSnapshot = Array<readonly [QueryKey, Issue[] | undefined]>;
 
-const INBOX_ARCHIVE_CONFIRMATION_GRACE_MS = 5_000;
+export const INBOX_ARCHIVE_CONFIRMATION_GRACE_MS = 5_000;
 const INBOX_ARCHIVE_MAX_GUARD_MS = 30_000;
 const EMPTY_ARCHIVED_ISSUE_IDS: ReadonlySet<string> = new Set();
 

--- a/ui/src/lib/inboxOrderPin.test.ts
+++ b/ui/src/lib/inboxOrderPin.test.ts
@@ -1,0 +1,171 @@
+import type { Issue } from "@paperclipai/shared";
+import { describe, expect, it } from "vitest";
+import type { InboxGroupedSection, InboxWorkItem } from "./inbox";
+import { INBOX_ARCHIVE_CONFIRMATION_GRACE_MS } from "./inboxArchiveCache";
+import {
+  captureInboxOrderPin,
+  reconcileInboxOrderPin,
+} from "./inboxOrderPin";
+
+function issue(id: string, title = id): Issue {
+  return {
+    id,
+    title,
+    status: "todo",
+  } as Issue;
+}
+
+function issueItem(value: Issue, timestamp = 0): InboxWorkItem {
+  return { kind: "issue", issue: value, timestamp };
+}
+
+function section(
+  key: string,
+  items: Issue[],
+  childrenByIssueId: ReadonlyArray<readonly [string, Issue[]]> = [],
+): InboxGroupedSection {
+  return {
+    key,
+    label: key,
+    displayItems: items.map((item) => issueItem(item)),
+    childrenByIssueId: new Map(childrenByIssueId),
+    searchSection: "none",
+  };
+}
+
+function sectionKeys(sections: readonly InboxGroupedSection[]): string[] {
+  return sections.map((value) => value.key);
+}
+
+function rowIds(value: InboxGroupedSection): string[] {
+  return value.displayItems.map((item) => item.kind === "issue" ? item.issue.id : "non-issue");
+}
+
+describe("inboxOrderPin", () => {
+  it("keeps a parent, its group, and neighboring groups in place when a child is archived", () => {
+    const parent = issue("parent");
+    const child = issue("child");
+    const neighbor = issue("neighbor");
+    const committed = [
+      section("parent-group", [parent], [[parent.id, [child]]]),
+      section("neighbor-group", [neighbor]),
+    ];
+    const pin = captureInboxOrderPin(committed);
+
+    const fresh = [
+      section("neighbor-group", [neighbor]),
+      section("parent-group", [parent], [[parent.id, []]]),
+    ];
+    const result = reconcileInboxOrderPin(pin, fresh, 100);
+
+    expect(sectionKeys(result.sections)).toEqual(["parent-group", "neighbor-group"]);
+    expect(rowIds(result.sections[0]!)).toEqual([parent.id]);
+    expect(result.sections[0]!.childrenByIssueId.get(parent.id)).toEqual([]);
+  });
+
+  it("removes a group in place when its last row is archived", () => {
+    const archived = issue("archived");
+    const neighbor = issue("neighbor");
+    const pin = captureInboxOrderPin([
+      section("archived-group", [archived]),
+      section("neighbor-group", [neighbor]),
+    ]);
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [section("neighbor-group", [neighbor])],
+      200,
+    );
+
+    expect(sectionKeys(result.sections)).toEqual(["neighbor-group"]);
+    expect(rowIds(result.sections[0]!)).toEqual([neighbor.id]);
+    expect(result.pin.sections.map((value) => [value.key, value.missingSince])).toEqual([
+      ["archived-group", 200],
+      ["neighbor-group", null],
+    ]);
+  });
+
+  it("restores an archived row to its original position within the tombstone grace window", () => {
+    const first = issue("first");
+    const restored = issue("restored");
+    const last = issue("last");
+    const pin = captureInboxOrderPin([section("group", [first, restored, last])]);
+    const archived = reconcileInboxOrderPin(pin, [section("group", [last, first])], 1_000);
+
+    expect(rowIds(archived.sections[0]!)).toEqual([first.id, last.id]);
+
+    const undone = reconcileInboxOrderPin(
+      archived.pin,
+      [section("group", [last, restored, first])],
+      1_000 + INBOX_ARCHIVE_CONFIRMATION_GRACE_MS - 1,
+    );
+
+    expect(rowIds(undone.sections[0]!)).toEqual([first.id, restored.id, last.id]);
+    expect(undone.pin.sections[0]!.rows.every((entry) => entry.missingSince === null)).toBe(true);
+  });
+
+  it("treats a row restored after the grace window as a new algorithmic insertion", () => {
+    const first = issue("first");
+    const expired = issue("expired");
+    const last = issue("last");
+    const pin = captureInboxOrderPin([section("group", [first, expired, last])]);
+    const archived = reconcileInboxOrderPin(pin, [section("group", [last, first])], 1_000);
+
+    const restored = reconcileInboxOrderPin(
+      archived.pin,
+      [section("group", [last, first, expired])],
+      1_000 + INBOX_ARCHIVE_CONFIRMATION_GRACE_MS,
+    );
+
+    expect(rowIds(restored.sections[0]!)).toEqual([first.id, last.id, expired.id]);
+  });
+
+  it("inserts new rows and groups algorithmically without reordering existing entries", () => {
+    const first = issue("first");
+    const last = issue("last");
+    const inserted = issue("inserted");
+    const neighbor = issue("neighbor");
+    const newGroupItem = issue("new-group-item");
+    const pin = captureInboxOrderPin([
+      section("existing", [first, last]),
+      section("neighbor", [neighbor]),
+    ]);
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [
+        section("neighbor", [neighbor]),
+        section("new-group", [newGroupItem]),
+        section("existing", [last, inserted, first]),
+      ],
+      300,
+    );
+
+    expect(sectionKeys(result.sections)).toEqual(["existing", "new-group", "neighbor"]);
+    expect(rowIds(result.sections[0]!)).toEqual([first.id, inserted.id, last.id]);
+  });
+
+  it("uses fresh row content while retaining the pinned order", () => {
+    const first = issue("first", "Old first");
+    const last = issue("last", "Old last");
+    const pin = captureInboxOrderPin([section("group", [first, last])]);
+    const freshLast = { ...last, title: "Updated last", status: "in_progress" } as Issue;
+    const freshFirst = { ...first, title: "Updated first", status: "blocked" } as Issue;
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [section("group", [freshLast, freshFirst])],
+      400,
+    );
+
+    expect(rowIds(result.sections[0]!)).toEqual([first.id, last.id]);
+    expect(result.sections[0]!.displayItems[0]).toBeDefined();
+    expect(result.sections[0]!.displayItems[0]!.kind).toBe("issue");
+    expect(result.sections[0]!.displayItems[0]).toMatchObject({
+      issue: { title: "Updated first", status: "blocked" },
+    });
+    expect(result.sections[0]!.displayItems[1]).toMatchObject({
+      issue: { title: "Updated last", status: "in_progress" },
+    });
+  });
+});

--- a/ui/src/lib/inboxOrderPin.test.ts
+++ b/ui/src/lib/inboxOrderPin.test.ts
@@ -1,6 +1,10 @@
-import type { Issue } from "@paperclipai/shared";
+import type { Approval, HeartbeatRun, Issue, JoinRequest } from "@paperclipai/shared";
 import { describe, expect, it } from "vitest";
-import type { InboxGroupedSection, InboxWorkItem } from "./inbox";
+import {
+  getInboxWorkItemKey,
+  type InboxGroupedSection,
+  type InboxWorkItem,
+} from "./inbox";
 import { INBOX_ARCHIVE_CONFIRMATION_GRACE_MS } from "./inboxArchiveCache";
 import {
   captureInboxOrderPin,
@@ -35,6 +39,16 @@ function section(
 
 function sectionKeys(sections: readonly InboxGroupedSection[]): string[] {
   return sections.map((value) => value.key);
+}
+
+function workItemSection(key: string, displayItems: InboxWorkItem[]): InboxGroupedSection {
+  return {
+    key,
+    label: key,
+    displayItems,
+    childrenByIssueId: new Map(),
+    searchSection: "none",
+  };
 }
 
 function rowIds(value: InboxGroupedSection): string[] {
@@ -166,6 +180,51 @@ describe("inboxOrderPin", () => {
     });
     expect(result.sections[0]!.displayItems[1]).toMatchObject({
       issue: { title: "Updated last", status: "in_progress" },
+    });
+  });
+
+  it("pins approval, failed-run, and join-request rows by their stable keys", () => {
+    const approval = {
+      kind: "approval",
+      timestamp: 3,
+      approval: { id: "approval", status: "pending" } as Approval,
+    } satisfies InboxWorkItem;
+    const failedRun = {
+      kind: "failed_run",
+      timestamp: 2,
+      run: { id: "run", status: "failed" } as HeartbeatRun,
+    } satisfies InboxWorkItem;
+    const joinRequest = {
+      kind: "join_request",
+      timestamp: 1,
+      joinRequest: { id: "join", status: "pending_approval" } as JoinRequest,
+    } satisfies InboxWorkItem;
+    const pin = captureInboxOrderPin([
+      workItemSection("mixed", [approval, failedRun, joinRequest]),
+    ]);
+
+    const result = reconcileInboxOrderPin(
+      pin,
+      [workItemSection("mixed", [
+        { ...joinRequest, timestamp: 4 },
+        { ...failedRun, timestamp: 5 },
+        {
+          ...approval,
+          timestamp: 6,
+          approval: { ...approval.approval, status: "approved" } as Approval,
+        },
+      ])],
+      500,
+    );
+
+    expect(result.sections[0]!.displayItems.map(getInboxWorkItemKey)).toEqual([
+      "approval:approval",
+      "run:run",
+      "join:join",
+    ]);
+    expect(result.sections[0]!.displayItems[0]).toMatchObject({
+      timestamp: 6,
+      approval: { status: "approved" },
     });
   });
 });

--- a/ui/src/lib/inboxOrderPin.ts
+++ b/ui/src/lib/inboxOrderPin.ts
@@ -1,0 +1,242 @@
+import type { Issue } from "@paperclipai/shared";
+import {
+  getInboxWorkItemKey,
+  type InboxGroupedSection,
+  type InboxWorkItem,
+} from "./inbox";
+import { INBOX_ARCHIVE_CONFIRMATION_GRACE_MS } from "./inboxArchiveCache";
+
+export interface InboxPinnedKey {
+  key: string;
+  missingSince: number | null;
+}
+
+export interface InboxPinnedSectionOrder extends InboxPinnedKey {
+  rows: readonly InboxPinnedKey[];
+  childrenByIssueId: ReadonlyMap<string, readonly InboxPinnedKey[]>;
+}
+
+export interface InboxOrderPin {
+  sections: readonly InboxPinnedSectionOrder[];
+}
+
+export interface InboxOrderPinReconcileResult {
+  sections: InboxGroupedSection[];
+  pin: InboxOrderPin;
+}
+
+interface ReconciledKeys {
+  entries: InboxPinnedKey[];
+  retainedPinnedKeys: ReadonlySet<string>;
+  visibleKeys: string[];
+}
+
+function inboxOrderRowKey(item: InboxWorkItem): string {
+  return item.kind === "issue" ? item.issue.id : getInboxWorkItemKey(item);
+}
+
+function captureKeys(keys: Iterable<string>): InboxPinnedKey[] {
+  return Array.from(keys, (key) => ({ key, missingSince: null }));
+}
+
+function captureSection(section: InboxGroupedSection): InboxPinnedSectionOrder {
+  return {
+    key: section.key,
+    missingSince: null,
+    rows: captureKeys(section.displayItems.map(inboxOrderRowKey)),
+    childrenByIssueId: new Map(
+      Array.from(section.childrenByIssueId, ([issueId, children]) => [
+        issueId,
+        captureKeys(children.map((child) => child.id)),
+      ]),
+    ),
+  };
+}
+
+export function captureInboxOrderPin(
+  sections: readonly InboxGroupedSection[],
+): InboxOrderPin {
+  return { sections: sections.map(captureSection) };
+}
+
+function insertionIndexForVisiblePosition(
+  entries: readonly InboxPinnedKey[],
+  visibleKeys: ReadonlySet<string>,
+  visibleIndex: number,
+): number {
+  let seenVisible = 0;
+  for (let index = 0; index < entries.length; index += 1) {
+    if (seenVisible === visibleIndex) return index;
+    if (visibleKeys.has(entries[index]!.key)) seenVisible += 1;
+  }
+  return entries.length;
+}
+
+function reconcileKeys(
+  pinned: readonly InboxPinnedKey[],
+  freshKeys: readonly string[],
+  nowMs: number,
+): ReconciledKeys {
+  const freshKeySet = new Set(freshKeys);
+  const entries = pinned.flatMap((entry): InboxPinnedKey[] => {
+    if (freshKeySet.has(entry.key)) {
+      return entry.missingSince === null
+        || nowMs - entry.missingSince < INBOX_ARCHIVE_CONFIRMATION_GRACE_MS
+        ? [{ key: entry.key, missingSince: null }]
+        : [];
+    }
+
+    const missingSince = entry.missingSince ?? nowMs;
+    return nowMs - missingSince < INBOX_ARCHIVE_CONFIRMATION_GRACE_MS
+      ? [{ key: entry.key, missingSince }]
+      : [];
+  });
+  const retainedPinnedKeys = new Set(entries.map((entry) => entry.key));
+
+  const visibleKeys = new Set(
+    entries
+      .filter((entry) => entry.missingSince === null)
+      .map((entry) => entry.key),
+  );
+
+  freshKeys.forEach((key, freshIndex) => {
+    if (retainedPinnedKeys.has(key)) return;
+    const insertionIndex = insertionIndexForVisiblePosition(entries, visibleKeys, freshIndex);
+    entries.splice(insertionIndex, 0, { key, missingSince: null });
+    visibleKeys.add(key);
+  });
+
+  return {
+    entries,
+    retainedPinnedKeys,
+    visibleKeys: entries
+      .filter((entry) => entry.missingSince === null)
+      .map((entry) => entry.key),
+  };
+}
+
+function reconcileChildren(
+  pinned: ReadonlyMap<string, readonly InboxPinnedKey[]>,
+  fresh: ReadonlyMap<string, Issue[]>,
+  nowMs: number,
+): {
+  pin: ReadonlyMap<string, readonly InboxPinnedKey[]>;
+  display: Map<string, Issue[]>;
+} {
+  const parentIssueIds = new Set([...pinned.keys(), ...fresh.keys()]);
+  const nextPin = new Map<string, readonly InboxPinnedKey[]>();
+  const display = new Map<string, Issue[]>();
+
+  for (const parentIssueId of parentIssueIds) {
+    const freshChildren = fresh.get(parentIssueId) ?? [];
+    const freshChildById = new Map(freshChildren.map((child) => [child.id, child]));
+    const reconciled = reconcileKeys(
+      pinned.get(parentIssueId) ?? [],
+      freshChildren.map((child) => child.id),
+      nowMs,
+    );
+
+    if (reconciled.entries.length > 0) {
+      nextPin.set(parentIssueId, reconciled.entries);
+    }
+    if (fresh.has(parentIssueId)) {
+      display.set(
+        parentIssueId,
+        reconciled.visibleKeys.flatMap((key) => {
+          const child = freshChildById.get(key);
+          return child ? [child] : [];
+        }),
+      );
+    }
+  }
+
+  return { pin: nextPin, display };
+}
+
+function reconcileSection(
+  pinned: InboxPinnedSectionOrder | undefined,
+  fresh: InboxGroupedSection,
+  nowMs: number,
+): { pin: InboxPinnedSectionOrder; display: InboxGroupedSection } {
+  if (!pinned) {
+    return { pin: captureSection(fresh), display: fresh };
+  }
+
+  const freshItemByKey = new Map(
+    fresh.displayItems.map((item) => [inboxOrderRowKey(item), item]),
+  );
+  const rows = reconcileKeys(
+    pinned.rows,
+    fresh.displayItems.map(inboxOrderRowKey),
+    nowMs,
+  );
+  const children = reconcileChildren(pinned.childrenByIssueId, fresh.childrenByIssueId, nowMs);
+
+  return {
+    pin: {
+      key: fresh.key,
+      missingSince: null,
+      rows: rows.entries,
+      childrenByIssueId: children.pin,
+    },
+    display: {
+      ...fresh,
+      displayItems: rows.visibleKeys.flatMap((key) => {
+        const item = freshItemByKey.get(key);
+        return item ? [item] : [];
+      }),
+      childrenByIssueId: children.display,
+    },
+  };
+}
+
+/**
+ * Applies a previously committed Inbox order to freshly computed sections.
+ *
+ * `nowMs` is explicit so reconciliation remains pure. Callers should retain the
+ * returned pin between reconciliations and replace it with `captureInboxOrderPin`
+ * at an attention/refresh commit point.
+ */
+export function reconcileInboxOrderPin(
+  pinned: InboxOrderPin,
+  freshSections: readonly InboxGroupedSection[],
+  nowMs: number,
+): InboxOrderPinReconcileResult {
+  const freshSectionByKey = new Map(freshSections.map((section) => [section.key, section]));
+  const sections = reconcileKeys(
+    pinned.sections,
+    freshSections.map((section) => section.key),
+    nowMs,
+  );
+  const pinnedSectionByKey = new Map(pinned.sections.map((section) => [section.key, section]));
+  const reconciledByKey = new Map<string, ReturnType<typeof reconcileSection>>();
+
+  for (const freshSection of freshSections) {
+    reconciledByKey.set(
+      freshSection.key,
+      reconcileSection(
+        sections.retainedPinnedKeys.has(freshSection.key)
+          ? pinnedSectionByKey.get(freshSection.key)
+          : undefined,
+        freshSection,
+        nowMs,
+      ),
+    );
+  }
+
+  const nextPinnedSections = sections.entries.flatMap((entry): InboxPinnedSectionOrder[] => {
+    const reconciled = reconciledByKey.get(entry.key);
+    if (reconciled) return [{ ...reconciled.pin, missingSince: entry.missingSince }];
+    const previous = pinnedSectionByKey.get(entry.key);
+    return previous ? [{ ...previous, missingSince: entry.missingSince }] : [];
+  });
+
+  return {
+    sections: sections.visibleKeys.flatMap((key) => {
+      const freshSection = freshSectionByKey.get(key);
+      if (!freshSection) return [];
+      return [reconciledByKey.get(key)?.display ?? freshSection];
+    }),
+    pin: { sections: nextPinnedSections },
+  };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The inbox helps operators process active work without losing their place.
> - Archiving an item updates activity data and can change the computed sort order.
> - That reorder can move nearby rows and groups while the operator is still archiving.
> - The inbox needs a pure reconciliation layer that keeps the committed order while it uses fresh row data.
> - This pull request adds that order-pin utility and focused tests.
> - The benefit is stable spatial order during archive bursts without changing the inbox sort algorithm.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The board inbox can recompute group and row positions immediately after an optimistic archive update.

**Subsystem affected**

`ui/` — React and Vite board UI.

**Current behavior**

An archive can change subtree activity. The existing algorithm can then move the parent, neighboring rows, or neighboring groups before the operator finishes the archive sequence.

**Proposed behavior**

Reconcile fresh inbox sections against a committed order pin. Keep existing section, root-row, non-issue, and nested-child positions stable. Insert new data according to the fresh algorithmic order. Keep fresh row content. Retain missing entries for the existing five-second archive undo window.

**Reason and benefit**

The utility separates fresh data from displayed order. Later inbox integration can keep the list spatially stable during rapid archive actions and adopt a new order only at an explicit commit boundary.

**Breaking changes**

None. The utility is additive and is not connected to the inbox in this pull request.

**Additional context**

Related PR #10620 adds the independent attention-boundary hook that later integration can use to commit a new order.

## What Changed

- Added a pure order-pin capture and reconcile utility for inbox sections, root rows, non-issue items, and nested children.
- Reused the inbox archive confirmation grace period for reversible tombstones.
- Preserved fresh issue content while retaining the committed relative order.
- Added tests for child archives, empty groups, undo restoration, tombstone expiry, new insertions, and live content updates.

## Verification

- `pnpm exec vitest run ui/src/lib/inboxOrderPin.test.ts` (7 tests passed)
- `pnpm check:token-gates`
- `pnpm -r typecheck`
- `pnpm test:run`
- `pnpm build`

## Risks

- Low risk. The utility is additive and is not yet connected to the inbox.
- Later integration must retain the returned pin between reconciliations and replace it only at a defined commit boundary.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5. The exact serving snapshot and context-window size are not exposed to this session. The model used reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
