### PR TITLE
fix(issues): reject an oversized issue-list limit instead of clamping it silently

### DIFF
--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -16,6 +16,7 @@ import {
   issueRoutes,
 } from "../routes/issues.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
+import { ISSUE_LIST_MAX_LIMIT } from "../services/index.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
 import { resolveRequiredSuccessfulRunHandoffOnValidPath } from "../services/successful-run-handoff-state.js";
 
@@ -718,6 +719,65 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     expect(res.body).toMatchObject({
       error: "assigneeAgentId must be a UUID or 'null'",
     });
+  });
+
+  it("rejects a limit above the maximum instead of silently clamping it", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId,
+      title: "Board issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const app = createApp(companyId);
+    for (const limit of [String(ISSUE_LIST_MAX_LIMIT + 1), "100000"]) {
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ limit });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body).toMatchObject({
+        error: `limit must be a positive integer up to ${ISSUE_LIST_MAX_LIMIT}`,
+      });
+      // The old behavior answered 200 with a silently truncated page.
+      expect(Array.isArray(res.body)).toBe(false);
+    }
+  });
+
+  it("still serves a limit at the maximum, which is what the board UI asks for", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ limit: String(ISSUE_LIST_MAX_LIMIT) });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([issueId]);
   });
 
   it("returns opt-in live descendant counts for offscreen live descendants only", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4781,7 +4781,17 @@ export function issueRoutes(
       res.status(400).json({ error: "view must be 'compact' when provided" });
       return;
     }
-    if (rawLimit !== undefined && (parsedLimit === null || !Number.isInteger(parsedLimit) || parsedLimit <= 0)) {
+    // A limit above ISSUE_LIST_MAX_LIMIT used to be clamped silently, so `?limit=100000` answered
+    // with exactly ISSUE_LIST_MAX_LIMIT rows and no signal that the rest of the board was cut off.
+    // Callers that trusted the number read a partial board as a complete one; reject loudly instead
+    // and let them page with `offset`.
+    if (
+      rawLimit !== undefined
+      && (parsedLimit === null
+        || !Number.isInteger(parsedLimit)
+        || parsedLimit <= 0
+        || parsedLimit > ISSUE_LIST_MAX_LIMIT)
+    ) {
       res.status(400).json({ error: `limit must be a positive integer up to ${ISSUE_LIST_MAX_LIMIT}` });
       return;
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue list endpoint `GET /api/companies/{id}/issues` is what the board UI, the CLI and every agent-side audit tool read the work state from
> - That endpoint documents a ceiling in its own error message — "limit must be a positive integer up to 1000" — but only enforced the lower bound; an oversized `?limit=` was silently clamped by `clampIssueListLimit()`
> - So `?limit=100000` answered `200` with exactly 1000 rows and no `total`, no `hasMore` and no header: a caller asking for the whole board received a truncated one that is indistinguishable from a complete one
> - That is worse than it sounds, because the list is roughly activity-sorted — the rows dropped are the stalest ones, which is exactly what an audit or a stale-work sweep is looking for
> - This pull request extends the existing 400 guard to the `> ISSUE_LIST_MAX_LIMIT` case, so the endpoint fails loudly instead of quietly breaking its own documented contract
> - The benefit is that callers either get the data they asked for or a clear error telling them to page with `offset` — they can no longer read a partial board as a complete one

## Linked Issues or Issue Description

No public GitHub issue exists for this, so the problem is described in-PR (bug report shape):

**What happened.** `GET /api/companies/{id}/issues?limit=100000` returns HTTP `200` with exactly 1000 issues.

**What I expected.** HTTP `400` with `limit must be a positive integer up to 1000` — the message the endpoint already produces for other invalid limits.

**Why the current behavior is a bug.** The response carries no `total`, no `hasMore` and no truncation header, so a caller cannot tell a clamped page from a complete one. The endpoint's own error string already promises the ceiling, and the `400` path for it already exists; only the `> MAX` comparison was missing.

**Steps to reproduce.** Against any instance with at least one issue:

```bash
curl -s -o /dev/null -w '%{http_code}\n' \
  "$PAPERCLIP_API_URL/api/companies/$COMPANY_ID/issues?limit=100000"
# before: 200   (body: exactly ISSUE_LIST_MAX_LIMIT rows)
# after:  400
```

Related, but not duplicates — both are about *other* limit problems on this endpoint and neither adds the upper-bound guard: #3339 (adds default limits) and #1964 (duplicate query params). I also searched open and closed PRs for `ISSUE_LIST_MAX_LIMIT`, `issue list limit`, `oversized limit` and `limit clamping` and found no PR carrying this change.

## What Changed

- `server/src/routes/issues.ts`: the existing issue-list `limit` validation now also rejects `parsedLimit > ISSUE_LIST_MAX_LIMIT`, returning the same `400` and the same error message the endpoint already used for the other invalid-limit cases. No new error string, no new code path.
- `clampIssueListLimit()` is deliberately left in place as a backstop for any internal caller that does not go through this route.
- `server/src/__tests__/issue-list-assignee-filter-routes.test.ts`: two tests — one asserting `ISSUE_LIST_MAX_LIMIT + 1` and `100000` are rejected with `400`, one asserting `limit=ISSUE_LIST_MAX_LIMIT` still serves `200`, which is what the board UI actually asks for.

## Verification

```bash
npx vitest run server/src/__tests__/issue-list-assignee-filter-routes.test.ts -t "limit"
```

- **After this change:** 2 passed.
- **Before this change** (production hunk reverted, both tests kept): the rejection test fails with `expected 200 to be 400` and a body of exactly one issue row — i.e. the test reproduces the reported defect rather than merely restating the new code. The at-maximum test passes both before and after, which is the point: this PR does not narrow the usable range.
- `npx tsc --noEmit -p server/tsconfig.json` reports no errors in either touched file.

Callers that legitimately need more than `ISSUE_LIST_MAX_LIMIT` rows should page with `offset`, which this endpoint already supports.

## Risks

Low, but not zero — this converts a previously-accepted request shape into a `400`, so it is a behavioral change for any caller that was passing an oversized limit and quietly living with the clamped page.

I checked the in-repo call sites before making it strict: the board UI tops out at `WORKSPACE_FILTER_ISSUE_LIMIT = 1000` (exactly the maximum, covered by the second test), every other UI call site requests `<= 500`, and the local tooling pages with `offset` at `<= 1000` per request. So nothing in this repository asks for more than the maximum. An out-of-tree client that did would now get a clear, actionable `400` naming the ceiling instead of silently truncated data — which is the intended correction.

No migration, no schema change, no new dependency.

One housekeeping note for the reviewer: this branch is based on a commit that is somewhat behind `master`. The touched region of `server/src/routes/issues.ts` is byte-identical on `master`, so the merge is clean, but feel free to press "Update branch" before merging.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking enabled, with tool use and code execution (ran the test suite and type-checker locally to produce the before/after evidence above).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (the endpoint's own error message already documented the ceiling; no other docs assert the old clamping behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
