### PR TITLE
fix(heartbeat): surface local API outages

### DIFF
--- a/server/src/__tests__/paperclip-heartbeat-inbox-script.test.ts
+++ b/server/src/__tests__/paperclip-heartbeat-inbox-script.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const helperPath = path.join(repoRoot, "skills/paperclip/scripts/heartbeat-inbox.sh");
+
+function makeFakeCurl(mode: "all-fail" | "empty-success") {
+  const root = mkdtempSync(path.join(os.tmpdir(), "paperclip-heartbeat-inbox-test-"));
+  const binDir = path.join(root, "bin");
+  const scratchDir = path.join(root, "run-scratch");
+  const curlLog = path.join(root, "curl.log");
+  const curlPath = path.join(binDir, "curl");
+  mkdirSync(binDir);
+  writeFileSync(curlLog, "");
+  writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+set -u
+output=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    -w) shift 2 ;;
+    -H|-X) shift 2 ;;
+    http://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+printf '%s %s\\n' "$url" "$output" >> "$CURL_LOG"
+if [[ "$HEARTBEAT_CURL_MODE" == "all-fail" ]]; then
+  exit 7
+fi
+printf '{"items":[]}\\n' > "$output"
+printf '200'
+`,
+  );
+  chmodSync(curlPath, 0o755);
+  return { root, binDir, scratchDir, curlLog };
+}
+
+function runHelper(
+  mode: "all-fail" | "empty-success",
+  options: { apiUrl?: string } = {},
+) {
+  const fixture = makeFakeCurl(mode);
+  try {
+    const env = {
+      ...process.env,
+      PATH: `${fixture.binDir}:${process.env.PATH ?? ""}`,
+      CURL_LOG: fixture.curlLog,
+      HEARTBEAT_CURL_MODE: mode,
+      PAPERCLIP_API_URL: options.apiUrl ?? "http://paperclip.invalid",
+      PAPERCLIP_RUN_SCRATCH_DIR: fixture.scratchDir,
+      PAPERCLIP_HEARTBEAT_RETRY_DELAY_SECONDS: "0",
+    };
+    try {
+      const stdout = execFileSync("bash", [helperPath], { env, encoding: "utf8" });
+      return { status: 0, stdout, stderr: "", calls: readFileSync(fixture.curlLog, "utf8") };
+    } catch (error) {
+      const result = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+      return {
+        status: result.status ?? 1,
+        stdout: String(result.stdout ?? ""),
+        stderr: String(result.stderr ?? ""),
+        calls: readFileSync(fixture.curlLog, "utf8"),
+      };
+    }
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+describe("paperclip heartbeat inbox helper", () => {
+  it("surfaces an API outage after attempting the loopback fallback", () => {
+    const result = runHelper("all-fail");
+
+    expect(result.status).not.toBe(0);
+    expect(result.calls).toContain("http://paperclip.invalid");
+    expect(result.calls).toContain("http://127.0.0.1:3100");
+    expect(result.stderr).toContain("trying loopback fallback");
+    expect(result.stderr).toContain("ERROR: Paperclip API unreachable");
+    expect(result.stderr).not.toContain("no new assignments");
+    expect(result.calls).not.toContain("/tmp/pc_inbox.json");
+  });
+
+  it("allows a genuine 200 empty inbox to exit cleanly", () => {
+    const result = runHelper("empty-success");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('{"items":[]}');
+    expect(result.calls).toContain("http://paperclip.invalid");
+    expect(result.calls).not.toContain("127.0.0.1");
+    expect(result.stderr).not.toContain("ERROR: Paperclip API unreachable");
+    expect(result.stderr).not.toContain("trying loopback fallback");
+  });
+});

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -44,6 +44,23 @@ Follow these steps every time you wake up:
 
 **Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
 
+**Connection failure is an error, not "no work":** You MUST distinguish a successful empty inbox (`200 OK`, `{"items":[]}`) from a connection failure (curl exit 7, HTTP 000, or any non-2xx status). Only a successful 2xx response may be parsed as an inbox; a valid `200 OK` empty list means "nothing to do — exit cleanly." Any other result is an error and must be handled as such.
+
+When making control-plane calls via `curl` (applies to all local `opencode_local` / shell-dispatched agents):
+
+1. **Capture both the HTTP status and the curl exit code** — never rely on an empty response body alone to determine success.
+2. **On failure, retry once against the loopback fallback** (`http://127.0.0.1:${PAPERCLIP_LISTEN_PORT:-3100}`) with the configured retry backoff before giving up. Co-located agents can use loopback even when the injected `$PAPERCLIP_API_URL` hostname is wrong or temporarily unreachable.
+3. **Use a per-run response file** — prefer `$PAPERCLIP_RUN_SCRATCH_DIR` or `$PAPERCLIP_SCRATCH_DIR`; otherwise create a `mktemp` directory and clean it with `trap`. Never use a shared `/tmp/pc_inbox.json` path.
+4. **If the loopback retry also fails, do not exit cleanly.** Emit an error line to stderr and exit non-zero so the failure surfaces in the agent record. Never exit with `reason: stop` or log "no new assignments" when the API was unreachable.
+
+The bundled `skills/paperclip/scripts/heartbeat-inbox.sh` implements this contract for shell-dispatched callers. It logs the fallback warning only after the primary endpoint fails, and emits the terminal error only after both attempts fail:
+
+```bash
+bash "${PAPERCLIP_SKILL_DIR:-skills/paperclip}/scripts/heartbeat-inbox.sh"
+```
+
+Keep the same status/exit-code, fallback, and per-run scratch-file contract for other control-plane calls; a transport failure must never be represented as an empty response.
+
 **Step 4 — Pick work.** Priority: `in_progress` → `in_review` (if woken by a comment on it — check `PAPERCLIP_WAKE_COMMENT_ID`) → `todo`. Skip `blocked` unless you can unblock.
 
 Overrides and special cases:

--- a/skills/paperclip/scripts/heartbeat-inbox.sh
+++ b/skills/paperclip/scripts/heartbeat-inbox.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Fetch the compact heartbeat inbox without turning transport failures into an
+# empty assignment list. This is intentionally a small shell boundary so local
+# adapters can use the same status/exit-code contract as the agent scaffold.
+set -u
+
+: "${PAPERCLIP_API_URL:?PAPERCLIP_API_URL is required}"
+
+scratch_dir="${PAPERCLIP_RUN_SCRATCH_DIR:-${PAPERCLIP_SCRATCH_DIR:-}}"
+owns_scratch_dir=0
+if [[ -z "$scratch_dir" ]]; then
+  scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/paperclip-heartbeat.XXXXXX")"
+  owns_scratch_dir=1
+else
+  mkdir -p -- "$scratch_dir"
+fi
+
+inbox_file="$scratch_dir/inbox-lite.json"
+trap 'rm -f -- "$inbox_file"; if [[ "$owns_scratch_dir" -eq 1 ]]; then rmdir -- "$scratch_dir" 2>/dev/null || true; fi' EXIT
+
+loopback_url="http://127.0.0.1:${PAPERCLIP_LISTEN_PORT:-3100}"
+retry_delay="${PAPERCLIP_HEARTBEAT_RETRY_DELAY_SECONDS:-1}"
+api_url="$PAPERCLIP_API_URL"
+http_status="000"
+curl_exit=1
+attempted_loopback=0
+
+for endpoint in "$api_url" "$loopback_url"; do
+  if [[ "$endpoint" == "$api_url" && "$attempted_loopback" -eq 1 ]]; then
+    continue
+  fi
+  if [[ "$endpoint" == "$loopback_url" ]]; then
+    attempted_loopback=1
+  fi
+
+  : > "$inbox_file"
+  http_status="$(curl -sS -o "$inbox_file" -w '%{http_code}' \
+    -H "Authorization: Bearer ${PAPERCLIP_API_KEY:-}" \
+    "$endpoint/api/agents/me/inbox-lite")"
+  curl_exit=$?
+  http_status="${http_status:-000}"
+
+  if [[ "$curl_exit" -eq 0 && "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+    cat -- "$inbox_file"
+    exit 0
+  fi
+
+  if [[ "$endpoint" == "$api_url" && "$loopback_url" != "$api_url" ]]; then
+    printf '[paperclip] WARNING: inbox-lite failed at %s (exit=%s, http=%s); trying loopback fallback\n' \
+      "$endpoint" "$curl_exit" "$http_status" >&2
+    if [[ "$retry_delay" != "0" ]]; then
+      sleep "$retry_delay"
+    fi
+  fi
+done
+
+printf '[paperclip] ERROR: Paperclip API unreachable — tried %s and loopback fallback. exit=%s http=%s\n' \
+  "$api_url" "$curl_exit" "$http_status" >&2
+exit 1


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local shell-dispatched agents use the Paperclip control plane during every heartbeat to discover assignments
> - The heartbeat inbox helper previously treated an empty response as no work without proving that the API call succeeded
> - A connection-level curl failure can therefore make an agent exit cleanly while its record remains idle and healthy-looking
> - This pull request hardens the heartbeat boundary by checking both curl exit status and HTTP status, retrying loopback, and failing non-zero after both endpoints fail
> - The benefit is that control-plane outages become visible errors instead of silent no-assignment exits

## Linked Issues or Issue Description

Refs #7627
Refs #7552

## What Changed

- Added a shared heartbeat inbox helper that distinguishes successful empty inboxes from curl and non-2xx failures.
- Added one loopback fallback attempt with configurable retry delay and clear warning/error stderr output.
- Added per-run scratch-file handling with cleanup instead of a shared /tmp response path.
- Documented the same control-plane failure contract in the Paperclip skill.
- Added regression coverage for both outage and genuine empty-inbox behavior.

## Verification

- `pnpm exec vitest run server/src/__tests__/paperclip-heartbeat-inbox-script.test.ts` — 1 file passed, 2 tests passed.
- The outage test confirms non-zero exit, loopback attempt, terminal error output, and no silent no-assignment message.
- The empty-inbox test confirms HTTP 200 with `{"items":[]}` exits 0 without a fallback warning.

## Risks

Low risk. The change is isolated to the local heartbeat shell boundary, skill guidance, and regression tests. Successful 2xx responses retain the existing behavior; only transport failures and non-2xx responses now fail visibly after the loopback retry.

## Model Used

OpenAI Codex, exact model ID `gpt-5.6-luna`, tool-enabled code execution and repository verification. The runtime does not expose a separate context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (pending CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge