### PR TITLE
docs(execution-semantics): specify the in_review maintained-invariant review contract

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -477,7 +477,7 @@ Allowed transitions:
 - `backlog -> todo | cancelled`
 - `todo -> in_progress | blocked | cancelled`
 - `in_progress -> in_review | blocked | done | cancelled`
-- `in_review -> in_progress | done | cancelled`
+- `in_review -> in_progress | todo | done | cancelled`
 - `blocked -> todo | in_progress | cancelled`
 - terminal: `done`, `cancelled`
 
@@ -486,6 +486,7 @@ Side effects:
 - entering `in_progress` sets `started_at` if null
 - entering `done` sets `completed_at`
 - entering `cancelled` sets `cancelled_at`
+- a user or board transition of an agent-assigned issue from `in_review` to `todo` is a send-back that expresses resume intent; it enqueues the `issue_status_changed` dispatch wake, subject to the normal rewake throttle
 
 V1 non-terminal liveness rule:
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -414,10 +414,16 @@ This is dispatch state: ready to start, not yet actively claimed.
 A healthy dispatch state means at least one of these is true:
 
 - the issue already has a queued wake path
-- the issue is intentionally resting in `todo` after a completed agent heartbeat, with no interrupted dispatch evidence
+- the issue is intentionally resting in `todo` after a completed agent heartbeat, with no interrupted dispatch evidence and no unserviced resume-intent transition (see below)
 - the issue has been explicitly surfaced as stranded through a visible blocked/recovery path
 
 An assigned `todo` issue is stalled when dispatch was interrupted, no wake remains queued or running, and no recovery path has been opened.
+
+#### Resume-intent transitions
+
+A user or board transition of an agent-assigned issue from `in_review` to `todo` expresses resume intent: the human is sending the work back to the agent, not parking it. That transition MUST enqueue the same `issue_status_changed` dispatch wake that the `blocked`, `backlog`, and closed-to-`todo` transitions produce, subject to the normal rewake throttle.
+
+"Intentionally resting" never describes this state. An agent-assigned `todo` issue that arrived via a user `in_review -> todo` transition and has no queued wake is a missed handoff — stalled dispatch, not healthy rest — even though the last agent heartbeat completed normally. A reviewer sending work back to `todo` with no wake fired is exactly how issues die while looking calm.
 
 ### Agent-assigned `backlog`
 
@@ -446,6 +452,8 @@ An agent-owned `in_progress` issue is stalled when it has no active run, no queu
 
 This is review/approval state: execution is paused because the next move belongs to a reviewer, approver, board user, or recovery owner.
 
+For agent-owned issues, the review path is a maintained invariant, not an entry check. Passing the entry gate once does not keep the issue healthy: every later event that consumes the issue's last review path — a pending interaction expiring, being superseded, or resolving without a status change; a linked approval resolving; a monitor exhausting its bounds; a participant run reaching a terminal state — must either restore a valid review path or route the issue onward.
+
 A healthy `in_review` issue has at least one valid action path:
 
 - a typed execution-policy participant who can approve or request changes
@@ -457,7 +465,15 @@ A healthy `in_review` issue has at least one valid action path:
 
 Agent-assigned `in_review` with no typed participant is only healthy when one of the other paths exists. Assignment to the same agent that produced the handoff is not, by itself, a review path.
 
-An `in_review` issue is stalled when it has no typed participant, no pending interaction or approval, no user owner, no active monitor, no active run, no queued wake, and no explicit recovery action. Paperclip should surface that state as recovery work rather than silently completing the issue or leaving blocker chains parked indefinitely.
+An `in_review` issue is stalled when it has no typed participant, no pending interaction or approval, no user owner, no active monitor, no active run, no queued wake, and no explicit recovery action. Paperclip must not silently complete the issue or leave blocker chains parked indefinitely.
+
+When the last review path of an agent-owned `in_review` issue is consumed and nothing restores or replaces it, recovery is bounded and idempotent:
+
+1. Paperclip queues at most one `issue_review_path_lost` recovery wake for the assignee, fingerprinted on the consumed path id (the interaction, approval, monitor, or participant run that evaporated), so repeated evaluation of the same loss cannot fan out into a wake loop. The wake payload tells the assignee it must restore a waiting path or choose a disposition.
+2. If that recovery run also finishes with the issue `in_review` and zero paths, no further wakes are queued for that fingerprint. The issue enters a visible stalled-review state: surfaced as needs-attention on the issue page and fed to the decisions desk as a decide-now item, rather than drifting silently.
+3. A new consumed-path fingerprint — a later interaction, approval, or monitor that itself evaporates — may start one new bounded cycle; unchanged evidence must not.
+
+`in_review` with zero paths is never a terminal-OK state for recovery accounting; it is stalled work awaiting routing.
 
 When an execution-policy review stage has a pending agent participant, the participant's run is part of the review path only while it is live or queued. If that participant run reaches a terminal state while `executionState.status` remains `pending`, no decision has been recorded. Paperclip should queue one bounded normal-model recovery wake for the same participant when the agent is invokable and no other review path exists. If that recovery run also finishes while the stage remains pending, or the participant cannot be invoked, Paperclip must move the source issue to an explicit blocked/recovery path instead of leaving `in_review` to drift silently.
 
@@ -555,7 +571,24 @@ An accepted interaction supersedes a continuation park recorded before that acce
 
 This keeps the post-decomposition umbrella (§7) on a real waiting path instead of relying on `parentId` rollup, which §6 does not treat as a dependency.
 
-### 9.3 Recovery model-profile lane
+### 9.3 Stranded assigned `in_review`
+
+Example:
+
+- issue is assigned to an agent
+- status is `in_review`
+- a run finalizes while that issue is still checked out to it, and the issue has zero valid review paths under §8 (no typed participant, pending interaction or approval, user owner, active monitor, active run, queued wake, or open recovery action)
+
+Run finalization must validate the review disposition, not just the run's own exit status. A run that enters or leaves an issue `in_review` without a surviving review path has stranded a handoff even when the run itself ended successfully — for example, a run woken by review feedback that replies in a comment and ends without restoring a waiting path.
+
+Recovery rule:
+
+- Paperclip queues one bounded `issue_review_path_lost` recovery wake for the assignee, fingerprinted on the consumed path id (§8 `in_review`)
+- if that recovery run also finalizes with the issue `in_review` and zero paths, no further wakes are queued for that fingerprint; the issue surfaces as a stalled review on the issue page and the decisions desk
+
+This is a review-handoff continuity recovery. It mirrors §9.1 and §9.2: one bounded wake per fingerprint, then visible escalation instead of a requeue loop.
+
+### 9.4 Recovery model-profile lane
 
 Cheap model profiles are only for status-only operational recovery overhead. Paperclip may request `modelProfile: "cheap"` for bounded recovery-owner work that updates task liveness, clears bad status, records a disposition, or asks for human/manager intervention. Those wakes must carry guard context such as `allowDeliverableWork: false`, `allowDocumentUpdates: false`, and `resumeRequiresNormalModel: true`.
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -469,7 +469,7 @@ An `in_review` issue is stalled when it has no typed participant, no pending int
 
 When the last review path of an agent-owned `in_review` issue is consumed and nothing restores or replaces it, recovery is bounded and idempotent:
 
-1. Paperclip queues at most one `issue_review_path_lost` recovery wake for the assignee, fingerprinted on the consumed path id (the interaction, approval, monitor, or participant run that evaporated), so repeated evaluation of the same loss cannot fan out into a wake loop. The wake payload tells the assignee it must restore a waiting path or choose a disposition.
+1. Paperclip queues at most one `issue_review_path_lost` recovery wake for the assignee, fingerprinted on the consumed path id (the interaction, approval, monitor, or participant run that evaporated), so repeated evaluation of the same loss cannot fan out into a wake loop. When the issue became pathless without a consumed path — for example, it entered `in_review` and no review path was ever created — the fingerprint is the id of the finalizing run or status-change event that left it pathless, so the recovery key is always stable. The wake payload tells the assignee it must restore a waiting path or choose a disposition.
 2. If that recovery run also finishes with the issue `in_review` and zero paths, no further wakes are queued for that fingerprint. The issue enters a visible stalled-review state: surfaced as needs-attention on the issue page and fed to the decisions desk as a decide-now item, rather than drifting silently.
 3. A new consumed-path fingerprint — a later interaction, approval, or monitor that itself evaporates — may start one new bounded cycle; unchanged evidence must not.
 
@@ -583,7 +583,7 @@ Run finalization must validate the review disposition, not just the run's own ex
 
 Recovery rule:
 
-- Paperclip queues one bounded `issue_review_path_lost` recovery wake for the assignee, fingerprinted on the consumed path id (§8 `in_review`)
+- Paperclip queues one bounded `issue_review_path_lost` recovery wake for the assignee, fingerprinted on the consumed path id or, when no path was consumed, on the id of the finalizing run that left the issue pathless (§8 `in_review`)
 - if that recovery run also finalizes with the issue `in_review` and zero paths, no further wakes are queued for that fingerprint; the issue surfaces as a stalled review on the issue page and the decisions desk
 
 This is a review-handoff continuity recovery. It mirrors §9.1 and §9.2: one bounded wake per fingerprint, then visible escalation instead of a requeue loop.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The execution-semantics contract (`doc/execution-semantics.md`) defines when a non-terminal issue counts as healthy or stalled
> - Agent-owned `in_review` issues can lose their last review path after entry: an interaction gets superseded, a monitor exhausts, or a run ends without a surviving path
> - The current text validates the review path only at entry, and it calls an agent-assigned `todo` issue "intentionally resting" even when a reviewer sent it back with no dispatch wake
> - Work then waits forever while it looks calm, and nobody sees a next action
> - This pull request amends the contract: the review path is a maintained invariant, loss of the last path triggers one bounded recovery wake and then a visible stalled state, and a user `in_review -> todo` transition must enqueue a dispatch wake
> - The benefit is that review handoffs cannot die silently; the contract now names the recovery wake, its fingerprint bound, and the visible escalation surfaces

## Linked Issues or Issue Description

**Issue type**

Missing contract semantics (docs).

**Where is the issue?**

`doc/execution-semantics.md`, section 8 (`in_review`, agent-assigned `todo`) and section 9 (crash and restart recovery). Also `doc/SPEC-implementation.md` section 8.2 (allowed status transitions).

**What's wrong?**

The contract gates the review path only when an issue enters `in_review`. It does not say what must happen when a later event consumes the last review path. It also classifies an agent-assigned `todo` issue as "intentionally resting" after a completed heartbeat, which wrongly marks a reviewer send-back with no wake as healthy. Section 9 has no run-end validation for review dispositions.

**Suggested fix**

State the maintained invariant, the bounded `issue_review_path_lost` recovery wake with its fingerprint rule, the visible stalled-review surfaces, the resume-intent wake for user `in_review -> todo` transitions, and run-end review-disposition validation.

## What Changed

- Section 8 `in_review`: the review path is a maintained invariant, not an entry check. On loss of the last path, Paperclip queues at most one `issue_review_path_lost` recovery wake, fingerprinted on the consumed path id. If that run also ends with zero paths, the issue shows a visible stalled-review state on the issue page and the decisions desk. Zero-path `in_review` is never terminal-OK for recovery accounting.
- Section 8 agent-assigned `todo`: a user transition from `in_review` to `todo` expresses resume intent and MUST enqueue the same `issue_status_changed` dispatch wake as the other reactivation transitions. The "intentionally resting" language now excludes unserviced resume-intent transitions.
- Section 9: new section 9.3 "Stranded assigned `in_review`" adds run-end disposition validation — a run that finalizes with its checked-out issue `in_review` and zero paths triggers the bounded recovery wake, then visible escalation. The model-profile lane moved to section 9.4.
- `doc/SPEC-implementation.md` section 8.2: `in_review -> todo` is now an allowed transition, with the resume-intent dispatch wake listed as a side effect. This keeps the status contract consistent with the resume-intent rule (review feedback).
- The recovery fingerprint has a defined fallback: when the issue became pathless without a consumed path, the fingerprint is the id of the finalizing run or status-change event. The recovery key is always stable (review feedback).

## Verification

- Docs-only change. Read `doc/execution-semantics.md` sections 8 and 9.
- `grep -n "issue_review_path_lost" doc/execution-semantics.md` shows the new bounded-wake contract.
- No code, schema, or behavior changes are in this PR; the enforcement work lands separately.

## Risks

- Low risk. Documentation only. The named wake reason and surfaces match the implementation work that follows; if that work changes shape, this contract text is the source of truth to update.

## Model Used

- Claude Fable 5 (`claude-fable-5`), Anthropic, extended thinking with tool use, via Claude Agent SDK.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
