### PR TITLE
feat(adapters): add agentsky_cloud built-in adapter (AgentSky cloud agents)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY packages/kv-demo-mcp-server/package.json packages/kv-demo-mcp-server/
 COPY packages/mcp-server/package.json packages/mcp-server/
 COPY packages/skills-catalog/package.json packages/skills-catalog/
 COPY packages/teams-catalog/package.json packages/teams-catalog/
+COPY packages/adapters/agentsky-cloud/package.json packages/adapters/agentsky-cloud/
 COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-cloud/package.json packages/adapters/cursor-cloud/

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "@paperclipai/adapter-agentsky-cloud": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printCursorCloudEvent } from "@paperclipai/adapter-cursor-cloud/cli";
+import { printAgentskyCloudEvent } from "@paperclipai/adapter-agentsky-cloud/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printGrokStreamEvent } from "@paperclipai/adapter-grok-local/cli";
 import { formatStdoutEvent as printHermesGatewayStreamEvent } from "@paperclipai/hermes-paperclip-adapter/gateway/cli";
@@ -43,6 +44,11 @@ const cursorCloudCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printCursorCloudEvent,
 };
 
+const agentskyCloudCLIAdapter: CLIAdapterModule = {
+  type: "agentsky_cloud",
+  formatStdoutEvent: printAgentskyCloudEvent,
+};
+
 const geminiLocalCLIAdapter: CLIAdapterModule = {
   type: "gemini_local",
   formatStdoutEvent: printGeminiStreamEvent,
@@ -76,6 +82,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     cursorCloudCLIAdapter,
+    agentskyCloudCLIAdapter,
     geminiLocalCLIAdapter,
     grokLocalCLIAdapter,
     hermesGatewayCLIAdapter,

--- a/docs/adapters/agentsky-cloud.md
+++ b/docs/adapters/agentsky-cloud.md
@@ -1,0 +1,63 @@
+---
+title: AgentSky
+summary: Drive AgentSky cloud-hosted persistent agents from Paperclip
+---
+
+The `agentsky_cloud` adapter connects Paperclip to [AgentSky](https://agentsky.dev) — a platform
+that hosts long-lived agents (Claude Code, Codex, OpenClaw, Hermes) as always-on cloud pods with
+their own persistent filesystem, memory, and context. Paperclip wakes the remote agent on each
+heartbeat over AgentSky's public API and records the agent's final message as the run report.
+
+## How it works
+
+- On the first heartbeat the adapter **auto-creates** an AgentSky agent (with the configured
+  harness and model) plus a chat session, and persists both in Paperclip's session state. Later
+  heartbeats reuse the same durable session, so the remote agent accrues context across wakes.
+- Each heartbeat sends one wake message and then follows the session's event ledger
+  (`GET /api/v1/sessions/{id}/events`) until the turn completes.
+- Changing `harness`, `model`, or `agentSlug` provisions a fresh AgentSky agent/session on the
+  next heartbeat; the old one is abandoned, never deleted.
+- Alternatively, set `agentSlug` to **attach** to an agent you already created on agentsky.dev;
+  the adapter then only creates sessions and ignores the harness/model fields (the existing agent
+  already has both).
+
+## Configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `harness` | No (default `claude_code`) | AgentSky agent type: `claude_code`, `codex`, `openclaw`, `hermes` |
+| `model` | No | Model id; must be compatible with the harness (table below). Empty = harness default |
+| `agentSlug` | No | Attach to an existing AgentSky agent instead of auto-creating one |
+| `apiBaseUrl` | No (default `https://agentsky.dev`) | Override for staging/self-hosted AgentSky |
+| `instructionsFilePath` | No | Agent instructions file prepended to the prompt |
+| `promptTemplate` / `bootstrapPromptTemplate` | No | Standard Paperclip prompt templates |
+| `timeoutSec` | No (default 3600) | Max seconds to wait for the remote turn |
+| `env.AGENTSKY_API_TOKEN` | **Yes** | AgentSky API token (`ast_…`), created at agentsky.dev → Settings → API tokens |
+
+### Harness / model compatibility
+
+| Harness | Models (first is the default) |
+|---------|-------------------------------|
+| `claude_code` | `claude-opus-5`, `claude-fable-5`, `claude-sonnet-4-6`, `kimi-k3` |
+| `codex` | `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.6-terra` |
+| `openclaw` | `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.6-terra`, `deepseek-v4-pro`, `deepseek-v4-flash`, `gemini-3.5-flash`, `glm-5.2`, `kimi-k3` |
+| `hermes` | `deepseek-v4-pro`, `deepseek-v4-flash`, `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.6-terra`, `gemini-3.5-flash`, `glm-5.2`, `kimi-k3` |
+
+## No repository plumbing
+
+Unlike `cursor_cloud`, there is **no `repoUrl` field**. AgentSky pods own a persistent filesystem;
+if the agent should work on a repository, name it (and how to access it) directly in the prompt,
+goal, or instructions file. The pod clones it once and keeps it across heartbeats.
+
+## Runtime values and callbacks
+
+The AgentSky message plane has no environment-variable injection, so PAPERCLIP_* runtime values
+(`PAPERCLIP_AGENT_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`, task/wake ids) are delivered as a
+"Paperclip runtime note" text section inside the wake prompt. No Paperclip API key is sent, and a
+Paperclip server bound to localhost is unreachable from the cloud agent (the environment test
+warns about this) — **the agent's final message each turn is the feedback channel**.
+
+## Billing
+
+Runs bill the AgentSky account's credit wallet (`biller: agentsky`, `billingType: api`). An
+exhausted balance surfaces as a failed run with error code `insufficient_credits`.

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -27,6 +27,7 @@ When a heartbeat fires, Paperclip:
 | Hermes | `hermes_local` | Runs the local Hermes CLI through `@paperclipai/hermes-paperclip-adapter` |
 | Hermes Gateway | `hermes_gateway` | Calls an already-running Hermes API server through `@paperclipai/hermes-paperclip-adapter/gateway` |
 | OpenClaw Gateway | `openclaw_gateway` | Connects to an OpenClaw gateway endpoint |
+| [AgentSky](/adapters/agentsky-cloud) | `agentsky_cloud` | Drives an AgentSky cloud-hosted persistent agent (agentsky.dev) |
 | [Process](/adapters/process) | `process` | Executes arbitrary shell commands |
 | [HTTP](/adapters/http) | `http` | Sends webhooks to external agents |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -99,6 +99,7 @@
             "group": "Agent Adapters",
             "pages": [
               "adapters/overview",
+              "adapters/agentsky-cloud",
               "adapters/claude-local",
               "adapters/codex-local",
               "adapters/process",

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -37,6 +37,7 @@ const ADAPTER_MANAGED_SESSION_POLICY: SessionCompactionPolicy = {
 };
 
 export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
+  "agentsky_cloud",
   "claude_local",
   "codex_local",
   "cursor_cloud",
@@ -48,6 +49,13 @@ export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
 ]);
 
 export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement> = {
+  // AgentSky pods are long-lived agents that manage their own context;
+  // threshold-based rotation would abandon a healthy remote session.
+  agentsky_cloud: {
+    supportsSessionResume: true,
+    nativeContextManagement: "confirmed",
+    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
+  },
   claude_local: {
     supportsSessionResume: true,
     nativeContextManagement: "confirmed",

--- a/packages/adapters/agentsky-cloud/package.json
+++ b/packages/adapters/agentsky-cloud/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-agentsky-cloud",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/agentsky-cloud"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/agentsky-cloud/src/cli/format-event.ts
+++ b/packages/adapters/agentsky-cloud/src/cli/format-event.ts
@@ -1,0 +1,42 @@
+import pc from "picocolors";
+import { parseAgentskyCloudStdoutLine } from "../ui/parse-stdout.js";
+
+export function printAgentskyCloudEvent(raw: string, _debug: boolean): void {
+  const entries = parseAgentskyCloudStdoutLine(raw, new Date().toISOString());
+  for (const entry of entries) {
+    switch (entry.kind) {
+      case "assistant":
+        console.log(pc.green(`assistant: ${entry.text}`));
+        break;
+      case "thinking":
+        console.log(pc.gray(`thinking: ${entry.text}`));
+        break;
+      case "user":
+        console.log(pc.gray(`user: ${entry.text}`));
+        break;
+      case "tool_call":
+        console.log(pc.yellow(`tool_call: ${entry.name}`));
+        break;
+      case "tool_result":
+        console.log((entry.isError ? pc.red : pc.cyan)(entry.content || "tool result"));
+        break;
+      case "result":
+        console.log((entry.isError ? pc.red : pc.blue)(`result: ${entry.subtype}${entry.text ? ` - ${entry.text}` : ""}`));
+        break;
+      case "stderr":
+        console.error(pc.red(entry.text));
+        break;
+      case "system":
+        console.log(pc.blue(entry.text));
+        break;
+      case "init":
+        console.log(pc.blue(`AgentSky init (${entry.sessionId})`));
+        break;
+      case "stdout":
+        console.log(entry.text);
+        break;
+      default:
+        console.log("text" in entry ? entry.text : JSON.stringify(entry));
+    }
+  }
+}

--- a/packages/adapters/agentsky-cloud/src/cli/index.ts
+++ b/packages/adapters/agentsky-cloud/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printAgentskyCloudEvent } from "./format-event.js";

--- a/packages/adapters/agentsky-cloud/src/index.ts
+++ b/packages/adapters/agentsky-cloud/src/index.ts
@@ -1,0 +1,39 @@
+import { renderAgentskyModelMatrix } from "./models.js";
+
+export const type = "agentsky_cloud";
+export const label = "AgentSky";
+
+export const agentConfigurationDoc = `# agentsky_cloud agent configuration
+
+Adapter: agentsky_cloud
+
+Use when:
+- You want Paperclip to drive a long-lived AgentSky cloud agent (agentsky.dev)
+- You want a persistent remote agent with its own filesystem, memory, and context
+- You want Paperclip to keep task state while AgentSky hosts the execution surface
+
+Core fields:
+- harness (string, optional, default "claude_code"): claude_code | codex | openclaw | hermes
+- model (string, optional): must be compatible with the chosen harness; omit for the harness default:
+${renderAgentskyModelMatrix()}
+- agentSlug (string, optional): attach to a pre-existing AgentSky agent instead of auto-creating
+  one; harness and model above are then ignored (the existing agent already has both)
+- apiBaseUrl (string, optional, default "https://agentsky.dev"): override only for staging or
+  self-hosted AgentSky
+- instructionsFilePath (string, optional): agent instructions file prepended to the prompt
+- promptTemplate (string, optional): heartbeat prompt template
+- bootstrapPromptTemplate (string, optional): first-run-only bootstrap prompt template
+- timeoutSec (number, optional, default 3600): max seconds to wait for the agent's turn
+- env.AGENTSKY_API_TOKEN (string, required): AgentSky API token (ast_...)
+
+Notes:
+- There is no repoUrl: the AgentSky pod has a persistent filesystem. Name any repository the
+  agent should work on directly in the prompt or goal text.
+- The first heartbeat auto-creates an AgentSky agent + session with the configured harness/model
+  and persists them; changing harness, model, or agentSlug provisions a fresh one.
+- PAPERCLIP_* runtime values are delivered as a text note inside the wake prompt, not as
+  environment variables in the agent's shell.
+- The agent's final message each turn is the run report Paperclip records.
+- Billing rides the AgentSky account's credits; an exhausted balance surfaces as a run failure
+  with error code insufficient_credits.
+`;

--- a/packages/adapters/agentsky-cloud/src/models.ts
+++ b/packages/adapters/agentsky-cloud/src/models.ts
@@ -1,0 +1,62 @@
+export const AGENTSKY_HARNESSES = ["claude_code", "codex", "openclaw", "hermes"] as const;
+
+export type AgentskyHarness = (typeof AGENTSKY_HARNESSES)[number];
+
+export const AGENTSKY_HARNESS_LABELS: Record<AgentskyHarness, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  openclaw: "OpenClaw",
+  hermes: "Hermes",
+};
+
+/**
+ * AgentSky harness → selectable model ids. First entry is the harness default.
+ * AgentSky has no public model-listing API; this mirrors its creation menu.
+ */
+export const AGENTSKY_MODELS: Record<AgentskyHarness, readonly string[]> = {
+  claude_code: ["claude-opus-5", "claude-fable-5", "claude-sonnet-4-6", "kimi-k3"],
+  codex: ["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra"],
+  openclaw: [
+    "gpt-5.6-sol",
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "gemini-3.5-flash",
+    "glm-5.2",
+    "kimi-k3",
+  ],
+  hermes: [
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "gpt-5.6-sol",
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gemini-3.5-flash",
+    "glm-5.2",
+    "kimi-k3",
+  ],
+};
+
+export const DEFAULT_AGENTSKY_HARNESS: AgentskyHarness = "claude_code";
+
+export const DEFAULT_AGENTSKY_API_BASE_URL = "https://agentsky.dev";
+
+export function isAgentskyHarness(value: string): value is AgentskyHarness {
+  return (AGENTSKY_HARNESSES as readonly string[]).includes(value);
+}
+
+export function defaultAgentskyModel(harness: AgentskyHarness): string {
+  return AGENTSKY_MODELS[harness][0];
+}
+
+export function isAgentskyModelCompatible(harness: AgentskyHarness, model: string): boolean {
+  return AGENTSKY_MODELS[harness].includes(model);
+}
+
+export function renderAgentskyModelMatrix(): string {
+  return AGENTSKY_HARNESSES.map((harness) => {
+    const [first, ...rest] = AGENTSKY_MODELS[harness];
+    return `  - ${harness}: ${[`${first} (default)`, ...rest].join(", ")}`;
+  }).join("\n");
+}

--- a/packages/adapters/agentsky-cloud/src/server/agentsky-api.ts
+++ b/packages/adapters/agentsky-cloud/src/server/agentsky-api.ts
@@ -1,0 +1,160 @@
+export type AgentskyEventEnvelope = {
+  id: string;
+  type: string;
+  sessionId?: string;
+  agent?: string;
+  at?: string;
+  [key: string]: unknown;
+};
+
+export type AgentskyEventsPage = {
+  events: AgentskyEventEnvelope[];
+  cursor: string | null;
+  hasMore: boolean;
+};
+
+export type AgentskyAgentSummary = {
+  slug: string;
+  agentType?: string;
+  llm?: string;
+  archived?: boolean;
+  displayName?: string;
+};
+
+export class AgentskyApiError extends Error {
+  status: number;
+  code: string | null;
+  retryAfterSec: number | null;
+
+  constructor(input: { status: number; code: string | null; message: string; retryAfterSec?: number | null }) {
+    super(input.message);
+    this.name = "AgentskyApiError";
+    this.status = input.status;
+    this.code = input.code;
+    this.retryAfterSec = input.retryAfterSec ?? null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+async function readError(response: Response): Promise<AgentskyApiError> {
+  let code: string | null = null;
+  let message = `AgentSky API responded ${response.status}`;
+  try {
+    const body = asRecord(await response.json());
+    const error = asRecord(body?.error);
+    if (error) {
+      if (typeof error.code === "string" && error.code) code = error.code;
+      if (typeof error.message === "string" && error.message) message = error.message;
+    }
+  } catch {
+    // Non-JSON error body; keep the status message.
+  }
+  const retryAfterRaw = response.headers.get("retry-after");
+  const retryAfterSec = retryAfterRaw && /^\d+$/.test(retryAfterRaw.trim()) ? Number(retryAfterRaw.trim()) : null;
+  return new AgentskyApiError({ status: response.status, code, message, retryAfterSec });
+}
+
+export type AgentskyClient = {
+  whoami(): Promise<{ email: string | null; universe: string | null; scopes: string[] }>;
+  getAgent(slug: string): Promise<AgentskyAgentSummary>;
+  createAgent(input: {
+    name: string;
+    displayName?: string;
+    agentType: string;
+    llm: string;
+    description?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<AgentskyAgentSummary>;
+  createSession(input: { agent: string; title?: string; metadata?: Record<string, unknown> }): Promise<{ id: string }>;
+  sendMessage(sessionId: string, text: string): Promise<void>;
+  listEvents(sessionId: string, cursor: string | null, limit: number): Promise<AgentskyEventsPage>;
+};
+
+export function createAgentskyClient(input: { baseUrl: string; token: string }): AgentskyClient {
+  const baseUrl = input.baseUrl.replace(/\/+$/, "");
+
+  async function request(method: string, path: string, body?: unknown): Promise<unknown> {
+    const response = await fetch(`${baseUrl}/api/v1${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${input.token}`,
+        ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    if (!response.ok) throw await readError(response);
+    if (response.status === 202 || response.status === 204) return null;
+    try {
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+
+  function readAgent(body: unknown): AgentskyAgentSummary {
+    const agent = asRecord(asRecord(body)?.agent);
+    const slug = typeof agent?.slug === "string" ? agent.slug : "";
+    if (!slug) throw new AgentskyApiError({ status: 0, code: null, message: "AgentSky API returned no agent slug." });
+    return {
+      slug,
+      agentType: typeof agent?.agentType === "string" ? agent.agentType : undefined,
+      llm: typeof agent?.llm === "string" ? agent.llm : undefined,
+      archived: agent?.archived === true,
+      displayName: typeof agent?.displayName === "string" ? agent.displayName : undefined,
+    };
+  }
+
+  return {
+    async whoami() {
+      const body = asRecord(await request("GET", "/whoami"));
+      const user = asRecord(body?.user);
+      const universe = asRecord(body?.universe);
+      return {
+        email: typeof user?.email === "string" ? user.email : null,
+        universe: typeof universe?.slug === "string" ? universe.slug : null,
+        scopes: Array.isArray(body?.scopes) ? body.scopes.filter((s): s is string => typeof s === "string") : [],
+      };
+    },
+    async getAgent(slug) {
+      return readAgent(await request("GET", `/agents/${encodeURIComponent(slug)}`));
+    },
+    async createAgent(body) {
+      return readAgent(await request("POST", "/agents", body));
+    },
+    async createSession(body) {
+      const parsed = asRecord(asRecord(await request("POST", "/sessions", body))?.session);
+      const id = typeof parsed?.id === "string" ? parsed.id : "";
+      if (!id) throw new AgentskyApiError({ status: 0, code: null, message: "AgentSky API returned no session id." });
+      return { id };
+    },
+    async sendMessage(sessionId, text) {
+      await request("POST", `/sessions/${encodeURIComponent(sessionId)}/messages`, {
+        parts: [{ type: "text", index: 0, text }],
+      });
+    },
+    async listEvents(sessionId, cursor, limit) {
+      const params = new URLSearchParams();
+      if (cursor) params.set("cursor", cursor);
+      params.set("limit", String(limit));
+      const body = asRecord(
+        await request("GET", `/sessions/${encodeURIComponent(sessionId)}/events?${params.toString()}`),
+      );
+      const events = Array.isArray(body?.events)
+        ? body.events
+            .map((entry) => asRecord(entry))
+            .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+            .filter((entry): entry is AgentskyEventEnvelope =>
+              typeof entry.id === "string" && typeof entry.type === "string")
+        : [];
+      return {
+        events,
+        cursor: typeof body?.cursor === "string" ? body.cursor : null,
+        hasMore: body?.hasMore === true,
+      };
+    },
+  };
+}

--- a/packages/adapters/agentsky-cloud/src/server/execute.test.ts
+++ b/packages/adapters/agentsky-cloud/src/server/execute.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { execute } from "./execute.js";
+
+type RouteResult = { status: number; body?: unknown; headers?: Record<string, string> };
+type Router = (method: string, path: string, body: unknown, callIndex: number) => RouteResult;
+
+type RecordedCall = { method: string; path: string; search: string; body: unknown };
+
+function installFetchRouter(router: Router): RecordedCall[] {
+  const calls: RecordedCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: { method?: string; body?: string }) => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(init.body) : undefined;
+      const index = calls.length;
+      calls.push({ method, path: url.pathname, search: url.search, body });
+      const result = router(method, url.pathname, body, index);
+      return new Response(result.body !== undefined ? JSON.stringify(result.body) : null, {
+        status: result.status,
+        headers: result.headers,
+      });
+    }),
+  );
+  return calls;
+}
+
+function apiEvent(id: string, type: string, extra: Record<string, unknown> = {}) {
+  return { id, type, sessionId: "sess-1", agent: "slug-1", at: "2026-01-01T00:00:00.000Z", ...extra };
+}
+
+function eventsPage(events: unknown[], cursor: string | null, hasMore = false): RouteResult {
+  return { status: 200, body: { events, cursor, hasMore } };
+}
+
+const CREATED_AGENT: RouteResult = {
+  status: 200,
+  body: { agent: { slug: "slug-1", agentType: "claude_code", llm: "claude-opus-5", archived: false } },
+};
+const CREATED_SESSION: RouteResult = { status: 200, body: { session: { id: "sess-1" } } };
+
+function happyTurnEvents(): unknown[] {
+  return [
+    apiEvent("m1", "user.message", { text: "ignored-echo", channel: "api" }),
+    apiEvent("t1#accepted", "turn.accepted"),
+    apiEvent("m2#0", "agent.reasoning", { part: { text: "thinking hard" } }),
+    apiEvent("m2#1", "agent.tool_use", { part: { tool_name: "bash", args: { cmd: "ls" } } }),
+    apiEvent("m2", "agent.message", { text: "All done\nWith detail" }),
+    apiEvent("t1#idle", "turn.status_idle", { stop_reason: "end_turn" }),
+  ];
+}
+
+function createContext(
+  overrides: Partial<AdapterExecutionContext> = {},
+): AdapterExecutionContext & { logs: Array<{ stream: string; chunk: string }> } {
+  const logs: Array<{ stream: string; chunk: string }> = [];
+  const base: AdapterExecutionContext = {
+    runId: "run-heartbeat-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "AgentSky Agent",
+      adapterType: "agentsky_cloud",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: {
+      env: { AGENTSKY_API_TOKEN: "ast_test_token" },
+      promptTemplate: "Do the work for {{agent.name}}",
+    },
+    context: { taskId: "issue-1", issueId: "issue-1", wakeReason: "issue_commented" },
+    onLog: async (stream, chunk) => {
+      logs.push({ stream, chunk });
+    },
+    ...overrides,
+  };
+  return Object.assign(base, { logs });
+}
+
+function stdoutEventTypes(logs: Array<{ stream: string; chunk: string }>): string[] {
+  return logs
+    .filter((entry) => entry.stream === "stdout")
+    .map((entry) => {
+      try {
+        return String(JSON.parse(entry.chunk).type);
+      } catch {
+        return "raw";
+      }
+    });
+}
+
+const MATCHING_SESSION_PARAMS = {
+  agentSlug: "slug-1",
+  sessionId: "sess-1",
+  harness: "claude_code",
+  model: "claude-opus-5",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("agentsky_cloud execute", () => {
+  it("creates an agent + session on first run and completes the turn", async () => {
+    const calls = installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") return CREATED_AGENT;
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        return isBaseline ? eventsPage([], null) : eventsPage(happyTurnEvents(), "c2");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const ctx = createContext();
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.provider).toBe("agentsky");
+    expect(result.biller).toBe("agentsky");
+    expect(result.billingType).toBe("api");
+    expect(result.model).toBe("claude-opus-5");
+    expect(result.summary).toBe("All done");
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.sessionParams).toMatchObject({ ...MATCHING_SESSION_PARAMS, lastEventCursor: "c2" });
+    expect(result.resultJson).toMatchObject({ status: "finished", stopReason: "end_turn" });
+
+    const createAgentCall = calls.find((c) => c.method === "POST" && c.path === "/api/v1/agents");
+    expect(createAgentCall?.body).toMatchObject({ agentType: "claude_code", llm: "claude-opus-5" });
+    const messageCall = calls.find((c) => c.path === "/api/v1/sessions/sess-1/messages");
+    expect(messageCall?.body).toMatchObject({ parts: [{ type: "text", index: 0 }] });
+
+    const types = stdoutEventTypes(ctx.logs);
+    expect(types[0]).toBe("agentsky_cloud.init");
+    expect(types).toContain("agentsky_cloud.message");
+    expect(types[types.length - 1]).toBe("agentsky_cloud.result");
+    const resultLine = JSON.parse(ctx.logs.filter((l) => l.stream === "stdout").at(-1)!.chunk);
+    expect(resultLine.status).toBe("finished");
+    expect(resultLine.result).toBe("All done\nWith detail");
+  });
+
+  it("reuses a matching persisted session without creating anything", async () => {
+    const calls = installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        return isBaseline ? eventsPage([], "c1") : eventsPage(happyTurnEvents(), "c2");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const ctx = createContext({
+      runtime: {
+        sessionId: "sess-1",
+        sessionParams: { ...MATCHING_SESSION_PARAMS, lastEventCursor: "c0" },
+        sessionDisplayId: "sess-1",
+        taskKey: null,
+      },
+    });
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(calls.some((c) => c.method === "POST" && c.path === "/api/v1/agents")).toBe(false);
+    expect(calls.some((c) => c.method === "POST" && c.path === "/api/v1/sessions")).toBe(false);
+    const baselineCall = calls.find((c) => c.path.endsWith("/events"));
+    expect(baselineCall?.search).toContain("cursor=c0");
+  });
+
+  it("provisions a fresh agent when the configured harness changed", async () => {
+    const calls = installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") {
+        return {
+          status: 200,
+          body: { agent: { slug: "slug-2", agentType: "codex", llm: "gpt-5.6-sol", archived: false } },
+        };
+      }
+      if (method === "POST" && path === "/api/v1/sessions") return { status: 200, body: { session: { id: "sess-2" } } };
+      if (method === "POST" && path === "/api/v1/sessions/sess-2/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-2/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        const events = [
+          apiEvent("m1", "user.message", { channel: "api" }),
+          apiEvent("t9#accepted", "turn.accepted"),
+          apiEvent("m3", "agent.message", { text: "ok" }),
+          apiEvent("t9#idle", "turn.status_idle"),
+        ];
+        return isBaseline ? eventsPage([], null) : eventsPage(events, "c9");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const ctx = createContext({
+      config: { env: { AGENTSKY_API_TOKEN: "ast_test_token" }, harness: "codex" },
+      runtime: {
+        sessionId: "sess-1",
+        sessionParams: MATCHING_SESSION_PARAMS,
+        sessionDisplayId: "sess-1",
+        taskKey: null,
+      },
+    });
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(calls.some((c) => c.method === "POST" && c.path === "/api/v1/agents")).toBe(true);
+    expect(result.sessionParams).toMatchObject({ agentSlug: "slug-2", sessionId: "sess-2", harness: "codex" });
+  });
+
+  it("attaches to an existing agent via agentSlug without creating one", async () => {
+    const calls = installFetchRouter((method, path) => {
+      if (method === "GET" && path === "/api/v1/agents/existing-agent") {
+        return {
+          status: 200,
+          body: { agent: { slug: "existing-agent", agentType: "openclaw", llm: "gpt-5.6-sol", archived: false } },
+        };
+      }
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        return isBaseline ? eventsPage([], null) : eventsPage(happyTurnEvents(), "c2");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const ctx = createContext({
+      config: { env: { AGENTSKY_API_TOKEN: "ast_test_token" }, agentSlug: "existing-agent" },
+    });
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(calls.some((c) => c.method === "POST" && c.path === "/api/v1/agents")).toBe(false);
+    expect(result.sessionParams).toMatchObject({
+      agentSlug: "existing-agent",
+      harness: "openclaw",
+      model: "gpt-5.6-sol",
+      attached: true,
+    });
+  });
+
+  it("ignores a stale idle event from a turn that predates the wake message", async () => {
+    const events = [
+      apiEvent("t0#idle", "turn.status_idle", { stop_reason: "end_turn" }),
+      apiEvent("m1", "user.message", { channel: "api" }),
+      apiEvent("t1#accepted", "turn.accepted"),
+      apiEvent("m2", "agent.message", { text: "our result" }),
+      apiEvent("t1#idle", "turn.status_idle", { stop_reason: "end_turn" }),
+    ];
+    const calls = installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") return CREATED_AGENT;
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        return isBaseline ? eventsPage([], null) : eventsPage(events, "c2");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const result = await execute(createContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("our result");
+  });
+
+  it("fails without AGENTSKY_API_TOKEN", async () => {
+    installFetchRouter(() => ({ status: 500 }));
+    const result = await execute(createContext({ config: { env: {} } }));
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("AGENTSKY_API_TOKEN");
+  });
+
+  it("fails on a harness-incompatible model without calling the API", async () => {
+    const calls = installFetchRouter(() => ({ status: 500 }));
+    const result = await execute(
+      createContext({
+        config: { env: { AGENTSKY_API_TOKEN: "ast_test_token" }, harness: "codex", model: "claude-opus-5" },
+      }),
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("not compatible");
+    expect(calls.length).toBe(0);
+  });
+
+  it("maps 402 on send to insufficient_credits and preserves the session", async () => {
+    installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") return CREATED_AGENT;
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") return eventsPage([], null);
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") {
+        return { status: 402, body: { error: { code: "insufficient_credits", message: "wallet empty" } } };
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const result = await execute(createContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("insufficient_credits");
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.clearSession).toBe(false);
+    expect(result.sessionParams).toMatchObject({ agentSlug: "slug-1", sessionId: "sess-1" });
+  });
+
+  it("returns a failure and keeps the session when the turn is interrupted", async () => {
+    const events = [
+      apiEvent("m1", "user.message", { channel: "api" }),
+      apiEvent("t1#accepted", "turn.accepted"),
+      apiEvent("t1#interrupted", "turn.interrupted"),
+    ];
+    const calls = installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") return CREATED_AGENT;
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        return isBaseline ? eventsPage([], null) : eventsPage(events, "c2");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const result = await execute(createContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("interrupted");
+    expect(result.clearSession).toBe(false);
+    expect(result.sessionParams).toMatchObject({ sessionId: "sess-1" });
+  });
+
+  it("clears the session when the remote session is deleted", async () => {
+    const events = [
+      apiEvent("m1", "user.message", { channel: "api" }),
+      apiEvent("s1", "session.deleted"),
+    ];
+    const calls = installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") return CREATED_AGENT;
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") {
+        const isBaseline = calls.filter((c) => c.path.endsWith("/events")).length === 1;
+        return isBaseline ? eventsPage([], null) : eventsPage(events, "c2");
+      }
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const result = await execute(createContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.clearSession).toBe(true);
+    expect(result.sessionParams).toBeNull();
+  });
+
+  it("times out when the turn never completes, preserving the session", async () => {
+    vi.useFakeTimers();
+    installFetchRouter((method, path) => {
+      if (method === "POST" && path === "/api/v1/agents") return CREATED_AGENT;
+      if (method === "POST" && path === "/api/v1/sessions") return CREATED_SESSION;
+      if (method === "POST" && path === "/api/v1/sessions/sess-1/messages") return { status: 202 };
+      if (method === "GET" && path === "/api/v1/sessions/sess-1/events") return eventsPage([], null);
+      return { status: 404, body: { error: { code: "not_found", message: "no route" } } };
+    });
+
+    const resultPromise = execute(
+      createContext({ config: { env: { AGENTSKY_API_TOKEN: "ast_test_token" }, timeoutSec: 60 } }),
+    );
+    let settled = false;
+    const tracked = resultPromise.then((value) => {
+      settled = true;
+      return value;
+    });
+    for (let i = 0; i < 100 && !settled; i += 1) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    const result = await tracked;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBe(1);
+    expect(result.clearSession).toBe(false);
+    expect(result.sessionParams).toMatchObject({ sessionId: "sess-1" });
+  });
+});

--- a/packages/adapters/agentsky-cloud/src/server/execute.ts
+++ b/packages/adapters/agentsky-cloud/src/server/execute.ts
@@ -1,0 +1,703 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+  AdapterInvocationMeta,
+} from "@paperclipai/adapter-utils";
+import {
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  asNumber,
+  asString,
+  buildPaperclipEnv,
+  isPaperclipRecoveryWakePayload,
+  joinPromptSections,
+  parseObject,
+  readPaperclipIssueWorkModeFromContext,
+  renderPaperclipWakePrompt,
+  renderTemplate,
+  stringifyPaperclipWakePayload,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  DEFAULT_AGENTSKY_API_BASE_URL,
+  DEFAULT_AGENTSKY_HARNESS,
+  AGENTSKY_MODELS,
+  defaultAgentskyModel,
+  isAgentskyHarness,
+  isAgentskyModelCompatible,
+  AGENTSKY_HARNESSES,
+} from "../models.js";
+import { AgentskyApiError, createAgentskyClient, type AgentskyClient, type AgentskyEventEnvelope } from "./agentsky-api.js";
+import { normalizeAgentskySession, type AgentskyCloudSession } from "./session.js";
+
+const POLL_INTERVAL_MS = 1500;
+const EVENTS_PAGE_LIMIT = 200;
+const MAX_CONSECUTIVE_POLL_FAILURES = 5;
+const ERROR_EVENT_GRACE_MS = 60_000;
+
+type AgentskyCloudStdoutEvent =
+  | { type: "agentsky_cloud.init"; sessionId: string; agentSlug: string; harness: string; model: string }
+  | { type: "agentsky_cloud.status"; status: string; message?: string }
+  | { type: "agentsky_cloud.message"; event: AgentskyEventEnvelope }
+  | {
+      type: "agentsky_cloud.result";
+      status: string;
+      result?: string;
+      model?: string;
+      durationMs?: number;
+      error?: string;
+    };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asStringEnvMap(value: unknown): Record<string, string> {
+  const parsed = parseObject(value);
+  const env: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (typeof entry === "string") {
+      env[key] = entry;
+    } else if (typeof entry === "object" && entry !== null && !Array.isArray(entry)) {
+      const rec = entry as Record<string, unknown>;
+      if (rec.type === "plain" && typeof rec.value === "string") env[key] = rec.value;
+    }
+  }
+  return env;
+}
+
+function trimNullable(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function eventLine(event: AgentskyCloudStdoutEvent): string {
+  return `${JSON.stringify(event)}\n`;
+}
+
+async function emitStatus(onLog: AdapterExecutionContext["onLog"], status: string, message?: string) {
+  await onLog("stdout", eventLine({ type: "agentsky_cloud.status", status, ...(message ? { message } : {}) }));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** A deterministic-but-unique AgentSky agent name derived from the Paperclip agent. */
+function agentskyAgentName(paperclipAgentName: string): string {
+  const base = paperclipAgentName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40) || "agent";
+  return `paperclip-${base}-${Date.now().toString(36)}`;
+}
+
+function buildPaperclipRuntimeValues(ctx: AdapterExecutionContext): Record<string, string> {
+  const { runId, agent, context } = ctx;
+  const values: Record<string, string> = {
+    ...buildPaperclipEnv(agent),
+    PAPERCLIP_RUN_ID: runId,
+  };
+  // The AgentSky message plane has no env-injection surface, so these are
+  // rendered into the prompt. Credentials never belong there: the Paperclip
+  // run token is not minted for this adapter (supportsLocalAgentJwt: false)
+  // and the AgentSky token is stripped defensively.
+  delete values.PAPERCLIP_API_KEY;
+  delete values.AGENTSKY_API_TOKEN;
+
+  const wakeTaskId = trimNullable(context.taskId) ?? trimNullable(context.issueId);
+  const wakeReason = trimNullable(context.wakeReason);
+  const wakeCommentId = trimNullable(context.wakeCommentId) ?? trimNullable(context.commentId);
+  const approvalId = trimNullable(context.approvalId);
+  const approvalStatus = trimNullable(context.approvalStatus);
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  const issueWorkMode = readPaperclipIssueWorkModeFromContext(context);
+
+  if (wakeTaskId) values.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (wakeReason) values.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) values.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) values.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) values.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) values.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (wakePayloadJson) values.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+  if (issueWorkMode) values.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
+  return values;
+}
+
+function renderPaperclipRuntimeNote(values: Record<string, string>): string {
+  const keys = Object.keys(values)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (keys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    "You are driven by a Paperclip orchestrator. The following runtime values apply to this wake",
+    "(they are NOT set as environment variables in your shell):",
+    ...keys.map((key) => `${key}=${values[key]}`),
+    "Your final message in this turn is returned to Paperclip as this run's report.",
+  ].join("\n");
+}
+
+async function buildInstructionsPrefix(
+  config: Record<string, unknown>,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<{ prefix: string; notes: string[]; chars: number }> {
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  if (!instructionsFilePath) {
+    return { prefix: "", notes: [], chars: 0 };
+  }
+
+  try {
+    const contents = await fs.readFile(instructionsFilePath, "utf8");
+    const instructionsDir = `${path.dirname(instructionsFilePath)}/`;
+    const prefix = `${contents.trim()}\n\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsDir}.\n`;
+    return {
+      prefix,
+      chars: prefix.length,
+      notes: [
+        `Loaded agent instructions from ${instructionsFilePath}`,
+        `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
+      ],
+    };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    await onLog(
+      "stderr",
+      `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+    );
+    return {
+      prefix: "",
+      chars: 0,
+      notes: [
+        `Configured instructionsFilePath ${instructionsFilePath}, but file could not be read; continuing without injected instructions.`,
+      ],
+    };
+  }
+}
+
+function sessionMatches(
+  session: AgentskyCloudSession | null,
+  resolved: { agentSlugConfig: string | null; harness: string; model: string; apiBaseUrl: string },
+): boolean {
+  if (!session) return false;
+  if ((session.apiBaseUrl ?? DEFAULT_AGENTSKY_API_BASE_URL) !== resolved.apiBaseUrl) return false;
+  if (resolved.agentSlugConfig) {
+    return session.attached === true && session.agentSlug === resolved.agentSlugConfig;
+  }
+  return session.attached !== true && session.harness === resolved.harness && session.model === resolved.model;
+}
+
+type FailureOverrides = Partial<AdapterExecutionResult> & { errorMessage: string };
+
+function failure(session: AgentskyCloudSession | null, overrides: FailureOverrides): AdapterExecutionResult {
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    sessionId: session?.sessionId ?? null,
+    sessionDisplayId: session?.sessionId ?? null,
+    sessionParams: session,
+    provider: "agentsky",
+    biller: "agentsky",
+    billingType: "api",
+    costUsd: null,
+    clearSession: false,
+    ...overrides,
+  };
+}
+
+function failureFromApiError(
+  err: unknown,
+  session: AgentskyCloudSession | null,
+  phase: string,
+): AdapterExecutionResult {
+  if (err instanceof AgentskyApiError) {
+    if (err.status === 402 || err.code === "insufficient_credits") {
+      return failure(session, {
+        errorMessage: `AgentSky credits exhausted while ${phase}: ${err.message}`,
+        errorCode: "insufficient_credits",
+        errorFamily: "provider_quota",
+      });
+    }
+    if (err.status === 429) {
+      const retrySec = Math.min(err.retryAfterSec ?? 30, 300);
+      return failure(session, {
+        errorMessage: `AgentSky API rate-limited while ${phase}: ${err.message}`,
+        errorFamily: "transient_upstream",
+        retryNotBefore: new Date(Date.now() + retrySec * 1000).toISOString(),
+      });
+    }
+    if (session && (err.status === 404 || err.status === 409 || err.status === 410)) {
+      // The remote session/agent is gone (deleted, archived, or masked by
+      // authorization). Drop the persisted identity so the next heartbeat
+      // re-provisions instead of failing forever.
+      return failure(session, {
+        errorMessage: `AgentSky session ${session.sessionId} is no longer reachable while ${phase} (${err.message}); it will be re-provisioned on the next heartbeat.`,
+        sessionParams: null,
+        clearSession: true,
+      });
+    }
+    return failure(session, { errorMessage: `AgentSky API error while ${phase}: ${err.message}` });
+  }
+  const reason = err instanceof Error ? err.message : String(err);
+  return failure(session, {
+    errorMessage: `AgentSky request failed while ${phase}: ${reason}`,
+    errorFamily: "transient_upstream",
+  });
+}
+
+async function collectBaselineCursor(
+  client: AgentskyClient,
+  sessionId: string,
+  startCursor: string | null,
+): Promise<string | null> {
+  let cursor = startCursor;
+  for (;;) {
+    const page = await client.listEvents(sessionId, cursor, 500);
+    cursor = page.cursor ?? cursor;
+    if (!page.hasMore) return cursor;
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta } = ctx;
+  const startedAt = Date.now();
+
+  const envConfig = asStringEnvMap(config.env);
+  const apiToken = asString(envConfig.AGENTSKY_API_TOKEN, "").trim();
+  const priorSession = normalizeAgentskySession(runtime.sessionParams);
+  if (!apiToken) {
+    return failure(priorSession, { errorMessage: "AGENTSKY_API_TOKEN is required for agentsky_cloud." });
+  }
+
+  const agentSlugConfig = trimNullable(config.agentSlug);
+  const harness = asString(config.harness, "").trim() || DEFAULT_AGENTSKY_HARNESS;
+  if (!isAgentskyHarness(harness)) {
+    return failure(priorSession, {
+      errorMessage: `Unknown AgentSky harness "${harness}". Valid harnesses: ${AGENTSKY_HARNESSES.join(", ")}.`,
+    });
+  }
+  const model = asString(config.model, "").trim() || defaultAgentskyModel(harness);
+  if (!isAgentskyModelCompatible(harness, model)) {
+    return failure(priorSession, {
+      errorMessage: `Model "${model}" is not compatible with harness "${harness}". Valid models: ${AGENTSKY_MODELS[harness].join(", ")}.`,
+    });
+  }
+  const apiBaseUrl =
+    (asString(config.apiBaseUrl, "").trim() || DEFAULT_AGENTSKY_API_BASE_URL).replace(/\/+$/, "");
+  const timeoutSecRaw = asNumber(config.timeoutSec, 3600);
+  const timeoutSec = timeoutSecRaw <= 0 ? 3600 : Math.max(60, timeoutSecRaw);
+  const deadline = startedAt + timeoutSec * 1000;
+
+  const client = createAgentskyClient({ baseUrl: apiBaseUrl, token: apiToken });
+  const resolved = { agentSlugConfig, harness, model, apiBaseUrl };
+  const canReuseSession = sessionMatches(priorSession, resolved);
+
+  let session: AgentskyCloudSession;
+  if (canReuseSession && priorSession) {
+    session = priorSession;
+  } else {
+    try {
+      if (agentSlugConfig) {
+        const remote = await client.getAgent(agentSlugConfig);
+        if (remote.archived) {
+          return failure(priorSession, {
+            errorMessage: `AgentSky agent "${agentSlugConfig}" is archived and cannot start new sessions.`,
+          });
+        }
+        const created = await client.createSession({
+          agent: remote.slug,
+          title: `Paperclip ${agent.name}`.slice(0, 120),
+          metadata: { paperclipAgentId: agent.id, paperclipCompanyId: agent.companyId },
+        });
+        session = {
+          agentSlug: remote.slug,
+          sessionId: created.id,
+          harness: remote.agentType ?? harness,
+          model: remote.llm ?? model,
+          attached: true,
+          ...(apiBaseUrl !== DEFAULT_AGENTSKY_API_BASE_URL ? { apiBaseUrl } : {}),
+        };
+      } else {
+        const created = await client.createAgent({
+          name: agentskyAgentName(agent.name),
+          displayName: `Paperclip ${agent.name}`.slice(0, 60),
+          agentType: harness,
+          llm: model,
+          description: "Managed by Paperclip.",
+          metadata: { paperclipAgentId: agent.id, paperclipCompanyId: agent.companyId },
+        });
+        const createdSession = await client.createSession({
+          agent: created.slug,
+          title: `Paperclip ${agent.name}`.slice(0, 120),
+          metadata: { paperclipAgentId: agent.id, paperclipCompanyId: agent.companyId },
+        });
+        session = {
+          agentSlug: created.slug,
+          sessionId: createdSession.id,
+          harness,
+          model,
+          ...(apiBaseUrl !== DEFAULT_AGENTSKY_API_BASE_URL ? { apiBaseUrl } : {}),
+        };
+      }
+    } catch (err) {
+      return failureFromApiError(err, priorSession, "provisioning the AgentSky agent");
+    }
+  }
+
+  const instructions = await buildInstructionsPrefix(config, onLog);
+  const promptTemplate = asString(config.promptTemplate, DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE);
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: canReuseSession });
+  const renderedBootstrapPrompt =
+    !canReuseSession && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const renderedPrompt =
+    (canReuseSession && wakePrompt.length > 0) || isPaperclipRecoveryWakePayload(context.paperclipWake)
+      ? ""
+      : renderTemplate(promptTemplate, templateData).trim();
+  const runtimeNote = renderPaperclipRuntimeNote(buildPaperclipRuntimeValues(ctx));
+  const prompt = joinPromptSections([
+    instructions.prefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    runtimeNote,
+    renderedPrompt,
+  ]);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const finalPrompt = joinPromptSections([prompt, sessionHandoffNote]);
+
+  const commandNotes = [
+    ...instructions.notes,
+    canReuseSession
+      ? `Reusing AgentSky session ${session.sessionId} (agent ${session.agentSlug})`
+      : session.attached
+        ? `Created AgentSky session ${session.sessionId} on existing agent ${session.agentSlug}`
+        : `Created AgentSky agent ${session.agentSlug} (${session.harness} / ${session.model}) with session ${session.sessionId}`,
+    `AgentSky API: ${apiBaseUrl}`,
+  ];
+
+  if (onMeta) {
+    const meta: AdapterInvocationMeta = {
+      adapterType: "agentsky_cloud",
+      command: "agentsky /api/v1",
+      commandNotes,
+      prompt: finalPrompt,
+      promptMetrics: {
+        promptChars: finalPrompt.length,
+        instructionsChars: instructions.chars,
+        bootstrapPromptChars: renderedBootstrapPrompt.length,
+        wakePromptChars: wakePrompt.length,
+        heartbeatPromptChars: renderedPrompt.length,
+      },
+      context: {
+        agentskyCloud: {
+          harness: session.harness,
+          model: session.model,
+          agentSlug: session.agentSlug,
+          sessionId: session.sessionId,
+          apiBaseUrl,
+          canReuseSession,
+        },
+      },
+    };
+    await onMeta(meta);
+  }
+
+  await onLog(
+    "stdout",
+    eventLine({
+      type: "agentsky_cloud.init",
+      sessionId: session.sessionId,
+      agentSlug: session.agentSlug,
+      harness: session.harness,
+      model: session.model,
+    }),
+  );
+
+  // Baseline the events ledger BEFORE sending, so the poll loop only ever sees
+  // events that could belong to this turn. The ledger (not the live SSE
+  // stream) is the documented recovery surface, which is why this adapter
+  // polls /events instead of holding /stream open; an SSE hybrid would only
+  // shave latency a heartbeat does not need.
+  let cursor: string | null;
+  try {
+    cursor = await collectBaselineCursor(client, session.sessionId, session.lastEventCursor ?? null);
+  } catch (err) {
+    return failureFromApiError(err, session, "reading the session event ledger");
+  }
+
+  try {
+    try {
+      await client.sendMessage(session.sessionId, finalPrompt);
+    } catch (err) {
+      if (err instanceof AgentskyApiError && err.status === 429) {
+        await sleep(Math.min(err.retryAfterSec ?? 5, 30) * 1000);
+        await client.sendMessage(session.sessionId, finalPrompt);
+      } else {
+        throw err;
+      }
+    }
+  } catch (err) {
+    return failureFromApiError(err, session, "sending the wake message");
+  }
+  await emitStatus(onLog, "running", `Sent wake message to AgentSky session ${session.sessionId}.`);
+
+  let echoSeen = false;
+  let ourTurnHash: string | null = null;
+  let finished = false;
+  let interrupted = false;
+  let sessionDeleted = false;
+  let stopReason: string | null = null;
+  let lastMessageText = "";
+  const errorEvents: string[] = [];
+  let lastErrorAt: number | null = null;
+  let consecutivePollFailures = 0;
+  let timedOut = false;
+
+  const emitApiEvent = async (event: AgentskyEventEnvelope) => {
+    await onLog("stdout", eventLine({ type: "agentsky_cloud.message", event }));
+  };
+
+  while (!finished && !interrupted && !sessionDeleted && !timedOut) {
+    if (Date.now() >= deadline) {
+      timedOut = true;
+      break;
+    }
+
+    let page;
+    try {
+      page = await client.listEvents(session.sessionId, cursor, EVENTS_PAGE_LIMIT);
+      consecutivePollFailures = 0;
+    } catch (err) {
+      if (err instanceof AgentskyApiError && (err.status === 404 || err.status === 410)) {
+        return failureFromApiError(err, session, "polling the session event ledger");
+      }
+      consecutivePollFailures += 1;
+      if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+        return failure(session, {
+          errorMessage: `AgentSky event polling failed ${consecutivePollFailures} times in a row: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          errorFamily: "transient_upstream",
+        });
+      }
+      const backoffMs =
+        err instanceof AgentskyApiError && err.status === 429 && err.retryAfterSec
+          ? Math.min(err.retryAfterSec, 30) * 1000
+          : Math.min(1000 * 2 ** (consecutivePollFailures - 1), 30_000);
+      await sleep(backoffMs);
+      continue;
+    }
+
+    for (const event of page.events) {
+      const eventTurnHash = event.id.includes("#") ? event.id.split("#")[0] : null;
+      switch (event.type) {
+        case "user.message": {
+          if (!echoSeen) {
+            const text = typeof event.text === "string" ? event.text : "";
+            const channel = typeof event.channel === "string" ? event.channel : "";
+            if (text === finalPrompt || channel === "api" || channel === "") echoSeen = true;
+          }
+          await emitApiEvent(event);
+          break;
+        }
+        case "turn.accepted": {
+          if (echoSeen && !ourTurnHash) {
+            ourTurnHash = eventTurnHash;
+            await emitStatus(onLog, "running", "AgentSky accepted the turn.");
+          }
+          break;
+        }
+        case "turn.status_idle": {
+          const matchesOurTurn = ourTurnHash
+            ? eventTurnHash === ourTurnHash
+            : echoSeen; // Fallback when the accepted event was not observed.
+          if (matchesOurTurn) {
+            finished = true;
+            stopReason = trimNullable(event.stop_reason);
+          }
+          break;
+        }
+        case "turn.interrupted": {
+          const matchesOurTurn = ourTurnHash ? eventTurnHash === ourTurnHash : echoSeen;
+          if (matchesOurTurn) interrupted = true;
+          break;
+        }
+        case "session.deleted": {
+          sessionDeleted = true;
+          break;
+        }
+        case "session.updated": {
+          break;
+        }
+        case "error": {
+          const message =
+            trimNullable(event.message) ?? trimNullable(event.code) ?? "AgentSky reported an unknown error.";
+          errorEvents.push(message);
+          lastErrorAt = Date.now();
+          await onLog("stderr", `[agentsky] ${message}\n`);
+          break;
+        }
+        case "agent.message": {
+          const text = typeof event.text === "string" ? event.text : "";
+          if (ourTurnHash !== null || echoSeen) {
+            if (text.trim().length > 0) lastMessageText = text;
+          }
+          await emitApiEvent(event);
+          break;
+        }
+        case "agent.reasoning":
+        case "agent.tool_use":
+        case "agent.tool_result":
+        case "agent.status": {
+          await emitApiEvent(event);
+          break;
+        }
+        default:
+          break;
+      }
+      if (finished || interrupted || sessionDeleted) break;
+    }
+    cursor = page.cursor ?? cursor;
+
+    if (finished || interrupted || sessionDeleted) break;
+    if (
+      lastErrorAt !== null &&
+      Date.now() - lastErrorAt >= ERROR_EVENT_GRACE_MS &&
+      errorEvents.length > 0
+    ) {
+      return failure(
+        { ...session, lastEventCursor: cursor ?? undefined },
+        {
+          errorMessage: `AgentSky reported an error and the turn did not complete: ${errorEvents[errorEvents.length - 1]}`,
+          errorFamily: "transient_upstream",
+        },
+      );
+    }
+    if (!page.hasMore) await sleep(POLL_INTERVAL_MS);
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const nextSession: AgentskyCloudSession = {
+    ...session,
+    ...(cursor ? { lastEventCursor: cursor } : {}),
+  };
+
+  if (sessionDeleted) {
+    await onLog(
+      "stdout",
+      eventLine({ type: "agentsky_cloud.result", status: "error", error: "AgentSky session was deleted." }),
+    );
+    return failure(null, {
+      errorMessage: `AgentSky session ${session.sessionId} was deleted; it will be re-provisioned on the next heartbeat.`,
+      sessionParams: null,
+      clearSession: true,
+      sessionId: session.sessionId,
+      sessionDisplayId: session.sessionId,
+    });
+  }
+
+  if (timedOut) {
+    // Deliberately no interrupt: the long-lived agent may still be doing
+    // useful work; the next wake resumes the same session.
+    await onLog(
+      "stdout",
+      eventLine({
+        type: "agentsky_cloud.result",
+        status: "timeout",
+        model: session.model,
+        durationMs,
+        error: `AgentSky turn did not complete within ${timeoutSec}s`,
+      }),
+    );
+    return {
+      ...failure(nextSession, {
+        errorMessage: `AgentSky turn did not complete within ${timeoutSec}s.`,
+      }),
+      timedOut: true,
+    };
+  }
+
+  if (interrupted) {
+    await onLog(
+      "stdout",
+      eventLine({
+        type: "agentsky_cloud.result",
+        status: "interrupted",
+        model: session.model,
+        durationMs,
+        error: "AgentSky turn interrupted",
+      }),
+    );
+    return failure(nextSession, {
+      errorMessage: "AgentSky turn was interrupted.",
+      resultJson: {
+        status: "interrupted",
+        agentSlug: session.agentSlug,
+        sessionId: session.sessionId,
+        harness: session.harness,
+        model: session.model,
+      },
+    });
+  }
+
+  await onLog(
+    "stdout",
+    eventLine({
+      type: "agentsky_cloud.result",
+      status: "finished",
+      ...(lastMessageText ? { result: lastMessageText } : {}),
+      model: session.model,
+      durationMs,
+    }),
+  );
+
+  return {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    sessionId: session.sessionId,
+    sessionDisplayId: session.sessionId,
+    sessionParams: nextSession,
+    provider: "agentsky",
+    biller: "agentsky",
+    billingType: "api",
+    model: session.model,
+    costUsd: null,
+    summary: lastMessageText ? firstNonEmptyLine(lastMessageText) : null,
+    resultJson: {
+      status: "finished",
+      agentSlug: session.agentSlug,
+      sessionId: session.sessionId,
+      harness: session.harness,
+      model: session.model,
+      ...(stopReason ? { stopReason } : {}),
+      ...(errorEvents.length > 0 ? { errors: errorEvents } : {}),
+    },
+    clearSession: false,
+  };
+}

--- a/packages/adapters/agentsky-cloud/src/server/index.ts
+++ b/packages/adapters/agentsky-cloud/src/server/index.ts
@@ -1,0 +1,63 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { sessionCodec } from "./session.js";
+
+import type { AdapterConfigSchema } from "@paperclipai/adapter-utils";
+import {
+  AGENTSKY_HARNESSES,
+  AGENTSKY_HARNESS_LABELS,
+  AGENTSKY_MODELS,
+  DEFAULT_AGENTSKY_API_BASE_URL,
+  DEFAULT_AGENTSKY_HARNESS,
+} from "../models.js";
+
+export function getConfigSchema(): AdapterConfigSchema {
+  return {
+    fields: [
+      {
+        key: "harness",
+        label: "Harness",
+        type: "select",
+        default: DEFAULT_AGENTSKY_HARNESS,
+        required: true,
+        options: AGENTSKY_HARNESSES.map((harness) => ({
+          value: harness,
+          label: AGENTSKY_HARNESS_LABELS[harness],
+        })),
+        hint: "AgentSky agent type provisioned for this Paperclip agent.",
+      },
+      {
+        key: "model",
+        label: "Model",
+        // combobox (not select): model ids repeat across harness groups, and
+        // the combobox renderer groups options so repeated values stay distinct.
+        type: "combobox",
+        default: "",
+        options: [
+          { value: "", label: "Harness default" },
+          ...AGENTSKY_HARNESSES.flatMap((harness) =>
+            AGENTSKY_MODELS[harness].map((model) => ({
+              value: model,
+              label: model,
+              group: AGENTSKY_HARNESS_LABELS[harness],
+            })),
+          ),
+        ],
+        hint: "Must be compatible with the chosen harness (options are grouped by harness). Leave empty for the harness default.",
+      },
+      {
+        key: "agentSlug",
+        label: "Existing agent slug",
+        type: "text",
+        hint: "Optional: attach to a pre-existing AgentSky agent instead of auto-creating one. Harness and model above are then ignored.",
+      },
+      {
+        key: "apiBaseUrl",
+        label: "API base URL",
+        type: "text",
+        default: DEFAULT_AGENTSKY_API_BASE_URL,
+        hint: "Override only for staging or self-hosted AgentSky.",
+      },
+    ],
+  };
+}

--- a/packages/adapters/agentsky-cloud/src/server/session.test.ts
+++ b/packages/adapters/agentsky-cloud/src/server/session.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAgentskySession, sessionCodec } from "./session.js";
+
+describe("agentsky_cloud session codec", () => {
+  it("round-trips a full session", () => {
+    const params = {
+      agentSlug: "slug-1",
+      sessionId: "sess-1",
+      harness: "claude_code",
+      model: "claude-opus-5",
+      apiBaseUrl: "https://staging.agentsky.dev",
+      lastEventCursor: "c42",
+      attached: true,
+    };
+    const serialized = sessionCodec.serialize(params);
+    expect(serialized).toEqual(params);
+    expect(sessionCodec.deserialize(serialized)).toEqual(params);
+  });
+
+  it("drops optional fields that are empty and defaults harness/model to empty strings", () => {
+    const normalized = normalizeAgentskySession({
+      agentSlug: " slug-1 ",
+      sessionId: "sess-1",
+      apiBaseUrl: "",
+      lastEventCursor: "  ",
+      attached: false,
+    });
+    expect(normalized).toEqual({
+      agentSlug: "slug-1",
+      sessionId: "sess-1",
+      harness: "",
+      model: "",
+    });
+  });
+
+  it("rejects params without a session id or agent slug", () => {
+    expect(sessionCodec.deserialize({ agentSlug: "slug-1" })).toBeNull();
+    expect(sessionCodec.deserialize({ sessionId: "sess-1" })).toBeNull();
+    expect(sessionCodec.deserialize(null)).toBeNull();
+    expect(sessionCodec.deserialize("sess-1")).toBeNull();
+  });
+
+  it("uses the session id as the display id", () => {
+    expect(
+      sessionCodec.getDisplayId?.({
+        agentSlug: "slug-1",
+        sessionId: "sess-1",
+        harness: "hermes",
+        model: "deepseek-v4-pro",
+      }),
+    ).toBe("sess-1");
+    expect(sessionCodec.getDisplayId?.(null)).toBeNull();
+  });
+});

--- a/packages/adapters/agentsky-cloud/src/server/session.ts
+++ b/packages/adapters/agentsky-cloud/src/server/session.ts
@@ -1,0 +1,54 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export type AgentskyCloudSession = {
+  agentSlug: string;
+  sessionId: string;
+  harness: string;
+  model: string;
+  apiBaseUrl?: string;
+  lastEventCursor?: string;
+  attached?: boolean;
+};
+
+export function normalizeAgentskySession(raw: unknown): AgentskyCloudSession | null {
+  const record = asRecord(raw);
+  if (!record) return null;
+  const sessionId = readString(record.sessionId);
+  const agentSlug = readString(record.agentSlug);
+  if (!sessionId || !agentSlug) return null;
+  const harness = readString(record.harness) ?? "";
+  const model = readString(record.model) ?? "";
+  const apiBaseUrl = readString(record.apiBaseUrl);
+  const lastEventCursor = readString(record.lastEventCursor);
+  return {
+    agentSlug,
+    sessionId,
+    harness,
+    model,
+    ...(apiBaseUrl ? { apiBaseUrl } : {}),
+    ...(lastEventCursor ? { lastEventCursor } : {}),
+    ...(record.attached === true ? { attached: true } : {}),
+  };
+}
+
+function normalize(raw: unknown): Record<string, unknown> | null {
+  return normalizeAgentskySession(raw);
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize: normalize,
+  serialize: normalize,
+  getDisplayId(params) {
+    const normalized = normalizeAgentskySession(params);
+    return normalized ? normalized.sessionId : null;
+  },
+};

--- a/packages/adapters/agentsky-cloud/src/server/test.ts
+++ b/packages/adapters/agentsky-cloud/src/server/test.ts
@@ -1,0 +1,207 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, buildPaperclipEnv, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import {
+  AGENTSKY_HARNESSES,
+  AGENTSKY_MODELS,
+  DEFAULT_AGENTSKY_API_BASE_URL,
+  DEFAULT_AGENTSKY_HARNESS,
+  defaultAgentskyModel,
+  isAgentskyHarness,
+  isAgentskyModelCompatible,
+} from "../models.js";
+import { AgentskyApiError, createAgentskyClient } from "./agentsky-api.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function asStringEnvMap(value: unknown): Record<string, string> {
+  const parsed = parseObject(value);
+  const env: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (typeof entry === "string") {
+      env[key] = entry;
+    } else if (typeof entry === "object" && entry !== null && !Array.isArray(entry)) {
+      const rec = entry as Record<string, unknown>;
+      if (rec.type === "plain" && typeof rec.value === "string") env[key] = rec.value;
+    }
+  }
+  return env;
+}
+
+function isLoopbackUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "0.0.0.0" ||
+      hostname === "::1" ||
+      hostname === "[::1]" ||
+      hostname.startsWith("127.")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const env = asStringEnvMap(config.env);
+  const apiToken = asString(env.AGENTSKY_API_TOKEN, "").trim();
+  const agentSlug = asString(config.agentSlug, "").trim();
+  const harness = asString(config.harness, "").trim() || DEFAULT_AGENTSKY_HARNESS;
+  const model = asString(config.model, "").trim();
+  const apiBaseUrl = asString(config.apiBaseUrl, "").trim() || DEFAULT_AGENTSKY_API_BASE_URL;
+
+  if (!apiToken) {
+    checks.push({
+      code: "agentsky_cloud_api_token_missing",
+      level: "error",
+      message: "AGENTSKY_API_TOKEN is required.",
+      hint: "Add AGENTSKY_API_TOKEN under environment variables for this adapter (mint one at agentsky.dev → Settings → API tokens).",
+    });
+  } else if (!apiToken.startsWith("ast_")) {
+    checks.push({
+      code: "agentsky_cloud_api_token_format",
+      level: "warn",
+      message: "AGENTSKY_API_TOKEN does not look like an AgentSky token (expected an ast_ prefix).",
+    });
+  }
+
+  let baseUrlValid = true;
+  try {
+    const parsed = new URL(apiBaseUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("not http(s)");
+  } catch {
+    baseUrlValid = false;
+    checks.push({
+      code: "agentsky_cloud_base_url_invalid",
+      level: "error",
+      message: "apiBaseUrl must be an http(s) URL.",
+      detail: apiBaseUrl,
+    });
+  }
+
+  if (!isAgentskyHarness(harness)) {
+    checks.push({
+      code: "agentsky_cloud_harness_invalid",
+      level: "error",
+      message: `Unknown harness "${harness}". Valid harnesses: ${AGENTSKY_HARNESSES.join(", ")}.`,
+    });
+  } else if (model && !isAgentskyModelCompatible(harness, model)) {
+    checks.push({
+      code: "agentsky_cloud_model_incompatible",
+      level: "error",
+      message: `Model "${model}" is not compatible with harness "${harness}". Valid models: ${AGENTSKY_MODELS[harness].join(", ")}.`,
+    });
+  } else if (!model) {
+    checks.push({
+      code: "agentsky_cloud_model_default",
+      level: "info",
+      message: `No model configured; the ${harness} default (${defaultAgentskyModel(harness)}) will be used.`,
+    });
+  }
+
+  if (apiToken && baseUrlValid) {
+    const client = createAgentskyClient({ baseUrl: apiBaseUrl, token: apiToken });
+    try {
+      const me = await client.whoami();
+      checks.push({
+        code: "agentsky_cloud_auth_ok",
+        level: "info",
+        message: "AgentSky API token is valid.",
+        detail: [
+          me.email ? `Authenticated as ${me.email}` : null,
+          me.universe ? `universe ${me.universe}` : null,
+          me.scopes.length > 0 ? `scopes: ${me.scopes.join(", ")}` : null,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+      });
+      if (me.scopes.length > 0 && !me.scopes.includes("write") && !me.scopes.includes("admin")) {
+        checks.push({
+          code: "agentsky_cloud_scope_missing",
+          level: "warn",
+          message: "The token lacks the write scope; agent/session creation and message sends will fail.",
+        });
+      }
+    } catch (err) {
+      checks.push({
+        code: "agentsky_cloud_auth_failed",
+        level: "error",
+        message:
+          err instanceof AgentskyApiError
+            ? `AgentSky rejected the token${err.code ? ` (${err.code})` : ""}: ${err.message}`
+            : err instanceof Error
+              ? `Failed to reach the AgentSky API: ${err.message}`
+              : "Failed to validate the AgentSky API token.",
+      });
+    }
+
+    if (agentSlug && !checks.some((check) => check.code === "agentsky_cloud_auth_failed")) {
+      try {
+        const remote = await client.getAgent(agentSlug);
+        if (remote.archived) {
+          checks.push({
+            code: "agentsky_cloud_agent_archived",
+            level: "warn",
+            message: `AgentSky agent "${agentSlug}" is archived; new sessions cannot be started on it.`,
+          });
+        } else {
+          checks.push({
+            code: "agentsky_cloud_agent_ok",
+            level: "info",
+            message: `AgentSky agent "${agentSlug}" is reachable${
+              remote.agentType ? ` (${remote.agentType}${remote.llm ? ` / ${remote.llm}` : ""})` : ""
+            }.`,
+          });
+          if (
+            (remote.agentType && remote.agentType !== harness) ||
+            (model && remote.llm && remote.llm !== model)
+          ) {
+            checks.push({
+              code: "agentsky_cloud_agent_mismatch",
+              level: "warn",
+              message: `Configured harness/model (${harness}${model ? ` / ${model}` : ""}) differ from the attached agent's (${remote.agentType ?? "?"} / ${remote.llm ?? "?"}); the attached agent's values win.`,
+            });
+          }
+        }
+      } catch (err) {
+        checks.push({
+          code: "agentsky_cloud_agent_not_found",
+          level: "error",
+          message:
+            err instanceof AgentskyApiError && err.status === 404
+              ? `AgentSky agent "${agentSlug}" was not found (or the token cannot see it).`
+              : `Failed to look up AgentSky agent "${agentSlug}": ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+  }
+
+  const paperclipApiUrl = buildPaperclipEnv({ id: "environment-test", companyId: ctx.companyId }).PAPERCLIP_API_URL;
+  if (paperclipApiUrl && isLoopbackUrl(paperclipApiUrl)) {
+    checks.push({
+      code: "agentsky_cloud_paperclip_api_local",
+      level: "warn",
+      message: `The Paperclip API URL advertised to agents (${paperclipApiUrl}) is a loopback address; cloud AgentSky agents cannot reach it, so agent-initiated callbacks will not work and the run report is the only feedback channel.`,
+      hint: "Expose Paperclip publicly and set PAPERCLIP_API_URL if agents should call back.",
+    });
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/agentsky-cloud/src/ui/build-config.test.ts
+++ b/packages/adapters/agentsky-cloud/src/ui/build-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import { buildAgentskyCloudConfig } from "./build-config.js";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "agentsky_cloud",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    adapterSchemaValues: {},
+    ...overrides,
+  };
+}
+
+describe("buildAgentskyCloudConfig", () => {
+  it("persists schema values and top-level prompt fields", () => {
+    const config = buildAgentskyCloudConfig(
+      makeValues({
+        instructionsFilePath: ".agentsky/AGENTS.md",
+        promptTemplate: "hello {{agent.name}}",
+        bootstrapPrompt: "bootstrap",
+        adapterSchemaValues: {
+          harness: "codex",
+          model: "gpt-5.6-sol",
+          agentSlug: "my-agent",
+          apiBaseUrl: "https://staging.agentsky.dev",
+        },
+      }),
+    );
+
+    expect(config).toMatchObject({
+      instructionsFilePath: ".agentsky/AGENTS.md",
+      promptTemplate: "hello {{agent.name}}",
+      bootstrapPromptTemplate: "bootstrap",
+      harness: "codex",
+      model: "gpt-5.6-sol",
+      agentSlug: "my-agent",
+      apiBaseUrl: "https://staging.agentsky.dev",
+    });
+  });
+
+  it("lets the generic model value override the schema model", () => {
+    const config = buildAgentskyCloudConfig(
+      makeValues({
+        model: "claude-fable-5",
+        adapterSchemaValues: { harness: "claude_code", model: "claude-opus-5" },
+      }),
+    );
+    expect(config.model).toBe("claude-fable-5");
+  });
+
+  it("merges structured env bindings over legacy envVars text", () => {
+    const config = buildAgentskyCloudConfig(
+      makeValues({
+        envVars: ["AGENTSKY_API_TOKEN=legacy-token", "PLAIN=value", "INVALID KEY=nope"].join("\n"),
+        envBindings: {
+          AGENTSKY_API_TOKEN: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+          STRUCTURED_ONLY: "from-binding",
+        },
+      }),
+    );
+
+    expect(config.env).toEqual({
+      AGENTSKY_API_TOKEN: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+      PLAIN: { type: "plain", value: "value" },
+      STRUCTURED_ONLY: { type: "plain", value: "from-binding" },
+    });
+  });
+});

--- a/packages/adapters/agentsky-cloud/src/ui/build-config.ts
+++ b/packages/adapters/agentsky-cloud/src/ui/build-config.ts
@@ -1,0 +1,67 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseEnvVars(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (typeof bindings !== "object" || bindings === null || Array.isArray(bindings)) return {};
+  const env: Record<string, unknown> = {};
+  for (const [key, raw] of Object.entries(bindings)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (typeof raw === "string") {
+      env[key] = { type: "plain", value: raw };
+      continue;
+    }
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const rec = raw as Record<string, unknown>;
+    if (rec.type === "plain" && typeof rec.value === "string") {
+      env[key] = { type: "plain", value: rec.value };
+      continue;
+    }
+    if (rec.type === "secret_ref" && typeof rec.secretId === "string") {
+      env[key] = {
+        type: "secret_ref",
+        secretId: rec.secretId,
+        ...(typeof rec.version === "number" || rec.version === "latest"
+          ? { version: rec.version }
+          : {}),
+      };
+    }
+  }
+  return env;
+}
+
+export function buildAgentskyCloudConfig(values: CreateConfigValues): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    ...(values.adapterSchemaValues ?? {}),
+  };
+  if (values.instructionsFilePath) config.instructionsFilePath = values.instructionsFilePath;
+  if (values.promptTemplate) config.promptTemplate = values.promptTemplate;
+  if (values.bootstrapPrompt) config.bootstrapPromptTemplate = values.bootstrapPrompt;
+  if (values.model?.trim()) config.model = values.model.trim();
+
+  const env = parseEnvBindings(values.envBindings);
+  const legacy = parseEnvVars(values.envVars);
+  for (const [key, value] of Object.entries(legacy)) {
+    if (!Object.prototype.hasOwnProperty.call(env, key)) {
+      env[key] = { type: "plain", value };
+    }
+  }
+  if (Object.keys(env).length > 0) {
+    config.env = env;
+  }
+
+  return config;
+}

--- a/packages/adapters/agentsky-cloud/src/ui/index.ts
+++ b/packages/adapters/agentsky-cloud/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { buildAgentskyCloudConfig } from "./build-config.js";
+export { parseAgentskyCloudStdoutLine } from "./parse-stdout.js";

--- a/packages/adapters/agentsky-cloud/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/agentsky-cloud/src/ui/parse-stdout.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { parseAgentskyCloudStdoutLine } from "./parse-stdout.js";
+
+const TS = "2026-01-01T00:00:00.000Z";
+
+function line(payload: Record<string, unknown>): string {
+  return JSON.stringify(payload);
+}
+
+function apiEventLine(event: Record<string, unknown>): string {
+  return line({ type: "agentsky_cloud.message", event });
+}
+
+describe("parseAgentskyCloudStdoutLine", () => {
+  it("parses init lines", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      line({
+        type: "agentsky_cloud.init",
+        sessionId: "sess-1",
+        agentSlug: "slug-1",
+        harness: "claude_code",
+        model: "claude-opus-5",
+      }),
+      TS,
+    );
+    expect(entries).toEqual([{ kind: "init", ts: TS, model: "claude-opus-5", sessionId: "sess-1" }]);
+  });
+
+  it("parses status lines as system entries", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      line({ type: "agentsky_cloud.status", status: "running", message: "Sent wake message" }),
+      TS,
+    );
+    expect(entries).toEqual([{ kind: "system", ts: TS, text: "running: Sent wake message" }]);
+  });
+
+  it("maps agent.message to an assistant entry", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      apiEventLine({ id: "m2", type: "agent.message", text: "All done" }),
+      TS,
+    );
+    expect(entries).toEqual([{ kind: "assistant", ts: TS, text: "All done" }]);
+  });
+
+  it("maps agent.reasoning to a thinking entry", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      apiEventLine({ id: "m2#0", type: "agent.reasoning", part: { text: "hmm" } }),
+      TS,
+    );
+    expect(entries).toEqual([{ kind: "thinking", ts: TS, text: "hmm" }]);
+  });
+
+  it("maps agent.tool_use and agent.tool_result", () => {
+    const call = parseAgentskyCloudStdoutLine(
+      apiEventLine({ id: "m2#1", type: "agent.tool_use", part: { tool_name: "bash", args: { cmd: "ls" } } }),
+      TS,
+    );
+    expect(call).toEqual([
+      { kind: "tool_call", ts: TS, name: "bash", toolUseId: "m2#1", input: { cmd: "ls" } },
+    ]);
+
+    const result = parseAgentskyCloudStdoutLine(
+      apiEventLine({ id: "m2#2", type: "agent.tool_result", part: { tool_name: "bash", status: "error", text: "boom" } }),
+      TS,
+    );
+    expect(result).toEqual([
+      { kind: "tool_result", ts: TS, toolUseId: "m2#2", toolName: "bash", content: "boom", isError: true },
+    ]);
+  });
+
+  it("suppresses the adapter's own user.message echo", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      apiEventLine({ id: "m1", type: "user.message", text: "the wake prompt", channel: "api" }),
+      TS,
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it("maps error events to stderr entries", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      apiEventLine({ id: "e1", type: "error", code: "pod_crash", message: "pod restarted" }),
+      TS,
+    );
+    expect(entries).toEqual([{ kind: "stderr", ts: TS, text: "error: pod restarted" }]);
+  });
+
+  it("parses result lines with error status", () => {
+    const entries = parseAgentskyCloudStdoutLine(
+      line({ type: "agentsky_cloud.result", status: "timeout", error: "took too long" }),
+      TS,
+    );
+    expect(entries).toEqual([
+      {
+        kind: "result",
+        ts: TS,
+        text: "",
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+        costUsd: 0,
+        subtype: "timeout",
+        isError: true,
+        errors: ["took too long"],
+      },
+    ]);
+  });
+
+  it("passes non-JSON lines through as stdout", () => {
+    expect(parseAgentskyCloudStdoutLine("plain text", TS)).toEqual([
+      { kind: "stdout", ts: TS, text: "plain text" },
+    ]);
+  });
+});

--- a/packages/adapters/agentsky-cloud/src/ui/parse-stdout.ts
+++ b/packages/adapters/agentsky-cloud/src/ui/parse-stdout.ts
@@ -1,0 +1,132 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseApiEvent(eventRaw: unknown, ts: string): TranscriptEntry[] {
+  const event = asRecord(eventRaw);
+  if (!event) return [];
+  const type = asString(event.type);
+  const part = asRecord(event.part);
+
+  if (type === "agent.message") {
+    const text = asString(event.text).trim();
+    return text ? [{ kind: "assistant", ts, text }] : [];
+  }
+
+  if (type === "agent.reasoning") {
+    const text = asString(part?.text).trim();
+    return text ? [{ kind: "thinking", ts, text }] : [];
+  }
+
+  if (type === "agent.tool_use") {
+    return [{
+      kind: "tool_call",
+      ts,
+      name: asString(part?.tool_name, "tool"),
+      toolUseId: asString(event.id) || undefined,
+      input: part?.args ?? {},
+    }];
+  }
+
+  if (type === "agent.tool_result") {
+    return [{
+      kind: "tool_result",
+      ts,
+      toolUseId: asString(event.id, "tool_result"),
+      toolName: asString(part?.tool_name, "tool"),
+      content: stringifyUnknown(part?.text ?? part ?? {}),
+      isError: asString(part?.status).toLowerCase() === "error",
+    }];
+  }
+
+  if (type === "agent.status") {
+    const text = asString(part?.text).trim();
+    const level = asString(part?.level).trim();
+    return text ? [{ kind: "system", ts, text: `${level ? `${level}: ` : ""}${text}` }] : [];
+  }
+
+  if (type === "user.message") {
+    // The adapter's own wake prompt echoes back as an api-channel user
+    // message; repeating it in the transcript would drown the run output.
+    return [];
+  }
+
+  if (type === "error") {
+    const text = asString(event.message, asString(event.code, "unknown error"));
+    return [{ kind: "stderr", ts, text: `error: ${text}` }];
+  }
+
+  return [];
+}
+
+export function parseAgentskyCloudStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type);
+  if (type === "agentsky_cloud.init") {
+    return [{
+      kind: "init",
+      ts,
+      model: asString(parsed.model, "agentsky_cloud"),
+      sessionId: asString(parsed.sessionId),
+    }];
+  }
+
+  if (type === "agentsky_cloud.status") {
+    return [{
+      kind: "system",
+      ts,
+      text: `${asString(parsed.status, "status")}${parsed.message ? `: ${asString(parsed.message)}` : ""}`,
+    }];
+  }
+
+  if (type === "agentsky_cloud.message") {
+    return parseApiEvent(parsed.event, ts);
+  }
+
+  if (type === "agentsky_cloud.result") {
+    const status = asString(parsed.status, "error");
+    return [{
+      kind: "result",
+      ts,
+      text: asString(parsed.result),
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      costUsd: 0,
+      subtype: status,
+      isError: status !== "finished",
+      errors: parsed.error ? [asString(parsed.error)] : [],
+    }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/agentsky-cloud/tsconfig.json
+++ b/packages/adapters/agentsky-cloud/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,6 +30,7 @@ export type AgentStatus = (typeof AGENT_STATUSES)[number];
 export const AGENT_ADAPTER_TYPES = [
   "process",
   "http",
+  "agentsky_cloud",
   "claude_local",
   "codex_local",
   "cursor_cloud",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@paperclipai/adapter-agentsky-cloud':
+        specifier: workspace:*
+        version: link:../packages/adapters/agentsky-cloud
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -125,6 +128,22 @@ importers:
       acpx:
         specifier: 0.12.0
         version: 0.12.0(patch_hash=tb5cdbd7kiiblhylbkroxfdcha)
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/agentsky-cloud:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -725,6 +744,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1075.0
         version: 3.1075.0
+      '@paperclipai/adapter-agentsky-cloud':
+        specifier: workspace:*
+        version: link:../packages/adapters/agentsky-cloud
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local
@@ -894,6 +916,9 @@ importers:
       '@mdxeditor/editor':
         specifier: ^3.55.0
         version: 3.55.0(@codemirror/language@6.12.4)(@lezer/highlight@1.2.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)(yjs@13.6.29)
+      '@paperclipai/adapter-agentsky-cloud':
+        specifier: workspace:*
+        version: link:../packages/adapters/agentsky-cloud
       '@paperclipai/adapter-claude-local':
         specifier: workspace:*
         version: link:../packages/adapters/claude-local

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -5,6 +5,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/agentsky-cloud",
+    "name": "@paperclipai/adapter-agentsky-cloud",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/adapters/claude-local",
     "name": "@paperclipai/adapter-claude-local",
     "publishFromCi": true

--- a/server/package.json
+++ b/server/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1075.0",
+    "@paperclipai/adapter-agentsky-cloud": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -3,6 +3,7 @@
  */
 export const BUILTIN_ADAPTER_TYPES = new Set([
   "acpx_local",
+  "agentsky_cloud",
   "claude_local",
   "codex_local",
   "cursor_cloud",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -59,6 +59,13 @@ import {
 } from "@paperclipai/adapter-cursor-cloud/server";
 import { agentConfigurationDoc as cursorCloudAgentConfigurationDoc } from "@paperclipai/adapter-cursor-cloud";
 import {
+  execute as agentskyCloudExecute,
+  getConfigSchema as getAgentskyCloudConfigSchema,
+  sessionCodec as agentskyCloudSessionCodec,
+  testEnvironment as agentskyCloudTestEnvironment,
+} from "@paperclipai/adapter-agentsky-cloud/server";
+import { agentConfigurationDoc as agentskyCloudAgentConfigurationDoc } from "@paperclipai/adapter-agentsky-cloud";
+import {
   execute as geminiExecute,
   listGeminiSkills,
   syncGeminiSkills,
@@ -318,6 +325,21 @@ const cursorCloudAdapter: ServerAdapterModule = {
   getConfigSchema: getCursorCloudConfigSchema,
 };
 
+const agentskyCloudAdapter: ServerAdapterModule = {
+  type: "agentsky_cloud",
+  execute: agentskyCloudExecute,
+  testEnvironment: agentskyCloudTestEnvironment,
+  sessionCodec: agentskyCloudSessionCodec,
+  sessionManagement: getAdapterSessionManagement("agentsky_cloud") ?? undefined,
+  models: [],
+  supportsLocalAgentJwt: false,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: agentskyCloudAgentConfigurationDoc,
+  getConfigSchema: getAgentskyCloudConfigSchema,
+};
+
 const geminiLocalAdapter: ServerAdapterModule = {
   type: "gemini_local",
   execute: geminiExecute,
@@ -440,6 +462,7 @@ function registerBuiltInAdapters() {
     openCodeLocalAdapter,
     piLocalAdapter,
     cursorCloudAdapter,
+    agentskyCloudAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
     grokLocalAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@lexical/link": "0.48.0",
     "@mdxeditor/editor": "^3.55.0",
+    "@paperclipai/adapter-agentsky-cloud": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -8,6 +8,7 @@
 import type { ComponentType } from "react";
 import {
   Bot,
+  Cloud,
   Code,
   Gem,
   MousePointer2,
@@ -119,6 +120,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     label: "Cursor Cloud",
     description: "Managed remote Cursor agent",
     icon: MousePointer2,
+  },
+  agentsky_cloud: {
+    label: "AgentSky",
+    description: "AgentSky cloud-hosted persistent agent",
+    icon: Cloud,
   },
   openclaw_gateway: {
     label: "OpenClaw Gateway",

--- a/ui/src/adapters/agentsky-cloud/index.ts
+++ b/ui/src/adapters/agentsky-cloud/index.ts
@@ -1,0 +1,14 @@
+import type { UIAdapterModule } from "../types";
+import { SchemaConfigFields } from "../schema-config-fields";
+import {
+  buildAgentskyCloudConfig,
+  parseAgentskyCloudStdoutLine,
+} from "@paperclipai/adapter-agentsky-cloud/ui";
+
+export const agentskyCloudUIAdapter: UIAdapterModule = {
+  type: "agentsky_cloud",
+  label: "AgentSky",
+  parseStdoutLine: parseAgentskyCloudStdoutLine,
+  ConfigFields: SchemaConfigFields,
+  buildAdapterConfig: buildAgentskyCloudConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -1,4 +1,5 @@
 import type { UIAdapterModule } from "./types";
+import { agentskyCloudUIAdapter } from "./agentsky-cloud";
 import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorCloudUIAdapter } from "./cursor-cloud";
@@ -52,6 +53,7 @@ setDynamicParserResultNotifier(notifyAdapterChange);
 
 function registerBuiltInUIAdapters() {
   for (const adapter of [
+    agentskyCloudUIAdapter,
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     cursorCloudUIAdapter,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/skills-catalog",
       "packages/db",
       "packages/adapter-utils",
+      "packages/adapters/agentsky-cloud",
       "packages/adapters/claude-local",
       "packages/adapters/codex-local",
       "packages/adapters/cursor-cloud",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Adapters connect Paperclip's orchestration layer to agent runtimes; most run local CLIs, and `cursor_cloud` is the one cloud-vendor adapter
> - There is no adapter for AgentSky (agentsky.dev), a platform that hosts long-lived agents (Claude Code, Codex, OpenClaw, Hermes) as always-on cloud pods with a persistent filesystem and a public HTTP API
> - Users who keep agents on AgentSky cannot hire them into a Paperclip company today; they must run local CLIs instead
> - This pull request adds a built-in `agentsky_cloud` adapter, modeled closely on `cursor_cloud`, that provisions and wakes AgentSky agents over their public API
> - The harness and model are configurable, so a Paperclip CEO agent can author the configuration from `agentConfigurationDoc` alone
> - The benefit is a second cloud-vendor integration: durable remote agents with zero local setup, reusing the exact registration surfaces `cursor_cloud` already uses

## Linked Issues or Issue Description

No existing issue. Feature description (per `adapter_request.yml`):

- **Agent or provider:** AgentSky (agentsky.dev) — hosted long-lived agents: Claude Code, Codex, OpenClaw, Hermes.
- **Why this adapter is useful:** Paperclip users can hire always-on cloud agents without running any local CLI. The remote agent keeps its own filesystem, memory, and context across heartbeats, which fits Paperclip's durable-session model.
- **How the agent is invoked:** Public HTTP API (`/api/v1`): create agent spec → create session → `POST /sessions/{id}/messages` → follow `GET /sessions/{id}/events` until the turn goes idle. Auth is a bearer token (`ast_…`).
- **Willing to implement:** Yes — this PR.

Related (not duplicates): #5081 added `cursor_sdk` as a separate cloud adapter; #8546 touches the cursor-cloud callback reachability problem this PR also documents for AgentSky. I searched GitHub for "agentsky" PRs and issues; there are none.

## What Changed

- New package `packages/adapters/agentsky-cloud` (`@paperclipai/adapter-agentsky-cloud`), structured exactly like `cursor-cloud`: shared metadata + `agentConfigurationDoc`, `server/` (execute, testEnvironment, sessionCodec, getConfigSchema, fetch-based API client — no SDK dependency), `ui/` (stdout parser + config builder), `cli/` (event formatter), with colocated tests for all four surfaces (27 tests).
- `execute()` auto-creates an AgentSky agent + durable session on the first heartbeat (configured `harness` + `model`), or attaches to an existing agent via `agentSlug`. It reuses the persisted session while the config identity matches; drift provisions a fresh one. Each heartbeat sends one wake message, then polls the session's event ledger (the documented recovery surface) until `turn.status_idle` for this turn's hash; the agent's final message becomes the run summary. Timeout, 402 `insufficient_credits` (`provider_quota`), 429 with `Retry-After`, interrupt, and session-deleted paths are handled explicitly.
- No `repoUrl` field on purpose: AgentSky pods own a persistent filesystem, so repositories are named in the prompt/goal text.
- PAPERCLIP_* runtime values ride the wake prompt as a text note. The AgentSky message plane has no environment injection. `supportsLocalAgentJwt` is `false`, like `cursor_cloud`, so no Paperclip API key is sent; the environment test warns when the advertised Paperclip API URL is a loopback address.
- Registration edits, one per existing surface: `AGENT_ADAPTER_TYPES`, `BUILTIN_ADAPTER_TYPES`, `ADAPTER_SESSION_MANAGEMENT` (+`LEGACY_SESSIONED_ADAPTER_TYPES`), server registry module, UI registry + display registry (label "AgentSky", `Cloud` icon), CLI registry, three `package.json` workspace deps + lockfile, `vitest.config.ts` project, `Dockerfile` COPY line, release-package manifest.
- Docs: new `docs/adapters/agentsky-cloud.md` (config reference, harness/model matrix, callback caveat), nav entry in `docs.json`, row in `docs/adapters/overview.md`.

## Verification

- `pnpm vitest run --project "@paperclipai/adapter-agentsky-cloud"` — 4 files, 27 tests, all pass. They cover: first-run provisioning, session reuse, re-provisioning on harness change, attach mode, stale-idle rejection, missing token, incompatible model, 402 mapping, interrupt, session-deleted (`clearSession`), and timeout (fake timers).
- `pnpm vitest run --project "@paperclipai/server" src/adapters src/__tests__/adapter-registry src/__tests__/agent-adapter-validation` — 28 tests pass (registry wiring).
- `pnpm vitest run --project "@paperclipai/ui" src/adapters` — 27 tests pass. CLI project: 245/246 pass.
- Typecheck clean for the new package, `server`, `ui`, `cli`, `@paperclipai/shared`, and `@paperclipai/adapter-utils`.
- `node scripts/check-no-git-push.mjs` passes.
- Pre-existing local failures unrelated to this change: `adapter-utils` `local-process-sandbox.test.ts` (Linux-only bubblewrap, run on macOS), `shared` `gitignore-runtime.test.ts` (shells out to `git`; my checkout is Sapling), CLI `company-import-export-e2e` (external skill-source pinning). None touch adapter code paths.

## Risks

- Additive: no existing adapter, schema, or migration changes beyond appending the new type to registries. Unknown adapter types already flow through validation as strings.
- The turn-completion detector relies on AgentSky's deterministic event ids (`<turnHash>#accepted|#idle|#interrupted`) with a documented fallback; a concurrent turn started from the AgentSky web UI is ignored via the echo/accepted ordering guard.
- Polling `GET /events` every 1.5 s (~40 req/min) stays under AgentSky's 120 req/min token limit; 429s honor `Retry-After`.
- Agent-initiated callbacks to Paperclip do not work when Paperclip runs on localhost (same limitation as `cursor_cloud`, see #8546); the environment test warns and the run report is the feedback channel.
- On timeout the adapter returns `timedOut` without interrupting the remote agent; the next wake resumes the same session.

## Model Used

- Claude (Anthropic) — Claude Fable 5 (`claude-fable-5`), extended thinking, agentic tool use via Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (the shipped "Cloud / Sandbox agents" item covers sandbox providers, not vendor adapters)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
