### PR TITLE
fix(cli): stop reporting healthy instances as down on slow health probes

### DIFF
--- a/cli/src/__tests__/service-health-check.test.ts
+++ b/cli/src/__tests__/service-health-check.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -123,6 +125,36 @@ describe("service health doctor checks", () => {
 
     expect(results.every((result) => result.status === "pass")).toBe(true);
   });
+
+  it("reports a healthy instance that answers slower than the previous 2s probe budget", async () => {
+    // The instance is healthy. It is only slow to answer, which is what a
+    // server does while it warms up. A 2s budget aborted this probe and made
+    // doctor report a serving instance as unreachable.
+    delete process.env.PAPERCLIP_SERVICE_MANAGED;
+    const responseDelayMs = 3_000;
+    const server = http.createServer((_request, response) => {
+      setTimeout(() => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ status: "ok", serverVersion: "1.2.3" }));
+      }, responseDelayMs);
+    });
+    await new Promise<void>((resolve) => { server.listen(0, "127.0.0.1", () => resolve()); });
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      // No `probe` override here: this drives the real probe and its timeout.
+      const results = await serviceHealthChecks(
+        { server: { host: "127.0.0.1", port } } as PaperclipConfig,
+        { detect: vi.fn(async () => ({ supported: true as const, manager: managerFixture() })) },
+      );
+
+      expect(results).toContainEqual(
+        expect.objectContaining({ name: "Service health", status: "pass" }),
+      );
+    } finally {
+      await new Promise<void>((resolve) => { server.close(() => resolve()); });
+    }
+  }, 20_000);
 
   it("detects a foreground process on the configured port while the service is inactive", async () => {
     const manager = managerFixture(false);

--- a/cli/src/checks/service-health-check.ts
+++ b/cli/src/checks/service-health-check.ts
@@ -6,7 +6,7 @@ import {
   detectServiceManager,
   type ServiceManagerDetection,
 } from "../services/service-manager.js";
-import { buildLocalHealthUrl } from "../utils/health-url.js";
+import { buildLocalHealthUrl, HEALTH_PROBE_TIMEOUT_MS } from "../utils/health-url.js";
 import type { CheckResult } from "./index.js";
 
 type HealthResult = { ok: boolean; version: string | null; error?: string };
@@ -18,7 +18,7 @@ type ServiceCheckDependencies = {
 async function probeHealth(config: PaperclipConfig): Promise<HealthResult> {
   try {
     const response = await fetch(buildLocalHealthUrl(config.server.host, config.server.port), {
-      signal: AbortSignal.timeout(2_000),
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
     });
     const body = (await response.json()) as {
       status?: unknown;

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -5,7 +5,7 @@ import type { Command } from "commander";
 import { readConfig, resolveConfigPath } from "../config/store.js";
 import { resolvePaperclipInstanceId, resolvePaperclipInstanceRoot } from "../config/home.js";
 import { detectServiceManager, type ServiceManager, type ServiceStatus } from "../services/service-manager.js";
-import { buildLocalHealthUrl } from "../utils/health-url.js";
+import { buildLocalHealthUrl, HEALTH_PROBE_TIMEOUT_MS, HEALTH_READY_TIMEOUT_MS } from "../utils/health-url.js";
 
 type CommonOptions = { instance?: string; json?: boolean };
 type HealthResult = { ok: boolean; serverVersion: string | null; error?: string };
@@ -31,7 +31,7 @@ function healthUrl(instanceId: string): string {
 
 async function probeHealth(instanceId: string): Promise<HealthResult> {
   try {
-    const response = await fetch(healthUrl(instanceId), { signal: AbortSignal.timeout(2_000) });
+    const response = await fetch(healthUrl(instanceId), { signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS) });
     const body = await response.json() as { status?: unknown; serverVersion?: unknown; version?: unknown };
     return { ok: response.ok && body.status === "ok", serverVersion: typeof body.serverVersion === "string" ? body.serverVersion : typeof body.version === "string" ? body.version : null };
   } catch (error) {
@@ -39,7 +39,7 @@ async function probeHealth(instanceId: string): Promise<HealthResult> {
   }
 }
 
-async function waitForHealth(instanceId: string, expectedVersion: string | null, timeoutMs = 60_000): Promise<HealthResult> {
+async function waitForHealth(instanceId: string, expectedVersion: string | null, timeoutMs = HEALTH_READY_TIMEOUT_MS): Promise<HealthResult> {
   const deadline = Date.now() + timeoutMs;
   let last: HealthResult = { ok: false, serverVersion: null };
   while (Date.now() < deadline) {

--- a/cli/src/utils/health-url.ts
+++ b/cli/src/utils/health-url.ts
@@ -1,3 +1,19 @@
+// A healthy instance does not always answer /api/health promptly. Measured on
+// macOS/arm64, a server that curl confirmed healthy seconds later answered in
+// 2.5s-3.1s while still warming up, because migrations, background sweeps and
+// plugin loading all contend during the first minutes after a start. At a 2s
+// budget the probe reported such a server as down, so `service status` printed
+// `ok: false` for a service that was in fact serving requests.
+export const HEALTH_PROBE_TIMEOUT_MS = 10_000;
+
+// First boot after a payload upgrade applies database migrations before the
+// server binds, and that is unbounded in the instance's size rather than in
+// anything the CLI controls. A 148MB instance upgrading across roughly 200
+// commits took ~250s to answer, and a plain supervised restart of the same
+// instance took ~100s. At 60s `service restart` reported "did not become
+// healthy" for restarts that then succeeded on their own.
+export const HEALTH_READY_TIMEOUT_MS = 300_000;
+
 export function buildLocalHealthUrl(host: string | undefined, port: number): string {
   const configuredHost = host?.trim();
   const reachableHost = !configuredHost || configuredHost === "0.0.0.0" || configuredHost === "::"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The managed CLI runs an instance as a background service. It supervises that service with `paperclipai service` and diagnoses it with `paperclipai doctor`
> - Both surfaces decide "is this instance healthy?" from one HTTP probe against `/api/health`
> - That probe has a 2 second budget, and the readiness wait has a 60 second budget. Both are shorter than the time a healthy instance can take to answer
> - The result is a false negative. The CLI tells the operator that a running, serving instance is down
> - A false negative here is worse than a slow answer. It makes an operator restart or reinstall a service that needs no repair
> - This pull request moves the two budgets into named constants, and raises them to values that the observed response times support
> - The benefit is that `service status`, `service restart` and `doctor` report the true state of an instance that is slow to answer

## Linked Issues or Issue Description

Refs #10739 — the same managed-install session that produced that issue also produced these two false negatives.

**What happened:**
`paperclipai service status --instance <id>` reported `"health": { "ok": false, "error": "The operation was aborted due to timeout" }`. The instance was healthy. A direct `curl` against the same URL returned `{"status":"ok"}` seconds later. `paperclipai service restart` failed with `Paperclip service did not become healthy: fetch failed`. The restart had in fact succeeded. The instance answered about 100 seconds later.

**Expected behavior:**
The CLI reports an instance as healthy when the instance is healthy. The CLI waits for a restart for as long as a restart can legitimately take.

**Steps to reproduce:**

1. Install the managed CLI and onboard an instance with a database of significant size.
2. Run `paperclipai service install --instance <id>`. The first boot applies migrations.
3. Run `paperclipai service status --instance <id>` while the server warms up.
4. The command reports `ok: false`. A `curl` against `/api/health` succeeds.

**Paperclip version/commit:**
`2026.803.0-canary.4`; branch cut from `2c90cf0f2`.

**Deployment mode:**
`local_trusted` / `private`, loopback, embedded PostgreSQL, launchd service on macOS.

## What Changed

- Add `HEALTH_PROBE_TIMEOUT_MS` (10s) and `HEALTH_READY_TIMEOUT_MS` (300s) to `cli/src/utils/health-url.ts`. This is the module both health call sites already import.
- Use `HEALTH_PROBE_TIMEOUT_MS` for the `service` command probe in `cli/src/commands/service.ts`. It replaces the literal `2_000`.
- Use `HEALTH_PROBE_TIMEOUT_MS` for the doctor probe in `cli/src/checks/service-health-check.ts`. It replaces the second literal `2_000`.
- Use `HEALTH_READY_TIMEOUT_MS` as the `waitForHealth` default in `cli/src/commands/service.ts`. It replaces the literal `60_000`.
- Record the measured response times in comments next to each constant. A later reader can then see why the numbers are what they are.
- Add a regression test in `cli/src/__tests__/service-health-check.test.ts`.

The change does not add configuration, and it does not change control flow. Callers that pass an explicit `timeoutMs` keep their value.

## Verification

### Regression test

The new test starts a local HTTP server that answers `/api/health` correctly after 3s, which is what an instance does while it warms up. It then calls `serviceHealthChecks` **without** the injected `probe`, so the real probe and its timeout budget run.

The test fails on the code before this change, with the exact production symptom:

```
FAIL  src/__tests__/service-health-check.test.ts > reports a healthy instance that answers slower than the previous 2s probe budget
AssertionError: expected [ … ] to deep equally contain ObjectContaining{…}
    "message": "The operation was aborted due to timeout"
 Tests  1 failed | 7 passed (8)
```

It passes with this change applied:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Reproduce both directions:

```sh
pnpm exec vitest run cli/src/__tests__/service-health-check.test.ts
git stash && pnpm exec vitest run cli/src/__tests__/service-health-check.test.ts && git stash pop
```

### Field measurements

Measured on macOS 15 (Darwin 25.5.0), arm64, Node v22.22.3, against a 148MB instance:

| Observation                        | Old budget | Measured            |
| ---------------------------------- | ---------- | ------------------- |
| Healthy server, still warming up   | 2s probe   | 2.5s–3.1s to answer |
| Supervised restart                 | 60s wait   | ~100s to answer     |
| First boot after a payload upgrade | 60s wait   | ~250s to answer     |

The new values give headroom above each measurement. They stay below the point where an operator would think the command has hung.

### Type checking

```sh
cd cli && ../node_modules/.bin/tsc --noEmit
```

The changed files produce no TypeScript errors.

### Full CLI suite

`pnpm exec vitest run cli/src/__tests__` reports failures on my machine in `company-import-export-e2e`, `doctor`, `install-command` (3), `update-notice` and `worktree`. They reproduce on an unmodified checkout of `origin/master`, and none of them are in a file this pull request touches. The exact set is not stable between runs on this machine, so I treat CI as the authority on suite state rather than my local numbers. Please tell me if any of them are green in CI and red only here — I will investigate that separately.

## Risks

Low risk.

- A genuinely unreachable instance now takes 10s instead of 2s to report as unreachable. This is one probe, in commands an operator runs by hand.
- `service restart` now waits up to 300s before it declares failure. It still returns as soon as the instance answers, so a fast restart stays fast. Only a restart that was already failing waits longer.
- The new test adds about 3s of wall time to the CLI suite.
- No public API, schema, or migration is affected.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking was on. The session used tool execution: it read the repository, ran the test suite and the type checker, and measured the health endpoint against a live managed install on the machine described in Verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass — the files this PR touches pass. The suite has unrelated pre-existing failures on my machine. See Verification.
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no documentation states these values
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — to confirm after the CI run
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — Greptile returned 5/5 with no open items on the first commit; awaiting its pass on the test commit
- [x] I will address all Greptile and reviewer comments before requesting merge
