### PR TITLE
feat(acpx): pass locally-configured stdio MCP servers to agent runs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,7 +68,8 @@
               "guides/agent-developer/task-workflow",
               "guides/agent-developer/comments-and-communication",
               "guides/agent-developer/handling-approvals",
-              "guides/agent-developer/cost-reporting"
+              "guides/agent-developer/cost-reporting",
+              "guides/agent-developer/local-stdio-mcp-servers"
             ]
           }
         ]

--- a/docs/guides/agent-developer/local-stdio-mcp-servers.md
+++ b/docs/guides/agent-developer/local-stdio-mcp-servers.md
@@ -1,0 +1,85 @@
+# Local stdio MCP servers
+
+Paperclip passes two kinds of MCP server to an agent run:
+
+1. **Paperclip-managed connections** — HTTP, minted per run with a scoped bearer
+   token. Nothing to configure here; they come from the company's connections.
+2. **Locally-configured stdio servers** — anything the host operator runs as a
+   local process (`mem0`, `browsermcp`, a homegrown tool server).
+
+This page covers the second kind.
+
+## Why a Paperclip-level file
+
+The ACPX engine launches the vendored CLI in headless/SDK mode. That mode does
+**not** read the user-scope MCP registry (`~/.claude.json`), so a server you
+added interactively with `claude mcp add` is invisible to every Paperclip run.
+
+Writing a project-scope `.mcp.json` into each agent's working directory does
+work, but it is per-workspace: the file dies when a workspace is recreated, and
+a newly-created workspace starts with no MCP servers at all. Configuration that
+must apply to every run therefore lives outside every workspace:
+
+```
+<paperclip-instance-root>/mcp-servers.json
+```
+
+which by default is `~/.paperclip/instances/<instance-id>/mcp-servers.json`.
+
+## Format
+
+The file uses the familiar `.mcp.json` shape:
+
+```json
+{
+  "mcpServers": {
+    "mem0": {
+      "type": "stdio",
+      "command": "/opt/mem0-mcp-server/run.sh",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+- `type` is optional and defaults to `stdio`. `http`/`sse` entries are skipped —
+  remote connections belong to Paperclip's managed connection system, which
+  mints per-run credentials for them.
+- `disabled: true` keeps an entry in the file without launching it.
+- `command`, `args`, and `env` values expand `${VAR}` and `$VAR` against the
+  environment Paperclip builds for the run, so per-agent values such as
+  `MEM0_USER_ID` or `PAPERCLIP_AGENT_ID` resolve without repeating them per
+  entry. An undefined variable is left as written rather than silently emptied.
+- A bare `{ "<name>": { ... } }` map (no `mcpServers` wrapper) is also accepted.
+
+## Precedence
+
+Later layers win on a name collision:
+
+1. `<instance-root>/mcp-servers.json`
+2. `PAPERCLIP_MCP_SERVERS_FILE` — an explicit path override, mainly for tests
+   and one-off runs. Unlike the instance file, a missing path here is reported.
+3. the agent's adapter config `mcpServers` value, for per-agent additions.
+
+A Paperclip-managed connection always wins over a local entry of the same name;
+the local entry is dropped and the run logs a warning.
+
+## Verifying
+
+Local stdio servers only apply to **local** execution. A run targeting a remote
+or sandboxed execution environment skips them (the configured commands are host
+paths that do not exist there) and logs how many were skipped.
+
+Each run logs the servers it passed:
+
+```
+[paperclip] Passing 1 locally-configured stdio MCP server(s) to the agent: mem0
+(from /Users/me/.paperclip/instances/default/mcp-servers.json).
+```
+
+To confirm the agent actually received them, read the `system` stream event with
+`subtype == "init"` and check its `mcp_servers` array. Do not verify by looking
+for the server process — a server can be spawned and still fail to register.
+
+Malformed entries never abort a run: they are skipped with a warning on stderr.

--- a/docs/guides/agent-developer/local-stdio-mcp-servers.md
+++ b/docs/guides/agent-developer/local-stdio-mcp-servers.md
@@ -83,3 +83,9 @@ To confirm the agent actually received them, read the `system` stream event with
 for the server process — a server can be spawned and still fail to register.
 
 Malformed entries never abort a run: they are skipped with a warning on stderr.
+A warning is logged on every lane, including a remote run that applies nothing.
+
+Each local server joins the session identity as `{name, command, args, envHash}`,
+so editing the config — including an `env` value — invalidates a warm handle and
+the next run starts a session that has the change. Env values are hashed rather
+than stored, because session parameters are persisted.

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -3628,4 +3628,168 @@ describe("ACPX engine per-step startup timing (run.startup.step events)", () => 
     expect(emitted.has("bridge.paperclip")).toBe(false);
     expect(emitted.has("bridge.process-session")).toBe(false);
   });
+
+  describe("locally-configured stdio MCP servers", () => {
+    // Headless/SDK mode never reads the user-scope `~/.claude.json` MCP
+    // registry, so these must reach `mcpServers` through the Paperclip-level
+    // config file or they are invisible to every run.
+    async function withPaperclipInstance<T>(
+      instanceRoot: string,
+      run: () => Promise<T>,
+    ): Promise<T> {
+      const previousHome = process.env.PAPERCLIP_HOME;
+      const previousInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
+      process.env.PAPERCLIP_HOME = path.dirname(path.dirname(instanceRoot));
+      process.env.PAPERCLIP_INSTANCE_ID = path.basename(instanceRoot);
+      try {
+        return await run();
+      } finally {
+        if (previousHome === undefined) delete process.env.PAPERCLIP_HOME;
+        else process.env.PAPERCLIP_HOME = previousHome;
+        if (previousInstanceId === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+        else process.env.PAPERCLIP_INSTANCE_ID = previousInstanceId;
+      }
+    }
+
+    async function writeInstanceMcpConfig(root: string, document: unknown): Promise<string> {
+      const instanceRoot = path.join(root, "paperclip-home", "instances", "default");
+      await fs.mkdir(instanceRoot, { recursive: true });
+      await fs.writeFile(path.join(instanceRoot, "mcp-servers.json"), JSON.stringify(document), "utf8");
+      return instanceRoot;
+    }
+
+    it("passes an instance-configured stdio server to the runtime and into the session identity", async () => {
+      const root = await makeTempRoot();
+      const instanceRoot = await writeInstanceMcpConfig(root, {
+        mcpServers: {
+          mem0: { type: "stdio", command: "/opt/mem0/run.sh", args: ["--user", "${PAPERCLIP_AGENT_ID}"] },
+        },
+      });
+
+      const { runtimeOptions, result } = await withPaperclipInstance(instanceRoot, () =>
+        runExecutor({
+          agent: "custom",
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+        }),
+      );
+
+      expect(runtimeOptions[0]?.mcpServers).toEqual([
+        { name: "mem0", command: "/opt/mem0/run.sh", args: ["--user", "agent-1"], env: [] },
+      ]);
+      // Session identity feeds the fingerprint, so a config change invalidates a
+      // warm handle instead of silently reusing a session without the server.
+      const sessionParams = (result as { sessionParams?: Record<string, unknown> }).sessionParams;
+      expect(sessionParams?.mcpServers).toEqual([
+        { name: "mem0", command: "/opt/mem0/run.sh", args: ["--user", "agent-1"] },
+      ]);
+    });
+
+    it("keeps Paperclip-managed http connections ahead of local stdio servers and never lets a local entry shadow one", async () => {
+      const root = await makeTempRoot();
+      const instanceRoot = await writeInstanceMcpConfig(root, {
+        mcpServers: {
+          managed: { command: "/opt/impostor.sh" },
+          mem0: { command: "/opt/mem0/run.sh" },
+        },
+      });
+
+      const { runtimeOptions, logs } = await withPaperclipInstance(instanceRoot, () =>
+        runExecutor(
+          {
+            agent: "custom",
+            agentCommand: "node ./fake-acp.js",
+            stateDir: path.join(root, "state"),
+          },
+          {
+            runtimeMcp: {
+              getServers: () => [
+                { name: "managed", url: "https://mcp.test/managed", token: "t0ken", connectionId: "conn-1" },
+              ],
+            } as never,
+          },
+        ),
+      );
+
+      expect(runtimeOptions[0]?.mcpServers).toEqual([
+        {
+          type: "http",
+          name: "managed",
+          url: "https://mcp.test/managed",
+          headers: [{ name: "Authorization", value: "Bearer t0ken" }],
+        },
+        { name: "mem0", command: "/opt/mem0/run.sh", args: [], env: [] },
+      ]);
+      expect(logs.some((entry) => entry.text.includes("collides with a Paperclip-managed connection"))).toBe(true);
+    });
+
+    it("skips local stdio servers on a remote execution target", async () => {
+      const root = await makeTempRoot();
+      const instanceRoot = await writeInstanceMcpConfig(root, {
+        mcpServers: { mem0: { command: "/opt/mem0/run.sh" } },
+      });
+
+      const { runtimeOptions, logs } = await withPaperclipInstance(instanceRoot, () =>
+        runExecutor(
+          {
+            agent: "custom",
+            agentCommand: "node ./fake-acp.js",
+            stateDir: path.join(root, "state"),
+          },
+          {
+            executionTarget: {
+              kind: "remote",
+              transport: "ssh",
+              remoteCwd: "/remote/work",
+              spec: {
+                host: "build-host",
+                port: 22,
+                username: "paperclip",
+                remoteCwd: "/remote/work",
+              },
+            },
+          },
+        ),
+      );
+
+      expect(runtimeOptions[0]?.mcpServers).toEqual([]);
+      expect(logs.some((entry) => entry.text.includes("remote execution environment"))).toBe(true);
+    });
+
+    it("skips a malformed entry with a warning instead of failing the run", async () => {
+      const root = await makeTempRoot();
+      const instanceRoot = await writeInstanceMcpConfig(root, {
+        mcpServers: { broken: { args: ["--nope"] }, mem0: { command: "/opt/mem0/run.sh" } },
+      });
+
+      const { runtimeOptions, logs } = await withPaperclipInstance(instanceRoot, () =>
+        runExecutor({
+          agent: "custom",
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+        }),
+      );
+
+      expect(runtimeOptions[0]?.mcpServers).toEqual([
+        { name: "mem0", command: "/opt/mem0/run.sh", args: [], env: [] },
+      ]);
+      expect(logs.some((entry) => entry.text.includes("has no 'command'"))).toBe(true);
+    });
+
+    it("leaves mcpServers untouched when no local config exists", async () => {
+      const root = await makeTempRoot();
+      const instanceRoot = path.join(root, "paperclip-home", "instances", "default");
+      await fs.mkdir(instanceRoot, { recursive: true });
+
+      const { runtimeOptions } = await withPaperclipInstance(instanceRoot, () =>
+        runExecutor({
+          agent: "custom",
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+        }),
+      );
+
+      expect(runtimeOptions[0]?.mcpServers).toEqual([]);
+    });
+  });
 });

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -45,6 +45,23 @@ async function makeTempRoot() {
   return root;
 }
 
+// The engine reads Paperclip-level state (`mcp-servers.json`, managed homes)
+// out of the instance root, which defaults to the real `~/.paperclip`. Point
+// every test at an empty temp instance so a developer's own host config cannot
+// leak into a run. Tests that need a populated instance root set these two
+// variables themselves, and their `finally` restores the value set here.
+let defaultPaperclipHome = "";
+beforeEach(async () => {
+  defaultPaperclipHome = await makeTempRoot();
+  process.env.PAPERCLIP_HOME = defaultPaperclipHome;
+  process.env.PAPERCLIP_INSTANCE_ID = "default";
+});
+
+afterEach(() => {
+  delete process.env.PAPERCLIP_HOME;
+  delete process.env.PAPERCLIP_INSTANCE_ID;
+});
+
 afterEach(async () => {
   // A remote run stages a process-session bridge whose detached event writer can
   // still be flushing a trailing event file into `.../process-sessions/<id>/events`
@@ -3681,8 +3698,43 @@ describe("ACPX engine per-step startup timing (run.startup.step events)", () => 
       // warm handle instead of silently reusing a session without the server.
       const sessionParams = (result as { sessionParams?: Record<string, unknown> }).sessionParams;
       expect(sessionParams?.mcpServers).toEqual([
-        { name: "mem0", command: "/opt/mem0/run.sh", args: ["--user", "agent-1"] },
+        {
+          name: "mem0",
+          command: "/opt/mem0/run.sh",
+          args: ["--user", "agent-1"],
+          // Hashed, never carried in cleartext: session params are persisted.
+          envHash: expect.any(String),
+        },
       ]);
+    });
+
+    it("changes the fingerprint when only a local server's env changes", async () => {
+      const fingerprintFor = async (envValue: string): Promise<string> => {
+        const root = await makeTempRoot();
+        const instanceRoot = await writeInstanceMcpConfig(root, {
+          mcpServers: { mem0: { command: "/opt/mem0/run.sh", env: { MEM0_PROFILE: envValue } } },
+        });
+        const { result } = await withPaperclipInstance(instanceRoot, () =>
+          runExecutor({
+            agent: "custom",
+            agentCommand: "node ./fake-acp.js",
+            // A fixed stateDir keeps every other fingerprint input equal, so the
+            // env value is the only thing that can move the hash.
+            stateDir: "/tmp/paperclip-local-mcp-fingerprint-state",
+            cwd: "/tmp/paperclip-local-mcp-fingerprint-cwd",
+          }),
+        );
+        const sessionParams = (result as { sessionParams?: { configFingerprint?: string } }).sessionParams;
+        return String(sessionParams?.configFingerprint);
+      };
+
+      const [first, second, firstAgain] = [
+        await fingerprintFor("alpha"),
+        await fingerprintFor("beta"),
+        await fingerprintFor("alpha"),
+      ];
+      expect(first).not.toBe(second);
+      expect(first).toBe(firstAgain);
     });
 
     it("keeps Paperclip-managed http connections ahead of local stdio servers and never lets a local entry shadow one", async () => {
@@ -3754,6 +3806,34 @@ describe("ACPX engine per-step startup timing (run.startup.step events)", () => 
 
       expect(runtimeOptions[0]?.mcpServers).toEqual([]);
       expect(logs.some((entry) => entry.text.includes("remote execution environment"))).toBe(true);
+    });
+
+    it("still reports a malformed local config on a remote execution target", async () => {
+      const root = await makeTempRoot();
+      const instanceRoot = path.join(root, "paperclip-home", "instances", "default");
+      await fs.mkdir(instanceRoot, { recursive: true });
+      await fs.writeFile(path.join(instanceRoot, "mcp-servers.json"), "{ not json", "utf8");
+
+      const { runtimeOptions, logs } = await withPaperclipInstance(instanceRoot, () =>
+        runExecutor(
+          {
+            agent: "custom",
+            agentCommand: "node ./fake-acp.js",
+            stateDir: path.join(root, "state"),
+          },
+          {
+            executionTarget: {
+              kind: "remote",
+              transport: "ssh",
+              remoteCwd: "/remote/work",
+              spec: { host: "build-host", port: 22, username: "paperclip", remoteCwd: "/remote/work" },
+            },
+          },
+        ),
+      );
+
+      expect(runtimeOptions[0]?.mcpServers).toEqual([]);
+      expect(logs.some((entry) => entry.text.includes("invalid JSON"))).toBe(true);
     });
 
     it("skips a malformed entry with a warning instead of failing the run", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -83,6 +83,7 @@ import {
   DEFAULT_ACP_ENGINE_TIMEOUT_SEC,
   DEFAULT_ACP_ENGINE_WARM_HANDLE_IDLE_MS,
 } from "./constants.js";
+import { resolveLocalStdioMcpServers } from "./local-mcp-servers.js";
 import {
   measureStartupStep,
   NOOP_STARTUP_SPAN,
@@ -95,6 +96,14 @@ import {
 import type { CommandManagedRuntimeRunner } from "../command-managed-runtime.js";
 
 const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
+
+// Session-identity view of one MCP server. Paperclip-managed connections keep
+// their historical `{name,url,connectionId}` shape; locally-configured stdio
+// servers carry the launch identity that actually determines what tools the
+// session sees.
+type AcpxMcpIdentityEntry =
+  | { name: string; url: string; connectionId: string }
+  | { name: string; command: string; args: string[] };
 const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
 const BENIGN_NES_CLOSE_STDERR = /method: ['"]nes\/close['"].*-32601/;
 
@@ -402,7 +411,10 @@ interface AcpxPreparedRuntime {
   childStderrLogPath: string | null;
   paperclipClaudeSettings: PaperclipClaudeSettingsResult | null;
   mcpServers: NonNullable<AcpRuntimeOptions["mcpServers"]>;
-  mcpIdentity: Array<{ name: string; url: string; connectionId: string }>;
+  // Paperclip-managed http connections first, then locally-configured stdio
+  // servers. The two shapes stay distinct so an http-only run hashes exactly as
+  // it did before local stdio support existed (no fleet-wide warm-handle churn).
+  mcpIdentity: AcpxMcpIdentityEntry[];
   // Per-step round-trip / provider-duration readers sourced from the sandbox
   // runner's counters (Open Q1). Empty for local runs and the runner-less
   // fallback, where no host→sandbox exec seam exists. Threaded into the
@@ -1481,7 +1493,7 @@ async function buildRuntime(input: {
   const requestedThinkingEffort = normalizeRequestedThinkingEffort(config);
   const fastMode = acpxAgent === "codex" && config.fastMode === true;
   const runtimeMcpServers = input.ctx.runtimeMcp?.getServers() ?? [];
-  const mcpIdentity = runtimeMcpServers.map(({ name, url, connectionId }) => ({
+  const mcpIdentity: AcpxMcpIdentityEntry[] = runtimeMcpServers.map(({ name, url, connectionId }) => ({
     name,
     url,
     connectionId,
@@ -1591,6 +1603,56 @@ async function buildRuntime(input: {
       );
     }
     if (codexStartupConfig.value) env.CODEX_CONFIG = codexStartupConfig.value;
+  }
+
+  // Locally-configured stdio MCP servers (mem0, browsermcp, ...). Headless/SDK
+  // mode never reads the user-scope `~/.claude.json` MCP registry, so without
+  // this every such server is invisible to every Paperclip run. Resolved here —
+  // after `env` is fully assembled — so `${VAR}` refs in the config expand
+  // against the same environment the agent process will get (per-agent values
+  // such as MEM0_USER_ID included).
+  //
+  // Local-execution only: the command paths are host paths, so a remote/sandbox
+  // execution target would spawn something that does not exist there.
+  if (executionTargetIsRemote) {
+    const remoteLocalMcp = await resolveLocalStdioMcpServers({
+      instanceRoot: defaultPaperclipInstanceDir(),
+      env,
+      adapterConfigValue: config.mcpServers,
+    });
+    if (remoteLocalMcp.servers.length > 0) {
+      await input.ctx.onLog(
+        "stderr",
+        `[paperclip] Skipping ${remoteLocalMcp.servers.length} locally-configured stdio MCP server(s) — this run targets a remote execution environment where the host command paths do not exist.\n`,
+      );
+    }
+  } else {
+    const localMcp = await resolveLocalStdioMcpServers({
+      instanceRoot: defaultPaperclipInstanceDir(),
+      env,
+      adapterConfigValue: config.mcpServers,
+      reservedNames: mcpServers.map((server) => server.name),
+    });
+    for (const warning of localMcp.warnings) {
+      await input.ctx.onLog("stderr", `[paperclip] Local MCP config: ${warning}\n`);
+    }
+    for (const server of localMcp.servers) {
+      mcpServers.push({
+        name: server.name,
+        command: server.command,
+        args: server.args,
+        env: server.env,
+      });
+      mcpIdentity.push({ name: server.name, command: server.command, args: server.args });
+    }
+    if (localMcp.servers.length > 0) {
+      await input.ctx.onLog(
+        "stderr",
+        `[paperclip] Passing ${localMcp.servers.length} locally-configured stdio MCP server(s) to the agent: ${localMcp.servers
+          .map((server) => server.name)
+          .join(", ")} (from ${localMcp.sources.join(", ")}).\n`,
+      );
+    }
   }
 
   let skillPromptInstructions = "";

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -103,7 +103,7 @@ const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
 // session sees.
 type AcpxMcpIdentityEntry =
   | { name: string; url: string; connectionId: string }
-  | { name: string; command: string; args: string[] };
+  | { name: string; command: string; args: string[]; envHash: string };
 const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
 const BENIGN_NES_CLOSE_STDERR = /method: ['"]nes\/close['"].*-32601/;
 
@@ -1614,38 +1614,42 @@ async function buildRuntime(input: {
   //
   // Local-execution only: the command paths are host paths, so a remote/sandbox
   // execution target would spawn something that does not exist there.
-  if (executionTargetIsRemote) {
-    const remoteLocalMcp = await resolveLocalStdioMcpServers({
-      instanceRoot: defaultPaperclipInstanceDir(),
-      env,
-      adapterConfigValue: config.mcpServers,
-    });
-    if (remoteLocalMcp.servers.length > 0) {
+  const localMcp = await resolveLocalStdioMcpServers({
+    instanceRoot: defaultPaperclipInstanceDir(),
+    env,
+    adapterConfigValue: config.mcpServers,
+    reservedNames: mcpServers.map((server) => server.name),
+  });
+  // Config problems are worth reporting on every lane, including the remote one
+  // that ends up applying nothing — otherwise an unreadable or malformed file is
+  // completely silent there.
+  for (const warning of localMcp.warnings) {
+    await input.ctx.onLog("stderr", `[paperclip] Local MCP config: ${warning}\n`);
+  }
+  if (localMcp.servers.length > 0) {
+    if (executionTargetIsRemote) {
       await input.ctx.onLog(
         "stderr",
-        `[paperclip] Skipping ${remoteLocalMcp.servers.length} locally-configured stdio MCP server(s) — this run targets a remote execution environment where the host command paths do not exist.\n`,
+        `[paperclip] Skipping ${localMcp.servers.length} locally-configured stdio MCP server(s) — this run targets a remote execution environment where the host command paths do not exist.\n`,
       );
-    }
-  } else {
-    const localMcp = await resolveLocalStdioMcpServers({
-      instanceRoot: defaultPaperclipInstanceDir(),
-      env,
-      adapterConfigValue: config.mcpServers,
-      reservedNames: mcpServers.map((server) => server.name),
-    });
-    for (const warning of localMcp.warnings) {
-      await input.ctx.onLog("stderr", `[paperclip] Local MCP config: ${warning}\n`);
-    }
-    for (const server of localMcp.servers) {
-      mcpServers.push({
-        name: server.name,
-        command: server.command,
-        args: server.args,
-        env: server.env,
-      });
-      mcpIdentity.push({ name: server.name, command: server.command, args: server.args });
-    }
-    if (localMcp.servers.length > 0) {
+    } else {
+      for (const server of localMcp.servers) {
+        mcpServers.push({
+          name: server.name,
+          command: server.command,
+          args: server.args,
+          env: server.env,
+        });
+        // Hash the env rather than carrying it: a changed value (rotated
+        // credential, different profile) must still invalidate a warm handle,
+        // but session params are persisted and must not hold secret values.
+        mcpIdentity.push({
+          name: server.name,
+          command: server.command,
+          args: server.args,
+          envHash: shortHash(server.env),
+        });
+      }
       await input.ctx.onLog(
         "stderr",
         `[paperclip] Passing ${localMcp.servers.length} locally-configured stdio MCP server(s) to the agent: ${localMcp.servers

--- a/packages/adapter-utils/src/acpx-engine/local-mcp-servers.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/local-mcp-servers.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  LOCAL_MCP_SERVERS_FILENAME,
+  parseLocalStdioMcpServers,
+  resolveLocalStdioMcpServers,
+} from "./local-mcp-servers.js";
+
+const cleanupRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanupRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function makeInstanceRoot(document?: unknown): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-local-mcp-"));
+  cleanupRoots.push(root);
+  if (document !== undefined) {
+    await fs.writeFile(path.join(root, LOCAL_MCP_SERVERS_FILENAME), JSON.stringify(document), "utf8");
+  }
+  return root;
+}
+
+describe("parseLocalStdioMcpServers", () => {
+  it("reads the wrapped .mcp.json shape and defaults the transport to stdio", () => {
+    const result = parseLocalStdioMcpServers({
+      document: { mcpServers: { mem0: { command: "/opt/mem0/run.sh", args: ["--quiet"] } } },
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.servers).toEqual([{ name: "mem0", command: "/opt/mem0/run.sh", args: ["--quiet"], env: [] }]);
+  });
+
+  it("accepts a bare name→entry map", () => {
+    const result = parseLocalStdioMcpServers({ document: { mem0: { command: "/opt/mem0/run.sh" } } });
+    expect(result.servers.map((server) => server.name)).toEqual(["mem0"]);
+  });
+
+  it("expands ${VAR} and $VAR against the run env in command, args, and env values", () => {
+    const result = parseLocalStdioMcpServers({
+      document: {
+        mcpServers: {
+          mem0: {
+            command: "${MEM0_HOME}/run.sh",
+            args: ["--user", "$MEM0_USER_ID"],
+            env: { MEM0_PROFILE: "${MEM0_USER_ID}-profile" },
+          },
+        },
+      },
+      env: { MEM0_HOME: "/opt/mem0", MEM0_USER_ID: "devops-engineer" },
+    });
+    expect(result.servers[0]).toEqual({
+      name: "mem0",
+      command: "/opt/mem0/run.sh",
+      args: ["--user", "devops-engineer"],
+      env: [{ name: "MEM0_PROFILE", value: "devops-engineer-profile" }],
+    });
+  });
+
+  it("leaves an unknown variable reference untouched rather than emptying the value", () => {
+    const result = parseLocalStdioMcpServers({
+      document: { mcpServers: { mem0: { command: "${NOT_SET}/run.sh" } } },
+      env: {},
+    });
+    expect(result.servers[0]?.command).toBe("${NOT_SET}/run.sh");
+  });
+
+  it("skips http/sse entries, commandless entries, and disabled entries with warnings", () => {
+    const result = parseLocalStdioMcpServers({
+      document: {
+        mcpServers: {
+          managed: { type: "http", url: "https://example.test" },
+          broken: { args: ["x"] },
+          off: { command: "/bin/true", disabled: true },
+          good: { command: "/bin/true" },
+        },
+      },
+      source: "cfg",
+    });
+    expect(result.servers.map((server) => server.name)).toEqual(["good"]);
+    expect(result.warnings).toEqual([
+      "cfg: MCP server 'managed' has transport 'http'; only stdio is sourced locally. Skipped.",
+      "cfg: MCP server 'broken' has no 'command'; skipped.",
+    ]);
+  });
+});
+
+describe("resolveLocalStdioMcpServers", () => {
+  it("returns nothing when the instance has no config file", async () => {
+    const root = await makeInstanceRoot();
+    const result = await resolveLocalStdioMcpServers({ instanceRoot: root, env: {} });
+    expect(result).toEqual({ servers: [], warnings: [], sources: [] });
+  });
+
+  it("reads <instanceRoot>/mcp-servers.json and reports it as the source", async () => {
+    const root = await makeInstanceRoot({
+      mcpServers: { mem0: { type: "stdio", command: "/opt/mem0/run.sh", args: [], env: {} } },
+    });
+    const result = await resolveLocalStdioMcpServers({ instanceRoot: root, env: {} });
+    expect(result.servers).toEqual([{ name: "mem0", command: "/opt/mem0/run.sh", args: [], env: [] }]);
+    expect(result.sources).toEqual([path.join(root, LOCAL_MCP_SERVERS_FILENAME)]);
+  });
+
+  it("lets the adapter config override the instance file by name", async () => {
+    const root = await makeInstanceRoot({ mcpServers: { mem0: { command: "/instance/run.sh" } } });
+    const result = await resolveLocalStdioMcpServers({
+      instanceRoot: root,
+      env: {},
+      adapterConfigValue: { mcpServers: { mem0: { command: "/agent/run.sh" } } },
+    });
+    expect(result.servers).toEqual([{ name: "mem0", command: "/agent/run.sh", args: [], env: [] }]);
+  });
+
+  it("never shadows a Paperclip-managed connection name", async () => {
+    const root = await makeInstanceRoot({ mcpServers: { managed: { command: "/opt/impostor.sh" } } });
+    const result = await resolveLocalStdioMcpServers({
+      instanceRoot: root,
+      env: {},
+      reservedNames: ["managed"],
+    });
+    expect(result.servers).toEqual([]);
+    expect(result.warnings).toEqual([
+      "MCP server 'managed' collides with a Paperclip-managed connection; the managed connection wins.",
+    ]);
+  });
+
+  it("warns instead of throwing on invalid JSON", async () => {
+    const root = await makeInstanceRoot();
+    await fs.writeFile(path.join(root, LOCAL_MCP_SERVERS_FILENAME), "{ not json", "utf8");
+    const result = await resolveLocalStdioMcpServers({ instanceRoot: root, env: {} });
+    expect(result.servers).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("invalid JSON");
+  });
+
+  it("honors PAPERCLIP_MCP_SERVERS_FILE and warns when that explicit path is missing", async () => {
+    const root = await makeInstanceRoot();
+    const overridePath = path.join(root, "override.json");
+    await fs.writeFile(overridePath, JSON.stringify({ mcpServers: { extra: { command: "/bin/true" } } }), "utf8");
+    const present = await resolveLocalStdioMcpServers({
+      instanceRoot: root,
+      env: { PAPERCLIP_MCP_SERVERS_FILE: overridePath },
+    });
+    expect(present.servers.map((server) => server.name)).toEqual(["extra"]);
+
+    const missing = await resolveLocalStdioMcpServers({
+      instanceRoot: root,
+      env: { PAPERCLIP_MCP_SERVERS_FILE: path.join(root, "nope.json") },
+    });
+    expect(missing.servers).toEqual([]);
+    expect(missing.warnings[0]).toContain("unreadable");
+  });
+});

--- a/packages/adapter-utils/src/acpx-engine/local-mcp-servers.ts
+++ b/packages/adapter-utils/src/acpx-engine/local-mcp-servers.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Locally-configured stdio MCP servers.
+ *
+ * The ACPX engine launches the vendored CLI in headless/SDK mode, which does
+ * NOT read the user-scope MCP registry (`~/.claude.json`). Only Paperclip's own
+ * managed `http` connections reached `mcpServers`, so any stdio MCP server the
+ * host operator configured locally (mem0, browsermcp, ...) was invisible to
+ * every Paperclip run.
+ *
+ * Rather than implicitly inheriting `~/.claude.json` — unreviewable, and shaped
+ * by whatever the interactive CLI happened to write — the list is read from an
+ * explicit Paperclip-level file that lives OUTSIDE any workspace, so it
+ * survives workspace recreation:
+ *
+ *   <paperclip-instance-root>/mcp-servers.json
+ *
+ * Shape (mirrors the familiar `.mcp.json` / Claude MCP config):
+ *
+ *   {
+ *     "mcpServers": {
+ *       "mem0": {
+ *         "type": "stdio",
+ *         "command": "/abs/path/to/run.sh",
+ *         "args": [],
+ *         "env": { "MEM0_PROFILE": "${PAPERCLIP_AGENT_ID}" }
+ *       }
+ *     }
+ *   }
+ *
+ * `${VAR}` / `$VAR` in `command`, `args`, and `env` values expand against the
+ * environment Paperclip already builds for the run, so per-agent values such as
+ * `MEM0_USER_ID` resolve without duplicating them per entry.
+ */
+
+/** ACP's stdio `McpServer` member — the transport every ACP agent must support. */
+export interface LocalStdioMcpServer {
+  name: string;
+  command: string;
+  args: string[];
+  env: Array<{ name: string; value: string }>;
+}
+
+export interface LocalStdioMcpResolution {
+  servers: LocalStdioMcpServer[];
+  /** Non-fatal problems (bad entry, unknown transport, name collision, unreadable file). */
+  warnings: string[];
+  /** Config files actually read, in precedence order (lowest first). */
+  sources: string[];
+}
+
+const EMPTY_RESOLUTION: LocalStdioMcpResolution = { servers: [], warnings: [], sources: [] };
+
+export const LOCAL_MCP_SERVERS_FILENAME = "mcp-servers.json";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Expand `${VAR}` and `$VAR` against `env`. An undefined variable expands to the
+ * empty string (matching shell semantics) and is reported by the caller through
+ * the "resolved to empty" warning path only when it empties an entire value we
+ * need, so a partially-templated arg still works.
+ */
+function expandEnvRefs(value: string, env: Record<string, string>): string {
+  return value.replace(/\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g, (match, braced, bare) => {
+    const key = (braced ?? bare) as string;
+    const resolved = env[key];
+    return resolved === undefined ? match : resolved;
+  });
+}
+
+function parseEntry(input: {
+  name: string;
+  raw: unknown;
+  env: Record<string, string>;
+  source: string;
+  warnings: string[];
+}): LocalStdioMcpServer | null {
+  const { name, raw, env, source, warnings } = input;
+  if (!isRecord(raw)) {
+    warnings.push(`${source}: MCP server '${name}' is not an object; skipped.`);
+    return null;
+  }
+  if (raw.disabled === true) return null;
+
+  // `type` is optional in `.mcp.json` and defaults to stdio. Anything else
+  // (http/sse) is Paperclip-managed territory and is not sourced from here.
+  const type = typeof raw.type === "string" ? raw.type.trim().toLowerCase() : "stdio";
+  if (type !== "stdio") {
+    warnings.push(`${source}: MCP server '${name}' has transport '${type}'; only stdio is sourced locally. Skipped.`);
+    return null;
+  }
+
+  const commandRaw = typeof raw.command === "string" ? raw.command.trim() : "";
+  if (!commandRaw) {
+    warnings.push(`${source}: MCP server '${name}' has no 'command'; skipped.`);
+    return null;
+  }
+  const command = expandEnvRefs(commandRaw, env);
+
+  const argsRaw = Array.isArray(raw.args) ? raw.args : [];
+  const args: string[] = [];
+  for (const arg of argsRaw) {
+    if (typeof arg !== "string") {
+      warnings.push(`${source}: MCP server '${name}' has a non-string arg; skipped that arg.`);
+      continue;
+    }
+    args.push(expandEnvRefs(arg, env));
+  }
+
+  const envEntries: Array<{ name: string; value: string }> = [];
+  if (isRecord(raw.env)) {
+    for (const [envName, envValue] of Object.entries(raw.env)) {
+      if (typeof envValue !== "string") {
+        warnings.push(`${source}: MCP server '${name}' env '${envName}' is not a string; skipped.`);
+        continue;
+      }
+      envEntries.push({ name: envName, value: expandEnvRefs(envValue, env) });
+    }
+    envEntries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  }
+
+  return { name, command, args, env: envEntries };
+}
+
+/**
+ * Parse a `.mcp.json`-shaped document. Accepts either the wrapped
+ * `{ "mcpServers": { name: entry } }` form or a bare `{ name: entry }` map.
+ */
+export function parseLocalStdioMcpServers(input: {
+  document: unknown;
+  env?: Record<string, string>;
+  source?: string;
+}): LocalStdioMcpResolution {
+  const env = input.env ?? {};
+  const source = input.source ?? "<inline>";
+  const warnings: string[] = [];
+  if (!isRecord(input.document)) {
+    warnings.push(`${source}: expected a JSON object; ignored.`);
+    return { servers: [], warnings, sources: [] };
+  }
+  const map = isRecord(input.document.mcpServers) ? input.document.mcpServers : input.document;
+  const servers: LocalStdioMcpServer[] = [];
+  for (const [name, raw] of Object.entries(map)) {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      warnings.push(`${source}: MCP server with an empty name; skipped.`);
+      continue;
+    }
+    const parsed = parseEntry({ name: trimmed, raw, env, source, warnings });
+    if (parsed) servers.push(parsed);
+  }
+  servers.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { servers, warnings, sources: [] };
+}
+
+async function readConfigFile(input: {
+  filePath: string;
+  env: Record<string, string>;
+  required: boolean;
+}): Promise<LocalStdioMcpResolution> {
+  let text: string;
+  try {
+    text = await fs.readFile(input.filePath, "utf8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" && !input.required) return EMPTY_RESOLUTION;
+    return {
+      servers: [],
+      warnings: [`${input.filePath}: unreadable (${String(error)}); ignored.`],
+      sources: [],
+    };
+  }
+  let document: unknown;
+  try {
+    document = JSON.parse(text);
+  } catch (error) {
+    return {
+      servers: [],
+      warnings: [`${input.filePath}: invalid JSON (${String(error)}); ignored.`],
+      sources: [],
+    };
+  }
+  const parsed = parseLocalStdioMcpServers({ document, env: input.env, source: input.filePath });
+  return { ...parsed, sources: [input.filePath] };
+}
+
+/**
+ * Resolve the local stdio MCP servers for a run.
+ *
+ * Precedence (later wins on a name collision):
+ *   1. `<instanceRoot>/mcp-servers.json`
+ *   2. `PAPERCLIP_MCP_SERVERS_FILE` (explicit override; missing file is an error worth warning about)
+ *   3. the adapter's own `mcpServers` config value (per-agent, from the Paperclip adapter settings)
+ */
+export async function resolveLocalStdioMcpServers(input: {
+  instanceRoot: string;
+  env: Record<string, string>;
+  /** Adapter-config value, if the agent's adapter config carries an `mcpServers` object. */
+  adapterConfigValue?: unknown;
+  /** Names already claimed by Paperclip-managed connections; those always win. */
+  reservedNames?: Iterable<string>;
+}): Promise<LocalStdioMcpResolution> {
+  const layers: LocalStdioMcpResolution[] = [];
+
+  layers.push(
+    await readConfigFile({
+      filePath: path.join(input.instanceRoot, LOCAL_MCP_SERVERS_FILENAME),
+      env: input.env,
+      required: false,
+    }),
+  );
+
+  const overridePath = input.env.PAPERCLIP_MCP_SERVERS_FILE?.trim();
+  if (overridePath) {
+    layers.push(await readConfigFile({ filePath: path.resolve(overridePath), env: input.env, required: true }));
+  }
+
+  if (input.adapterConfigValue !== undefined && input.adapterConfigValue !== null) {
+    layers.push({
+      ...parseLocalStdioMcpServers({
+        document: input.adapterConfigValue,
+        env: input.env,
+        source: "adapter config 'mcpServers'",
+      }),
+      sources: ["adapter config 'mcpServers'"],
+    });
+  }
+
+  const warnings: string[] = [];
+  const sources: string[] = [];
+  const byName = new Map<string, LocalStdioMcpServer>();
+  for (const layer of layers) {
+    warnings.push(...layer.warnings);
+    sources.push(...layer.sources);
+    for (const server of layer.servers) byName.set(server.name, server);
+  }
+
+  const reserved = new Set(input.reservedNames ?? []);
+  const servers: LocalStdioMcpServer[] = [];
+  for (const server of byName.values()) {
+    if (reserved.has(server.name)) {
+      warnings.push(
+        `MCP server '${server.name}' collides with a Paperclip-managed connection; the managed connection wins.`,
+      );
+      continue;
+    }
+    servers.push(server);
+  }
+  servers.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { servers, warnings, sources };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The ACPX engine starts each agent run and gives the agent its MCP servers
> - The engine starts the vendored CLI in headless/SDK mode, and that mode does not read the user-scope `~/.claude.json` MCP registry
> - `packages/adapter-utils/src/acpx-engine/execute.ts` maps only Paperclip-managed **http** connections into `mcpServers`, so a locally-configured **stdio** MCP server reaches no run
> - An operator can work around this with a project-scope `.mcp.json` in each agent working directory, but that file dies when a workspace is recreated, and a new workspace starts with no MCP servers
> - This pull request reads stdio MCP servers from one Paperclip-level file outside all workspaces and passes them to the agent as ACP stdio `McpServer` entries
> - The benefit is that a locally-configured MCP server stays available to every run, and the set of servers is explicit and reviewable in one file

## Linked Issues or Issue Description

No public issue exists. The problem follows the feature-request template.

**Subsystem affected**

ACPX engine / adapters (`packages/adapter-utils/src/acpx-engine/execute.ts`).

**Problem or motivation**

A stdio MCP server that the host operator runs locally is invisible to every Paperclip run. The engine starts the CLI in headless/SDK mode, which does not read `~/.claude.json`, and the engine itself maps only Paperclip-managed http connections into `mcpServers`. The failure is silent: the `system`/`init` stream event reports `mcp_servers: []` and no error appears. An agent fleet whose instructions require a memory `recall` at the start of every heartbeat ran memory-blind for this reason.

**Proposed solution**

Read stdio MCP servers from `<paperclip-instance-root>/mcp-servers.json`, in the familiar `.mcp.json` shape, and emit them as stdio `McpServer` entries next to the managed http entries. ACP's `McpServer` union covers stdio (`{name, command, args, env}`), and the specification requires all agents to support that transport. `packages/adapter-utils/src/mcp-isolation.integration.test.ts` already builds this exact shape.

**Alternatives considered**

Inherit `~/.claude.json` implicitly. This was rejected. That file is written by the interactive CLI, so its content is not reviewable and not stable. A Paperclip-level file keeps the set explicit.

Write a project-scope `.mcp.json` into each agent working directory. This was rejected as the durable answer. It is per-workspace, so it does not survive workspace recreation, and a new workspace starts with no servers.

**Roadmap alignment**

`ROADMAP.md` does not list this work. The change is small and additive.

**Additional context**

Related PR search: #3876 (adds a specific MCP server, not transport plumbing) and #8190 (adapter integration). Neither changes how the ACPX engine passes MCP servers to a run.

## What Changed

- Add `packages/adapter-utils/src/acpx-engine/local-mcp-servers.ts`. It parses and resolves locally-configured stdio MCP servers.
- Read `<paperclip-instance-root>/mcp-servers.json`. The file uses the `.mcp.json` shape. A bare `{name: entry}` map is also accepted. `type` defaults to `stdio`.
- Expand `${VAR}` and `$VAR` in `command`, `args`, and `env` values against the run environment. Per-agent values such as `MEM0_USER_ID` and `PAPERCLIP_AGENT_ID` resolve without repetition. An undefined reference stays as written.
- Apply this precedence, where the later layer wins a name collision: instance file, then `PAPERCLIP_MCP_SERVERS_FILE`, then the adapter config `mcpServers` value.
- Keep a Paperclip-managed connection ahead of a local entry with the same name. The local entry is dropped and the run logs a warning.
- Skip `http` and `sse` entries in the local file. Remote connections stay with the managed connection system, which mints per-run credentials.
- Skip local stdio servers when the run targets a remote or sandbox execution environment. The configured commands are host paths that do not exist there. The run logs how many servers it skipped.
- Skip a malformed entry with a warning on stderr. A malformed entry never fails a run.
- Add local servers to the session identity, and therefore to the fingerprint. A config change now invalidates a warm handle. The http identity entries keep their previous shape, so a run with no local config produces the same fingerprint as before.
- Add `docs/guides/agent-developer/local-stdio-mcp-servers.md` and list it in `docs/docs.json`.

## Verification

Run these commands from the repository root:

```
pnpm --filter @paperclipai/adapter-utils typecheck
pnpm --filter @paperclipai/server typecheck
npx vitest run packages/adapter-utils/src/acpx-engine/local-mcp-servers.test.ts
npx vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts
```

Local results: both typechecks are clean. `local-mcp-servers.test.ts` passes 11 of 11. `execute.test.ts` passes 104 of 104, which is the 97 existing tests plus 7 new tests.

The 7 new `execute.test.ts` cases assert against the captured `AcpRuntimeOptions`, which is the value the engine gives to acpx. They show that an instance-configured server reaches `mcpServers` and the session identity, that a managed http connection is never shadowed, that a remote target skips local servers, that a malformed entry becomes a warning, and that a run with no config is unchanged.

To confirm a real run, read the `system` stream event with `subtype == "init"` and check its `mcp_servers` array. Do not look for the server process. A server can start and still fail to register.

## Risks

Low risk.

- A host with no `mcp-servers.json` gets the previous behavior. The file is optional, and a missing file is not an error.
- The fingerprint is unchanged when no local server is configured, because the http identity entries keep their previous shape. No warm handle is invalidated on hosts that do not use this feature.
- A local stdio server starts a host process, so an operator can start an unwanted process through this file. The file is host-local and requires operator write access, which is the same trust level as the adapter configuration.
- Remote and sandbox execution is unaffected, because local servers are skipped there.

## Model Used

Claude Opus 5, model ID `claude-opus-5[1m]`, 1M context window, extended thinking, with tool use and code execution through Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
