### PR TITLE
fix(backup): remove raw sql sidecars from JS backups

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -173,6 +173,7 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
         expect(result.backupFile).toMatch(/paperclip-test-.*\.sql\.gz$/);
         expect(result.sizeBytes).toBeGreaterThan(0);
         expect(fs.existsSync(result.backupFile)).toBe(true);
+        expect(fs.readdirSync(backupDir).sort()).toEqual([path.basename(result.backupFile)]);
 
         await runDatabaseRestore({
           connectionString: restoreConnectionString,

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -1,4 +1,4 @@
-import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { spawn } from "node:child_process";
@@ -442,23 +442,27 @@ async function* readRestoreStatements(backupFile: string): AsyncGenerator<string
   }
 }
 
-export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
-  const filePromise = openFile(filePath, "w");
-  const flushThreshold = Math.max(1, Math.trunc(maxBufferedBytes));
+type BufferedTextWriter = {
+  emit(line: string): void;
+  drain(): Promise<void>;
+  writeRaw(chunk: string | Buffer): Promise<void>;
+  close(): Promise<void>;
+  abort(): Promise<void>;
+};
+
+function createBufferedTextWriter(opts: {
+  label: string;
+  maxBufferedBytes?: number;
+  writeChunk: (chunk: string | Buffer) => Promise<void>;
+  closeTarget: () => Promise<void>;
+  abortTarget: () => Promise<void>;
+}): BufferedTextWriter {
+  const flushThreshold = Math.max(1, Math.trunc(opts.maxBufferedBytes ?? DEFAULT_BACKUP_WRITE_BUFFER_BYTES));
   let bufferedLines: string[] = [];
   let bufferedBytes = 0;
   let firstChunk = true;
   let closed = false;
   let pendingWrite = Promise.resolve();
-
-  const writeChunk = async (chunk: string | Buffer): Promise<void> => {
-    const file = await filePromise;
-    if (typeof chunk === "string") {
-      await file.write(chunk, null, "utf8");
-    } else {
-      await file.write(chunk);
-    }
-  };
 
   const flushBufferedLines = () => {
     if (bufferedLines.length === 0) return;
@@ -468,13 +472,13 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
     const chunkBody = linesToWrite.join("\n");
     const chunk = firstChunk ? chunkBody : `\n${chunkBody}`;
     firstChunk = false;
-    pendingWrite = pendingWrite.then(() => writeChunk(chunk));
+    pendingWrite = pendingWrite.then(() => opts.writeChunk(chunk));
   };
 
   return {
     emit(line: string) {
       if (closed) {
-        throw new Error(`Cannot write to closed backup file: ${filePath}`);
+        throw new Error(`Cannot write to closed backup target: ${opts.label}`);
       }
       bufferedLines.push(line);
       bufferedBytes += Buffer.byteLength(line, "utf8") + 1;
@@ -484,18 +488,18 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
     },
     async drain() {
       if (closed) {
-        throw new Error(`Cannot drain closed backup file: ${filePath}`);
+        throw new Error(`Cannot drain closed backup target: ${opts.label}`);
       }
       flushBufferedLines();
       await pendingWrite;
     },
     async writeRaw(chunk: string | Buffer) {
       if (closed) {
-        throw new Error(`Cannot write to closed backup file: ${filePath}`);
+        throw new Error(`Cannot write to closed backup target: ${opts.label}`);
       }
       flushBufferedLines();
       firstChunk = false;
-      pendingWrite = pendingWrite.then(() => writeChunk(chunk));
+      pendingWrite = pendingWrite.then(() => opts.writeChunk(chunk));
       await pendingWrite;
     },
     async close() {
@@ -503,8 +507,7 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
       closed = true;
       flushBufferedLines();
       await pendingWrite;
-      const file = await filePromise;
-      await file.close();
+      await opts.closeTarget();
     },
     async abort() {
       if (closed) return;
@@ -512,6 +515,30 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
       bufferedLines = [];
       bufferedBytes = 0;
       await pendingWrite.catch(() => {});
+      await opts.abortTarget();
+    },
+  };
+}
+
+export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
+  const filePromise = openFile(filePath, "w");
+
+  return createBufferedTextWriter({
+    label: filePath,
+    maxBufferedBytes,
+    writeChunk: async (chunk) => {
+      const file = await filePromise;
+      if (typeof chunk === "string") {
+        await file.write(chunk, null, "utf8");
+      } else {
+        await file.write(chunk);
+      }
+    },
+    closeTarget: async () => {
+      const file = await filePromise;
+      await file.close();
+    },
+    abortTarget: async () => {
       await filePromise.then((file) => file.close()).catch(() => {});
       if (existsSync(filePath)) {
         try {
@@ -521,7 +548,75 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
         }
       }
     },
-  };
+  });
+}
+
+function createBufferedTextGzipFileWriter(filePath: string, maxBufferedBytes = DEFAULT_BACKUP_WRITE_BUFFER_BYTES) {
+  const gzip = createGzip();
+  const output = createWriteStream(filePath);
+  const completion = pipeline(gzip, output);
+
+  const writeChunk = (chunk: string | Buffer) =>
+    new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        gzip.off("error", onError);
+        output.off("error", onError);
+        reject(error);
+      };
+      gzip.once("error", onError);
+      output.once("error", onError);
+      gzip.write(chunk, (error?: Error | null) => {
+        gzip.off("error", onError);
+        output.off("error", onError);
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+  const endStream = () =>
+    new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        gzip.off("error", onError);
+        output.off("error", onError);
+        reject(error);
+      };
+      gzip.once("error", onError);
+      output.once("error", onError);
+      gzip.end((error?: Error | null) => {
+        gzip.off("error", onError);
+        output.off("error", onError);
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+  return createBufferedTextWriter({
+    label: filePath,
+    maxBufferedBytes,
+    writeChunk,
+    closeTarget: async () => {
+      await endStream();
+      await completion;
+    },
+    abortTarget: async () => {
+      gzip.destroy();
+      output.destroy();
+      await completion.catch(() => {});
+      if (existsSync(filePath)) {
+        try {
+          unlinkSync(filePath);
+        } catch {
+          // Preserve the original backup failure if temporary file cleanup also fails.
+        }
+      }
+    },
+  });
 }
 
 export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise<RunDatabaseBackupResult> {
@@ -540,9 +635,9 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     await sql.end();
   };
   mkdirSync(opts.backupDir, { recursive: true });
-  const sqlFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql`);
-  const backupFile = `${sqlFile}.gz`;
-  const writer = createBufferedTextFileWriter(sqlFile);
+  const backupFile = resolve(opts.backupDir, `${filenamePrefix}-${timestamp()}.sql.gz`);
+  const tempBackupFile = `${backupFile}.part`;
+  let writer: BufferedTextWriter | null = null;
 
   try {
     if (backupEngine === "pg_dump" || (backupEngine === "auto" && canUsePgDump)) {
@@ -551,10 +646,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         await closeSql();
         await runPgDumpBackup({
           connectionString: opts.connectionString,
-          backupFile,
+          backupFile: tempBackupFile,
           connectTimeout,
         });
-        await writer.abort();
+        renameSync(tempBackupFile, backupFile);
         const sizeBytes = statSync(backupFile).size;
         const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
         return {
@@ -575,8 +670,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     }
 
     await sql`SELECT 1`;
+    const activeWriter = createBufferedTextGzipFileWriter(tempBackupFile);
+    writer = activeWriter;
 
-    const emit = (line: string) => writer.emit(line);
+    const emit = (line: string) => activeWriter.emit(line);
     const emitStatement = (statement: string) => {
       emit(statement);
       emit(STATEMENT_BREAKPOINT);
@@ -904,19 +1001,19 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       const nullifiedColumns = nullifiedColumnsByTable.get(currentTableKey) ?? new Set<string>();
       if (backupEngine !== "javascript" && nullifiedColumns.size === 0) {
         emit(`COPY ${qualifiedTableName} (${colNames}) FROM stdin;`);
-        await writer.writeRaw("\n");
-        const copySql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
+        await activeWriter.writeRaw("\n");
+        const copySql = await sql.reserve();
         try {
           const copyStream = await copySql
             .unsafe(`COPY ${qualifiedTableName} (${colNames}) TO STDOUT`)
             .readable();
           for await (const chunk of copyStream) {
-            await writer.writeRaw(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+            await activeWriter.writeRaw(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
           }
         } finally {
-          await copySql.end();
+          copySql.release();
         }
-        await writer.writeRaw("\\.\n");
+        await activeWriter.writeRaw("\\.\n");
         emitStatementBoundary();
         emit("");
         continue;
@@ -933,7 +1030,7 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
           );
           emitStatement(`INSERT INTO ${qualifiedTableName} (${colNames}) VALUES (${values.join(", ")});`);
         }
-        await writer.drain();
+        await activeWriter.drain();
       }
       emit("");
     }
@@ -959,13 +1056,9 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     emitStatement("COMMIT;");
     emit("");
 
-    await writer.close();
-
-    // Compress the SQL file with gzip
-    const sqlReadStream = createReadStream(sqlFile);
-    const gzWriteStream = createWriteStream(backupFile);
-    await pipeline(sqlReadStream, createGzip(), gzWriteStream);
-    unlinkSync(sqlFile);
+    await activeWriter.close();
+    writer = null;
+    renameSync(tempBackupFile, backupFile);
 
     const sizeBytes = statSync(backupFile).size;
     const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
@@ -976,12 +1069,12 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
       prunedCount,
     };
   } catch (error) {
-    await writer.abort();
+    await writer?.abort();
     if (existsSync(backupFile)) {
       try { unlinkSync(backupFile); } catch { /* ignore */ }
     }
-    if (existsSync(sqlFile)) {
-      try { unlinkSync(sqlFile); } catch { /* ignore */ }
+    if (existsSync(tempBackupFile)) {
+      try { unlinkSync(tempBackupFile); } catch { /* ignore */ }
     }
     throw error;
   } finally {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip relies on logical database backups to protect that work.
> - The JavaScript backup path still writes a raw final-name `.sql` file before gzip finishes.
> - A stalled compression or cleanup step can leave that raw sidecar on disk even after SQL emission stops.
> - That failure mode is large enough to push the root volume into a critical state.
> - This pull request streams backup output into a temporary gzip artifact and renames it only after success.
> - The benefit is that successful backups publish the same `.sql.gz` output, but the raw sidecar no longer exists for this failure mode.

## Linked Issues or Issue Description

Refs #9756
Refs #1770
Refs #1545

- Related PR: #9756 covers atomic backup publication and health checks on an older base.
- This PR stays on current `master` and focuses on the raw `.sql` sidecar incident in the JavaScript backup path.

## What Changed

- Write backup output to a temporary compressed file (`.sql.gz.part`) and rename it atomically to the final `.sql.gz` path only after success.
- Remove the separate raw `.sql` write then gzip step from the JavaScript backup path.
- Use a reserved SQL connection for `COPY ... TO STDOUT` streaming instead of a throwaway client teardown path.
- Add a regression assertion that a successful backup leaves no raw `.sql` artifact in the backup directory.

## Verification

- `pnpm vitest run packages/db/src/backup-lib.test.ts`
- `pnpm exec tsc -p packages/db/tsconfig.json --noEmit`

## Risks

- Low risk. The change stays inside the shared backup library and keeps the published backup format unchanged.
- This does not clean up an already-stuck live backup process. It prevents the same raw-sidecar shape on future successful runs.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, local terminal tool use, long-context reasoning mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
