### PR TITLE
feat: defer worktree database seeding until runtime

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -425,12 +425,25 @@ describe("worktree helpers", () => {
       expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-pending"))).toBe(false);
       expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-complete"))).toBe(true);
 
-      const incompleteLockPath = path.join(targetRoot, ".paperclip", "seed.lock");
+      const abandonedLockPath = path.join(targetRoot, ".paperclip", "seed.lock.abandoned.json");
       fs.rmSync(path.join(targetRoot, ".paperclip", "seed-complete"));
       markWorktreeSeedPending({ configPath: targetConfigPath, sourceConfigPath });
-      fs.writeFileSync(incompleteLockPath, "");
-      const staleTime = new Date(Date.now() - 60_000);
-      fs.utimesSync(incompleteLockPath, staleTime, staleTime);
+      fs.writeFileSync(abandonedLockPath, `${JSON.stringify({
+        version: 1,
+        state: "ready",
+        pid: 2_147_483_647,
+        token: "abandoned",
+        ticket: 1,
+      })}\n`);
+      fs.writeFileSync(
+        path.join(targetRoot, ".paperclip", "seed.lock.abandoned-choosing.json"),
+        `${JSON.stringify({
+          version: 1,
+          state: "choosing",
+          pid: 2_147_483_647,
+          token: "abandoned-choosing",
+        })}\n`,
+      );
 
       const recoveredSeedDatabase = vi.fn().mockImplementation(async () => {
         await new Promise<void>((resolve) => setTimeout(resolve, 25));
@@ -455,8 +468,10 @@ describe("worktree helpers", () => {
 
       expect(recoveredSeedDatabase).toHaveBeenCalledTimes(1);
       expect(recoveredSeeds.filter((result) => result.seeded)).toHaveLength(1);
-      expect(fs.existsSync(incompleteLockPath)).toBe(false);
-      expect(fs.existsSync(`${incompleteLockPath}.reclaim`)).toBe(false);
+      expect(
+        fs.readdirSync(path.join(targetRoot, ".paperclip"))
+          .filter((name) => name.startsWith("seed.lock.")),
+      ).toEqual([]);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -20,6 +20,8 @@ import {
 import {
   copyGitHooksToWorktreeGitDir,
   copySeededSecretsKey,
+  ensureWorktreeSeeded,
+  markWorktreeSeedPending,
   pauseSeededScheduledRoutines,
   quarantineSeededWorktreeExecutionState,
   readSourceAttachmentBody,
@@ -349,6 +351,109 @@ describe("worktree helpers", () => {
 
     expect(full.excludedTables).toEqual([]);
     expect(full.nullifyColumns).toEqual({});
+  });
+
+  it("ensure-seeded seeds once and fast-exits on the seed-complete marker", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-ensure-seeded-"));
+    try {
+      const sourceConfigPath = path.join(tempRoot, "source", "config.json");
+      const targetRoot = path.join(tempRoot, "worktree");
+      const targetConfigPath = path.join(targetRoot, ".paperclip", "config.json");
+      const targetPaths = resolveWorktreeLocalPaths({
+        cwd: targetRoot,
+        homeDir: path.join(tempRoot, "worktree-home"),
+        instanceId: "ensure-seeded-test",
+      });
+      const sourceConfig = buildSourceConfig();
+      const targetConfig = buildWorktreeConfig({
+        sourceConfig,
+        paths: targetPaths,
+        serverPort: 3199,
+        databasePort: 54999,
+      });
+      fs.mkdirSync(path.dirname(sourceConfigPath), { recursive: true });
+      fs.mkdirSync(path.dirname(targetConfigPath), { recursive: true });
+      fs.writeFileSync(sourceConfigPath, `${JSON.stringify(sourceConfig)}\n`);
+      fs.writeFileSync(targetConfigPath, `${JSON.stringify(targetConfig)}\n`);
+      fs.writeFileSync(
+        path.join(targetRoot, ".paperclip", ".env"),
+        `PAPERCLIP_HOME=${targetPaths.homeDir}\nPAPERCLIP_INSTANCE_ID=${targetPaths.instanceId}\n`,
+      );
+      markWorktreeSeedPending({ configPath: targetConfigPath, sourceConfigPath });
+
+      const seedDatabase = vi.fn().mockResolvedValue({
+        backupSummary: "snapshot.sql",
+        pausedScheduledRoutines: 2,
+        executionQuarantine: {
+          disabledTimerHeartbeats: 1,
+          resetRunningAgents: 1,
+          quarantinedInProgressIssues: 1,
+          unassignedTodoIssues: 1,
+          unassignedReviewIssues: 1,
+        },
+        reboundWorkspaces: [],
+      });
+
+      await expect(
+        ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase }),
+      ).resolves.toMatchObject({ seeded: true, reason: "seeded" });
+      await expect(
+        ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase }),
+      ).resolves.toEqual({ seeded: false, reason: "complete_marker" });
+
+      expect(seedDatabase).toHaveBeenCalledTimes(1);
+      expect(seedDatabase).toHaveBeenCalledWith(expect.objectContaining({
+        sourceConfigPath,
+        seedMode: "minimal",
+        instanceId: "ensure-seeded-test",
+      }));
+      expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-pending"))).toBe(false);
+      expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-complete"))).toBe(true);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("ensure-seeded keeps the pending marker when seeding fails", async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-ensure-seeded-failure-"));
+    try {
+      const sourceConfigPath = path.join(tempRoot, "source", "config.json");
+      const targetRoot = path.join(tempRoot, "worktree");
+      const targetConfigPath = path.join(targetRoot, ".paperclip", "config.json");
+      const targetPaths = resolveWorktreeLocalPaths({
+        cwd: targetRoot,
+        homeDir: path.join(tempRoot, "worktree-home"),
+        instanceId: "ensure-seeded-failure",
+      });
+      const sourceConfig = buildSourceConfig();
+      const targetConfig = buildWorktreeConfig({
+        sourceConfig,
+        paths: targetPaths,
+        serverPort: 3198,
+        databasePort: 54998,
+      });
+      fs.mkdirSync(path.dirname(sourceConfigPath), { recursive: true });
+      fs.mkdirSync(path.dirname(targetConfigPath), { recursive: true });
+      fs.writeFileSync(sourceConfigPath, `${JSON.stringify(sourceConfig)}\n`);
+      fs.writeFileSync(targetConfigPath, `${JSON.stringify(targetConfig)}\n`);
+      fs.writeFileSync(
+        path.join(targetRoot, ".paperclip", ".env"),
+        `PAPERCLIP_HOME=${targetPaths.homeDir}\nPAPERCLIP_INSTANCE_ID=${targetPaths.instanceId}\n`,
+      );
+      markWorktreeSeedPending({ configPath: targetConfigPath, sourceConfigPath });
+
+      await expect(
+        ensureWorktreeSeeded(
+          { config: targetConfigPath },
+          { seedDatabase: vi.fn().mockRejectedValue(new Error("seed failed")) },
+        ),
+      ).rejects.toThrow("seed failed");
+
+      expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-pending"))).toBe(true);
+      expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-complete"))).toBe(false);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   itEmbeddedPostgres("quarantines copied live execution state in seeded worktree databases", async () => {

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -353,7 +353,7 @@ describe("worktree helpers", () => {
     expect(full.nullifyColumns).toEqual({});
   });
 
-  it("ensure-seeded seeds once and fast-exits on the seed-complete marker", async () => {
+  it("ensure-seeded serializes concurrent seeds and fast-exits on the seed-complete marker", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-worktree-ensure-seeded-"));
     try {
       const sourceConfigPath = path.join(tempRoot, "source", "config.json");
@@ -381,25 +381,40 @@ describe("worktree helpers", () => {
       );
       markWorktreeSeedPending({ configPath: targetConfigPath, sourceConfigPath });
 
-      const seedDatabase = vi.fn().mockResolvedValue({
-        backupSummary: "snapshot.sql",
-        pausedScheduledRoutines: 2,
-        executionQuarantine: {
-          disabledTimerHeartbeats: 1,
-          resetRunningAgents: 1,
-          quarantinedInProgressIssues: 1,
-          unassignedTodoIssues: 1,
-          unassignedReviewIssues: 1,
-        },
-        reboundWorkspaces: [],
+      let releaseSeed: (() => void) | undefined;
+      let reportSeedStarted: (() => void) | undefined;
+      const seedStarted = new Promise<void>((resolve) => {
+        reportSeedStarted = resolve;
+      });
+      const seedGate = new Promise<void>((resolve) => {
+        releaseSeed = resolve;
+      });
+      const seedDatabase = vi.fn().mockImplementation(async () => {
+        reportSeedStarted?.();
+        await seedGate;
+        return {
+          backupSummary: "snapshot.sql",
+          pausedScheduledRoutines: 2,
+          executionQuarantine: {
+            disabledTimerHeartbeats: 1,
+            resetRunningAgents: 1,
+            quarantinedInProgressIssues: 1,
+            unassignedTodoIssues: 1,
+            unassignedReviewIssues: 1,
+          },
+          reboundWorkspaces: [],
+        };
       });
 
-      await expect(
-        ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase }),
-      ).resolves.toMatchObject({ seeded: true, reason: "seeded" });
-      await expect(
-        ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase }),
-      ).resolves.toEqual({ seeded: false, reason: "complete_marker" });
+      const firstSeed = ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase });
+      await seedStarted;
+      const concurrentSeed = ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase });
+      await new Promise<void>((resolve) => setTimeout(resolve, 150));
+      expect(seedDatabase).toHaveBeenCalledTimes(1);
+      releaseSeed?.();
+
+      await expect(firstSeed).resolves.toMatchObject({ seeded: true, reason: "seeded" });
+      await expect(concurrentSeed).resolves.toEqual({ seeded: false, reason: "complete_marker" });
 
       expect(seedDatabase).toHaveBeenCalledTimes(1);
       expect(seedDatabase).toHaveBeenCalledWith(expect.objectContaining({

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -424,6 +424,15 @@ describe("worktree helpers", () => {
       }));
       expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-pending"))).toBe(false);
       expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-complete"))).toBe(true);
+
+      const incompleteLockPath = path.join(targetRoot, ".paperclip", "seed.lock");
+      fs.writeFileSync(incompleteLockPath, "");
+      const staleTime = new Date(Date.now() - 60_000);
+      fs.utimesSync(incompleteLockPath, staleTime, staleTime);
+      await expect(
+        ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase }),
+      ).resolves.toEqual({ seeded: false, reason: "complete_marker" });
+      expect(fs.existsSync(incompleteLockPath)).toBe(false);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -426,13 +426,37 @@ describe("worktree helpers", () => {
       expect(fs.existsSync(path.join(targetRoot, ".paperclip", "seed-complete"))).toBe(true);
 
       const incompleteLockPath = path.join(targetRoot, ".paperclip", "seed.lock");
+      fs.rmSync(path.join(targetRoot, ".paperclip", "seed-complete"));
+      markWorktreeSeedPending({ configPath: targetConfigPath, sourceConfigPath });
       fs.writeFileSync(incompleteLockPath, "");
       const staleTime = new Date(Date.now() - 60_000);
       fs.utimesSync(incompleteLockPath, staleTime, staleTime);
-      await expect(
-        ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase }),
-      ).resolves.toEqual({ seeded: false, reason: "complete_marker" });
+
+      const recoveredSeedDatabase = vi.fn().mockImplementation(async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        return {
+          backupSummary: "recovered.sql",
+          pausedScheduledRoutines: 0,
+          executionQuarantine: {
+            disabledTimerHeartbeats: 0,
+            resetRunningAgents: 0,
+            quarantinedInProgressIssues: 0,
+            unassignedTodoIssues: 0,
+            unassignedReviewIssues: 0,
+          },
+          reboundWorkspaces: [],
+        };
+      });
+      const recoveredSeeds = await Promise.all(
+        Array.from({ length: 8 }, () => (
+          ensureWorktreeSeeded({ config: targetConfigPath }, { seedDatabase: recoveredSeedDatabase })
+        )),
+      );
+
+      expect(recoveredSeedDatabase).toHaveBeenCalledTimes(1);
+      expect(recoveredSeeds.filter((result) => result.seeded)).toHaveLength(1);
       expect(fs.existsSync(incompleteLockPath)).toBe(false);
+      expect(fs.existsSync(`${incompleteLockPath}.reclaim`)).toBe(false);
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -432,6 +432,7 @@ describe("worktree helpers", () => {
         version: 1,
         state: "ready",
         pid: 2_147_483_647,
+        processIdentity: "dead-process",
         token: "abandoned",
         ticket: 1,
       })}\n`);
@@ -441,7 +442,19 @@ describe("worktree helpers", () => {
           version: 1,
           state: "choosing",
           pid: 2_147_483_647,
+          processIdentity: "dead-process",
           token: "abandoned-choosing",
+        })}\n`,
+      );
+      fs.writeFileSync(
+        path.join(targetRoot, ".paperclip", "seed.lock.reused-pid.json"),
+        `${JSON.stringify({
+          version: 1,
+          state: "ready",
+          pid: process.pid,
+          processIdentity: "previous-process-with-same-pid",
+          token: "reused-pid",
+          ticket: 1,
         })}\n`,
       );
 

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -18,6 +18,7 @@ import {
 } from "../config/home.js";
 import { assertForegroundRunAllowed } from "../services/service-manager.js";
 import { printUpdateNotice } from "../update-notice.js";
+import { ensureWorktreeSeeded } from "./worktree.js";
 
 interface RunOptions {
   config?: string;
@@ -65,6 +66,11 @@ export async function runCommand(opts: RunOptions): Promise<void> {
 
     p.log.step("No config found. Starting onboarding...");
     await onboard({ config: configPath, invokedByRun: true, bind: opts.bind });
+  }
+
+  const seedResult = await ensureWorktreeSeeded({ config: configPath });
+  if (seedResult.seeded) {
+    p.log.success("Completed deferred worktree database seed.");
   }
 
   p.log.step("Running doctor checks...");

--- a/cli/src/commands/worktree-lib.ts
+++ b/cli/src/commands/worktree-lib.ts
@@ -5,6 +5,8 @@ import { expandHomePrefix } from "../config/home.js";
 
 export const DEFAULT_WORKTREE_HOME = "~/.paperclip-worktrees";
 export const WORKTREE_SEED_MODES = ["minimal", "full"] as const;
+export const WORKTREE_SEED_PENDING_MARKER = "seed-pending";
+export const WORKTREE_SEED_COMPLETE_MARKER = "seed-complete";
 
 export type WorktreeSeedMode = (typeof WORKTREE_SEED_MODES)[number];
 
@@ -49,6 +51,19 @@ export type WorktreeUiBranding = {
   name: string;
   color: string;
 };
+
+export type WorktreeSeedMarkerPaths = {
+  pending: string;
+  complete: string;
+};
+
+export function resolveWorktreeSeedMarkerPaths(configPath: string): WorktreeSeedMarkerPaths {
+  const configDir = path.dirname(path.resolve(configPath));
+  return {
+    pending: path.resolve(configDir, WORKTREE_SEED_PENDING_MARKER),
+    complete: path.resolve(configDir, WORKTREE_SEED_COMPLETE_MARKER),
+  };
+}
 
 export function isWorktreeSeedMode(value: string): value is WorktreeSeedMode {
   return (WORKTREE_SEED_MODES as readonly string[]).includes(value);

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1454,116 +1454,136 @@ function readWorktreeSeedPendingMarker(filePath: string): WorktreeSeedPendingMar
   return parsed as WorktreeSeedPendingMarker;
 }
 
-const WORKTREE_SEED_LOCK_FILE = "seed.lock";
-const WORKTREE_SEED_RECLAIM_FILE = "seed.lock.reclaim";
+const WORKTREE_SEED_LOCK_PREFIX = "seed.lock.";
+const WORKTREE_SEED_LOCK_SUFFIX = ".json";
 const WORKTREE_SEED_LOCK_TIMEOUT_MS = 30 * 60 * 1_000;
-const WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS = 5_000;
 
-async function worktreeSeedLockExists(lockPath: string): Promise<boolean> {
+type WorktreeSeedLockEntry = {
+  version: 1;
+  state: "choosing" | "ready";
+  pid: number;
+  token: string;
+  ticket?: number;
+};
+
+function parseWorktreeSeedLockEntry(value: string): WorktreeSeedLockEntry | null {
   try {
-    await fsPromises.access(lockPath);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
-    throw error;
+    const parsed = JSON.parse(value) as Partial<WorktreeSeedLockEntry>;
+    if (
+      parsed.version !== 1
+      || (parsed.state !== "choosing" && parsed.state !== "ready")
+      || !Number.isInteger(parsed.pid)
+      || (parsed.pid ?? 0) <= 0
+      || typeof parsed.token !== "string"
+      || !parsed.token
+      || (parsed.state === "ready" && (!Number.isSafeInteger(parsed.ticket) || (parsed.ticket ?? 0) <= 0))
+    ) {
+      return null;
+    }
+    return parsed as WorktreeSeedLockEntry;
+  } catch {
+    return null;
   }
 }
 
-async function removeOwnedWorktreeSeedLock(lockPath: string, token: string): Promise<void> {
+function worktreeSeedLockOwnerIsAlive(pid: number): boolean {
   try {
-    if ((await fsPromises.readFile(lockPath, "utf8")).trim() === token) {
-      await fsPromises.rm(lockPath, { force: true });
-    }
+    process.kill(pid, 0);
+    return true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
+}
+
+async function writeWorktreeSeedLockEntry(
+  entryPath: string,
+  entry: WorktreeSeedLockEntry,
+): Promise<void> {
+  const tempPath = `${entryPath}.tmp-${Math.random().toString(16).slice(2)}`;
+  try {
+    await fsPromises.writeFile(tempPath, `${JSON.stringify(entry)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    await fsPromises.rename(tempPath, entryPath);
+  } finally {
+    await fsPromises.rm(tempPath, { force: true });
+  }
+}
+
+async function listLiveWorktreeSeedLocks(lockDir: string): Promise<WorktreeSeedLockEntry[]> {
+  const entries: WorktreeSeedLockEntry[] = [];
+  for (const name of await fsPromises.readdir(lockDir)) {
+    if (!name.startsWith(WORKTREE_SEED_LOCK_PREFIX) || !name.endsWith(WORKTREE_SEED_LOCK_SUFFIX)) {
+      continue;
+    }
+    const entryPath = path.join(lockDir, name);
+    let entry: WorktreeSeedLockEntry | null;
+    try {
+      entry = parseWorktreeSeedLockEntry(await fsPromises.readFile(entryPath, "utf8"));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
+    if (!entry || !worktreeSeedLockOwnerIsAlive(entry.pid)) {
+      await fsPromises.rm(entryPath, { force: true });
+      continue;
+    }
+    entries.push(entry);
+  }
+  return entries;
 }
 
 async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
-  const lockPath = path.resolve(path.dirname(configPath), WORKTREE_SEED_LOCK_FILE);
-  const reclaimPath = path.resolve(path.dirname(configPath), WORKTREE_SEED_RECLAIM_FILE);
-  const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  const lockDir = path.resolve(path.dirname(configPath));
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const entryPath = path.join(lockDir, `${WORKTREE_SEED_LOCK_PREFIX}${token}${WORKTREE_SEED_LOCK_SUFFIX}`);
   const deadline = Date.now() + WORKTREE_SEED_LOCK_TIMEOUT_MS;
-  await fsPromises.mkdir(path.dirname(lockPath), { recursive: true });
+  await fsPromises.mkdir(lockDir, { recursive: true });
+  await writeWorktreeSeedLockEntry(entryPath, {
+    version: 1,
+    state: "choosing",
+    pid: process.pid,
+    token,
+  });
 
-  while (true) {
-    try {
-      if (await worktreeSeedLockExists(reclaimPath)) {
-        throw Object.assign(new Error("Seed lock reclamation is in progress."), { code: "EEXIST" });
-      }
-      await fsPromises.writeFile(lockPath, `${token}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
-      if (await worktreeSeedLockExists(reclaimPath)) {
-        await removeOwnedWorktreeSeedLock(lockPath, token);
-        throw Object.assign(new Error("Seed lock reclamation is in progress."), { code: "EEXIST" });
-      }
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      try {
-        const existingToken = (await fsPromises.readFile(lockPath, "utf8")).trim();
-        const ownerPid = Number.parseInt(existingToken.split(":", 1)[0] ?? "", 10);
-        let ownerIsAlive: boolean | null = null;
-        if (Number.isInteger(ownerPid) && ownerPid > 0) {
-          try {
-            process.kill(ownerPid, 0);
-            ownerIsAlive = true;
-          } catch (processError) {
-            ownerIsAlive = (processError as NodeJS.ErrnoException).code !== "ESRCH";
-          }
-        }
-        const incompleteLockIsStale = ownerIsAlive === null
-          && Date.now() - (await fsPromises.stat(lockPath)).mtimeMs >= WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS;
-        if (ownerIsAlive === false || incompleteLockIsStale) {
-          const reclaimToken = `${token}:reclaim`;
-          try {
-            await fsPromises.writeFile(reclaimPath, `${reclaimToken}\n`, {
-              encoding: "utf8",
-              mode: 0o600,
-              flag: "wx",
-            });
-            const currentToken = (await fsPromises.readFile(lockPath, "utf8")).trim();
-            if (currentToken === existingToken) {
-              const currentOwnerPid = Number.parseInt(currentToken.split(":", 1)[0] ?? "", 10);
-              let currentOwnerIsAlive: boolean | null = null;
-              if (Number.isInteger(currentOwnerPid) && currentOwnerPid > 0) {
-                try {
-                  process.kill(currentOwnerPid, 0);
-                  currentOwnerIsAlive = true;
-                } catch (processError) {
-                  currentOwnerIsAlive = (processError as NodeJS.ErrnoException).code !== "ESRCH";
-                }
-              }
-              const currentIncompleteLockIsStale = currentOwnerIsAlive === null
-                && Date.now() - (await fsPromises.stat(lockPath)).mtimeMs >= WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS;
-              if (currentOwnerIsAlive === false || currentIncompleteLockIsStale) {
-                await fsPromises.rm(lockPath, { force: true });
-              }
-            }
-          } catch (reclaimError) {
-            if ((reclaimError as NodeJS.ErrnoException).code !== "EEXIST") throw reclaimError;
-          } finally {
-            await removeOwnedWorktreeSeedLock(reclaimPath, reclaimToken);
-          }
-          continue;
-        }
-      } catch (readError) {
-        if ((readError as NodeJS.ErrnoException).code === "ENOENT") continue;
-        throw readError;
-      }
+  try {
+    const ticket = Math.max(
+      0,
+      ...(await listLiveWorktreeSeedLocks(lockDir))
+        .filter((entry) => entry.state === "ready")
+        .map((entry) => entry.ticket ?? 0),
+    ) + 1;
+    await writeWorktreeSeedLockEntry(entryPath, {
+      version: 1,
+      state: "ready",
+      pid: process.pid,
+      token,
+      ticket,
+    });
+
+    while (true) {
+      const entries = await listLiveWorktreeSeedLocks(lockDir);
+      const anotherEntryIsChoosing = entries.some((entry) => entry.token !== token && entry.state === "choosing");
+      const firstReadyEntry = entries
+        .filter((entry): entry is WorktreeSeedLockEntry & { ticket: number } => (
+          entry.state === "ready" && entry.ticket !== undefined
+        ))
+        .sort((left, right) => left.ticket - right.ticket || left.token.localeCompare(right.token))[0];
+      if (!anotherEntryIsChoosing && firstReadyEntry?.token === token) break;
       if (Date.now() >= deadline) {
         throw new Error(
           `Another worktree database seed is still running. ` +
-          `If no seed process is active, remove the stale lock at ${lockPath} and retry.`,
+          `If no seed process is active, remove stale seed lock entries from ${lockDir} and retry.`,
         );
       }
       await new Promise<void>((resolve) => setTimeout(resolve, 100));
     }
-  }
 
-  try {
     return await callback();
   } finally {
-    await removeOwnedWorktreeSeedLock(lockPath, token);
+    await fsPromises.rm(entryPath, { force: true });
   }
 }
 

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
@@ -1536,7 +1537,7 @@ async function writeWorktreeSeedLockEntry(
   entryPath: string,
   entry: WorktreeSeedLockEntry,
 ): Promise<void> {
-  const tempPath = `${entryPath}.tmp-${Math.random().toString(16).slice(2)}`;
+  const tempPath = `${entryPath}.tmp-${randomUUID()}`;
   try {
     await fsPromises.writeFile(tempPath, `${JSON.stringify(entry)}\n`, {
       encoding: "utf8",
@@ -1579,7 +1580,7 @@ async function listLiveWorktreeSeedLocks(lockDir: string): Promise<WorktreeSeedL
 
 async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
   const lockDir = path.resolve(path.dirname(configPath));
-  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const token = `${process.pid}-${Date.now()}-${randomUUID()}`;
   const processIdentity = readWorktreeSeedProcessIdentity(process.pid);
   if (!processIdentity) {
     throw new Error(`Unable to determine process identity before locking worktree seed state at ${lockDir}.`);

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1455,18 +1455,47 @@ function readWorktreeSeedPendingMarker(filePath: string): WorktreeSeedPendingMar
 }
 
 const WORKTREE_SEED_LOCK_FILE = "seed.lock";
+const WORKTREE_SEED_RECLAIM_FILE = "seed.lock.reclaim";
 const WORKTREE_SEED_LOCK_TIMEOUT_MS = 30 * 60 * 1_000;
 const WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS = 5_000;
 
+async function worktreeSeedLockExists(lockPath: string): Promise<boolean> {
+  try {
+    await fsPromises.access(lockPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function removeOwnedWorktreeSeedLock(lockPath: string, token: string): Promise<void> {
+  try {
+    if ((await fsPromises.readFile(lockPath, "utf8")).trim() === token) {
+      await fsPromises.rm(lockPath, { force: true });
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
 async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
   const lockPath = path.resolve(path.dirname(configPath), WORKTREE_SEED_LOCK_FILE);
+  const reclaimPath = path.resolve(path.dirname(configPath), WORKTREE_SEED_RECLAIM_FILE);
   const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
   const deadline = Date.now() + WORKTREE_SEED_LOCK_TIMEOUT_MS;
   await fsPromises.mkdir(path.dirname(lockPath), { recursive: true });
 
   while (true) {
     try {
+      if (await worktreeSeedLockExists(reclaimPath)) {
+        throw Object.assign(new Error("Seed lock reclamation is in progress."), { code: "EEXIST" });
+      }
       await fsPromises.writeFile(lockPath, `${token}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      if (await worktreeSeedLockExists(reclaimPath)) {
+        await removeOwnedWorktreeSeedLock(lockPath, token);
+        throw Object.assign(new Error("Seed lock reclamation is in progress."), { code: "EEXIST" });
+      }
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
@@ -1484,11 +1513,37 @@ async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promi
         }
         const incompleteLockIsStale = ownerIsAlive === null
           && Date.now() - (await fsPromises.stat(lockPath)).mtimeMs >= WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS;
-        if (
-          (ownerIsAlive === false || incompleteLockIsStale)
-          && (await fsPromises.readFile(lockPath, "utf8")).trim() === existingToken
-        ) {
-          await fsPromises.rm(lockPath, { force: true });
+        if (ownerIsAlive === false || incompleteLockIsStale) {
+          const reclaimToken = `${token}:reclaim`;
+          try {
+            await fsPromises.writeFile(reclaimPath, `${reclaimToken}\n`, {
+              encoding: "utf8",
+              mode: 0o600,
+              flag: "wx",
+            });
+            const currentToken = (await fsPromises.readFile(lockPath, "utf8")).trim();
+            if (currentToken === existingToken) {
+              const currentOwnerPid = Number.parseInt(currentToken.split(":", 1)[0] ?? "", 10);
+              let currentOwnerIsAlive: boolean | null = null;
+              if (Number.isInteger(currentOwnerPid) && currentOwnerPid > 0) {
+                try {
+                  process.kill(currentOwnerPid, 0);
+                  currentOwnerIsAlive = true;
+                } catch (processError) {
+                  currentOwnerIsAlive = (processError as NodeJS.ErrnoException).code !== "ESRCH";
+                }
+              }
+              const currentIncompleteLockIsStale = currentOwnerIsAlive === null
+                && Date.now() - (await fsPromises.stat(lockPath)).mtimeMs >= WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS;
+              if (currentOwnerIsAlive === false || currentIncompleteLockIsStale) {
+                await fsPromises.rm(lockPath, { force: true });
+              }
+            }
+          } catch (reclaimError) {
+            if ((reclaimError as NodeJS.ErrnoException).code !== "EEXIST") throw reclaimError;
+          } finally {
+            await removeOwnedWorktreeSeedLock(reclaimPath, reclaimToken);
+          }
           continue;
         }
       } catch (readError) {
@@ -1508,13 +1563,7 @@ async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promi
   try {
     return await callback();
   } finally {
-    try {
-      if ((await fsPromises.readFile(lockPath, "utf8")).trim() === token) {
-        await fsPromises.rm(lockPath, { force: true });
-      }
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-    }
+    await removeOwnedWorktreeSeedLock(lockPath, token);
   }
 }
 

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -64,6 +64,7 @@ import {
   isWorktreeSeedMode,
   resolveSuggestedWorktreeName,
   resolveWorktreeSeedPlan,
+  resolveWorktreeSeedMarkerPaths,
   resolveWorktreeLocalPaths,
   sanitizeWorktreeInstanceId,
   type WorktreeSeedPlan,
@@ -147,6 +148,14 @@ type WorktreeRepairOptions = {
   allowLiveTarget?: boolean;
 };
 
+type WorktreeEnsureSeededOptions = {
+  config?: string;
+  fromConfig?: string;
+  fromDataDir?: string;
+  fromInstance?: string;
+  preserveLiveWork?: boolean;
+};
+
 type EmbeddedPostgresInstance = {
   initialise(): Promise<void>;
   start(): Promise<void>;
@@ -192,6 +201,29 @@ type SeedWorktreeDatabaseResult = {
     fromCwd: string;
     toCwd: string;
   }>;
+};
+
+type WorktreeSeedPendingMarker = {
+  version: 1;
+  state: "pending";
+  sourceConfigPath: string;
+  seedMode: "minimal";
+  createdAt: string;
+};
+
+type WorktreeSeedCompleteMarker = {
+  version: 1;
+  state: "complete";
+  seedMode: WorktreeSeedMode;
+  completedAt: string;
+};
+
+type SeedWorktreeDatabase = typeof seedWorktreeDatabase;
+
+export type EnsureWorktreeSeededResult = {
+  seeded: boolean;
+  reason: "seeded" | "complete_marker" | "legacy_unmarked";
+  details?: SeedWorktreeDatabaseResult;
 };
 
 export type SeededWorktreeExecutionQuarantineSummary = {
@@ -1359,6 +1391,125 @@ async function seedWorktreeDatabase(input: {
   }
 }
 
+function writeWorktreeSeedMarker(
+  filePath: string,
+  marker: WorktreeSeedPendingMarker | WorktreeSeedCompleteMarker,
+): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(marker, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function markWorktreeSeedPending(input: {
+  configPath: string;
+  sourceConfigPath: string;
+  now?: Date;
+}): void {
+  const markers = resolveWorktreeSeedMarkerPaths(input.configPath);
+  rmSync(markers.complete, { force: true });
+  writeWorktreeSeedMarker(markers.pending, {
+    version: 1,
+    state: "pending",
+    sourceConfigPath: path.resolve(input.sourceConfigPath),
+    seedMode: "minimal",
+    createdAt: (input.now ?? new Date()).toISOString(),
+  });
+}
+
+export function markWorktreeSeedComplete(input: {
+  configPath: string;
+  seedMode?: WorktreeSeedMode;
+  now?: Date;
+}): void {
+  const markers = resolveWorktreeSeedMarkerPaths(input.configPath);
+  writeWorktreeSeedMarker(markers.complete, {
+    version: 1,
+    state: "complete",
+    seedMode: input.seedMode ?? "minimal",
+    completedAt: (input.now ?? new Date()).toISOString(),
+  });
+  rmSync(markers.pending, { force: true });
+}
+
+function readWorktreeSeedPendingMarker(filePath: string): WorktreeSeedPendingMarker {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Invalid worktree seed-pending marker at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (
+    !parsed
+    || typeof parsed !== "object"
+    || (parsed as { version?: unknown }).version !== 1
+    || (parsed as { state?: unknown }).state !== "pending"
+    || typeof (parsed as { sourceConfigPath?: unknown }).sourceConfigPath !== "string"
+    || !(parsed as { sourceConfigPath: string }).sourceConfigPath.trim()
+  ) {
+    throw new Error(`Invalid worktree seed-pending marker at ${filePath}.`);
+  }
+
+  return parsed as WorktreeSeedPendingMarker;
+}
+
+export async function ensureWorktreeSeeded(
+  opts: WorktreeEnsureSeededOptions = {},
+  dependencies: { seedDatabase?: SeedWorktreeDatabase } = {},
+): Promise<EnsureWorktreeSeededResult> {
+  const configPath = resolveConfigPath(opts.config);
+  const markers = resolveWorktreeSeedMarkerPaths(configPath);
+
+  if (existsSync(markers.complete)) {
+    return { seeded: false, reason: "complete_marker" };
+  }
+  if (!existsSync(markers.pending)) {
+    // Worktrees created before lazy seeding shipped were seeded eagerly and
+    // have neither marker. Preserve that compatibility without re-cloning.
+    return { seeded: false, reason: "legacy_unmarked" };
+  }
+
+  const pending = readWorktreeSeedPendingMarker(markers.pending);
+  const sourceConfigPath = opts.fromConfig || opts.fromDataDir || opts.fromInstance
+    ? resolveSourceConfigPath({
+        fromConfig: opts.fromConfig,
+        fromDataDir: opts.fromDataDir,
+        fromInstance: opts.fromInstance,
+      })
+    : path.resolve(pending.sourceConfigPath);
+
+  if (path.resolve(sourceConfigPath) === path.resolve(configPath)) {
+    throw new Error(
+      "Source and target Paperclip configs are the same. Pass --from-config for the source instance.",
+    );
+  }
+
+  const sourceConfig = readConfig(sourceConfigPath);
+  if (!sourceConfig) {
+    throw new Error(`Source config not found at ${sourceConfigPath}.`);
+  }
+  const targetConfig = readConfig(configPath);
+  if (!targetConfig) {
+    throw new Error(`Target config not found at ${configPath}.`);
+  }
+
+  const targetRoot = path.dirname(path.dirname(configPath));
+  const targetPaths = resolveWorktreeReseedTargetPaths({ configPath, rootPath: targetRoot });
+  const seedDatabase = dependencies.seedDatabase ?? seedWorktreeDatabase;
+  const details = await seedDatabase({
+    sourceConfigPath,
+    sourceConfig,
+    targetConfig,
+    targetPaths,
+    instanceId: targetPaths.instanceId,
+    seedMode: "minimal",
+    preserveLiveWork: opts.preserveLiveWork,
+  });
+  markWorktreeSeedComplete({ configPath });
+  return { seeded: true, reason: "seeded", details };
+}
+
 export function resolveWorktreeSeedBackupEngine(seedPlan: WorktreeSeedPlan): "auto" | "javascript" {
   return seedPlan.excludedTables.length === 0 && Object.keys(seedPlan.nullifyColumns).length === 0
     ? "auto"
@@ -1401,6 +1552,9 @@ async function runWorktreeInit(opts: WorktreeInitOptions): Promise<void> {
     // checkout, and a recursive rmSync here would nuke them all.
     rmSync(paths.configPath, { force: true });
     rmSync(paths.envPath, { force: true });
+    const seedMarkers = resolveWorktreeSeedMarkerPaths(paths.configPath);
+    rmSync(seedMarkers.pending, { force: true });
+    rmSync(seedMarkers.complete, { force: true });
     rmSync(paths.instanceRoot, { recursive: true, force: true });
   }
 
@@ -1420,6 +1574,10 @@ async function runWorktreeInit(opts: WorktreeInitOptions): Promise<void> {
   });
 
   writeConfig(targetConfig, paths.configPath);
+  markWorktreeSeedPending({
+    configPath: paths.configPath,
+    sourceConfigPath,
+  });
   const sourceEnvEntries = readPaperclipEnvEntries(resolvePaperclipEnvFile(sourceConfigPath));
   const existingAgentJwtSecret =
     nonEmpty(sourceEnvEntries.PAPERCLIP_AGENT_JWT_SECRET) ??
@@ -1461,6 +1619,7 @@ async function runWorktreeInit(opts: WorktreeInitOptions): Promise<void> {
       seedExecutionQuarantineSummary = seeded.executionQuarantine;
       pausedScheduledRoutineCount = seeded.pausedScheduledRoutines;
       reboundWorkspaceSummary = seeded.reboundWorkspaces;
+      markWorktreeSeedComplete({ configPath: paths.configPath, seedMode });
       spinner.stop(`Seeded isolated worktree database (${seedMode}).`);
     } catch (error) {
       spinner.stop(pc.red("Failed to seed worktree database."));
@@ -1509,6 +1668,46 @@ export async function worktreeInitCommand(opts: WorktreeInitOptions): Promise<vo
   printPaperclipCliBanner();
   p.intro(pc.bgCyan(pc.black(" paperclipai worktree init ")));
   await runWorktreeInit(opts);
+}
+
+export async function worktreeEnsureSeededCommand(opts: WorktreeEnsureSeededOptions): Promise<void> {
+  printPaperclipCliBanner();
+  p.intro(pc.bgCyan(pc.black(" paperclipai worktree ensure-seeded ")));
+
+  const markers = resolveWorktreeSeedMarkerPaths(resolveConfigPath(opts.config));
+  if (existsSync(markers.complete) || !existsSync(markers.pending)) {
+    const result = await ensureWorktreeSeeded(opts);
+    const reason = result.reason === "complete_marker"
+      ? "Seed-complete marker already present."
+      : "No seed-pending marker found; treating this legacy worktree as already seeded.";
+    p.outro(pc.green(reason));
+    return;
+  }
+
+  const spinner = p.spinner();
+  spinner.start("Seeding isolated worktree database from source instance (minimal)...");
+  try {
+    const result = await ensureWorktreeSeeded(opts);
+    spinner.stop("Seeded isolated worktree database (minimal).");
+    if (result.details) {
+      p.log.message(pc.dim(`Seed snapshot: ${result.details.backupSummary}`));
+      p.log.message(
+        pc.dim(
+          `Seed execution quarantine: ${formatSeededWorktreeExecutionQuarantineSummary(result.details.executionQuarantine)}`,
+        ),
+      );
+      p.log.message(pc.dim(`Paused scheduled routines: ${result.details.pausedScheduledRoutines}`));
+      for (const rebound of result.details.reboundWorkspaces) {
+        p.log.message(
+          pc.dim(`Rebound workspace ${rebound.name}: ${rebound.fromCwd} -> ${rebound.toCwd}`),
+        );
+      }
+    }
+    p.outro(pc.green("Worktree database seed complete."));
+  } catch (error) {
+    spinner.stop(pc.red("Failed to seed worktree database."));
+    throw error;
+  }
 }
 
 export async function worktreeMakeCommand(nameArg: string, opts: WorktreeMakeOptions): Promise<void> {
@@ -3158,6 +3357,7 @@ async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
       seedMode,
       preserveLiveWork: opts.preserveLiveWork,
     });
+    markWorktreeSeedComplete({ configPath: targetEndpoint.configPath, seedMode });
     spinner.stop(`Reseeded ${targetEndpoint.label} (${seedMode}).`);
     p.log.message(pc.dim(`Source: ${source.configPath}`));
     p.log.message(pc.dim(`Target: ${targetEndpoint.configPath}`));
@@ -3318,6 +3518,16 @@ export function registerWorktreeCommands(program: Command): void {
     .option("-c, --config <path>", "Path to config file")
     .option("--json", "Print JSON instead of shell exports")
     .action(worktreeEnvCommand);
+
+  worktree
+    .command("ensure-seeded")
+    .description("Seed a seed-pending worktree database exactly once from its source instance")
+    .option("-c, --config <path>", "Path to the target worktree config file")
+    .option("--from-config <path>", "Source config.json to seed from (defaults to the seed-pending marker)")
+    .option("--from-data-dir <path>", "Source PAPERCLIP_HOME used when deriving the source config")
+    .option("--from-instance <id>", "Source instance id when deriving the source config")
+    .option("--preserve-live-work", "Do not quarantine copied agent timers or assigned open issues", false)
+    .action(worktreeEnsureSeededCommand);
 
   program
     .command("worktree:list")

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1462,6 +1462,7 @@ type WorktreeSeedLockEntry = {
   version: 1;
   state: "choosing" | "ready";
   pid: number;
+  processIdentity: string;
   token: string;
   ticket?: number;
 };
@@ -1474,6 +1475,8 @@ function parseWorktreeSeedLockEntry(value: string): WorktreeSeedLockEntry | null
       || (parsed.state !== "choosing" && parsed.state !== "ready")
       || !Number.isInteger(parsed.pid)
       || (parsed.pid ?? 0) <= 0
+      || typeof parsed.processIdentity !== "string"
+      || !parsed.processIdentity
       || typeof parsed.token !== "string"
       || !parsed.token
       || (parsed.state === "ready" && (!Number.isSafeInteger(parsed.ticket) || (parsed.ticket ?? 0) <= 0))
@@ -1486,12 +1489,37 @@ function parseWorktreeSeedLockEntry(value: string): WorktreeSeedLockEntry | null
   }
 }
 
-function worktreeSeedLockOwnerIsAlive(pid: number): boolean {
+function readWorktreeSeedProcessIdentity(pid: number): string | null {
   try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+    if (process.platform === "linux") {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fieldsAfterCommand = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+      const startTicks = fieldsAfterCommand[19];
+      if (!startTicks) return null;
+      const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+      return `linux:${bootId}:${startTicks}`;
+    }
+    if (process.platform === "win32") {
+      const startedAt = execFileSync(
+        "powershell.exe",
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+        ],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      ).trim();
+      return startedAt ? `win32:${startedAt}` : null;
+    }
+    const startedAt = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return startedAt ? `${process.platform}:${startedAt}` : null;
+  } catch {
+    return null;
   }
 }
 
@@ -1526,7 +1554,7 @@ async function listLiveWorktreeSeedLocks(lockDir: string): Promise<WorktreeSeedL
       if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
       throw error;
     }
-    if (!entry || !worktreeSeedLockOwnerIsAlive(entry.pid)) {
+    if (!entry || readWorktreeSeedProcessIdentity(entry.pid) !== entry.processIdentity) {
       await fsPromises.rm(entryPath, { force: true });
       continue;
     }
@@ -1538,6 +1566,10 @@ async function listLiveWorktreeSeedLocks(lockDir: string): Promise<WorktreeSeedL
 async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
   const lockDir = path.resolve(path.dirname(configPath));
   const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const processIdentity = readWorktreeSeedProcessIdentity(process.pid);
+  if (!processIdentity) {
+    throw new Error(`Unable to determine process identity before locking worktree seed state at ${lockDir}.`);
+  }
   const entryPath = path.join(lockDir, `${WORKTREE_SEED_LOCK_PREFIX}${token}${WORKTREE_SEED_LOCK_SUFFIX}`);
   const deadline = Date.now() + WORKTREE_SEED_LOCK_TIMEOUT_MS;
   await fsPromises.mkdir(lockDir, { recursive: true });
@@ -1545,6 +1577,7 @@ async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promi
     version: 1,
     state: "choosing",
     pid: process.pid,
+    processIdentity,
     token,
   });
 
@@ -1559,6 +1592,7 @@ async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promi
       version: 1,
       state: "ready",
       pid: process.pid,
+      processIdentity,
       token,
       ticket,
     });

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1454,11 +1454,71 @@ function readWorktreeSeedPendingMarker(filePath: string): WorktreeSeedPendingMar
   return parsed as WorktreeSeedPendingMarker;
 }
 
-export async function ensureWorktreeSeeded(
+const WORKTREE_SEED_LOCK_FILE = "seed.lock";
+const WORKTREE_SEED_LOCK_TIMEOUT_MS = 30 * 60 * 1_000;
+
+async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
+  const lockPath = path.resolve(path.dirname(configPath), WORKTREE_SEED_LOCK_FILE);
+  const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  const deadline = Date.now() + WORKTREE_SEED_LOCK_TIMEOUT_MS;
+  await fsPromises.mkdir(path.dirname(lockPath), { recursive: true });
+
+  while (true) {
+    try {
+      await fsPromises.writeFile(lockPath, `${token}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        const existingToken = (await fsPromises.readFile(lockPath, "utf8")).trim();
+        const ownerPid = Number.parseInt(existingToken.split(":", 1)[0] ?? "", 10);
+        // Treat a missing or partially written token as owned. Another process
+        // can observe the lock after its exclusive create but before its token
+        // write completes, and removing it here would defeat the mutex.
+        let ownerIsAlive = true;
+        if (Number.isInteger(ownerPid) && ownerPid > 0) {
+          try {
+            process.kill(ownerPid, 0);
+          } catch (processError) {
+            ownerIsAlive = (processError as NodeJS.ErrnoException).code !== "ESRCH";
+          }
+        }
+        if (!ownerIsAlive && (await fsPromises.readFile(lockPath, "utf8")).trim() === existingToken) {
+          await fsPromises.rm(lockPath, { force: true });
+          continue;
+        }
+      } catch (readError) {
+        if ((readError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw readError;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Another worktree database seed is still running. ` +
+          `If no seed process is active, remove the stale lock at ${lockPath} and retry.`,
+        );
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    try {
+      if ((await fsPromises.readFile(lockPath, "utf8")).trim() === token) {
+        await fsPromises.rm(lockPath, { force: true });
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function ensureWorktreeSeededUnlocked(
+  configPath: string,
   opts: WorktreeEnsureSeededOptions = {},
   dependencies: { seedDatabase?: SeedWorktreeDatabase } = {},
 ): Promise<EnsureWorktreeSeededResult> {
-  const configPath = resolveConfigPath(opts.config);
   const markers = resolveWorktreeSeedMarkerPaths(configPath);
 
   if (existsSync(markers.complete)) {
@@ -1508,6 +1568,17 @@ export async function ensureWorktreeSeeded(
   });
   markWorktreeSeedComplete({ configPath });
   return { seeded: true, reason: "seeded", details };
+}
+
+export async function ensureWorktreeSeeded(
+  opts: WorktreeEnsureSeededOptions = {},
+  dependencies: { seedDatabase?: SeedWorktreeDatabase } = {},
+): Promise<EnsureWorktreeSeededResult> {
+  const configPath = resolveConfigPath(opts.config);
+  return withWorktreeSeedLock(
+    configPath,
+    () => ensureWorktreeSeededUnlocked(configPath, opts, dependencies),
+  );
 }
 
 export function resolveWorktreeSeedBackupEngine(seedPlan: WorktreeSeedPlan): "auto" | "javascript" {

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1587,7 +1587,7 @@ export function resolveWorktreeSeedBackupEngine(seedPlan: WorktreeSeedPlan): "au
     : "javascript";
 }
 
-async function runWorktreeInit(opts: WorktreeInitOptions): Promise<void> {
+async function runWorktreeInitUnlocked(opts: WorktreeInitOptions): Promise<void> {
   const cwd = process.cwd();
   const worktreeName = resolveSuggestedWorktreeName(
     cwd,
@@ -1733,6 +1733,21 @@ async function runWorktreeInit(opts: WorktreeInitOptions): Promise<void> {
       `Worktree ready. Run Paperclip inside this repo and the CLI/server will use ${paths.instanceId} automatically.`,
     ),
   );
+}
+
+async function runWorktreeInit(opts: WorktreeInitOptions): Promise<void> {
+  const cwd = process.cwd();
+  const worktreeName = resolveSuggestedWorktreeName(
+    cwd,
+    opts.name ?? detectGitBranchName(cwd) ?? undefined,
+  );
+  const instanceId = sanitizeWorktreeInstanceId(opts.instance ?? worktreeName);
+  const configPath = resolveWorktreeLocalPaths({
+    cwd,
+    homeDir: resolveWorktreeHome(opts.home),
+    instanceId,
+  }).configPath;
+  await withWorktreeSeedLock(configPath, () => runWorktreeInitUnlocked(opts));
 }
 
 export async function worktreeInitCommand(opts: WorktreeInitOptions): Promise<void> {
@@ -3363,15 +3378,15 @@ export async function worktreeMergeHistoryCommand(sourceArg: string | undefined,
   }
 }
 
-async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
+async function runWorktreeReseedUnlocked(
+  opts: WorktreeReseedOptions,
+  targetEndpoint: ResolvedWorktreeEndpoint,
+): Promise<void> {
   const seedMode = opts.seedMode ?? "full";
   if (!isWorktreeSeedMode(seedMode)) {
     throw new Error(`Unsupported seed mode "${seedMode}". Expected one of: minimal, full.`);
   }
 
-  const targetEndpoint = opts.to
-    ? resolveWorktreeEndpointFromSelector(opts.to, { allowCurrent: true })
-    : resolveCurrentEndpoint();
   const source = resolveWorktreeReseedSource(opts);
 
   if (path.resolve(source.configPath) === path.resolve(targetEndpoint.configPath)) {
@@ -3451,6 +3466,16 @@ async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
     spinner.stop(pc.red("Failed to reseed worktree database."));
     throw error;
   }
+}
+
+async function runWorktreeReseed(opts: WorktreeReseedOptions): Promise<void> {
+  const targetEndpoint = opts.to
+    ? resolveWorktreeEndpointFromSelector(opts.to, { allowCurrent: true })
+    : resolveCurrentEndpoint();
+  await withWorktreeSeedLock(
+    targetEndpoint.configPath,
+    () => runWorktreeReseedUnlocked(opts, targetEndpoint),
+  );
 }
 
 export async function worktreeReseedCommand(opts: WorktreeReseedOptions): Promise<void> {

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1456,6 +1456,7 @@ function readWorktreeSeedPendingMarker(filePath: string): WorktreeSeedPendingMar
 
 const WORKTREE_SEED_LOCK_FILE = "seed.lock";
 const WORKTREE_SEED_LOCK_TIMEOUT_MS = 30 * 60 * 1_000;
+const WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS = 5_000;
 
 async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promise<T>): Promise<T> {
   const lockPath = path.resolve(path.dirname(configPath), WORKTREE_SEED_LOCK_FILE);
@@ -1472,18 +1473,21 @@ async function withWorktreeSeedLock<T>(configPath: string, callback: () => Promi
       try {
         const existingToken = (await fsPromises.readFile(lockPath, "utf8")).trim();
         const ownerPid = Number.parseInt(existingToken.split(":", 1)[0] ?? "", 10);
-        // Treat a missing or partially written token as owned. Another process
-        // can observe the lock after its exclusive create but before its token
-        // write completes, and removing it here would defeat the mutex.
-        let ownerIsAlive = true;
+        let ownerIsAlive: boolean | null = null;
         if (Number.isInteger(ownerPid) && ownerPid > 0) {
           try {
             process.kill(ownerPid, 0);
+            ownerIsAlive = true;
           } catch (processError) {
             ownerIsAlive = (processError as NodeJS.ErrnoException).code !== "ESRCH";
           }
         }
-        if (!ownerIsAlive && (await fsPromises.readFile(lockPath, "utf8")).trim() === existingToken) {
+        const incompleteLockIsStale = ownerIsAlive === null
+          && Date.now() - (await fsPromises.stat(lockPath)).mtimeMs >= WORKTREE_SEED_INCOMPLETE_LOCK_GRACE_MS;
+        if (
+          (ownerIsAlive === false || incompleteLockIsStale)
+          && (await fsPromises.readFile(lockPath, "utf8")).trim() === existingToken
+        ) {
           await fsPromises.rm(lockPath, { force: true });
           continue;
         }

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -1523,6 +1523,15 @@ function readWorktreeSeedProcessIdentity(pid: number): string | null {
   }
 }
 
+function worktreeSeedProcessExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
 async function writeWorktreeSeedLockEntry(
   entryPath: string,
   entry: WorktreeSeedLockEntry,
@@ -1554,7 +1563,12 @@ async function listLiveWorktreeSeedLocks(lockDir: string): Promise<WorktreeSeedL
       if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
       throw error;
     }
-    if (!entry || readWorktreeSeedProcessIdentity(entry.pid) !== entry.processIdentity) {
+    if (!entry || !worktreeSeedProcessExists(entry.pid)) {
+      await fsPromises.rm(entryPath, { force: true });
+      continue;
+    }
+    const processIdentity = readWorktreeSeedProcessIdentity(entry.pid);
+    if (processIdentity !== null && processIdentity !== entry.processIdentity) {
       await fsPromises.rm(entryPath, { force: true });
       continue;
     }

--- a/scripts/__tests__/provision-worktree-self-heal.test.mjs
+++ b/scripts/__tests__/provision-worktree-self-heal.test.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 const script = new URL("../provision-worktree.sh", import.meta.url).pathname;
+const runtimeScript = new URL("../provision-worktree-runtime.sh", import.meta.url).pathname;
 
 // Keep the PATH minimal so the fallback ladder is deterministic: node must be
 // reachable, but a globally installed `paperclipai` must not shadow the paths
@@ -34,7 +35,7 @@ test.after(() => {
  * initExit: exit code for `... index.ts worktree init ...`; on 0 the fake CLI
  *           writes a marker config so tests can tell CLI init from fallback.
  */
-function makeBaseWorkspace({ helpExit, initExit }) {
+function makeBaseWorkspace({ helpExit, initExit, ensureExit = 0 }) {
   const baseCwd = makeTempDir("paperclip-provision-base-");
   const runnerPath = path.join(baseCwd, "cli", "node_modules", "tsx", "dist", "cli.mjs");
   const entryPath = path.join(baseCwd, "cli", "src", "index.ts");
@@ -46,6 +47,7 @@ function makeBaseWorkspace({ helpExit, initExit }) {
     `
 import fs from "node:fs";
 const cliArgs = process.argv.slice(3);
+fs.appendFileSync(${JSON.stringify(path.join(baseCwd, "cli-invocations.log"))}, JSON.stringify(cliArgs) + "\\n");
 if (cliArgs.includes("--help")) {
   if (${helpExit} !== 0) console.error("ERR_MODULE_NOT_FOUND: drizzle-orm");
   process.exit(${helpExit});
@@ -58,6 +60,15 @@ if (cliArgs[0] === "worktree" && cliArgs[1] === "init") {
   fs.mkdirSync(".paperclip", { recursive: true });
   fs.writeFileSync(".paperclip/config.json", JSON.stringify({ $meta: { source: "fake-cli" } }));
   fs.writeFileSync(".paperclip/.env", "PAPERCLIP_IN_WORKTREE=true\\n");
+  process.exit(0);
+}
+if (cliArgs[0] === "worktree" && cliArgs[1] === "ensure-seeded") {
+  if (${ensureExit} !== 0) {
+    console.error("fake worktree ensure-seeded failure");
+    process.exit(${ensureExit});
+  }
+  fs.rmSync(".paperclip/seed-pending", { force: true });
+  fs.writeFileSync(".paperclip/seed-complete", "{}\\n");
   process.exit(0);
 }
 process.exit(0);
@@ -85,6 +96,34 @@ function runProvision(baseCwd, { pathPrefix } = {}) {
   return { result, worktreeCwd, worktreesHome };
 }
 
+function runRuntimeProvision(baseCwd, worktreeCwd) {
+  const worktreesHome = makeTempDir("paperclip-provision-runtime-home-");
+  return spawnSync("bash", [runtimeScript], {
+    cwd: worktreeCwd,
+    encoding: "utf8",
+    env: {
+      PATH: testPath,
+      HOME: os.homedir(),
+      PAPERCLIP_WORKSPACE_BASE_CWD: baseCwd,
+      PAPERCLIP_WORKSPACE_CWD: worktreeCwd,
+      PAPERCLIP_WORKSPACE_BRANCH: "feature/provision-runtime-test",
+      PAPERCLIP_WORKTREES_DIR: worktreesHome,
+      PAPERCLIP_HOME: path.join(worktreesHome, "no-such-instance-home"),
+    },
+  });
+}
+
+function readCliInvocations(baseCwd) {
+  const logPath = path.join(baseCwd, "cli-invocations.log");
+  if (!fs.existsSync(logPath)) return [];
+  return fs
+    .readFileSync(logPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
 function readWorktreeConfig(worktreeCwd) {
   const configPath = path.join(worktreeCwd, ".paperclip", "config.json");
   assert.ok(fs.existsSync(configPath), `expected ${configPath} to exist`);
@@ -98,6 +137,14 @@ test("uses the base CLI when its import graph boots", () => {
   assert.equal(result.status, 0, result.stderr);
   const config = readWorktreeConfig(worktreeCwd);
   assert.equal(config.$meta.source, "fake-cli");
+  assert.ok(fs.existsSync(path.join(worktreeCwd, ".paperclip", "seed-pending")));
+  const initInvocation = readCliInvocations(baseCwd).find(
+    (args) => args[0] === "worktree" && args[1] === "init",
+  );
+  assert.ok(
+    initInvocation?.includes("--no-seed"),
+    `expected --no-seed in ${JSON.stringify(initInvocation)}`,
+  );
 });
 
 test("falls back to an isolated config when the base CLI cannot boot", () => {
@@ -119,6 +166,7 @@ test("falls back to an isolated config when the base CLI cannot boot", () => {
   );
   const env = fs.readFileSync(path.join(worktreeCwd, ".paperclip", ".env"), "utf8");
   assert.match(env, /PAPERCLIP_IN_WORKTREE=true/);
+  assert.ok(fs.existsSync(path.join(worktreeCwd, ".paperclip", "seed-pending")));
 });
 
 test("repairs an unhealthy base install under the lock and then uses the CLI", (t) => {
@@ -201,4 +249,44 @@ test("a failed CLI init fails provisioning instead of being masked as success", 
   assert.equal(result.status, 3, result.stderr);
   assert.match(result.stderr, /fake worktree init failure/);
   assert.ok(!fs.existsSync(path.join(worktreeCwd, ".paperclip", "config.json")));
+});
+
+test("runtime provisioning invokes ensure-seeded once and fast-exits after success", () => {
+  const baseCwd = makeBaseWorkspace({ helpExit: 0, initExit: 0 });
+  const worktreeCwd = makeTempDir("paperclip-provision-runtime-worktree-");
+  fs.mkdirSync(path.join(worktreeCwd, ".paperclip"), { recursive: true });
+  fs.writeFileSync(path.join(worktreeCwd, ".paperclip", "config.json"), "{}\n");
+  fs.writeFileSync(path.join(worktreeCwd, ".paperclip", "seed-pending"), "{}\n");
+
+  const first = runRuntimeProvision(baseCwd, worktreeCwd);
+  assert.equal(first.status, 0, first.stderr);
+  assert.ok(fs.existsSync(path.join(worktreeCwd, ".paperclip", "seed-complete")));
+  assert.ok(!fs.existsSync(path.join(worktreeCwd, ".paperclip", "seed-pending")));
+
+  const ensureCallsAfterFirst = readCliInvocations(baseCwd)
+    .filter((args) => args[0] === "worktree" && args[1] === "ensure-seeded");
+  assert.equal(ensureCallsAfterFirst.length, 1);
+  assert.ok(ensureCallsAfterFirst[0].includes("--config"));
+  assert.ok(ensureCallsAfterFirst[0].includes("--from-config"));
+
+  const second = runRuntimeProvision(baseCwd, worktreeCwd);
+  assert.equal(second.status, 0, second.stderr);
+  assert.match(second.stderr, /already seeded; skipping/);
+  const ensureCallsAfterSecond = readCliInvocations(baseCwd)
+    .filter((args) => args[0] === "worktree" && args[1] === "ensure-seeded");
+  assert.equal(ensureCallsAfterSecond.length, 1);
+});
+
+test("runtime provisioning leaves seed-pending in place when ensure-seeded fails", () => {
+  const baseCwd = makeBaseWorkspace({ helpExit: 0, initExit: 0, ensureExit: 4 });
+  const worktreeCwd = makeTempDir("paperclip-provision-runtime-failure-");
+  fs.mkdirSync(path.join(worktreeCwd, ".paperclip"), { recursive: true });
+  fs.writeFileSync(path.join(worktreeCwd, ".paperclip", "config.json"), "{}\n");
+  fs.writeFileSync(path.join(worktreeCwd, ".paperclip", "seed-pending"), "{}\n");
+
+  const result = runRuntimeProvision(baseCwd, worktreeCwd);
+  assert.equal(result.status, 4, result.stderr);
+  assert.match(result.stderr, /fake worktree ensure-seeded failure/);
+  assert.ok(fs.existsSync(path.join(worktreeCwd, ".paperclip", "seed-pending")));
+  assert.ok(!fs.existsSync(path.join(worktreeCwd, ".paperclip", "seed-complete")));
 });

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -8,7 +8,7 @@ import { stdin, stdout } from "node:process";
 import { createCapturedOutputBuffer, parseJsonResponseWithLimit } from "./dev-runner-output.ts";
 import { collectWatchedSnapshot as collectDevServerWatchedSnapshot, diffSnapshots } from "./dev-runner-snapshot.mjs";
 import { createDevServiceIdentity, repoRoot } from "./dev-service-profile.ts";
-import { bootstrapDevRunnerWorktreeEnv } from "../server/src/dev-runner-worktree.ts";
+import { bootstrapDevRunnerWorktreeEnv, isWorktreeSeedPending } from "../server/src/dev-runner-worktree.ts";
 import {
   findAdoptableLocalService,
   removeLocalServiceRegistryRecord,
@@ -25,6 +25,12 @@ const worktreeEnvBootstrap = bootstrapDevRunnerWorktreeEnv(repoRoot, process.env
 if (worktreeEnvBootstrap.missingEnv) {
   console.error(
     `[paperclip] linked git worktree at ${repoRoot} is missing ${path.relative(repoRoot, worktreeEnvBootstrap.envPath)}. Run \`paperclipai worktree init\` in this worktree before \`pnpm dev\`.`,
+  );
+  process.exit(1);
+}
+if (isWorktreeSeedPending(repoRoot)) {
+  console.error(
+    "[paperclip] this worktree database is seed-pending. Run `pnpm paperclipai worktree ensure-seeded` before `pnpm dev`.",
   );
   process.exit(1);
 }

--- a/scripts/provision-worktree-runtime.sh
+++ b/scripts/provision-worktree-runtime.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_cwd="${PAPERCLIP_WORKSPACE_BASE_CWD:?PAPERCLIP_WORKSPACE_BASE_CWD is required}"
+worktree_cwd="${PAPERCLIP_WORKSPACE_CWD:?PAPERCLIP_WORKSPACE_CWD is required}"
+paperclip_home="${PAPERCLIP_HOME:-$HOME/.paperclip}"
+paperclip_instance_id="${PAPERCLIP_INSTANCE_ID:-default}"
+paperclip_dir="$worktree_cwd/.paperclip"
+worktree_config_path="$paperclip_dir/config.json"
+seed_pending_marker_path="$paperclip_dir/seed-pending"
+seed_complete_marker_path="$paperclip_dir/seed-complete"
+
+if [[ ! -d "$base_cwd" ]]; then
+  echo "Base workspace does not exist: $base_cwd" >&2
+  exit 1
+fi
+
+if [[ ! -d "$worktree_cwd" ]]; then
+  echo "Derived worktree does not exist: $worktree_cwd" >&2
+  exit 1
+fi
+
+if [[ -e "$seed_complete_marker_path" || ! -e "$seed_pending_marker_path" ]]; then
+  echo "Worktree database is already seeded; skipping runtime provisioning." >&2
+  exit 0
+fi
+
+if [[ ! -f "$worktree_config_path" ]]; then
+  echo "Worktree config does not exist: $worktree_config_path" >&2
+  exit 1
+fi
+
+source_config_path="${PAPERCLIP_CONFIG:-}"
+if [[ -z "$source_config_path" && ( -e "$base_cwd/.paperclip/config.json" || -L "$base_cwd/.paperclip/config.json" ) ]]; then
+  source_config_path="$base_cwd/.paperclip/config.json"
+fi
+if [[ -z "$source_config_path" ]]; then
+  source_config_path="$paperclip_home/instances/$paperclip_instance_id/config.json"
+fi
+source_config_args=(--from-config "$source_config_path")
+if [[ "$source_config_path" == "$worktree_config_path" ]]; then
+  # A human may invoke this after sourcing `worktree env`, which points
+  # PAPERCLIP_CONFIG at the target. In that case the CLI reads the original
+  # source config from the seed-pending marker instead.
+  source_config_args=()
+fi
+
+base_cli_runner_path="$base_cwd/cli/node_modules/tsx/dist/cli.mjs"
+base_cli_entry_path="$base_cwd/cli/src/index.ts"
+
+base_cli_files_present() {
+  [[ -f "$base_cli_runner_path" && -f "$base_cli_entry_path" ]]
+}
+
+base_cli_healthy() {
+  base_cli_files_present || return 1
+  (cd "$base_cwd" && node "$base_cli_runner_path" "$base_cli_entry_path" --help >/dev/null 2>&1)
+}
+
+repair_base_workspace_install() {
+  command -v pnpm >/dev/null 2>&1 || return 1
+  [[ -f "$base_cwd/package.json" && -f "$base_cwd/pnpm-lock.yaml" ]] || return 1
+  echo "Base workspace CLI at $base_cli_entry_path failed its health check (typically dangling pnpm symlinks after a partial install); repairing with pnpm install in $base_cwd." >&2
+  local repair_cmd=(pnpm install --prod=false --force --frozen-lockfile --config.confirmModulesPurge=false)
+  local repair_lock_dir=""
+  if command -v git >/dev/null 2>&1; then
+    repair_lock_dir="$(git -C "$base_cwd" rev-parse --absolute-git-dir 2>/dev/null || true)"
+  fi
+  if [[ ! -d "$repair_lock_dir" && -d "$base_cwd/.git" ]]; then
+    repair_lock_dir="$base_cwd/.git"
+  fi
+  if command -v flock >/dev/null 2>&1 && [[ -d "$repair_lock_dir" ]]; then
+    (
+      cd "$base_cwd" || exit 1
+      exec 9>"$repair_lock_dir/paperclip-provision-repair.lock"
+      flock 9
+      if base_cli_healthy; then
+        echo "Base workspace CLI became healthy while waiting for the repair lock; skipping reinstall." >&2
+        exit 0
+      fi
+      env -u NODE_ENV CI=true "${repair_cmd[@]}" >&2 || exit 1
+      base_cli_healthy
+    )
+  else
+    (cd "$base_cwd" && env -u NODE_ENV CI=true "${repair_cmd[@]}" >&2 && base_cli_healthy)
+  fi
+}
+
+ensure_base_cli_healthy() {
+  base_cli_files_present || return 1
+  base_cli_healthy && return 0
+  repair_base_workspace_install
+}
+
+run_ensure_seeded() {
+  if ensure_base_cli_healthy; then
+    (
+      cd "$worktree_cwd" &&
+        node "$base_cli_runner_path" "$base_cli_entry_path" worktree ensure-seeded --config "$worktree_config_path" "${source_config_args[@]}"
+    )
+    return
+  fi
+
+  if command -v pnpm >/dev/null 2>&1 && pnpm paperclipai --help >/dev/null 2>&1; then
+    (
+      cd "$worktree_cwd" &&
+        pnpm paperclipai worktree ensure-seeded --config "$worktree_config_path" "${source_config_args[@]}"
+    )
+    return
+  fi
+
+  if command -v paperclipai >/dev/null 2>&1; then
+    (
+      cd "$worktree_cwd" &&
+        paperclipai worktree ensure-seeded --config "$worktree_config_path" "${source_config_args[@]}"
+    )
+    return
+  fi
+
+  return 127
+}
+
+if run_ensure_seeded; then
+  exit 0
+else
+  exit_code=$?
+  if [[ "$exit_code" -eq 127 ]]; then
+    echo "No usable paperclipai CLI found; cannot seed the worktree database." >&2
+  fi
+  exit "$exit_code"
+fi

--- a/scripts/provision-worktree.sh
+++ b/scripts/provision-worktree.sh
@@ -8,7 +8,10 @@ paperclip_instance_id="${PAPERCLIP_INSTANCE_ID:-default}"
 paperclip_dir="$worktree_cwd/.paperclip"
 worktree_config_path="$paperclip_dir/config.json"
 worktree_env_path="$paperclip_dir/.env"
+seed_pending_marker_path="$paperclip_dir/seed-pending"
+seed_complete_marker_path="$paperclip_dir/seed-complete"
 worktree_name="${PAPERCLIP_WORKSPACE_BRANCH:-$(basename "$worktree_cwd")}"
+created_worktree_config=0
 
 if [[ ! -d "$base_cwd" ]]; then
   echo "Base workspace does not exist: $base_cwd" >&2
@@ -95,7 +98,7 @@ run_isolated_worktree_init() {
   if ensure_base_cli_healthy; then
     (
       cd "$worktree_cwd" &&
-        node "$base_cli_runner_path" "$base_cli_entry_path" worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+        node "$base_cli_runner_path" "$base_cli_entry_path" worktree init --force --no-seed --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
     )
     return
   fi
@@ -103,7 +106,7 @@ run_isolated_worktree_init() {
   if command -v pnpm >/dev/null 2>&1 && pnpm paperclipai --help >/dev/null 2>&1; then
     (
       cd "$worktree_cwd" &&
-        pnpm paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+        pnpm paperclipai worktree init --force --no-seed --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
     )
     return
   fi
@@ -111,7 +114,7 @@ run_isolated_worktree_init() {
   if command -v paperclipai >/dev/null 2>&1; then
     (
       cd "$worktree_cwd" &&
-        paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+        paperclipai worktree init --force --no-seed --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
     )
     return
   fi
@@ -210,6 +213,31 @@ for (const rawValue of runtimePaths) {
     fail(`existing worktree config path is outside ${instanceRoot}: ${resolved}`);
   }
 }
+EOF
+}
+
+write_seed_pending_marker() {
+  SEED_PENDING_MARKER_PATH="$seed_pending_marker_path" \
+  SEED_COMPLETE_MARKER_PATH="$seed_complete_marker_path" \
+  SOURCE_CONFIG_PATH="$source_config_path" \
+  node <<'EOF'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const pendingPath = process.env.SEED_PENDING_MARKER_PATH;
+const completePath = process.env.SEED_COMPLETE_MARKER_PATH;
+fs.rmSync(completePath, { force: true });
+fs.writeFileSync(
+  pendingPath,
+  `${JSON.stringify({
+    version: 1,
+    state: "pending",
+    sourceConfigPath: path.resolve(process.env.SOURCE_CONFIG_PATH),
+    seedMode: "minimal",
+    createdAt: new Date().toISOString(),
+  }, null, 2)}\n`,
+  { mode: 0o600 },
+);
 EOF
 }
 
@@ -504,6 +532,11 @@ else
     echo "paperclipai worktree init unavailable; writing isolated fallback config without DB seeding." >&2
     write_fallback_worktree_config
   fi
+  created_worktree_config=1
+fi
+
+if [[ "$created_worktree_config" -eq 1 && ! -e "$seed_pending_marker_path" && ! -e "$seed_complete_marker_path" ]]; then
+  write_seed_pending_marker
 fi
 
 list_base_node_modules_paths() {

--- a/server/src/__tests__/dev-runner-worktree.test.ts
+++ b/server/src/__tests__/dev-runner-worktree.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   bootstrapDevRunnerWorktreeEnv,
+  isWorktreeSeedPending,
   isLinkedGitWorktreeCheckout,
   resolveWorktreeEnvFilePath,
 } from "../dev-runner-worktree.ts";
@@ -24,6 +25,17 @@ function createTempRoot(prefix: string): string {
 }
 
 describe("dev-runner worktree env bootstrap", () => {
+  it("guards seed-pending worktrees until a seed-complete marker exists", () => {
+    const root = createTempRoot("paperclip-dev-runner-seed-pending-");
+    fs.mkdirSync(path.join(root, ".paperclip"), { recursive: true });
+    fs.writeFileSync(path.join(root, ".paperclip", "seed-pending"), "{}\n", "utf8");
+
+    expect(isWorktreeSeedPending(root)).toBe(true);
+
+    fs.writeFileSync(path.join(root, ".paperclip", "seed-complete"), "{}\n", "utf8");
+    expect(isWorktreeSeedPending(root)).toBe(false);
+  });
+
   it("detects linked git worktrees from .git files", () => {
     const root = createTempRoot("paperclip-dev-runner-worktree-");
     fs.writeFileSync(path.join(root, ".git"), "gitdir: /tmp/paperclip/.git/worktrees/feature\n", "utf8");

--- a/server/src/dev-runner-worktree.ts
+++ b/server/src/dev-runner-worktree.ts
@@ -56,6 +56,12 @@ export function resolveWorktreeEnvFilePath(rootDir: string): string {
   return path.resolve(rootDir, ".paperclip", ".env");
 }
 
+export function isWorktreeSeedPending(rootDir: string): boolean {
+  const markerDir = path.resolve(rootDir, ".paperclip");
+  return existsSync(path.resolve(markerDir, "seed-pending"))
+    && !existsSync(path.resolve(markerDir, "seed-complete"));
+}
+
 function expandHomePrefix(value: string): string {
   if (value === "~") return os.homedir();
   if (value.startsWith("~/")) return path.resolve(os.homedir(), value.slice(2));


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip creates isolated worktrees for agent tasks
> - A worktree needs an isolated database before its service can run
> - The existing provision step clones the database even when no service starts
> - This makes every worktree pay the cost of runtime setup
> - Paperclip needs a lean provision step and a separate idempotent runtime step
> - This pull request defers database seeding and prevents an unseeded service from starting
> - The benefit is faster worktree creation without a silent empty-database failure

## Linked Issues or Issue Description

**Subsystem affected**

CLI worktree commands, repository provision scripts, and the development runner.

**Problem or motivation**

The worktree provision script clones and seeds a database during every isolated workspace creation. Many worktrees never start a service, so this work adds avoidable setup time and storage. A worktree that skips the seed can also start against an empty database unless the runner detects that state.

**Proposed solution**

Add an idempotent `paperclipai worktree ensure-seeded` command. Make the normal provision script create the isolated config and a seed-pending marker without cloning the database. Add a runtime provision script that performs the seed once. Make `paperclipai run` seed automatically and make the development runner stop with an exact recovery command before an empty database can start.

**Alternatives considered**

Keep eager database seeding for every worktree. This preserves the old behavior but does not reduce setup cost. Remove the seed without a marker or runner guard. This is unsafe because a service can use an empty database without an obvious error.

**Roadmap alignment**

This change improves isolated execution workspaces. It supports the Cloud / Sandbox agents milestone by making worktree setup lighter while preserving reliable runtime startup.

## What Changed

- Added `worktree ensure-seeded` with success-only completion markers and retry-safe pending markers.
- Split worktree setup into a lean provision script and an idempotent runtime provision script.
- Added automatic seeding to `paperclipai run` and an unseeded-worktree guard to the development runner.
- Serialized ensure, init, and reseed operations with a crash-safe queued lock that rejects stale process identities.
- Added CLI, runner, and shell self-heal coverage for success, failure, and repeated execution.

## Verification

- `node scripts/__tests__/provision-worktree-self-heal.test.mjs` — 6 tests passed.
- `pnpm exec vitest run cli/src/__tests__/worktree.test.ts server/src/__tests__/dev-runner-worktree.test.ts` — 44 tests passed.
- `pnpm exec vitest run cli/src/__tests__/worktree.test.ts` — 39 tests passed after lock hardening.
- `pnpm --filter paperclipai --filter @paperclipai/server typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.
- Latest-head GitHub CI and all three e2e shards — passed.

## Risks

- The lean provision script no longer seeds by default. Callers that need a runnable service must use the runtime provision script or `worktree ensure-seeded`.
- A later integration change must connect the runtime provision script to managed service startup. This pull request keeps manual and CLI startup safe in the meantime.
- Legacy worktrees without either marker remain treated as seeded for compatibility.
- Concurrent seed operations use per-process queue entries. Dead and reused process owners are removed only after positive identity checks.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with the `gpt-5` model. The context-window size is not exposed. Reasoning, tool use, code execution, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
