### PR TITLE
Add heartbeat loop circuit breaker

### DIFF
--- a/server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts
+++ b/server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts
@@ -158,6 +158,8 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
     status?: string;
     finishedSecondsAgo: number;
     startedSecondsAgo?: number;
+    wakeReason?: string;
+    usageJson?: Record<string, unknown>;
   }) {
     const runId = randomUUID();
     const finishedAt = new Date(Date.now() - input.finishedSecondsAgo * 1000);
@@ -174,7 +176,8 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
       createdAt: startedAt,
       startedAt,
       finishedAt,
-      contextSnapshot: { issueId: input.issueId, wakeReason: "issue_assigned" },
+      usageJson: input.usageJson,
+      contextSnapshot: { issueId: input.issueId, wakeReason: input.wakeReason ?? "issue_assigned" },
     });
     return runId;
   }
@@ -342,5 +345,141 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
     const wake = await assignmentWake(agentId, issueId);
     expect(wake).toBeNull();
     expect((await latestWakeRequest(agentId))?.reason).toBe("issue_rewake_throttled");
+  });
+
+  it("pauses the agent and blocks the issue when same-issue recovery wakes trip the circuit breaker", async () => {
+    const { companyId, agentId, issueId } = await seedCompanyAgentIssue();
+
+    for (const finishedSecondsAgo of [290, 230, 170, 110, 50]) {
+      await seedTerminalRun({
+        companyId,
+        agentId,
+        issueId,
+        finishedSecondsAgo,
+        wakeReason: "source_scoped_recovery_action",
+        usageJson: {
+          inputTokens: 100_000,
+          outputTokens: 10_000,
+        },
+      });
+    }
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "source_scoped_recovery_action",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "source_scoped_recovery_action" },
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+    expect(wake).toBeNull();
+
+    const skipped = await latestWakeRequest(agentId);
+    expect(skipped?.status).toBe("skipped");
+    expect(skipped?.reason).toBe("heartbeat_circuit_breaker_tripped");
+
+    const [agent] = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, agentId));
+    expect(agent).toEqual({ status: "paused", pauseReason: "system" });
+
+    const [issue] = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId));
+    expect(issue?.status).toBe("blocked");
+
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(and(eq(issueComments.issueId, issueId), eq(issueComments.companyId, companyId)));
+    expect(comments.some((comment) => comment.body.includes("Heartbeat circuit breaker tripped"))).toBe(true);
+  });
+
+  it("cancels deferred wake promotion when the circuit breaker has already tripped", async () => {
+    const { companyId, agentId, issueId } = await seedCompanyAgentIssue();
+
+    for (const finishedSecondsAgo of [290, 230, 170, 110, 50]) {
+      await seedTerminalRun({
+        companyId,
+        agentId,
+        issueId,
+        finishedSecondsAgo,
+        wakeReason: "finish_successful_run_handoff",
+        usageJson: {
+          inputTokens: 95_000,
+          outputTokens: 8_000,
+        },
+      });
+    }
+
+    const activeRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: activeRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      startedAt: new Date(Date.now() - 5_000),
+      responsibleUserId: "responsible-user",
+      contextSnapshot: { issueId, wakeReason: "source_scoped_recovery_action" },
+    });
+    await db
+      .update(issues)
+      .set({
+        executionRunId: activeRunId,
+        executionLockedAt: new Date(Date.now() - 5_000),
+      })
+      .where(eq(issues.id, issueId));
+
+    const deferredWakeupId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeupId,
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "finish_successful_run_handoff",
+      payload: {
+        issueId,
+        _paperclipWakeContext: {
+          issueId,
+          wakeReason: "finish_successful_run_handoff",
+        },
+      },
+      status: "deferred_issue_execution",
+      requestedByActorType: "system",
+      requestedByActorId: "test",
+    });
+
+    await heartbeat.cancelRun(activeRunId, "test cancellation releases issue execution");
+    await drainHeartbeatRunsToQuiescence(db, heartbeat);
+
+    const promotedRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.agentId, agentId),
+        sql`${heartbeatRuns.contextSnapshot} ->> 'wakeReason' = 'finish_successful_run_handoff'`,
+        sql`${heartbeatRuns.id} <> ${activeRunId}`,
+      ));
+    expect(promotedRuns).toHaveLength(5);
+
+    const [deferredWakeup] = await db
+      .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, deferredWakeupId));
+    expect(deferredWakeup?.status).toBe("cancelled");
+    expect(deferredWakeup?.error).toContain("heartbeat circuit breaker");
+
+    const [agent] = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, agentId));
+    expect(agent).toEqual({ status: "paused", pauseReason: "system" });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -114,8 +114,12 @@ import {
   ISSUE_PROGRESS_ACTIVITY_ACTIONS,
   ISSUE_REWAKE_LOOKBACK_MS,
   ISSUE_REWAKE_RUN_SAMPLE_LIMIT,
+  HEARTBEAT_CIRCUIT_BREAKER_REASON,
+  HEARTBEAT_CIRCUIT_BREAKER_RUN_WINDOW_MS,
   evaluateIssueRewakeThrottle,
+  evaluateHeartbeatCircuitBreaker,
   isThrottleCandidateIssueRewake,
+  type HeartbeatCircuitBreakerDecision,
 } from "./issue-rewake-throttle.js";
 import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
 import {
@@ -15888,6 +15892,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           payload: promotedPayload,
         });
 
+        if (issue.status !== "done" && issue.status !== "cancelled") {
+          const breakerNow = new Date();
+          const requestedWakeReason = readNonEmptyString(promotedContextSnapshot.wakeReason) ?? promotedReason;
+          const breakerDecision = await evaluateHeartbeatCircuitBreakerForIssue(tx, {
+            companyId: deferredAgent.companyId,
+            agentId: deferredAgent.id,
+            issueId: issue.id,
+            requestedWakeReason,
+            now: breakerNow,
+          });
+          if (breakerDecision.blocked) {
+            await tripHeartbeatCircuitBreaker(tx, {
+              companyId: deferredAgent.companyId,
+              agentId: deferredAgent.id,
+              issueId: issue.id,
+              decision: breakerDecision,
+              requestedWakeReason,
+              currentWakeupRequestId: deferred.id,
+            });
+            return {
+              kind: "skipped" as const,
+              reason: HEARTBEAT_CIRCUIT_BREAKER_REASON,
+            };
+          }
+        }
+
         const sessionBefore =
           readNonEmptyString(promotedContextSnapshot.resumeSessionDisplayId) ??
           await resolveSessionBeforeForWakeup(deferredAgent, promotedTaskKey);
@@ -16326,6 +16356,208 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
 
     await startNextQueuedRunForAgent(promotedRun.agentId);
+  }
+
+  async function evaluateHeartbeatCircuitBreakerForIssue(
+    tx: any,
+    input: {
+      companyId: string;
+      agentId: string;
+      issueId: string;
+      requestedWakeReason: string | null;
+      now: Date;
+    },
+  ) {
+    const recentRuns = await tx
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        finishedAt: heartbeatRuns.finishedAt,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        usageJson: heartbeatRuns.usageJson,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, input.companyId),
+          eq(heartbeatRuns.agentId, input.agentId),
+          sql`${heartbeatRuns.finishedAt} is not null`,
+          gte(heartbeatRuns.finishedAt, new Date(input.now.getTime() - HEARTBEAT_CIRCUIT_BREAKER_RUN_WINDOW_MS)),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.finishedAt));
+
+    return evaluateHeartbeatCircuitBreaker({
+      now: input.now,
+      requestedWakeReason: input.requestedWakeReason,
+      recentTerminalRuns: recentRuns,
+    });
+  }
+
+  function buildHeartbeatCircuitBreakerComment(input: {
+    decision: Extract<HeartbeatCircuitBreakerDecision, { blocked: true }>;
+    requestedWakeReason: string | null;
+  }) {
+    return [
+      "Heartbeat circuit breaker tripped.",
+      "",
+      "- Action: paused the agent and blocked this issue for manual investigation.",
+      `- Trigger: ${input.decision.reason}`,
+      `- Requested wake reason: ${input.requestedWakeReason ?? "unknown"}`,
+      `- Recent runs in 60m: ${input.decision.runCount}`,
+      `- Active tokens in 60m: ${input.decision.activeTokens}`,
+      `- Same wake reason runs in 30m: ${input.decision.sameReasonCount}`,
+      `- Window start: ${input.decision.windowStart.toISOString()}`,
+      "",
+      "Resume the agent only after the wake/recovery loop is understood or this issue has a durable disposition.",
+    ].join("\n");
+  }
+
+  async function tripHeartbeatCircuitBreaker(
+    tx: any,
+    input: {
+      agentId: string;
+      companyId: string;
+      issueId: string;
+      decision: Extract<HeartbeatCircuitBreakerDecision, { blocked: true }>;
+      requestedWakeReason: string | null;
+      currentWakeupRequestId?: string | null;
+      skippedWake?: {
+        source: string;
+        triggerDetail: string | null;
+        payload: Record<string, unknown> | null;
+        requestedByActorType: string | null;
+        requestedByActorId: string | null;
+        idempotencyKey: string | null;
+      };
+    },
+  ) {
+    const now = new Date();
+    await tx
+      .update(agents)
+      .set({
+        status: "paused",
+        pauseReason: "system",
+        pausedAt: now,
+        updatedAt: now,
+      })
+      .where(and(eq(agents.id, input.agentId), inArray(agents.status, ["active", "idle", "running", "error"])));
+
+    await tx
+      .update(issues)
+      .set({
+        status: "blocked",
+        updatedAt: now,
+      })
+      .where(and(eq(issues.id, input.issueId), eq(issues.companyId, input.companyId), notInArray(issues.status, ["done", "cancelled"])));
+
+    await tx
+      .update(agentWakeupRequests)
+      .set({
+        status: "cancelled",
+        finishedAt: now,
+        error: "Cancelled because heartbeat circuit breaker tripped",
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, input.companyId),
+          eq(agentWakeupRequests.agentId, input.agentId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${input.issueId}`,
+        ),
+      );
+
+    if (input.currentWakeupRequestId) {
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: "Cancelled because heartbeat circuit breaker tripped",
+          updatedAt: now,
+        })
+        .where(eq(agentWakeupRequests.id, input.currentWakeupRequestId));
+    }
+
+    if (input.skippedWake) {
+      await tx.insert(agentWakeupRequests).values({
+        companyId: input.companyId,
+        agentId: input.agentId,
+        source: input.skippedWake.source,
+        triggerDetail: input.skippedWake.triggerDetail,
+        reason: HEARTBEAT_CIRCUIT_BREAKER_REASON,
+        payload: {
+          ...(input.skippedWake.payload ?? {}),
+          issueId: input.issueId,
+          heartbeatCircuitBreaker: {
+            reason: input.decision.reason,
+            requestedWakeReason: input.requestedWakeReason,
+            runCount: input.decision.runCount,
+            activeTokens: input.decision.activeTokens,
+            sameReasonCount: input.decision.sameReasonCount,
+            windowStart: input.decision.windowStart.toISOString(),
+          },
+        },
+        status: "skipped",
+        requestedByActorType: input.skippedWake.requestedByActorType,
+        requestedByActorId: input.skippedWake.requestedByActorId,
+        idempotencyKey: input.skippedWake.idempotencyKey,
+        finishedAt: now,
+      });
+    }
+
+    await tx.insert(issueComments).values({
+      companyId: input.companyId,
+      issueId: input.issueId,
+      authorType: "system",
+      body: buildHeartbeatCircuitBreakerComment({
+        decision: input.decision,
+        requestedWakeReason: input.requestedWakeReason,
+      }),
+      presentation: {
+        kind: "system_notice",
+        tone: "danger",
+        title: "Heartbeat circuit breaker tripped",
+        detailsDefaultOpen: false,
+      },
+      metadata: {
+        version: 1,
+        sections: [
+          {
+            title: "Circuit breaker",
+            rows: [
+              { type: "key_value", label: "Trigger", value: input.decision.reason },
+              { type: "key_value", label: "Requested wake reason", value: input.requestedWakeReason ?? "unknown" },
+              { type: "key_value", label: "Recent runs in 60m", value: String(input.decision.runCount) },
+              { type: "key_value", label: "Active tokens in 60m", value: String(input.decision.activeTokens) },
+              { type: "key_value", label: "Same wake reason runs in 30m", value: String(input.decision.sameReasonCount) },
+            ],
+          },
+        ],
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await logActivity(tx as unknown as Db, {
+      companyId: input.companyId,
+      actorType: "system",
+      actorId: "heartbeat",
+      agentId: input.agentId,
+      runId: null,
+      action: "heartbeat.circuit_breaker_tripped",
+      entityType: "issue",
+      entityId: input.issueId,
+      details: {
+        reason: input.decision.reason,
+        requestedWakeReason: input.requestedWakeReason,
+        runCount: input.decision.runCount,
+        activeTokens: input.decision.activeTokens,
+        sameReasonCount: input.decision.sameReasonCount,
+      },
+    });
   }
 
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
@@ -17059,6 +17291,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 resolvedMode,
                 resolvedStrategy,
                 hasResolvablePriorSessionWorkspace,
+              },
+            });
+            return { kind: "skipped" as const };
+          }
+        }
+
+        if (!activeExecutionRun && issue.status !== "done" && issue.status !== "cancelled") {
+          const breakerNow = new Date();
+          const requestedWakeReason = readNonEmptyString(enrichedContextSnapshot.wakeReason) ?? reason;
+          const breakerDecision = await evaluateHeartbeatCircuitBreakerForIssue(tx, {
+            companyId: agent.companyId,
+            agentId,
+            issueId: issue.id,
+            requestedWakeReason,
+            now: breakerNow,
+          });
+          if (breakerDecision.blocked) {
+            await tripHeartbeatCircuitBreaker(tx, {
+              companyId: agent.companyId,
+              agentId,
+              issueId: issue.id,
+              decision: breakerDecision,
+              requestedWakeReason,
+              skippedWake: {
+                source,
+                triggerDetail,
+                payload,
+                requestedByActorType: opts.requestedByActorType ?? null,
+                requestedByActorId: opts.requestedByActorId ?? null,
+                idempotencyKey: opts.idempotencyKey ?? null,
               },
             });
             return { kind: "skipped" as const };

--- a/server/src/services/issue-rewake-throttle.ts
+++ b/server/src/services/issue-rewake-throttle.ts
@@ -37,6 +37,13 @@ export const ISSUE_REWAKE_LOOKBACK_MS = 6 * 60 * 60_000;
 /** How many recent terminal runs to sample when computing the streak. */
 export const ISSUE_REWAKE_RUN_SAMPLE_LIMIT = 8;
 
+export const HEARTBEAT_CIRCUIT_BREAKER_REASON = "heartbeat_circuit_breaker_tripped";
+export const HEARTBEAT_CIRCUIT_BREAKER_RUN_WINDOW_MS = 60 * 60_000;
+export const HEARTBEAT_CIRCUIT_BREAKER_REASON_WINDOW_MS = 30 * 60_000;
+export const HEARTBEAT_CIRCUIT_BREAKER_RUN_THRESHOLD = 20;
+export const HEARTBEAT_CIRCUIT_BREAKER_ACTIVE_TOKEN_THRESHOLD = 500_000;
+export const HEARTBEAT_CIRCUIT_BREAKER_SAME_REASON_THRESHOLD = 5;
+
 /**
  * Wake reasons that assert issue state rather than deliver a new event.
  * These (plus reason-less on-demand invokes) are the only wakes the throttle
@@ -120,6 +127,11 @@ export interface RecentIssueRunSample {
   finishedAt: Date | null;
 }
 
+export interface HeartbeatCircuitBreakerRunSample extends RecentIssueRunSample {
+  contextSnapshot?: Record<string, unknown> | null;
+  usageJson?: Record<string, unknown> | null;
+}
+
 export interface IssueRewakeThrottleInput {
   now: Date;
   /** Terminal runs for the same (agent, issue), newest finish first. */
@@ -174,4 +186,89 @@ export function evaluateIssueRewakeThrottle(input: IssueRewakeThrottleInput): Is
     return { blocked: true, noProgressStreak, cooldownMs, lastRunFinishedAt, nextAllowedAt };
   }
   return { blocked: false, noProgressStreak };
+}
+
+export interface HeartbeatCircuitBreakerInput {
+  now: Date;
+  requestedWakeReason: string | null;
+  recentTerminalRuns: HeartbeatCircuitBreakerRunSample[];
+}
+
+export type HeartbeatCircuitBreakerDecision =
+  | { blocked: false; runCount: number; activeTokens: number; sameReasonCount: number }
+  | {
+      blocked: true;
+      reason: "run_count" | "active_tokens" | "same_wake_reason";
+      runCount: number;
+      activeTokens: number;
+      sameReasonCount: number;
+      windowStart: Date;
+    };
+
+function readNumber(value: unknown) {
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? Math.max(0, Math.floor(numeric)) : 0;
+}
+
+function activeTokens(usageJson: Record<string, unknown> | null | undefined) {
+  if (!usageJson) return 0;
+  return readNumber(usageJson.inputTokens ?? usageJson.input_tokens) +
+    readNumber(usageJson.outputTokens ?? usageJson.output_tokens);
+}
+
+function readWakeReason(contextSnapshot: Record<string, unknown> | null | undefined) {
+  const value = contextSnapshot?.wakeReason;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function evaluateHeartbeatCircuitBreaker(
+  input: HeartbeatCircuitBreakerInput,
+): HeartbeatCircuitBreakerDecision {
+  const runWindowStart = new Date(input.now.getTime() - HEARTBEAT_CIRCUIT_BREAKER_RUN_WINDOW_MS);
+  const reasonWindowStart = new Date(input.now.getTime() - HEARTBEAT_CIRCUIT_BREAKER_REASON_WINDOW_MS);
+  const runWindowRuns = input.recentTerminalRuns.filter((run) =>
+    run.finishedAt && run.finishedAt.getTime() >= runWindowStart.getTime()
+  );
+  const reasonWindowRuns = input.requestedWakeReason
+    ? input.recentTerminalRuns.filter((run) =>
+        run.finishedAt &&
+        run.finishedAt.getTime() >= reasonWindowStart.getTime() &&
+        readWakeReason(run.contextSnapshot) === input.requestedWakeReason
+      )
+    : [];
+  const runCount = runWindowRuns.length;
+  const activeTokenCount = runWindowRuns.reduce((sum, run) => sum + activeTokens(run.usageJson), 0);
+  const sameReasonCount = reasonWindowRuns.length;
+
+  if (sameReasonCount >= HEARTBEAT_CIRCUIT_BREAKER_SAME_REASON_THRESHOLD) {
+    return {
+      blocked: true,
+      reason: "same_wake_reason",
+      runCount,
+      activeTokens: activeTokenCount,
+      sameReasonCount,
+      windowStart: reasonWindowStart,
+    };
+  }
+  if (runCount >= HEARTBEAT_CIRCUIT_BREAKER_RUN_THRESHOLD) {
+    return {
+      blocked: true,
+      reason: "run_count",
+      runCount,
+      activeTokens: activeTokenCount,
+      sameReasonCount,
+      windowStart: runWindowStart,
+    };
+  }
+  if (activeTokenCount >= HEARTBEAT_CIRCUIT_BREAKER_ACTIVE_TOKEN_THRESHOLD) {
+    return {
+      blocked: true,
+      reason: "active_tokens",
+      runCount,
+      activeTokens: activeTokenCount,
+      sameReasonCount,
+      windowStart: runWindowStart,
+    };
+  }
+  return { blocked: false, runCount, activeTokens: activeTokenCount, sameReasonCount };
 }


### PR DESCRIPTION
## Summary
- add native heartbeat circuit-breaker thresholds for same-agent/same-issue run storms
- pause the agent, block the issue, cancel queued/deferred wakes, and add a system notice when tripped
- gate both direct wake enqueue and deferred wake promotion paths
- add regression coverage for direct recovery wakes and deferred promotion loops

## Why
A successful-run handoff/recovery loop can keep creating issue-visible comments and therefore bypass no-progress throttling. This adds a higher-level safety stop based on run frequency, active token burn, and repeated same wake reason for one issue.

## Verification
- pnpm exec vitest run server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts server/src/services/recovery/successful-run-handoff.test.ts
- pnpm --filter @paperclipai/server typecheck