### PR TITLE
fix(server): persist built-in agent opt-outs across restarts

### DIFF
--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -18,6 +18,7 @@ import {
   createDb,
   issueThreadInteractions,
   issues,
+  instanceSettings,
   principalPermissionGrants,
   routines,
   routineTriggers,
@@ -39,6 +40,7 @@ import {
   validateBuiltInAgentDefinitions,
 } from "../services/built-in-agents.ts";
 import { readBuiltInAgentMarker, withBuiltInAgentMarker } from "../services/built-in-agent-metadata.ts";
+import { instanceSettingsService } from "../services/instance-settings.ts";
 import { issueThreadInteractionService } from "../services/issue-thread-interactions.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -138,6 +140,7 @@ describeEmbeddedPostgres("built-in agents", () => {
     await db.delete(agents);
     await db.delete(budgetPolicies);
     await db.delete(companies);
+    await db.delete(instanceSettings);
     // Some tests drop the built-in marker unique index to simulate legacy
     // (pre-migration 0192) duplicates; restore it now that all rows are gone.
     await db.execute(sql.raw(BUILT_IN_MARKER_UNIQUE_INDEX_DDL));
@@ -166,6 +169,43 @@ describeEmbeddedPostgres("built-in agents", () => {
     });
     return companyId;
   }
+
+  async function enableBuiltInAgents() {
+    await instanceSettingsService(db).updateExperimental({ enableBuiltInAgents: true });
+  }
+
+  it("skips automatic bundled-agent provisioning when the instance flag is disabled", async () => {
+    const companyId = await seedCompany({ requireApproval: true });
+    const service = builtInAgentService(db);
+
+    const direct = await service.autoProvisionBundledAgents(companyId);
+    expect(direct).toEqual({
+      autoEnsured: 0,
+      pendingApprovals: 0,
+      defaultGrantsEnsured: 0,
+      outcomes: {
+        skipped_by_flag: 2,
+        skipped_by_tombstone: 0,
+        provisioned: 0,
+        already_present: 0,
+      },
+    });
+
+    const startup = await reconcileBuiltInAgentsOnStartup(db);
+    expect(startup).toMatchObject({
+      autoEnsured: 0,
+      pendingApprovals: 0,
+      defaultGrantsEnsured: 0,
+      outcomes: {
+        skipped_by_flag: 2,
+        skipped_by_tombstone: 0,
+        provisioned: 0,
+        already_present: 0,
+      },
+    });
+    expect(await db.select().from(agents).where(eq(agents.companyId, companyId))).toHaveLength(0);
+    expect(await db.select().from(approvals).where(eq(approvals.companyId, companyId))).toHaveLength(0);
+  });
 
   it("validates the static registry and rejects invalid definitions", () => {
     const definitions = listBuiltInAgentDefinitions();
@@ -570,6 +610,7 @@ describeEmbeddedPostgres("built-in agents", () => {
   });
 
   it("auto-provisions a paused Reflection Coach bundle with skill sync and a disabled routine", async () => {
+    await enableBuiltInAgents();
     const companyId = await seedCompany({ requireApproval: false });
     const root = await agentService(db).create(companyId, {
       name: "CEO",
@@ -694,6 +735,7 @@ describeEmbeddedPostgres("built-in agents", () => {
   });
 
   it("preserves new-agent approval gates during automatic Reflection Coach provisioning", async () => {
+    await enableBuiltInAgents();
     const companyId = await seedCompany({ requireApproval: true });
     const root = await agentService(db).create(companyId, {
       name: "CEO",
@@ -788,6 +830,55 @@ describeEmbeddedPostgres("built-in agents", () => {
     expect(agentRows.filter((row) => readBuiltInAgentMarker(row.metadata)?.key === "reflection-coach")).toHaveLength(1);
     const approvalRows = await db.select().from(approvals).where(eq(approvals.companyId, companyId));
     expect(approvalRows).toHaveLength(2);
+  });
+
+  it("treats a rejected built-in hire as a restart-safe tombstone while allowing manual reprovision", async () => {
+    await enableBuiltInAgents();
+    const companyId = await seedCompany({ requireApproval: true });
+    const service = builtInAgentService(db);
+
+    await service.autoProvisionBundledAgents(companyId);
+    const initialState = await service.get(companyId, "reflection-coach");
+    const initialApprovals = await db.select().from(approvals).where(eq(approvals.companyId, companyId));
+    const initialApproval = initialApprovals.find(
+      (row) => (row.payload as { sourceBuiltInAgentKey?: string }).sourceBuiltInAgentKey === "reflection-coach",
+    );
+    expect(initialApproval).toBeDefined();
+    await approvalService(db).reject(initialApproval!.id, "board-user", "Opt out");
+
+    const restart = await reconcileBuiltInAgentsOnStartup(db);
+    expect(restart.outcomes).toMatchObject({
+      skipped_by_flag: 0,
+      skipped_by_tombstone: 1,
+      provisioned: 0,
+      already_present: 1,
+    });
+    const afterRestartRows = (await db.select().from(agents).where(eq(agents.companyId, companyId)))
+      .filter((row) => readBuiltInAgentMarker(row.metadata)?.key === "reflection-coach");
+    expect(afterRestartRows).toHaveLength(1);
+    expect(afterRestartRows[0]).toMatchObject({ id: initialState.agentId, status: "terminated" });
+    const afterRestartApprovals = (await db.select().from(approvals).where(eq(approvals.companyId, companyId)))
+      .filter((row) => (row.payload as { sourceBuiltInAgentKey?: string }).sourceBuiltInAgentKey === "reflection-coach");
+    expect(afterRestartApprovals).toHaveLength(1);
+    expect(afterRestartApprovals[0]?.status).toBe("rejected");
+
+    const manual = await service.provision(companyId, "reflection-coach", {}, { requestedByUserId: "board-user" });
+    expect(manual.state).toMatchObject({ status: "pending_approval" });
+    expect(manual.state.agentId).not.toBe(initialState.agentId);
+    expect(manual.approval).toMatchObject({ status: "pending" });
+
+    const secondRestart = await reconcileBuiltInAgentsOnStartup(db);
+    expect(secondRestart.outcomes).toMatchObject({
+      skipped_by_tombstone: 0,
+      provisioned: 0,
+      already_present: 2,
+    });
+    const finalRows = (await db.select().from(agents).where(eq(agents.companyId, companyId)))
+      .filter((row) => readBuiltInAgentMarker(row.metadata)?.key === "reflection-coach");
+    expect(finalRows).toHaveLength(2);
+    const finalApprovals = (await db.select().from(approvals).where(eq(approvals.companyId, companyId)))
+      .filter((row) => (row.payload as { sourceBuiltInAgentKey?: string }).sourceBuiltInAgentKey === "reflection-coach");
+    expect(finalApprovals).toHaveLength(2);
   });
 
   it("preserves Reflection Coach instruction drift on reconcile and restores it on reset", async () => {
@@ -1058,6 +1149,7 @@ describeEmbeddedPostgres("built-in agents", () => {
   });
 
   it("self-heals duplicates during startup reconciliation without aborting later companies", async () => {
+    await enableBuiltInAgents();
     const affectedCompanyId = await seedCompany({ requireApproval: false });
     const { olderId, newerId } = await seedLegacyDuplicateBriefs(affectedCompanyId);
     // A second company created after the affected one — previously skipped

--- a/server/src/__tests__/companies-service.test.ts
+++ b/server/src/__tests__/companies-service.test.ts
@@ -14,6 +14,7 @@ import {
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
+  instanceSettings,
   principalPermissionGrants,
   routines,
   routineTriggers,
@@ -25,6 +26,7 @@ import {
 import { companyService } from "../services/companies.js";
 import { readBuiltInAgentMarker } from "../services/built-in-agent-metadata.js";
 import { reconcileBuiltInAgentsOnStartup } from "../services/built-in-agents.js";
+import { instanceSettingsService } from "../services/instance-settings.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -59,6 +61,7 @@ describeEmbeddedPostgres("companyService", () => {
     await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
     await db.delete(companies);
+    await db.delete(instanceSettings);
   });
 
   afterAll(async () => {
@@ -81,7 +84,18 @@ describeEmbeddedPostgres("companyService", () => {
     expect(rows.map((row) => row.issuePrefix).sort()).toEqual(["ARO", "AROA"]);
   });
 
+  it("does not auto-provision bundled agents for a new company while the flag is disabled", async () => {
+    const created = await companyService(db).create({
+      name: "Opted-out Company",
+    });
+
+    expect(await db.select().from(agents).where(eq(agents.companyId, created.id))).toHaveLength(0);
+    expect(await db.select().from(companySkills).where(eq(companySkills.companyId, created.id))).toHaveLength(0);
+    expect(await db.select().from(routines).where(eq(routines.companyId, created.id))).toHaveLength(0);
+  });
+
   it("auto-provisions one paused Reflection Coach bundle for a freshly created company", async () => {
+    await instanceSettingsService(db).updateExperimental({ enableBuiltInAgents: true });
     const created = await companyService(db).create({
       name: "Fresh Company",
     });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -834,6 +834,9 @@ export async function startServer(): Promise<StartedServer> {
         || result.duplicates > 0
         || result.autoEnsured > 0
         || result.companyFailures > 0
+        || (result.outcomes?.skipped_by_flag ?? 0) > 0
+        || (result.outcomes?.skipped_by_tombstone ?? 0) > 0
+        || (result.outcomes?.provisioned ?? 0) > 0
       ) {
         logger.warn(
           result,

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -19,6 +19,7 @@ import {
   withBuiltInAgentMarker,
 } from "./built-in-agent-metadata.js";
 import { companySkillService } from "./company-skills.js";
+import { instanceSettingsService } from "./instance-settings.js";
 import { routineService } from "./routines.js";
 import { accessService } from "./access.js";
 import { listAdapterModels } from "../adapters/registry.js";
@@ -825,6 +826,7 @@ export function builtInAgentService(db: Db) {
   const accessSvc = accessService(db);
   const approvalSvc = approvalService(db);
   const instructionsSvc = agentInstructionsService();
+  const instanceSettingsSvc = instanceSettingsService(db);
   const skillSvc = companySkillService(db);
   const routineSvc = routineService(db);
 
@@ -1593,6 +1595,14 @@ export function builtInAgentService(db: Db) {
     return agent as Agent | null;
   }
 
+  async function hasTerminatedAgent(companyId: string, definition: BuiltInAgentDefinition) {
+    const rows = await db
+      .select({ metadata: agents.metadata })
+      .from(agents)
+      .where(and(eq(agents.companyId, companyId), eq(agents.status, "terminated")));
+    return rows.some((row) => readBuiltInAgentMarker(row.metadata)?.key === definition.key);
+  }
+
   async function state(
     definition: BuiltInAgentDefinition,
     agent: Agent | null,
@@ -1943,19 +1953,54 @@ export function builtInAgentService(db: Db) {
 
   async function autoProvisionBundledAgents(companyId: string) {
     const company = await ensureCompany(companyId);
+    const definitions = DEFINITIONS.filter((entry) => entry.bundle);
+    const experimental = await instanceSettingsSvc.getExperimental();
+    if (experimental.enableBuiltInAgents !== true) {
+      return {
+        autoEnsured: 0,
+        pendingApprovals: 0,
+        defaultGrantsEnsured: 0,
+        outcomes: {
+          skipped_by_flag: definitions.length,
+          skipped_by_tombstone: 0,
+          provisioned: 0,
+          already_present: 0,
+        },
+      };
+    }
     let autoEnsured = 0;
     let pendingApprovals = 0;
-    for (const definition of DEFINITIONS.filter((entry) => entry.bundle)) {
+    let skippedByTombstone = 0;
+    let provisioned = 0;
+    let alreadyPresent = 0;
+    for (const definition of definitions) {
+      const existing = await findSingleAgent(companyId, definition);
+      if (!existing && await hasTerminatedAgent(companyId, definition)) {
+        skippedByTombstone += 1;
+        continue;
+      }
       if (company.requireBoardApprovalForNewAgents) {
         const result = await provision(companyId, definition.key);
         if (result.approval) pendingApprovals += 1;
       } else {
         await ensure(companyId, definition.key);
       }
+      if (existing) alreadyPresent += 1;
+      else provisioned += 1;
       autoEnsured += 1;
     }
     const defaultGrantsEnsured = await ensureCompanyDefaultAgentGrants(companyId);
-    return { autoEnsured, pendingApprovals, defaultGrantsEnsured };
+    return {
+      autoEnsured,
+      pendingApprovals,
+      defaultGrantsEnsured,
+      outcomes: {
+        skipped_by_flag: 0,
+        skipped_by_tombstone: skippedByTombstone,
+        provisioned,
+        already_present: alreadyPresent,
+      },
+    };
   }
 
   return {
@@ -1993,6 +2038,12 @@ export async function reconcileBuiltInAgentsOnStartup(db: Db) {
   let autoEnsured = 0;
   let pendingApprovals = 0;
   let defaultGrantsEnsured = 0;
+  const outcomes = {
+    skipped_by_flag: 0,
+    skipped_by_tombstone: 0,
+    provisioned: 0,
+    already_present: 0,
+  };
   // Isolate per-company failures so one bad company (e.g. an unresolvable data
   // problem) can no longer abort reconciliation for every company after it.
   let companyFailures = 0;
@@ -2002,6 +2053,10 @@ export async function reconcileBuiltInAgentsOnStartup(db: Db) {
       autoEnsured += result.autoEnsured;
       pendingApprovals += result.pendingApprovals;
       defaultGrantsEnsured += result.defaultGrantsEnsured;
+      outcomes.skipped_by_flag += result.outcomes.skipped_by_flag;
+      outcomes.skipped_by_tombstone += result.outcomes.skipped_by_tombstone;
+      outcomes.provisioned += result.outcomes.provisioned;
+      outcomes.already_present += result.outcomes.already_present;
     } catch (err) {
       companyFailures += 1;
       console.error(
@@ -2050,5 +2105,15 @@ export async function reconcileBuiltInAgentsOnStartup(db: Db) {
     }
   }
 
-  return { scanned, reconciled, unknown, duplicates, autoEnsured, pendingApprovals, defaultGrantsEnsured, companyFailures };
+  return {
+    scanned,
+    reconciled,
+    unknown,
+    duplicates,
+    autoEnsured,
+    pendingApprovals,
+    defaultGrantsEnsured,
+    companyFailures,
+    outcomes,
+  };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their lifecycle for each company.
> - The server can provision optional built-in agents during company creation and startup.
> - A disabled feature flag did not stop that automatic provisioning path.
> - A rejected built-in agent also disappeared from the active lookup.
> - The next restart could create the same agent and approval again.
> - This pull request makes the automatic path honor the flag and the terminated record.
> - The benefit is a stable opt-out with no repeated agent or approval creation.

## Linked Issues or Issue Description

Refs #10116

Refs #10170

**What happened?**

Paperclip could provision built-in agents during startup when `enableBuiltInAgents` was not true. If an operator rejected a built-in agent hire, the terminated agent was not part of the active lookup. A later startup could then create a new agent row and a new approval.

**Expected behavior**

Automatic provisioning must stop when the feature flag is not true. A terminated built-in agent must act as an opt-out tombstone for later automatic runs. An explicit manual provisioning action must still work.

**Steps to reproduce**

1. Disable built-in agents.
2. Start the server or create a company.
3. Observe an automatic built-in agent request.
4. Reject the request and restart the server.
5. Observe another agent row and approval for the same built-in agent.

**Paperclip version or commit**

The bug was reproduced from base commit `0f12721ee99e7dd2a0412d61316ad77ee58ecfb1`.

**Deployment mode**

Self-hosted server and focused test harness.

**Agent adapter(s) involved**

Not adapter-specific. This is a server lifecycle bug.

## What Changed

- Stop automatic built-in agent provisioning unless `enableBuiltInAgents` is exactly true.
- Treat a terminated built-in agent record as an automatic-provisioning tombstone.
- Keep explicit manual provisioning available after an opt-out.
- Report `skipped_by_flag`, `skipped_by_tombstone`, `provisioned`, and `already_present` outcomes.
- Log the new outcome counters during startup reconciliation.
- Add regressions for feature-off startup, feature-off company creation, reject-and-restart, feature-on behavior, and manual reprovisioning.

## Verification

- The independent review ran 62 focused tests across the built-in-agent, company-service, and route suites. All tests passed.
- A second authorization check ran 48 focused built-in-agent and company-service tests. All tests passed.
- The server TypeScript check passed on the exact commit.
- `git diff --check` passed.
- The verified commit is `f091df1b6ca72dc6ec703769bf85d4da4e074d83` with tree `3964112786006fef15d70e3242bac835e61065e1`.
- A merge-tree check against current `master` completed without conflicts.

## Risks

- The change affects only automatic built-in agent provisioning and startup outcome logging.
- The feature-off early return also skips startup backfill of default root-agent grants in this function. Agent creation still applies those grants, and existing grants are not removed.
- The exact commit is six commits behind current `master`, but the merge-tree check is clean. Any required code change must receive a new review before this draft can advance.
- Rollback is a revert of one server commit.
- This pull request is draft. It does not authorize merge, release, installation, restart, or deployment.

This is a bug fix. It does not add a roadmap feature.

## Model Used

OpenAI Codex from the GPT-5 model family produced the change with high reasoning, tool use, and code execution. Anthropic Claude performed an independent review. The hosted runtimes did not expose more specific public model IDs or context-window values in the artifact.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change is required; this enforces an existing setting)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

This draft preserves the reviewed commit and tree. Any head change requires a new independent review and authorization.
