### PR TITLE
fix(productivity-review): close reviews whose source issue reached a terminal status

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
+  PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
   productivityReviewService,
@@ -208,6 +209,68 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
 
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
+  });
+
+  it("auto-resolves an open review after the source issue reaches a terminal status", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    const first = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(first.created).toBe(1);
+    expect(first.autoResolved).toBe(0);
+
+    const [openReview] = await listProductivityReviews(seeded.companyId);
+    expect(openReview?.status).toBe("todo");
+
+    await db
+      .update(issues)
+      .set({ status: "done" })
+      .where(eq(issues.id, seeded.issueId));
+
+    const second = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(second.autoResolved).toBe(1);
+    expect(second.autoResolvedIssueIds).toEqual([openReview!.id]);
+    const [resolvedReview] = await listProductivityReviews(seeded.companyId);
+    expect(resolvedReview?.status).toBe("cancelled");
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, openReview!.id));
+    expect(
+      comments.some((comment) => comment.body.startsWith(PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX)),
+    ).toBe(true);
+
+    const third = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(third.autoResolved).toBe(0);
+  });
+
+  it("keeps an open review while the source issue is not terminal", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const second = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(second.autoResolved).toBe(0);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.status).toBe("todo");
   });
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -399,6 +399,82 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.status).toBe("cancelled");
   }, 30_000);
 
+  it("auto-resolves past a full page of terminal-source reviews that agents are judging right now", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+
+    // Terminal source, so the source-status filter alone would select every one
+    // of these, and the in-loop active-run guard would skip all of them.
+    const busyRuns: Array<typeof heartbeatRuns.$inferInsert> = [];
+    for (let index = 0; index < MAX_OPEN_REVIEWS_PER_RECONCILE; index += 1) {
+      const pair = await seedReviewPair({
+        companyId: seeded.companyId,
+        issuePrefix: seeded.issuePrefix,
+        assigneeAgentId: seeded.coderId,
+        managerAgentId: seeded.managerId,
+        index,
+        sourceStatus: "done",
+        createdAt: new Date(seeded.createdAt.getTime() + index * 1_000),
+      });
+      busyRuns.push({
+        id: randomUUID(),
+        companyId: seeded.companyId,
+        agentId: seeded.managerId,
+        status: "running",
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        startedAt: now,
+        contextSnapshot: { issueId: pair.reviewIssueId, taskId: pair.reviewIssueId },
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    await db.insert(heartbeatRuns).values(busyRuns);
+
+    const actionable = await seedReviewPair({
+      companyId: seeded.companyId,
+      issuePrefix: seeded.issuePrefix,
+      assigneeAgentId: seeded.coderId,
+      managerAgentId: seeded.managerId,
+      index: MAX_OPEN_REVIEWS_PER_RECONCILE,
+      sourceStatus: "done",
+      createdAt: new Date(seeded.createdAt.getTime() + MAX_OPEN_REVIEWS_PER_RECONCILE * 1_000),
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.autoResolvedIssueIds).toEqual([actionable.reviewIssueId]);
+    const [review] = await db.select().from(issues).where(eq(issues.id, actionable.reviewIssueId));
+    expect(review?.status).toBe("cancelled");
+  }, 30_000);
+
+  it("writes one audit comment when two reconciliations overlap on the same review", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const pair = await seedReviewPair({
+      companyId: seeded.companyId,
+      issuePrefix: seeded.issuePrefix,
+      assigneeAgentId: seeded.coderId,
+      managerAgentId: seeded.managerId,
+      index: 0,
+      sourceStatus: "done",
+      createdAt: seeded.createdAt,
+    });
+
+    const service = productivityReviewService(db);
+    const [a, b] = await Promise.all([
+      service.reconcileProductivityReviews({ now, companyId: seeded.companyId }),
+      service.reconcileProductivityReviews({ now, companyId: seeded.companyId }),
+    ]);
+
+    // Exactly one pass does the work; the other finds the lock held and defers.
+    expect([a.autoResolved, b.autoResolved].sort()).toEqual([0, 1]);
+    expect(await listAutoResolveComments(pair.reviewIssueId)).toHaveLength(1);
+    const [review] = await db.select().from(issues).where(eq(issues.id, pair.reviewIssueId));
+    expect(review?.status).toBe("cancelled");
+  });
+
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
+  MAX_OPEN_REVIEWS_PER_RECONCILE,
   PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
@@ -169,6 +170,64 @@ describeEmbeddedPostgres("productivity review service", () => {
       .orderBy(issues.createdAt);
   }
 
+  async function listAutoResolveComments(reviewIssueId: string) {
+    return db
+      .select()
+      .from(issueComments)
+      .where(and(
+        eq(issueComments.issueId, reviewIssueId),
+        sql`${issueComments.body} like ${`${PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX}%`}`,
+      ));
+  }
+
+  // Inserts a source issue plus the productivity review that points at it,
+  // bypassing the creation path so a test can build many pairs cheaply.
+  async function seedReviewPair(input: {
+    companyId: string;
+    issuePrefix: string;
+    assigneeAgentId: string;
+    managerAgentId: string;
+    index: number;
+    sourceStatus: "in_progress" | "done" | "cancelled";
+    createdAt: Date;
+  }) {
+    const sourceIssueId = randomUUID();
+    const reviewIssueId = randomUUID();
+    const sourceNumber = 1000 + input.index * 2;
+    await db.insert(issues).values([
+      {
+        id: sourceIssueId,
+        companyId: input.companyId,
+        title: `Source ${input.index}`,
+        status: input.sourceStatus,
+        priority: "medium",
+        assigneeAgentId: input.assigneeAgentId,
+        originKind: "manual",
+        issueNumber: sourceNumber,
+        identifier: `${input.issuePrefix}-${sourceNumber}`,
+        createdAt: input.createdAt,
+        updatedAt: input.createdAt,
+      },
+      {
+        id: reviewIssueId,
+        companyId: input.companyId,
+        title: `Productivity review ${input.index}`,
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: input.managerAgentId,
+        parentId: sourceIssueId,
+        originKind: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+        originId: sourceIssueId,
+        originFingerprint: `productivity-review:${sourceIssueId}`,
+        issueNumber: sourceNumber + 1,
+        identifier: `${input.issuePrefix}-${sourceNumber + 1}`,
+        createdAt: input.createdAt,
+        updatedAt: input.createdAt,
+      },
+    ]);
+    return { sourceIssueId, reviewIssueId };
+  }
+
   async function listRefreshComments(reviewIssueId: string) {
     return db
       .select()
@@ -272,6 +331,73 @@ describeEmbeddedPostgres("productivity review service", () => {
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.status).toBe("todo");
   });
+
+  it("does not repeat the audit comment when an earlier pass commented but failed to cancel", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const pair = await seedReviewPair({
+      companyId: seeded.companyId,
+      issuePrefix: seeded.issuePrefix,
+      assigneeAgentId: seeded.coderId,
+      managerAgentId: seeded.managerId,
+      index: 0,
+      sourceStatus: "done",
+      createdAt: seeded.createdAt,
+    });
+    // The state a partial write leaves behind: audit comment present, review still open.
+    await db.insert(issueComments).values({
+      companyId: seeded.companyId,
+      issueId: pair.reviewIssueId,
+      authorAgentId: seeded.managerId,
+      body: `${PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX} The source issue reached terminal status \`done\`, so no productivity decision is necessary.`,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.autoResolved).toBe(1);
+    expect(result.autoResolvedIssueIds).toEqual([pair.reviewIssueId]);
+    expect(await listAutoResolveComments(pair.reviewIssueId)).toHaveLength(1);
+    const [review] = await db.select().from(issues).where(eq(issues.id, pair.reviewIssueId));
+    expect(review?.status).toBe("cancelled");
+  });
+
+  it("auto-resolves a terminal-source review that sits behind a full page of older open reviews", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+
+    // Older than the actionable review and never resolvable: under an
+    // oldest-first scan of all open reviews these would fill the page forever.
+    for (let index = 0; index < MAX_OPEN_REVIEWS_PER_RECONCILE; index += 1) {
+      await seedReviewPair({
+        companyId: seeded.companyId,
+        issuePrefix: seeded.issuePrefix,
+        assigneeAgentId: seeded.coderId,
+        managerAgentId: seeded.managerId,
+        index,
+        sourceStatus: "in_progress",
+        createdAt: new Date(seeded.createdAt.getTime() + index * 1_000),
+      });
+    }
+    const actionable = await seedReviewPair({
+      companyId: seeded.companyId,
+      issuePrefix: seeded.issuePrefix,
+      assigneeAgentId: seeded.coderId,
+      managerAgentId: seeded.managerId,
+      index: MAX_OPEN_REVIEWS_PER_RECONCILE,
+      sourceStatus: "done",
+      createdAt: new Date(seeded.createdAt.getTime() + MAX_OPEN_REVIEWS_PER_RECONCILE * 1_000),
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.autoResolvedIssueIds).toEqual([actionable.reviewIssueId]);
+    const [review] = await db.select().from(issues).where(eq(issues.id, actionable.reviewIssueId));
+    expect(review?.status).toBe("cancelled");
+  }, 30_000);
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -37,9 +37,11 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CONSECUTIVE_NO_ACTION_REVIEWS = 3;
 const TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
+const MAX_OPEN_REVIEWS_PER_RECONCILE = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
 export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
+export const PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX = "Productivity review resolved automatically.";
 
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
@@ -265,6 +267,38 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .orderBy(desc(issues.updatedAt))
       .limit(1)
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function listOpenProductivityReviews(companyId?: string) {
+    return db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          companyId ? eq(issues.companyId, companyId) : undefined,
+          eq(issues.originKind, PRODUCTIVITY_REVIEW_ORIGIN_KIND),
+          visibleIssueCondition(),
+          notInArray(issues.status, ["done", "cancelled"]),
+          sql`${issues.originId} is not null`,
+        ),
+      )
+      .orderBy(asc(issues.createdAt), asc(issues.id))
+      .limit(MAX_OPEN_REVIEWS_PER_RECONCILE);
+  }
+
+  async function hasActiveRunForIssue(companyId: string, issueId: string) {
+    return db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          inArray(heartbeatRuns.status, [...ACTIVE_RUN_STATUSES]),
+          issueRunScopeSql(issueId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows.length > 0);
   }
 
   async function findRecentTerminalProductivityReview(
@@ -824,6 +858,59 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return { kind: "created" as const, reviewIssueId: review.id };
   }
 
+  // A review stays open after its source issue finishes, because only a manager
+  // decision closes it. Close those reviews automatically: there is no work left
+  // to judge once the source reaches a terminal status.
+  async function autoResolveTerminalSourceReviews(companyId?: string) {
+    const openReviews = await listOpenProductivityReviews(companyId);
+    const autoResolvedIssueIds: string[] = [];
+
+    for (const review of openReviews) {
+      if (!review.originId) continue;
+      const sourceIssue = await db
+        .select({ id: issues.id, status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.companyId, review.companyId), eq(issues.id, review.originId)))
+        .then((rows) => rows[0] ?? null);
+      if (!sourceIssue || !["done", "cancelled"].includes(sourceIssue.status)) continue;
+      // Do not close a review that an agent is judging right now.
+      if (await hasActiveRunForIssue(review.companyId, review.id)) continue;
+
+      try {
+        await issuesSvc.addComment(
+          review.id,
+          `${PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX} The source issue reached terminal status \`${sourceIssue.status}\`, so no productivity decision is necessary.`,
+          {},
+        );
+        await issuesSvc.update(review.id, { status: "cancelled" });
+      } catch (err) {
+        logger.warn(
+          { err, companyId: review.companyId, issueId: review.id, sourceIssueId: sourceIssue.id },
+          "productivity review auto-resolution failed",
+        );
+        continue;
+      }
+
+      await logActivity(db, {
+        companyId: review.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "issue.productivity_review_auto_resolved",
+        entityType: "issue",
+        entityId: review.id,
+        agentId: review.assigneeAgentId,
+        details: {
+          source: "productivity_review.reconcile",
+          sourceIssueId: sourceIssue.id,
+          sourceIssueStatus: sourceIssue.status,
+        },
+      });
+      autoResolvedIssueIds.push(review.id);
+    }
+
+    return autoResolvedIssueIds;
+  }
+
   async function reconcileProductivityReviews(opts?: {
     now?: Date;
     companyId?: string;
@@ -832,6 +919,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   }) {
     const now = opts?.now ?? new Date();
     const thresholds = buildThresholds(opts?.thresholds);
+    const autoResolvedIssueIds = await autoResolveTerminalSourceReviews(opts?.companyId);
     const candidates = await db
       .select()
       .from(issues)
@@ -859,8 +947,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       noActionSuppressed: 0,
       skipped: 0,
       failed: 0,
+      autoResolved: autoResolvedIssueIds.length,
       reviewIssueIds: [] as string[],
       failedIssueIds: [] as string[],
+      autoResolvedIssueIds,
     };
 
     const prefixCache = new Map<string, string>();

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, notExists, notInArray, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
@@ -38,6 +38,7 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CONSECUTIVE_NO_ACTION_REVIEWS = 3;
 const TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
 const TERMINAL_ISSUE_STATUSES = ["done", "cancelled"] as const;
 const sourceIssues = alias(issues, "source_issues");
+const activeRuns = alias(heartbeatRuns, "active_runs");
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
 export const MAX_OPEN_REVIEWS_PER_RECONCILE = 250;
@@ -301,6 +302,25 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           visibleIssueCondition(),
           notInArray(issues.status, ["done", "cancelled"]),
           inArray(sourceIssues.status, [...TERMINAL_ISSUE_STATUSES]),
+          // A review an agent is judging right now is skipped, so excluding it
+          // here as well keeps it from holding a slot the page owes to a review
+          // the pass can actually resolve.
+          notExists(
+            db
+              .select({ one: sql`1` })
+              .from(activeRuns)
+              .where(
+                and(
+                  eq(activeRuns.companyId, issues.companyId),
+                  inArray(activeRuns.status, [...ACTIVE_RUN_STATUSES]),
+                  sql`(
+                    ${activeRuns.contextSnapshot}->>'issueId' = ${issues.id}::text
+                    or ${activeRuns.contextSnapshot}->>'taskId' = ${issues.id}::text
+                    or ${activeRuns.contextSnapshot}->>'taskKey' = ${issues.id}::text
+                  )`,
+                ),
+              ),
+          ),
         ),
       )
       .orderBy(asc(issues.createdAt), asc(issues.id))
@@ -899,12 +919,34 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   // A review stays open after its source issue finishes, because only a manager
   // decision closes it. Close those reviews automatically: there is no work left
   // to judge once the source reaches a terminal status.
+  //
+  // The pass runs under an advisory lock. Reading a review and writing its audit
+  // comment are separate statements, so two overlapping reconciliations would
+  // both read the review as uncommented and both write the comment. `try` rather
+  // than a blocking acquire: a second pass has nothing to add, so it should skip
+  // and let the next cycle pick the work up instead of queueing behind this one.
+  // The lock is transaction-scoped, so a pass that throws cannot strand it.
   async function autoResolveTerminalSourceReviews(companyId?: string) {
+    return db.transaction(async (tx) => {
+      const lockKey = `paperclip:productivity-review:auto-resolve:${companyId ?? "all"}`;
+      const acquired = await tx
+        .execute(sql<{ acquired: boolean }>`
+          select pg_try_advisory_xact_lock(hashtextextended(${lockKey}, 0)) as acquired
+        `)
+        .then((rows) => Boolean(Array.from(rows as Iterable<{ acquired: boolean }>)[0]?.acquired));
+      if (!acquired) return [] as string[];
+      return runAutoResolvePass(companyId);
+    });
+  }
+
+  async function runAutoResolvePass(companyId?: string) {
     const openReviews = await listTerminalSourceOpenReviews(companyId);
     const autoResolvedIssueIds: string[] = [];
 
     for (const review of openReviews) {
-      // Do not close a review that an agent is judging right now.
+      // The scan already excludes reviews with an active run, so this only
+      // catches a run that started since. It cannot starve the page: a row that
+      // reaches this point was actionable when the page was built.
       if (await hasActiveRunForIssue(review.companyId, review.id)) continue;
 
       try {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,4 +1,5 @@
 import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
 import {
@@ -35,9 +36,11 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 1;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CONSECUTIVE_NO_ACTION_REVIEWS = 3;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "interrupted", "failed", "cancelled", "timed_out"] as const;
+const TERMINAL_ISSUE_STATUSES = ["done", "cancelled"] as const;
+const sourceIssues = alias(issues, "source_issues");
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
-const MAX_OPEN_REVIEWS_PER_RECONCILE = 250;
+export const MAX_OPEN_REVIEWS_PER_RECONCILE = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
 export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
@@ -269,21 +272,56 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .then((rows) => rows[0] ?? null);
   }
 
-  async function listOpenProductivityReviews(companyId?: string) {
+  // Select on the source status rather than filtering in the loop, so the page
+  // holds only reviews this pass can act on. A page of open-but-not-actionable
+  // reviews would otherwise sit at the head of every scan and starve the rest.
+  async function listTerminalSourceOpenReviews(companyId?: string) {
     return db
-      .select()
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        assigneeAgentId: issues.assigneeAgentId,
+        sourceIssueId: sourceIssues.id,
+        sourceIssueStatus: sourceIssues.status,
+      })
       .from(issues)
+      .innerJoin(
+        sourceIssues,
+        and(
+          // `origin_id` is text and does not always hold a uuid, so widen the
+          // uuid side rather than casting the column and risking a parse error.
+          sql`${sourceIssues.id}::text = ${issues.originId}`,
+          eq(sourceIssues.companyId, issues.companyId),
+        ),
+      )
       .where(
         and(
           companyId ? eq(issues.companyId, companyId) : undefined,
           eq(issues.originKind, PRODUCTIVITY_REVIEW_ORIGIN_KIND),
           visibleIssueCondition(),
           notInArray(issues.status, ["done", "cancelled"]),
-          sql`${issues.originId} is not null`,
+          inArray(sourceIssues.status, [...TERMINAL_ISSUE_STATUSES]),
         ),
       )
       .orderBy(asc(issues.createdAt), asc(issues.id))
       .limit(MAX_OPEN_REVIEWS_PER_RECONCILE);
+  }
+
+  // The status update and the audit comment are separate writes. If the update
+  // fails after the comment lands, the retry must not comment a second time.
+  async function hasAutoResolveComment(companyId: string, reviewIssueId: string) {
+    return db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.issueId, reviewIssueId),
+          sql`${issueComments.body} like ${`${PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX}%`}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows.length > 0);
   }
 
   async function hasActiveRunForIssue(companyId: string, issueId: string) {
@@ -862,30 +900,25 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   // decision closes it. Close those reviews automatically: there is no work left
   // to judge once the source reaches a terminal status.
   async function autoResolveTerminalSourceReviews(companyId?: string) {
-    const openReviews = await listOpenProductivityReviews(companyId);
+    const openReviews = await listTerminalSourceOpenReviews(companyId);
     const autoResolvedIssueIds: string[] = [];
 
     for (const review of openReviews) {
-      if (!review.originId) continue;
-      const sourceIssue = await db
-        .select({ id: issues.id, status: issues.status })
-        .from(issues)
-        .where(and(eq(issues.companyId, review.companyId), eq(issues.id, review.originId)))
-        .then((rows) => rows[0] ?? null);
-      if (!sourceIssue || !["done", "cancelled"].includes(sourceIssue.status)) continue;
       // Do not close a review that an agent is judging right now.
       if (await hasActiveRunForIssue(review.companyId, review.id)) continue;
 
       try {
-        await issuesSvc.addComment(
-          review.id,
-          `${PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX} The source issue reached terminal status \`${sourceIssue.status}\`, so no productivity decision is necessary.`,
-          {},
-        );
+        if (!(await hasAutoResolveComment(review.companyId, review.id))) {
+          await issuesSvc.addComment(
+            review.id,
+            `${PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX} The source issue reached terminal status \`${review.sourceIssueStatus}\`, so no productivity decision is necessary.`,
+            {},
+          );
+        }
         await issuesSvc.update(review.id, { status: "cancelled" });
       } catch (err) {
         logger.warn(
-          { err, companyId: review.companyId, issueId: review.id, sourceIssueId: sourceIssue.id },
+          { err, companyId: review.companyId, issueId: review.id, sourceIssueId: review.sourceIssueId },
           "productivity review auto-resolution failed",
         );
         continue;
@@ -901,8 +934,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         agentId: review.assigneeAgentId,
         details: {
           source: "productivity_review.reconcile",
-          sourceIssueId: sourceIssue.id,
-          sourceIssueStatus: sourceIssue.status,
+          sourceIssueId: review.sourceIssueId,
+          sourceIssueStatus: review.sourceIssueStatus,
         },
       });
       autoResolvedIssueIds.push(review.id);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The productivity-review service files a "Review productivity" issue for a manager when an assignee looks stalled
> - The service creates those reviews automatically, but it never closes them automatically
> - A review therefore stays open after its source issue reaches `done` or `cancelled`, because only a manager decision closes it
> - The manager then opens a review, finds the source work already finished, and closes the review by hand — repeatedly
> - This pull request adds an auto-resolution pass that cancels a review when its source issue is terminal
> - The benefit is that the manager queue holds only reviews that still have work to judge

## Linked Issues or Issue Description

Refs #5763

**Bug report**

- **What happened.** A productivity review is created while the source issue is legitimately `in_progress`. The assignee then finishes the work and the source issue moves to `done`. The review stays open. In a sample of six reviews on one instance, four had a source issue that was already `done` at the time a human opened the review.
- **Expected behavior.** A review with a terminal source issue has nothing left to judge, so the system must close it.
- **Steps to reproduce.**
  1. Let `reconcileProductivityReviews` create a review for an issue.
  2. Set the source issue status to `done`.
  3. Run `reconcileProductivityReviews` again.
  4. The review is still open.
- **Deployment mode.** Self-hosted, local dev server.
- **Commit.** Reproduced on `master` at the time of writing.

Note on detection: the detector cannot fire on a terminal source. The candidate query restricts to `todo` and `in_progress`, and `elapsedMs` is `null` unless the source is `in_progress`. The gap is only in the lifetime of a review that was already created.

Related open pull request:

- #10666 changes the `long_active_duration` trigger in the same file. The two changes touch different functions and do not conflict.

## What Changed

- `server/src/services/productivity-review.ts`: adds `autoResolveTerminalSourceReviews`. `reconcileProductivityReviews` runs it before the candidate scan.
- The pass lists open reviews (`originKind = issue_productivity_review`, status not `done` or `cancelled`), reads the source issue named by `originId`, and cancels the review when the source is `done` or `cancelled`.
- The pass writes a one-line comment before it cancels, prefixed with the new exported constant `PRODUCTIVITY_REVIEW_AUTO_RESOLVE_COMMENT_PREFIX`.
- The pass records an `issue.productivity_review_auto_resolved` activity entry.
- The pass skips a review that has a queued, running, or retry-scheduled run, because an agent can be judging that review at that moment. This mirrors the `hasActiveRunForIssueId` guard in the liveness-recovery retirement pass.
- A failed comment or update is logged and skipped. It does not stop the pass.
- The reconcile result gains `autoResolved` and `autoResolvedIssueIds`.
- `server/src/__tests__/productivity-review-service.test.ts`: adds two tests — one that flips the source to `done` and asserts the review is cancelled with the comment present and the pass is idempotent on a third run, and one that asserts a non-terminal source leaves the review open.

The review is set to `cancelled`, not `done`. `countConsecutiveNoActionProductivityReviews` counts only `done` reviews toward its suppression streak, so a system closure must not enter that count as if a manager had made a decision.

## Verification

```
npx vitest run server/src/__tests__/productivity-review-service.test.ts
  Test Files  1 passed (1)
       Tests  17 passed (17)

npx vitest run server/src/__tests__/attention-service.test.ts \
              server/src/__tests__/heartbeat-responsible-user-invariant.test.ts
  Test Files  2 passed (2)
       Tests  19 passed (19)

pnpm --filter @paperclipai/server typecheck
  clean
```

## Risks

Low.

- The pass adds one query per open review on each reconcile. The list is capped at 250 reviews per reconcile, the same cap that the candidate scan already uses. On a healthy instance the open-review count is small.
- A manager loses the chance to record a decision on a review whose source has already finished. That decision has no effect on the source work, so the loss is small. The comment and the activity entry keep the closure auditable.
- No migration. No schema change. No telemetry contract change.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking, tool use through Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
