### PR TITLE
fix(claude-local): read Anthropic OAuth token from macOS Keychain

### DIFF
--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -85,13 +85,7 @@ function trimToLatestUsagePanel(text: string): string | null {
   return tail;
 }
 
-async function readClaudeTokenFromFile(credPath: string): Promise<string | null> {
-  let raw: string;
-  try {
-    raw = await fs.readFile(credPath, "utf8");
-  } catch {
-    return null;
-  }
+function parseClaudeCredentialsJson(raw: string): string | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -104,6 +98,36 @@ async function readClaudeTokenFromFile(credPath: string): Promise<string | null>
   if (typeof oauth !== "object" || oauth === null) return null;
   const token = (oauth as Record<string, unknown>)["accessToken"];
   return typeof token === "string" && token.length > 0 ? token : null;
+}
+
+async function readClaudeTokenFromFile(credPath: string): Promise<string | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(credPath, "utf8");
+  } catch {
+    return null;
+  }
+  return parseClaudeCredentialsJson(raw);
+}
+
+const MACOS_KEYCHAIN_CLAUDE_SERVICE = "Claude Code-credentials";
+
+/** On macOS, the Claude Code CLI stores its OAuth credentials in the system
+ *  Keychain instead of a credentials file — read them from there so
+ *  quota polling isn't blind on every default macOS install. */
+async function readClaudeTokenFromMacKeychain(): Promise<string | null> {
+  if (process.platform !== "darwin") return null;
+  try {
+    const { stdout } = await execFileAsync("security", [
+      "find-generic-password",
+      "-s",
+      MACOS_KEYCHAIN_CLAUDE_SERVICE,
+      "-w",
+    ]);
+    return parseClaudeCredentialsJson(stdout);
+  } catch {
+    return null;
+  }
 }
 
 interface ClaudeAuthStatus {
@@ -143,7 +167,7 @@ export async function readClaudeToken(): Promise<string | null> {
     const token = await readClaudeTokenFromFile(path.join(configDir, filename));
     if (token) return token;
   }
-  return null;
+  return readClaudeTokenFromMacKeychain();
 }
 
 interface AnthropicUsageWindow {

--- a/server/src/__tests__/quota-windows.test.ts
+++ b/server/src/__tests__/quota-windows.test.ts
@@ -3,6 +3,22 @@ import os from "node:os";
 import path from "node:path";
 import type { QuotaWindow } from "@paperclipai/adapter-utils";
 
+// child_process.execFile has a built-in util.promisify.custom implementation
+// that resolves to { stdout, stderr }; the mock exposes the same symbol so
+// `promisify(execFile)` inside the adapter behaves identically under test.
+const execFileCustom = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async () => {
+  const { promisify: nodePromisify } = await import("node:util");
+  return { execFile: Object.assign(vi.fn(), { [nodePromisify.custom]: execFileCustom }) };
+});
+
+// Default to "no Keychain entry" so pre-existing file-based tests are unaffected
+// regardless of which platform they run on; individual tests override as needed.
+beforeEach(() => {
+  execFileCustom.mockReset();
+  execFileCustom.mockRejectedValue(new Error("SecKeychainSearchCopyNext: The specified item could not be found in the keychain."));
+});
+
 // Pure utility functions — import directly from adapter source
 import {
   toPercent,
@@ -297,6 +313,73 @@ describe("readClaudeToken", () => {
     const token = await readClaudeToken();
     expect(token).toBe("dotfile-token");
     await import("node:fs/promises").then((fs) => fs.rm(tmpDir, { recursive: true }));
+  });
+
+  describe("macOS Keychain fallback", () => {
+    const savedPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: savedPlatform });
+    });
+
+    it("falls back to the macOS Keychain when no credentials file exists", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.env.CLAUDE_CONFIG_DIR = "/tmp/__no_such_paperclip_dir__";
+      execFileCustom.mockResolvedValue({
+        stdout: JSON.stringify({ claudeAiOauth: { accessToken: "keychain-token" } }),
+        stderr: "",
+      });
+
+      const token = await readClaudeToken();
+
+      expect(token).toBe("keychain-token");
+      expect(execFileCustom).toHaveBeenCalledWith(
+        "security",
+        ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+      );
+    });
+
+    it("returns null when the Keychain lookup fails", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      process.env.CLAUDE_CONFIG_DIR = "/tmp/__no_such_paperclip_dir__";
+      execFileCustom.mockRejectedValue(new Error("not found"));
+
+      const token = await readClaudeToken();
+
+      expect(token).toBe(null);
+    });
+
+    it("never shells out to the Keychain on non-macOS platforms", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      process.env.CLAUDE_CONFIG_DIR = "/tmp/__no_such_paperclip_dir__";
+
+      const token = await readClaudeToken();
+
+      expect(token).toBe(null);
+      expect(execFileCustom).not.toHaveBeenCalled();
+    });
+
+    it("prefers the credentials file over the Keychain when both are present", async () => {
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      const tmpDir = path.join(os.tmpdir(), `paperclip-test-claude-${Date.now()}`);
+      const creds = { claudeAiOauth: { accessToken: "file-token" } };
+      await import("node:fs/promises").then((fs) =>
+        fs.mkdir(tmpDir, { recursive: true }).then(() =>
+          fs.writeFile(path.join(tmpDir, "credentials.json"), JSON.stringify(creds)),
+        ),
+      );
+      process.env.CLAUDE_CONFIG_DIR = tmpDir;
+      execFileCustom.mockResolvedValue({
+        stdout: JSON.stringify({ claudeAiOauth: { accessToken: "keychain-token" } }),
+        stderr: "",
+      });
+
+      const token = await readClaudeToken();
+
+      expect(token).toBe("file-token");
+      expect(execFileCustom).not.toHaveBeenCalled();
+      await import("node:fs/promises").then((fs) => fs.rm(tmpDir, { recursive: true }));
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- On a default macOS install, the Claude Code CLI stores its OAuth token in the system Keychain (service `Claude Code-credentials`), not in `~/.claude/.credentials.json` or `credentials.json`. `readClaudeToken()` only checked those two file paths, so it always returned `null` on macOS installs that use the Keychain — silently forcing every quota poll onto the much more brittle fallback that drives the CLI's interactive `/usage` screen through a pty scrape, instead of the plain HTTP `/api/oauth/usage` endpoint.
- `readClaudeToken()` now falls back to `security find-generic-password -s "Claude Code-credentials" -w` after both credentials-file checks miss, gated to `darwin` only. The existing file-based checks are unchanged and still take priority.
- Verified live: pulled a real token from Keychain on a macOS host and called `https://api.anthropic.com/api/oauth/usage` with it directly — `HTTP 200`, real `five_hour.utilization`. Confirms the HTTP path (`fetchClaudeQuota`) works fine once it actually has a token to use.

## Test plan
- [x] `pnpm exec vitest run src/__tests__/quota-windows.test.ts` (server package) — 62 passed, including 4 new cases covering the Keychain fallback (found via Keychain, Keychain lookup fails, non-macOS skip, credentials-file takes priority over Keychain)
- [x] `tsc --noEmit` in `packages/adapters/claude-local` and `server` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)