### PR TITLE
fix(recovery): skip stranded escalation over zombie output and cleared cooldown

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -526,6 +526,144 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
+  it("DON-207: skips stranded escalation when a cancelled zombie still advances last_output_at", async () => {
+    // Specimen shape from DON-172: latest run is a short-lived agent_paused
+    // continuation retry, while an older cancelled run keeps updating
+    // last_output_at (process-tree orphan / DON-127). Status-only active-path
+    // checks would escalate; recent output evidence must suppress that.
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    const zombieRunId = randomUUID();
+    const pausedRetryRunId = randomUUID();
+    const zombieFinishedAt = new Date(Date.now() - 20 * 60 * 1000);
+    const recentOutputAt = new Date(Date.now() - 2 * 60 * 1000);
+    const retryFinishedAt = new Date(Date.now() - 60 * 1000);
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: zombieRunId,
+        companyId,
+        agentId: coderId,
+        invocationSource: "assignment",
+        status: "cancelled",
+        errorCode: "cancelled",
+        error: "cancelled",
+        startedAt: new Date(zombieFinishedAt.getTime() - 5 * 60 * 1000),
+        finishedAt: zombieFinishedAt,
+        createdAt: new Date(zombieFinishedAt.getTime() - 6 * 60 * 1000),
+        lastOutputAt: recentOutputAt,
+        contextSnapshot: { issueId: sourceIssueId, wakeReason: "issue_assigned" },
+      },
+      {
+        id: pausedRetryRunId,
+        companyId,
+        agentId: coderId,
+        invocationSource: "automation",
+        status: "cancelled",
+        errorCode: "agent_paused",
+        error: "agent paused",
+        startedAt: new Date(retryFinishedAt.getTime() - 500),
+        finishedAt: retryFinishedAt,
+        createdAt: new Date(retryFinishedAt.getTime() - 1000),
+        lastOutputAt: null,
+        contextSnapshot: {
+          issueId: sourceIssueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+        },
+      },
+    ]);
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: coderId,
+    });
+    expect(await db.select().from(issueRecoveryActions)).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("DON-207: skips stranded re-escalation within cooldown after a cleared recovery", async () => {
+    // Specimen shape from DON-172 second firing: Louis cleared the stranded
+    // recovery, then the same agent_paused continuation shape re-fired within
+    // minutes. Cleared source-scoped stranded recovery must suppress re-fire
+    // for DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS.
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const pausedRetryRunId = randomUUID();
+    const retryFinishedAt = new Date(Date.now() - 60 * 1000);
+    const clearedAt = new Date(Date.now() - 10 * 60 * 1000);
+
+    await db.insert(heartbeatRuns).values({
+      id: pausedRetryRunId,
+      companyId,
+      agentId: coderId,
+      invocationSource: "automation",
+      status: "cancelled",
+      errorCode: "agent_paused",
+      error: "agent paused",
+      startedAt: new Date(retryFinishedAt.getTime() - 500),
+      finishedAt: retryFinishedAt,
+      createdAt: new Date(retryFinishedAt.getTime() - 1000),
+      lastOutputAt: null,
+      contextSnapshot: {
+        issueId: sourceIssueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+        source: "issue.continuation_recovery",
+      },
+    });
+
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "agent_paused",
+      fingerprint: `source_scoped_recovery:${companyId}:${sourceIssueId}:stranded_assigned_issue`,
+      evidence: { latestRunId: pausedRetryRunId },
+      nextAction: "Restore a live execution path.",
+      wakePolicy: { type: "wake_owner" },
+    });
+    await db
+      .update(issueRecoveryActions)
+      .set({
+        status: "resolved",
+        outcome: "restored",
+        resolutionNote: "Stale agent_paused false positive; restored assignee.",
+        resolvedAt: clearedAt,
+        updatedAt: clearedAt,
+      })
+      .where(eq(issueRecoveryActions.id, action.id));
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    const [updatedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(updatedIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: coderId,
+    });
+    const activeActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.sourceIssueId, sourceIssueId), eq(issueRecoveryActions.status, "active")));
+    expect(activeActions).toHaveLength(0);
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
   it("schedules a quota monitor for a cross-agent active review participant", async () => {
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     const stageId = randomUUID();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -526,11 +526,11 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
-  it("DON-207: skips stranded escalation when a cancelled zombie still advances last_output_at", async () => {
-    // Specimen shape from DON-172: latest run is a short-lived agent_paused
-    // continuation retry, while an older cancelled run keeps updating
-    // last_output_at (process-tree orphan / DON-127). Status-only active-path
-    // checks would escalate; recent output evidence must suppress that.
+  it("skips stranded escalation when a cancelled zombie still advances last_output_at", async () => {
+    // Specimen: latest run is a short-lived agent_paused continuation retry,
+    // while an older cancelled run keeps updating last_output_at (process-tree
+    // orphan). Status-only active-path checks would escalate; recent output
+    // evidence must suppress only that exhausted-continuation escalate.
     const { companyId, coderId, sourceIssueId } = await seedCompany();
     const zombieRunId = randomUUID();
     const pausedRetryRunId = randomUUID();
@@ -590,10 +590,10 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(enqueueWakeup).not.toHaveBeenCalled();
   });
 
-  it("DON-207: skips stranded re-escalation within cooldown after a cleared recovery", async () => {
-    // Specimen shape from DON-172 second firing: Louis cleared the stranded
-    // recovery, then the same agent_paused continuation shape re-fired within
-    // minutes. Cleared source-scoped stranded recovery must suppress re-fire
+  it("skips stranded re-escalation within cooldown after a cleared recovery", async () => {
+    // Specimen: a cleared stranded recovery is followed by the same
+    // agent_paused continuation shape within minutes. Cleared source-scoped
+    // stranded recovery must suppress only exhausted-continuation re-escalate
     // for DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS.
     const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
     const pausedRetryRunId = randomUUID();

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1119,6 +1119,58 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Boolean(comment || attachment);
   }
 
+  // DON-207: zombie/cancelled runs can keep updating last_output_at after the
+  // control plane marks them terminal (see DON-127). Status-only active-path
+  // checks then false-positive "no live execution path" and escalate over a
+  // process that is still producing output.
+  async function hasRecentRunOutputEvidence(
+    companyId: string,
+    issueId: string,
+    windowMs: number,
+  ) {
+    const since = new Date(Date.now() - windowMs);
+    return db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          or(
+            gt(heartbeatRuns.lastOutputAt, since),
+            gt(heartbeatRuns.lastUsefulActionAt, since),
+          ),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  // DON-207: stranded recovery lacks the issue-graph liveness re-escalation
+  // cooldown. After a source-scoped action is cleared, the same fingerprint
+  // can re-fire within minutes on a stale agent_paused retry.
+  async function hasRecentlyClearedStrandedRecovery(
+    companyId: string,
+    issueId: string,
+    windowMs: number,
+  ) {
+    const since = new Date(Date.now() - windowMs);
+    return db
+      .select({ id: issueRecoveryActions.id })
+      .from(issueRecoveryActions)
+      .where(
+        and(
+          eq(issueRecoveryActions.companyId, companyId),
+          eq(issueRecoveryActions.sourceIssueId, issueId),
+          eq(issueRecoveryActions.kind, "stranded_assigned_issue"),
+          inArray(issueRecoveryActions.status, ["resolved", "cancelled"]),
+          gt(issueRecoveryActions.resolvedAt, since),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -3692,6 +3744,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      // DON-207: treat recent last_output_at / last_useful_action_at as a
+      // live path even when the run row is already cancelled/failed.
+      if (await hasRecentRunOutputEvidence(
+        issue.companyId,
+        issue.id,
+        STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+      )) {
+        result.skipped += 1;
+        continue;
+      }
+
+      // DON-207: suppress stranded re-escalation shortly after a cleared
+      // source-scoped recovery (mirrors issue-graph liveness cooldown).
+      if (await hasRecentlyClearedStrandedRecovery(
+        issue.companyId,
+        issue.id,
+        DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS,
+      )) {
+        result.skipped += 1;
+        continue;
+      }
+
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
@@ -4215,6 +4289,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             classification.errorCode,
           );
           if (consecutive >= classification.maxAttempts) {
+            // DON-207 defense-in-depth: never escalate over recent output
+            // or a just-cleared stranded recovery, even if earlier skips
+            // were bypassed by a race with getLatestIssueRun.
+            if (
+              await hasRecentRunOutputEvidence(
+                issue.companyId,
+                issue.id,
+                STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+              ) ||
+              await hasRecentlyClearedStrandedRecovery(
+                issue.companyId,
+                issue.id,
+                DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS,
+              ) ||
+              await hasRecentVisibleProgress(
+                issue.companyId,
+                issue.id,
+                agentId,
+                STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+              )
+            ) {
+              result.skipped += 1;
+              continue;
+            }
             const failureSummary = summarizeRunFailureForIssueComment(latestRun);
             const attemptCopy = consecutive <= 1 ? "" : ` (${consecutive}× attempts)`;
             const causeCopy = classification.errorCode

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1119,10 +1119,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Boolean(comment || attachment);
   }
 
-  // DON-207: zombie/cancelled runs can keep updating last_output_at after the
-  // control plane marks them terminal (see DON-127). Status-only active-path
-  // checks then false-positive "no live execution path" and escalate over a
-  // process that is still producing output.
+  // Cancelled zombie runs can keep updating last_output_at after the control
+  // plane marks them terminal. Status-only active-path checks then
+  // false-positive "no live execution path" and escalate over a process that
+  // is still producing output.
   async function hasRecentRunOutputEvidence(
     companyId: string,
     issueId: string,
@@ -1146,9 +1146,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
-  // DON-207: stranded recovery lacks the issue-graph liveness re-escalation
-  // cooldown. After a source-scoped action is cleared, the same fingerprint
-  // can re-fire within minutes on a stale agent_paused retry.
+  // Stranded recovery lacked the issue-graph liveness re-escalation cooldown.
+  // After a source-scoped action is cleared, the same fingerprint can re-fire
+  // within minutes on a stale agent_paused retry.
   async function hasRecentlyClearedStrandedRecovery(
     companyId: string,
     issueId: string,
@@ -1169,6 +1169,34 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       )
       .limit(1)
       .then((rows) => Boolean(rows[0]));
+  }
+
+  // Suppress only exhausted-continuation stranded escalation. Do not early-exit
+  // the reconciler — quota monitors, configuration escalation, and review
+  // participant recovery must still classify when a distinct failure is present.
+  async function shouldSuppressExhaustedContinuationEscalation(
+    companyId: string,
+    issueId: string,
+    agentId: string,
+  ) {
+    return (
+      await hasRecentRunOutputEvidence(
+        companyId,
+        issueId,
+        STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+      ) ||
+      await hasRecentlyClearedStrandedRecovery(
+        companyId,
+        issueId,
+        DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS,
+      ) ||
+      await hasRecentVisibleProgress(
+        companyId,
+        issueId,
+        agentId,
+        STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
+      )
+    );
   }
 
   async function enqueueStrandedIssueRecovery(input: {
@@ -3744,28 +3772,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
-      // DON-207: treat recent last_output_at / last_useful_action_at as a
-      // live path even when the run row is already cancelled/failed.
-      if (await hasRecentRunOutputEvidence(
-        issue.companyId,
-        issue.id,
-        STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
-      )) {
-        result.skipped += 1;
-        continue;
-      }
-
-      // DON-207: suppress stranded re-escalation shortly after a cleared
-      // source-scoped recovery (mirrors issue-graph liveness cooldown).
-      if (await hasRecentlyClearedStrandedRecovery(
-        issue.companyId,
-        issue.id,
-        DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS,
-      )) {
-        result.skipped += 1;
-        continue;
-      }
-
       if (await hasPendingWakeInteraction(issue.companyId, issue.id)) {
         result.skipped += 1;
         continue;
@@ -4289,27 +4295,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             classification.errorCode,
           );
           if (consecutive >= classification.maxAttempts) {
-            // DON-207 defense-in-depth: never escalate over recent output
-            // or a just-cleared stranded recovery, even if earlier skips
-            // were bypassed by a race with getLatestIssueRun.
-            if (
-              await hasRecentRunOutputEvidence(
-                issue.companyId,
-                issue.id,
-                STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
-              ) ||
-              await hasRecentlyClearedStrandedRecovery(
-                issue.companyId,
-                issue.id,
-                DEFAULT_LIVENESS_REESCALATION_COOLDOWN_MS,
-              ) ||
-              await hasRecentVisibleProgress(
-                issue.companyId,
-                issue.id,
-                agentId,
-                STRANDED_RECENT_PROGRESS_EXEMPTION_MS,
-              )
-            ) {
+            // Suppress only this stranded escalate. Other recovery branches
+            // (quota monitor, configuration, review participants) already ran
+            // above and must not be masked by zombie output or cooldown.
+            if (await shouldSuppressExhaustedContinuationEscalation(
+              issue.companyId,
+              issue.id,
+              agentId,
+            )) {
               result.skipped += 1;
               continue;
             }


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server recovery subsystem reconciles assigned issues that appear to have no live execution path
> - Cancelled zombie runs can keep updating `last_output_at` after the control plane marks them terminal
> - Status-only active-path checks then treat the issue as dead and escalate to `blocked`, sometimes again soon after a cleared recovery
> - This pull request suppresses only exhausted-continuation stranded escalation when recent run output exists or a stranded recovery was recently cleared
> - The benefit is fewer false stranded escalations without masking quota monitors, configuration recovery, or review-participant recovery

## Linked Issues or Issue Description

**Bug report (in-PR):**

**Describe the bug**
`reconcileStrandedAssignedIssues` escalates an assigned `in_progress` issue to `blocked` when the latest issue-scoped run is a short-lived `agent_paused` continuation retry, even though an older cancelled run for the same issue is still advancing `last_output_at`. After a human clears that stranded recovery, the same shape re-fires within minutes because stranded recovery has no re-escalation cooldown.

**To Reproduce**
1. Assign an issue and start a run that later becomes `cancelled` while the process tree keeps writing output.
2. Let stranded recovery enqueue an `issue_continuation_needed` retry that dies immediately with `agent_paused`.
3. Observe stranded escalation to `blocked` on that retry.
4. Clear/restore the recovery, then wait for another `agent_paused` retry within the hour.

**Expected behavior**
Recent `last_output_at` / `last_useful_action_at` should suppress exhausted-continuation stranded escalation. A cleared `stranded_assigned_issue` recovery should suppress the same escalate path for one hour. Other recovery classifications (provider quota monitor, configuration incomplete, review participants) must still run.

**Related public search**
- Refs open recovery work in the same area: #8587, #5666, #4391, #8539
- Dedup search covered open PRs/issues matching stranded recovery / zombie output; no duplicate of this specific guard set found.

## What Changed

- Added `hasRecentRunOutputEvidence` for recent `last_output_at` / `last_useful_action_at` on issue-scoped runs
- Added `hasRecentlyClearedStrandedRecovery` mirroring issue-graph liveness re-escalation cooldown
- Applied both guards only immediately before exhausted-continuation `escalateStrandedAssignedIssue` (via `shouldSuppressExhaustedContinuationEscalation`)
- Left earlier reconciler branches free to classify quota, configuration, and review-participant recovery
- Added regression tests for zombie output suppression and cleared-recovery cooldown

## Verification

- [x] CI: server general + serialized suites, build, e2e (see PR checks on first commit)
- [ ] Local/reviewer: `pnpm --filter @paperclipai/server test -- issue-recovery-actions`
- [ ] Confirm new cases:
  - skips escalation when a cancelled zombie still advances `last_output_at`
  - skips re-escalation within cooldown after a cleared stranded recovery
- [ ] Confirm existing stranded-continuation escalation still fires when neither guard applies
- [ ] Confirm a distinct provider-quota failure still schedules a quota monitor even if another run has recent output

## Risks

- Medium behavioral shift: exhausted-continuation stranded escalation is suppressed for up to 30 minutes of recent run output and up to 1 hour after a cleared stranded recovery.
- Mitigated by scoping: guards do not early-exit the reconciler, so quota monitors and configuration escalation remain available.
- No schema or migration changes.

## Model Used

- Provider: Cursor Agent (Composer)
- Model family: Composer / agent router used for implementation assistance
- Capabilities: tool use, code edit, GitHub CLI
- Human oversight: Raz-Tau authored/pushed the branch and owns merge judgment

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
