### PR TITLE
fix: reap orphaned remote and local process trees

### DIFF
--- a/cli/src/__tests__/company-import-export-e2e.test.ts
+++ b/cli/src/__tests__/company-import-export-e2e.test.ts
@@ -14,6 +14,52 @@ import { createStoredZipArchive } from "./helpers/zip.js";
 
 const execFileAsync = promisify(execFile);
 type ServerProcess = ReturnType<typeof spawn>;
+const SERVER_PROCESS_TERM_GRACE_MS = 5_000;
+const SERVER_PROCESS_KILL_GRACE_MS = 2_000;
+
+function isProcessAlive(pid: number) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function isProcessGroupAlive(processGroupId: number) {
+  if (process.platform === "win32" || !Number.isInteger(processGroupId) || processGroupId <= 0) {
+    return false;
+  }
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function waitForProcessExit(predicate: () => boolean, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !predicate();
+}
+
+function spawnServerProcess(
+  command: string,
+  args: string[],
+  options: Parameters<typeof spawn>[2],
+) {
+  return spawn(command, args, {
+    ...options,
+    // POSIX descendants inherit this dedicated process group. Teardown can
+    // then terminate the actual server tree instead of only the pnpm wrapper.
+    detached: process.platform !== "win32",
+    windowsHide: true,
+  });
+}
 
 async function getAvailablePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -188,17 +234,90 @@ function collectTextFiles(root: string, current: string, files: Record<string, s
 }
 
 async function stopServerProcess(child: ServerProcess | null) {
-  if (!child || child.exitCode !== null) return;
-  child.kill("SIGTERM");
-  await new Promise<void>((resolve) => {
-    child.once("exit", () => resolve());
-    setTimeout(() => {
-      if (child.exitCode === null) {
-        child.kill("SIGKILL");
-      }
-    }, 5_000);
-  });
+  const processId = child?.pid;
+  if (!child || !processId) return;
+
+  if (process.platform === "win32") {
+    await execFileAsync("taskkill", ["/PID", String(processId), "/T", "/F"]).catch((error) => {
+      if (isProcessAlive(processId)) throw error;
+    });
+    const stopped = await waitForProcessExit(
+      () => isProcessAlive(processId),
+      SERVER_PROCESS_KILL_GRACE_MS,
+    );
+    if (!stopped) {
+      throw new Error(`Failed to stop Paperclip test server process tree rooted at pid ${processId}.`);
+    }
+    return;
+  }
+
+  const signalGroup = (signal: NodeJS.Signals) => {
+    try {
+      process.kill(-processId, signal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    }
+  };
+
+  signalGroup("SIGTERM");
+  if (await waitForProcessExit(() => isProcessGroupAlive(processId), SERVER_PROCESS_TERM_GRACE_MS)) {
+    return;
+  }
+
+  signalGroup("SIGKILL");
+  if (!(await waitForProcessExit(() => isProcessGroupAlive(processId), SERVER_PROCESS_KILL_GRACE_MS))) {
+    throw new Error(`Failed to stop Paperclip test server process group ${processId}.`);
+  }
 }
+
+describe("company import/export e2e process cleanup", () => {
+  it("terminates the pnpm-style wrapper and its descendants", async () => {
+    const tempRoot = mkdtempSync(path.join(os.tmpdir(), "paperclip-server-tree-cleanup-"));
+    const descendantPidPath = path.join(tempRoot, "descendant.pid");
+    const wrapperPath = path.join(tempRoot, "wrapper.cjs");
+    writeFileSync(
+      wrapperPath,
+      [
+        'const { spawn } = require("node:child_process");',
+        'const { writeFileSync } = require("node:fs");',
+        `const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });`,
+        `writeFileSync(${JSON.stringify(descendantPidPath)}, String(child.pid));`,
+        "setInterval(() => {}, 1000);",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const wrapper = spawnServerProcess(process.execPath, [wrapperPath], {
+      stdio: "ignore",
+    });
+    let descendantPid = 0;
+    try {
+      const markerReady = await waitForProcessExit(
+        () => !existsSync(descendantPidPath),
+        5_000,
+      );
+      expect(markerReady).toBe(true);
+      descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
+      expect(isProcessAlive(wrapper.pid!)).toBe(true);
+      expect(isProcessAlive(descendantPid)).toBe(true);
+
+      await stopServerProcess(wrapper);
+
+      expect(isProcessAlive(wrapper.pid!)).toBe(false);
+      expect(isProcessAlive(descendantPid)).toBe(false);
+    } finally {
+      await stopServerProcess(wrapper).catch(() => undefined);
+      if (descendantPid > 0 && isProcessAlive(descendantPid)) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // Best-effort test cleanup.
+        }
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }, 15_000);
+});
 
 async function api<T>(baseUrl: string, pathname: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${baseUrl}${pathname}`, init);
@@ -301,7 +420,7 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
 
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
     const output = { stdout: [] as string[], stderr: [] as string[] };
-    const child = spawn(
+    const child = spawnServerProcess(
       "pnpm",
       ["paperclipai", "run", "--config", configPath],
       {

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http";
 import net from "node:net";
 import { execFile, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -103,6 +103,30 @@ describe("sandbox adapter execution targets", () => {
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
     throw new Error(message);
+  }
+
+  function isProcessAlive(pid: number | null | undefined) {
+    if (!pid || !Number.isInteger(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code === "EPERM";
+    }
+  }
+
+  async function readProcessSessionState(runtimeRootDir: string) {
+    const sessionsRoot = path.join(runtimeRootDir, "process-sessions");
+    const sessionNames = (await readdir(sessionsRoot, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+      .map((entry) => entry.name);
+    expect(sessionNames).toHaveLength(1);
+    const sessionDir = path.join(sessionsRoot, sessionNames[0]!);
+    const state = JSON.parse(await readFile(path.join(sessionDir, "process-state.json"), "utf8")) as {
+      bridgePid: number;
+      childPid: number | null;
+    };
+    return { sessionDir, state };
   }
 
   async function runProxyWithInput(command: string, input: string): Promise<{ stdout: string; stderr: string; code: number | null }> {
@@ -386,6 +410,274 @@ describe("sandbox adapter execution targets", () => {
       await bridge?.stop();
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "lets the remote bridge exit after its child closes without a stdin marker",
+    async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-child-close-"));
+      cleanupDirs.push(rootDir);
+      const runtimeRootDir = path.posix.join(rootDir, ".paperclip-runtime", "acpx");
+      const childPath = path.join(rootDir, "short-lived-acp-child.mjs");
+      await writeFile(childPath, "setTimeout(() => process.exit(0), 25);\n", "utf8");
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "local-test",
+        remoteCwd: rootDir,
+        timeoutMs: 30_000,
+        runner: createLocalSandboxRunner(),
+      };
+
+      const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+        runId: "run-process-session-child-close",
+        target,
+        runtimeRootDir,
+        adapterKey: "acpx",
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        env: {},
+        timeoutSec: 5,
+        onLog: async () => {},
+      });
+      expect(bridge).not.toBeNull();
+
+      try {
+        const { state } = await readProcessSessionState(runtimeRootDir);
+        await waitForCondition(
+          () => !isProcessAlive(state.bridgePid),
+          `Remote process-session bridge ${state.bridgePid} survived its child close.`,
+          3_000,
+        );
+        expect(isProcessAlive(state.childPid)).toBe(false);
+      } finally {
+        await bridge?.stop();
+      }
+    },
+    10_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rolls back the remote process tree when launch state cannot be acquired",
+    async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-launch-rollback-"));
+      cleanupDirs.push(rootDir);
+      const runtimeRootDir = path.posix.join(rootDir, ".paperclip-runtime", "acpx");
+      const childPath = path.join(rootDir, "launch-rollback-acp-child.mjs");
+      await writeFile(childPath, "process.stdin.resume(); setInterval(() => {}, 1000);\n", "utf8");
+      const baseRunner = createLocalSandboxRunner();
+      let launchedState: { bridgePid: number; childPid: number | null } | null = null;
+      const runner = {
+        execute: async (input: Parameters<typeof baseRunner.execute>[0]) => {
+          const result = await baseRunner.execute(input);
+          const script = input.args?.join("\n") ?? "";
+          if (script.includes("nohup node") && (result.exitCode ?? 1) === 0) {
+            launchedState = JSON.parse(result.stdout) as { bridgePid: number; childPid: number | null };
+            return { ...result, stdout: "{}\n" };
+          }
+          return result;
+        },
+      };
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "local-test",
+        remoteCwd: rootDir,
+        timeoutMs: 30_000,
+        runner,
+      };
+
+      await expect(startAdapterExecutionTargetProcessSessionBridge({
+        runId: "run-process-session-launch-rollback",
+        target,
+        runtimeRootDir,
+        adapterKey: "acpx",
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        env: {},
+        timeoutSec: 5,
+        onLog: async () => {},
+      })).rejects.toThrow("state did not match");
+
+      expect(launchedState).not.toBeNull();
+      expect(isProcessAlive(launchedState!.bridgePid)).toBe(false);
+      expect(isProcessAlive(launchedState!.childPid)).toBe(false);
+      const sessionDirs = (await readdir(path.join(runtimeRootDir, "process-sessions"), { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."));
+      expect(sessionDirs).toHaveLength(0);
+    },
+    10_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "keeps the stdin control directory until a stubborn remote child is terminated",
+    async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-stop-"));
+      cleanupDirs.push(rootDir);
+      const runtimeRootDir = path.posix.join(rootDir, ".paperclip-runtime", "acpx");
+      const childPath = path.join(rootDir, "stubborn-acp-child.mjs");
+      await writeFile(
+        childPath,
+        [
+          "process.on('SIGTERM', () => {});",
+          "process.stdin.resume();",
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+        "utf8",
+      );
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "local-test",
+        remoteCwd: rootDir,
+        timeoutMs: 30_000,
+        runner: createLocalSandboxRunner(),
+      };
+
+      const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+        runId: "run-process-session-stop",
+        target,
+        runtimeRootDir,
+        adapterKey: "acpx",
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        env: {},
+        timeoutSec: 5,
+        onLog: async () => {},
+      });
+      expect(bridge).not.toBeNull();
+
+      const { sessionDir, state } = await readProcessSessionState(runtimeRootDir);
+      expect(isProcessAlive(state.bridgePid)).toBe(true);
+      expect(isProcessAlive(state.childPid)).toBe(true);
+
+      await bridge?.stop();
+
+      expect(isProcessAlive(state.bridgePid)).toBe(false);
+      expect(isProcessAlive(state.childPid)).toBe(false);
+      await expect(access(sessionDir)).rejects.toThrow();
+    },
+    10_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "terminates persisted session identities when the remote control directory is already missing",
+    async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-missing-state-"));
+      cleanupDirs.push(rootDir);
+      const runtimeRootDir = path.posix.join(rootDir, ".paperclip-runtime", "acpx");
+      const childPath = path.join(rootDir, "missing-state-acp-child.mjs");
+      await writeFile(
+        childPath,
+        [
+          "process.on('SIGTERM', () => {});",
+          "process.stdin.resume();",
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+        "utf8",
+      );
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "local-test",
+        remoteCwd: rootDir,
+        timeoutMs: 30_000,
+        runner: createLocalSandboxRunner(),
+      };
+
+      const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+        runId: "run-process-session-missing-state",
+        target,
+        runtimeRootDir,
+        adapterKey: "acpx",
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        env: {},
+        timeoutSec: 5,
+        onLog: async () => {},
+      });
+      expect(bridge).not.toBeNull();
+
+      const { sessionDir, state } = await readProcessSessionState(runtimeRootDir);
+      expect(isProcessAlive(state.bridgePid)).toBe(true);
+      expect(isProcessAlive(state.childPid)).toBe(true);
+      await rm(sessionDir, { recursive: true, force: true });
+
+      await bridge?.stop();
+
+      expect(isProcessAlive(state.bridgePid)).toBe(false);
+      expect(isProcessAlive(state.childPid)).toBe(false);
+    },
+    10_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "allows a later remote teardown retry after bounded runner failures",
+    async () => {
+      const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-stop-retry-"));
+      cleanupDirs.push(rootDir);
+      const runtimeRootDir = path.posix.join(rootDir, ".paperclip-runtime", "acpx");
+      const childPath = path.join(rootDir, "stop-retry-acp-child.mjs");
+      await writeFile(
+        childPath,
+        [
+          "process.on('SIGTERM', () => {});",
+          "process.stdin.resume();",
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+        "utf8",
+      );
+      const baseRunner = createLocalSandboxRunner();
+      let stopAttempts = 0;
+      const runner = {
+        execute: async (input: Parameters<typeof baseRunner.execute>[0]) => {
+          const script = input.args?.join("\n") ?? "";
+          if (script.includes("bridge_pid=") && script.includes("session_identity_conflict")) {
+            stopAttempts += 1;
+            if (stopAttempts <= 2) throw new Error("transient stop runner failure");
+          }
+          return await baseRunner.execute(input);
+        },
+      };
+      const target: AdapterSandboxExecutionTarget = {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "local-test",
+        remoteCwd: rootDir,
+        timeoutMs: 30_000,
+        runner,
+      };
+
+      const bridge = await startAdapterExecutionTargetProcessSessionBridge({
+        runId: "run-process-session-stop-retry",
+        target,
+        runtimeRootDir,
+        adapterKey: "acpx",
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        env: {},
+        timeoutSec: 5,
+        onLog: async () => {},
+      });
+      expect(bridge).not.toBeNull();
+      const { state } = await readProcessSessionState(runtimeRootDir);
+
+      await expect(bridge?.stop()).rejects.toThrow("transient stop runner failure");
+      expect(isProcessAlive(state.bridgePid)).toBe(true);
+      expect(isProcessAlive(state.childPid)).toBe(true);
+
+      await bridge?.stop();
+
+      expect(stopAttempts).toBe(3);
+      expect(isProcessAlive(state.bridgePid)).toBe(false);
+      expect(isProcessAlive(state.childPid)).toBe(false);
+    },
+    10_000,
+  );
 
   it("ignores unauthenticated connections to the process session bridge", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-auth-"));

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1274,6 +1274,55 @@ async function readBridgeForwardResponseBody(response: Response, maxBodyBytes: n
 const PROCESS_SESSION_PROXY_SCRIPT = "paperclip-process-session-proxy.mjs";
 const PROCESS_SESSION_REMOTE_SCRIPT = "paperclip-process-session-remote.mjs";
 const PROCESS_SESSION_AUTH_TIMEOUT_MS = 5_000;
+const PROCESS_SESSION_STOP_NATURAL_GRACE_STEPS = 10;
+const PROCESS_SESSION_STOP_TERM_GRACE_STEPS = 40;
+const PROCESS_SESSION_STOP_KILL_GRACE_STEPS = 40;
+const PROCESS_SESSION_STOP_MAX_ATTEMPTS = 2;
+
+type RemoteProcessSessionState = {
+  version: 1;
+  sessionId: string;
+  bridgePid: number;
+  childPid: number | null;
+  childProcessGroupId: number | null;
+};
+
+function parseRemoteProcessSessionState(raw: string, expectedSessionId: string): RemoteProcessSessionState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.trim());
+  } catch (error) {
+    throw new Error(
+      `Sandbox ACP process session bridge wrote invalid state JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Sandbox ACP process session bridge wrote an invalid state payload.");
+  }
+  const state = parsed as Record<string, unknown>;
+  const bridgePid = typeof state.bridgePid === "number" && Number.isInteger(state.bridgePid) && state.bridgePid > 0
+    ? state.bridgePid
+    : null;
+  const childPid = typeof state.childPid === "number" && Number.isInteger(state.childPid) && state.childPid > 0
+    ? state.childPid
+    : null;
+  const childProcessGroupId =
+    typeof state.childProcessGroupId === "number"
+      && Number.isInteger(state.childProcessGroupId)
+      && state.childProcessGroupId > 0
+      ? state.childProcessGroupId
+      : null;
+  if (state.version !== 1 || state.sessionId !== expectedSessionId || bridgePid === null) {
+    throw new Error("Sandbox ACP process session bridge state did not match the launched session.");
+  }
+  return {
+    version: 1,
+    sessionId: expectedSessionId,
+    bridgePid,
+    childPid,
+    childProcessGroupId,
+  };
+}
 
 function jsonLine(value: unknown): string {
   return `${JSON.stringify(value)}\n`;
@@ -1387,6 +1436,7 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
   const sessionDir = path.posix.join(bridgeRuntimeDir, sessionId);
   const stdinDir = path.posix.join(sessionDir, "stdin");
   const eventsDir = path.posix.join(sessionDir, "events");
+  const stateFile = path.posix.join(sessionDir, "process-state.json");
   const remoteScriptPath = path.posix.join(bridgeRuntimeDir, PROCESS_SESSION_REMOTE_SCRIPT);
   const client = createCommandManagedSandboxCallbackBridgeQueueClient({
     runner,
@@ -1394,6 +1444,107 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     timeoutMs,
     shellCommand,
   });
+  const cleanupTimeoutMs = Math.max(10_000, Math.min(timeoutMs ?? 15_000, 30_000));
+  const rollbackRemoteLaunch = async () => {
+    const sessionEnvMarker = `PAPERCLIP_PROCESS_SESSION_ID=${sessionId}`;
+    const rollbackResult = await runner.execute({
+      command: shellCommand,
+      args: shellCommandArgs(
+        [
+          `session_env_marker=${shellQuote(sessionEnvMarker)}`,
+          "pid_is_zombie() {",
+          "  pid=\"$1\"",
+          "  [ -r \"/proc/$pid/stat\" ] || return 1",
+          "  stat_line=$(cat \"/proc/$pid/stat\" 2>/dev/null) || return 1",
+          "  stat_tail=${stat_line##*) }",
+          "  set -- $stat_tail",
+          "  [ \"${1:-}\" = \"Z\" ]",
+          "}",
+          "pid_group() {",
+          "  pid=\"$1\"",
+          "  [ -r \"/proc/$pid/stat\" ] || return 1",
+          "  stat_line=$(cat \"/proc/$pid/stat\" 2>/dev/null) || return 1",
+          "  stat_tail=${stat_line##*) }",
+          "  set -- $stat_tail",
+          "  printf '%s\\n' \"${3:-0}\"",
+          "}",
+          "pid_has_session_marker() {",
+          "  pid=\"$1\"",
+          "  [ -r \"/proc/$pid/environ\" ] || return 1",
+          "  tr '\\000' '\\n' < \"/proc/$pid/environ\" | grep -Fqx \"$session_env_marker\"",
+          "}",
+          "session_processes_alive() {",
+          "  for environ_path in /proc/[0-9]*/environ; do",
+          "    [ -r \"$environ_path\" ] || continue",
+          "    pid=${environ_path#/proc/}",
+          "    pid=${pid%/environ}",
+          "    if pid_has_session_marker \"$pid\" && ! pid_is_zombie \"$pid\"; then return 0; fi",
+          "  done",
+          "  return 1",
+          "}",
+          "signal_session_processes() {",
+          "  signal=\"$1\"",
+          "  for environ_path in /proc/[0-9]*/environ; do",
+          "    [ -r \"$environ_path\" ] || continue",
+          "    pid=${environ_path#/proc/}",
+          "    pid=${pid%/environ}",
+          "    pid_has_session_marker \"$pid\" || continue",
+          "    group_id=$(pid_group \"$pid\" 2>/dev/null || printf '0\\n')",
+          "    if [ \"$group_id\" = \"$pid\" ]; then",
+          "      kill \"-$signal\" -- \"-$group_id\" 2>/dev/null || true",
+          "    else",
+          "      kill \"-$signal\" \"$pid\" 2>/dev/null || true",
+          "    fi",
+          "  done",
+          "}",
+          "wait_for_session_exit() {",
+          "  limit=\"$1\"",
+          "  i=0",
+          "  while session_processes_alive && [ \"$i\" -lt \"$limit\" ]; do",
+          "    i=$((i + 1))",
+          "    sleep 0.05",
+          "  done",
+          "  ! session_processes_alive",
+          "}",
+          "if [ ! -d /proc ]; then",
+          "  echo \"Cannot verify sandbox ACP process identities without /proc.\" >&2",
+          "  exit 1",
+          "fi",
+          "signal_session_processes TERM",
+          `if ! wait_for_session_exit ${PROCESS_SESSION_STOP_TERM_GRACE_STEPS}; then`,
+          "  signal_session_processes KILL",
+          `  wait_for_session_exit ${PROCESS_SESSION_STOP_KILL_GRACE_STEPS} || true`,
+          "fi",
+          "if session_processes_alive; then",
+          "  echo \"Sandbox ACP process session remained alive after launch rollback.\" >&2",
+          "  exit 1",
+          "fi",
+        ].join("\n"),
+      ),
+      cwd: target.remoteCwd,
+      env: {
+        PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
+      },
+      timeoutMs: cleanupTimeoutMs,
+    });
+    if (rollbackResult.timedOut || (rollbackResult.exitCode ?? 1) !== 0) {
+      throw new Error(
+        `Failed to roll back sandbox ACP process session launch: ${rollbackResult.stderr || rollbackResult.stdout || "remote cleanup failed"}`,
+      );
+    }
+    await client.remove(sessionDir).catch(() => undefined);
+  };
+  const throwAfterLaunchRollback = async (launchError: unknown): Promise<never> => {
+    try {
+      await rollbackRemoteLaunch();
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [launchError, rollbackError],
+        "Sandbox ACP process session launch failed and its remote rollback could not be confirmed.",
+      );
+    }
+    throw launchError;
+  };
 
   // The launch exec below re-creates stdinDir and eventsDir with one `mkdir -p`,
   // and the remote script also creates them on start. No reader touches the two
@@ -1419,29 +1570,59 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
   }), "utf8").toString("base64");
 
   await onLog("stdout", `[paperclip] Starting ACP process session bridge in sandbox (${target.providerKey ?? "provider"}).\n`);
-  const startResult = await runner.execute({
-    command: shellCommand,
-    args: shellCommandArgs(
-      [
-        `mkdir -p ${shellQuote(stdinDir)} ${shellQuote(eventsDir)}`,
-        `PAPERCLIP_PROCESS_SESSION_DIR=${shellQuote(sessionDir)} ` +
-          `PAPERCLIP_PROCESS_SESSION_COMMAND_B64=${shellQuote(commandPayload)} ` +
-          `nohup node ${shellQuote(remoteScriptPath)} >/dev/null 2>&1 < /dev/null &`,
-        "printf '%s\\n' \"$!\"",
-      ].join("\n"),
-    ),
-    cwd: target.remoteCwd,
-    env: {
-      PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
-    },
-    timeoutMs,
-  });
+  let startResult: RunProcessResult;
+  try {
+    startResult = await runner.execute({
+      command: shellCommand,
+      args: shellCommandArgs(
+        [
+          `mkdir -p ${shellQuote(stdinDir)} ${shellQuote(eventsDir)}`,
+          `rm -f ${shellQuote(stateFile)}`,
+          `PAPERCLIP_PROCESS_SESSION_DIR=${shellQuote(sessionDir)} ` +
+            `PAPERCLIP_PROCESS_SESSION_ID=${shellQuote(sessionId)} ` +
+            `PAPERCLIP_PROCESS_SESSION_COMMAND_B64=${shellQuote(commandPayload)} ` +
+            `nohup node ${shellQuote(remoteScriptPath)} >/dev/null 2>&1 < /dev/null &`,
+          "bridge_pid=$!",
+          "i=0",
+          `while [ "$i" -lt 100 ] && [ ! -s ${shellQuote(stateFile)} ]; do`,
+          "  if ! kill -0 \"$bridge_pid\" 2>/dev/null; then",
+          "    echo \"Sandbox ACP process session bridge exited before writing process state.\" >&2",
+          "    exit 1",
+          "  fi",
+          "  i=$((i + 1))",
+          "  sleep 0.05",
+          "done",
+          `if [ ! -s ${shellQuote(stateFile)} ]; then`,
+          "  echo \"Timed out waiting for sandbox ACP process session bridge state.\" >&2",
+          "  exit 1",
+          "fi",
+          `cat ${shellQuote(stateFile)}`,
+        ].join("\n"),
+      ),
+      cwd: target.remoteCwd,
+      env: {
+        PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
+      },
+      timeoutMs,
+    });
+  } catch (error) {
+    return await throwAfterLaunchRollback(error);
+  }
   if (startResult.timedOut || (startResult.exitCode ?? 1) !== 0) {
-    throw new Error(`Failed to start sandbox ACP process session bridge: ${startResult.stderr || startResult.stdout}`);
+    return await throwAfterLaunchRollback(
+      new Error(`Failed to start sandbox ACP process session bridge: ${startResult.stderr || startResult.stdout}`),
+    );
+  }
+  let remoteState: RemoteProcessSessionState;
+  try {
+    remoteState = parseRemoteProcessSessionState(startResult.stdout, sessionId);
+  } catch (error) {
+    return await throwAfterLaunchRollback(error);
   }
 
   let socket: net.Socket | null = null;
   let stopping = false;
+  let stopPromise: Promise<void> | null = null;
   let stdinSeq = 0;
   let pollTimer: NodeJS.Timeout | null = null;
   const pendingRemoteEvents: Array<{
@@ -1453,7 +1634,12 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     message?: string;
   }> = [];
   const token = createSandboxCallbackBridgeToken(18);
-  const proxyDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-proxy-"));
+  let proxyDir: string;
+  try {
+    proxyDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-process-session-proxy-"));
+  } catch (error) {
+    return await throwAfterLaunchRollback(error);
+  }
 
   const writeRemoteEventToSocket = (event: (typeof pendingRemoteEvents)[number]) => {
     if (!socket) return false;
@@ -1578,24 +1764,231 @@ export async function startAdapterExecutionTargetProcessSessionBridge(input: {
     }
   };
 
-  const port = await waitForLocalServerListen(server);
-  const agentCommand = await writeProcessSessionProxyScript(proxyDir, port, token);
+  let agentCommand: string;
+  try {
+    const port = await waitForLocalServerListen(server);
+    agentCommand = await writeProcessSessionProxyScript(proxyDir, port, token);
+  } catch (error) {
+    stopping = true;
+    for (const liveSocket of liveSockets) liveSocket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve())).catch(() => undefined);
+    await fs.rm(proxyDir, { recursive: true, force: true }).catch(() => undefined);
+    return await throwAfterLaunchRollback(error);
+  }
   pollTimer = setTimeout(() => void poll(), 100);
   pollTimer.unref?.();
+
+  const stopRemoteSession = async () => {
+    stopping = true;
+    if (pollTimer) clearTimeout(pollTimer);
+    pollTimer = null;
+    for (const liveSocket of liveSockets) liveSocket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve())).catch(() => undefined);
+
+    stdinSeq += 1;
+    await client.writeTextFile(
+      path.posix.join(stdinDir, `${String(stdinSeq).padStart(12, "0")}.json`),
+      jsonLine({ type: "stdinEnd" }),
+    ).catch(() => undefined);
+
+    const bridgePid = String(remoteState.bridgePid);
+    const childPid = String(remoteState.childPid ?? 0);
+    const childProcessGroupId = String(remoteState.childProcessGroupId ?? 0);
+    const sessionEnvMarker = `PAPERCLIP_PROCESS_SESSION_ID=${sessionId}`;
+    const stopTimeoutMs = Math.max(10_000, Math.min(timeoutMs ?? 15_000, 30_000));
+    let remoteStopped = false;
+    try {
+      const stopResult = await runner.execute({
+        command: shellCommand,
+        args: shellCommandArgs(
+          [
+            `bridge_pid=${shellQuote(bridgePid)}`,
+            `child_pid=${shellQuote(childPid)}`,
+            `child_group_id=${shellQuote(childProcessGroupId)}`,
+            `session_env_marker=${shellQuote(sessionEnvMarker)}`,
+            "pid_exists() {",
+            "  [ \"$1\" -gt 0 ] 2>/dev/null || return 1",
+            "  if [ -d /proc ]; then [ -d \"/proc/$1\" ]; else kill -0 \"$1\" 2>/dev/null; fi",
+            "}",
+            "pid_is_zombie() {",
+            "  pid=\"$1\"",
+            "  [ -r \"/proc/$pid/stat\" ] || return 1",
+            "  stat_line=$(cat \"/proc/$pid/stat\" 2>/dev/null) || return 1",
+            "  stat_tail=${stat_line##*) }",
+            "  set -- $stat_tail",
+            "  [ \"${1:-}\" = \"Z\" ]",
+            "}",
+            "pid_active() { pid_exists \"$1\" && ! pid_is_zombie \"$1\"; }",
+            "pid_in_group() {",
+            "  pid=\"$1\"",
+            "  expected_group=\"$2\"",
+            "  [ -r \"/proc/$pid/stat\" ] || return 1",
+            "  stat_line=$(cat \"/proc/$pid/stat\" 2>/dev/null) || return 1",
+            "  stat_tail=${stat_line##*) }",
+            "  set -- $stat_tail",
+            "  [ \"${3:-}\" = \"$expected_group\" ]",
+            "}",
+            "group_has_active_members() {",
+            "  group_id=\"$1\"",
+            "  [ \"$group_id\" -gt 0 ] 2>/dev/null || return 1",
+            "  if [ -d /proc ]; then",
+            "    for stat_path in /proc/[0-9]*/stat; do",
+            "      [ -r \"$stat_path\" ] || continue",
+            "      candidate_pid=${stat_path#/proc/}",
+            "      candidate_pid=${candidate_pid%/stat}",
+            "      if pid_in_group \"$candidate_pid\" \"$group_id\" && ! pid_is_zombie \"$candidate_pid\"; then",
+            "        return 0",
+            "      fi",
+            "    done",
+            "    return 1",
+            "  fi",
+            "  kill -0 -- \"-$group_id\" 2>/dev/null",
+            "}",
+            "pid_has_session_marker() {",
+            "  pid=\"$1\"",
+            "  if [ -r \"/proc/$pid/environ\" ]; then",
+            "    tr '\\000' '\\n' < \"/proc/$pid/environ\" | grep -Fqx \"$session_env_marker\"",
+            "    return $?",
+            "  fi",
+            "  return 1",
+            "}",
+            "pid_matches_session() {",
+            "  pid=\"$1\"",
+            "  pid_active \"$pid\" || return 1",
+            "  if [ -d /proc ]; then pid_has_session_marker \"$pid\"; else return 1; fi",
+            "}",
+            "pid_identity_conflict() {",
+            "  pid=\"$1\"",
+            "  pid_active \"$pid\" && ! pid_matches_session \"$pid\" && pid_active \"$pid\"",
+            "}",
+            "group_matches_session() {",
+            "  group_id=\"$1\"",
+            "  group_has_active_members \"$group_id\" || return 1",
+            "  if pid_exists \"$child_pid\" && pid_is_zombie \"$child_pid\" && pid_in_group \"$child_pid\" \"$group_id\"; then",
+            "    return 0",
+            "  fi",
+            "  if [ -d /proc ]; then",
+            "    for stat_path in /proc/[0-9]*/stat; do",
+            "      [ -r \"$stat_path\" ] || continue",
+            "      candidate_pid=${stat_path#/proc/}",
+            "      candidate_pid=${candidate_pid%/stat}",
+            "      if pid_in_group \"$candidate_pid\" \"$group_id\" && pid_active \"$candidate_pid\" && pid_has_session_marker \"$candidate_pid\"; then",
+            "        return 0",
+            "      fi",
+            "    done",
+            "    return 1",
+            "  fi",
+            "  return 1",
+            "}",
+            "group_identity_conflict() {",
+            "  group_id=\"$1\"",
+            "  group_has_active_members \"$group_id\" && ! group_matches_session \"$group_id\" && group_has_active_members \"$group_id\"",
+            "}",
+            "bridge_alive() { pid_matches_session \"$bridge_pid\"; }",
+            "child_alive() {",
+            "  if [ \"$child_group_id\" -gt 0 ] 2>/dev/null; then",
+            "    group_matches_session \"$child_group_id\"",
+            "  else",
+            "    pid_matches_session \"$child_pid\"",
+            "  fi",
+            "}",
+            "session_alive() { bridge_alive || child_alive; }",
+            "session_identity_conflict() {",
+            "  pid_identity_conflict \"$bridge_pid\" && return 0",
+            "  if [ \"$child_group_id\" -gt 0 ] 2>/dev/null; then",
+            "    group_identity_conflict \"$child_group_id\"",
+            "  else",
+            "    pid_identity_conflict \"$child_pid\"",
+            "  fi",
+            "}",
+            "wait_for_exit() {",
+            "  limit=\"$1\"",
+            "  i=0",
+            "  while session_alive && [ \"$i\" -lt \"$limit\" ]; do",
+            "    i=$((i + 1))",
+            "    sleep 0.05",
+            "  done",
+            "  ! session_alive",
+            "}",
+            `if ! wait_for_exit ${PROCESS_SESSION_STOP_NATURAL_GRACE_STEPS}; then`,
+            "  if child_alive; then",
+            "    if [ \"$child_group_id\" -gt 0 ] 2>/dev/null; then",
+            "      kill -TERM -- \"-$child_group_id\" 2>/dev/null || true",
+            "    else",
+            "      kill -TERM \"$child_pid\" 2>/dev/null || true",
+            "    fi",
+            "  fi",
+            "  if bridge_alive; then kill -TERM \"$bridge_pid\" 2>/dev/null || true; fi",
+            `  if ! wait_for_exit ${PROCESS_SESSION_STOP_TERM_GRACE_STEPS}; then`,
+            "    if child_alive; then",
+            "      if [ \"$child_group_id\" -gt 0 ] 2>/dev/null; then",
+            "        kill -KILL -- \"-$child_group_id\" 2>/dev/null || true",
+            "      else",
+            "        kill -KILL \"$child_pid\" 2>/dev/null || true",
+            "      fi",
+            "    fi",
+            "    if bridge_alive; then kill -KILL \"$bridge_pid\" 2>/dev/null || true; fi",
+            `    wait_for_exit ${PROCESS_SESSION_STOP_KILL_GRACE_STEPS} || true`,
+            "  fi",
+            "fi",
+            "if session_alive; then",
+            "  echo \"Sandbox ACP process session bridge or child remained alive after SIGKILL.\" >&2",
+            "  exit 1",
+            "fi",
+            "if session_identity_conflict; then",
+            "  echo \"Refusing to signal a reused or unverifiable sandbox ACP process identity.\" >&2",
+            "  exit 1",
+            "fi",
+          ].join("\n"),
+        ),
+        cwd: target.remoteCwd,
+        env: {
+          PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
+        },
+        timeoutMs: stopTimeoutMs,
+      });
+      if (stopResult.timedOut || (stopResult.exitCode ?? 1) !== 0) {
+        throw new Error(
+          `Failed to stop sandbox ACP process session bridge: ${stopResult.stderr || stopResult.stdout || "remote cleanup failed"}`,
+        );
+      }
+      remoteStopped = true;
+    } finally {
+      // The stdin marker directory is the remote bridge's control plane. Keep
+      // it intact unless the persisted bridge/child identities are confirmed
+      // dead, otherwise removing it strands pollStdin in a permanent empty loop.
+      if (remoteStopped) {
+        await client.remove(sessionDir).catch(() => undefined);
+      }
+      await fs.rm(proxyDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  };
 
   return {
     agentCommand,
     stop: async () => {
-      stopping = true;
-      if (pollTimer) clearTimeout(pollTimer);
-      for (const liveSocket of liveSockets) liveSocket.destroy();
-      await new Promise<void>((resolve) => server.close(() => resolve())).catch(() => undefined);
-      await client.writeTextFile(
-        path.posix.join(stdinDir, `${String(stdinSeq + 1).padStart(12, "0")}.json`),
-        jsonLine({ type: "stdinEnd" }),
-      ).catch(() => undefined);
-      await client.remove(sessionDir).catch(() => undefined);
-      await fs.rm(proxyDir, { recursive: true, force: true }).catch(() => undefined);
+      if (!stopPromise) {
+        stopPromise = (async () => {
+          let lastError: unknown;
+          for (let attempt = 1; attempt <= PROCESS_SESSION_STOP_MAX_ATTEMPTS; attempt += 1) {
+            try {
+              await stopRemoteSession();
+              return;
+            } catch (error) {
+              lastError = error;
+            }
+          }
+          throw lastError;
+        })();
+      }
+      try {
+        await stopPromise;
+      } catch (error) {
+        // A later teardown attempt must be able to retry a transient runner
+        // failure. The remote control directory remains intact on failure.
+        stopPromise = null;
+        throw error;
+      }
     },
   };
 }
@@ -1653,13 +2046,17 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 
 const sessionDir = process.env.PAPERCLIP_PROCESS_SESSION_DIR;
+const sessionId = process.env.PAPERCLIP_PROCESS_SESSION_ID;
 const commandPayload = process.env.PAPERCLIP_PROCESS_SESSION_COMMAND_B64;
-if (!sessionDir || !commandPayload) throw new Error("Missing process session bridge env.");
+if (!sessionDir || !sessionId || !commandPayload) throw new Error("Missing process session bridge env.");
 
 const stdinDir = path.posix.join(sessionDir, "stdin");
 const eventsDir = path.posix.join(sessionDir, "events");
+const stateFile = path.posix.join(sessionDir, "process-state.json");
 let seq = 0;
 let stdinClosed = false;
+let childClosed = false;
+let forceKillTimer = null;
 
 const config = JSON.parse(Buffer.from(commandPayload, "base64").toString("utf8"));
 await fs.mkdir(stdinDir, { recursive: true });
@@ -1680,19 +2077,66 @@ function writeEvent(event) {
 
 const child = spawn(config.command, Array.isArray(config.args) ? config.args : [], {
   cwd: config.cwd || process.cwd(),
-  env: { ...process.env, ...(config.env || {}) },
+  env: { ...process.env, ...(config.env || {}), PAPERCLIP_PROCESS_SESSION_ID: sessionId },
+  detached: process.platform !== "win32",
   stdio: ["pipe", "pipe", "pipe"],
 });
+const childPid = typeof child.pid === "number" ? child.pid : null;
+const childProcessGroupId = process.platform !== "win32" ? childPid : null;
+const stateWrite = fs
+  .writeFile(
+    stateFile + ".tmp",
+    JSON.stringify({
+      version: 1,
+      sessionId,
+      bridgePid: process.pid,
+      childPid,
+      childProcessGroupId,
+    }) + "\\n",
+    "utf8",
+  )
+  .then(() => fs.rename(stateFile + ".tmp", stateFile));
+
+function signalChildTree(signal) {
+  if (!childPid || childClosed) return;
+  try {
+    process.kill(childProcessGroupId ? -childProcessGroupId : childPid, signal);
+  } catch {
+    // Child/process-group exit races are expected during bounded cleanup.
+  }
+}
+
+function beginShutdown() {
+  stdinClosed = true;
+  if (!child.stdin.destroyed) child.stdin.end();
+  signalChildTree("SIGTERM");
+  if (!childClosed && !forceKillTimer) {
+    forceKillTimer = setTimeout(() => signalChildTree("SIGKILL"), 1000);
+    forceKillTimer.unref?.();
+  }
+}
 
 child.stdout.on("data", (chunk) => void writeEvent({ type: "data", stream: "stdout", data: Buffer.from(chunk).toString("base64") }));
 child.stderr.on("data", (chunk) => void writeEvent({ type: "data", stream: "stderr", data: Buffer.from(chunk).toString("base64") }));
-child.on("error", (error) => void writeEvent({ type: "error", message: error.message }));
+child.on("error", (error) => {
+  childClosed = true;
+  stdinClosed = true;
+  if (forceKillTimer) clearTimeout(forceKillTimer);
+  void writeEvent({ type: "error", message: error.message });
+});
 // "close" (not "exit") so stdout/stderr fully drain before the exit event;
 // the write chain then guarantees the exit file lands after every data file.
-child.on("close", (code, signal) => void writeEvent({ type: "exit", code, signal }));
+child.on("close", (code, signal) => {
+  childClosed = true;
+  stdinClosed = true;
+  if (forceKillTimer) clearTimeout(forceKillTimer);
+  void writeEvent({ type: "exit", code, signal });
+});
+process.on("SIGTERM", beginShutdown);
+process.on("SIGINT", beginShutdown);
 
 async function pollStdin() {
-  while (!stdinClosed) {
+  while (!stdinClosed && !childClosed) {
     const entries = (await fs.readdir(stdinDir).catch(() => [])).filter((name) => name.endsWith(".json")).sort();
     for (const name of entries) {
       const file = path.posix.join(stdinDir, name);
@@ -1701,18 +2145,25 @@ async function pollStdin() {
       if (!raw) continue;
       const message = JSON.parse(raw);
       if (message.type === "stdin" && typeof message.data === "string") {
-        child.stdin.write(Buffer.from(message.data, "base64"));
+        if (!childClosed && !child.stdin.destroyed) child.stdin.write(Buffer.from(message.data, "base64"));
       } else if (message.type === "stdinEnd") {
         stdinClosed = true;
-        child.stdin.end();
+        if (!child.stdin.destroyed) child.stdin.end();
         break;
       }
     }
-    if (!stdinClosed) await new Promise((resolve) => setTimeout(resolve, 50));
+    if (!stdinClosed && !childClosed) await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }
 
-void pollStdin().catch((error) => void writeEvent({ type: "error", message: error instanceof Error ? error.message : String(error) }));
+await stateWrite;
+if (!childClosed) {
+  void pollStdin().catch((error) => {
+    stdinClosed = true;
+    void writeEvent({ type: "error", message: error instanceof Error ? error.message : String(error) });
+    beginShutdown();
+  });
+}
 `;
 }
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -5220,13 +5220,14 @@ describeEmbeddedPostgres("workspace runtime service control persistence", () => 
 
       const companyId = randomUUID();
       const childPidPath = path.join(workspaceRoot, "child.pid");
+      const childPidPathForShell = childPidPath.replaceAll("\\", "/");
       const childScript =
         "require('node:http').createServer((_req,res)=>res.end('ok')).listen(Number(process.env.PORT), '127.0.0.1'); setInterval(() => {}, 1000);";
       const parentScript = [
         "const { spawn } = require('node:child_process');",
         "const { writeFileSync } = require('node:fs');",
         `const child = spawn(process.execPath, [\"-e\", ${JSON.stringify(childScript)}], { stdio: \"ignore\" });`,
-        `writeFileSync(${JSON.stringify(childPidPath)}, String(child.pid));`,
+        `writeFileSync(${JSON.stringify(childPidPathForShell)}, String(child.pid));`,
         "setInterval(() => {}, 1000);",
       ].join(" ");
       const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(parentScript)}`;

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -44,6 +44,7 @@ import {
 } from "../services/workspace-runtime.ts";
 import {
   findAdoptableLocalService,
+  isPidAlive,
   isLocalServiceRegistryCwdCompatible,
   isLocalServiceProcessInWorkspace,
   readLocalServicePortOwner,
@@ -64,6 +65,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 
 const execFileAsync = promisify(execFile);
+const originalShellEnv = process.env.SHELL;
 
 function stableStringifyForTest(value: unknown): string {
   if (Array.isArray(value)) {
@@ -353,6 +355,8 @@ afterEach(async () => {
   delete process.env.PAPERCLIP_INSTANCE_ID;
   delete process.env.PAPERCLIP_WORKTREES_DIR;
   delete process.env.DATABASE_URL;
+  if (originalShellEnv === undefined) delete process.env.SHELL;
+  else process.env.SHELL = originalShellEnv;
   await resetRuntimeServicesForTests();
 });
 
@@ -3384,6 +3388,64 @@ describe("ensureRuntimeServicesForRun", () => {
     expect(services).toEqual([]);
   });
 
+  it(
+    "terminates registered runtime services before resetting test state",
+    async () => {
+      if (process.platform === "win32") {
+        const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+        const gitShell = path.join(programFiles, "Git", "bin", "sh.exe");
+        expect(existsSync(gitShell)).toBe(true);
+        process.env.SHELL = gitShell;
+      }
+      const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-reset-"));
+      const workspace = buildWorkspace(workspaceRoot);
+      const services = await startRuntimeServicesForWorkspaceControl({
+        actor: {
+          id: "agent-reset",
+          name: "Codex Coder",
+          companyId: "company-reset",
+        },
+        issue: null,
+        workspace,
+        executionWorkspaceId: "execution-workspace-reset",
+        config: {
+          workspaceRuntime: {
+            services: [
+              {
+                name: "web",
+                command:
+                  "node -e \"require('node:http').createServer((req,res)=>res.end('ok')).listen(Number(process.env.PORT), '127.0.0.1')\"",
+                port: { type: "auto" },
+                readiness: {
+                  type: "http",
+                  urlTemplate: "http://127.0.0.1:{{port}}",
+                  timeoutSec: 10,
+                  intervalMs: 100,
+                },
+                lifecycle: "shared",
+                reuseScope: "execution_workspace",
+                stopPolicy: { type: "manual" },
+              },
+            ],
+          },
+        },
+        adapterEnv: {},
+      });
+
+      expect(services).toHaveLength(1);
+      const service = services[0]!;
+      const pid = Number.parseInt(service.providerRef ?? "", 10);
+      expect(isPidAlive(pid)).toBe(true);
+      await expect(fetch(service.url!)).resolves.toMatchObject({ ok: true });
+
+      await resetRuntimeServicesForTests();
+
+      expect(isPidAlive(pid)).toBe(false);
+      await expect(fetch(service.url!)).rejects.toThrow();
+    },
+    15_000,
+  );
+
   it("requires Paperclip dev runtime services to pass /api/health readiness", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-health-"));
     const workspace = buildWorkspace(workspaceRoot);
@@ -5264,6 +5326,9 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
   });
 
   afterEach(async () => {
+    // Runtime records still reference these rows while teardown persists the
+    // final stopped state, so process cleanup must precede fixture deletion.
+    await resetRuntimeServicesForTests();
     await db.delete(workspaceRuntimeServices);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
@@ -5273,7 +5338,7 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
     await db.delete(companies);
   });
 
-  it("adopts a live auto-port shared service after runtime state is reset", async () => {
+  it("adopts a live auto-port shared service during startup reconciliation", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-reconcile-"));
     const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-home-"));
     process.env.PAPERCLIP_HOME = paperclipHome;
@@ -5360,8 +5425,6 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
     await expect(fetch(service!.url!)).resolves.toMatchObject({ ok: true });
 
     await fs.rm(paperclipHome, { recursive: true, force: true });
-    await resetRuntimeServicesForTests();
-
     const result = await reconcilePersistedRuntimeServicesOnStartup(db);
     expect(result).toMatchObject({ reconciled: 1, adopted: 1, stopped: 0 });
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { parse as parseEnvContents } from "dotenv";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agents,
@@ -29,6 +29,7 @@ import {
   ensurePersistedExecutionWorkspaceAvailable,
   ensureServerWorkspaceLinksCurrent,
   ensureRuntimeServicesForRun,
+  inspectRuntimeServicesForTests,
   listConfiguredRuntimeServiceEntries,
   normalizeAdapterManagedRuntimeServices,
   reconcilePersistedRuntimeServicesOnStartup,
@@ -42,6 +43,7 @@ import {
   stopRuntimeServicesForExecutionWorkspace,
   type RealizedExecutionWorkspace,
 } from "../services/workspace-runtime.ts";
+import * as localServiceSupervisor from "../services/local-service-supervisor.ts";
 import {
   findAdoptableLocalService,
   isPidAlive,
@@ -3446,6 +3448,85 @@ describe("ensureRuntimeServicesForRun", () => {
     15_000,
   );
 
+  it(
+    "retains runtime state when process termination fails so reset can retry",
+    async () => {
+      const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-reset-retry-"));
+      const workspace = buildWorkspace(workspaceRoot);
+      const runId = randomUUID();
+      const services = await ensureRuntimeServicesForRun({
+        runId,
+        agent: {
+          id: "agent-reset-retry",
+          name: "Codex Coder",
+          companyId: "company-reset-retry",
+        },
+        issue: null,
+        workspace,
+        config: {
+          workspaceRuntime: {
+            services: [
+              {
+                name: "web",
+                command:
+                  "node -e \"require('node:http').createServer((req,res)=>res.end('ok')).listen(Number(process.env.PORT), '127.0.0.1')\"",
+                port: { type: "auto" },
+                readiness: {
+                  type: "http",
+                  urlTemplate: "http://127.0.0.1:{{port}}",
+                  timeoutSec: 10,
+                  intervalMs: 100,
+                },
+                lifecycle: "shared",
+                reuseScope: "execution_workspace",
+                stopPolicy: { type: "manual" },
+              },
+            ],
+          },
+        },
+        adapterEnv: {},
+      });
+
+      expect(services).toHaveLength(1);
+      const service = services[0]!;
+      const pid = Number.parseInt(service.providerRef ?? "", 10);
+      expect(isPidAlive(pid)).toBe(true);
+      expect(inspectRuntimeServicesForTests()).toEqual({
+        serviceIds: [service.id],
+        reuseServiceIds: [service.id],
+        leasesByRun: [[runId, [service.id]]],
+      });
+
+      const terminationError = new Error("synthetic termination failure");
+      const terminateSpy = vi
+        .spyOn(localServiceSupervisor, "terminateLocalService")
+        .mockRejectedValueOnce(terminationError);
+      try {
+        await expect(resetRuntimeServicesForTests()).rejects.toMatchObject({
+          errors: [terminationError],
+        });
+      } finally {
+        terminateSpy.mockRestore();
+      }
+
+      expect(isPidAlive(pid)).toBe(true);
+      expect(inspectRuntimeServicesForTests()).toEqual({
+        serviceIds: [service.id],
+        reuseServiceIds: [service.id],
+        leasesByRun: [[runId, [service.id]]],
+      });
+
+      await expect(resetRuntimeServicesForTests()).resolves.toBeUndefined();
+      expect(isPidAlive(pid)).toBe(false);
+      expect(inspectRuntimeServicesForTests()).toEqual({
+        serviceIds: [],
+        reuseServiceIds: [],
+        leasesByRun: [],
+      });
+    },
+    15_000,
+  );
+
   it("requires Paperclip dev runtime services to pass /api/health readiness", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-health-"));
     const workspace = buildWorkspace(workspaceRoot);
@@ -5127,6 +5208,101 @@ describeEmbeddedPostgres("workspace runtime service control persistence", () => 
     await db.delete(agents);
     await db.delete(companies);
   });
+
+  it(
+    "treats persistence and registry cleanup as best-effort after terminating the process tree",
+    async () => {
+      const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-reset-tree-"));
+      const paperclipHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-reset-home-"));
+      const instanceId = `runtime-reset-${randomUUID()}`;
+      process.env.PAPERCLIP_HOME = paperclipHome;
+      process.env.PAPERCLIP_INSTANCE_ID = instanceId;
+
+      const companyId = randomUUID();
+      const childPidPath = path.join(workspaceRoot, "child.pid");
+      const childScript =
+        "require('node:http').createServer((_req,res)=>res.end('ok')).listen(Number(process.env.PORT), '127.0.0.1'); setInterval(() => {}, 1000);";
+      const parentScript = [
+        "const { spawn } = require('node:child_process');",
+        "const { writeFileSync } = require('node:fs');",
+        `const child = spawn(process.execPath, [\"-e\", ${JSON.stringify(childScript)}], { stdio: \"ignore\" });`,
+        `writeFileSync(${JSON.stringify(childPidPath)}, String(child.pid));`,
+        "setInterval(() => {}, 1000);",
+      ].join(" ");
+      const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(parentScript)}`;
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip reset",
+        issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      const services = await startRuntimeServicesForWorkspaceControl({
+        db,
+        invocationId: randomUUID(),
+        actor: {
+          id: null,
+          name: "Board",
+          companyId,
+        },
+        issue: null,
+        workspace: {
+          ...buildWorkspace(workspaceRoot),
+          projectId: null,
+          workspaceId: null,
+        },
+        config: {
+          workspaceRuntime: {
+            services: [
+              {
+                name: "tree",
+                command,
+                lifecycle: "shared",
+                reuseScope: "agent",
+                port: { type: "auto", envKey: "PORT" },
+                expose: { urlTemplate: "http://127.0.0.1:{{port}}" },
+                readiness: { type: "http", intervalMs: 50, timeoutSec: 10 },
+                stopPolicy: { type: "manual" },
+              },
+            ],
+          },
+        },
+        adapterEnv: {},
+      });
+
+      expect(services).toHaveLength(1);
+      const service = services[0]!;
+      const parentPid = Number.parseInt(service.providerRef ?? "", 10);
+      const childPid = Number.parseInt(await fs.readFile(childPidPath, "utf8"), 10);
+      expect(isPidAlive(parentPid)).toBe(true);
+      expect(isPidAlive(childPid)).toBe(true);
+      expect(inspectRuntimeServicesForTests()).toMatchObject({
+        serviceIds: [service.id],
+        reuseServiceIds: [service.id],
+        leasesByRun: [],
+      });
+
+      await db.delete(workspaceRuntimeServices);
+      await db.delete(companies);
+      const registryDir = path.join(paperclipHome, "instances", instanceId, "runtime-services");
+      await fs.rm(registryDir, { recursive: true, force: true });
+      await fs.writeFile(registryDir, "registry fixture already removed", "utf8");
+
+      await expect(resetRuntimeServicesForTests()).resolves.toBeUndefined();
+
+      expect(isPidAlive(parentPid)).toBe(false);
+      expect(isPidAlive(childPid)).toBe(false);
+      expect(inspectRuntimeServicesForTests()).toEqual({
+        serviceIds: [],
+        reuseServiceIds: [],
+        leasesByRun: [],
+      });
+      await expect(fetch(service.url!)).rejects.toThrow();
+      await fs.rm(paperclipHome, { recursive: true, force: true });
+    },
+    15_000,
+  );
 
   it("commits a starting service row before waiting for slow readiness", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-runtime-slow-control-"));

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -366,8 +366,31 @@ export async function terminateLocalService(
   record: Pick<LocalServiceRegistryRecord, "pid" | "processGroupId">,
   opts?: { signal?: NodeJS.Signals; forceAfterMs?: number },
 ) {
+  if (process.platform === "win32") {
+    try {
+      // Runtime services are launched through a shell wrapper. taskkill /T is
+      // required so the actual server descendant cannot outlive that wrapper.
+      await execFileAsync(
+        "taskkill",
+        ["/PID", String(record.pid), "/T", "/F"],
+        { windowsHide: true },
+      );
+    } catch (error) {
+      if (isPidAlive(record.pid)) throw error;
+      return;
+    }
+    const deadline = Date.now() + (opts?.forceAfterMs ?? 2_000);
+    while (isPidAlive(record.pid) && Date.now() < deadline) {
+      await delay(50);
+    }
+    if (isPidAlive(record.pid)) {
+      throw new Error(`Local service process tree ${record.pid} remained alive after taskkill.`);
+    }
+    return;
+  }
+
   const signal = opts?.signal ?? "SIGTERM";
-  const targetProcessGroup = process.platform !== "win32" && record.processGroupId && record.processGroupId > 0;
+  const targetProcessGroup = record.processGroupId && record.processGroupId > 0;
   try {
     if (targetProcessGroup) {
       process.kill(-record.processGroupId!, signal);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -161,6 +161,16 @@ const runtimeServicesByReuseKey = new Map<string, string>();
 const runtimeServiceLeasesByRun = new Map<string, string[]>();
 const DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES = 256 * 1024;
 
+export function inspectRuntimeServicesForTests() {
+  return {
+    serviceIds: Array.from(runtimeServicesById.keys()).sort(),
+    reuseServiceIds: Array.from(runtimeServicesByReuseKey.values()).sort(),
+    leasesByRun: Array.from(runtimeServiceLeasesByRun.entries())
+      .map(([runId, serviceIds]) => [runId, [...serviceIds].sort()] as const)
+      .sort(([leftRunId], [rightRunId]) => leftRunId.localeCompare(rightRunId)),
+  };
+}
+
 type ProcessOutputCapture = {
   text: string;
   truncated: boolean;
@@ -187,23 +197,20 @@ export async function resetRuntimeServicesForTests() {
       try {
         await terminateRuntimeServiceProcess(record);
       } catch (error) {
-        return { record, terminationError: error, cleanupErrors: [] as unknown[] };
+        return { record, terminationError: error };
       }
 
       record.status = "stopped";
       record.healthStatus = "unknown";
       record.lastUsedAt = new Date().toISOString();
       record.stoppedAt = record.lastUsedAt;
-      const cleanupResults = await Promise.allSettled([
+      await Promise.allSettled([
         removeLocalServiceRegistryRecord(record.serviceKey),
         persistRuntimeServiceRecord(record.db, record),
       ]);
       return {
         record,
         terminationError: null,
-        cleanupErrors: cleanupResults
-          .filter((result): result is PromiseRejectedResult => result.status === "rejected")
-          .map((result) => result.reason),
       };
     }),
   );
@@ -224,7 +231,6 @@ export async function resetRuntimeServicesForTests() {
     ) {
       runtimeServicesByReuseKey.delete(result.record.reuseKey);
     }
-    stopFailures.push(...result.cleanupErrors);
   }
   for (const [reuseKey, serviceId] of runtimeServicesByReuseKey) {
     if (!runtimeServicesById.has(serviceId)) runtimeServicesByReuseKey.delete(reuseKey);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -24,6 +24,8 @@ import {
   createLocalServiceKey,
   findLocalServiceRegistryRecordByRuntimeServiceId,
   findAdoptableLocalService,
+  isPidAlive,
+  isProcessGroupAlive,
   isLocalServiceProcessInWorkspace,
   readLocalServiceProcessCwd,
   readLocalServicePortOwner,
@@ -135,6 +137,7 @@ export interface RuntimeServiceRef {
 interface RuntimeServiceRecord extends RuntimeServiceRef {
   db?: Db;
   child: ChildProcess | null;
+  exitListener?: (code: number | null, signal: NodeJS.Signals | null) => void;
   leaseRunIds: Set<string>;
   idleTimer: ReturnType<typeof globalThis.setTimeout> | null;
   envFingerprint: string;
@@ -170,12 +173,74 @@ type ProcessOutputAccumulator = {
 };
 
 export async function resetRuntimeServicesForTests() {
-  for (const record of runtimeServicesById.values()) {
+  const records = Array.from(runtimeServicesById.values());
+  for (const record of records) {
     clearIdleTimer(record);
+    // The registered exit listener normally removes the record immediately.
+    // During a test reset, keep the registry stable until every process has
+    // completed its bounded termination attempt.
+    detachRuntimeServiceExitListener(record);
   }
-  runtimeServicesById.clear();
-  runtimeServicesByReuseKey.clear();
-  runtimeServiceLeasesByRun.clear();
+
+  const stopResults = await Promise.all(
+    records.map(async (record) => {
+      try {
+        await terminateRuntimeServiceProcess(record);
+      } catch (error) {
+        return { record, terminationError: error, cleanupErrors: [] as unknown[] };
+      }
+
+      record.status = "stopped";
+      record.healthStatus = "unknown";
+      record.lastUsedAt = new Date().toISOString();
+      record.stoppedAt = record.lastUsedAt;
+      const cleanupResults = await Promise.allSettled([
+        removeLocalServiceRegistryRecord(record.serviceKey),
+        persistRuntimeServiceRecord(record.db, record),
+      ]);
+      return {
+        record,
+        terminationError: null,
+        cleanupErrors: cleanupResults
+          .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+          .map((result) => result.reason),
+      };
+    }),
+  );
+  const stopFailures: unknown[] = [];
+  for (const result of stopResults) {
+    if (result.terminationError) {
+      // Keep the live record, reuse index, leases, and exit listener so a
+      // later teardown can retry. Losing these references would create the
+      // exact orphan that this reset is meant to prevent.
+      attachRuntimeServiceExitListener(result.record.db, result.record);
+      stopFailures.push(result.terminationError);
+      continue;
+    }
+    runtimeServicesById.delete(result.record.id);
+    if (
+      result.record.reuseKey
+      && runtimeServicesByReuseKey.get(result.record.reuseKey) === result.record.id
+    ) {
+      runtimeServicesByReuseKey.delete(result.record.reuseKey);
+    }
+    stopFailures.push(...result.cleanupErrors);
+  }
+  for (const [reuseKey, serviceId] of runtimeServicesByReuseKey) {
+    if (!runtimeServicesById.has(serviceId)) runtimeServicesByReuseKey.delete(reuseKey);
+  }
+  for (const [runId, serviceIds] of runtimeServiceLeasesByRun) {
+    const retainedServiceIds = serviceIds.filter((serviceId) => runtimeServicesById.has(serviceId));
+    if (retainedServiceIds.length > 0) runtimeServiceLeasesByRun.set(runId, retainedServiceIds);
+    else runtimeServiceLeasesByRun.delete(runId);
+  }
+
+  if (stopFailures.length > 0) {
+    throw new AggregateError(
+      stopFailures,
+      `Failed to fully reset ${stopFailures.length} runtime service cleanup operation(s).`,
+    );
+  }
 }
 
 function stableStringify(value: unknown): string {
@@ -4173,6 +4238,43 @@ function scheduleIdleStop(record: RuntimeServiceRecord) {
   }, idleSeconds * 1000);
 }
 
+async function terminateRuntimeServiceProcess(record: RuntimeServiceRecord) {
+  let pid: number | null = null;
+  let processGroupId: number | null = null;
+  if (record.child?.pid) {
+    pid = record.child.pid;
+    processGroupId = record.processGroupId ?? record.child.pid;
+  } else if (record.providerRef) {
+    const providerPid = Number.parseInt(record.providerRef, 10);
+    if (Number.isInteger(providerPid) && providerPid > 0) {
+      pid = providerPid;
+      processGroupId = record.processGroupId;
+    }
+  }
+  if (!pid) return;
+  // A stale or synthetic registry entry must never make test cleanup signal
+  // the Vitest/Paperclip host process itself. There is no child service to
+  // reap in this case, so clearing the in-memory record is the safe outcome.
+  if (pid === process.pid) return;
+
+  await terminateLocalService({
+    pid,
+    processGroupId,
+  });
+
+  const processAlive = () =>
+    process.platform !== "win32" && processGroupId
+      ? isProcessGroupAlive(processGroupId)
+      : isPidAlive(pid!);
+  const deadline = Date.now() + 1_000;
+  while (processAlive() && Date.now() < deadline) {
+    await delay(50);
+  }
+  if (processAlive()) {
+    throw new Error(`Runtime service process ${pid} remained alive after bounded TERM/KILL cleanup.`);
+  }
+}
+
 async function stopRuntimeService(serviceId: string) {
   const record = runtimeServicesById.get(serviceId);
   if (!record) return;
@@ -4185,20 +4287,7 @@ async function stopRuntimeService(serviceId: string) {
   if (record.reuseKey && runtimeServicesByReuseKey.get(record.reuseKey) === record.id) {
     runtimeServicesByReuseKey.delete(record.reuseKey);
   }
-  if (record.child && record.child.pid) {
-    await terminateLocalService({
-      pid: record.child.pid,
-      processGroupId: record.processGroupId ?? record.child.pid,
-    });
-  } else if (record.providerRef) {
-    const pid = Number.parseInt(record.providerRef, 10);
-    if (Number.isInteger(pid) && pid > 0) {
-      await terminateLocalService({
-        pid,
-        processGroupId: record.processGroupId,
-      });
-    }
-  }
+  await terminateRuntimeServiceProcess(record);
   await removeLocalServiceRegistryRecord(record.serviceKey);
   await persistRuntimeServiceRecord(record.db, record);
 }
@@ -4225,14 +4314,18 @@ async function markPersistedRuntimeServicesStoppedForExecutionWorkspace(input: {
     );
 }
 
-function registerRuntimeService(db: Db | undefined, record: RuntimeServiceRecord) {
-  record.db = db;
-  runtimeServicesById.set(record.id, record);
-  if (record.reuseKey) {
-    runtimeServicesByReuseKey.set(record.reuseKey, record.id);
+function detachRuntimeServiceExitListener(record: RuntimeServiceRecord) {
+  if (record.child && record.exitListener) {
+    record.child.off("exit", record.exitListener);
   }
+  record.exitListener = undefined;
+}
 
-  record.child?.on("exit", (code, signal) => {
+function attachRuntimeServiceExitListener(db: Db | undefined, record: RuntimeServiceRecord) {
+  if (!record.child) return;
+  detachRuntimeServiceExitListener(record);
+  const exitListener = (code: number | null, signal: NodeJS.Signals | null) => {
+    record.exitListener = undefined;
     const current = runtimeServicesById.get(record.id);
     if (!current) return;
     clearIdleTimer(current);
@@ -4246,7 +4339,18 @@ function registerRuntimeService(db: Db | undefined, record: RuntimeServiceRecord
     }
     void removeLocalServiceRegistryRecord(current.serviceKey);
     void persistRuntimeServiceRecord(db, current);
-  });
+  };
+  record.exitListener = exitListener;
+  record.child.on("exit", exitListener);
+}
+
+function registerRuntimeService(db: Db | undefined, record: RuntimeServiceRecord) {
+  record.db = db;
+  runtimeServicesById.set(record.id, record);
+  if (record.reuseKey) {
+    runtimeServicesByReuseKey.set(record.reuseKey, record.id);
+  }
+  attachRuntimeServiceExitListener(db, record);
 }
 
 function readRuntimeServiceEntries(config: Record<string, unknown>) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Remote ACP sessions, workspace runtime services, and CLI tests start operating-system process trees
> - Paperclip must stop those trees before it removes their control state or reports cleanup as complete
> - The remote bridge discarded process identity, test reset cleared live handles, and CLI teardown stopped only the wrapper
> - Those gaps left bridge, service, and test-server descendants alive after their owner had finished
> - This pull request adds identity-bound and bounded tree termination to all three cleanup paths
> - The benefit is that completed runs and tests no longer leave hidden processes that consume memory, hold ports, or keep working

## Linked Issues or Issue Description

Fixes #10525.

Related work: #10213 improves the same bridge poller but does not stop its process tree. #8535, #9597, and #7218 cover other startup or shutdown orphan paths. They do not cover this bridge lifecycle or test reset.

Prior attempt: #8218 identified the CLI wrapper leak. Thank you to @MontyCraig for the process-group approach. This pull request carries that approach forward. It also checks group liveness instead of the wrapper exit code and adds a regression test.

**What happened?**

The remote ACP bridge used `nohup`, discarded its process identity, and removed the stdin control directory during `stop()`. The remote poll loop converted the missing directory into an empty list and continued forever. `resetRuntimeServicesForTests()` cleared maps and timers without stopping registered services. The company import/export e2e teardown stopped only the `pnpm` wrapper and could leave the Node server alive.

**Expected behavior**

Cleanup must stop the full owned process tree before it deletes control state or forgets the process handle. It must use a bounded TERM, grace, and KILL sequence. It must fail closed when process identity cannot be verified.

**Steps to reproduce**

1. Start a sandbox ACP process session and call `stop()` after the child ignores SIGTERM. Observe the old bridge and child after the session directory is gone.
2. Start a workspace runtime service and call `resetRuntimeServicesForTests()`. Observe the old service after the in-memory maps are empty.
3. Start the CLI e2e server through a wrapper and stop only the wrapper. Observe the descendant that still owns the HTTP port.

**Paperclip version or commit**

The bug reproduced on `master` at `ee851fc3`.

**Deployment mode**

Remote Linux sandbox execution and local source-based test runs.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

ACP sandbox process sessions. The workspace and CLI leaks are not adapter-specific.

**Database mode**

Not database-related.

**Operating system**

Linux for remote process sessions. Linux and Windows for local process-tree teardown.

## What Changed

- Persist a versioned session id, bridge pid, child pid, and child process-group id before returning a remote bridge handle.
- Stop the remote stdin poll when the child closes. Handle bridge signals and terminate the detached child group.
- Roll back the remote process tree when launch state or local proxy acquisition fails.
- Verify Linux process identity with the exact session environment marker. Treat missing state safely. Refuse reused or unverifiable identities.
- Use bounded natural, TERM, and KILL waits. Preserve the remote control directory until termination is confirmed. Retry transient stop failures and permit a later retry after bounded failures.
- Stop every registered workspace runtime service before test reset removes its maps, reuse indexes, or leases. Retain live failed records and their exit listeners for another cleanup attempt.
- Use `taskkill /T /F` for local service trees on Windows. Keep dedicated POSIX process groups on Linux.
- Spawn the company import/export test server in a dedicated group. Wait for the full group or Windows tree to exit before deleting test state.
- Add regressions for child-close polling, missing remote state, launch rollback, retryable teardown, workspace reset on Linux and Windows, and wrapper descendants.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` passed on Windows and Linux.
- `pnpm --filter @paperclipai/server typecheck` passed on Windows and Linux.
- `pnpm --filter paperclipai typecheck` passed on Windows and Linux.
- `pnpm exec vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts` passed on Linux: 32 of 32 tests.
- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t ensureRuntimeServicesForRun` passed on Linux: 11 focused tests.
- The workspace reset regression passed on Windows and Linux: 1 focused test per platform.
- The embedded PostgreSQL adoption teardown regression that failed in CI passed on Windows and Linux as a non-root user: 1 test with 100 unrelated tests skipped.
- The CLI descendant regression passed on Linux and Windows: 1 test on each platform.
- `git diff --check` passed.
- A post-test process and state-file sweep found no process or session state under the Linux validation checkout.

The first root-only Linux run skipped embedded PostgreSQL because PostgreSQL refuses to initialize as root. The exact failing adoption teardown regression was then repeated as an unprivileged user and passed. The complete Paperclip CI matrix also passed on the final commit.

## Risks

- Remote teardown can wait for the bounded grace windows and can retry once. This can make a failing stop slower.
- Linux process identity uses `/proc/<pid>/environ`. A non-Linux remote host fails closed and preserves control state instead of signaling an unverified pid.
- Windows local teardown uses forced tree termination. This is intentional for owned runtime and test processes.
- A failed identity check leaves the remote control directory in place for diagnosis and a later retry.
- There are no database migrations, API contract changes, or telemetry changes.
- `ROADMAP.md` contains broader self-healing work. It does not contain this targeted process-lifecycle fix.

## Model Used

OpenAI Codex with the GPT-5 model family. The runtime does not expose the exact serving suffix or context-window size. The session used agentic reasoning, shell execution, TypeScript tests, Git, SSH, and GitHub CLI tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable; this changes internal cleanup and tests only)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
