### PR TITLE
fix: worktree reuse guard + git locale consistency (#10683, #10681)

### DIFF
--- a/server/src/__tests__/git-error-includes.test.ts
+++ b/server/src/__tests__/git-error-includes.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+// Replicate the gitErrorIncludes function from workspace-runtime.ts
+function gitErrorIncludes(error: unknown, needle: string): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.toLowerCase().includes(needle.toLowerCase());
+}
+
+describe("gitErrorIncludes", () => {
+  it("matches the old git worktree error message", () => {
+    const err = new Error("fatal: 'feature/test' is already checked out at '/tmp/wt1'");
+    expect(gitErrorIncludes(err, "already checked out")).toBe(true);
+  });
+
+  it("matches the new git 2.42+ worktree error message", () => {
+    const err = new Error("fatal: 'feature/test' is already used by worktree at '/tmp/wt2'");
+    expect(gitErrorIncludes(err, "already used by worktree")).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    const err = new Error("fatal: pathspec 'feature/test' did not match any file(s) known to git");
+    expect(gitErrorIncludes(err, "already checked out")).toBe(false);
+    expect(gitErrorIncludes(err, "already used by worktree")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    const err = new Error("fatal: 'feature/test' is already CHECKED OUT at '/tmp/wt1'");
+    expect(gitErrorIncludes(err, "already checked out")).toBe(true);
+  });
+});

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -578,11 +578,16 @@ async function executeProcess(input: {
 }
 
 async function runGit(args: string[], cwd: string, opts?: { env?: NodeJS.ProcessEnv }): Promise<string> {
+  // Force C locale to ensure git outputs English messages regardless of system locale.
+  // This is critical because gitErrorIncludes matches English substrings in error output.
+  const gitEnv = { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' };
+  const mergedEnv = opts?.env ? { ...gitEnv, ...opts.env } : gitEnv;
+
   const proc = await executeProcess({
     command: "git",
     args,
     cwd,
-    env: opts?.env,
+    env: mergedEnv,
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);
@@ -976,6 +981,7 @@ async function getGitWorktreeBranchAncestryVerdict(input: {
     command: "git",
     args: ["merge-base", "--is-ancestor", input.expectedHeadSha, input.actualHeadSha],
     cwd: input.repoRoot,
+    env: { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' },
   }).catch(() => null);
   if (!proc) return "unknown";
   if (proc.code === 0) return "ancestor";
@@ -2519,10 +2525,12 @@ async function recordGitOperation(
     cwd: input.cwd,
     metadata: input.metadata ?? null,
     run: async () => {
+      // Force C locale for consistent English git output
       const result = await executeProcess({
         command: "git",
         args: input.args,
         cwd: input.cwd,
+        env: { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' },
       });
       stdout = result.stdout;
       stderr = result.stderr;
@@ -2939,7 +2947,7 @@ export async function realizeExecutionWorkspace(input: {
         failureLabel: `git worktree add ${worktreePath}`,
       });
     } catch (attachError) {
-      if (!gitErrorIncludes(attachError, "already checked out")) {
+      if (!gitErrorIncludes(attachError, "already checked out") && !gitErrorIncludes(attachError, "already used by worktree")) {
         throw attachError;
       }
       const reusablePath = await findRegisteredGitWorktreeByBranch(repoRoot, branchName);


### PR DESCRIPTION
## Summary

This PR fixes two related issues in `server/src/services/workspace-runtime.ts`:

### Issue #10683: Worktree reuse guard fails on git 2.42+

**Problem:** The guard that catches `"already checked out"` errors fails to match the new git 2.42+ message `"already used by worktree at"`. This makes the worktree-reuse path unreachable on systems with newer git versions.

**Fix:** Updated `gitErrorIncludes` to match both error patterns:
```ts
if (!gitErrorIncludes(attachError, "already checked out") && !gitErrorIncludes(attachError, "already used by worktree")) {
```

### Issue #10681: git error classification breaks on non-English hosts

**Problem:** `runGit` spawns git with the host environment, so on non-English locales git outputs translated diagnostics. The English-substring matching in `gitErrorIncludes` then fails.

**Fix:** Force C locale when spawning git in `runGit`, `recordGitOperation`, and `getGitWorktreeBranchAncestryVerdict`:
```ts
const gitEnv = { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' };
const mergedEnv = opts?.env ? { ...gitEnv, ...opts.env } : gitEnv;
```

## Thinking Path

Paperclip uses git worktrees to isolate each agent task's codebase. The `realizeExecutionWorkspace` function in `server/src/services/workspace-runtime.ts` creates or reuses worktrees via `git worktree add`. When a branch is already checked out elsewhere, git emits an error that Paperclip intercepts and tries to handle by reusing the existing worktree instead of creating a duplicate.

**Issue #10683:** The existing guard checked for `"already checked out"` — the message git 2.41 and earlier emitted. Git 2.42 changed this to `"already used by worktree at"`. On newer git versions, the guard failed to match, causing the code to re-throw the error and lose the worktree-reuse optimization. Fix: match both messages with an `OR` condition.

**Issue #10681:** `runGit` (and two other git call sites: `recordGitOperation` and `getGitWorktreeBranchAncestryVerdict`) passed the host environment to `spawn()`. On non-English systems, git translates its error messages. Paperclip's `gitErrorIncludes` helper matches English substrings ("already checked out", "already exists", etc.). Translated messages break these matches, causing spurious failures. Fix: inject `LC_ALL=C` into git's environment so diagnostics are always in English.

Both fixes are defensive — they expand match coverage without changing behavior for correctly-matching cases.

## What Changed

- `server/src/services/workspace-runtime.ts` line 581-588: `runGit` now sets `LC_ALL=C`, `LANG=C`, `LANGUAGE=C` to force English git output
- `server/src/services/workspace-runtime.ts` line 2943: `gitErrorIncludes` guard now matches both `"already checked out"` AND `"already used by worktree"`
- `server/src/services/workspace-runtime.ts` line 2527-2530: `recordGitOperation` also forces C locale (merged into `process.env`)
- `server/src/services/workspace-runtime.ts` line 981: `getGitWorktreeBranchAncestryVerdict` also forces C locale (merged into `process.env`)

## Verification

- Manual reproduction: confirmed git 2.42+ message format ("already used by worktree at")
- Manual reproduction: confirmed old git message format ("already checked out at")  
- Logic analysis: the new `&&` condition correctly re-throws only when NEITHER pattern matches
- Locale test: `git worktree add` produces identical English output under `LC_ALL=C` vs default locale in this environment
- All git call sites in the file now use the C locale
- Existing test at `workspace-runtime.test.ts:993` covers the worktree-reuse path

## Risks

- **Very low.** Both changes are additive and defensive.
- The locale fix sets environment variables but preserves any explicitly-overridden `opts.env` values (merged last).
- The error pattern match adds a second substring check — false positives would only cause the worktree-reuse path to activate when it previously would have thrown, which is the safer direction.

## Model Used

Claude Sonnet 4 (custom:omniroute, 200K context, tool use)

## Checklist

- [x] I have read and followed the [Contributing Guide](CONTRIBUTING.md)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] Changes are small, focused, and easy to review
- [x] Tests pass (existing worktree-reuse test covers the path; logic verified via manual reproduction)
- [x] No breaking changes
- [x] PR template sections filled
- [x] Model Used section included
