### PR TITLE
fix(routines): accept triggers on routine create and reject them on PATCH

### DIFF
--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -34,11 +34,20 @@ POST /api/companies/{companyId}/routines
   "priority": "medium",
   "status": "active",
   "concurrencyPolicy": "coalesce_if_active",
-  "catchUpPolicy": "skip_missed"
+  "catchUpPolicy": "skip_missed",
+  "triggers": [
+    { "kind": "schedule", "cronExpression": "0 9 * * 1", "timezone": "UTC" }
+  ]
 }
 ```
 
 **Agents can only create routines assigned to themselves.** Board operators can assign to any agent.
+
+A routine without a trigger never fires. Pass `triggers` to create the routine and its schedule in
+one call: the response carries the created triggers, and they belong to the routine's first
+revision. Webhook triggers are the one exception — create them with [Add Trigger](#add-trigger),
+which returns the one-time signing secret. An invalid cron expression rejects the whole request with
+`422` and no routine is created.
 
 Fields:
 
@@ -54,6 +63,7 @@ Fields:
 | `status` | no | `active` (default), `paused`, `archived` |
 | `concurrencyPolicy` | no | Behaviour when a run fires while a previous one is still active |
 | `catchUpPolicy` | no | Behaviour for missed scheduled runs |
+| `triggers` | no | Up to 10 `schedule` or `api` triggers, same body as [Add Trigger](#add-trigger) |
 
 **Concurrency policies:**
 
@@ -80,7 +90,7 @@ PATCH /api/routines/{routineId}
 }
 ```
 
-All fields from create are updatable. `baseRevisionId` is optional for backward compatibility; when provided, stale values return `409 Conflict` with the current revision id. **Agents can only update routines assigned to themselves and cannot reassign a routine to another agent.**
+All fields from create are updatable except `triggers`, which returns `400` here — a whole-array replace would delete webhook triggers together with their secrets. Use [Add Trigger](#add-trigger), [Update Trigger](#update-trigger), and [Delete Trigger](#delete-trigger) instead. `baseRevisionId` is optional for backward compatibility; when provided, stale values return `409 Conflict` with the current revision id. **Agents can only update routines assigned to themselves and cannot reassign a routine to another agent.**
 
 ## List Revisions
 

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -61,6 +61,53 @@ export const routineVariableSchema = z.object({
   }
 });
 
+const baseTriggerSchema = z.object({
+  label: z.string().trim().max(120).optional().nullable(),
+  enabled: z.boolean().optional().default(true),
+});
+
+export const createRoutineTriggerSchema = z.discriminatedUnion("kind", [
+  baseTriggerSchema.extend({
+    kind: z.literal("schedule"),
+    cronExpression: z.string().trim().min(1),
+    timezone: z.string().trim().min(1).default("UTC"),
+  }),
+  baseTriggerSchema.extend({
+    kind: z.literal("webhook"),
+    signingMode: z.enum(ROUTINE_TRIGGER_SIGNING_MODES).optional().default("bearer"),
+    replayWindowSec: z.number().int().min(30).max(86_400).optional().default(300),
+  }),
+  baseTriggerSchema.extend({
+    kind: z.literal("api"),
+  }),
+]);
+
+export type CreateRoutineTrigger = z.infer<typeof createRoutineTriggerSchema>;
+
+export const MAX_INLINE_ROUTINE_TRIGGERS = 10;
+
+const INLINE_WEBHOOK_TRIGGER_MESSAGE =
+  "Webhook triggers cannot be created inline. Use POST /api/routines/{routineId}/triggers so the one-time signing secret is returned.";
+
+/**
+ * Triggers accepted in the body of a routine create. Webhook triggers are excluded because
+ * their signing secret is only ever returned once, by the dedicated trigger endpoint.
+ */
+export const createRoutineInlineTriggersSchema = z
+  .array(createRoutineTriggerSchema)
+  .max(MAX_INLINE_ROUTINE_TRIGGERS)
+  .superRefine((triggers, ctx) => {
+    triggers.forEach((trigger, index) => {
+      if (trigger.kind === "webhook") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, "kind"],
+          message: INLINE_WEBHOOK_TRIGGER_MESSAGE,
+        });
+      }
+    });
+  });
+
 export const createRoutineSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   folderId: z.string().uuid().optional().nullable(),
@@ -77,13 +124,26 @@ export const createRoutineSchema = z.object({
   activityGateScope: z.enum(ROUTINE_ACTIVITY_GATE_SCOPES).optional(),
   variables: z.array(routineVariableSchema).optional().default([]),
   env: envConfigSchema.optional().nullable(),
+  triggers: createRoutineInlineTriggersSchema.optional(),
 });
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;
 
-export const updateRoutineSchema = createRoutineSchema.partial().extend({
-  baseRevisionId: z.string().uuid().optional().nullable(),
-});
+export const updateRoutineSchema = createRoutineSchema
+  .omit({ triggers: true })
+  .partial()
+  .extend({
+    baseRevisionId: z.string().uuid().optional().nullable(),
+    // Triggers are not patchable as part of the routine body: a whole-array replace would
+    // silently delete webhook triggers together with their secrets. Reject the field loudly
+    // instead of stripping it, so callers are told where the trigger write routes are.
+    triggers: z
+      .never({
+        invalid_type_error:
+          "Triggers cannot be updated here. Use POST /api/routines/{routineId}/triggers, PATCH /api/routine-triggers/{triggerId}, or DELETE /api/routine-triggers/{triggerId}.",
+      })
+      .optional(),
+  });
 export type UpdateRoutine = z.infer<typeof updateRoutineSchema>;
 
 export const routineRevisionSnapshotRoutineV1Schema = z.object({
@@ -128,29 +188,6 @@ export const routineRevisionSnapshotV1Schema = z.object({
 export const routineRevisionSnapshotSchema = routineRevisionSnapshotV1Schema;
 export type RoutineRevisionSnapshotV1 = z.infer<typeof routineRevisionSnapshotV1Schema>;
 export type RoutineRevisionSnapshot = z.infer<typeof routineRevisionSnapshotSchema>;
-
-const baseTriggerSchema = z.object({
-  label: z.string().trim().max(120).optional().nullable(),
-  enabled: z.boolean().optional().default(true),
-});
-
-export const createRoutineTriggerSchema = z.discriminatedUnion("kind", [
-  baseTriggerSchema.extend({
-    kind: z.literal("schedule"),
-    cronExpression: z.string().trim().min(1),
-    timezone: z.string().trim().min(1).default("UTC"),
-  }),
-  baseTriggerSchema.extend({
-    kind: z.literal("webhook"),
-    signingMode: z.enum(ROUTINE_TRIGGER_SIGNING_MODES).optional().default("bearer"),
-    replayWindowSec: z.number().int().min(30).max(86_400).optional().default(300),
-  }),
-  baseTriggerSchema.extend({
-    kind: z.literal("api"),
-  }),
-]);
-
-export type CreateRoutineTrigger = z.infer<typeof createRoutineTriggerSchema>;
 
 export const updateRoutineTriggerSchema = z.object({
   label: z.string().trim().max(120).optional().nullable(),

--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -358,6 +358,149 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
     );
   }, 15_000);
 
+  it("creates schedule triggers supplied in the routine create body", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Quarterly cost review",
+        assigneeAgentId: agentId,
+        triggers: [
+          { kind: "schedule", label: "quarterly", cronExpression: "0 6 1 */3 *", timezone: "UTC" },
+        ],
+      });
+
+    expect([200, 201], JSON.stringify(createRes.body)).toContain(createRes.status);
+    expect(createRes.body.triggers).toHaveLength(1);
+    expect(createRes.body.triggers[0].kind).toBe("schedule");
+    expect(createRes.body.triggers[0].label).toBe("quarterly");
+    expect(createRes.body.triggers[0].enabled).toBe(true);
+    expect(createRes.body.triggers[0].nextRunAt).toBeTruthy();
+
+    const routineId = createRes.body.id as string;
+
+    const persistedTriggers = await db
+      .select({ id: routineTriggers.id, cronExpression: routineTriggers.cronExpression, nextRunAt: routineTriggers.nextRunAt })
+      .from(routineTriggers)
+      .where(eq(routineTriggers.routineId, routineId));
+    expect(persistedTriggers).toHaveLength(1);
+    expect(persistedTriggers[0]?.cronExpression).toBe("0 6 1 */3 *");
+    expect(persistedTriggers[0]?.nextRunAt).toBeInstanceOf(Date);
+
+    const detailRes = await request(app).get(`/api/routines/${routineId}`);
+    expect(detailRes.status).toBe(200);
+    expect(detailRes.body.triggers).toHaveLength(1);
+
+    // The trigger must be part of the first revision snapshot, not a later one.
+    const revisionsRes = await request(app).get(`/api/routines/${routineId}/revisions`);
+    expect(revisionsRes.status).toBe(200);
+    expect(revisionsRes.body).toHaveLength(1);
+    expect(revisionsRes.body[0].revisionNumber).toBe(1);
+    expect(revisionsRes.body[0].snapshot.triggers).toHaveLength(1);
+
+    const actions = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId));
+    expect(actions.map((entry) => entry.action)).toEqual(
+      expect.arrayContaining(["routine.created", "routine.trigger_created"]),
+    );
+  }, 15_000);
+
+  it("rejects an invalid inline cron before the routine row is created", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Broken cron routine",
+        assigneeAgentId: agentId,
+        triggers: [
+          { kind: "schedule", cronExpression: "0 6 1 */3 *", timezone: "UTC" },
+          { kind: "schedule", cronExpression: "not-a-cron", timezone: "UTC" },
+        ],
+      });
+
+    expect(createRes.status).toBe(422);
+
+    const orphans = await db
+      .select({ id: routines.id })
+      .from(routines)
+      .where(eq(routines.companyId, companyId));
+    expect(orphans).toHaveLength(0);
+  }, 15_000);
+
+  it("rejects inline webhook triggers and points at the trigger endpoint", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Inline webhook routine",
+        assigneeAgentId: agentId,
+        triggers: [{ kind: "webhook" }],
+      });
+
+    expect(createRes.status).toBe(400);
+    expect(JSON.stringify(createRes.body)).toContain("/api/routines/{routineId}/triggers");
+  }, 15_000);
+
+  it("rejects triggers on routine PATCH instead of silently dropping them", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({ projectId, title: "Patch guard routine", assigneeAgentId: agentId });
+    expect([200, 201], JSON.stringify(createRes.body)).toContain(createRes.status);
+
+    const patchRes = await request(app)
+      .patch(`/api/routines/${createRes.body.id}`)
+      .send({
+        triggers: [{ kind: "schedule", cronExpression: "0 6 1 */3 *", timezone: "UTC" }],
+      });
+
+    expect(patchRes.status).toBe(400);
+    expect(JSON.stringify(patchRes.body)).toContain("/api/routines/{routineId}/triggers");
+
+    const persistedTriggers = await db
+      .select({ id: routineTriggers.id })
+      .from(routineTriggers)
+      .where(eq(routineTriggers.routineId, createRes.body.id));
+    expect(persistedTriggers).toHaveLength(0);
+  }, 15_000);
+
   it("runs routines with variable inputs and interpolates the execution issue description", async () => {
     const { companyId, agentId, projectId, userId } = await seedFixture();
     const app = await createApp({

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -197,7 +197,7 @@ describe("routine routes", () => {
     vi.clearAllMocks();
     mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
     mockRoutineService.list.mockResolvedValue([routine]);
-    mockRoutineService.create.mockResolvedValue(routine);
+    mockRoutineService.create.mockResolvedValue({ ...routine, triggers: [] });
     mockRoutineService.get.mockResolvedValue(routine);
     mockRoutineService.getTrigger.mockResolvedValue(trigger);
     mockRoutineService.update.mockResolvedValue({ ...routine, assigneeAgentId: otherAgentId });

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -176,6 +176,20 @@ export function routineRoutes(
       entityId: created.id,
       details: { title: created.title, assigneeAgentId: created.assigneeAgentId },
     });
+    for (const trigger of created.triggers) {
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        action: "routine.trigger_created",
+        entityType: "routine_trigger",
+        entityId: trigger.id,
+        details: { routineId: created.id, kind: trigger.kind },
+      });
+    }
     const telemetryClient = getTelemetryClient();
     if (telemetryClient) {
       trackRoutineCreated(telemetryClient);
@@ -186,7 +200,7 @@ export function routineRoutes(
       revisionId: created.latestRevisionId,
       revisionNumber: created.latestRevisionNumber,
       changeSummary: "Created routine",
-      triggerCount: 0,
+      triggerCount: created.triggers.length,
     });
     res.status(201).json(created);
   });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1556,6 +1556,55 @@ export function routineService(
     return { secret, secretValue };
   }
 
+  /**
+   * Validates a schedule trigger against the routine it will belong to and returns its first
+   * fire time. Non-schedule kinds have no schedule state, so they resolve to null.
+   */
+  function resolveTriggerNextRunAt(
+    routineVariables: RoutineVariable[] | null | undefined,
+    input: CreateRoutineTrigger,
+  ): Date | null {
+    if (input.kind !== "schedule") return null;
+    assertScheduleCompatibleVariables(routineVariables ?? []);
+    const timeZone = input.timezone || "UTC";
+    assertTimeZone(timeZone);
+    const error = validateCron(input.cronExpression);
+    if (error) throw unprocessable(error);
+    return nextCronTickInTimeZone(input.cronExpression, timeZone, new Date());
+  }
+
+  async function insertRoutineTriggerRow(
+    executor: Db,
+    routine: RoutineRow,
+    input: CreateRoutineTrigger,
+    actor: Actor,
+    prepared: { nextRunAt: Date | null; publicId: string | null; secretId: string | null },
+  ) {
+    const [createdTrigger] = await executor
+      .insert(routineTriggers)
+      .values({
+        companyId: routine.companyId,
+        routineId: routine.id,
+        kind: input.kind,
+        label: input.label ?? null,
+        enabled: input.enabled ?? true,
+        cronExpression: input.kind === "schedule" ? input.cronExpression : null,
+        timezone: input.kind === "schedule" ? (input.timezone || "UTC") : null,
+        nextRunAt: prepared.nextRunAt,
+        publicId: prepared.publicId,
+        secretId: prepared.secretId,
+        signingMode: input.kind === "webhook" ? input.signingMode : null,
+        replayWindowSec: input.kind === "webhook" ? input.replayWindowSec : null,
+        lastRotatedAt: input.kind === "webhook" ? new Date() : null,
+        createdByAgentId: actor.agentId ?? null,
+        createdByUserId: actor.userId ?? null,
+        updatedByAgentId: actor.agentId ?? null,
+        updatedByUserId: actor.userId ?? null,
+      })
+      .returning();
+    return createdTrigger;
+  }
+
   async function resolveTriggerSecret(trigger: typeof routineTriggers.$inferSelect, companyId: string) {
     if (!trigger.secretId) throw notFound("Routine trigger secret not found");
     const secret = await db
@@ -2074,7 +2123,11 @@ export function routineService(
 
     getDescriptionDocument: async (routineId: string) => getRoutineDescriptionDocument(routineId),
 
-    create: async (companyId: string, input: CreateRoutine, actor: Actor): Promise<Routine> => {
+    create: async (
+      companyId: string,
+      input: CreateRoutine,
+      actor: Actor,
+    ): Promise<Routine & { triggers: RoutineTrigger[] }> => {
       await assertProject(companyId, input.projectId ?? null);
       await assertRoutineFolder(companyId, input.folderId ?? null);
       await assertAssignableAgent(db, companyId, input.assigneeAgentId ?? null, { kind: "routine" });
@@ -2096,6 +2149,10 @@ export function routineService(
       if (!responsibleUserId) {
         throw unprocessable("Routine requires a responsible user");
       }
+      // Reject every bad trigger before the routine row exists, so an invalid cron in the
+      // second trigger cannot leave a half-configured routine behind.
+      const triggerInputs = input.triggers ?? [];
+      const triggerNextRunAt = triggerInputs.map((trigger) => resolveTriggerNextRunAt(variables, trigger));
       const createdRoutine = await db.transaction(async (tx) => {
         const txDb = tx as unknown as Db;
         const [created] = await txDb
@@ -2124,6 +2181,17 @@ export function routineService(
             updatedByUserId: actor.userId ?? null,
           })
           .returning();
+        // Triggers are inserted before the first revision so the "Created routine" snapshot
+        // already carries them, exactly as it would for a routine created in the UI.
+        const createdTriggers: RoutineTrigger[] = [];
+        for (const [index, triggerInput] of triggerInputs.entries()) {
+          const trigger = await insertRoutineTriggerRow(txDb, created, triggerInput, actor, {
+            nextRunAt: triggerNextRunAt[index],
+            publicId: null,
+            secretId: null,
+          });
+          createdTriggers.push(trigger as RoutineTrigger);
+        }
         const { routine } = await appendRoutineRevision(txDb, created, actor, {
           changeSummary: "Created routine",
         });
@@ -2135,7 +2203,7 @@ export function routineService(
             { db: tx },
           );
         }
-        return routine;
+        return { ...routine, triggers: createdTriggers };
       });
       return createdRoutine;
     },
@@ -2332,16 +2400,7 @@ export function routineService(
       let secretMaterial: RoutineTriggerSecretMaterial | null = null;
       let secretId: string | null = null;
       let publicId: string | null = null;
-      let nextRunAt: Date | null = null;
-
-      if (input.kind === "schedule") {
-        assertScheduleCompatibleVariables(routine.variables ?? []);
-        const timeZone = input.timezone || "UTC";
-        assertTimeZone(timeZone);
-        const error = validateCron(input.cronExpression);
-        if (error) throw unprocessable(error);
-        nextRunAt = nextCronTickInTimeZone(input.cronExpression, timeZone, new Date());
-      }
+      const nextRunAt = resolveTriggerNextRunAt(routine.variables, input);
 
       if (input.kind === "webhook") {
         publicId = crypto.randomBytes(12).toString("hex");
@@ -2356,28 +2415,11 @@ export function routineService(
       const { trigger, revision } = await db.transaction(async (tx) => {
         const txDb = tx as unknown as Db;
         await tx.execute(sql`select id from ${routines} where ${routines.id} = ${routine.id} for update`);
-        const [createdTrigger] = await txDb
-          .insert(routineTriggers)
-          .values({
-            companyId: routine.companyId,
-            routineId: routine.id,
-            kind: input.kind,
-            label: input.label ?? null,
-            enabled: input.enabled ?? true,
-            cronExpression: input.kind === "schedule" ? input.cronExpression : null,
-            timezone: input.kind === "schedule" ? (input.timezone || "UTC") : null,
-            nextRunAt,
-            publicId,
-            secretId,
-            signingMode: input.kind === "webhook" ? input.signingMode : null,
-            replayWindowSec: input.kind === "webhook" ? input.replayWindowSec : null,
-            lastRotatedAt: input.kind === "webhook" ? new Date() : null,
-            createdByAgentId: actor.agentId ?? null,
-            createdByUserId: actor.userId ?? null,
-            updatedByAgentId: actor.agentId ?? null,
-            updatedByUserId: actor.userId ?? null,
-          })
-          .returning();
+        const createdTrigger = await insertRoutineTriggerRow(txDb, routine, input, actor, {
+          nextRunAt,
+          publicId,
+          secretId,
+        });
         const latestRoutine = await txDb.select().from(routines).where(eq(routines.id, routine.id)).then((rows) => rows[0] ?? routine);
         const appended = await appendRoutineRevision(txDb, latestRoutine, actor, {
           changeSummary: `Created ${input.kind} trigger`,

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -40,9 +40,17 @@ POST /api/companies/{companyId}/routines
   "concurrencyPolicy": "coalesce_if_active",
   "catchUpPolicy": "skip_missed",
   "activityGatePolicy": "always",
-  "activityGateScope": "company"
+  "activityGateScope": "company",
+  "triggers": [                   // optional — a routine with no trigger never fires
+    { "kind": "schedule", "cronExpression": "0 9 * * 1", "timezone": "UTC" }
+  ]
 }
 ```
+
+**A routine with `status: "active"` and no trigger never fires.** Create the schedule in the same
+call with `triggers`, or add it afterwards with `POST /api/routines/{routineId}/triggers`. The
+create response lists the triggers it created, so an empty `triggers` array in the response means
+the routine has no wake path yet.
 
 | Field | Required | Notes |
 |-------|----------|-------|
@@ -58,6 +66,7 @@ POST /api/companies/{companyId}/routines
 | `catchUpPolicy` | no | See below |
 | `activityGatePolicy` | no | `always` (default) or `require_external_activity`; see below |
 | `activityGateScope` | no | `company` (default) or `project`; see below |
+| `triggers` | no | Up to 10 `schedule` or `api` triggers; webhook triggers must use the trigger endpoint |
 
 ---
 
@@ -211,12 +220,15 @@ POST /api/routines/{routineId}/run
 
 ## Updating a Routine
 
-All create fields are updatable. Agents cannot reassign a routine to another agent.
+All create fields are updatable except `triggers`. Agents cannot reassign a routine to another agent.
 
 ```
 PATCH /api/routines/{routineId}
 { "status": "paused", "title": "New title" }
 ```
+
+`triggers` returns `400` here. Change triggers with `POST /api/routines/{routineId}/triggers`,
+`PATCH /api/routine-triggers/{triggerId}`, or `DELETE /api/routine-triggers/{triggerId}`.
 
 ---
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Routines are the scheduling subsystem. A routine fires from a trigger. A routine with no trigger never fires.
> - The routine create endpoint accepted a `triggers` array in the body and dropped it without an error. The routine PATCH endpoint did the same.
> - An agent that follows the documented "move recurring work onto a routine" guidance gets HTTP 201, a routine with `status: "active"`, and no wake path. The failure is silent, so the agent believes the work is scheduled.
> - The create endpoint validates all other fields strictly, so the silent drop of one field is unexpected behaviour.
> - This pull request accepts `triggers` on create, writes the triggers in the create transaction, and rejects `triggers` on PATCH with a message that names the trigger endpoints.
> - The benefit is that a routine and its schedule are made in one request, and a caller can no longer get a routine that cannot fire without an error.

## Linked Issues or Issue Description

Refs #4376 — that pull request fixes the same defect with rejection only. This pull request keeps the rejection on PATCH and also makes the create path work. If this one is merged, #4376 becomes unnecessary.

**What happened?**

`POST /api/companies/{companyId}/routines` with a `triggers` array returns `201`. The routine is made, but the triggers are not. The response and all later reads show no triggers. `PATCH /api/routines/{routineId}` with the same array returns `200` and also makes no triggers. Zod strips the unknown key, so no error is given.

**What did you expect to happen?**

Either the triggers are made, or the request fails with an error that names the correct endpoint.

**Steps to reproduce**

1. `POST /api/companies/{companyId}/routines` with:
   `{"title":"T","assigneeAgentId":"...","projectId":"...","triggers":[{"kind":"schedule","cronExpression":"0 6 9 8 *","timezone":"UTC"}]}`
2. Read the status: `201`.
3. `GET /api/routines/{routineId}`: `triggers` is `[]`.
4. `PATCH /api/routines/{routineId}` with the same `triggers` array: `200`, and `triggers` stays `[]`.

**Impact**

The routine has `status: "active"` and no fire path. The scheduler has nothing to tick. The caller gets no signal. Trigger creation is possible today only through a second call to `POST /api/routines/{routineId}/triggers`.

**Version / environment**

Reproduced on `master` at `8540ce297` with a local server and an agent API key.

## What Changed

- `createRoutineSchema` accepts an optional `triggers` array. The limit is 10 triggers.
- Inline triggers are written inside the routine create transaction, before the first revision. The "Created routine" revision snapshot therefore carries the triggers, and one `routine.trigger_created` activity entry is written per trigger.
- Every inline cron expression, timezone, and schedule/variable combination is checked before the routine row is written. A bad expression fails the whole request with `422` and leaves no routine behind.
- The create response now carries a `triggers` array. This is an added field. No existing field changed.
- `updateRoutineSchema` rejects `triggers` with `400`. The message names `POST /api/routines/{routineId}/triggers`, `PATCH /api/routine-triggers/{triggerId}`, and `DELETE /api/routine-triggers/{triggerId}`. A whole-array replace on PATCH would delete webhook triggers together with their secrets, so PATCH stays out of the trigger business.
- Inline `webhook` triggers are rejected with `400`, because the signing secret is returned one time only, by the dedicated trigger endpoint.
- The trigger insert and the schedule validation are now shared by `create` and `createTrigger`, so the two paths cannot drift.
- `docs/api/routines.md` and `skills/paperclip/references/routines.md` document the field, the webhook exception, and the PATCH rejection.

## Verification

```bash
npx vitest run server/src/__tests__/routines-e2e.test.ts          # 9 passed (4 new)
npx vitest run server/src/__tests__/routines-routes.test.ts \
  server/src/__tests__/routines-service.test.ts \
  server/src/__tests__/plugin-managed-routines.test.ts \
  server/src/__tests__/routine-run-telemetry.test.ts \
  server/src/__tests__/qa-routine-secrets-e2e.test.ts \
  server/src/__tests__/company-portability.test.ts                # 158 passed
npx vitest run server/src/__tests__/openapi-routes.test.ts        # 3 passed
pnpm typecheck                                                    # all packages pass
```

The four new end-to-end tests use the embedded Postgres harness:

1. A create with an inline schedule trigger persists the trigger, computes `nextRunAt`, returns the trigger in the response, puts it in revision 1, and writes the activity entry.
2. A create with a valid first cron and an invalid second cron returns `422` and leaves zero routines in the company.
3. A create with an inline webhook trigger returns `400` and names the trigger endpoint.
4. A PATCH with `triggers` returns `400` and creates no trigger rows.

## Risks

Low risk.

- The create response gains a `triggers` key. Clients that read known fields are not affected.
- PATCH with `triggers` changes from a silent `200` to `400`. This is the intended fix. The web UI does not send `triggers` on PATCH (the routine edit draft has no such field), so no in-tree caller is affected.
- Inline triggers use the same insert path and the same validation as the existing trigger endpoint, so the two cannot produce different rows.
- Trigger rows are written in the same transaction as the routine row. A failure rolls both back.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context window, extended thinking, run through Claude Code with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
