### PR TITLE
fix(scripts): link the plugin SDK with a junction on Windows

### DIFF
--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -78,7 +78,9 @@ export function linkSdkInto(packageDir) {
   try {
     const stat = lstatSync(linkTarget);
     if (stat.isSymbolicLink()) {
-      if (readlinkSync(linkTarget) === relativeSdkDir) {
+      // Windows junctions report an absolute target, POSIX symlinks the relative one.
+      const currentTarget = readlinkSync(linkTarget);
+      if (currentTarget === relativeSdkDir || resolve(scopeDir, currentTarget) === sdkDir) {
         // Already linked to the in-repo SDK; nothing to do.
         return false;
       }
@@ -93,6 +95,13 @@ export function linkSdkInto(packageDir) {
     if (error?.code !== "ENOENT") throw error;
   }
 
-  symlinkSync(relativeSdkDir, linkTarget, "dir");
+  // On Windows a real directory symlink requires SeCreateSymbolicLinkPrivilege
+  // (elevation or Developer Mode); a junction does not and behaves the same for
+  // module resolution. Junction targets must be absolute.
+  if (process.platform === "win32") {
+    symlinkSync(sdkDir, linkTarget, "junction");
+  } else {
+    symlinkSync(relativeSdkDir, linkTarget, "dir");
+  }
   return true;
 }

--- a/scripts/link-plugin-dev-sdk.test.js
+++ b/scripts/link-plugin-dev-sdk.test.js
@@ -81,9 +81,31 @@ test("linkSdkInto replaces a symlink that points somewhere else", () => {
   const pkg = makePackage(join(workDir, "stale-link"));
   const scopeDir = join(pkg, "node_modules", "@paperclipai");
   mkdirSync(scopeDir, { recursive: true });
-  symlinkSync("../somewhere-else", join(scopeDir, "plugin-sdk"), "dir");
+  // Build the stale link the same way the script links on this platform. A directory
+  // symlink needs SeCreateSymbolicLinkPrivilege on Windows, which a normal developer
+  // shell does not hold, so this fixture would fail there rather than test anything.
+  const staleDir = join(pkg, "node_modules", "somewhere-else");
+  mkdirSync(staleDir, { recursive: true });
+  if (process.platform === "win32") {
+    symlinkSync(staleDir, join(scopeDir, "plugin-sdk"), "junction");
+  } else {
+    symlinkSync("../somewhere-else", join(scopeDir, "plugin-sdk"), "dir");
+  }
 
   assert.equal(linkSdkInto(pkg), true);
-  assert.notEqual(readlinkSync(join(scopeDir, "plugin-sdk")), "../somewhere-else");
+  const relinked = readlinkSync(join(scopeDir, "plugin-sdk"));
+  assert.notEqual(relinked, "../somewhere-else");
+  assert.notEqual(relinked, staleDir);
   assert.ok(existsSync(scopeDir));
+});
+
+test("linkSdkInto creates a link the module resolver can follow", () => {
+  // The link type differs by platform, so assert the property that matters instead:
+  // the SDK's own files are reachable through the link that was just created.
+  const pkg = makePackage(join(workDir, "resolvable"));
+
+  assert.equal(linkSdkInto(pkg), true);
+
+  const link = join(pkg, "node_modules", "@paperclipai", "plugin-sdk");
+  assert.ok(existsSync(join(link, "package.json")));
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a pnpm monorepo. Some plugin packages are excluded from the workspace, listed in `pnpm-workspace.yaml`.
> - Workspace members get `@paperclipai/plugin-sdk` linked in by pnpm. Excluded packages do not, so the repo links the SDK into them itself.
> - The root `postinstall` script does that work. It runs `scripts/link-plugin-dev-sdk.mjs` on every install.
> - That script created a directory symlink. On Windows, a directory symlink needs the `SeCreateSymbolicLinkPrivilege` right. A normal developer shell does not hold it. Only an elevated shell, or a machine with Developer Mode enabled, holds it.
> - Therefore the postinstall failed with `EPERM` on Windows, and the install stopped. A contributor could not install the repository at all.
> - Windows has a second link type, the junction. A junction needs no special right, and module resolution follows it in the same way.
> - This pull request creates a junction on Windows, and keeps the symlink everywhere else.
> - The benefit is that a Windows contributor can install the repository without changing a system setting.

## Linked Issues or Issue Description

No existing issue describes this. The problem and its cause are as follows.

**What fails.** On Windows, in a shell without administrator rights and on a machine without Developer Mode, `pnpm install` fails during the root postinstall:

```
Error: EPERM: operation not permitted, symlink '..\..\..\..\sdk' ->
'...\packages\plugins\sandbox-providers\cloudflare\node_modules\@paperclipai\plugin-sdk'
    at symlinkSync (node:fs:1868:11)
    at linkSdkInto (file:///.../scripts/link-plugin-dev-sdk.mjs:96:3)
    at linkExcludedPlugins (file:///.../scripts/link-plugin-dev-sdk.mjs:33:9)
  errno: -4048,
  code: 'EPERM',
  syscall: 'symlink',
```

**Why it fails.** `symlinkSync(target, path, "dir")` asks Windows for a directory symlink. Windows grants that call only to a caller holding `SeCreateSymbolicLinkPrivilege`. By default, only administrators hold it. Enabling Developer Mode grants it to a standard user, but that changes a system setting, and a contributor should not have to change one to install a repository.

**Scope.** The script links 8 packages: the 7 under `packages/plugins/sandbox-providers`, and `packages/plugins/examples/plugin-orchestration-smoke-example`. The first of these to be linked raises the error, so the postinstall stops there.

**Why CI does not catch it.** CI runs on Linux, where `symlinkSync` needs no privilege.

## What Changed

- `scripts/link-plugin-dev-sdk.mjs` — create a junction on Windows, and keep the directory symlink on every other platform. A junction needs no privilege, and module resolution follows it in the same way as a symlink.
- A junction target must be absolute. Windows therefore receives the absolute SDK path, and other platforms keep the relative path they had. The relative path is preserved off Windows, so a moved or copied checkout still resolves.
- The "already linked" check now accepts either form. `readlinkSync` returns the relative target for a POSIX symlink, and the absolute target for a Windows junction, so comparing against only the relative path would have reported every junction as wrong. It would then have been deleted and recreated on each install. The check now matches the relative target, or resolves the stored target and compares that to the SDK directory.
- `scripts/link-plugin-dev-sdk.test.js` — the fixture in "replaces a symlink that points somewhere else" called `symlinkSync(..., "dir")` itself, so that test hit the same `EPERM` and could not run on Windows. It now builds the stale link the same way the script does, and asserts the link no longer points at the stale target in either form.
- `scripts/link-plugin-dev-sdk.test.js` — added "linkSdkInto creates a link the module resolver can follow". The link type differs by platform, so the test asserts the property that actually broke instead: the SDK's own `package.json` is reachable through the link that was just created. This test fails on `master` on Windows and passes on Linux, on both.

Nothing else changes. No production code path is touched, because this script is dev-only and is not referenced from any plugin's own `package.json`.

## Verification

**Tests.** 8 of 8 pass, on Windows 11, in a shell without administrator rights and with Developer Mode off:

```
node --test scripts/link-plugin-dev-sdk.test.js
```

```
ℹ tests 8
ℹ pass 8
ℹ fail 0
```

On `master`, in the same shell, 7 tests run and 1 fails: the stale-link fixture raises `EPERM` before it can assert anything. With this branch's test file but `master`'s script, the new resolvability test also fails with `EPERM`, which shows the test detects the defect rather than restating the fix.

**Before and after, on the real repository.** I deleted the link for one managed package and ran the postinstall script.

| | `master` @ `ee851fc3` | this branch |
|---|---|---|
| `node scripts/link-plugin-dev-sdk.mjs` | `Error: EPERM ... syscall: 'symlink'`, exit 1 | `✓ Linked ... into 1 excluded plugin(s) (skipped 7)`, exit 0 |
| link created | none | `Junction` to `packages\plugins\sdk` |
| `require(".../plugin-sdk/package.json").name` | cannot resolve | `@paperclipai/plugin-sdk` |
| second run | never reached | `✓ ... 0 excluded plugin(s) (skipped 8)`, so idempotent |

**Idempotency.** With all 8 links present, the script reports 0 linked and 8 skipped, and it leaves each junction in place. This confirms the relaxed "already linked" check recognises a junction, and does not delete and recreate it on every install.

**Not verified by me.** I have no macOS or Linux machine in this session, so I did not run the suite there. The change is guarded by `process.platform === "win32"`, and the non-Windows branch is the existing call with the existing relative target, so behaviour off Windows is unchanged by construction. Please confirm on CI.

**A pre-existing, unrelated failure.** `scripts/release-registry-versions.test.mjs` fails on Windows, all 7 of its tests, on a clean `master` checkout with no changes applied. It drives shell scripts that need a POSIX shell. It is untouched by this change, and I have not tried to fix it here.

## Risks

- **Low risk. Windows only.** The new branch is behind `process.platform === "win32"`. Every other platform runs the same call, with the same relative target, as before.
- **Junctions differ from symlinks in two ways that do not matter here.** A junction works only on a local volume, and only for a directory. The SDK is a directory inside the same checkout, so both conditions hold. A checkout on a mapped network drive would be the exception, and a directory symlink would not have worked there either without the privilege.
- **The absolute target makes a Windows link checkout-specific.** Moving or renaming a checkout leaves a stale junction. The next `pnpm install` repairs it, because the "already linked" check resolves the stored target, sees that it no longer matches, and relinks. A relative junction is not an option, since Windows requires an absolute target.
- **The looser "already linked" check accepts two forms of the same target.** It matches the exact relative target, or resolves the stored target against the link's own directory and compares to the SDK path. A link pointing somewhere else still fails both, and is still replaced. The existing test for that case still passes.
- **This does not make Windows a supported development platform.** It removes one hard stop in the install. I have not audited the rest of the toolchain, and other scripts may assume POSIX. `scripts/release-registry-versions.test.mjs` already fails there, as noted above.
- **No change to published artifacts.** The script is dev-only, is invoked from the root `postinstall`, and is deliberately not referenced from any plugin's own `package.json`. Published tarballs are unaffected.

## Model Used

- **Provider and model:** Anthropic Claude, used through Claude Code.
- **Exact model id:** `claude-opus-5` (Claude Opus 5).
- **Context window:** the default for a Claude Code session. No extended-context mode was used.
- **Reasoning mode:** extended thinking enabled.
- **Other capabilities:** tool use and local code execution. The model reproduced the `EPERM` failure, made the edits, ran the test suite, and ran the before-and-after comparison in the table above on a real checkout.
- **Human role:** the human contributor hit the install failure, set the goal, and authorised this pull request.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — I found none for this script or for the Windows `EPERM` on postinstall
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template — described in-PR above, with the error and its cause
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass — 8 of 8, command above. One pre-existing unrelated Windows failure is named under Verification.
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — **not applicable.** No document on `master` describes this script or the platform requirements for installing. Tell me if you want a note added, and where.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — to be confirmed once CI runs on this branch.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — to be confirmed once Greptile runs.
- [x] I will address all Greptile and reviewer comments before requesting merge
