### PR TITLE
fix(plugins): resolve unscoped proactive config.get for single-company plugins

### DIFF
--- a/server/src/__tests__/plugin-worker-manager.test.ts
+++ b/server/src/__tests__/plugin-worker-manager.test.ts
@@ -779,3 +779,79 @@ describe("plugin proactive events.subscribe: options-seeded scope + filter parit
     }
   });
 });
+
+
+describe('plugin proactive config.get: single-company fallback', () => {
+  // Chat-style plugins (telegram/discord gateway) call ctx.config.get() from
+  // setup() with NO company argument. That arrives as a proactive (no-invocation)
+  // config.get with no company reference, and used to be rejected with
+  // "company context is required" even when the plugin had exactly one
+  // configured company - leaving such plugins dead on activation.
+  // The fallback resolves only that case: exactly one configured company, and
+  // only for config.get with no explicit company reference. Everything else
+  // (no configured company, multiple companies, explicit other company) still
+  // denies by default.
+  function makeConfigHandle(seededCompanies) {
+    const configGet = vi.fn(async () => ({ ok: true }));
+    const hostHandlers = createHostClientHandlers({
+      pluginId: "test.plugin",
+      capabilities: [],
+      services: {
+        config: { get: configGet },
+      },
+    });
+    const handle = createPluginWorkerHandle("test.plugin", {
+      entrypointPath: INVOCATION_SCOPE_WORKER_ENTRYPOINT,
+      manifest: TEST_MANIFEST,
+      config: {},
+      instanceInfo: { instanceId: "instance-1", hostVersion: "1.0.0" },
+      apiVersion: 1,
+      hostHandlers,
+      proactiveCompanyScopes: seededCompanies,
+    });
+    return { handle, configGet };
+  }
+
+  it("admits an unscoped proactive config.get when the plugin has exactly one configured company", async () => {
+    const { handle, configGet } = makeConfigHandle(["company-1"]);
+    try {
+      await handle.start();
+      await handle.call("getData", {
+        params: { mode: "omit", hostMethod: "config.get", requestedCompanyId: undefined },
+      });
+      expect(configGet).toHaveBeenCalledTimes(1);
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("still denies an unscoped proactive config.get when no company is configured", async () => {
+    const { handle, configGet } = makeConfigHandle([]);
+    try {
+      await handle.start();
+      await expect(handle.call("getData", {
+        params: { mode: "omit", hostMethod: "config.get", requestedCompanyId: undefined },
+      })).rejects.toMatchObject({
+        code: PLUGIN_RPC_ERROR_CODES.INVOCATION_SCOPE_DENIED,
+      });
+      expect(configGet).not.toHaveBeenCalled();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+
+  it("still denies an unscoped proactive config.get when several companies are configured (ambiguity)", async () => {
+    const { handle, configGet } = makeConfigHandle(["company-1", "company-2"]);
+    try {
+      await handle.start();
+      await expect(handle.call("getData", {
+        params: { mode: "omit", hostMethod: "config.get", requestedCompanyId: undefined },
+      })).rejects.toMatchObject({
+        code: PLUGIN_RPC_ERROR_CODES.INVOCATION_SCOPE_DENIED,
+      });
+      expect(configGet).not.toHaveBeenCalled();
+    } finally {
+      await handle.stop().catch(() => undefined);
+    }
+  });
+});

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -697,6 +697,19 @@ export function createPluginWorkerHandle(
       if (proactiveCompanyId && proactiveCompanyScopes.has(proactiveCompanyId)) {
         return { invocationScope: { companyId: proactiveCompanyId } };
       }
+      // Single-company fallback: a no-invocation company-scoped read that names
+      // no company (e.g. config.get() with no companyId) resolves to the
+      // plugin's only configured company. Ambiguity (0 or 2+ configured
+      // companies) keeps the existing deny-by-default behavior, so this never
+      // widens access beyond the plugin's configured companies.
+      if (
+        !proactiveCompanyId &&
+        message.method === "config.get" &&
+        proactiveCompanyScopes.size === 1
+      ) {
+        const onlyCompanyId = proactiveCompanyScopes.values().next().value;
+        if (onlyCompanyId) return { invocationScope: { companyId: onlyCompanyId } };
+      }
       const hasActiveInvocation = activeInvocations.size > 0 ||
         Array.from(pendingRequests.values()).some((pending) => pending.invocationId);
       return hasActiveInvocation ? { invalidInvocationScope: true } : {};

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -702,6 +702,13 @@ export function createPluginWorkerHandle(
       // plugin's only configured company. Ambiguity (0 or 2+ configured
       // companies) keeps the existing deny-by-default behavior, so this never
       // widens access beyond the plugin's configured companies.
+      const hasActiveInvocation = activeInvocations.size > 0 ||
+        Array.from(pendingRequests.values()).some((pending) => pending.invocationId);
+      if (hasActiveInvocation) return { invalidInvocationScope: true };
+      // Single-company fallback for unscoped proactive reads. Only applies when
+      // no host invocation is in flight: while one is active, an unscoped
+      // proactive call stays invalidInvocationScope (never acquires a scope
+      // belonging to a concurrent invocation).
       if (
         !proactiveCompanyId &&
         message.method === "config.get" &&
@@ -710,9 +717,7 @@ export function createPluginWorkerHandle(
         const onlyCompanyId = proactiveCompanyScopes.values().next().value;
         if (onlyCompanyId) return { invocationScope: { companyId: onlyCompanyId } };
       }
-      const hasActiveInvocation = activeInvocations.size > 0 ||
-        Array.from(pendingRequests.values()).some((pending) => pending.invocationId);
-      return hasActiveInvocation ? { invalidInvocationScope: true } : {};
+      return {};
     }
     const entry = activeInvocations.get(invocationId);
     if (!entry) return { invalidInvocationScope: true };


### PR DESCRIPTION
## Thinking Path

The telegram/discord-style chat plugins call `ctx.config.get()` from `setup()` with no company argument. On the wire that is a proactive (no-invocation) worker→host call with no company reference, so the governed-access gate in `contextForWorkerMessage` rejects it with "company context is required" and the plugin dies at activation (`Worker initialize failed`).

The gate already has a safe channel for proactive access: `proactiveCompanyScopes` seeded from the plugin's configured companies. The missing case is a call that names NO company at all. When the plugin has exactly one configured company, the intended scope is unambiguous — the fallback resolves it. Zero or multiple configured companies stay denied, and an explicit reference to another company stays denied.

Greptile review fix (commit 2): the fallback now runs only when no host-issued invocation is in flight; otherwise the call stays `invalidInvocationScope`, so a concurrent proactive call can never acquire a scope belonging to an active invocation.

## What Changed

- `server/src/services/plugin-worker-manager.ts`: in `contextForWorkerMessage`, after the existing seeded-scope match and after the active-invocation check, unscoped proactive `config.get` resolves to the plugin's single configured company (size === 1). All other shapes unchanged.
- `server/src/__tests__/plugin-worker-manager.test.ts`: three new real-worker tests (admit on single configured company; deny on none; deny on two).

## Verification

- `vitest run server/src/__tests__/plugin-worker-manager.test.ts` → 31/31 pass, including all pre-existing LOOA-629 / LOOA-695 gate tests (in-container run on arm64).
- Reproduced live against `paperclip-plugin-telegram@0.7.1` on master (`8540ce2`): activation failed before the fix, activates after.

## Risks

- Scope: the fallback is limited to `config.get` with no explicit company reference and exactly one configured company. Deny-by-default is untouched for zero/multi-company setups, explicit cross-company references, and in-flight invocation ambiguity.
- Plugins with multiple companies get no behavior change (still must pass a companyId).

## Model Used

Kimi Code CLI (frontier model) with human operator; live-tested against a self-hosted Paperclip instance running a five-agent company.

## Dedup search

- [x] I searched the GitHub PR list for similar PRs (keywords: proactive config.get, company context is required, plugin scope fallback) — none found. Related: #5429 / PAP-2394 (secrets.resolve kill-switch) is intentionally NOT touched here.
