### PR TITLE
ci: pass e2e shard specs without separator

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -442,7 +442,7 @@ jobs:
           specs="$(node ./scripts/e2e-shard.mjs \
             --shard-index ${{ matrix.shard_index }} --shard-count ${{ matrix.shard_count }})"
           echo "shard ${{ matrix.shard_label }} specs: $specs"
-          pnpm run test:e2e -- $specs
+          pnpm run test:e2e $specs
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/scripts/__tests__/e2e-shard.test.mjs
+++ b/scripts/__tests__/e2e-shard.test.mjs
@@ -142,3 +142,18 @@ test("pr.yml keeps a stable aggregate check named e2e over the shard matrix", ()
     assert.equal(entry.shardLabel, `${entry.shardIndex + 1}/${SHARD_COUNT}`, "each shard label must match its index");
   }
 });
+
+test("pr.yml passes the shard's spec filter to Playwright without a literal --", () => {
+  // `pnpm run test:e2e -- $specs` forwards the literal separator to Playwright,
+  // so the specs after it are not applied as file filters.
+  const workflow = readFileSync(prWorkflow, "utf8");
+  assert.ok(
+    !/pnpm run test:e2e --\s/.test(workflow),
+    "pr.yml must not insert a literal `--` between `pnpm run test:e2e` and the spec filter",
+  );
+  assert.match(
+    workflow,
+    /pnpm run test:e2e \$specs/,
+    "pr.yml e2e_shards must invoke `pnpm run test:e2e $specs`",
+  );
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses pull request CI to test changes before merge.
> - The e2e PR lane runs Playwright specs in a shard matrix.
> - Each shard builds a list of spec files for its matrix entry.
> - The workflow passed that list after a literal `--` separator.
> - Playwright did not receive the list as file filters.
> - This pull request removes the separator and adds a guard test.
> - The benefit is that each e2e shard runs only its assigned specs.

## Linked Issues or Issue Description

Refs #10629.

**What happened?**

The e2e shard step used `pnpm run test:e2e -- $specs`. The shard spec list was not applied as Playwright file filters.

**Expected behavior**

Each e2e shard should pass only its selected specs to Playwright.

**Steps to reproduce**

1. Inspect `.github/workflows/pr.yml` at the merge commit for #10629.
2. Find the `e2e_shards` command that invokes `pnpm run test:e2e`.
3. See the literal `--` before `$specs`.

**Paperclip version or commit**

`86767951`

**Deployment mode**

GitHub Actions PR CI.

## What Changed

- Removed the literal `--` from the e2e shard `pnpm run test:e2e $specs` invocation.
- Added a regression test that checks the workflow passes `$specs` without that separator.

## Verification

- `node --test scripts/__tests__/e2e-shard.test.mjs`

## Risks

Low risk. This changes one CI command and one workflow guard test. The main risk is shell argument handling in the workflow, and the guard now covers the expected command shape.

## Model Used

OpenAI GPT-5 through Codex. The run used shell and GitHub CLI tool access. The runtime did not expose a context window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge