### PR TITLE
fix: detect effective PR approvals at head SHA

### DIFF
--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -465,6 +465,117 @@ describe("GitHub external object provider", () => {
     });
   });
 
+  it("does not report approval when the approver later requests changes", async () => {
+    const fetch = vi.fn(async (url: string) => {
+      if (url === "https://api.github.com/graphql") {
+        return response({
+          data: {
+            repository: {
+              pullRequest: {
+                latestOpinionatedReviews: {
+                  nodes: [{ author: { login: "WrightBot" }, state: "CHANGES_REQUESTED" }],
+                },
+              },
+            },
+          },
+        });
+      }
+      if (url.includes("/reviews?per_page=100")) {
+        return response([
+          { commit_id: "head-sha-2", state: "APPROVED", user: { login: "WrightBot" } },
+        ]);
+      }
+      return response({
+        state: "open",
+        draft: false,
+        merged: false,
+        title: "Ship it",
+        head: { ref: "main", sha: "head-sha-2" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.not.objectContaining({ reviewDecision: expect.any(String) }),
+      }),
+    });
+  });
+
+  it("follows REST and GraphQL pagination when resolving an approval", async () => {
+    const fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://api.github.com/graphql") {
+        const variables = JSON.parse(String(init?.body)).variables;
+        return variables.after
+          ? response({
+            data: {
+              repository: {
+                pullRequest: {
+                  latestOpinionatedReviews: {
+                    nodes: [{ author: { login: "WrightBot" }, state: "APPROVED" }],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              },
+            },
+          })
+          : response({
+            data: {
+              repository: {
+                pullRequest: {
+                  latestOpinionatedReviews: {
+                    nodes: [],
+                    pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+                  },
+                },
+              },
+            },
+          });
+      }
+      if (url.endsWith("reviews?per_page=100")) {
+        return response([], {
+          headers: {
+            link: '<https://api.github.com/repos/acme/app/pulls/42/reviews?per_page=100&page=2>; rel="next"',
+          },
+        });
+      }
+      if (url.endsWith("reviews?per_page=100&page=2")) {
+        return response([
+          { commit_id: "head-sha-paged", state: "APPROVED", user: { login: "WrightBot" } },
+        ]);
+      }
+      return response({
+        state: "open",
+        draft: false,
+        merged: false,
+        title: "Ship it",
+        head: { ref: "main", sha: "head-sha-paged" },
+      });
+    });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        data: expect.objectContaining({ reviewDecision: "APPROVED" }),
+      }),
+    });
+    expect(fetch).toHaveBeenCalledTimes(5);
+  });
+
   it("does not query pull request reviews for merged pull requests", async () => {
     const fetch = vi.fn(async () =>
       response({

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -150,7 +150,7 @@ describe("GitHub external object provider", () => {
     } as any;
   }
 
-  function response(body: Record<string, unknown>, init: ResponseInit = {}) {
+  function response(body: unknown, init: ResponseInit = {}) {
     return new Response(JSON.stringify(body), {
       status: 200,
       headers: { "content-type": "application/json", etag: '"etag-1"', ...(init.headers ?? {}) },
@@ -312,6 +312,196 @@ describe("GitHub external object provider", () => {
 
     expect(result.ok).toBe(true);
     expect(JSON.stringify(result)).not.toContain("ghp_secret");
+  });
+
+  it("computes approval from the pull request reviews at the current head SHA", async () => {
+    const fetch = vi
+      .fn(async (url: string, init?: RequestInit) => {
+        if (url === "https://api.github.com/graphql") {
+          return response({
+            data: {
+              repository: {
+                pullRequest: {
+                  latestOpinionatedReviews: {
+                    nodes: [
+                      {
+                        author: {
+                          login: "WrightBot",
+                        },
+                        state: "APPROVED",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+        }
+        if (url.includes("/reviews?per_page=100")) {
+          expect(init?.method).toBeFalsy();
+          return response([
+            {
+              commit_id: "head-sha-1",
+              state: "APPROVED",
+              user: {
+                login: "WrightBot",
+              },
+            },
+          ]);
+        }
+        return response({
+          state: "open",
+          draft: false,
+          merged: false,
+          title: "Ship it",
+          updated_at: "2026-04-24T01:02:03Z",
+          head: {
+            ref: "main",
+            sha: "head-sha-1",
+          },
+        });
+      });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/pulls/42",
+      expect.objectContaining({ headers: expect.not.objectContaining({ authorization: expect.any(String) }) }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/pulls/42/reviews?per_page=100",
+      expect.objectContaining({ headers: expect.objectContaining({ accept: "application/vnd.github+json" }) }),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/graphql",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          accept: "application/vnd.github+json",
+          "content-type": "application/json",
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        statusKey: "open",
+        statusLabel: "Open",
+        data: expect.objectContaining({
+          reviewDecision: "APPROVED",
+          headSha: "head-sha-1",
+        }),
+      }),
+    });
+  });
+
+  it("does not report current approval when the latest opinionated review is dismissed", async () => {
+    const fetch = vi
+      .fn(async (url: string) => {
+        if (url === "https://api.github.com/graphql") {
+          return response({
+            data: {
+              repository: {
+                pullRequest: {
+                  latestOpinionatedReviews: {
+                    nodes: [
+                      {
+                        author: {
+                          login: "WrightBot",
+                        },
+                        state: "DISMISSED",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+        }
+        if (url.includes("/reviews?per_page=100")) {
+          return response([
+            {
+              commit_id: "head-sha-2",
+              state: "APPROVED",
+              user: {
+                login: "WrightBot",
+              },
+            },
+          ]);
+        }
+        return response({
+          state: "open",
+          draft: false,
+          merged: false,
+          title: "Ship it",
+          updated_at: "2026-04-24T01:02:03Z",
+          head: {
+            ref: "main",
+            sha: "head-sha-2",
+          },
+        });
+      });
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        statusKey: "open",
+        statusLabel: "Open",
+        data: expect.not.objectContaining({ reviewDecision: expect.any(String) }),
+      }),
+    });
+  });
+
+  it("does not query pull request reviews for merged pull requests", async () => {
+    const fetch = vi.fn(async () =>
+      response({
+        state: "closed",
+        draft: false,
+        merged: true,
+        title: "Merged PR",
+        updated_at: "2026-04-24T01:02:03Z",
+        head: {
+          ref: "main",
+          sha: "head-sha-3",
+        },
+      }),
+    );
+    const provider = createGitHubExternalObjectProvider({} as any, { fetch, tokenProvider: null });
+    const resolver = provider.resolvers.find((entry) => entry.objectType === "pull_request")!;
+
+    const result = await resolver.resolve({
+      companyId: "company-1",
+      object: githubObject("pull/42", "pull_request"),
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/app/pulls/42",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({ authorization: expect.any(String) }),
+      }),
+    );
+    expect(result).toEqual({
+      ok: true,
+      snapshot: expect.objectContaining({
+        statusKey: "merged",
+        statusLabel: "Merged",
+        data: expect.not.objectContaining({ reviewDecision: expect.any(String) }),
+      }),
+    });
   });
 
   it.each([

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -47,6 +47,10 @@ function asBoolean(value: unknown) {
   return typeof value === "boolean" ? value : null;
 }
 
+function asArray(value: unknown): unknown[] | null {
+  return Array.isArray(value) ? value : null;
+}
+
 function asNestedString(record: Record<string, unknown>, key: string, nestedKey: string) {
   const nested = asRecord(record[key]);
   return nested ? asString(nested[nestedKey]) : null;
@@ -188,7 +192,7 @@ function notFoundSnapshot(identity: GitHubObjectIdentity, etag: string | null): 
   };
 }
 
-function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string, unknown>, etag: string | null): ExternalObjectResolverSnapshot {
+function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string, unknown>, etag: string | null, reviewDecision?: string): ExternalObjectResolverSnapshot {
   const title = asString(body.title);
   const state = asString(body.state) ?? "unknown";
   const draft = asBoolean(body.draft) ?? false;
@@ -196,7 +200,7 @@ function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string
   const authorLogin = asNestedString(body, "user", "login");
   const headRef = asNestedString(body, "head", "ref");
   const baseRef = asNestedString(body, "base", "ref");
-  const reviewDecision = asString(body.review_decision);
+  const headSha = asNestedString(body, "head", "sha");
 
   let statusKey = state;
   let statusLabel = state === "open" ? "Open" : state === "closed" ? "Closed" : "Unknown";
@@ -253,6 +257,7 @@ function pullRequestSnapshot(identity: GitHubObjectIdentity, body: Record<string
       ...(authorLogin ? { authorLogin } : {}),
       ...(headRef ? { headRef } : {}),
       ...(baseRef ? { baseRef } : {}),
+      ...(headSha ? { headSha } : {}),
       ...(reviewDecision ? { reviewDecision } : {}),
     },
   };
@@ -303,6 +308,129 @@ async function safeJson(response: Response) {
   } catch {
     return null;
   }
+}
+
+type OpinionatedReviewMap = Map<string, string>;
+
+async function fetchLatestOpinionatedReviews(
+  fetchImpl: FetchLike,
+  baseUrl: string,
+  headers: Record<string, string>,
+  owner: string,
+  repo: string,
+  number: number,
+): Promise<OpinionatedReviewMap | null> {
+  const query = `
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          latestOpinionatedReviews(first: 10) {
+            nodes {
+              author {
+                login
+              }
+              state
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${baseUrl}/graphql`, {
+      method: "POST",
+      headers: { ...headers, "content-type": "application/json" },
+      body: JSON.stringify({ query, variables: { owner, repo, number } }),
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) return null;
+
+  const body = await safeJson(response);
+  if (!body) return null;
+  const data = asRecord(body.data);
+  const repository = asRecord(data?.repository);
+  const pullRequest = asRecord(repository?.pullRequest);
+  const latestOpinionatedReviews = asRecord(pullRequest?.latestOpinionatedReviews);
+  const nodes = asArray(latestOpinionatedReviews?.nodes);
+  if (!nodes) return new Map();
+
+  const reviewStates = new Map<string, string>();
+  for (const node of nodes) {
+    const review = asRecord(node);
+    if (!review) continue;
+    const authorLogin = asNestedString(review, "author", "login");
+    const state = asString(review.state);
+    if (!authorLogin || !state || reviewStates.has(authorLogin)) continue;
+    reviewStates.set(authorLogin, state);
+  }
+
+  return reviewStates;
+}
+
+async function hasApprovalAtHead(
+  fetchImpl: FetchLike,
+  baseUrl: string,
+  headers: Record<string, string>,
+  identity: GitHubObjectIdentity,
+  headSha: string,
+): Promise<boolean> {
+  const reviewsUrl = `${baseUrl}/repos/${encodeURIComponent(identity.owner)}/${encodeURIComponent(identity.repo)}/pulls/${
+    identity.number
+  }/reviews?per_page=100`;
+  let reviewsResponse: Response;
+  try {
+    reviewsResponse = await fetchImpl(reviewsUrl, { headers });
+  } catch {
+    return false;
+  }
+
+  if (!reviewsResponse.ok) return false;
+  const reviewFailure = failureFromGitHubResponse(reviewsResponse);
+  if (reviewFailure) return false;
+
+  let reviewsJson: unknown;
+  try {
+    reviewsJson = await reviewsResponse.json();
+  } catch {
+    return false;
+  }
+  if (!reviewsJson) return false;
+  const reviews = asArray(reviewsJson);
+  if (!reviews) return false;
+
+  const approverLogins = new Set<string>();
+  for (const review of reviews) {
+    const reviewRecord = asRecord(review);
+    if (!reviewRecord) continue;
+    if (asString(reviewRecord.commit_id) !== headSha) continue;
+    if (asString(reviewRecord.state) !== "APPROVED") continue;
+    const login = asNestedString(reviewRecord, "user", "login");
+    if (login) approverLogins.add(login);
+  }
+
+  if (approverLogins.size === 0) return false;
+
+  const latestOpinionatedReviews = await fetchLatestOpinionatedReviews(
+    fetchImpl,
+    baseUrl,
+    headers,
+    identity.owner,
+    identity.repo,
+    identity.number,
+  );
+  if (!latestOpinionatedReviews) return false;
+
+  for (const login of approverLogins) {
+    const latestState = latestOpinionatedReviews.get(login);
+    if (latestState && latestState !== "DISMISSED") return true;
+  }
+
+  return false;
 }
 
 async function defaultTokenProvider(db: Db, companyId: string, secretNames: readonly string[]) {
@@ -384,8 +512,9 @@ export function createGitHubExternalObjectProvider(
         };
         if (token) headers.authorization = `Bearer ${token}`;
 
+        const apiBase = gitHubApiBase(identity.host);
         const apiKind = objectType === "pull_request" ? "pulls" : "issues";
-        const url = `${gitHubApiBase(identity.host)}/repos/${encodeURIComponent(identity.owner)}/${encodeURIComponent(identity.repo)}/${apiKind}/${identity.number}`;
+        const url = `${apiBase}/repos/${encodeURIComponent(identity.owner)}/${encodeURIComponent(identity.repo)}/${apiKind}/${identity.number}`;
 
         let response: Response;
         try {
@@ -428,10 +557,20 @@ export function createGitHubExternalObjectProvider(
           };
         }
 
+        let reviewDecision: string | undefined;
+        if (objectType === "pull_request") {
+          const merged = (asBoolean(body.merged) ?? false) || Boolean(asString(body.merged_at));
+          const headSha = asNestedString(body, "head", "sha");
+          if (!merged && headSha) {
+            const hasApproval = await hasApprovalAtHead(fetchImpl, apiBase, headers, identity, headSha);
+            if (hasApproval) reviewDecision = "APPROVED";
+          }
+        }
+
         return {
           ok: true,
           snapshot: objectType === "pull_request"
-            ? pullRequestSnapshot(identity, body, etag)
+            ? pullRequestSnapshot(identity, body, etag, reviewDecision)
             : issueSnapshot(identity, body, etag),
         };
       },

--- a/server/src/services/github-external-object-provider.ts
+++ b/server/src/services/github-external-object-provider.ts
@@ -312,6 +312,21 @@ async function safeJson(response: Response) {
 
 type OpinionatedReviewMap = Map<string, string>;
 
+function graphQlUrlFor(apiBaseUrl: string) {
+  return apiBaseUrl.endsWith("/api/v3")
+    ? `${apiBaseUrl.slice(0, -"/api/v3".length)}/api/graphql`
+    : `${apiBaseUrl}/graphql`;
+}
+
+function parseNextPageUrl(linkHeader: string | null) {
+  if (!linkHeader) return null;
+  for (const link of linkHeader.split(",")) {
+    const match = /^\s*<([^>]+)>;\s*rel="([^"]+)"\s*$/.exec(link);
+    if (match?.[2] === "next") return match[1] ?? null;
+  }
+  return null;
+}
+
 async function fetchLatestOpinionatedReviews(
   fetchImpl: FetchLike,
   baseUrl: string,
@@ -321,15 +336,19 @@ async function fetchLatestOpinionatedReviews(
   number: number,
 ): Promise<OpinionatedReviewMap | null> {
   const query = `
-    query($owner: String!, $repo: String!, $number: Int!) {
+    query($owner: String!, $repo: String!, $number: Int!, $after: String) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $number) {
-          latestOpinionatedReviews(first: 10) {
+          latestOpinionatedReviews(first: 100, after: $after) {
             nodes {
               author {
                 login
               }
               state
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
             }
           }
         }
@@ -337,37 +356,46 @@ async function fetchLatestOpinionatedReviews(
     }
   `;
 
-  let response: Response;
-  try {
-    response = await fetchImpl(`${baseUrl}/graphql`, {
-      method: "POST",
-      headers: { ...headers, "content-type": "application/json" },
-      body: JSON.stringify({ query, variables: { owner, repo, number } }),
-    });
-  } catch {
-    return null;
-  }
-
-  if (!response.ok) return null;
-
-  const body = await safeJson(response);
-  if (!body) return null;
-  const data = asRecord(body.data);
-  const repository = asRecord(data?.repository);
-  const pullRequest = asRecord(repository?.pullRequest);
-  const latestOpinionatedReviews = asRecord(pullRequest?.latestOpinionatedReviews);
-  const nodes = asArray(latestOpinionatedReviews?.nodes);
-  if (!nodes) return new Map();
-
   const reviewStates = new Map<string, string>();
-  for (const node of nodes) {
-    const review = asRecord(node);
-    if (!review) continue;
-    const authorLogin = asNestedString(review, "author", "login");
-    const state = asString(review.state);
-    if (!authorLogin || !state || reviewStates.has(authorLogin)) continue;
-    reviewStates.set(authorLogin, state);
-  }
+  let after: string | null = null;
+
+  do {
+    let response: Response;
+    try {
+      response = await fetchImpl(graphQlUrlFor(baseUrl), {
+        method: "POST",
+        headers: { ...headers, "content-type": "application/json" },
+        body: JSON.stringify({ query, variables: { owner, repo, number, after } }),
+      });
+    } catch {
+      return null;
+    }
+
+    if (!response.ok) return null;
+
+    const body = await safeJson(response);
+    if (!body) return null;
+    const data = asRecord(body.data);
+    const repository = asRecord(data?.repository);
+    const pullRequest = asRecord(repository?.pullRequest);
+    const latestOpinionatedReviews = asRecord(pullRequest?.latestOpinionatedReviews);
+    const nodes = asArray(latestOpinionatedReviews?.nodes);
+    if (!nodes) return reviewStates;
+
+    for (const node of nodes) {
+      const review = asRecord(node);
+      if (!review) continue;
+      const authorLogin = asNestedString(review, "author", "login");
+      const state = asString(review.state);
+      if (!authorLogin || !state) continue;
+      reviewStates.set(authorLogin, state);
+    }
+
+    const pageInfo = asRecord(latestOpinionatedReviews?.pageInfo);
+    const hasNextPage = asBoolean(pageInfo?.hasNextPage) ?? false;
+    after = hasNextPage ? asString(pageInfo?.endCursor) : null;
+    if (hasNextPage && !after) return null;
+  } while (after);
 
   return reviewStates;
 }
@@ -379,38 +407,42 @@ async function hasApprovalAtHead(
   identity: GitHubObjectIdentity,
   headSha: string,
 ): Promise<boolean> {
-  const reviewsUrl = `${baseUrl}/repos/${encodeURIComponent(identity.owner)}/${encodeURIComponent(identity.repo)}/pulls/${
+  let reviewsUrl: string | null = `${baseUrl}/repos/${encodeURIComponent(identity.owner)}/${encodeURIComponent(identity.repo)}/pulls/${
     identity.number
   }/reviews?per_page=100`;
-  let reviewsResponse: Response;
-  try {
-    reviewsResponse = await fetchImpl(reviewsUrl, { headers });
-  } catch {
-    return false;
-  }
-
-  if (!reviewsResponse.ok) return false;
-  const reviewFailure = failureFromGitHubResponse(reviewsResponse);
-  if (reviewFailure) return false;
-
-  let reviewsJson: unknown;
-  try {
-    reviewsJson = await reviewsResponse.json();
-  } catch {
-    return false;
-  }
-  if (!reviewsJson) return false;
-  const reviews = asArray(reviewsJson);
-  if (!reviews) return false;
-
   const approverLogins = new Set<string>();
-  for (const review of reviews) {
-    const reviewRecord = asRecord(review);
-    if (!reviewRecord) continue;
-    if (asString(reviewRecord.commit_id) !== headSha) continue;
-    if (asString(reviewRecord.state) !== "APPROVED") continue;
-    const login = asNestedString(reviewRecord, "user", "login");
-    if (login) approverLogins.add(login);
+
+  while (reviewsUrl) {
+    let reviewsResponse: Response;
+    try {
+      reviewsResponse = await fetchImpl(reviewsUrl, { headers });
+    } catch {
+      return false;
+    }
+
+    if (!reviewsResponse.ok) return false;
+    const reviewFailure = failureFromGitHubResponse(reviewsResponse);
+    if (reviewFailure) return false;
+
+    let reviewsJson: unknown;
+    try {
+      reviewsJson = await reviewsResponse.json();
+    } catch {
+      return false;
+    }
+    const reviews = asArray(reviewsJson);
+    if (!reviews) return false;
+
+    for (const review of reviews) {
+      const reviewRecord = asRecord(review);
+      if (!reviewRecord) continue;
+      if (asString(reviewRecord.commit_id) !== headSha) continue;
+      if (asString(reviewRecord.state) !== "APPROVED") continue;
+      const login = asNestedString(reviewRecord, "user", "login");
+      if (login) approverLogins.add(login);
+    }
+
+    reviewsUrl = parseNextPageUrl(reviewsResponse.headers.get("link"));
   }
 
   if (approverLogins.size === 0) return false;
@@ -427,7 +459,7 @@ async function hasApprovalAtHead(
 
   for (const login of approverLogins) {
     const latestState = latestOpinionatedReviews.get(login);
-    if (latestState && latestState !== "DISMISSED") return true;
+    if (latestState === "APPROVED") return true;
   }
 
   return false;


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates durable work between users and AI agents.
> - GitHub pull requests are represented as external objects whose snapshots feed PR coordination.
> - The coordinator treated GitHub's branch-protection `reviewDecision` as evidence that an approval exists.
> - Repositories without required-review protection return no decision even when the current head is approved, creating duplicate review work.
> - Merged pull requests could also remain eligible long enough to generate stale tasks.
> - This pull request derives approval from current-head reviews, confirms each reviewer's latest live opinion, and avoids review lookup for merged pull requests.
> - The benefit is accurate review-task suppression without relying on branch-protection configuration.

## Linked Issues or Issue Description

### Bug description

On repositories without required-review branch protection, GitHub's `reviewDecision` is empty even when a pull request has an approval at its current head SHA. PR coordination therefore generates duplicate review tasks. A recently merged pull request can also be treated as reviewable.

### Expected behavior

An open pull request approved at its current head by a reviewer whose latest opinion remains `APPROVED` is suppressed from review work. A merged pull request is never probed or considered for review work.

### Reproduction

Create or locate a pull request on a repository without required-review branch protection, approve its current head, then refresh its external-object snapshot. Previously the snapshot omitted effective approval because the branch-protection decision was null.

## What Changed

- Record the pull request head SHA and derive effective approval from REST reviews at that SHA.
- Confirm the approving reviewer's latest live GraphQL opinion is exactly `APPROVED`.
- Follow REST and GraphQL pagination, and use the correct GitHub Enterprise GraphQL endpoint.
- Skip approval lookup for merged pull requests.
- Add regression coverage for current-head approval, dismissal, later changes requested, pagination, and merged pull requests.

## Verification

- `pnpm exec vitest run server/src/__tests__/external-objects-service.test.ts` — 27 tests passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `git diff --check` — passed.
- This repository does not provide `bin/ci`; GitHub's full PR workflow is the CI-equivalent gate.

## Risks

- Low behavioral risk: approval probing adds paginated GitHub API requests only for unmerged pull requests with a head SHA.
- API failures fail closed by omitting effective approval, preserving the existing behavior instead of incorrectly suppressing review work.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 family agentic coding model, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
