### PR TITLE
fix(server): bound detached process-loss recovery

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -575,6 +575,20 @@ On startup and on the periodic recovery loop, Paperclip now does five things in 
 
 The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output. The productivity-review pass is later and separate; it reviews unusual progression patterns on assigned source issues, not stale run handles after a source issue already has a valid disposition.
 
+### Detached-process dead-start recovery
+
+A local-adapter run can survive in the database with a live recorded child PID but no in-memory process handle or output stream. Continuing to treat that row as healthy leaves the run nonterminal and unobservable, so orphan recovery uses a bounded policy:
+
+- the first orphan pass conditionally marks the still-running row with `errorCode: process_detached` and emits a warning lifecycle event
+- hot-restart-adopted runs remain exempt while their adoption metadata is valid
+- if no handle is restored within a five-minute grace, the reaper terminates the recorded PID/process group, conditionally terminalizes the row as `failed`/`process_lost`, fails its wakeup, and emits an error lifecycle event with `detachedProcessCleanup` evidence
+- the terminal run may enqueue one normal-model process-loss retry; `processLossRetryCount` and the retry context are preserved across both immediate cleanup and periodic stranded-work reconciliation
+- if that retry also loses its process, recovery blocks the source and creates a source-scoped recovery action instead of converting it into a fresh generic dispatch, continuation, or reviewer retry
+
+Operators can monitor `process_detached` warnings, `process_lost` terminal rows, `detachedProcessCleanup` result/event payloads, `reaped orphaned heartbeat runs` log entries, and source-scoped `process_lost` recovery actions. A termination failure leaves the row marked `process_detached`; the next periodic pass retries cleanup and the scheduler logs the failed reap.
+
+This path adds no schema or API compatibility requirement. The main rollout risk is terminating a still-productive local child whose output handle cannot be recovered; the grace limits false positives, adopted hot-restart runs are excluded, and the retry resumes from durable context. Rollback is a code-only revert with no data migration: existing `process_detached`, `process_lost`, retry-count, event, and JSON evidence remain readable. Reverting restores the prior risk that detached live children can remain nonterminal until they exit independently, so operators should retain the run/recovery evidence before rollback.
+
 ## 11. Task Watchdog for Issue Trees
 
 A task watchdog watches a configured issue subtree after that subtree has stopped moving. It is a product-level verification and recovery mechanism for selected work, not a process monitor.

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -98,6 +98,7 @@ vi.mock("../adapters/index.ts", async () => {
 });
 
 import {
+  DETACHED_PROCESS_RECOVERY_GRACE_MS,
   INTERACTION_CONTINUATION_INFRA_RETRY_REASON,
   INTERACTION_CONTINUATION_INFRA_WAKE_REASON,
   heartbeatService,
@@ -662,7 +663,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   async function seedStrandedIssueFixture(input: {
     status: "todo" | "in_progress";
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
-    retryReason?: "assignment_recovery" | "issue_continuation_needed" | "execution_review_participant_recovery" | null;
+    retryReason?: "assignment_recovery" | "issue_continuation_needed" | "execution_review_participant_recovery" | "process_lost" | null;
+    processLossRetryCount?: number;
     runSource?: string | null;
     assignToUser?: boolean;
     activePauseHold?: boolean;
@@ -731,7 +733,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         taskId: issueId,
         wakeReason: input.retryReason === "assignment_recovery"
           ? "issue_assignment_recovery"
-          : input.retryReason ?? "issue_assigned",
+          : input.retryReason === "process_lost"
+            ? "process_lost_retry"
+            : input.retryReason ?? "issue_assigned",
         ...(input.retryReason ? { retryReason: input.retryReason } : {}),
         ...(input.runSource ? { source: input.runSource } : {}),
       },
@@ -746,6 +750,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         : ("runError" in input ? input.runError : "run failed before issue advanced"),
       livenessState: input.livenessState ?? null,
       resultJson: input.resultJson ?? null,
+      processLossRetryCount: input.processLossRetryCount ?? 0,
     });
 
     await db.insert(issues).values([
@@ -977,7 +982,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     issueId: string;
     runId: string;
     previousStatus: "todo" | "in_progress" | "in_review";
-    retryReason?: "assignment_recovery" | "issue_continuation_needed" | "execution_review_participant_recovery" | null;
+    retryReason?: "assignment_recovery" | "issue_continuation_needed" | "execution_review_participant_recovery" | "process_lost" | null;
     cause?: string;
     kind?: string;
     previousOwnerAgentId?: string | null;
@@ -1211,6 +1216,82 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(agentWakeupRequests.id, wakeupRequestId))
       .then((rows) => rows[0] ?? null);
     expect(wakeup?.status).toBe("claimed");
+  });
+
+  it("terminalizes a detached live process after one bounded grace and hands off exactly one retry", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    const childPid = child.pid;
+    expect(childPid).toBeTypeOf("number");
+
+    const { agentId, runId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: childPid ?? null,
+      includeIssue: false,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const firstPass = await heartbeat.reapOrphanedRuns();
+    expect(firstPass).toEqual({ reaped: 0, runIds: [] });
+    expect(await heartbeat.getRun(runId)).toMatchObject({
+      status: "running",
+      errorCode: "process_detached",
+    });
+
+    const secondPass = await heartbeat.reapOrphanedRuns({ detachedProcessGraceMs: 0 });
+    expect(secondPass).toEqual({ reaped: 1, runIds: [runId] });
+    expect(await waitForPidExit(childPid ?? 0)).toBe(true);
+    childProcesses.delete(child);
+
+    const failedRun = await heartbeat.getRun(runId);
+    expect(failedRun).toMatchObject({
+      status: "failed",
+      errorCode: "process_lost",
+      processLossRetryCount: 0,
+    });
+    expect(failedRun?.resultJson).toMatchObject({
+      stopReason: "process_lost",
+      detachedProcessCleanup: {
+        kind: "detached_process_grace_expired",
+        graceMs: 0,
+        processPid: childPid,
+      },
+    });
+
+    const retries = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.retryOfRunId, runId)));
+    expect(retries).toHaveLength(1);
+    expect(retries[0]?.processLossRetryCount).toBe(1);
+
+    const terminalEvents = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(and(eq(heartbeatRunEvents.runId, runId), eq(heartbeatRunEvents.level, "error")));
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]).toMatchObject({
+      eventType: "lifecycle",
+      payload: expect.objectContaining({
+        detachedProcessCleanup: true,
+        detachedProcessGraceMs: 0,
+        retryRunId: retries[0]?.id,
+      }),
+    });
+
+    expect(await heartbeat.reapOrphanedRuns({ detachedProcessGraceMs: 0 })).toEqual({
+      reaped: 0,
+      runIds: [],
+    });
+    const retriesAfterReplay = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.retryOfRunId, runId)));
+    expect(retriesAfterReplay).toHaveLength(1);
+    if (!retries[0]?.id) throw new Error("Expected the process-loss retry to exist");
+    await waitForRunToSettle(heartbeat, retries[0].id);
+    expect(await heartbeat.getRun(retries[0].id)).toMatchObject({ status: "succeeded" });
+    expect(DETACHED_PROCESS_RECOVERY_GRACE_MS).toBe(5 * 60 * 1000);
   });
 
   it("skips generic timer wakes without invoking an adapter when no assigned work is actionable", async () => {
@@ -2152,9 +2233,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
-  it("blocks the issue when process-loss retry is exhausted and the immediate continuation recovery also fails", async () => {
-    mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
-
+  it("blocks the issue when the bounded process-loss retry is exhausted without generic continuation", async () => {
     const { companyId, agentId, runId, issueId } = await seedRunFixture({
       agentStatus: "idle",
       processPid: 999_999_999,
@@ -2187,13 +2266,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .select()
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(2);
     expect(runs.find((row) => row.id === runId)?.status).toBe("failed");
-    const continuationRun = runs.find((row) => row.id !== runId);
-    expect(continuationRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
-      retryReason: "issue_continuation_needed",
-      retryOfRunId: runId,
-    });
+    expect(runs.some((row) => {
+      const context = row.contextSnapshot as Record<string, unknown> | null;
+      return context?.retryReason === "issue_continuation_needed" && context?.retryOfRunId === runId;
+    })).toBe(false);
 
     const blockedIssue = await waitForValue(async () =>
       db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
@@ -2204,15 +2281,13 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(blockedIssue?.status).toBe("blocked");
     expect(blockedIssue?.executionRunId).toBeNull();
     expect(blockedIssue?.checkoutRunId).toBeNull();
-    if (!continuationRun?.id) throw new Error("Expected continuation recovery run to exist");
-
     const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
       companyId,
       agentId,
       issueId,
-      runId: continuationRun.id,
+      runId,
       previousStatus: "in_progress",
-      retryReason: "issue_continuation_needed",
+      cause: "process_lost",
     });
 
     await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
@@ -4593,6 +4668,41 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       }
     },
   );
+
+  it("does not reset the retry budget after a process-loss retry fails", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "process_lost",
+      processLossRetryCount: 1,
+      runErrorCode: "process_lost",
+      runError: "Process-loss retry also lost its child process",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.find((run) => run.id === runId)).toMatchObject({ id: runId, processLossRetryCount: 1 });
+    expect(runs.some((run) => {
+      const context = run.contextSnapshot as Record<string, unknown> | null;
+      return context?.retryReason === "issue_continuation_needed" && context?.retryOfRunId === runId;
+    })).toBe(false);
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "process_lost",
+      cause: "process_lost",
+    });
+  });
 
   it.each([
     "wake_assignee",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -327,6 +327,7 @@ const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_AGENT_MESSAGE_KEY = "paperclipAgentMessage";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+export const DETACHED_PROCESS_RECOVERY_GRACE_MS = 5 * 60 * 1000;
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -3385,6 +3386,18 @@ function didAutomaticRecoveryFail(
   );
 }
 
+function isProcessLossRetryRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "contextSnapshot" | "errorCode" | "processLossRetryCount"> | null,
+) {
+  if (!run || run.errorCode !== "process_lost") return false;
+  const context = parseObject(run.contextSnapshot);
+  return (
+    (run.processLossRetryCount ?? 0) > 0 ||
+    readNonEmptyString(context.wakeReason) === "process_lost_retry" ||
+    readNonEmptyString(context.retryReason) === "process_lost"
+  );
+}
+
 function isExecutionReviewParticipantRecoveryRun(
   run: Pick<typeof heartbeatRuns.$inferSelect, "contextSnapshot"> | null,
 ) {
@@ -5957,7 +5970,10 @@ async function terminateHeartbeatRunProcess(input: {
 function buildProcessLossMessage(run: {
   processPid: number | null;
   processGroupId: number | null;
-}, options?: { descendantOnly?: boolean }) {
+}, options?: { descendantOnly?: boolean; detachedGraceExpired?: boolean }) {
+  if (options?.detachedGraceExpired) {
+    return `Process lost -- in-memory handle did not recover within the detached-process grace; child pid ${run.processPid ?? "unknown"} was terminated`;
+  }
   if (options?.descendantOnly && run.processGroupId) {
     return `Process lost -- parent pid ${run.processPid ?? "unknown"} exited, but descendant process group ${run.processGroupId} was still alive and was terminated`;
   }
@@ -12368,9 +12384,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
-  async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
+  async function reapOrphanedRuns(opts?: {
+    staleThresholdMs?: number;
+    detachedProcessGraceMs?: number;
+    now?: Date;
+  }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
-    const now = new Date();
+    const detachedProcessGraceMs = Math.max(0, opts?.detachedProcessGraceMs ?? DETACHED_PROCESS_RECOVERY_GRACE_MS);
+    const now = opts?.now ?? new Date();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
     const activeRuns = await db
@@ -12426,13 +12447,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ) {
         continue;
       }
+      let detachedProcessCleanup = false;
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
-          const detachedRun = await setRunStatus(run.id, "running", {
+          const detachedUpdate = await setRunStatusIfRunning(run.id, "running", {
             error: detachedMessage,
             errorCode: DETACHED_PROCESS_ERROR_CODE,
           });
+          const detachedRun = detachedUpdate.updated ? detachedUpdate.run : null;
           if (detachedRun) {
             await appendRunEvent(detachedRun, await nextRunEventSeq(detachedRun.id), {
               eventType: "lifecycle",
@@ -12444,12 +12467,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               },
             });
           }
+          continue;
         }
-        continue;
+
+        const detachedDetectedAt = run.updatedAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt;
+        if (now.getTime() - detachedDetectedAt.getTime() < detachedProcessGraceMs) continue;
+
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+        detachedProcessCleanup = true;
       }
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      if (!detachedProcessCleanup && processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,
@@ -12470,7 +12502,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         (tracksLocalChild && (!!run.processPid || !!run.processGroupId)) ||
         monitorDispatchLostWithoutFutureWake
       );
-      const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const baseMessage = buildProcessLossMessage(
+        run,
+        detachedProcessCleanup
+          ? { detachedGraceExpired: true }
+          : descendantOnlyCleanup
+            ? { descendantOnly: true }
+            : undefined,
+      );
       const unmanagedBackgroundTaskEvidence = descendantOnlyCleanup
         ? {
           kind: "orphaned_process_group_cleanup",
@@ -12481,8 +12520,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           processGroupId: run.processGroupId ?? null,
         }
         : null;
+      const detachedProcessCleanupEvidence = detachedProcessCleanup
+        ? {
+          kind: "detached_process_grace_expired",
+          detectedAt: run.updatedAt?.toISOString() ?? null,
+          graceMs: detachedProcessGraceMs,
+          processPid: run.processPid ?? null,
+          processGroupId: run.processGroupId ?? null,
+        }
+        : null;
 
-      let finalizedRun = await setRunStatus(run.id, "failed", {
+      const terminalUpdate = await setRunStatusIfRunning(run.id, "failed", {
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
         errorCode: "process_lost",
         finishedAt: now,
@@ -12496,21 +12544,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
             },
           );
-          return unmanagedBackgroundTaskEvidence
-            ? {
+          if (unmanagedBackgroundTaskEvidence) {
+            return {
               ...result,
               stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
               unmanagedBackgroundTask: unmanagedBackgroundTaskEvidence,
+            };
+          }
+          return detachedProcessCleanupEvidence
+            ? {
+              ...result,
+              detachedProcessCleanup: detachedProcessCleanupEvidence,
             }
             : result;
         })(),
       });
+      if (!terminalUpdate.updated || !terminalUpdate.run) continue;
+      let finalizedRun = terminalUpdate.run;
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
         error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
       });
-      if (!finalizedRun) finalizedRun = await getRun(run.id);
-      if (!finalizedRun) continue;
       finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
       await releaseEnvironmentLeasesForRun({
         runId: finalizedRun.id,
@@ -12546,6 +12600,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
+          ...(detachedProcessCleanup ? { detachedProcessCleanup: true, detachedProcessGraceMs } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
         },
       });
@@ -16109,6 +16164,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         !recoveryAgent ||
         isWorkspaceValidationFailedRun(run) ||
         isConfigurationIncompleteFailedRun(run) ||
+        isProcessLossRetryRun(run) ||
         didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
       if (shouldBlockImmediately) {
         const workspaceValidationFailure = isWorkspaceValidationFailedRun(run);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -147,6 +147,7 @@ type LatestIssueRun = Pick<
   | "errorCode"
   | "contextSnapshot"
   | "livenessState"
+  | "processLossRetryCount"
   | "startedAt"
   | "createdAt"
 > & {
@@ -669,6 +670,20 @@ function isUnsuccessfulTerminalIssueRun(latestRun: LatestIssueRun) {
   );
 }
 
+function isExhaustedProcessLossRetryRun(latestRun: LatestIssueRun) {
+  if (
+    !isUnsuccessfulTerminalIssueRun(latestRun) ||
+    !latestRun ||
+    latestRun.errorCode !== "process_lost"
+  ) return false;
+  const context = parseObject(latestRun.contextSnapshot);
+  return (
+    (latestRun.processLossRetryCount ?? 0) > 0 ||
+    readNonEmptyString(context.wakeReason) === "process_lost_retry" ||
+    readNonEmptyString(context.retryReason) === "process_lost"
+  );
+}
+
 function isSuccessfulInProgressContinuationRun(latestRun: LatestIssueRun): latestRun is SuccessfulLatestIssueRun {
   return latestRun?.status === "succeeded";
 }
@@ -806,6 +821,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        processLossRetryCount: heartbeatRuns.processLossRetryCount,
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
@@ -836,6 +852,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        processLossRetryCount: heartbeatRuns.processLossRetryCount,
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
@@ -1075,6 +1092,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        processLossRetryCount: heartbeatRuns.processLossRetryCount,
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
@@ -3967,6 +3985,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
+        if (isExhaustedProcessLossRetryRun(participantLatestRun)) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_review",
+            latestRun: participantLatestRun,
+            recoveryCause: "process_lost",
+            recoveryOwnerAgentId: participantAgentId,
+            comment:
+              "Paperclip's one bounded process-loss retry for the active review participant also ended without a live " +
+              "execution path. Moving the issue to `blocked` instead of resetting the retry budget through generic reviewer recovery.",
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
         if (!agentInvokable) {
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -4063,6 +4101,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           !(await wasTodoHandedBackDuringOrAfterLatestRun(issue, latestRun))
         ) {
           result.skipped += 1;
+          continue;
+        }
+
+        if (isExhaustedProcessLossRetryRun(latestRun)) {
+          const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "todo",
+            latestRun,
+            recoveryCause: "process_lost",
+            comment:
+              "Paperclip's one bounded process-loss retry for this assigned `todo` issue also ended without a live " +
+              `execution path.${failureSummary ?? ""} Moving it to \`blocked\` instead of resetting the retry budget through generic dispatch recovery.`,
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
           continue;
         }
 
@@ -4196,6 +4254,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
       if (isUnsuccessfulTerminalIssueRun(latestRun)) {
+        if (isExhaustedProcessLossRetryRun(latestRun)) {
+          const failureSummary = summarizeRunFailureForIssueComment(latestRun);
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_progress",
+            latestRun,
+            recoveryCause: "process_lost",
+            comment:
+              "Paperclip's one bounded process-loss retry for this assigned `in_progress` issue also ended without a live " +
+              `execution path.${failureSummary ?? ""} Moving it to \`blocked\` instead of resetting the retry budget through generic continuation recovery.`,
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
         const classification = classifyContinuationFailure(latestRun);
 
         if (classification.errorCode === CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Heartbeat orchestration runs local adapter processes and persists their state
> - A process can remain recorded as live after its in-memory handle and output stream are lost
> - The old recovery path could leave that run nonterminal or reset the one-retry budget through generic continuation recovery
> - This pull request adds bounded detached-process cleanup, terminal evidence, and retry-lineage guards
> - The benefit is visible failure ownership and bounded recovery without silent retry loops

## Linked Issues or Issue Description

**What existing behavior does this improve?**

It improves recovery for heartbeat runs whose recorded child process outlives the local process handle.

**Subsystem affected**

The server heartbeat reaper, recovery service, lifecycle events, and execution-semantics documentation are affected.

**Current behavior**

A detached child can keep a run nonterminal, and a later generic recovery can reset process-loss retry lineage.

**Proposed behavior**

The reaper grants a five-minute grace period, then records cleanup and terminal failure evidence. One process-loss retry is allowed. Exhaustion creates a source-scoped blocked recovery action.

**Reason and benefit**

This makes process loss observable and prevents unbounded automatic retries while preserving productive continuation.

**Breaking changes**

No schema or API migration is required. Existing persisted evidence remains readable.

Related PR search found [#10325](https://github.com/paperclipai/paperclip/pull/10325), [#6273](https://github.com/paperclipai/paperclip/pull/6273), and [#8539](https://github.com/paperclipai/paperclip/pull/8539). This PR targets the missing bounded grace, terminal-event, and retry-lineage contract.

## What Changed

- Bound detached-process recovery to a five-minute grace period with best-effort PID/process-group cleanup.
- Persist terminal `process_lost` evidence and lifecycle event metadata.
- Preserve process-loss retry lineage across immediate and periodic recovery.
- Escalate an exhausted process-loss retry to a source-scoped blocked action.
- Document rollout risk and code-only rollback behavior.

## Verification

- `CI=true ./node_modules/.bin/vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t 'terminalizes a detached live process|blocks the issue when the bounded process-loss retry|does not reset the retry budget'` passed 3 tests; 96 tests were skipped by the filter.\n- `server/node_modules/.bin/tsc --noEmit -p server/tsconfig.json` passed.\n\n## Risks\n\nA still-productive child may be terminated if its handle cannot be recovered. The five-minute grace and hot-restart adoption exemption reduce this risk. Rollback is a code-only revert with no data migration.\n\n## Model Used\n\nOpenAI Codex, GPT-5, with tool-enabled code execution and repository test verification.\n\n## Checklist\n\n- [x] I have included a thinking path that traces from project context to this change\n- [x] I have specified the model used (with version and capability details)\n- [x] I have searched GitHub for duplicate or related PRs and linked them above\n- [x] I have described the issue in-PR following the enhancement template\n- [x] I have run tests locally and they pass\n- [x] I have added or updated tests where applicable\n- [x] I have updated relevant documentation to reflect my changes\n- [ ] All Paperclip CI gates are green\n- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups\n- [ ] I will address all Greptile and reviewer comments before requesting merge