### PR TITLE
fix(issues): reject stale terminal status mutations

### DIFF
--- a/server/src/__tests__/decisions-service.test.ts
+++ b/server/src/__tests__/decisions-service.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -440,18 +440,20 @@ describePg("decisionService", () => {
 
   it("bounds expiration work to the configured batch size", async () => {
     process.env.PAPERCLIP_DECISIONS_SWEEP_BATCH_SIZE = "1";
-    await createCommentDecision("lenient", { idempotencyKey: "batch-1", expiresAt: new Date(Date.now() + 5) });
-    await createCommentDecision("lenient", { idempotencyKey: "batch-2", expiresAt: new Date(Date.now() + 5) });
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    const first = await createCommentDecision("lenient", { idempotencyKey: "batch-1" });
+    const second = await createCommentDecision("lenient", { idempotencyKey: "batch-2" });
+    await db.update(decisions).set({ expiresAt: new Date(Date.now() - 1) })
+      .where(inArray(decisions.id, [first.id, second.id]));
     expect((await service().sweepExpired()).expired).toBe(1);
     expect((await service().sweepExpired()).expired).toBe(1);
   });
 
   it("falls back to the default sweep batch size for invalid configuration", async () => {
     process.env.PAPERCLIP_DECISIONS_SWEEP_BATCH_SIZE = "not-a-number";
-    await createCommentDecision("lenient", { idempotencyKey: "invalid-batch-1", expiresAt: new Date(Date.now() + 5) });
-    await createCommentDecision("lenient", { idempotencyKey: "invalid-batch-2", expiresAt: new Date(Date.now() + 5) });
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    const first = await createCommentDecision("lenient", { idempotencyKey: "invalid-batch-1" });
+    const second = await createCommentDecision("lenient", { idempotencyKey: "invalid-batch-2" });
+    await db.update(decisions).set({ expiresAt: new Date(Date.now() - 1) })
+      .where(inArray(decisions.id, [first.id, second.id]));
 
     await expect(service().sweepExpired()).resolves.toMatchObject({ expired: 2 });
   });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1699,7 +1699,19 @@ describe.sequential("issue comment reopen routes", () => {
   });
 
   it("explicit same-agent resume comments reopen closed issues and mark the wake payload", async () => {
-    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      completedAt,
+      updatedAt: completedAt,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId: "company-1",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      startedAt: new Date("2026-08-02T09:01:00.000Z"),
+      createdAt: new Date("2026-08-02T09:00:59.000Z"),
+    });
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
       ...patch,
@@ -1712,7 +1724,13 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      {
+        status: "todo",
+        terminalStatusGuard: {
+          runStartedAt: new Date("2026-08-02T09:01:00.000Z"),
+          explicitResume: true,
+        },
+      },
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
@@ -1742,6 +1760,36 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     );
+  });
+
+  it("rejects a stale agent run that tries to resume a terminal issue through a comment", async () => {
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      completedAt,
+      updatedAt: completedAt,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId: "company-1",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      startedAt: new Date("2026-08-02T08:59:00.000Z"),
+      createdAt: new Date("2026-08-02T08:58:59.000Z"),
+    });
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "obsolete continuation result", resume: true });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Stale agent run cannot change a terminal issue",
+      code: "stale_terminal_issue_mutation",
+      issueStatus: "done",
+      requestedStatus: "todo",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects explicit agent resume intent from a non-assignee", async () => {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -769,6 +769,91 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("rejects a stale agent run that tries to overwrite a terminal issue status", async () => {
+    const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      completedAt,
+      updatedAt: completedAt,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-stale",
+      companyId: "company-1",
+      agentId: assigneeAgentId,
+      startedAt: new Date("2026-08-02T08:59:00.000Z"),
+      createdAt: new Date("2026-08-02T08:58:59.000Z"),
+    });
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: assigneeAgentId,
+        companyId: "company-1",
+        runId: "run-stale",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        status: "blocked",
+        comment: "obsolete continuation result",
+        unblockDescriptor: {
+          owner: { agentId: assigneeAgentId },
+          action: "Resume old work",
+        },
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Stale agent run cannot change a terminal issue",
+      code: "stale_terminal_issue_mutation",
+      issueStatus: "done",
+      requestedStatus: "blocked",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.updated" }),
+    );
+  });
+
+  it("requires explicit resume intent for a fresh agent run changing a terminal status", async () => {
+    const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      completedAt,
+      updatedAt: completedAt,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-fresh",
+      companyId: "company-1",
+      agentId: assigneeAgentId,
+      startedAt: new Date("2026-08-02T09:01:00.000Z"),
+      createdAt: new Date("2026-08-02T09:00:59.000Z"),
+    });
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: assigneeAgentId,
+        companyId: "company-1",
+        runId: "run-fresh",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Agent status changes on terminal issues require explicit resume intent",
+      code: "terminal_issue_resume_required",
+      issueStatus: "done",
+      requestedStatus: "todo",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   // The guard compares against the issue's current assignee, not the requested
   // one — so an admin agent reassigning a different agent's terminal issue to
   // themselves with comment + reopen=true still reopens as today (AC-3).

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -817,6 +817,62 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("rejects a stale PATCH comment when resume derives the terminal status change", async () => {
+    const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("done"),
+      completedAt,
+      updatedAt: completedAt,
+    });
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-stale",
+      companyId: "company-1",
+      agentId: assigneeAgentId,
+      startedAt: new Date("2026-08-02T08:59:00.000Z"),
+      createdAt: new Date("2026-08-02T08:58:59.000Z"),
+    });
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: assigneeAgentId,
+        companyId: "company-1",
+        runId: "run-stale",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "obsolete continuation result", resume: true });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Stale agent run cannot change a terminal issue",
+      code: "stale_terminal_issue_mutation",
+      issueStatus: "done",
+      requestedStatus: "todo",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects a terminal status change when agent run metadata is unavailable", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "todo", comment: "resume without verifiable run", resume: true });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Agent run context is required to change a terminal issue",
+      code: "terminal_issue_run_context_required",
+      issueStatus: "done",
+      requestedStatus: "todo",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("requires explicit resume intent for a fresh agent run changing a terminal status", async () => {
     const assigneeAgentId = "22222222-2222-4222-8222-222222222222";
     const completedAt = new Date("2026-08-02T09:00:53.000Z");
@@ -870,6 +926,13 @@ describe.sequential("issue comment reopen routes", () => {
       ...makeIssue("done"),
       ...patch,
     }));
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-other",
+      companyId: "company-1",
+      agentId: otherAgentId,
+      startedAt: new Date("2026-08-02T09:01:00.000Z"),
+      createdAt: new Date("2026-08-02T09:00:59.000Z"),
+    });
 
     const res = await request(
       await installActor(createApp(), {
@@ -1643,6 +1706,13 @@ describe.sequential("issue comment reopen routes", () => {
 
   it("explicit same-agent resume works through the PATCH comment path", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: "run-1",
+      companyId: "company-1",
+      agentId: "22222222-2222-4222-8222-222222222222",
+      startedAt: new Date("2026-08-02T09:01:00.000Z"),
+      createdAt: new Date("2026-08-02T09:00:59.000Z"),
+    });
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
       ...patch,
@@ -1785,6 +1855,25 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.body).toEqual({
       error: "Stale agent run cannot change a terminal issue",
       code: "stale_terminal_issue_mutation",
+      issueStatus: "done",
+      requestedStatus: "todo",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects a terminal comment resume when agent run metadata is unavailable", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "resume without verifiable run", resume: true });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      error: "Agent run context is required to change a terminal issue",
+      code: "terminal_issue_run_context_required",
       issueStatus: "done",
       requestedStatus: "todo",
     });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -338,6 +338,81 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     return companyId;
   }
 
+  it("rejects stale agent status writes against a terminal issue at the service boundary", async () => {
+    const companyId = await seedAssignableAgentCompany();
+    const issueId = randomUUID();
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal issue must stay terminal",
+      status: "done",
+      priority: "medium",
+      completedAt,
+      updatedAt: completedAt,
+    });
+
+    await expect(svc.update(issueId, {
+      status: "blocked",
+      terminalStatusGuard: {
+        runStartedAt: new Date("2026-08-02T08:59:00.000Z"),
+        explicitResume: true,
+      },
+    })).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "stale_terminal_issue_mutation",
+        issueStatus: "done",
+        requestedStatus: "blocked",
+      },
+    });
+
+    const persisted = await db
+      .select({ status: issues.status, completedAt: issues.completedAt })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(persisted).toEqual({ status: "done", completedAt });
+  });
+
+  it("requires explicit intent before a fresh agent run resumes a terminal issue", async () => {
+    const companyId = await seedAssignableAgentCompany();
+    const issueId = randomUUID();
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Fresh resume requires intent",
+      status: "done",
+      priority: "medium",
+      completedAt,
+      updatedAt: completedAt,
+    });
+
+    await expect(svc.update(issueId, {
+      status: "todo",
+      terminalStatusGuard: {
+        runStartedAt: new Date("2026-08-02T09:01:00.000Z"),
+        explicitResume: false,
+      },
+    })).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "terminal_issue_resume_required",
+        issueStatus: "done",
+        requestedStatus: "todo",
+      },
+    });
+
+    await expect(svc.update(issueId, {
+      status: "todo",
+      terminalStatusGuard: {
+        runStartedAt: new Date("2026-08-02T09:01:00.000Z"),
+        explicitResume: true,
+      },
+    })).resolves.toMatchObject({ status: "todo", completedAt: null });
+  });
+
   it("does not treat passive issue activity as touching it, but includes real user mutations", async () => {
     const companyId = await seedAssignableAgentCompany();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -375,6 +375,36 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(persisted).toEqual({ status: "done", completedAt });
   });
 
+  it("rejects unverifiable agent status writes against a terminal issue at the service boundary", async () => {
+    const companyId = await seedAssignableAgentCompany();
+    const issueId = randomUUID();
+    const completedAt = new Date("2026-08-02T09:00:53.000Z");
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal issue requires run context",
+      status: "done",
+      priority: "medium",
+      completedAt,
+      updatedAt: completedAt,
+    });
+
+    await expect(svc.update(issueId, {
+      status: "todo",
+      terminalStatusGuard: {
+        runStartedAt: null,
+        explicitResume: true,
+      },
+    })).rejects.toMatchObject({
+      status: 409,
+      details: {
+        code: "terminal_issue_run_context_required",
+        issueStatus: "done",
+        requestedStatus: "todo",
+      },
+    });
+  });
+
   it("requires explicit intent before a fresh agent run resumes a terminal issue", async () => {
     const companyId = await seedAssignableAgentCompany();
     const issueId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10222,6 +10222,47 @@ export function issueRoutes(
           executionRunId: issue.executionRunId,
         }) ||
         shouldResumeInProgressScheduledRetry);
+    let terminalStatusGuard:
+      | { runStartedAt: Date | string | null; explicitResume: boolean }
+      | undefined;
+    if (isClosed && req.actor.type === "agent" && effectiveMoveToTodoRequested) {
+      const actorRun = actor.runId
+        ? await heartbeat.getRun(actor.runId).catch(() => null)
+        : null;
+      const runStartedAt = actorRun?.startedAt ?? actorRun?.createdAt ?? null;
+      terminalStatusGuard = {
+        runStartedAt:
+          actorRun?.agentId === actor.agentId && actorRun.companyId === issue.companyId
+            ? runStartedAt
+            : null,
+        explicitResume: effectiveReopenRequested || effectiveResumeRequested,
+      };
+      const terminalAt = issue.status === "done"
+        ? issue.completedAt ?? issue.updatedAt
+        : issue.cancelledAt ?? issue.updatedAt;
+      if (
+        terminalStatusGuard.runStartedAt &&
+        terminalAt &&
+        new Date(terminalStatusGuard.runStartedAt).getTime() <= new Date(terminalAt).getTime()
+      ) {
+        res.status(409).json({
+          error: "Stale agent run cannot change a terminal issue",
+          code: "stale_terminal_issue_mutation",
+          issueStatus: issue.status,
+          requestedStatus: "todo",
+        });
+        return;
+      }
+      if (!terminalStatusGuard.explicitResume) {
+        res.status(409).json({
+          error: "Agent status changes on terminal issues require explicit resume intent",
+          code: "terminal_issue_resume_required",
+          issueStatus: issue.status,
+          requestedStatus: "todo",
+        });
+        return;
+      }
+    }
     const hasUnresolvedFirstClassBlockers =
       isBlocked && effectiveMoveToTodoRequested
         ? (await svc.getDependencyReadiness(issue.id)).unresolvedBlockerCount > 0
@@ -10252,7 +10293,10 @@ export function issueRoutes(
             actor,
           })
         : null;
-      const reopenedIssue = await svc.update(id, { status: "todo" });
+      const reopenedIssue = await svc.update(id, {
+        status: "todo",
+        ...(terminalStatusGuard ? { terminalStatusGuard } : {}),
+      });
       if (!reopenedIssue) {
         res.status(404).json({ error: "Issue not found" });
         return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7844,6 +7844,53 @@ export function issueRoutes(
       res.status(400).json({ error: "Follow-up intent requires a comment" });
       return;
     }
+    const requestedStatusChange =
+      typeof updateFields.status === "string" && updateFields.status !== existing.status
+        ? updateFields.status
+        : null;
+    let terminalStatusGuard:
+      | { runStartedAt: Date | string | null; explicitResume: boolean }
+      | undefined;
+    if (req.actor.type === "agent" && requestedStatusChange) {
+      const actorRun = actor.runId
+        ? await heartbeat.getRun(actor.runId).catch(() => null)
+        : null;
+      const runStartedAt = actorRun?.startedAt ?? actorRun?.createdAt ?? null;
+      terminalStatusGuard = {
+        runStartedAt:
+          actorRun?.agentId === actor.agentId && actorRun.companyId === existing.companyId
+            ? runStartedAt
+            : null,
+        explicitResume: reopenRequested === true || resumeRequested === true,
+      };
+      if (isClosed) {
+        const terminalAt = existing.status === "done"
+          ? existing.completedAt ?? existing.updatedAt
+          : existing.cancelledAt ?? existing.updatedAt;
+        if (
+          terminalStatusGuard.runStartedAt &&
+          terminalAt &&
+          new Date(terminalStatusGuard.runStartedAt).getTime() <= new Date(terminalAt).getTime()
+        ) {
+          res.status(409).json({
+            error: "Stale agent run cannot change a terminal issue",
+            code: "stale_terminal_issue_mutation",
+            issueStatus: existing.status,
+            requestedStatus: requestedStatusChange,
+          });
+          return;
+        }
+        if (!terminalStatusGuard.explicitResume) {
+          res.status(409).json({
+            error: "Agent status changes on terminal issues require explicit resume intent",
+            code: "terminal_issue_resume_required",
+            issueStatus: existing.status,
+            requestedStatus: requestedStatusChange,
+          });
+          return;
+        }
+      }
+    }
     if (
       (reopenRequested === true ||
         resumeRequested === true ||
@@ -8208,6 +8255,7 @@ export function issueRoutes(
             id,
             {
               ...updateFields,
+              terminalStatusGuard,
               actorAgentId: actor.agentId ?? null,
               actorUserId: actor.actorType === "user" ? actor.actorId : null,
             },
@@ -8238,6 +8286,7 @@ export function issueRoutes(
         issue = await db.transaction(async (tx) => {
           const updated = await svc.update(id, {
             ...updateFields,
+            terminalStatusGuard,
             actorAgentId: actor.agentId ?? null,
             actorUserId: actor.actorType === "user" ? actor.actorId : null,
           }, tx);
@@ -8248,6 +8297,7 @@ export function issueRoutes(
       } else {
         issue = await svc.update(id, {
           ...updateFields,
+          terminalStatusGuard,
           actorAgentId: actor.agentId ?? null,
           actorUserId: actor.actorType === "user" ? actor.actorId : null,
         });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7844,53 +7844,9 @@ export function issueRoutes(
       res.status(400).json({ error: "Follow-up intent requires a comment" });
       return;
     }
-    const requestedStatusChange =
-      typeof updateFields.status === "string" && updateFields.status !== existing.status
-        ? updateFields.status
-        : null;
     let terminalStatusGuard:
       | { runStartedAt: Date | string | null; explicitResume: boolean }
       | undefined;
-    if (req.actor.type === "agent" && requestedStatusChange) {
-      const actorRun = actor.runId
-        ? await heartbeat.getRun(actor.runId).catch(() => null)
-        : null;
-      const runStartedAt = actorRun?.startedAt ?? actorRun?.createdAt ?? null;
-      terminalStatusGuard = {
-        runStartedAt:
-          actorRun?.agentId === actor.agentId && actorRun.companyId === existing.companyId
-            ? runStartedAt
-            : null,
-        explicitResume: reopenRequested === true || resumeRequested === true,
-      };
-      if (isClosed) {
-        const terminalAt = existing.status === "done"
-          ? existing.completedAt ?? existing.updatedAt
-          : existing.cancelledAt ?? existing.updatedAt;
-        if (
-          terminalStatusGuard.runStartedAt &&
-          terminalAt &&
-          new Date(terminalStatusGuard.runStartedAt).getTime() <= new Date(terminalAt).getTime()
-        ) {
-          res.status(409).json({
-            error: "Stale agent run cannot change a terminal issue",
-            code: "stale_terminal_issue_mutation",
-            issueStatus: existing.status,
-            requestedStatus: requestedStatusChange,
-          });
-          return;
-        }
-        if (!terminalStatusGuard.explicitResume) {
-          res.status(409).json({
-            error: "Agent status changes on terminal issues require explicit resume intent",
-            code: "terminal_issue_resume_required",
-            issueStatus: existing.status,
-            requestedStatus: requestedStatusChange,
-          });
-          return;
-        }
-      }
-    }
     if (
       (reopenRequested === true ||
         resumeRequested === true ||
@@ -8040,6 +7996,58 @@ export function issueRoutes(
       updateFields.status === undefined
     ) {
       updateFields.status = "todo";
+    }
+    const requestedStatusChange =
+      typeof updateFields.status === "string" && updateFields.status !== existing.status
+        ? updateFields.status
+        : null;
+    if (req.actor.type === "agent" && requestedStatusChange) {
+      const actorRun = actor.runId
+        ? await heartbeat.getRun(actor.runId).catch(() => null)
+        : null;
+      const runStartedAt = actorRun?.startedAt ?? actorRun?.createdAt ?? null;
+      terminalStatusGuard = {
+        runStartedAt:
+          actorRun?.agentId === actor.agentId && actorRun.companyId === existing.companyId
+            ? runStartedAt
+            : null,
+        explicitResume: reopenRequested === true || resumeRequested === true,
+      };
+      if (isClosed) {
+        if (!terminalStatusGuard.runStartedAt) {
+          res.status(409).json({
+            error: "Agent run context is required to change a terminal issue",
+            code: "terminal_issue_run_context_required",
+            issueStatus: existing.status,
+            requestedStatus: requestedStatusChange,
+          });
+          return;
+        }
+        const terminalAt = existing.status === "done"
+          ? existing.completedAt ?? existing.updatedAt
+          : existing.cancelledAt ?? existing.updatedAt;
+        if (
+          terminalAt &&
+          new Date(terminalStatusGuard.runStartedAt).getTime() <= new Date(terminalAt).getTime()
+        ) {
+          res.status(409).json({
+            error: "Stale agent run cannot change a terminal issue",
+            code: "stale_terminal_issue_mutation",
+            issueStatus: existing.status,
+            requestedStatus: requestedStatusChange,
+          });
+          return;
+        }
+        if (!terminalStatusGuard.explicitResume) {
+          res.status(409).json({
+            error: "Agent status changes on terminal issues require explicit resume intent",
+            code: "terminal_issue_resume_required",
+            issueStatus: existing.status,
+            requestedStatus: requestedStatusChange,
+          });
+          return;
+        }
+      }
     }
     let cancelledScheduledRetryRunId: string | null = null;
     if (
@@ -10225,7 +10233,7 @@ export function issueRoutes(
     let terminalStatusGuard:
       | { runStartedAt: Date | string | null; explicitResume: boolean }
       | undefined;
-    if (isClosed && req.actor.type === "agent" && effectiveMoveToTodoRequested) {
+    if (req.actor.type === "agent" && effectiveMoveToTodoRequested) {
       const actorRun = actor.runId
         ? await heartbeat.getRun(actor.runId).catch(() => null)
         : null;
@@ -10237,30 +10245,40 @@ export function issueRoutes(
             : null,
         explicitResume: effectiveReopenRequested || effectiveResumeRequested,
       };
-      const terminalAt = issue.status === "done"
-        ? issue.completedAt ?? issue.updatedAt
-        : issue.cancelledAt ?? issue.updatedAt;
-      if (
-        terminalStatusGuard.runStartedAt &&
-        terminalAt &&
-        new Date(terminalStatusGuard.runStartedAt).getTime() <= new Date(terminalAt).getTime()
-      ) {
-        res.status(409).json({
-          error: "Stale agent run cannot change a terminal issue",
-          code: "stale_terminal_issue_mutation",
-          issueStatus: issue.status,
-          requestedStatus: "todo",
-        });
-        return;
-      }
-      if (!terminalStatusGuard.explicitResume) {
-        res.status(409).json({
-          error: "Agent status changes on terminal issues require explicit resume intent",
-          code: "terminal_issue_resume_required",
-          issueStatus: issue.status,
-          requestedStatus: "todo",
-        });
-        return;
+      if (isClosed) {
+        if (!terminalStatusGuard.runStartedAt) {
+          res.status(409).json({
+            error: "Agent run context is required to change a terminal issue",
+            code: "terminal_issue_run_context_required",
+            issueStatus: issue.status,
+            requestedStatus: "todo",
+          });
+          return;
+        }
+        const terminalAt = issue.status === "done"
+          ? issue.completedAt ?? issue.updatedAt
+          : issue.cancelledAt ?? issue.updatedAt;
+        if (
+          terminalAt &&
+          new Date(terminalStatusGuard.runStartedAt).getTime() <= new Date(terminalAt).getTime()
+        ) {
+          res.status(409).json({
+            error: "Stale agent run cannot change a terminal issue",
+            code: "stale_terminal_issue_mutation",
+            issueStatus: issue.status,
+            requestedStatus: "todo",
+          });
+          return;
+        }
+        if (!terminalStatusGuard.explicitResume) {
+          res.status(409).json({
+            error: "Agent status changes on terminal issues require explicit resume intent",
+            code: "terminal_issue_resume_required",
+            issueStatus: issue.status,
+            requestedStatus: "todo",
+          });
+          return;
+        }
       }
     }
     const hasUnresolvedFirstClassBlockers =

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7052,8 +7052,14 @@ export function issueService(db: Db) {
           ? current.completedAt ?? current.updatedAt
           : current.cancelledAt ?? current.updatedAt;
         const runStartedAt = terminalStatusGuard.runStartedAt;
+        if (!runStartedAt) {
+          throw conflict("Agent run context is required to change a terminal issue", {
+            code: "terminal_issue_run_context_required",
+            issueStatus: current.status,
+            requestedStatus: issueData.status,
+          });
+        }
         if (
-          runStartedAt &&
           terminalAt &&
           new Date(runStartedAt).getTime() <= new Date(terminalAt).getTime()
         ) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7014,6 +7014,10 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        terminalStatusGuard?: {
+          runStartedAt: Date | string | null;
+          explicitResume: boolean;
+        };
       },
       dbOrTx: any = db,
     ) => {
@@ -7029,8 +7033,44 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        terminalStatusGuard,
         ...issueData
       } = data;
+
+      const assertTerminalStatusMutationAllowed = (
+        current: typeof issues.$inferSelect,
+      ) => {
+        if (
+          !terminalStatusGuard ||
+          !issueData.status ||
+          issueData.status === current.status ||
+          (current.status !== "done" && current.status !== "cancelled")
+        ) {
+          return;
+        }
+        const terminalAt = current.status === "done"
+          ? current.completedAt ?? current.updatedAt
+          : current.cancelledAt ?? current.updatedAt;
+        const runStartedAt = terminalStatusGuard.runStartedAt;
+        if (
+          runStartedAt &&
+          terminalAt &&
+          new Date(runStartedAt).getTime() <= new Date(terminalAt).getTime()
+        ) {
+          throw conflict("Stale agent run cannot change a terminal issue", {
+            code: "stale_terminal_issue_mutation",
+            issueStatus: current.status,
+            requestedStatus: issueData.status,
+          });
+        }
+        if (!terminalStatusGuard.explicitResume) {
+          throw conflict("Agent status changes on terminal issues require explicit resume intent", {
+            code: "terminal_issue_resume_required",
+            issueStatus: current.status,
+            requestedStatus: issueData.status,
+          });
+        }
+      };
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -7038,6 +7078,7 @@ export function issueService(db: Db) {
         delete issueData.executionWorkspaceSettings;
       }
 
+      assertTerminalStatusMutationAllowed(existing);
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
       }
@@ -7184,6 +7225,9 @@ export function issueService(db: Db) {
           .for("update")
           .then((rows: Array<typeof issues.$inferSelect>) => rows[0] ?? null);
         if (!receiptExisting) return null;
+        // Recheck under the same row lock as the write. The issue may have
+        // become terminal after the route or service performed its first read.
+        assertTerminalStatusMutationAllowed(receiptExisting);
         const [previousLabelsByIssueId, previousRelationSummaries] = await Promise.all([
           nextLabelIds !== undefined
             ? labelMapForIssues(tx, [id])


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue routes and the issue service control durable issue status.
> - Agent runs can finish after another run or operator has already closed the issue.
> - A late run could change a terminal issue back to an open status.
> - The existing authorization checks do not compare run start time with terminal time.
> - This pull request adds that comparison at the route and transactional service boundaries.
> - The benefit is that stale runs cannot reopen completed work, while fresh explicit follow-up still works.

## Linked Issues or Issue Description

Related: Refs #9121. That pull request applies a broader automation-dead policy. This pull request preserves explicit fresh agent resume and adds a narrower stale-run race guard.

**What happened?**

An agent run that started before an issue reached `done` or `cancelled` could later update the status. The same stale update was possible through both `PATCH /issues/:id` and `POST /issues/:id/comments`.

**Expected behavior**

A run that started at or before the issue terminal timestamp must not change the terminal status. A fresh agent run must provide explicit reopen or resume intent.

**Steps to reproduce**

1. Start an agent run for an issue.
2. Complete the issue from another run or board action.
3. Let the old run send a status update or an explicit resume comment.
4. Observe that the old run reopens the issue without this change.

**Paperclip version or commit**

Master at `8540ce2973204a8938cd05ac18fbc37c6434f8f5`.

**Deployment mode**

Self-hosted server and local development.

**Agent adapter(s) involved**

Not adapter-specific. The bug is in the core issue mutation path.

**Access context**

Agent bearer API key.

**Privacy checklist**

I reviewed this description and the test data. It contains no secrets or private instance references.

## What Changed

- Add an optional terminal-status guard to issue-service updates.
- Evaluate the guard while the issue row is locked.
- Reject stale agent runs with a structured 409 response.
- Require explicit intent for fresh agent status changes on terminal issues.
- Apply the same guard to direct updates and comment-triggered resumes.
- Add route and service regression tests.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts --testTimeout=15000`: 78 tests passed.
- `pnpm --filter @paperclipai/server typecheck`: passed.
- `git diff --check`: passed.
- The service-level embedded Postgres tests passed on the source host before the route-parity change. The parity change does not alter the service implementation.

## Risks

Low risk. The change only affects agent-authenticated status mutations when the current issue is terminal. Board actions keep their current behavior. Fresh agent resumes still require explicit intent.

## Model Used

OpenAI Codex with GPT-5.6, high reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing public issue or described the issue in-PR with the bug template labels
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests
- [x] No documentation update is required for this internal safety invariant
- [x] I have considered and documented risks
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
