### PR TITLE
fix(cli): require confirmation for workspace deletes

### DIFF
--- a/cli/src/__tests__/operations-parity.test.ts
+++ b/cli/src/__tests__/operations-parity.test.ts
@@ -12,6 +12,10 @@ const PROJECT_WORKSPACE_ID = "77777777-7777-4777-8777-777777777777";
 const ENV_ID = "88888888-8888-4888-8888-888888888888";
 const INCIDENT_ID = "99999999-9999-4999-8999-999999999999";
 
+function stripAnsi(value: string): string {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
 function createProgram(): Command {
   const program = new Command();
   program.exitOverride();
@@ -141,7 +145,7 @@ describe("operations parity commands", () => {
     await expect(run(["environment", "delete", ENV_ID])).rejects.toThrow("exit:1");
     await expect(run(["project-workspace", "delete", PROJECT_ID, PROJECT_WORKSPACE_ID])).rejects.toThrow("exit:1");
 
-    expect(errorSpy.mock.calls.map((call) => String(call[0]))).toEqual([
+    expect(errorSpy.mock.calls.map((call) => stripAnsi(String(call[0])))).toEqual([
       "Deletion requires --yes.",
       "Deletion requires --yes.",
     ]);

--- a/cli/src/__tests__/operations-parity.test.ts
+++ b/cli/src/__tests__/operations-parity.test.ts
@@ -94,14 +94,14 @@ describe("operations parity commands", () => {
     await run(["environment", "get", ENV_ID]);
     await run(["environment", "leases", ENV_ID]);
     await run(["environment", "update", ENV_ID, "--payload-json", "{}"]);
-    await run(["environment", "delete", ENV_ID]);
+    await run(["environment", "delete", ENV_ID, "--yes"]);
     await run(["environment", "probe", ENV_ID]);
     await run(["environment", "probe-config", "--company-id", COMPANY_ID, "--payload-json", "{}"]);
     await run(["project-workspace", "list", PROJECT_ID]);
     await run(["project-workspace", "create", PROJECT_ID, "--payload-json", "{}"]);
     await run(["project-workspace", "update", PROJECT_ID, PROJECT_WORKSPACE_ID, "--payload-json", "{}"]);
     await run(["project-workspace", "runtime-command", PROJECT_ID, PROJECT_WORKSPACE_ID, "run", "--payload-json", "{}"]);
-    await run(["project-workspace", "delete", PROJECT_ID, PROJECT_WORKSPACE_ID]);
+    await run(["project-workspace", "delete", PROJECT_ID, PROJECT_WORKSPACE_ID, "--yes"]);
 
     expect(fetchMock.mock.calls.map((call) => [call[1]?.method ?? "GET", call[0]])).toEqual([
       ["GET", `http://localhost:3100/api/companies/${COMPANY_ID}/org`],
@@ -128,6 +128,24 @@ describe("operations parity commands", () => {
       ["POST", `http://localhost:3100/api/projects/${PROJECT_ID}/workspaces/${PROJECT_WORKSPACE_ID}/runtime-commands/run`],
       ["DELETE", `http://localhost:3100/api/projects/${PROJECT_ID}/workspaces/${PROJECT_WORKSPACE_ID}`],
     ]);
+  });
+
+  it("requires explicit confirmation before destructive workspace deletes", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as typeof process.exit);
+
+    await expect(run(["environment", "delete", ENV_ID])).rejects.toThrow("exit:1");
+    await expect(run(["project-workspace", "delete", PROJECT_ID, PROJECT_WORKSPACE_ID])).rejects.toThrow("exit:1");
+
+    expect(errorSpy.mock.calls.map((call) => String(call[0]))).toEqual([
+      "Deletion requires --yes.",
+      "Deletion requires --yes.",
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/src/commands/client/workspace.ts
+++ b/cli/src/commands/client/workspace.ts
@@ -20,6 +20,10 @@ interface RuntimeActionOptions extends BaseClientOptions {
   payloadJson?: string;
 }
 
+interface DeleteOptions extends BaseClientOptions {
+  yes?: boolean;
+}
+
 interface OrgOutputOptions extends CompanyOptions {
   out?: string;
 }
@@ -90,8 +94,10 @@ export function registerWorkspaceCommands(program: Command): void {
       .description("Delete a project workspace")
       .argument("<projectId>", "Project ID")
       .argument("<workspaceId>", "Workspace ID")
-      .action(async (projectId: string, workspaceId: string, opts: BaseClientOptions) => {
+      .option("--yes", "Confirm deletion")
+      .action(async (projectId: string, workspaceId: string, opts: DeleteOptions) => {
         try {
+          if (!opts.yes) throw new Error("Deletion requires --yes.");
           const ctx = resolveCommandContext(opts);
           const result = await ctx.api.delete(apiPath`/api/projects/${projectId}/workspaces/${workspaceId}`);
           printOutput(result, { json: ctx.json });
@@ -216,8 +222,10 @@ function addDelete(parent: Command, name: string, description: string, resource:
       .command(name)
       .description(description)
       .argument("<id>", "ID")
-      .action(async (id: string, opts: BaseClientOptions) => {
+      .option("--yes", "Confirm deletion")
+      .action(async (id: string, opts: DeleteOptions) => {
         try {
+          if (!opts.yes) throw new Error("Deletion requires --yes.");
           const ctx = resolveCommandContext(opts);
           const result = await ctx.api.delete(`/api/${resource}/${encodeURIComponent(id)}`);
           printOutput(result, { json: ctx.json });

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -971,7 +971,7 @@ npx paperclipai environment get <environment-id>
 npx paperclipai environment leases <environment-id>
 npx paperclipai environment lease <lease-id>
 npx paperclipai environment update <environment-id> --payload-json '{...}'
-npx paperclipai environment delete <environment-id>
+npx paperclipai environment delete <environment-id> --yes
 npx paperclipai environment probe <environment-id>
 npx paperclipai environment probe-config --company-id <company-id> --payload-json '{...}'
 ```
@@ -980,7 +980,7 @@ npx paperclipai environment probe-config --company-id <company-id> --payload-jso
 npx paperclipai project-workspace list <project-id>
 npx paperclipai project-workspace create <project-id> --payload-json '{...}'
 npx paperclipai project-workspace update <project-id> <workspace-id> --payload-json '{...}'
-npx paperclipai project-workspace delete <project-id> <workspace-id>
+npx paperclipai project-workspace delete <project-id> <workspace-id> --yes
 npx paperclipai project-workspace runtime-service <project-id> <workspace-id> restart --payload-json '{...}'
 npx paperclipai project-workspace runtime-command <project-id> <workspace-id> run --payload-json '{...}'
 ```


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents for work.
> - The CLI is an operator-facing control surface for that control plane.
> - Several CLI delete commands already require an explicit `--yes` flag before sending destructive API requests.
> - Workspace and environment operations are part of the execution/runtime layer, so deleting those resources should have the same local guardrail as project, goal, issue, agent, secret, and company deletes.
> - The gap was that `environment delete` and `project-workspace delete` sent DELETE requests immediately when invoked.
> - This pull request makes those two destructive commands require `--yes` before any API call is made.
> - The benefit is a small, reviewer-friendly safety consistency improvement for CLI operators without changing server API behavior.

## Linked Issues or Issue Description

Bug report:

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I am on the latest available `master` checkout used for this PR.
- [x] I have confirmed the error originates in Paperclip itself, not in an agent adapter, API provider, or local configuration.

### What happened?

`paperclipai environment delete` and `paperclipai project-workspace delete` did not require the local `--yes` confirmation used by neighboring destructive CLI commands. Invoking either command sent a DELETE request immediately.

### Expected behavior

Destructive CLI deletes should stop locally unless the operator passes an explicit confirmation flag.

### Steps to reproduce

1. Run `paperclipai environment delete <environment-id>`.
2. Run `paperclipai project-workspace delete <project-id> <workspace-id>`.
3. Observe that both commands send DELETE requests without requiring a local confirmation flag.

### Paperclip version or commit

Reproduced from the PR base checkout at `a6436126ce3ce65b77588063e6fb3d9b01e197aa` (`origin/master` in this worktree before the fix).

### Deployment mode

Local dev (`pnpm dev`) / CLI source checkout.

### Installation method

Built from source (`pnpm dev` / workspace CLI).

### Agent adapter(s) involved

Not adapter-specific (core CLI bug).

### Database mode

Not database-related.

### Access context

Board (human operator) CLI usage.

### Node.js version

Node.js 20+ per repository development requirements.

### Operating system

macOS local worktree during verification.

### Relevant logs or output

Before this PR, the unconfirmed delete commands reached `fetch`. The regression test added here asserts unconfirmed deletes print `Deletion requires --yes.` and make no network call.

### Relevant config (if applicable)

Not config-related.

### Additional context

This aligns the two affected commands with nearby destructive CLI commands such as project, goal, issue, agent, secret, and company deletes.

### Privacy checklist

- [x] I have reviewed all pasted output for PII and redacted where necessary.

## What Changed

- Added `--yes` confirmation handling to `environment delete` through the shared workspace-command delete helper.
- Added `--yes` confirmation handling to `project-workspace delete` before it sends the DELETE request.
- Updated operations parity tests to cover both confirmed delete paths and unconfirmed local refusal with no `fetch` call.
- Updated `doc/CLI.md` examples to show the required `--yes` flag.

## Verification

- `./node_modules/.bin/vitest run cli/src/__tests__/operations-parity.test.ts --config cli/vitest.config.ts`
- `git diff --check`
- Duplicate search before opening: `gh pr list --repo paperclipai/paperclip --state open --search "environment delete --yes project-workspace delete --yes Deletion requires --yes"`

## Risks

Low risk. This is a CLI-only safety guard for destructive commands. Existing scripts that intentionally delete environments or project workspaces must add `--yes`, matching other destructive Paperclip CLI commands.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex, coding-agent environment with terminal, git, GitHub CLI, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
