### PR TITLE
Reclaim isolated worktree instances during teardown

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -442,7 +442,7 @@ The server/UI use those values for worktree-specific branding such as the top ba
 Authenticated worktree servers also use the `PAPERCLIP_INSTANCE_ID` value to scope Better Auth cookie names.
 Browser cookies are shared by host rather than port, so this prevents logging into one `127.0.0.1:<port>` worktree from replacing another worktree server's session cookie.
 
-When Paperclip closes a server-managed git worktree, it also reclaims the isolated instance referenced by that worktree's repo-local `.paperclip/.env`. This cleanup stops a running embedded PostgreSQL process before removing the instance directory. The deletion guard only accepts canonical instance paths below `PAPERCLIP_WORKTREES_DIR/instances/`; pointers to the default/live Paperclip home or any other location are logged and left untouched.
+When Paperclip closes a server-managed git worktree, it also reclaims the isolated instance referenced by that worktree's repo-local `.paperclip/.env`. New server-managed worktrees use a collision-resistant instance id derived from the resolved absolute worktree path. Cleanup requires that exact id, stops a running embedded PostgreSQL process, and then removes the instance directory. The deletion guard only accepts canonical instance paths below `PAPERCLIP_WORKTREES_DIR/instances/`; legacy or mismatched ids, pointers to the default/live Paperclip home, and all other locations are logged and left untouched.
 
 Print shell exports explicitly when needed:
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -442,6 +442,8 @@ The server/UI use those values for worktree-specific branding such as the top ba
 Authenticated worktree servers also use the `PAPERCLIP_INSTANCE_ID` value to scope Better Auth cookie names.
 Browser cookies are shared by host rather than port, so this prevents logging into one `127.0.0.1:<port>` worktree from replacing another worktree server's session cookie.
 
+When Paperclip closes a server-managed git worktree, it also reclaims the isolated instance referenced by that worktree's repo-local `.paperclip/.env`. This cleanup stops a running embedded PostgreSQL process before removing the instance directory. The deletion guard only accepts canonical instance paths below `PAPERCLIP_WORKTREES_DIR/instances/`; pointers to the default/live Paperclip home or any other location are logged and left untouched.
+
 Print shell exports explicitly when needed:
 
 ```sh

--- a/scripts/provision-worktree.sh
+++ b/scripts/provision-worktree.sh
@@ -9,6 +9,22 @@ paperclip_dir="$worktree_cwd/.paperclip"
 worktree_config_path="$paperclip_dir/config.json"
 worktree_env_path="$paperclip_dir/.env"
 worktree_name="${PAPERCLIP_WORKSPACE_BRANCH:-$(basename "$worktree_cwd")}"
+worktree_instance_id="$(WORKTREE_CWD="$worktree_cwd" node <<'EOF'
+const crypto = require("node:crypto");
+const path = require("node:path");
+
+const resolvedWorkspacePath = path.resolve(process.env.WORKTREE_CWD);
+const normalized = path.basename(resolvedWorkspacePath)
+  .trim()
+  .toLowerCase()
+  .replace(/[^a-z0-9_-]+/g, "-")
+  .replace(/-+/g, "-")
+  .replace(/^[-_]+|[-_]+$/g, "");
+const prefix = (normalized || "worktree").slice(0, 48);
+const pathHash = crypto.createHash("sha256").update(resolvedWorkspacePath).digest("hex").slice(0, 12);
+process.stdout.write(`${prefix}-${pathHash}`);
+EOF
+)"
 
 if [[ ! -d "$base_cwd" ]]; then
   echo "Base workspace does not exist: $base_cwd" >&2
@@ -95,7 +111,7 @@ run_isolated_worktree_init() {
   if ensure_base_cli_healthy; then
     (
       cd "$worktree_cwd" &&
-        node "$base_cli_runner_path" "$base_cli_entry_path" worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+        node "$base_cli_runner_path" "$base_cli_entry_path" worktree init --force --seed-mode minimal --name "$worktree_name" --instance "$worktree_instance_id" --from-config "$source_config_path"
     )
     return
   fi
@@ -103,7 +119,7 @@ run_isolated_worktree_init() {
   if command -v pnpm >/dev/null 2>&1 && pnpm paperclipai --help >/dev/null 2>&1; then
     (
       cd "$worktree_cwd" &&
-        pnpm paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+        pnpm paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --instance "$worktree_instance_id" --from-config "$source_config_path"
     )
     return
   fi
@@ -111,7 +127,7 @@ run_isolated_worktree_init() {
   if command -v paperclipai >/dev/null 2>&1; then
     (
       cd "$worktree_cwd" &&
-        paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+        paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --instance "$worktree_instance_id" --from-config "$source_config_path"
     )
     return
   fi
@@ -138,6 +154,7 @@ paperclipai_command_available() {
 existing_worktree_config_is_usable() {
   WORKTREE_CONFIG_PATH="$worktree_config_path" \
   WORKTREE_ENV_PATH="$worktree_env_path" \
+  WORKTREE_INSTANCE_ID="$worktree_instance_id" \
   node <<'EOF'
 const fs = require("node:fs");
 const os = require("node:os");
@@ -187,8 +204,12 @@ if (envConfigPath && path.resolve(envConfigPath) !== configPath) {
 
 const homeDir = expandHomePrefix(env.PAPERCLIP_HOME);
 const instanceId = env.PAPERCLIP_INSTANCE_ID;
+const expectedInstanceId = process.env.WORKTREE_INSTANCE_ID;
 if (!homeDir || !instanceId) {
   fail("existing worktree env is missing PAPERCLIP_HOME or PAPERCLIP_INSTANCE_ID");
+}
+if (instanceId !== expectedInstanceId) {
+  fail(`existing worktree env names legacy or mismatched instance ${instanceId}, expected ${expectedInstanceId}`);
 }
 if (!fs.existsSync(homeDir)) {
   fail(`existing worktree home does not exist on this host: ${homeDir}`);
@@ -220,6 +241,7 @@ write_fallback_worktree_config() {
   PAPERCLIP_DIR="$paperclip_dir" \
   SOURCE_CONFIG_PATH="$source_config_path" \
   SOURCE_ENV_PATH="$source_env_path" \
+  WORKTREE_INSTANCE_ID="$worktree_instance_id" \
   PAPERCLIP_WORKTREES_DIR="${PAPERCLIP_WORKTREES_DIR:-}" \
   node <<'EOF'
 const fs = require("node:fs");
@@ -236,15 +258,6 @@ function expandHomePrefix(value) {
 
 function nonEmpty(value) {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function sanitizeInstanceId(value) {
-  const trimmed = String(value ?? "").trim().toLowerCase();
-  const normalized = trimmed
-    .replace(/[^a-z0-9_-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^[-_]+|[-_]+$/g, "");
-  return normalized || "worktree";
 }
 
 function parseEnvFile(contents) {
@@ -334,7 +347,10 @@ async function main() {
   const sourceConfigPath = process.env.SOURCE_CONFIG_PATH;
   const sourceEnvPath = process.env.SOURCE_ENV_PATH;
   const worktreeHome = path.resolve(expandHomePrefix(nonEmpty(process.env.PAPERCLIP_WORKTREES_DIR) ?? "~/.paperclip-worktrees"));
-  const instanceId = sanitizeInstanceId(worktreeName);
+  const instanceId = process.env.WORKTREE_INSTANCE_ID;
+  if (!/^[A-Za-z0-9_-]+$/.test(instanceId ?? "")) {
+    throw new Error("WORKTREE_INSTANCE_ID is missing or unsafe");
+  }
   const instanceRoot = path.resolve(worktreeHome, "instances", instanceId);
   const configPath = path.resolve(paperclipDir, "config.json");
   const envPath = path.resolve(paperclipDir, ".env");

--- a/server/src/__tests__/workspace-instance-cleanup.test.ts
+++ b/server/src/__tests__/workspace-instance-cleanup.test.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupWorktreeInstanceArtifacts,
+  readWorktreeInstancePointer,
+} from "../services/workspace-instance-cleanup.js";
+import type { WorkspaceOperation } from "@paperclipai/shared";
+import type { WorkspaceOperationRecorder } from "../services/workspace-operations.js";
+
+const tempRoots = new Set<string>();
+
+async function makeTempRoot(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempRoots.add(root);
+  return root;
+}
+
+async function writeWorkspaceEnv(workspacePath: string, homeDir: string, instanceId: string): Promise<void> {
+  const envDir = path.join(workspacePath, ".paperclip");
+  await fs.mkdir(envDir, { recursive: true });
+  await fs.writeFile(
+    path.join(envDir, ".env"),
+    `PAPERCLIP_HOME=${JSON.stringify(homeDir)}\nPAPERCLIP_INSTANCE_ID=${JSON.stringify(instanceId)}\n`,
+    "utf8",
+  );
+}
+
+function createRecorderDouble() {
+  const operations: Array<{
+    status: string;
+    metadata: Record<string, unknown> | null;
+    system: string | null;
+  }> = [];
+  const recorder: WorkspaceOperationRecorder = {
+    attachExecutionWorkspaceId: async () => {},
+    recordOperation: async (input) => {
+      const result = await input.run();
+      operations.push({
+        status: result.status ?? "succeeded",
+        metadata: input.metadata ?? null,
+        system: result.system ?? null,
+      });
+      return {
+        id: `op-${operations.length}`,
+        companyId: "company-1",
+        executionWorkspaceId: null,
+        heartbeatRunId: null,
+        issueId: null,
+        phase: input.phase,
+        command: input.command ?? null,
+        cwd: input.cwd ?? null,
+        status: (result.status ?? "succeeded") as WorkspaceOperation["status"],
+        exitCode: result.exitCode ?? null,
+        logStore: null,
+        logRef: null,
+        logBytes: null,
+        logSha256: null,
+        logCompressed: false,
+        stdoutExcerpt: result.stdout ?? null,
+        stderrExcerpt: result.stderr ?? null,
+        metadata: input.metadata ?? null,
+        startedAt: new Date(),
+        finishedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    },
+  };
+  return { recorder, operations };
+}
+
+afterEach(async () => {
+  await Promise.all(Array.from(tempRoots, (root) => fs.rm(root, { recursive: true, force: true })));
+  tempRoots.clear();
+  vi.restoreAllMocks();
+});
+
+describe("worktree instance cleanup", () => {
+  it("removes an instance directory inside the managed worktree instances root", async () => {
+    const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    const instanceId = "pap-16075";
+    const instanceRoot = path.join(worktreesDir, "instances", instanceId);
+    await fs.mkdir(path.join(instanceRoot, "db"), { recursive: true });
+    await fs.writeFile(path.join(instanceRoot, "marker"), "remove me", "utf8");
+    await writeWorkspaceEnv(workspacePath, worktreesDir, instanceId);
+
+    const pointer = await readWorktreeInstancePointer(workspacePath);
+    expect(pointer).not.toBeNull();
+    const result = await cleanupWorktreeInstanceArtifacts({
+      pointer: pointer!,
+      workspaceId: "workspace-1",
+      workspacePath,
+      worktreesDir,
+    });
+
+    expect(result).toMatchObject({ status: "removed", postgresStopped: false });
+    await expect(fs.stat(instanceRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("refuses and logs an instance pointer outside the managed worktree root", async () => {
+    const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
+    const liveHome = await makeTempRoot("paperclip-live-home-");
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    const liveInstanceRoot = path.join(liveHome, "instances", "default");
+    await fs.mkdir(liveInstanceRoot, { recursive: true });
+    await fs.writeFile(path.join(liveInstanceRoot, "marker"), "keep me", "utf8");
+    await writeWorkspaceEnv(workspacePath, liveHome, "default");
+    const { recorder, operations } = createRecorderDouble();
+    const stopEmbeddedPostgres = vi.fn(async () => false);
+    const removeInstanceRoot = vi.fn(async () => {});
+
+    const pointer = await readWorktreeInstancePointer(workspacePath);
+    const result = await cleanupWorktreeInstanceArtifacts({
+      pointer: pointer!,
+      workspaceId: "workspace-1",
+      workspacePath,
+      worktreesDir,
+      recorder,
+      dependencies: { stopEmbeddedPostgres, removeInstanceRoot },
+    });
+
+    expect(result).toMatchObject({ status: "refused", instanceRoot: liveInstanceRoot });
+    expect(stopEmbeddedPostgres).not.toHaveBeenCalled();
+    expect(removeInstanceRoot).not.toHaveBeenCalled();
+    expect(await fs.readFile(path.join(liveInstanceRoot, "marker"), "utf8")).toBe("keep me");
+    expect(operations).toEqual([
+      expect.objectContaining({
+        status: "skipped",
+        metadata: expect.objectContaining({
+          cleanupAction: "remove_worktree_instance",
+          refusalReason: "outside_managed_instances_dir",
+        }),
+      }),
+    ]);
+  });
+
+  it("treats a missing repo-local env file as a no-op", async () => {
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    await expect(readWorktreeInstancePointer(workspacePath)).resolves.toBeNull();
+  });
+
+  it("stops embedded Postgres before deleting the instance root", async () => {
+    const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    const instanceRoot = path.join(worktreesDir, "instances", "ordered-cleanup");
+    await fs.mkdir(path.join(instanceRoot, "db"), { recursive: true });
+    await writeWorkspaceEnv(workspacePath, worktreesDir, "ordered-cleanup");
+    const calls: string[] = [];
+
+    const pointer = await readWorktreeInstancePointer(workspacePath);
+    const result = await cleanupWorktreeInstanceArtifacts({
+      pointer: pointer!,
+      workspaceId: "workspace-1",
+      workspacePath,
+      worktreesDir,
+      dependencies: {
+        stopEmbeddedPostgres: async (dataDir) => {
+          expect(dataDir).toBe(path.join(instanceRoot, "db"));
+          expect(await fs.stat(instanceRoot)).toBeDefined();
+          calls.push("stop");
+          return true;
+        },
+        removeInstanceRoot: async (target) => {
+          calls.push("remove");
+          await fs.rm(target, { recursive: true, force: true });
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ status: "removed", postgresStopped: true });
+    expect(calls).toEqual(["stop", "remove"]);
+  });
+
+  it("refuses a managed-root symlink that canonically escapes the guard", async () => {
+    const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
+    const outsideRoot = await makeTempRoot("paperclip-outside-instance-");
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    const instancesDir = path.join(worktreesDir, "instances");
+    await fs.mkdir(instancesDir, { recursive: true });
+    await fs.symlink(outsideRoot, path.join(instancesDir, "escaped"), "dir");
+    await writeWorkspaceEnv(workspacePath, worktreesDir, "escaped");
+
+    const pointer = await readWorktreeInstancePointer(workspacePath);
+    const result = await cleanupWorktreeInstanceArtifacts({
+      pointer: pointer!,
+      workspaceId: "workspace-1",
+      workspacePath,
+      worktreesDir,
+    });
+
+    expect(result).toMatchObject({ status: "refused" });
+    expect((result as { warning: string }).warning).toContain("canonical path");
+    await expect(fs.stat(outsideRoot)).resolves.toBeDefined();
+  });
+
+  it("refuses when the managed instances directory itself is a symlink", async () => {
+    const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
+    const liveInstancesDir = await makeTempRoot("paperclip-live-instances-");
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    const liveInstanceRoot = path.join(liveInstancesDir, "default");
+    await fs.mkdir(liveInstanceRoot, { recursive: true });
+    await fs.symlink(liveInstancesDir, path.join(worktreesDir, "instances"), "dir");
+    await writeWorkspaceEnv(workspacePath, worktreesDir, "default");
+
+    const pointer = await readWorktreeInstancePointer(workspacePath);
+    const result = await cleanupWorktreeInstanceArtifacts({
+      pointer: pointer!,
+      workspaceId: "workspace-1",
+      workspacePath,
+      worktreesDir,
+    });
+
+    expect(result).toMatchObject({ status: "refused" });
+    expect((result as { warning: string }).warning).toContain("managed instances directory");
+    await expect(fs.stat(liveInstanceRoot)).resolves.toBeDefined();
+  });
+});

--- a/server/src/__tests__/workspace-instance-cleanup.test.ts
+++ b/server/src/__tests__/workspace-instance-cleanup.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupWorktreeInstanceArtifacts,
   readWorktreeInstancePointer,
+  stopEmbeddedPostgresIfRunning,
 } from "../services/workspace-instance-cleanup.js";
 import type { WorkspaceOperation } from "@paperclipai/shared";
 import type { WorkspaceOperationRecorder } from "../services/workspace-operations.js";
@@ -93,6 +94,7 @@ describe("worktree instance cleanup", () => {
       pointer: pointer!,
       workspaceId: "workspace-1",
       workspacePath,
+      expectedInstanceId: instanceId,
       worktreesDir,
     });
 
@@ -117,6 +119,7 @@ describe("worktree instance cleanup", () => {
       pointer: pointer!,
       workspaceId: "workspace-1",
       workspacePath,
+      expectedInstanceId: "default",
       worktreesDir,
       recorder,
       dependencies: { stopEmbeddedPostgres, removeInstanceRoot },
@@ -155,6 +158,7 @@ describe("worktree instance cleanup", () => {
       pointer: pointer!,
       workspaceId: "workspace-1",
       workspacePath,
+      expectedInstanceId: "ordered-cleanup",
       worktreesDir,
       dependencies: {
         stopEmbeddedPostgres: async (dataDir) => {
@@ -188,6 +192,7 @@ describe("worktree instance cleanup", () => {
       pointer: pointer!,
       workspaceId: "workspace-1",
       workspacePath,
+      expectedInstanceId: "escaped",
       worktreesDir,
     });
 
@@ -210,11 +215,54 @@ describe("worktree instance cleanup", () => {
       pointer: pointer!,
       workspaceId: "workspace-1",
       workspacePath,
+      expectedInstanceId: "default",
       worktreesDir,
     });
 
     expect(result).toMatchObject({ status: "refused" });
     expect((result as { warning: string }).warning).toContain("managed instances directory");
     await expect(fs.stat(liveInstanceRoot)).resolves.toBeDefined();
+  });
+
+  it("refuses an instance pointer that belongs to a sibling worktree", async () => {
+    const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
+    const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");
+    const siblingRoot = path.join(worktreesDir, "instances", "sibling-worktree");
+    await fs.mkdir(siblingRoot, { recursive: true });
+    await fs.writeFile(path.join(siblingRoot, "marker"), "keep me", "utf8");
+    await writeWorkspaceEnv(workspacePath, worktreesDir, "sibling-worktree");
+    const stopEmbeddedPostgres = vi.fn(async () => false);
+    const removeInstanceRoot = vi.fn(async () => {});
+
+    const pointer = await readWorktreeInstancePointer(workspacePath);
+    const result = await cleanupWorktreeInstanceArtifacts({
+      pointer: pointer!,
+      workspaceId: "workspace-1",
+      workspacePath,
+      expectedInstanceId: "owned-worktree",
+      worktreesDir,
+      dependencies: { stopEmbeddedPostgres, removeInstanceRoot },
+    });
+
+    expect(result).toMatchObject({ status: "refused", instanceRoot: siblingRoot });
+    expect((result as { warning: string }).warning).toContain("does not match the expected workspace instance");
+    expect(stopEmbeddedPostgres).not.toHaveBeenCalled();
+    expect(removeInstanceRoot).not.toHaveBeenCalled();
+    expect(await fs.readFile(path.join(siblingRoot, "marker"), "utf8")).toBe("keep me");
+  });
+
+  it("treats an ESRCH signal race as an already-stopped PostgreSQL process", async () => {
+    const instanceRoot = await makeTempRoot("paperclip-postgres-exit-race-");
+    const dataDir = path.join(instanceRoot, "db");
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(path.join(dataDir, "postmaster.pid"), `4242\n${dataDir}\n`, "utf8");
+    const signalError = Object.assign(new Error("process exited"), { code: "ESRCH" });
+
+    await expect(stopEmbeddedPostgresIfRunning(dataDir, {
+      processIsAlive: () => true,
+      readVerifiedPostgresCommand: async () => `postgres -D ${dataDir}`,
+      signalProcess: () => { throw signalError; },
+      wait: async () => {},
+    })).resolves.toBe(false);
   });
 });

--- a/server/src/__tests__/workspace-instance-cleanup.test.ts
+++ b/server/src/__tests__/workspace-instance-cleanup.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupWorktreeInstanceArtifacts,
+  deriveWorktreeInstanceId,
   readWorktreeInstancePointer,
   stopEmbeddedPostgresIfRunning,
 } from "../services/workspace-instance-cleanup.js";
@@ -79,6 +80,16 @@ afterEach(async () => {
 });
 
 describe("worktree instance cleanup", () => {
+  it("derives different instance IDs for distinct paths with the same normalized name", () => {
+    const parent = path.join(os.tmpdir(), "paperclip-instance-id-collision");
+    const plusPath = path.join(parent, "feature+cleanup");
+    const dashPath = path.join(parent, "feature-cleanup");
+
+    expect(deriveWorktreeInstanceId(plusPath)).not.toBe(deriveWorktreeInstanceId(dashPath));
+    expect(deriveWorktreeInstanceId(plusPath)).toMatch(/^feature-cleanup-[a-f0-9]{12}$/);
+    expect(deriveWorktreeInstanceId(dashPath)).toMatch(/^feature-cleanup-[a-f0-9]{12}$/);
+  });
+
   it("removes an instance directory inside the managed worktree instances root", async () => {
     const worktreesDir = await makeTempRoot("paperclip-managed-worktrees-");
     const workspacePath = await makeTempRoot("paperclip-cleanup-workspace-");

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -58,6 +58,7 @@ import type { Environment, EnvironmentLease } from "@paperclipai/shared";
 import { resolvePaperclipConfigPath } from "../paths.ts";
 import type { WorkspaceOperation } from "@paperclipai/shared";
 import type { WorkspaceOperationRecorder } from "../services/workspace-operations.ts";
+import { deriveWorktreeInstanceId } from "../services/workspace-instance-cleanup.ts";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -3315,12 +3316,13 @@ describe("realizeExecutionWorkspace", () => {
     });
 
     const worktreesDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cleanup-instances-"));
-    const instanceRoot = path.join(worktreesDir, "instances", "cleanup-recorder");
+    const instanceId = deriveWorktreeInstanceId(workspace.branchName!);
+    const instanceRoot = path.join(worktreesDir, "instances", instanceId);
     await fs.mkdir(path.join(instanceRoot, "db"), { recursive: true });
     await fs.mkdir(path.join(workspace.cwd, ".paperclip"), { recursive: true });
     await fs.writeFile(
       path.join(workspace.cwd, ".paperclip", ".env"),
-      `PAPERCLIP_HOME=${JSON.stringify(worktreesDir)}\nPAPERCLIP_INSTANCE_ID="cleanup-recorder"\n`,
+      `PAPERCLIP_HOME=${JSON.stringify(worktreesDir)}\nPAPERCLIP_INSTANCE_ID=${JSON.stringify(instanceId)}\n`,
       "utf8",
     );
     process.env.PAPERCLIP_WORKTREES_DIR = worktreesDir;

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3316,7 +3316,7 @@ describe("realizeExecutionWorkspace", () => {
     });
 
     const worktreesDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cleanup-instances-"));
-    const instanceId = deriveWorktreeInstanceId(workspace.branchName!);
+    const instanceId = deriveWorktreeInstanceId(workspace.cwd);
     const instanceRoot = path.join(worktreesDir, "instances", instanceId);
     await fs.mkdir(path.join(instanceRoot, "db"), { recursive: true });
     await fs.mkdir(path.join(workspace.cwd, ".paperclip"), { recursive: true });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1378,7 +1378,7 @@ describe("realizeExecutionWorkspace", () => {
       const envContents = await fs.readFile(envPath, "utf8");
       const configContents = JSON.parse(await fs.readFile(configPath, "utf8"));
       const configStats = await fs.lstat(configPath);
-      const expectedInstanceId = "pap-885-show-worktree-banner";
+      const expectedInstanceId = deriveWorktreeInstanceId(workspace.cwd);
       const expectedInstanceRoot = path.join(
         isolatedWorktreeHome,
         "instances",

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3314,6 +3314,17 @@ describe("realizeExecutionWorkspace", () => {
       },
     });
 
+    const worktreesDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-cleanup-instances-"));
+    const instanceRoot = path.join(worktreesDir, "instances", "cleanup-recorder");
+    await fs.mkdir(path.join(instanceRoot, "db"), { recursive: true });
+    await fs.mkdir(path.join(workspace.cwd, ".paperclip"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspace.cwd, ".paperclip", ".env"),
+      `PAPERCLIP_HOME=${JSON.stringify(worktreesDir)}\nPAPERCLIP_INSTANCE_ID="cleanup-recorder"\n`,
+      "utf8",
+    );
+    process.env.PAPERCLIP_WORKTREES_DIR = worktreesDir;
+
     await cleanupExecutionWorkspaceArtifacts({
       workspace: {
         id: "execution-workspace-1",
@@ -3339,16 +3350,23 @@ describe("realizeExecutionWorkspace", () => {
 
     expect(operations.map((operation) => operation.phase)).toEqual([
       "workspace_teardown",
+      "workspace_teardown",
       "worktree_cleanup",
       "worktree_cleanup",
     ]);
     expect(operations[0]?.command).toBe("printf 'cleanup ok\\n'");
     expect(operations[1]?.metadata).toMatchObject({
-      cleanupAction: "worktree_remove",
+      cleanupAction: "remove_worktree_instance",
+      instanceRoot,
     });
     expect(operations[2]?.metadata).toMatchObject({
+      cleanupAction: "worktree_remove",
+    });
+    expect(operations[3]?.metadata).toMatchObject({
       cleanupAction: "branch_delete",
     });
+    await expect(fs.stat(instanceRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    await fs.rm(worktreesDir, { recursive: true, force: true });
   });
 });
 

--- a/server/src/services/workspace-instance-cleanup.ts
+++ b/server/src/services/workspace-instance-cleanup.ts
@@ -12,6 +12,16 @@ const execFileAsync = promisify(execFile);
 const INSTANCE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const POSTGRES_STOP_TIMEOUT_MS = 10_000;
 
+export function deriveWorktreeInstanceId(worktreeName: string): string {
+  const normalized = worktreeName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "");
+  return normalized || "worktree";
+}
+
 export type WorktreeInstancePointer = {
   envPath: string;
   envContents: string;
@@ -28,11 +38,25 @@ export type WorktreeInstanceCleanupDependencies = {
   removeInstanceRoot: (instanceRoot: string) => Promise<void>;
 };
 
+export type EmbeddedPostgresStopDependencies = {
+  processIsAlive: (pid: number) => boolean;
+  readVerifiedPostgresCommand: (pid: number, dataDir: string) => Promise<string | null>;
+  signalProcess: (pid: number, signal: NodeJS.Signals) => void;
+  wait: (milliseconds: number) => Promise<unknown>;
+};
+
 const defaultCleanupDependencies: WorktreeInstanceCleanupDependencies = {
   stopEmbeddedPostgres: stopEmbeddedPostgresIfRunning,
   removeInstanceRoot: async (instanceRoot) => {
     await fs.rm(instanceRoot, { recursive: true, force: true });
   },
+};
+
+const defaultPostgresStopDependencies: EmbeddedPostgresStopDependencies = {
+  processIsAlive,
+  readVerifiedPostgresCommand,
+  signalProcess: (pid, signal) => process.kill(pid, signal),
+  wait: delay,
 };
 
 function isStrictChildPath(candidatePath: string, rootPath: string): boolean {
@@ -95,7 +119,10 @@ async function readVerifiedPostgresCommand(pid: number, dataDir: string): Promis
   }
 }
 
-export async function stopEmbeddedPostgresIfRunning(dataDir: string): Promise<boolean> {
+export async function stopEmbeddedPostgresIfRunning(
+  dataDir: string,
+  dependencies: EmbeddedPostgresStopDependencies = defaultPostgresStopDependencies,
+): Promise<boolean> {
   const postmasterPidPath = path.join(dataDir, "postmaster.pid");
   if (!await pathExists(postmasterPidPath)) return false;
 
@@ -112,14 +139,19 @@ export async function stopEmbeddedPostgresIfRunning(dataDir: string): Promise<bo
   if (canonicalRecordedDataDir !== canonicalDataDir) {
     throw new Error(`Refusing to remove ${dataDir}: postmaster.pid points at a different PostgreSQL data directory.`);
   }
-  if (!processIsAlive(pid)) return false;
-  if (await readVerifiedPostgresCommand(pid, canonicalDataDir) === null) return false;
+  if (!dependencies.processIsAlive(pid)) return false;
+  if (await dependencies.readVerifiedPostgresCommand(pid, canonicalDataDir) === null) return false;
 
-  process.kill(pid, "SIGINT");
+  try {
+    dependencies.signalProcess(pid, "SIGINT");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    throw error;
+  }
   const deadline = Date.now() + POSTGRES_STOP_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    if (!processIsAlive(pid)) return true;
-    await delay(100);
+    if (!dependencies.processIsAlive(pid)) return true;
+    await dependencies.wait(100);
   }
   throw new Error(`Embedded PostgreSQL process ${pid} did not stop within ${POSTGRES_STOP_TIMEOUT_MS}ms.`);
 }
@@ -137,19 +169,20 @@ export async function readWorktreeInstancePointer(workspacePath: string): Promis
   }
 }
 
-function resolveConfiguredInstanceRoot(pointer: WorktreeInstancePointer):
+function resolveConfiguredInstanceRoot(pointer: WorktreeInstancePointer, expectedInstanceId: string):
   | { instanceRoot: string }
-  | { warning: string; instanceRoot: string | null } {
+  | { warning: string; instanceRoot: string | null; refusalReason: string | null } {
   const env = parseEnvContents(pointer.envContents);
   const configuredHome = env.PAPERCLIP_HOME?.trim();
   const instanceId = env.PAPERCLIP_INSTANCE_ID?.trim();
   if (!configuredHome || !instanceId) {
-    return { warning: "", instanceRoot: null };
+    return { warning: "", instanceRoot: null, refusalReason: null };
   }
   if (!INSTANCE_ID_RE.test(instanceId)) {
     return {
       instanceRoot: null,
       warning: `Refusing worktree instance cleanup from ${pointer.envPath}: PAPERCLIP_INSTANCE_ID is not a safe path segment.`,
+      refusalReason: "unsafe_instance_id",
     };
   }
 
@@ -158,20 +191,30 @@ function resolveConfiguredInstanceRoot(pointer: WorktreeInstancePointer):
     return {
       instanceRoot: null,
       warning: `Refusing worktree instance cleanup from ${pointer.envPath}: PAPERCLIP_HOME is not absolute.`,
+      refusalReason: "non_absolute_home",
     };
   }
-  return { instanceRoot: path.resolve(expandedHome, "instances", instanceId) };
+  const instanceRoot = path.resolve(expandedHome, "instances", instanceId);
+  if (instanceId !== expectedInstanceId) {
+    return {
+      instanceRoot,
+      warning: `Refusing worktree instance cleanup from ${pointer.envPath}: PAPERCLIP_INSTANCE_ID "${instanceId}" does not match the expected workspace instance "${expectedInstanceId}".`,
+      refusalReason: "instance_id_mismatch",
+    };
+  }
+  return { instanceRoot };
 }
 
 export async function cleanupWorktreeInstanceArtifacts(input: {
   pointer: WorktreeInstancePointer;
   workspaceId: string;
   workspacePath: string;
+  expectedInstanceId: string;
   recorder?: WorkspaceOperationRecorder | null;
   worktreesDir?: string;
   dependencies?: WorktreeInstanceCleanupDependencies;
 }): Promise<WorktreeInstanceCleanupResult> {
-  const configured = resolveConfiguredInstanceRoot(input.pointer);
+  const configured = resolveConfiguredInstanceRoot(input.pointer, input.expectedInstanceId);
   if ("warning" in configured && !configured.warning) return { status: "not_configured" };
 
   const managedWorktreesDir = path.resolve(
@@ -197,8 +240,13 @@ export async function cleanupWorktreeInstanceArtifacts(input: {
     });
   };
 
-  if (!configuredInstanceRoot || !isStrictChildPath(configuredInstanceRoot, managedInstancesDir)) {
-    warning ||= `Refusing to remove instance directory "${configuredInstanceRoot ?? "unknown"}" because it is outside "${managedInstancesDir}".`;
+  if ("warning" in configured) {
+    await recordRefusal({ refusalReason: configured.refusalReason });
+    return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
+  }
+
+  if (!isStrictChildPath(configuredInstanceRoot, managedInstancesDir)) {
+    warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because it is outside "${managedInstancesDir}".`;
     await recordRefusal({ refusalReason: "outside_managed_instances_dir" });
     return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
   }

--- a/server/src/services/workspace-instance-cleanup.ts
+++ b/server/src/services/workspace-instance-cleanup.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,14 +13,17 @@ const execFileAsync = promisify(execFile);
 const INSTANCE_ID_RE = /^[A-Za-z0-9_-]+$/;
 const POSTGRES_STOP_TIMEOUT_MS = 10_000;
 
-export function deriveWorktreeInstanceId(worktreeName: string): string {
-  const normalized = worktreeName
+export function deriveWorktreeInstanceId(workspacePath: string): string {
+  const resolvedWorkspacePath = path.resolve(workspacePath);
+  const normalized = path.basename(resolvedWorkspacePath)
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^[-_]+|[-_]+$/g, "");
-  return normalized || "worktree";
+  const prefix = (normalized || "worktree").slice(0, 48);
+  const pathHash = createHash("sha256").update(resolvedWorkspacePath).digest("hex").slice(0, 12);
+  return `${prefix}-${pathHash}`;
 }
 
 export type WorktreeInstancePointer = {
@@ -221,9 +225,11 @@ export async function cleanupWorktreeInstanceArtifacts(input: {
     expandHomePrefix(input.worktreesDir?.trim() || process.env.PAPERCLIP_WORKTREES_DIR?.trim() || path.join(os.homedir(), ".paperclip-worktrees")),
   );
   const managedInstancesDir = path.join(managedWorktreesDir, "instances");
-  const configuredInstanceRoot = configured.instanceRoot;
-  let warning = "warning" in configured ? configured.warning : "";
-  const recordRefusal = async (metadata: Record<string, unknown>) => {
+  const recordRefusal = async (
+    instanceRoot: string | null,
+    refusalWarning: string,
+    metadata: Record<string, unknown>,
+  ) => {
     if (!input.recorder) return;
     await input.recorder.recordOperation({
       phase: "workspace_teardown",
@@ -231,23 +237,26 @@ export async function cleanupWorktreeInstanceArtifacts(input: {
       metadata: {
         workspaceId: input.workspaceId,
         workspacePath: input.workspacePath,
-        instanceRoot: configuredInstanceRoot,
+        instanceRoot,
         managedInstancesDir,
         cleanupAction: "remove_worktree_instance",
         ...metadata,
       },
-      run: async () => ({ status: "skipped", system: `${warning}\n` }),
+      run: async () => ({ status: "skipped", system: `${refusalWarning}\n` }),
     });
   };
 
   if ("warning" in configured) {
-    await recordRefusal({ refusalReason: configured.refusalReason });
-    return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
+    await recordRefusal(configured.instanceRoot, configured.warning, { refusalReason: configured.refusalReason });
+    return { status: "refused", instanceRoot: configured.instanceRoot, warning: configured.warning };
   }
+
+  const configuredInstanceRoot = configured.instanceRoot;
+  let warning = "";
 
   if (!isStrictChildPath(configuredInstanceRoot, managedInstancesDir)) {
     warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because it is outside "${managedInstancesDir}".`;
-    await recordRefusal({ refusalReason: "outside_managed_instances_dir" });
+    await recordRefusal(configuredInstanceRoot, warning, { refusalReason: "outside_managed_instances_dir" });
     return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
   }
 
@@ -260,19 +269,19 @@ export async function cleanupWorktreeInstanceArtifacts(input: {
   let canonicalInstanceRoot: string;
   try {
     [canonicalManagedWorktreesDir, canonicalManagedInstancesDir, canonicalInstanceRoot] = await Promise.all([
-      fs.realpath(managedWorktreesDir),
-      fs.realpath(managedInstancesDir),
-      fs.realpath(configuredInstanceRoot),
+      fs.realpath(managedWorktreesDir, { encoding: "utf8" }),
+      fs.realpath(managedInstancesDir, { encoding: "utf8" }),
+      fs.realpath(configuredInstanceRoot, { encoding: "utf8" }),
     ]);
   } catch (error) {
     warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because its canonical path could not be verified: ${error instanceof Error ? error.message : String(error)}`;
-    await recordRefusal({ refusalReason: "canonical_path_unavailable" });
+    await recordRefusal(configuredInstanceRoot, warning, { refusalReason: "canonical_path_unavailable" });
     return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
   }
 
   if (canonicalManagedInstancesDir !== path.join(canonicalManagedWorktreesDir, "instances")) {
     warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because the managed instances directory resolves outside "${canonicalManagedWorktreesDir}".`;
-    await recordRefusal({
+    await recordRefusal(configuredInstanceRoot, warning, {
       canonicalInstanceRoot,
       canonicalManagedInstancesDir,
       refusalReason: "managed_instances_dir_symlink",
@@ -282,7 +291,7 @@ export async function cleanupWorktreeInstanceArtifacts(input: {
 
   if (!isStrictChildPath(canonicalInstanceRoot, canonicalManagedInstancesDir)) {
     warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because its canonical path "${canonicalInstanceRoot}" is outside "${canonicalManagedInstancesDir}".`;
-    await recordRefusal({
+    await recordRefusal(configuredInstanceRoot, warning, {
       canonicalInstanceRoot,
       canonicalManagedInstancesDir,
       refusalReason: "canonical_path_outside_managed_instances_dir",
@@ -295,8 +304,8 @@ export async function cleanupWorktreeInstanceArtifacts(input: {
   const cleanup = async () => {
     postgresStopped = await dependencies.stopEmbeddedPostgres(path.join(canonicalInstanceRoot, "db"));
     const [currentManagedInstancesDir, currentInstanceRoot] = await Promise.all([
-      fs.realpath(managedInstancesDir),
-      fs.realpath(configuredInstanceRoot),
+      fs.realpath(managedInstancesDir, { encoding: "utf8" }),
+      fs.realpath(configuredInstanceRoot, { encoding: "utf8" }),
     ]);
     if (
       currentManagedInstancesDir !== canonicalManagedInstancesDir

--- a/server/src/services/workspace-instance-cleanup.ts
+++ b/server/src/services/workspace-instance-cleanup.ts
@@ -1,0 +1,288 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
+import { parse as parseEnvContents } from "dotenv";
+import { expandHomePrefix } from "../home-paths.js";
+import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
+
+const execFileAsync = promisify(execFile);
+const INSTANCE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const POSTGRES_STOP_TIMEOUT_MS = 10_000;
+
+export type WorktreeInstancePointer = {
+  envPath: string;
+  envContents: string;
+};
+
+export type WorktreeInstanceCleanupResult =
+  | { status: "not_configured" }
+  | { status: "already_absent"; instanceRoot: string }
+  | { status: "refused"; instanceRoot: string | null; warning: string }
+  | { status: "removed"; instanceRoot: string; postgresStopped: boolean };
+
+export type WorktreeInstanceCleanupDependencies = {
+  stopEmbeddedPostgres: (dataDir: string) => Promise<boolean>;
+  removeInstanceRoot: (instanceRoot: string) => Promise<void>;
+};
+
+const defaultCleanupDependencies: WorktreeInstanceCleanupDependencies = {
+  stopEmbeddedPostgres: stopEmbeddedPostgresIfRunning,
+  removeInstanceRoot: async (instanceRoot) => {
+    await fs.rm(instanceRoot, { recursive: true, force: true });
+  },
+};
+
+function isStrictChildPath(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  return relative.length > 0 && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+async function pathExists(value: string): Promise<boolean> {
+  return fs.lstat(value).then(() => true).catch(() => false);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function readVerifiedPostgresCommand(pid: number, dataDir: string): Promise<string | null> {
+  if (process.platform === "linux") {
+    const commandLinePath = `/proc/${pid}/cmdline`;
+    let commandLine: string;
+    try {
+      commandLine = await fs.readFile(commandLinePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+    const args = commandLine.split("\0").filter(Boolean);
+    const executable = path.basename(args[0] ?? "");
+    const dataDirFlagIndex = args.indexOf("-D");
+    const configuredDataDir = dataDirFlagIndex >= 0 ? args[dataDirFlagIndex + 1] : null;
+    if (!executable.includes("postgres") || !configuredDataDir) {
+      throw new Error(`Refusing to signal process ${pid}: it is not the expected embedded PostgreSQL process.`);
+    }
+    const canonicalConfiguredDataDir = await fs.realpath(configuredDataDir).catch(() => path.resolve(configuredDataDir));
+    if (canonicalConfiguredDataDir !== dataDir) {
+      throw new Error(`Refusing to signal process ${pid}: its PostgreSQL data directory does not match ${dataDir}.`);
+    }
+    return args.join(" ");
+  }
+
+  if (process.platform === "win32") {
+    throw new Error(`Refusing to signal process ${pid}: safe PostgreSQL process verification is unavailable on Windows.`);
+  }
+
+  try {
+    const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" });
+    const command = stdout.trim();
+    if (!command) return null;
+    if (!/(?:^|\/)postgres(?:\s|$)/.test(command) || !command.includes(dataDir)) {
+      throw new Error(`Refusing to signal process ${pid}: it is not the expected embedded PostgreSQL process.`);
+    }
+    return command;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return null;
+    throw error;
+  }
+}
+
+export async function stopEmbeddedPostgresIfRunning(dataDir: string): Promise<boolean> {
+  const postmasterPidPath = path.join(dataDir, "postmaster.pid");
+  if (!await pathExists(postmasterPidPath)) return false;
+
+  const canonicalDataDir = await fs.realpath(dataDir);
+  const pidContents = await fs.readFile(postmasterPidPath, "utf8");
+  const pidLines = pidContents.split(/\r?\n/);
+  const pid = Number(pidLines[0]?.trim());
+  const recordedDataDir = pidLines[1]?.trim();
+  if (!Number.isInteger(pid) || pid <= 0 || !recordedDataDir) {
+    throw new Error(`Refusing to remove ${dataDir}: its postmaster.pid is malformed.`);
+  }
+
+  const canonicalRecordedDataDir = await fs.realpath(recordedDataDir).catch(() => path.resolve(recordedDataDir));
+  if (canonicalRecordedDataDir !== canonicalDataDir) {
+    throw new Error(`Refusing to remove ${dataDir}: postmaster.pid points at a different PostgreSQL data directory.`);
+  }
+  if (!processIsAlive(pid)) return false;
+  if (await readVerifiedPostgresCommand(pid, canonicalDataDir) === null) return false;
+
+  process.kill(pid, "SIGINT");
+  const deadline = Date.now() + POSTGRES_STOP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!processIsAlive(pid)) return true;
+    await delay(100);
+  }
+  throw new Error(`Embedded PostgreSQL process ${pid} did not stop within ${POSTGRES_STOP_TIMEOUT_MS}ms.`);
+}
+
+export async function readWorktreeInstancePointer(workspacePath: string): Promise<WorktreeInstancePointer | null> {
+  const envPath = path.join(workspacePath, ".paperclip", ".env");
+  try {
+    return {
+      envPath,
+      envContents: await fs.readFile(envPath, "utf8"),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function resolveConfiguredInstanceRoot(pointer: WorktreeInstancePointer):
+  | { instanceRoot: string }
+  | { warning: string; instanceRoot: string | null } {
+  const env = parseEnvContents(pointer.envContents);
+  const configuredHome = env.PAPERCLIP_HOME?.trim();
+  const instanceId = env.PAPERCLIP_INSTANCE_ID?.trim();
+  if (!configuredHome || !instanceId) {
+    return { warning: "", instanceRoot: null };
+  }
+  if (!INSTANCE_ID_RE.test(instanceId)) {
+    return {
+      instanceRoot: null,
+      warning: `Refusing worktree instance cleanup from ${pointer.envPath}: PAPERCLIP_INSTANCE_ID is not a safe path segment.`,
+    };
+  }
+
+  const expandedHome = expandHomePrefix(configuredHome);
+  if (!path.isAbsolute(expandedHome)) {
+    return {
+      instanceRoot: null,
+      warning: `Refusing worktree instance cleanup from ${pointer.envPath}: PAPERCLIP_HOME is not absolute.`,
+    };
+  }
+  return { instanceRoot: path.resolve(expandedHome, "instances", instanceId) };
+}
+
+export async function cleanupWorktreeInstanceArtifacts(input: {
+  pointer: WorktreeInstancePointer;
+  workspaceId: string;
+  workspacePath: string;
+  recorder?: WorkspaceOperationRecorder | null;
+  worktreesDir?: string;
+  dependencies?: WorktreeInstanceCleanupDependencies;
+}): Promise<WorktreeInstanceCleanupResult> {
+  const configured = resolveConfiguredInstanceRoot(input.pointer);
+  if ("warning" in configured && !configured.warning) return { status: "not_configured" };
+
+  const managedWorktreesDir = path.resolve(
+    expandHomePrefix(input.worktreesDir?.trim() || process.env.PAPERCLIP_WORKTREES_DIR?.trim() || path.join(os.homedir(), ".paperclip-worktrees")),
+  );
+  const managedInstancesDir = path.join(managedWorktreesDir, "instances");
+  const configuredInstanceRoot = configured.instanceRoot;
+  let warning = "warning" in configured ? configured.warning : "";
+  const recordRefusal = async (metadata: Record<string, unknown>) => {
+    if (!input.recorder) return;
+    await input.recorder.recordOperation({
+      phase: "workspace_teardown",
+      cwd: input.workspacePath,
+      metadata: {
+        workspaceId: input.workspaceId,
+        workspacePath: input.workspacePath,
+        instanceRoot: configuredInstanceRoot,
+        managedInstancesDir,
+        cleanupAction: "remove_worktree_instance",
+        ...metadata,
+      },
+      run: async () => ({ status: "skipped", system: `${warning}\n` }),
+    });
+  };
+
+  if (!configuredInstanceRoot || !isStrictChildPath(configuredInstanceRoot, managedInstancesDir)) {
+    warning ||= `Refusing to remove instance directory "${configuredInstanceRoot ?? "unknown"}" because it is outside "${managedInstancesDir}".`;
+    await recordRefusal({ refusalReason: "outside_managed_instances_dir" });
+    return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
+  }
+
+  if (!await pathExists(configuredInstanceRoot)) {
+    return { status: "already_absent", instanceRoot: configuredInstanceRoot };
+  }
+
+  let canonicalManagedWorktreesDir: string;
+  let canonicalManagedInstancesDir: string;
+  let canonicalInstanceRoot: string;
+  try {
+    [canonicalManagedWorktreesDir, canonicalManagedInstancesDir, canonicalInstanceRoot] = await Promise.all([
+      fs.realpath(managedWorktreesDir),
+      fs.realpath(managedInstancesDir),
+      fs.realpath(configuredInstanceRoot),
+    ]);
+  } catch (error) {
+    warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because its canonical path could not be verified: ${error instanceof Error ? error.message : String(error)}`;
+    await recordRefusal({ refusalReason: "canonical_path_unavailable" });
+    return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
+  }
+
+  if (canonicalManagedInstancesDir !== path.join(canonicalManagedWorktreesDir, "instances")) {
+    warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because the managed instances directory resolves outside "${canonicalManagedWorktreesDir}".`;
+    await recordRefusal({
+      canonicalInstanceRoot,
+      canonicalManagedInstancesDir,
+      refusalReason: "managed_instances_dir_symlink",
+    });
+    return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
+  }
+
+  if (!isStrictChildPath(canonicalInstanceRoot, canonicalManagedInstancesDir)) {
+    warning = `Refusing to remove instance directory "${configuredInstanceRoot}" because its canonical path "${canonicalInstanceRoot}" is outside "${canonicalManagedInstancesDir}".`;
+    await recordRefusal({
+      canonicalInstanceRoot,
+      canonicalManagedInstancesDir,
+      refusalReason: "canonical_path_outside_managed_instances_dir",
+    });
+    return { status: "refused", instanceRoot: configuredInstanceRoot, warning };
+  }
+
+  const dependencies = input.dependencies ?? defaultCleanupDependencies;
+  let postgresStopped = false;
+  const cleanup = async () => {
+    postgresStopped = await dependencies.stopEmbeddedPostgres(path.join(canonicalInstanceRoot, "db"));
+    const [currentManagedInstancesDir, currentInstanceRoot] = await Promise.all([
+      fs.realpath(managedInstancesDir),
+      fs.realpath(configuredInstanceRoot),
+    ]);
+    if (
+      currentManagedInstancesDir !== canonicalManagedInstancesDir
+      || currentInstanceRoot !== canonicalInstanceRoot
+      || !isStrictChildPath(currentInstanceRoot, currentManagedInstancesDir)
+    ) {
+      throw new Error(`Refusing to remove instance directory "${configuredInstanceRoot}" because its canonical path changed during cleanup.`);
+    }
+    await dependencies.removeInstanceRoot(currentInstanceRoot);
+  };
+
+  if (input.recorder) {
+    await input.recorder.recordOperation({
+      phase: "workspace_teardown",
+      cwd: input.workspacePath,
+      metadata: {
+        workspaceId: input.workspaceId,
+        workspacePath: input.workspacePath,
+        instanceRoot: canonicalInstanceRoot,
+        managedInstancesDir: canonicalManagedInstancesDir,
+        cleanupAction: "remove_worktree_instance",
+      },
+      run: async () => {
+        await cleanup();
+        return {
+          status: "succeeded",
+          system: `Removed worktree instance directory ${canonicalInstanceRoot}\n`,
+          metadata: { postgresStopped },
+        };
+      },
+    });
+  } else {
+    await cleanup();
+  }
+
+  return { status: "removed", instanceRoot: canonicalInstanceRoot, postgresStopped };
+}

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -3204,16 +3204,12 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
   let worktreeInstancePointer: WorktreeInstancePointer | null = null;
   let expectedWorktreeInstanceId: string | null = null;
   if (input.workspace.providerType === "git_worktree" && workspacePath) {
-    if (!input.workspace.branchName) {
-      warnings.push("Could not clean worktree instance because the execution workspace has no authoritative branch name.");
-    } else {
-      expectedWorktreeInstanceId = deriveWorktreeInstanceId(input.workspace.branchName);
-      try {
-        // Capture the pointer before custom cleanup commands can remove the repo-local env file.
-        worktreeInstancePointer = await readWorktreeInstancePointer(workspacePath);
-      } catch (err) {
-        warnings.push(`Could not read worktree instance pointer: ${err instanceof Error ? err.message : String(err)}`);
-      }
+    expectedWorktreeInstanceId = deriveWorktreeInstanceId(workspacePath);
+    try {
+      // Capture the pointer before custom cleanup commands can remove the repo-local env file.
+      worktreeInstancePointer = await readWorktreeInstancePointer(workspacePath);
+    } catch (err) {
+      warnings.push(`Could not read worktree instance pointer: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
   const createdByRuntime = input.workspace.metadata?.createdByRuntime === true;

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -40,6 +40,7 @@ import { logActivity } from "./activity-log.js";
 import { readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
 import {
   cleanupWorktreeInstanceArtifacts,
+  deriveWorktreeInstanceId,
   readWorktreeInstancePointer,
   type WorktreeInstancePointer,
 } from "./workspace-instance-cleanup.js";
@@ -3201,12 +3202,18 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     projectWorkspaceCwd: input.projectWorkspace?.cwd ?? null,
   });
   let worktreeInstancePointer: WorktreeInstancePointer | null = null;
+  let expectedWorktreeInstanceId: string | null = null;
   if (input.workspace.providerType === "git_worktree" && workspacePath) {
-    try {
-      // Capture the pointer before custom cleanup commands can remove the repo-local env file.
-      worktreeInstancePointer = await readWorktreeInstancePointer(workspacePath);
-    } catch (err) {
-      warnings.push(`Could not read worktree instance pointer: ${err instanceof Error ? err.message : String(err)}`);
+    if (!input.workspace.branchName) {
+      warnings.push("Could not clean worktree instance because the execution workspace has no authoritative branch name.");
+    } else {
+      expectedWorktreeInstanceId = deriveWorktreeInstanceId(input.workspace.branchName);
+      try {
+        // Capture the pointer before custom cleanup commands can remove the repo-local env file.
+        worktreeInstancePointer = await readWorktreeInstancePointer(workspacePath);
+      } catch (err) {
+        warnings.push(`Could not read worktree instance pointer: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
   const createdByRuntime = input.workspace.metadata?.createdByRuntime === true;
@@ -3244,12 +3251,13 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     }
   }
 
-  if (worktreeInstancePointer && workspacePath) {
+  if (worktreeInstancePointer && workspacePath && expectedWorktreeInstanceId) {
     try {
       const result = await cleanupWorktreeInstanceArtifacts({
         pointer: worktreeInstancePointer,
         workspaceId: input.workspace.id,
         workspacePath,
+        expectedInstanceId: expectedWorktreeInstanceId,
         recorder: input.recorder,
       });
       if (result.status === "refused") warnings.push(result.warning);

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -38,6 +38,11 @@ import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { executionWorkspaceService, readExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { logActivity } from "./activity-log.js";
 import { readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
+import {
+  cleanupWorktreeInstanceArtifacts,
+  readWorktreeInstancePointer,
+  type WorktreeInstancePointer,
+} from "./workspace-instance-cleanup.js";
 
 export function resolveShell(): string {
   const fallback = process.platform === "win32" ? "sh" : "/bin/sh";
@@ -3195,6 +3200,15 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
     workspace: input.workspace,
     projectWorkspaceCwd: input.projectWorkspace?.cwd ?? null,
   });
+  let worktreeInstancePointer: WorktreeInstancePointer | null = null;
+  if (input.workspace.providerType === "git_worktree" && workspacePath) {
+    try {
+      // Capture the pointer before custom cleanup commands can remove the repo-local env file.
+      worktreeInstancePointer = await readWorktreeInstancePointer(workspacePath);
+    } catch (err) {
+      warnings.push(`Could not read worktree instance pointer: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
   const createdByRuntime = input.workspace.metadata?.createdByRuntime === true;
   const cleanupCommands = [
     input.cleanupCommand ?? null,
@@ -3227,6 +3241,20 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
       });
     } catch (err) {
       warnings.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  if (worktreeInstancePointer && workspacePath) {
+    try {
+      const result = await cleanupWorktreeInstanceArtifacts({
+        pointer: worktreeInstancePointer,
+        workspaceId: input.workspace.id,
+        workspacePath,
+        recorder: input.recorder,
+      });
+      if (result.status === "refused") warnings.push(result.warning);
+    } catch (err) {
+      warnings.push(`Failed to clean worktree instance: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip creates isolated instances for server-managed git worktrees.
> - The worktree teardown path removes the git worktree but leaves its isolated instance directory behind.
> - The leaked directory can retain an embedded PostgreSQL process and database files.
> - Teardown must remove only the collision-resistant instance assigned to that exact worktree path.
> - This pull request stops the verified embedded PostgreSQL process and removes the guarded instance directory.
> - The benefit is complete worktree cleanup without risk to another, default, or live Paperclip instance.

## Linked Issues or Issue Description

**What happened?**

Closing a server-managed git worktree removed the git worktree and branch, but it left the isolated Paperclip instance directory behind. A live embedded PostgreSQL process could also keep running against that directory.

**Expected behavior**

Worktree teardown must stop the isolated embedded PostgreSQL process and remove only the instance assigned to that exact worktree. It must refuse mismatched instance IDs and all paths outside `PAPERCLIP_WORKTREES_DIR/instances/`.

**Steps to reproduce**

1. Create a server-managed git worktree with a repo-local `.paperclip/.env` file.
2. Start its isolated embedded PostgreSQL instance.
3. Close the execution workspace.
4. Observe that the git worktree is removed but the isolated instance directory remains.

**Paperclip version or commit**

The bug reproduces on `master` before this change.

**Deployment mode**

Local development with a server-managed git worktree and embedded PostgreSQL.

## What Changed

- Give server-managed worktrees collision-resistant instance IDs derived from their resolved absolute paths.
- Capture the repo-local instance pointer before custom teardown commands can remove it.
- Require the pointer's instance ID to match the exact worktree-derived ID.
- Resolve and validate the instance path against the canonical managed worktree instance root.
- Verify and stop the matching embedded PostgreSQL process before directory removal, including process-exit races.
- Record successful and refused cleanup operations in the workspace operation log.
- Add focused ownership, process-race, path-safety, and runtime integration tests.
- Document automatic isolated-instance cleanup for server-managed worktrees.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/workspace-instance-cleanup.test.ts` — 9 tests passed.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/workspace-runtime.test.ts -t "records teardown and cleanup operations when a recorder is provided"` — 1 test passed and 99 tests skipped.
- `node scripts/__tests__/provision-worktree-self-heal.test.mjs` — 4 tests passed.
- `bash -n scripts/provision-worktree.sh` — passed.
- `pnpm --filter @paperclipai/server build` — passed.
- `git diff --check` — passed.

## Risks

The main risk is removal of the wrong instance directory. Provisioning assigns a path-derived ID with a SHA-256 suffix, and cleanup requires that exact ID in addition to a safe instance identifier, an absolute configured home, a strict child path, canonical path checks, and a second canonical path check immediately before removal. It refuses legacy or mismatched IDs, symlink escapes, and all paths outside the managed worktree instance root. Cleanup failures become visible warnings and do not delete an unverified path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5. The runtime does not expose the exact model snapshot or context-window size. The agent used reasoning, repository tools, GitHub tools, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
