### PR TITLE
fix: bound heartbeat run memory usage

### DIFF
--- a/doc/HEARTBEAT-RUN-MEMORY.md
+++ b/doc/HEARTBEAT-RUN-MEMORY.md
@@ -1,0 +1,46 @@
+# Heartbeat Run Memory Operations
+
+The heartbeat run list endpoint returns at most 200 rows by default and at most
+1,000 rows when a caller supplies a larger limit. List queries extract the
+small result summary in PostgreSQL. They do not materialize the full
+`result_json` value in Node.js. The single-run detail endpoint keeps its
+separate bounded detail contract.
+
+The server writes a `process_start` event when memory monitoring starts. It
+writes a `process_memory` event every 30 seconds. These records contain only
+process counters:
+
+- RSS
+- V8 heap used, total, and limit
+- external and array-buffer memory
+- GC count, GC duration, and GC pressure for the sample window
+- process uptime
+
+The records do not contain request bodies, run results, logs, prompts, or other
+private payloads. A new `process_start` event for the same instance identifies a
+restart. A missing memory sample after a pressure warning can identify an abrupt
+exit or OOM when it is correlated with the service manager exit reason.
+
+The server warns when heap use reaches 75% of the V8 heap limit or GC consumes
+20% of a sample window. Alert if either condition lasts for 10 minutes. Alert
+immediately when a new process start follows a memory-pressure warning or when
+the service manager reports an OOM exit.
+
+## Heap ceiling rollout
+
+Keep the current 12 GB old-space ceiling until the exact release head passes
+representative concurrent list and log polling. The sample must use synthetic
+payloads with production-shaped row counts and result sizes. It must not copy
+production content.
+
+Set the initial steady-state old-space ceiling to 4 GB only when all of these
+conditions hold for the exact release head:
+
+- p95 heap use is below 1 GB under representative traffic.
+- GC pressure does not remain above 20%.
+- No OOM or unexpected restart occurs.
+- List responses keep the documented summary contract.
+
+Return the ceiling to 12 GB if heap use remains above 75% for 10 minutes or any
+OOM or unexpected restart occurs. Preserve the memory samples and service
+manager exit reason for the follow-up investigation.

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -5,7 +5,13 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
-import { boundHeartbeatRunEventPayloadForStorage, heartbeatService } from "../services/heartbeat.ts";
+import {
+  HEARTBEAT_RUN_LIST_DEFAULT_LIMIT,
+  HEARTBEAT_RUN_LIST_MAX_LIMIT,
+  boundHeartbeatRunEventPayloadForStorage,
+  boundHeartbeatRunListLimit,
+  heartbeatService,
+} from "../services/heartbeat.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -99,6 +105,13 @@ describeEmbeddedPostgres("heartbeat list", () => {
         delete (heartbeatRuns as Record<string, unknown>).processGroupId;
       }
     }
+  });
+
+  it("applies a default and maximum list bound", () => {
+    expect(boundHeartbeatRunListLimit()).toBe(HEARTBEAT_RUN_LIST_DEFAULT_LIMIT);
+    expect(boundHeartbeatRunListLimit(Number.NaN)).toBe(HEARTBEAT_RUN_LIST_DEFAULT_LIMIT);
+    expect(boundHeartbeatRunListLimit(0)).toBe(1);
+    expect(boundHeartbeatRunListLimit(50_000)).toBe(HEARTBEAT_RUN_LIST_MAX_LIMIT);
   });
 
   it("returns small result json payloads unchanged from getRun", async () => {

--- a/server/src/__tests__/process-memory-monitor.test.ts
+++ b/server/src/__tests__/process-memory-monitor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createProcessMemorySample } from "../services/process-memory-monitor.js";
+import {
+  createProcessMemorySample,
+  getProcessMemoryMonitorSubscriberCount,
+  startProcessMemoryMonitor,
+} from "../services/process-memory-monitor.js";
 
 describe("process memory monitoring", () => {
   it("reports bounded metadata without process payloads", () => {
@@ -27,5 +31,17 @@ describe("process memory monitoring", () => {
       "rssBytes",
       "uptimeSeconds",
     ]);
+  });
+
+  it("shares one process monitor across repeated starts and cleans it up", () => {
+    const stopFirst = startProcessMemoryMonitor(60_000);
+    const stopSecond = startProcessMemoryMonitor(60_000);
+
+    expect(getProcessMemoryMonitorSubscriberCount()).toBe(2);
+    stopFirst();
+    stopFirst();
+    expect(getProcessMemoryMonitorSubscriberCount()).toBe(1);
+    stopSecond();
+    expect(getProcessMemoryMonitorSubscriberCount()).toBe(0);
   });
 });

--- a/server/src/__tests__/process-memory-monitor.test.ts
+++ b/server/src/__tests__/process-memory-monitor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { createProcessMemorySample } from "../services/process-memory-monitor.js";
+
+describe("process memory monitoring", () => {
+  it("reports bounded metadata without process payloads", () => {
+    const sample = createProcessMemorySample({ durationMs: 250, count: 4 }, 1_000);
+
+    expect(sample).toMatchObject({
+      event: "process_memory",
+      gcDurationMs: 250,
+      gcPressure: 0.25,
+      gcCount: 4,
+    });
+    expect(sample.rssBytes).toBeGreaterThan(0);
+    expect(sample.heapLimitBytes).toBeGreaterThan(0);
+    expect(Object.keys(sample).sort()).toEqual([
+      "arrayBuffersBytes",
+      "event",
+      "externalBytes",
+      "gcCount",
+      "gcDurationMs",
+      "gcPressure",
+      "heapLimitBytes",
+      "heapTotalBytes",
+      "heapUsedBytes",
+      "heapUtilization",
+      "rssBytes",
+      "uptimeSeconds",
+    ]);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -751,9 +751,9 @@ export async function startServer(): Promise<StartedServer> {
     decisionServiceOptions,
     managedPluginAutoInstall,
   });
-  const stopProcessMemoryMonitor = startProcessMemoryMonitor();
   const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
-  server.once("close", stopProcessMemoryMonitor);
+  let stopProcessMemoryMonitor: (() => void) | null = null;
+  server.once("close", () => stopProcessMemoryMonitor?.());
 
   // Increase keep-alive timeouts to safely outlive default idle timeouts
   // of common reverse proxies and load balancers (like AWS ALB, Nginx, or Traefik).
@@ -1251,6 +1251,7 @@ export async function startServer(): Promise<StartedServer> {
 
     server.once("error", onError);
     server.listen(listenPort, config.host, () => {
+      stopProcessMemoryMonitor = startProcessMemoryMonitor();
       server.off("error", onError);
       logger.info(`Server listening on ${config.host}:${listenPort}`);
       void systemdNotify(["--ready", `--status=Listening on ${config.host}:${listenPort}`]).then((notified) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -81,6 +81,7 @@ import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
 } from "./routes/instance-database-backups.js";
+import { startProcessMemoryMonitor } from "./services/process-memory-monitor.js";
 
 type BetterAuthSessionUser = {
   id: string;
@@ -750,7 +751,9 @@ export async function startServer(): Promise<StartedServer> {
     decisionServiceOptions,
     managedPluginAutoInstall,
   });
+  const stopProcessMemoryMonitor = startProcessMemoryMonitor();
   const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
+  server.once("close", stopProcessMemoryMonitor);
 
   // Increase keep-alive timeouts to safely outlive default idle timeouts
   // of common reverse proxies and load balancers (like AWS ALB, Nginx, or Traefik).

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -45,6 +45,7 @@ import {
   companySkillService,
   budgetService,
   heartbeatService,
+  boundHeartbeatRunListLimit,
   ISSUE_LIST_DEFAULT_LIMIT,
   issueApprovalService,
   issueRecoveryActionService,
@@ -3646,7 +3647,7 @@ export function agentRoutes(
     assertCompanyAccess(req, companyId);
     const agentId = req.query.agentId as string | undefined;
     const limitParam = req.query.limit as string | undefined;
-    const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
+    const limit = boundHeartbeatRunListLimit(limitParam ? Number(limitParam) : undefined);
     const summary = req.query.summary === "true" || req.query.summary === "1";
     const runs = await heartbeat.list(companyId, agentId, limit, { summary });
     res.json(runs);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1931,6 +1931,14 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
 const heartbeatRunProcessGroupIdColumn =
   heartbeatRuns.processGroupId ?? sql<number | null>`NULL`.as("processGroupId");
 
+export const HEARTBEAT_RUN_LIST_DEFAULT_LIMIT = 200;
+export const HEARTBEAT_RUN_LIST_MAX_LIMIT = 1000;
+
+export function boundHeartbeatRunListLimit(limit?: number): number {
+  if (!Number.isFinite(limit)) return HEARTBEAT_RUN_LIST_DEFAULT_LIMIT;
+  return Math.max(1, Math.min(HEARTBEAT_RUN_LIST_MAX_LIMIT, Math.trunc(limit as number)));
+}
+
 const heartbeatRunListColumns = {
   id: heartbeatRuns.id,
   companyId: heartbeatRuns.companyId,
@@ -17779,7 +17787,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         )
         .orderBy(desc(heartbeatRuns.createdAt));
 
-      const rows = limit ? await query.limit(limit) : await query;
+      const rows = await query.limit(boundHeartbeatRunListLimit(limit));
       return rows.map((row) => {
         const {
           contextIssueId,

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -84,7 +84,13 @@ export { toolAccessPolicyService } from "./tool-access-policy.js";
 export { routineService } from "./routines.js";
 export { costService } from "./costs.js";
 export { financeService } from "./finance.js";
-export { heartbeatService, resolveHeartbeatSchedulingSuppression } from "./heartbeat.js";
+export {
+  HEARTBEAT_RUN_LIST_DEFAULT_LIMIT,
+  HEARTBEAT_RUN_LIST_MAX_LIMIT,
+  boundHeartbeatRunListLimit,
+  heartbeatService,
+  resolveHeartbeatSchedulingSuppression,
+} from "./heartbeat.js";
 export {
   productivityReviewService,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,

--- a/server/src/services/process-memory-monitor.ts
+++ b/server/src/services/process-memory-monitor.ts
@@ -6,6 +6,8 @@ const DEFAULT_SAMPLE_INTERVAL_MS = 30_000;
 const HEAP_WARNING_RATIO = 0.75;
 const GC_PRESSURE_RATIO = 0.2;
 
+let activeMonitor: { subscribers: number; stop: () => void } | null = null;
+
 export interface ProcessMemorySample {
   event: "process_memory";
   rssBytes: number;
@@ -44,6 +46,20 @@ export function createProcessMemorySample(
 }
 
 export function startProcessMemoryMonitor(intervalMs = DEFAULT_SAMPLE_INTERVAL_MS): () => void {
+  if (activeMonitor) {
+    activeMonitor.subscribers += 1;
+    let released = false;
+    return () => {
+      if (released || !activeMonitor) return;
+      released = true;
+      activeMonitor.subscribers -= 1;
+      if (activeMonitor.subscribers === 0) {
+        activeMonitor.stop();
+        activeMonitor = null;
+      }
+    };
+  }
+
   let gcDurationMs = 0;
   let gcCount = 0;
   const observer = new PerformanceObserver((list) => {
@@ -74,8 +90,24 @@ export function startProcessMemoryMonitor(intervalMs = DEFAULT_SAMPLE_INTERVAL_M
   }, intervalMs);
   timer.unref();
 
-  return () => {
+  const stop = () => {
     clearInterval(timer);
     observer.disconnect();
   };
+  activeMonitor = { subscribers: 1, stop };
+
+  let released = false;
+  return () => {
+    if (released || !activeMonitor) return;
+    released = true;
+    activeMonitor.subscribers -= 1;
+    if (activeMonitor.subscribers === 0) {
+      activeMonitor.stop();
+      activeMonitor = null;
+    }
+  };
+}
+
+export function getProcessMemoryMonitorSubscriberCount(): number {
+  return activeMonitor?.subscribers ?? 0;
 }

--- a/server/src/services/process-memory-monitor.ts
+++ b/server/src/services/process-memory-monitor.ts
@@ -1,0 +1,81 @@
+import { PerformanceObserver, type PerformanceEntry } from "node:perf_hooks";
+import v8 from "node:v8";
+import { logger } from "../middleware/logger.js";
+
+const DEFAULT_SAMPLE_INTERVAL_MS = 30_000;
+const HEAP_WARNING_RATIO = 0.75;
+const GC_PRESSURE_RATIO = 0.2;
+
+export interface ProcessMemorySample {
+  event: "process_memory";
+  rssBytes: number;
+  heapUsedBytes: number;
+  heapTotalBytes: number;
+  heapLimitBytes: number;
+  externalBytes: number;
+  arrayBuffersBytes: number;
+  heapUtilization: number;
+  gcDurationMs: number;
+  gcPressure: number;
+  gcCount: number;
+  uptimeSeconds: number;
+}
+
+export function createProcessMemorySample(
+  gc: { durationMs: number; count: number },
+  intervalMs: number,
+): ProcessMemorySample {
+  const memory = process.memoryUsage();
+  const heapLimitBytes = v8.getHeapStatistics().heap_size_limit;
+  return {
+    event: "process_memory",
+    rssBytes: memory.rss,
+    heapUsedBytes: memory.heapUsed,
+    heapTotalBytes: memory.heapTotal,
+    heapLimitBytes,
+    externalBytes: memory.external,
+    arrayBuffersBytes: memory.arrayBuffers,
+    heapUtilization: heapLimitBytes > 0 ? memory.heapUsed / heapLimitBytes : 0,
+    gcDurationMs: gc.durationMs,
+    gcPressure: intervalMs > 0 ? gc.durationMs / intervalMs : 0,
+    gcCount: gc.count,
+    uptimeSeconds: process.uptime(),
+  };
+}
+
+export function startProcessMemoryMonitor(intervalMs = DEFAULT_SAMPLE_INTERVAL_MS): () => void {
+  let gcDurationMs = 0;
+  let gcCount = 0;
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries() as PerformanceEntry[]) {
+      gcDurationMs += entry.duration;
+      gcCount += 1;
+    }
+  });
+  observer.observe({ entryTypes: ["gc"] });
+
+  logger.info({
+    event: "process_start",
+    pid: process.pid,
+    parentPid: process.ppid,
+    startedAt: new Date(Date.now() - process.uptime() * 1000).toISOString(),
+    heapLimitBytes: v8.getHeapStatistics().heap_size_limit,
+  }, "Process memory monitoring started");
+
+  const timer = setInterval(() => {
+    const sample = createProcessMemorySample({ durationMs: gcDurationMs, count: gcCount }, intervalMs);
+    gcDurationMs = 0;
+    gcCount = 0;
+    if (sample.heapUtilization >= HEAP_WARNING_RATIO || sample.gcPressure >= GC_PRESSURE_RATIO) {
+      logger.warn(sample, "Process memory pressure detected");
+    } else {
+      logger.info(sample, "Process memory sample");
+    }
+  }, intervalMs);
+  timer.unref();
+
+  return () => {
+    clearInterval(timer);
+    observer.disconnect();
+  };
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -817,7 +817,7 @@ export function AgentDetail() {
 
   const { data: heartbeats } = useQuery({
     queryKey: queryKeys.heartbeats(resolvedCompanyId!, agent?.id ?? undefined),
-    queryFn: () => heartbeatsApi.list(resolvedCompanyId!, agent?.id ?? undefined),
+    queryFn: () => heartbeatsApi.list(resolvedCompanyId!, agent?.id ?? undefined, 200),
     enabled: !!resolvedCompanyId && !!agent?.id && shouldLoadHeartbeats,
   });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat history gives operators visibility into agent execution.
> - The history endpoint can scan every run when a caller omits a limit.
> - Large stored run results can make overlapping history polls exhaust the Node.js heap.
> - Existing SQL summary projections and log metadata projections reduce each row's payload.
> - This pull request adds mandatory query bounds and process memory telemetry.
> - The benefit is predictable memory use and actionable heap, GC, restart, and OOM evidence.

## Linked Issues or Issue Description

**What happened?**

The company heartbeat history endpoint accepted requests without a limit. Those requests could scan all historical runs. Repeated UI polling could overlap and cause excessive Node.js heap use on a large database.

**Expected behavior**

The server must enforce a safe default and maximum row count for every heartbeat history request. Operators must also have payload-free memory and GC evidence for capacity decisions.

**Steps to reproduce**

1. Create many heartbeat run rows with large synthetic result JSON values.
2. Request the company heartbeat history endpoint without a `limit` query parameter.
3. Repeat the request concurrently and observe that the server scans the full history.

**Paperclip version or commit**

`ee851fc364087aa36951aaec78afe2be42ce27e3`

## What Changed

- Enforce a 200-row default and a 1,000-row maximum in the route and service.
- Request 200 history rows from the agent detail page.
- Log RSS, V8 heap, external memory, array buffers, GC time, and GC pressure every 30 seconds.
- Log process start metadata and warn at 75% heap use or 20% GC pressure.
- Document exact-head heap ceiling and rollback criteria.
- Add regression tests for bounds and payload-free memory samples.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-list.test.ts server/src/__tests__/process-memory-monitor.test.ts ui/src/api/heartbeats.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm check:token-gates`
- `pnpm build`
- The full stable test run has unrelated failures in workspace runtime tests on the upstream head. Targeted tests pass.

## Risks

- Callers that relied on more than 1,000 history rows in one response must paginate or use a narrower query.
- Memory logs add one small structured record every 30 seconds.
- GC pressure is a process-wide signal. Operators must correlate it with request traffic and restart events.

> This work does not overlap the roadmap memory and knowledge feature. It fixes process memory use in heartbeat history.

## Model Used

- OpenAI Codex, GPT-5.6-sol, agentic coding with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
