### PR TITLE
fix(hermes): inject task-local Paperclip env into gateway runs

### DIFF
--- a/packages/adapters/hermes/src/gateway/index.ts
+++ b/packages/adapters/hermes/src/gateway/index.ts
@@ -47,12 +47,16 @@ Optional fields:
 Runtime mapping:
 - Creates runs with POST /v1/runs.
 - Sends Idempotency-Key equal to the Paperclip run id for correlation only; Hermes v0.16.0 did not dedupe duplicate creates.
+- Requests a heartbeat-scoped Paperclip agent JWT from the server.
+- Sends that JWT and the Paperclip URL, run id, agent id, company id, task id, and wake reason in the created Hermes run's environment only.
+- Ignores payloadTemplate.environment so configured values cannot override the heartbeat-scoped environment or forward unrelated secrets.
 - Streams GET /v1/runs/{run_id}/events and polls GET /v1/runs/{run_id} as fallback.
 - Calls POST /v1/runs/{run_id}/stop on timeout.
 
 Security guidance:
 - Prefer HTTPS or a private overlay network for non-loopback hosts.
 - Do not put Hermes apiKey or Paperclip bearer tokens in prompts, comments, logs, or result JSON.
+- Treat the injected Paperclip JWT as task-local and short-lived.
 - Keep the default issue-scoped session strategy unless shared agent memory is intentional.
 `;
 
@@ -64,7 +68,9 @@ export function createServerAdapter(): ServerAdapterModule {
     sessionCodec,
     sessionManagement,
     models,
-    supportsLocalAgentJwt: false,
+    // The gateway forwards the heartbeat-scoped JWT into the single remote
+    // Hermes run; it is not inherited by the Paperclip server process.
+    supportsLocalAgentJwt: true,
     supportsInstructionsBundle: false,
     requiresMaterializedRuntimeSkills: false,
     agentConfigurationDoc,

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -144,6 +144,48 @@ describe("execute", () => {
     expect(body.session_id).toBe("paperclip:company:company-1:agent:agent-1:issue:issue-1");
   });
 
+  it("injects the harness-minted Paperclip environment into only the Hermes run", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/v1/runs")) {
+        return new Response(JSON.stringify({ run_id: "run-hermes-env", status: "started" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ status: "completed", output: "done" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ctx = makeCtx({
+      apiBaseUrl: "http://127.0.0.1:8642",
+      apiKey: "hermes-gateway-key",
+      paperclipApiUrl: "http://127.0.0.1:3100",
+      payloadTemplate: {
+        environment: {
+          PAPERCLIP_API_KEY: "configured-key-must-not-win",
+          UNRELATED_SECRET: "must-not-forward",
+        },
+      },
+      timeoutSec: 5,
+    });
+    ctx.authToken = "short-lived-run-jwt";
+    ctx.context.wakeReason = "issue_assigned";
+
+    const result = await execute(ctx);
+    expect(result.exitCode).toBe(0);
+
+    const calls = fetchMock.mock.calls as Array<[RequestInfo | URL, RequestInit?]>;
+    const createCall = calls.find(([input]) => String(input).endsWith("/v1/runs"));
+    const body = JSON.parse(String(createCall?.[1]?.body));
+    expect(body.environment).toEqual({
+      PAPERCLIP_API_URL: "http://127.0.0.1:3100",
+      PAPERCLIP_API_KEY: "short-lived-run-jwt",
+      PAPERCLIP_RUN_ID: "pc-run-1",
+      PAPERCLIP_AGENT_ID: "agent-1",
+      PAPERCLIP_COMPANY_ID: "company-1",
+      PAPERCLIP_TASK_ID: "issue-1",
+      PAPERCLIP_WAKE_REASON: "issue_assigned",
+    });
+  });
+
   it("sends the task brief once on fresh runs and compacts it on stable-session resumes", async () => {
     const description = "Update launch-card.svg and change the CTA to Try Team free.";
     const fullTaskMarkdown = [
@@ -306,6 +348,7 @@ describe("execute", () => {
       apiKey: "secret-key",
       timeoutSec: 5,
     });
+    ctx.authToken = "short-lived-paperclip-jwt";
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith("/v1/runs")) {
@@ -316,10 +359,10 @@ describe("execute", () => {
           sseStream(
             [
               "event: message.delta",
-              "data: {\"delta\":\"Authorization: Bearer secret-key\\nX-Hermes-Session-Key: paperclip:company:company-1:agent:agent-1:issue:issue-1\"}",
+              "data: {\"delta\":\"Authorization: Bearer secret-key\\nPaperclip short-lived-paperclip-jwt\\nX-Hermes-Session-Key: paperclip:company:company-1:agent:agent-1:issue:issue-1\"}",
               "",
               "event: run.completed",
-              "data: {\"status\":\"completed\",\"output\":\"Authorization: Bearer secret-key\\nraw key secret-key\\nX-Hermes-Session-Key: paperclip:company:company-1:agent:agent-1:issue:issue-1\"}",
+              "data: {\"status\":\"completed\",\"output\":\"Authorization: Bearer secret-key\\nraw key secret-key\\nPaperclip short-lived-paperclip-jwt\\nX-Hermes-Session-Key: paperclip:company:company-1:agent:agent-1:issue:issue-1\"}",
               "",
             ].join("\n"),
           ),
@@ -338,11 +381,13 @@ describe("execute", () => {
     expect(result.summary).toContain("raw key [redacted len=10]");
     expect(result.summary).toContain("X-Hermes-Session-Key: [redacted]");
     expect(result.summary).not.toContain("secret-key");
+    expect(result.summary).not.toContain("short-lived-paperclip-jwt");
     expect(result.summary).not.toContain("paperclip:company:company-1:agent:agent-1:issue:issue-1");
     expect(result.resultJson?.output).toBe(result.summary);
     expect(logText).toContain("Bearer [redacted]");
     expect(logText).toContain("X-Hermes-Session-Key: [redacted]");
     expect(logText).not.toContain("secret-key");
+    expect(logText).not.toContain("short-lived-paperclip-jwt");
     expect(logText).not.toContain("paperclip:company:company-1:agent:agent-1:issue:issue-1");
   });
 

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -6,6 +6,7 @@ import type {
 import {
   asNumber,
   asString,
+  buildPaperclipEnv,
   parseObject,
   readPaperclipIssueWorkModeFromContext,
   renderPaperclipWakePrompt,
@@ -320,18 +321,41 @@ function buildInput(ctx: AdapterExecutionContext, paperclipApiUrl: string | null
 }
 
 function buildRunBody(ctx: AdapterExecutionContext, sessionKey: string | null): Record<string, unknown> {
-  const paperclipApiUrl = nonEmpty(ctx.config.paperclipApiUrl);
+  const basePaperclipEnv = buildPaperclipEnv(ctx.agent);
+  const paperclipApiUrl = nonEmpty(ctx.config.paperclipApiUrl) ?? basePaperclipEnv.PAPERCLIP_API_URL ?? null;
   const payloadTemplate = parseObject(ctx.config.payloadTemplate);
+  // The adapter owns the task-local environment. Never forward an environment
+  // supplied through the configurable payload template because it could
+  // override the harness-minted credential or smuggle unrelated secrets into
+  // the remote Hermes process.
+  const { environment: _configuredEnvironment, ...safePayloadTemplate } = payloadTemplate;
   const input = nonEmpty(payloadTemplate.input) ?? buildInput(ctx, paperclipApiUrl);
   const instructions =
     nonEmpty(ctx.config.instructions) ??
     nonEmpty(payloadTemplate.instructions) ??
     "Follow the Paperclip wake instructions exactly. Do not expose secrets in logs, comments, or final output.";
+  const authToken = nonEmpty(ctx.authToken);
+  const issueId = issueIdFromContext(ctx);
+  const issueWorkMode = readPaperclipIssueWorkModeFromContext(ctx.context);
+  const paperclipEnvironment = authToken
+    ? {
+        ...basePaperclipEnv,
+        ...(paperclipApiUrl ? { PAPERCLIP_API_URL: paperclipApiUrl } : {}),
+        PAPERCLIP_API_KEY: authToken,
+        PAPERCLIP_RUN_ID: ctx.runId,
+        ...(issueId ? { PAPERCLIP_TASK_ID: issueId } : {}),
+        ...(nonEmpty(ctx.context.wakeReason)
+          ? { PAPERCLIP_WAKE_REASON: nonEmpty(ctx.context.wakeReason)! }
+          : {}),
+        ...(issueWorkMode ? { PAPERCLIP_ISSUE_WORK_MODE: issueWorkMode } : {}),
+      }
+    : null;
   return {
-    ...payloadTemplate,
+    ...safePayloadTemplate,
     input,
     instructions,
     ...(sessionKey ? { session_id: sessionKey } : {}),
+    ...(paperclipEnvironment ? { environment: paperclipEnvironment } : {}),
   };
 }
 
@@ -848,6 +872,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const redactText = createTextRedactor([
     apiKey,
+    ctx.authToken,
     sessionKey,
     runHeaders.Authorization,
     runHeaders["X-Hermes-Session-Key"],

--- a/packages/adapters/hermes/src/index.test.ts
+++ b/packages/adapters/hermes/src/index.test.ts
@@ -35,7 +35,7 @@ test("root package export keeps explicit local and gateway adapter factories", (
   expect(localAdapter.type).toBe("hermes_local");
   expect(gatewayAdapter.type).toBe("hermes_gateway");
   expect(hermesGatewayType).toBe("hermes_gateway");
-  expect(gatewayAdapter.supportsLocalAgentJwt).toBe(false);
+  expect(gatewayAdapter.supportsLocalAgentJwt).toBe(true);
   expect(gatewayAdapter.supportsInstructionsBundle).toBe(false);
 });
 

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -142,7 +142,7 @@ describe("server adapter registry", () => {
     expect(builtInLocal?.getConfigSchema).toBeTypeOf("function");
 
     expect(builtInGateway).not.toBeNull();
-    expect(builtInGateway?.supportsLocalAgentJwt).toBe(false);
+    expect(builtInGateway?.supportsLocalAgentJwt).toBe(true);
     expect(builtInGateway?.supportsInstructionsBundle).toBe(false);
     expect(builtInGateway?.requiresMaterializedRuntimeSkills).toBe(false);
     expect(builtInGateway?.getConfigSchema).toBeTypeOf("function");

--- a/server/src/__tests__/adapter-routes.test.ts
+++ b/server/src/__tests__/adapter-routes.test.ts
@@ -235,7 +235,7 @@ describe("adapter routes", () => {
     expect(hermesGateway.capabilities).toMatchObject({
       supportsInstructionsBundle: false,
       supportsSkills: false,
-      supportsLocalAgentJwt: false,
+      supportsLocalAgentJwt: true,
       requiresMaterializedRuntimeSkills: false,
       supportsAcp: false,
     });


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their work.
> - The heartbeat service gives each supported adapter a short-lived agent JWT.
> - The Hermes Gateway adapter did not declare support for that JWT.
> - The adapter also did not send a Paperclip environment in the remote Hermes run body.
> - A remote Hermes worker therefore received the task prompt but no authenticated Paperclip access.
> - This pull request enables JWT minting and sends a bounded task-local environment.
> - The benefit is that a Hermes Gateway worker can read and update its assigned Paperclip task without a long-lived board credential.

## Linked Issues or Issue Description

**What happened?**

The built-in Hermes Gateway adapter set `supportsLocalAgentJwt` to `false`. The heartbeat service therefore did not create `ctx.authToken`. The gateway run body also did not create an `environment` object. A Hermes worker started by the gateway had no `PAPERCLIP_API_URL`, `PAPERCLIP_API_KEY`, or `PAPERCLIP_RUN_ID`.

**Expected behavior**

Each Hermes Gateway heartbeat must get a short-lived agent JWT. The created Hermes run must receive the Paperclip URL, JWT, run ID, agent ID, company ID, task ID, and wake reason. The adapter must not forward unrelated environment values from `payloadTemplate`.

**Steps to reproduce**

1. Configure an agent with the built-in `hermes_gateway` adapter.
2. Start an issue heartbeat.
3. Inspect the environment of the created Hermes run.
4. Observe that the Paperclip URL, API key, and run ID are absent on `master` before this change.

**Paperclip version or commit**

`ee851fc36` on `master`.

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Hermes.

## What Changed

- The Hermes Gateway adapter now declares `supportsLocalAgentJwt: true`.
- The gateway now builds a task-local Paperclip environment from the heartbeat context.
- The gateway sends the short-lived JWT only in the created Hermes run body.
- The gateway ignores `payloadTemplate.environment` to prevent credential override and unrelated secret forwarding.
- The gateway redactor now removes the Paperclip JWT from logs, streamed output, summaries, and result metadata.
- The adapter configuration document now describes the runtime and security contract.
- Tests cover capability discovery, exact environment injection, template isolation, and JWT redaction.

## Verification

- `pnpm --filter @paperclipai/hermes-paperclip-adapter test -- src/gateway/server/execute.test.ts src/index.test.ts` (27 tests passed).
- `pnpm --filter @paperclipai/hermes-paperclip-adapter typecheck` (passed).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-registry.test.ts` (14 tests passed).
- `git diff --check` (passed).
- The package lint command could not run because this workspace does not install an `eslint` executable.

## Risks

- A Hermes Gateway endpoint now receives a short-lived Paperclip agent JWT. Operators must protect the gateway transport and endpoint.
- The change intentionally drops any user-defined `payloadTemplate.environment`. This closes an unsafe override path but can affect a configuration that depended on that undocumented field.
- The JWT remains limited to the agent, company, run, and task scope enforced by Paperclip.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.6-Sol through Codex. The model used reasoning, repository tools, code execution, and test execution. The runtime did not report a context window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
