### PR TITLE
fix: add gpt-5.5 to Codex local model picker

### DIFF
--- a/packages/adapters/codex-local/src/index.test.ts
+++ b/packages/adapters/codex-local/src/index.test.ts
@@ -18,6 +18,7 @@ describe("codex local adapter metadata", () => {
       "gpt-5.6-terra",
       "gpt-5.6-luna",
     ]);
+    expect(modelIds).toContain("gpt-5.5");
     expect(modelIds).not.toContain("gpt-5.6");
     expect(isCodexLocalFastModeSupported(DEFAULT_CODEX_LOCAL_MODEL)).toBe(true);
     expect(modelIds).not.toContain("gpt-5.3-codex");

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -63,6 +63,7 @@ export const models = [
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
   { id: "gpt-5.6-terra", label: "gpt-5.6-terra" },
   { id: "gpt-5.6-luna", label: "gpt-5.6-luna" },
+  { id: "gpt-5.5", label: "gpt-5.5" },
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
   { id: "gpt-5", label: "gpt-5" },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Codex Local adapter supplies model choices for Codex agents.
> - The model picker uses the adapter `models` metadata.
> - `gpt-5.5` supports Codex Local fast mode, but the metadata omits it.
> - Users cannot select `gpt-5.5` from the picker without manual entry.
> - This pull request adds `gpt-5.5` to the selectable model list.
> - The picker now exposes the supported model.

## Linked Issues or Issue Description

**What happened?**

The Codex Local picker omits `gpt-5.5`, even though fast mode supports it. This supersedes the closed earlier attempt, [#6779](https://github.com/paperclipai/paperclip/pull/6779), which predates the GPT-5.6 model-family rewrite.

**Expected behavior**

The picker lists `gpt-5.5` with the other supported Codex models.

**Steps to reproduce**

1. Configure a Codex Local agent.
2. Open its model picker.
3. Confirm that `gpt-5.5` is absent.

**Paperclip version or commit**

`8540ce297` from `master`.

**Agent adapter(s) involved**

Codex.

## What Changed

- Added `gpt-5.5` to the Codex Local selectable models.
- Added a metadata test for the `gpt-5.5` model ID.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/index.test.ts`

## Risks

Low risk. This adds one picker option and does not change existing model normalization.

## Model Used

OpenAI Codex using GPT-5.6 with tool-assisted code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
