### PR TITLE
fix(executor): protect human ownership and retry sessions

### DIFF
--- a/server/src/__tests__/heartbeat-auto-checkout.test.ts
+++ b/server/src/__tests__/heartbeat-auto-checkout.test.ts
@@ -7,9 +7,21 @@ describe("shouldAutoCheckoutIssueForWake", () => {
       contextSnapshot: { wakeReason: "issue_assigned" },
       issueStatus: "todo",
       issueAssigneeAgentId: "agent-1",
+      issueAssigneeUserId: null,
       isDependencyReady: true,
       agentId: "agent-1",
     })).toBe(true);
+  });
+
+  it("does not auto-checkout an issue carrying a human assignee", () => {
+    expect(shouldAutoCheckoutIssueForWake({
+      contextSnapshot: { wakeReason: "issue_assigned" },
+      issueStatus: "todo",
+      issueAssigneeAgentId: "agent-1",
+      issueAssigneeUserId: "local-board",
+      isDependencyReady: true,
+      agentId: "agent-1",
+    })).toBe(false);
   });
 
   it("does not auto-checkout pending execution-review state even if the row status is todo", () => {
@@ -19,6 +31,7 @@ describe("shouldAutoCheckoutIssueForWake", () => {
       contextSnapshot: { wakeReason: "issue_recovery_action_restored" },
       issueStatus: "todo",
       issueAssigneeAgentId: reviewerAgentId,
+      issueAssigneeUserId: null,
       issueExecutionState: {
         status: "pending",
         currentStageId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1316,6 +1316,38 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(checkoutReleasedIssue?.checkoutRunId).toBeNull();
   });
 
+  it("keeps an unassigned process-loss retry on the source run session", async () => {
+    const sourceSessionId = "source-run-session";
+    const unrelatedSessionId = "unrelated-concurrent-run-session";
+    const { companyId, agentId, runId } = await seedRunFixture({
+      agentStatus: "idle",
+      includeIssue: false,
+      processPid: 999_999_999,
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({ sessionIdBefore: sourceSessionId })
+      .where(eq(heartbeatRuns.id, runId));
+    await db.insert(agentRuntimeState).values({
+      agentId,
+      companyId,
+      adapterType: "codex_local",
+      sessionId: unrelatedSessionId,
+      stateJson: {},
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.reapOrphanedRuns();
+
+    const retry = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(retry?.sessionIdBefore).toBe(sourceSessionId);
+    expect(retry?.sessionIdBefore).not.toBe(unrelatedSessionId);
+  });
+
   it("restores one lost monitor dispatch before escalating a second process loss", async () => {
     const { companyId, agentId, runId, issueId } = await seedRunFixture({
       adapterType: "openclaw_gateway",

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+function createHeartbeat() {
+  return { wakeup: vi.fn().mockResolvedValue({ id: "run-1" }) };
+}
+
+describe("queueIssueAssignmentWakeup", () => {
+  it("does not create a closed-loop wake when an agent creates its own assigned issue", async () => {
+    const heartbeat = createHeartbeat();
+
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: { id: "issue-1", assigneeAgentId: "agent-1", status: "todo" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.child_create",
+      requestedByActorType: "agent",
+      requestedByActorId: "agent-1",
+    });
+
+    expect(heartbeat.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("still wakes an agent when a different actor creates the assignment", async () => {
+    const heartbeat = createHeartbeat();
+
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: { id: "issue-1", assigneeAgentId: "agent-2", status: "todo" },
+      reason: "issue_assigned",
+      mutation: "create",
+      contextSource: "issue.create",
+      requestedByActorType: "agent",
+      requestedByActorId: "agent-1",
+    });
+
+    expect(heartbeat.wakeup).toHaveBeenCalledOnce();
+    expect(heartbeat.wakeup).toHaveBeenCalledWith(
+      "agent-2",
+      expect.objectContaining({ source: "assignment", reason: "issue_assigned" }),
+    );
+  });
+
+  it("still wakes the same agent for a later assignment mutation", async () => {
+    const heartbeat = createHeartbeat();
+
+    await queueIssueAssignmentWakeup({
+      heartbeat,
+      issue: { id: "issue-1", assigneeAgentId: "agent-1", status: "todo" },
+      reason: "issue_assigned",
+      mutation: "update",
+      contextSource: "issue.update",
+      requestedByActorType: "agent",
+      requestedByActorId: "agent-1",
+    });
+
+    expect(heartbeat.wakeup).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5596,13 +5596,10 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
-  it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
-    // Regression for PR #2482 checkout-adoption review finding: any adoption
-    // helper that re-locks an existing in_progress issue (e.g. when the prior
-    // checkout/execution run is terminal) must not strip the row's
-    // assigneeUserId. We exercise this via the adoptStaleCheckoutRun path,
-    // which fires when checkoutRunId points at a terminal run while
-    // executionRunId still points at a different, non-terminal run.
+  it("does not adopt a stale checkoutRunId when the issue has a user co-assignee", async () => {
+    // A human assignee is an execution boundary even on legacy rows that also
+    // carry an agent assignee. Stale-lock recovery must leave the row untouched
+    // rather than silently turning the human-owned issue into active agent work.
     const companyId = randomUUID();
     const agentId = randomUUID();
     const userId = randomUUID();
@@ -5667,8 +5664,8 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       executionLockedAt: new Date("2026-06-10T10:00:00.000Z"),
     });
 
-    const result = await svc.checkout(issueId, agentId, ["todo", "in_progress"], successorRunId);
-    expect(result).toBeTruthy();
+    await expect(svc.checkout(issueId, agentId, ["todo", "in_progress"], successorRunId))
+      .rejects.toMatchObject({ status: 409 });
 
     const row = await db
       .select({
@@ -5685,8 +5682,67 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       status: "in_progress",
       assigneeAgentId: agentId,
       assigneeUserId: userId,
-      checkoutRunId: successorRunId,
-      executionRunId: successorRunId,
+      checkoutRunId: failedCheckoutRunId,
+      executionRunId: queuedExecutionRunId,
+    });
+  });
+
+  it("does not allow checkout to overwrite a board/user-owned issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const checkoutRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date("2026-06-10T10:07:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board action awaiting human reply",
+      status: "todo",
+      priority: "medium",
+      assigneeUserId: "local-board",
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["todo", "backlog", "blocked"], checkoutRunId))
+      .rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeUserId: issues.assigneeUserId,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "todo",
+      assigneeUserId: "local-board",
+      assigneeAgentId: null,
     });
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5008,10 +5008,12 @@ export function shouldAutoCheckoutIssueForWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   issueStatus: string | null;
   issueAssigneeAgentId: string | null;
+  issueAssigneeUserId: string | null;
   issueExecutionState?: unknown;
   isDependencyReady: boolean;
   agentId: string;
 }) {
+  if (input.issueAssigneeUserId) return false;
   if (input.issueAssigneeAgentId !== input.agentId) return false;
   if (!input.isDependencyReady) return false;
   const executionState = parseIssueExecutionState(input.issueExecutionState);
@@ -6919,6 +6921,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         executionState: issues.executionState,
         executionWorkspaceSettings: issues.executionWorkspaceSettings,
         parentId: issues.parentId,
+        assigneeUserId: issues.assigneeUserId,
         createdByUserId: issues.createdByUserId,
         responsibleUserId: issues.responsibleUserId,
         originKind: issues.originKind,
@@ -8150,6 +8153,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const runtimeForRun = await getRuntimeState(agent.id);
     return runtimeForRun?.sessionId ?? null;
+  }
+
+  async function resolveSessionBeforeForProcessLossRetry(
+    agent: typeof agents.$inferSelect,
+    taskKey: string | null,
+    run: typeof heartbeatRuns.$inferSelect,
+  ) {
+    const sourceRunSession = truncateDisplayId(run.sessionIdAfter ?? run.sessionIdBefore);
+    if (!taskKey) return sourceRunSession;
+
+    return (await resolveSessionBeforeForWakeup(agent, taskKey)) ?? sourceRunSession;
   }
 
   async function hasResolvableSessionWorkspaceCwd(sessionParams: Record<string, unknown> | null | undefined) {
@@ -9712,7 +9726,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ? "issue_continuation_needed"
       : "process_lost";
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
-    const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const sessionBefore = await resolveSessionBeforeForProcessLossRetry(agent, taskKey, run);
     const retryContextSnapshot = withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
@@ -13159,6 +13173,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         contextSnapshot: context,
         issueStatus: issueContext.status,
         issueAssigneeAgentId: issueContext.assigneeAgentId,
+        issueAssigneeUserId: issueContext.assigneeUserId,
         issueExecutionState: issueContext.executionState,
         isDependencyReady: issueDependencyReadiness?.isDependencyReady ?? true,
         agentId: agent.id,

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -18,6 +18,21 @@ export interface IssueAssignmentWakeupDeps {
   ) => Promise<unknown>;
 }
 
+export function shouldQueueIssueAssignmentWakeup(input: {
+  issue: { assigneeAgentId: string | null; status: string };
+  mutation: string;
+  requestedByActorType?: "user" | "agent" | "system";
+  requestedByActorId?: string | null;
+}) {
+  if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return false;
+
+  return !(
+    input.mutation === "create" &&
+    input.requestedByActorType === "agent" &&
+    input.requestedByActorId === input.issue.assigneeAgentId
+  );
+}
+
 export function queueIssueAssignmentWakeup(input: {
   heartbeat: IssueAssignmentWakeupDeps;
   issue: { id: string; assigneeAgentId: string | null; status: string };
@@ -29,10 +44,11 @@ export function queueIssueAssignmentWakeup(input: {
   taskKey?: string | null;
   rethrowOnError?: boolean;
 }) {
-  if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
+  const assigneeAgentId = input.issue.assigneeAgentId;
+  if (!assigneeAgentId || !shouldQueueIssueAssignmentWakeup(input)) return;
 
   return input.heartbeat
-    .wakeup(input.issue.assigneeAgentId, {
+    .wakeup(assigneeAgentId, {
       source: "assignment",
       triggerDetail: "system",
       reason: input.reason,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4658,6 +4658,7 @@ export function issueService(db: Db) {
           id: issues.id,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
         })
@@ -4672,6 +4673,7 @@ export function issueService(db: Db) {
       if (
         lockedIssue.status !== "in_progress" ||
         lockedIssue.assigneeAgentId !== input.actorAgentId ||
+        lockedIssue.assigneeUserId != null ||
         lockedIssue.checkoutRunId !== input.expectedCheckoutRunId
       ) {
         return { adopted: null, latest: lockedIssue };
@@ -4717,6 +4719,7 @@ export function issueService(db: Db) {
             eq(issues.id, input.issueId),
             eq(issues.status, "in_progress"),
             eq(issues.assigneeAgentId, input.actorAgentId),
+            isNull(issues.assigneeUserId),
             eq(issues.checkoutRunId, input.expectedCheckoutRunId),
           ),
         )
@@ -4724,6 +4727,7 @@ export function issueService(db: Db) {
           id: issues.id,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
         })
@@ -4737,6 +4741,7 @@ export function issueService(db: Db) {
           id: issues.id,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
         })
@@ -4777,6 +4782,7 @@ export function issueService(db: Db) {
             eq(issues.id, input.issueId),
             eq(issues.status, "in_progress"),
             eq(issues.assigneeAgentId, input.actorAgentId),
+            isNull(issues.assigneeUserId),
             isNull(issues.checkoutRunId),
             or(isNull(issues.executionRunId), eq(issues.executionRunId, input.actorRunId)),
           ),
@@ -4785,6 +4791,7 @@ export function issueService(db: Db) {
           id: issues.id,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
         })
@@ -7529,9 +7536,14 @@ export function issueService(db: Db) {
       const sameRunAssigneeCondition = checkoutRunId
         ? and(
           eq(issues.assigneeAgentId, agentId),
+          isNull(issues.assigneeUserId),
           or(isNull(issues.checkoutRunId), eq(issues.checkoutRunId, checkoutRunId)),
         )
-        : and(eq(issues.assigneeAgentId, agentId), isNull(issues.checkoutRunId));
+        : and(
+          eq(issues.assigneeAgentId, agentId),
+          isNull(issues.assigneeUserId),
+          isNull(issues.checkoutRunId),
+        );
       const executionLockCondition = checkoutRunId
         ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
         : isNull(issues.executionRunId);
@@ -7550,7 +7562,10 @@ export function issueService(db: Db) {
           and(
             eq(issues.id, id),
             inArray(issues.status, expectedStatuses),
-            or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
+            and(
+              isNull(issues.assigneeUserId),
+              or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
+            ),
             executionLockCondition,
           ),
         )
@@ -7567,6 +7582,7 @@ export function issueService(db: Db) {
           id: issues.id,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
+          assigneeUserId: issues.assigneeUserId,
           checkoutRunId: issues.checkoutRunId,
           executionRunId: issues.executionRunId,
         })
@@ -7578,6 +7594,7 @@ export function issueService(db: Db) {
 
       if (
         current.assigneeAgentId === agentId &&
+        current.assigneeUserId == null &&
         current.status === "in_progress" &&
         current.checkoutRunId == null &&
         (current.executionRunId == null || current.executionRunId === checkoutRunId) &&
@@ -7595,6 +7612,7 @@ export function issueService(db: Db) {
               eq(issues.id, id),
               eq(issues.status, "in_progress"),
               eq(issues.assigneeAgentId, agentId),
+              isNull(issues.assigneeUserId),
               isNull(issues.checkoutRunId),
               or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId)),
             ),
@@ -7607,6 +7625,7 @@ export function issueService(db: Db) {
       if (
         checkoutRunId &&
         current.assigneeAgentId === agentId &&
+        current.assigneeUserId == null &&
         current.status === "in_progress" &&
         current.checkoutRunId &&
         current.checkoutRunId !== checkoutRunId
@@ -7626,13 +7645,14 @@ export function issueService(db: Db) {
       }
 
       // Adopt stale executionRunId — if the execution lock points to a terminal/missing run, clear it and proceed.
-      // Only adopts when the caller's expectedStatuses guard still holds; preserves any existing assigneeUserId
-      // and preserves the original startedAt when the issue is already in_progress.
+      // Only adopts when the caller's expectedStatuses guard still holds and no human owns the issue;
+      // preserves the original startedAt when the issue is already in_progress.
       if (
         checkoutRunId &&
         current.executionRunId &&
         current.executionRunId !== checkoutRunId &&
-        (current.assigneeAgentId === agentId || current.assigneeAgentId == null)
+        (current.assigneeAgentId === agentId || current.assigneeAgentId == null) &&
+        current.assigneeUserId == null
       ) {
         const stale = await isTerminalOrMissingHeartbeatRun(current.executionRunId);
         if (stale) {
@@ -7658,7 +7678,8 @@ export function issueService(db: Db) {
                 inArray(issues.status, expectedStatuses),
                 eq(issues.executionRunId, current.executionRunId),
                 or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
-              ),
+                isNull(issues.assigneeUserId),
+              )
             )
             .returning()
             .then((rows) => rows[0] ?? null);
@@ -7699,6 +7720,7 @@ export function issueService(db: Db) {
             id: issues.id,
             status: issues.status,
             assigneeAgentId: issues.assigneeAgentId,
+            assigneeUserId: issues.assigneeUserId,
             checkoutRunId: issues.checkoutRunId,
             executionRunId: issues.executionRunId,
           })
@@ -7713,12 +7735,14 @@ export function issueService(db: Db) {
         id: string;
         status: string;
         assigneeAgentId: string | null;
+        assigneeUserId: string | null;
         checkoutRunId: string | null;
         executionRunId: string | null;
       }) => {
         if (
           candidate.status === "in_progress" &&
           candidate.assigneeAgentId === actorAgentId &&
+          candidate.assigneeUserId == null &&
           sameRunLock(candidate.checkoutRunId, actorRunId)
         ) {
           return { ...candidate, adoptedFromRunId: null as string | null };
@@ -7729,12 +7753,14 @@ export function issueService(db: Db) {
       const canAdoptUnownedCheckout = (candidate: {
         status: string;
         assigneeAgentId: string | null;
+        assigneeUserId: string | null;
         checkoutRunId: string | null;
         executionRunId: string | null;
       }) => (
         actorRunId
         && candidate.status === "in_progress"
         && candidate.assigneeAgentId === actorAgentId
+        && candidate.assigneeUserId == null
         && candidate.checkoutRunId == null
         && (candidate.executionRunId == null || candidate.executionRunId === actorRunId)
       );
@@ -7744,6 +7770,7 @@ export function issueService(db: Db) {
           id: string;
           status: string;
           assigneeAgentId: string | null;
+          assigneeUserId: string | null;
           checkoutRunId: string | null;
           executionRunId: string | null;
         },
@@ -7773,6 +7800,7 @@ export function issueService(db: Db) {
           actorRunId &&
           candidate.status === "in_progress" &&
           candidate.assigneeAgentId === actorAgentId &&
+          candidate.assigneeUserId == null &&
           candidate.checkoutRunId &&
           candidate.checkoutRunId !== actorRunId
         ) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI agents for work.
> - The heartbeat executor starts agent runs and owns issue execution locks.
> - A human-owned issue must remain outside agent execution until the human hands it back.
> - An agent-created assignment must not start a second run for the same active agent.
> - A recovery run must resume the session of its source run, not a global session from other work.
> - This pull request adds these boundaries at the wake, checkout, stale-lock, and retry stages.
> - The benefit is stable human handoffs and stable run identity during concurrent recovery.

## Linked Issues or Issue Description

**What happened?**

The executor could adopt an issue that had a non-null human assignee. A create request could also queue an assignment wake for the same agent that made the request. Separately, an unassigned process-loss retry selected the agent's global runtime session. Another concurrent run could replace that global session before the retry was created.

**Expected behavior**

A human assignee must block every agent checkout and stale-lock adoption path. An agent that creates an issue assigned to itself must continue in its current run without a closed-loop assignment wake. A process-loss retry must use the source run's session lineage.

**Steps to reproduce**

1. Create an issue with a human assignee and attempt an agent checkout.
2. Create an agent-assigned issue from that same agent and inspect queued assignment wakes.
3. Start an unassigned run with one session, update the agent runtime with another session, and reap the first run as process-lost.
4. Observe that the old code can adopt human work, queues a self-wake, and assigns the unrelated runtime session to the retry.

**Paperclip version or commit**

Reproduced from `772fa9839` on `master`.

**Deployment mode**

Self-hosted server with concurrent local agent runs.

**Agent adapter(s) involved**

The defect is in the core executor. It is not adapter-specific.

## What Changed

- Reject auto-checkout and all stale or unowned checkout adoption when `assigneeUserId` is non-null.
- Suppress only create-time assignment wakes where the requesting agent is already the assignee.
- Select the process-loss retry session from the source run. Use the task session only when a task key exists.
- Add unit and embedded-Postgres regressions for human ownership, self-wake suppression, and concurrent session lineage.

No schema, migration, configuration, or UI change is required.

## Verification

- `corepack pnpm exec vitest run server/src/__tests__/heartbeat-auto-checkout.test.ts server/src/__tests__/issue-assignment-wakeup.test.ts` — 6 tests passed.
- `corepack pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "keeps an unassigned process-loss retry on the source run session"` — 1 test passed and 97 tests were skipped by the filter.
- `corepack pnpm exec vitest run server/src/__tests__/issues-service.test.ts -t "does not (adopt a stale checkoutRunId|allow checkout to overwrite a board/user-owned issue)"` — 2 selected tests passed.
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps` and `corepack pnpm exec tsc --noEmit` from `server/` — passed.
- The embedded-Postgres cold start exceeded the repository's local 20-second hook limit on this Windows host. I raised only the local hook timeout for the focused runs and restored the tracked timeout before commit.

## Risks

- Legacy rows that contain both a human assignee and an agent assignee can no longer be checked out or adopted by the agent. This is the intended human-ownership boundary.
- A same-agent issue created during an active run no longer receives an immediate assignment wake. Different-agent creates and later assignment mutations still wake normally.
- A no-task process-loss retry now starts fresh when its source run had no session. It no longer falls back to an unrelated global session.
- Roll back by reverting `b37630bf0` and its parent ownership guard commit. No data rollback is required.

## Model Used

- OpenAI Codex with GPT-5, tool use, code execution, and high reasoning. The deployment does not expose a more specific model ID or context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket ID or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
