### PR TITLE
fix(execution-policy): status=blocked/cancelled PATCH is not a changes-requested verdict (SQN-5074)

### DIFF
--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -2084,4 +2084,149 @@ describe("review round circuit breaker", () => {
       changesRequestedCount: 1,
     });
   });
+
+  describe("blocked/cancelled status is not a review verdict (SQN-4446/SQN-5074)", () => {
+    const policy = twoStagePolicy();
+    const reviewStageId = policy.stages[0].id;
+    const approvalStageId = policy.stages[1].id;
+
+    it("reviewer PATCHing status=blocked succeeds as a plain transition, not a review verdict", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "blocked",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        // No comment provided — under the old (buggy) code path this alone would have
+        // thrown "Requesting changes requires a comment". It must not throw at all.
+        commentBody: null,
+      });
+
+      expect(result.decision).toBeUndefined();
+      expect(result.patch.status).not.toBe("in_progress");
+      expect(result.patch.assigneeAgentId).not.toBe(coderAgentId);
+      expect(result.patch.executionState).toBeNull();
+    });
+
+    it("reviewer PATCHing status=cancelled succeeds as a plain transition, not a review verdict", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "cancelled",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: null,
+      });
+
+      expect(result.decision).toBeUndefined();
+      expect(result.patch.status).not.toBe("in_progress");
+      expect(result.patch.assigneeAgentId).not.toBe(coderAgentId);
+      expect(result.patch.executionState).toBeNull();
+    });
+
+    it("approver PATCHing status=blocked during the approval stage succeeds as a plain transition", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: null,
+          assigneeUserId: ctoUserId,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: approvalStageId,
+            currentStageIndex: 1,
+            currentStageType: "approval",
+            currentParticipant: { type: "user", userId: ctoUserId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [reviewStageId],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "blocked",
+        requestedAssigneePatch: {},
+        actor: { userId: ctoUserId },
+        commentBody: null,
+      });
+
+      expect(result.decision).toBeUndefined();
+      expect(result.patch.status).not.toBe("in_progress");
+      expect(result.patch.assigneeAgentId).not.toBe(coderAgentId);
+      expect(result.patch.executionState).toBeNull();
+    });
+
+    it("regression safety: a genuine changes-requested trigger (requestedStatus=in_progress) still works", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "in_progress",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: "Needs another pass on edge cases",
+      });
+
+      expect(result.patch.status).toBe("in_progress");
+      expect(result.patch.assigneeAgentId).toBe(coderAgentId);
+      expect(result.patch.executionState).toMatchObject({
+        status: "changes_requested",
+        currentStageType: "review",
+        returnAssignee: { type: "agent", agentId: coderAgentId },
+        lastDecisionOutcome: "changes_requested",
+      });
+      expect(result.decision).toMatchObject({
+        stageId: reviewStageId,
+        stageType: "review",
+        outcome: "changes_requested",
+      });
+    });
+  });
 });

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -848,6 +848,24 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
         return { patch };
       }
 
+      if (requestedStatus === "blocked" || requestedStatus === "cancelled") {
+        // The active participant marking their own in-review issue blocked or
+        // cancelled is abandoning the review, not rendering a verdict on it.
+        // Clear the execution state so the requested status applies as a
+        // plain transition instead of falling through into either the
+        // changes-requested branch below (SQN-4446/SQN-5074: silently
+        // misclassified as a review verdict) or the stage-advance guard
+        // further down (would otherwise reject the active participant's own
+        // status change as an unauthorized "stage advance").
+        clearExecutionStatePatch({
+          patch,
+          issueStatus: input.issue.status,
+          requestedStatus,
+          returnAssignee: existingState?.returnAssignee ?? null,
+        });
+        return { patch };
+      }
+
       if (requestedStatus && requestedStatus !== "in_review") {
         if (!input.commentBody?.trim()) {
           throw unprocessable(`Requesting changes requires a comment. ${STAGE_DECISION_COMMENT_HINT}`);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The execution-policy service (`server/src/services/issue-execution-policy.ts`) interprets PATCH requests from the active stage participant to decide whether it's a plain status transition or a review verdict
> - A PATCH with `requestedStatus="blocked"` or `"cancelled"` fell into the same branch as a genuine changes-requested PATCH, so it was silently reinterpreted as a changes-requested review decision and reassigned the issue back to the return assignee
> - This causes real production incidents: an agent legitimately marking its own issue blocked/cancelled gets its ownership yanked away instead
> - This PR gives blocked/cancelled their own early return that clears execution state (the same pattern already used elsewhere in this function for abandoning a review), so the requested status applies as a plain transition
> - The benefit is status=blocked/cancelled PATCHes from the active participant now actually succeed, and a regression test locks the behavior in

## Linked Issues or Issue Description

No public GitHub issue exists for this yet. Underlying bug, in bug-report form:

- **Expected behavior**: the active stage participant PATCHing an issue's `requestedStatus` to `"blocked"` or `"cancelled"` should succeed as a plain status transition.
- **Actual behavior**: it was misclassified as a changes-requested review verdict — throwing "Requesting changes requires a comment" when no comment was supplied, and reassigning the issue back to the return assignee when one was.
- **Repro**: call `applyIssueExecutionStageTransition` (or PATCH the issue) with `requestedStatus: "blocked"` (or `"cancelled"`) from the current active participant, no review comment — see the new tests in `blocked/cancelled status is not a review verdict` for exact inputs/expected outputs.
- **Impact observed**: this exact behavior caused an unintended reassignment during a live run (internal tracking SQN-5074/SQN-4446 — not a public issue).

Dedup search: I have searched GitHub for duplicate or related PRs and linked them above. Closest related-but-distinct: #10504 ("Allow changes-requested returns with linked blockers") — addresses a different mechanism (blockers alongside a changes-requested return), not this misclassification.

- [x] I have searched GitHub for duplicate or related PRs and linked them above.

## What Changed

- Gave `requestedStatus === "blocked"` and `requestedStatus === "cancelled"` their own early return in `applyIssueExecutionStageTransition`: clears execution state via the existing `clearExecutionStatePatch` helper (same pattern already used elsewhere in this function) instead of falling into the changes-requested branch.
- Added a regression test suite (`blocked/cancelled status is not a review verdict`) covering reviewer and approver stages PATCHing status=blocked/status=cancelled, asserting the PATCH actually succeeds (no throw, no changes-requested decision, execution state cleared).

**Note on iteration**: an earlier version of this fix only excluded blocked/cancelled from the changes-requested condition without an explicit return, which left the request falling through into a separate stage-advance guard further down that also rejected it (with a different error). An independent review caught this. This version gives blocked/cancelled an explicit early return so the PATCH actually succeeds, and the test assertions were strengthened to check for success rather than merely "not this specific wrong error."

## Verification

- `pnpm vitest run src/__tests__/issue-execution-policy.test.ts` (from `server/`) — 74/74 passed.
- Regression-proved: reverting the fix reproduces the original 3 failing tests (reviewer/approver PATCHing status=blocked/cancelled throwing "Requesting changes requires a comment"); restoring it is green.
- Ran the surrounding route/scheduler test suites (`issue-execution-policy-routes`, `issue-activity-events-routes`, `trust-preset-resolver`, `issue-comment-reopen-routes`, `issue-monitor-scheduler`) — all pass except one pre-existing, unrelated timeout flake in `issue-comment-reopen-routes.test.ts` (`treats reopen=true as a no-op when the issue is already open`), confirmed to fail identically on current master without this change.

## Risks

Low risk. Additive early-return branch plus tests; no schema/migration/API surface change. Reuses the existing `clearExecutionStatePatch` helper already exercised elsewhere in this file.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), Anthropic — used to diagnose the misclassification, write the regression tests, author the fix, and (via an independent second review pass) catch and correct a fallthrough gap in the first attempt.