### PR TITLE
fix(heartbeat): fail closed on semantic and profile errors

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -1006,7 +1006,8 @@ Behavior:
 
 - spawn child process
 - stream stdout/stderr to run logs
-- mark run status on exit code/timeout
+- mark run status on timeout, exit/error fields, and top-level structured adapter failure status; a top-level
+  `error`, `failed`, `failure`, or `errored` cannot persist as `succeeded` when exit code is zero
 - cancel sends SIGTERM then SIGKILL after grace
 
 ## 11.3 HTTP Adapter
@@ -1038,6 +1039,8 @@ Behavior:
 ## 11.5 Recovery Model Profiles
 
 The optional `modelProfiles.cheap` lane is not a retry worker lane. Paperclip may request the cheap profile only for status-only recovery coordination, and those wakes must include guard context that prevents deliverable work and document/plan updates (`allowDeliverableWork: false`, `allowDocumentUpdates: false`, `resumeRequiresNormalModel: true`).
+
+A requested model profile is an execution constraint. Unsupported, unresolved, or disabled profiles fail before adapter dispatch as `configuration_incomplete`; the primary adapter configuration is not an implicit fallback.
 
 Failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, and downstream source-work child/requeue/resume contexts must use the normal/original model lane. If cheap recovery repairs liveness while actual work remains, the next live continuation path must be a separate normal-model worker run with cheap hints scrubbed.
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -559,6 +559,8 @@ This keeps the post-decomposition umbrella (§7) on a real waiting path instead 
 
 Cheap model profiles are only for status-only operational recovery overhead. Paperclip may request `modelProfile: "cheap"` for bounded recovery-owner work that updates task liveness, clears bad status, records a disposition, or asks for human/manager intervention. Those wakes must carry guard context such as `allowDeliverableWork: false`, `allowDocumentUpdates: false`, and `resumeRequiresNormalModel: true`.
 
+Requested profiles fail closed: unsupported, unresolved, or disabled profiles produce `configuration_incomplete` before adapter dispatch and never fall through to the primary model. A top-level adapter `resultJson.status` of `error`, `failed`, `failure`, or `errored` likewise produces a failed run even with exit code zero.
+
 Automatic retries that can continue source work must use the original/normal model lane. This includes failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, assigned-todo dispatch recovery, and any run that can update repo files, issue documents, plans, work products, or attachments. When a cheap status-only recovery determines that actual work remains, it must hand back to a normal-model worker run before source work or persistent deliverable updates resume. Cheap recovery hints must be scrubbed from copied retry, resume, child, and downstream source-work contexts.
 
 ## 10. Startup and Periodic Reconciliation

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -561,6 +561,10 @@ Cheap model profiles are only for status-only operational recovery overhead. Pap
 
 Requested profiles fail closed: unsupported, unresolved, or disabled profiles produce `configuration_incomplete` before adapter dispatch and never fall through to the primary model. A top-level adapter `resultJson.status` of `error`, `failed`, `failure`, or `errored` likewise produces a failed run even with exit code zero.
 
+Semantic adapter failures use canonical `adapter_result_error`, discard adapter retry metadata, and do not trigger
+missing-comment retries, immediate recovery, interaction continuation, or successful-run handoff. Timeout and an
+already-terminal concurrent state retain precedence over the semantic payload.
+
 Automatic retries that can continue source work must use the original/normal model lane. This includes failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, assigned-todo dispatch recovery, and any run that can update repo files, issue documents, plans, work products, or attachments. When a cheap status-only recovery determines that actual work remains, it must hand back to a normal-model worker run before source work or persistent deliverable updates resume. Cheap recovery hints must be scrubbed from copied retry, resume, child, and downstream source-work contexts.
 
 ## 10. Startup and Periodic Reconciliation

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -107,6 +107,10 @@ export interface AdapterExecutionResult {
    * provider-reported `costUsd` as the cache-adjusted billed amount.
    */
   cacheAdjustedCostUsd?: number | null;
+  /**
+   * Adapter-owned structured result metadata. A top-level failure status is a
+   * terminal signal even when the adapter process exits with code zero.
+   */
   resultJson?: Record<string, unknown> | null;
   runtimeServices?: AdapterRuntimeServiceReport[];
   /**

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -182,6 +182,46 @@ describe("heartbeat model profile application", () => {
     );
   });
 
+  it("dispatches a status-only recovery hint on the base config when the adapter has no profiles", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [],
+      agentRuntimeConfig: {},
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap", recoveryIntent: "status_only" },
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "wake_context",
+      applied: null,
+      fallbackReason: "adapter_profile_not_supported",
+      bestEffortRecoveryHint: true,
+    });
+    // A best-effort recovery hint degrades to the base adapter config instead of
+    // failing the run closed; the missing-comment retry must still dispatch.
+    expect(() => assertRequestedModelProfileApplied(modelProfile)).not.toThrow();
+  });
+
+  it("keeps an explicit wake-context request fail-closed even when the adapter has no profiles", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [],
+      agentRuntimeConfig: {},
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap" },
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "wake_context",
+      applied: null,
+      fallbackReason: "adapter_profile_not_supported",
+      bestEffortRecoveryHint: false,
+    });
+    expect(() => assertRequestedModelProfileApplied(modelProfile)).toThrow(
+      /refusing to fall back to the primary adapter configuration/,
+    );
+  });
+
   it("normalizes a wake payload model profile into run context", () => {
     const contextSnapshot = normalizeModelProfileWakeContext({
       contextSnapshot: {},

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -4,8 +4,10 @@ import {
   type AdapterModelProfileDefinition,
 } from "../adapters/index.js";
 import {
+  assertRequestedModelProfileApplied,
   mergeModelProfileAdapterConfig,
   normalizeModelProfileWakeContext,
+  resolveAdapterRunOutcome,
   resolveModelProfileApplication,
   isConfigurationIncompleteFailedRun,
 } from "../services/heartbeat.ts";
@@ -108,7 +110,7 @@ describe("heartbeat model profile application", () => {
     });
   });
 
-  it("falls back to the primary config when the adapter does not support the requested profile", () => {
+  it("refuses the primary config when the adapter does not support the requested profile", () => {
     const modelProfile = resolveModelProfileApplication({
       adapterModelProfiles: [],
       agentRuntimeConfig: {
@@ -139,6 +141,45 @@ describe("heartbeat model profile application", () => {
       adapterConfig: null,
     });
     expect(merged).toEqual({ model: "primary" });
+    expect(() => assertRequestedModelProfileApplied(modelProfile)).toThrow(
+      /refusing to fall back to the primary adapter configuration/,
+    );
+  });
+
+  it("fails closed before dispatch when status-only recovery requests a disabled cheap profile", () => {
+    const modelProfile = resolveModelProfileApplication({
+      adapterModelProfiles: [cheapProfile],
+      agentRuntimeConfig: {
+        modelProfiles: {
+          cheap: {
+            enabled: false,
+            adapterConfig: { model: "disabled-cheap" },
+          },
+        },
+      },
+      issueModelProfile: null,
+      contextSnapshot: { modelProfile: "cheap", recoveryIntent: "status_only" },
+    });
+
+    expect(modelProfile).toMatchObject({
+      requested: "cheap",
+      requestedBy: "wake_context",
+      applied: null,
+      fallbackReason: "agent_runtime_profile_disabled",
+    });
+    expect(() => assertRequestedModelProfileApplied(modelProfile)).toThrowError(
+      expect.objectContaining({
+        name: "ConfigurationIncompleteFailure",
+        code: "configuration_incomplete",
+        resultJson: expect.objectContaining({
+          configurationIncomplete: expect.objectContaining({
+            reason: "requested_model_profile_unavailable",
+            requestedModelProfile: "cheap",
+            fallbackReason: "agent_runtime_profile_disabled",
+          }),
+        }),
+      }),
+    );
   });
 
   it("normalizes a wake payload model profile into run context", () => {
@@ -153,5 +194,55 @@ describe("heartbeat model profile application", () => {
   it("treats model resolution failures as non-retryable configuration failures", () => {
     expect(isConfigurationIncompleteFailedRun({ errorCode: "model_not_found" })).toBe(true);
     expect(isConfigurationIncompleteFailedRun({ errorCode: "provider_quota" })).toBe(false);
+  });
+});
+
+describe("heartbeat adapter outcome", () => {
+  it.each(["error", "failed", "failure", "errored", " ERROR "])(
+    "maps an exit-zero adapter result with status=%j to failed",
+    (status) => {
+      expect(resolveAdapterRunOutcome({
+        adapterResult: {
+          exitCode: 0,
+          timedOut: false,
+          errorMessage: null,
+          resultJson: { status },
+        },
+      })).toBe("failed");
+    },
+  );
+
+  it("keeps timeout priority over a semantic adapter failure", () => {
+    expect(resolveAdapterRunOutcome({
+      adapterResult: {
+        exitCode: 0,
+        timedOut: true,
+        errorMessage: null,
+        resultJson: { status: "error" },
+      },
+    })).toBe("timed_out");
+  });
+
+  it("preserves an already-terminal concurrent cancellation", () => {
+    expect(resolveAdapterRunOutcome({
+      currentTerminalStatus: "cancelled",
+      adapterResult: {
+        exitCode: 0,
+        timedOut: false,
+        errorMessage: null,
+        resultJson: { status: "completed" },
+      },
+    })).toBe("cancelled");
+  });
+
+  it("does not interpret nested status fields as the adapter outcome", () => {
+    expect(resolveAdapterRunOutcome({
+      adapterResult: {
+        exitCode: 0,
+        timedOut: false,
+        errorMessage: null,
+        resultJson: { status: "completed", detail: { status: "error" } },
+      },
+    })).toBe("succeeded");
   });
 });

--- a/server/src/__tests__/heartbeat-semantic-failure.test.ts
+++ b/server/src/__tests__/heartbeat-semantic-failure.test.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  companyMemberships,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRecoveryActions,
+  issues,
+  issueThreadInteractions,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn<() => Promise<AdapterExecutionResult>>(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Heartbeat semantic-failure integration test.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+import { runningProcesses } from "../adapters/index.ts";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+async function waitForTerminalRun(db: ReturnType<typeof createDb>, runId: string) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    if (run && run.status !== "queued" && run.status !== "running") return run;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return db
+    .select()
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+}
+
+describeEmbeddedPostgres("heartbeat semantic failure service boundary", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-semantic-failure-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 30_000);
+
+  beforeEach(() => {
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Follow-up adapter execution.",
+      provider: "test",
+      model: "test-model",
+    });
+  });
+
+  afterEach(async () => {
+    await heartbeat.drainActiveRunExecutions();
+    runningProcesses.clear();
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  }, 60_000);
+
+  async function seedAssignedIssue(input?: {
+    runtimeConfig?: Record<string, unknown>;
+    status?: "todo" | "in_progress";
+  }) {
+    const companyId = randomUUID();
+    const ownerUserId = `owner-${randomUUID()}`;
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `S${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      defaultResponsibleUserId: ownerUserId,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: ownerUserId,
+      membershipRole: "owner",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: { model: "primary-model" },
+      runtimeConfig: input?.runtimeConfig ?? {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Assigned semantic failure",
+      status: input?.status ?? "todo",
+      priority: "critical",
+      assigneeAgentId: agentId,
+      responsibleUserId: ownerUserId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  it("persists the canonical semantic failure and creates no recovery, wake, or interaction", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedIssue();
+    mockAdapterExecute.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      errorCode: "provider_quota",
+      errorFamily: "provider_quota",
+      retryNotBefore: new Date(Date.now() + 60_000).toISOString(),
+      resultJson: {
+        status: " ERROR ",
+        message: "The adapter returned a semantic error.",
+      },
+      summary: "Semantic error payload.",
+      provider: "test",
+      model: "test-model",
+    });
+
+    const sourceRun = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      requestedByActorType: "system",
+      requestedByActorId: "assignment",
+      payload: { issueId },
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+    });
+    expect(sourceRun).not.toBeNull();
+
+    const completed = await waitForTerminalRun(db, sourceRun!.id);
+    await heartbeat.drainActiveRunExecutions();
+
+    expect(completed).toMatchObject({
+      status: "failed",
+      errorCode: "adapter_result_error",
+    });
+    expect(completed?.resultJson).not.toHaveProperty("errorFamily");
+    expect(completed?.resultJson).not.toHaveProperty("retryNotBefore");
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+
+    const [runs, wakeups, comments, recoveryActions, interactions, assignedIssue] = await Promise.all([
+      db.select().from(heartbeatRuns).where(eq(heartbeatRuns.companyId, companyId)),
+      db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, companyId)),
+      db.select().from(issueComments).where(eq(issueComments.companyId, companyId)),
+      db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.companyId, companyId)),
+      db.select().from(issueThreadInteractions).where(eq(issueThreadInteractions.companyId, companyId)),
+      db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(runs).toHaveLength(1);
+    expect(wakeups).toHaveLength(1);
+    expect(comments).toHaveLength(0);
+    expect(recoveryActions).toHaveLength(0);
+    expect(interactions).toHaveLength(0);
+    expect(assignedIssue).toMatchObject({
+      status: "in_progress",
+      executionRunId: null,
+    });
+  });
+
+  it("fails a disabled requested profile before invoking the primary adapter", async () => {
+    const { agentId, issueId } = await seedAssignedIssue({
+      status: "in_progress",
+      runtimeConfig: {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+        modelProfiles: {
+          cheap: {
+            enabled: false,
+            adapterConfig: { model: "disabled-cheap-model" },
+          },
+        },
+      },
+    });
+
+    const sourceRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_continuation_needed",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat",
+      payload: { issueId, modelProfile: "cheap" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+        recoveryIntent: "status_only",
+        modelProfile: "cheap",
+        allowDeliverableWork: false,
+      },
+    });
+    expect(sourceRun).not.toBeNull();
+
+    const completed = await waitForTerminalRun(db, sourceRun!.id);
+    await heartbeat.drainActiveRunExecutions();
+
+    expect(completed).toMatchObject({
+      status: "failed",
+      errorCode: "configuration_incomplete",
+      resultJson: expect.objectContaining({
+        configurationIncomplete: expect.objectContaining({
+          reason: "requested_model_profile_unavailable",
+          requestedModelProfile: "cheap",
+          fallbackReason: "agent_runtime_profile_disabled",
+        }),
+      }),
+    });
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -212,6 +212,7 @@ import {
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import {
   recoveryAssigneeAdapterOverrides,
+  STATUS_ONLY_RECOVERY_GUARD_CONTEXT,
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
 import { recoveryService } from "./recovery/service.js";
@@ -2291,6 +2292,13 @@ export interface ModelProfileApplication {
   configSource: AppliedModelProfileConfigSource | null;
   fallbackReason: string | null;
   adapterConfig: Record<string, unknown> | null;
+  /**
+   * True when the requested profile is a best-effort status-only recovery hint
+   * (see {@link withRecoveryModelProfileHint}) rather than an explicit issue/user
+   * request. Such hints degrade gracefully to the base adapter config when the
+   * adapter cannot provide the profile, instead of failing the run closed.
+   */
+  bestEffortRecoveryHint: boolean;
 }
 
 export function assertRequestedModelProfileApplied(
@@ -2299,6 +2307,17 @@ export function assertRequestedModelProfileApplied(
   if (!modelProfile.requested || modelProfile.applied) return;
 
   const fallbackReason = modelProfile.fallbackReason ?? "requested_model_profile_unavailable";
+  // A best-effort status-only recovery hint (the cheap-model preference attached
+  // by withRecoveryModelProfileHint) must still dispatch on the base adapter
+  // config when the adapter simply cannot provide the profile. It only fails
+  // closed when the operator explicitly disabled the profile, preserving the
+  // fail-closed guarantee for explicit issue/user requests.
+  if (
+    modelProfile.bestEffortRecoveryHint &&
+    fallbackReason !== "agent_runtime_profile_disabled"
+  ) {
+    return;
+  }
   const metadata = modelProfileRunMetadata(modelProfile);
   throw new ConfigurationIncompleteFailure(
     `configuration incomplete: requested model profile "${modelProfile.requested}" could not be applied ` +
@@ -3232,6 +3251,13 @@ export function resolveModelProfileApplication(input: {
     : contextModelProfile
       ? "wake_context"
       : null;
+  // A cheap-model preference attached by a status-only recovery run is a
+  // best-effort hint, not an explicit request. An explicit issue override always
+  // wins over the context hint, so only a wake-context request can be soft.
+  const bestEffortRecoveryHint =
+    requestedBy === "wake_context" &&
+    parseObject(input.contextSnapshot).recoveryIntent ===
+      STATUS_ONLY_RECOVERY_GUARD_CONTEXT.recoveryIntent;
 
   if (!requested) {
     return {
@@ -3241,6 +3267,7 @@ export function resolveModelProfileApplication(input: {
       configSource: null,
       fallbackReason: null,
       adapterConfig: null,
+      bestEffortRecoveryHint: false,
     };
   }
 
@@ -3253,6 +3280,7 @@ export function resolveModelProfileApplication(input: {
       configSource: null,
       fallbackReason: input.profileResolutionFallbackReason ?? "adapter_profile_not_supported",
       adapterConfig: null,
+      bestEffortRecoveryHint,
     };
   }
 
@@ -3265,6 +3293,7 @@ export function resolveModelProfileApplication(input: {
       configSource: null,
       fallbackReason: "agent_runtime_profile_disabled",
       adapterConfig: null,
+      bestEffortRecoveryHint,
     };
   }
 
@@ -3278,6 +3307,7 @@ export function resolveModelProfileApplication(input: {
       ...parseObject(adapterProfile.adapterConfig),
       ...runtimeProfile.adapterConfig,
     },
+    bestEffortRecoveryHint,
   };
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -545,6 +545,18 @@ function mergeAdapterRecoveryMetadata(input: {
       : {}),
   };
 }
+
+function stripAdapterRecoveryMetadata(
+  resultJson: Record<string, unknown> | null | undefined,
+) {
+  if (!resultJson) return resultJson ?? null;
+  const sanitized = { ...resultJson };
+  delete sanitized.errorFamily;
+  delete sanitized.retryNotBefore;
+  delete sanitized.transientRetryNotBefore;
+  delete sanitized.providerQuotaRetryNotBefore;
+  return sanitized;
+}
 const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set([
   "approval_approved",
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
@@ -9538,6 +9550,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
   ) {
+    if (run.errorCode === "adapter_result_error") {
+      if (run.issueCommentStatus !== "not_applicable") {
+        await patchRunIssueCommentStatus(run.id, {
+          issueCommentStatus: "not_applicable",
+          issueCommentSatisfiedByCommentId: null,
+          issueCommentRetryQueuedAt: null,
+        });
+      }
+      return { outcome: "not_applicable" as const, queuedRun: null };
+    }
+
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
     if (!issueId) {
@@ -14906,6 +14929,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           : null,
         adapterResult,
       });
+      const semanticFailureOutcome = outcome === "failed" && adapterSemanticFailure !== null;
 
       const nextSessionState = resolveNextSessionState({
         adapterType: agent.adapterType,
@@ -14949,9 +14973,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ? (latestRun?.errorCode ?? "cancelled")
             : outcome === "failed"
               ? (
+                  (semanticFailureOutcome ? "adapter_result_error" : null) ??
                   adapterResult.errorCode ??
                   recordedResponsibleUserDenialCode ??
-                  (adapterSemanticFailure ? "adapter_result_error" : "adapter_failed")
+                  "adapter_failed"
                 )
               : null;
 
@@ -15018,11 +15043,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           resultJson: mergeModelProfileRunMetadata(
             mergeAdapterRecoveryMetadata({
               resultJson: {
-                ...parseObject(adapterResult.resultJson),
+                ...(semanticFailureOutcome
+                  ? stripAdapterRecoveryMetadata(parseObject(adapterResult.resultJson))
+                  : parseObject(adapterResult.resultJson)),
                 configFreshness: configFreshnessResultMetadata,
               },
-              errorFamily: adapterResult.errorFamily ?? null,
-              retryNotBefore: adapterResult.retryNotBefore ?? null,
+              errorFamily: semanticFailureOutcome ? null : (adapterResult.errorFamily ?? null),
+              retryNotBefore: semanticFailureOutcome ? null : (adapterResult.retryNotBefore ?? null),
             }),
             modelProfileApplication,
           ),
@@ -15143,7 +15170,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           await scheduleBoundedRetryForRun(livenessRun, agent);
         }
         const issueCommentPolicyResult = await finalizeIssueCommentPolicy(livenessRun, agent);
-        await releaseIssueExecutionAndPromote(livenessRun);
+        await releaseIssueExecutionAndPromote(livenessRun, {
+          suppressImmediateRecovery: semanticFailureOutcome,
+        });
         await handleRunLivenessContinuation(livenessRun);
         await handleSuccessfulRunHandoff(
           issueCommentPolicyResult.outcome === "retry_queued" || issueCommentPolicyResult.outcome === "retry_exhausted"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2281,6 +2281,28 @@ export interface ModelProfileApplication {
   adapterConfig: Record<string, unknown> | null;
 }
 
+export function assertRequestedModelProfileApplied(
+  modelProfile: ModelProfileApplication,
+): void {
+  if (!modelProfile.requested || modelProfile.applied) return;
+
+  const fallbackReason = modelProfile.fallbackReason ?? "requested_model_profile_unavailable";
+  const metadata = modelProfileRunMetadata(modelProfile);
+  throw new ConfigurationIncompleteFailure(
+    `configuration incomplete: requested model profile "${modelProfile.requested}" could not be applied ` +
+      `(${fallbackReason}); refusing to fall back to the primary adapter configuration`,
+    {
+      configurationIncomplete: {
+        reason: "requested_model_profile_unavailable",
+        requestedModelProfile: modelProfile.requested,
+        requestedBy: modelProfile.requestedBy,
+        fallbackReason,
+      },
+      ...(metadata ? { modelProfile: metadata } : {}),
+    },
+  );
+}
+
 /**
  * A single read-only referenced (mentioned) project workspace resolved for a run.
  * The run materializes one entry per authorized additional project, each in its own
@@ -6046,6 +6068,36 @@ export function normalizeSessionParams(params: Record<string, unknown> | null | 
 }
 
 type RunSessionOutcome = "succeeded" | "interrupted" | "failed" | "cancelled" | "timed_out";
+
+const ADAPTER_SEMANTIC_FAILURE_STATUSES = new Set(["error", "failed", "failure", "errored"]);
+
+function readAdapterSemanticFailure(
+  resultJson: Record<string, unknown> | null | undefined,
+): { status: string; message: string | null } | null {
+  const result = parseObject(resultJson);
+  const status = readNonEmptyString(result.status)?.trim().toLowerCase() ?? null;
+  if (!status || !ADAPTER_SEMANTIC_FAILURE_STATUSES.has(status)) return null;
+
+  return {
+    status,
+    message:
+      readNonEmptyString(result.errorMessage) ??
+      readNonEmptyString(result.error) ??
+      readNonEmptyString(result.message) ??
+      null,
+  };
+}
+
+export function resolveAdapterRunOutcome(input: {
+  currentTerminalStatus?: RunSessionOutcome | null;
+  adapterResult: Pick<AdapterExecutionResult, "timedOut" | "exitCode" | "errorMessage" | "resultJson">;
+}): RunSessionOutcome {
+  if (input.currentTerminalStatus) return input.currentTerminalStatus;
+  if (input.adapterResult.timedOut) return "timed_out";
+  if (readAdapterSemanticFailure(input.adapterResult.resultJson)) return "failed";
+  if ((input.adapterResult.exitCode ?? 0) === 0 && !input.adapterResult.errorMessage) return "succeeded";
+  return "failed";
+}
 
 type SkillTestHeartbeatCompletion = {
   outcome: "failed" | "cancelled";
@@ -13323,6 +13375,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     } else {
       delete context.paperclipModelProfile;
     }
+    assertRequestedModelProfileApplied(modelProfileApplication);
     const mergedConfig = mergeModelProfileAdapterConfig({
       baseConfig: workspaceManagedConfig,
       modelProfile: modelProfileApplication,
@@ -14845,17 +14898,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
       }
-      let outcome: RunSessionOutcome;
       const latestRun = await getRun(run.id);
-      if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
-        outcome = latestRun.status;
-      } else if (adapterResult.timedOut) {
-        outcome = "timed_out";
-      } else if ((adapterResult.exitCode ?? 0) === 0 && !adapterResult.errorMessage) {
-        outcome = "succeeded";
-      } else {
-        outcome = "failed";
-      }
+      const adapterSemanticFailure = readAdapterSemanticFailure(adapterResult.resultJson);
+      const outcome = resolveAdapterRunOutcome({
+        currentTerminalStatus: isHeartbeatRunTerminalStatus(latestRun?.status)
+          ? latestRun.status
+          : null,
+        adapterResult,
+      });
 
       const nextSessionState = resolveNextSessionState({
         adapterType: agent.adapterType,
@@ -14881,7 +14931,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           : outcome === "succeeded"
             ? null
             : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                adapterResult.errorMessage ??
+                  (outcome === "timed_out"
+                    ? "Timed out"
+                    : adapterSemanticFailure?.message ??
+                      (adapterSemanticFailure
+                        ? `Adapter reported ${adapterSemanticFailure.status} status`
+                        : "Adapter failed")),
                 currentUserRedactionOptions,
               );
       const recordedResponsibleUserDenialCode =
@@ -14892,7 +14948,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           : outcome === "cancelled"
             ? (latestRun?.errorCode ?? "cancelled")
             : outcome === "failed"
-              ? (adapterResult.errorCode ?? recordedResponsibleUserDenialCode ?? "adapter_failed")
+              ? (
+                  adapterResult.errorCode ??
+                  recordedResponsibleUserDenialCode ??
+                  (adapterSemanticFailure ? "adapter_result_error" : "adapter_failed")
+                )
               : null;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent work and records each execution result.
> - The heartbeat service converts adapter results into run state.
> - Some adapters can return a successful process exit with a top-level failure status.
> - Paperclip treated that result as success and could start recovery or human follow-up work.
> - An unavailable requested model profile could also fall back to another adapter.
> - This pull request makes both paths fail closed.
> - The benefit is accurate run state and fewer false recovery actions.

## Linked Issues or Issue Description

**What happened?**

An adapter could return a top-level semantic failure after a successful process exit. Paperclip persisted the run as successful and could create recovery work, interactions, or a successful handoff. Paperclip could also ignore an unavailable requested model profile and use the primary adapter.

**Expected behavior**

Paperclip must persist a top-level adapter failure as `adapter_result_error`. It must not create recovery work, interactions, or a successful handoff for that result. An explicit model profile request must fail before adapter dispatch when Paperclip cannot apply that profile.

**Steps to reproduce**

1. Return `{ "status": "failed" }` from an adapter with process exit code 0.
2. Observe the run state and follow-up work.
3. Request a disabled or incompatible model profile.
4. Observe that the primary adapter runs instead of rejecting the request.

**Paperclip version or commit**

The bug reproduces on the base commit `a388ea1`.

**Deployment mode**

Self-hosted server and focused test harness.

**Additional context**

A GitHub search found no open pull request with the same semantic-failure and requested-profile fix.

## What Changed

- Map top-level `error`, `failed`, `failure`, and `errored` adapter statuses to `adapter_result_error`.
- Suppress immediate recovery, interactions, and successful-run handoff after a semantic failure.
- Reject an unavailable requested model profile before adapter dispatch.
- Keep timeout and concurrent terminal-state precedence unchanged.
- Ignore nested `status` fields because they are not adapter outcomes.
- Update the execution contract and implementation documentation.

## Verification

- Focused semantic and model-profile tests passed: 43 of 43.
- The process-recovery suite passed: 97 of 97.
- Server and adapter-utils type checks passed.
- `git diff --check` passed.
- Independent review approved head `81d669d50bbedeaca23a89f69326b2df0d05a7ab`.
- Greptile reviewed the exact head with confidence 5 of 5.

## Risks

- This change intentionally converts some former successful runs into failed runs.
- Explicit unavailable profiles no longer use a silent fallback.
- The focused tests cover timeout precedence, terminal-state races, nested statuses, and recovery suppression.
- The pull request is draft. It does not authorize merge, release, installation, restart, or deployment.

The change follows the completed ROADMAP direction for enforced outcomes and self-healing runs. It does not add a new roadmap feature.

## Model Used

OpenAI Codex from the GPT-5 model family produced and reviewed this change with reasoning, tool use, and code execution. The hosted runtime did not expose a more specific public model ID or context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

This pull request keeps the immutable target head and tree. Any head change requires a new independent review and authorization.
