### PR TITLE
fix: preserve same-run checkout ownership

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -132,6 +132,50 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     };
   }
 
+  it("allows PATCH immediately after checkout when the authenticated run is already terminal locally", async () => {
+    const { companyId, agentId } = await seedCompanyAgentAndRuns();
+    const bridgedRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: bridgedRunId,
+      companyId,
+      agentId,
+      status: "succeeded",
+      invocationSource: "manual",
+      finishedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Bridged checkout",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const app = createApp(agentActor(companyId, agentId, bridgedRunId));
+    const checkout = await request(app)
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["todo"] });
+
+    expect(checkout.status, JSON.stringify(checkout.body)).toBe(200);
+    expect(checkout.body).toMatchObject({
+      checkoutRunId: bridgedRunId,
+      executionRunId: bridgedRunId,
+    });
+
+    const patch = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Bridged checkout updated" });
+
+    expect(patch.status, JSON.stringify(patch.body)).toBe(200);
+    expect(patch.body).toMatchObject({
+      title: "Bridged checkout updated",
+      checkoutRunId: bridgedRunId,
+      executionRunId: bridgedRunId,
+    });
+  });
+
   it("allows an assigned agent PATCH to recover a terminal stale executionRunId", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7528,8 +7528,6 @@ export function issueService(db: Db) {
     },
 
     assertCheckoutOwner: async (id: string, actorAgentId: string, actorRunId: string | null) => {
-      await clearExecutionRunIfTerminal(id);
-      await clearCheckoutRunIfTerminal(id);
       const loadCurrent = () =>
         db
           .select({
@@ -7542,8 +7540,26 @@ export function issueService(db: Db) {
           .from(issues)
           .where(eq(issues.id, id))
           .then((rows) => rows[0] ?? null);
-      const current = await loadCurrent();
+      let current = await loadCurrent();
 
+      if (!current) throw notFound("Issue not found");
+
+      // A successful checkout is the authoritative ownership grant for this
+      // request path. Check the exact lock before stale-run cleanup: bridged
+      // runtimes can report their heartbeat run terminal before the agent's
+      // final PATCH arrives, and cleanup would otherwise erase the lock that
+      // the immediately preceding checkout just granted.
+      if (
+        current.status === "in_progress" &&
+        current.assigneeAgentId === actorAgentId &&
+        sameRunLock(current.checkoutRunId, actorRunId)
+      ) {
+        return { ...current, adoptedFromRunId: null as string | null };
+      }
+
+      await clearExecutionRunIfTerminal(id);
+      await clearCheckoutRunIfTerminal(id);
+      current = await loadCurrent();
       if (!current) throw notFound("Issue not found");
 
       const resolveSameRunOwnership = (candidate: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent work through issue checkouts.
> - The issue service validates run ownership before an agent changes an active issue.
> - Checkout can grant a lock to a run that the local heartbeat table already marks terminal.
> - PATCH cleared that exact lock before it checked the authenticated run ID.
> - The agent then received a false 409 ownership conflict.
> - This pull request checks exact ownership before stale lock cleanup.
> - The benefit is that an agent can update its own checked-out issue without weakening foreign-run protection.

## Linked Issues or Issue Description

Refs #4177
Refs #6619

**What happened?**

An agent could receive HTTP 200 from `POST /api/issues/:id/checkout`. The response contained its run ID in both ownership fields. An immediate `PATCH /api/issues/:id` then returned HTTP 409. The conflict response showed that both ownership fields had been cleared.

**Expected behavior**

An agent with an exact checkout run ID match can change its own assigned, in-progress issue.

**Steps to reproduce**

1. Use an authenticated agent run that the local heartbeat table marks terminal.
2. Check out an assigned todo issue with that run ID.
3. Confirm that checkout returns the run ID in `checkoutRunId` and `executionRunId`.
4. PATCH the same issue with the same authenticated run ID.
5. Observe the false ownership conflict before this fix.

**Paperclip version or commit**

`ee851fc36`

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Codex, but the fault is in the core issue service.

## What Changed

- Check exact same-run checkout ownership before stale heartbeat cleanup.
- Keep the existing stale-owner adoption and foreign live-owner conflict paths.
- Add a route regression for the full checkout-to-PATCH sequence.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-stale-execution-lock-routes.test.ts` passed: 12 tests.
- `pnpm -r typecheck` passed for all workspace packages.
- `pnpm build` passed for all workspace packages.
- `pnpm test:run` was started. The general server lane did not produce a final summary after more than seven minutes, so it was stopped. The targeted changed suite passed separately.
- This repository has no `bin/ci`.

## Risks

- Low risk. The early return requires an in-progress issue, the assigned agent, and an exact authenticated run ID match.
- A different run still uses stale cleanup or receives the existing 409 conflict.
- No schema or API contract changes are included.

## Model Used

- OpenAI Codex based on GPT-5. The agent used repository tools, code execution, and test execution. The context window size was not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
