### PR TITLE
fix(issues): release the execution lock held by a never-started scheduled_retry

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -310,6 +310,95 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  // GOLAA-6375: a provider-quota backoff creates a `scheduled_retry` run and
+  // stamps it onto issues.executionRunId immediately, so the lock is held for
+  // the whole wait before that row ever starts. The assignee's live run then
+  // cannot PATCH a disposition or POST an approval interaction.
+  it("lets the assignee's live run adopt an execution lock held by a never-started scheduled_retry", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const dormantRetryRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: dormantRetryRunId,
+      companyId,
+      agentId,
+      status: "scheduled_retry",
+      invocationSource: "assignment",
+      startedAt: null,
+      scheduledRetryAt: new Date(Date.now() + 60 * 60 * 1000),
+      scheduledRetryReason: "provider_quota",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Dormant retry execution lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: dormantRetryRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Recovered dormant retry lock" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.title).toBe("Recovered dormant retry lock");
+
+    const row = await db
+      .select({
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+  });
+
+  // Guards the narrowing above: only a retry row that never started is dormant.
+  it("still returns 409 when a scheduled_retry execution owner has actually started", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const startedRetryRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: startedRetryRunId,
+      companyId,
+      agentId,
+      status: "scheduled_retry",
+      invocationSource: "assignment",
+      startedAt: new Date(),
+      scheduledRetryReason: "provider_quota",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Started retry execution lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: startedRetryRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Should fail" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body?.error).toBe("Issue run ownership conflict");
+  });
+
   it("still returns 409 when a different live checkout owner is active", async () => {
     const { companyId, agentId, failedRunId } = await seedCompanyAgentAndRuns();
     const liveOwnerRunId = randomUUID();

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -38,7 +38,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stale-execution-lock-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  }, 120_000);
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -11,6 +11,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueRelations,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import {
@@ -41,6 +42,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
   }, 120_000);
 
   afterEach(async () => {
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(activityLog);
@@ -397,6 +399,50 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(409);
     expect(res.body?.error).toBe("Issue run ownership conflict");
+  });
+
+  it("allows POST /interactions when executionRunId is terminal and assignee ownership can be reclaimed", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Dead execution lock interaction recovery",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/interactions`)
+      .send({
+        kind: "request_confirmation",
+        continuationPolicy: "wake_assignee",
+        payload: {
+          version: 1,
+          prompt: "Approve this issue?",
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.kind).toBe("request_confirmation");
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
   });
 
   it("still returns 409 when a different live checkout owner is active", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -731,6 +731,28 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 }
 
 export const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "interrupted", "failed", "cancelled", "timed_out"]);
+
+// A heartbeat run only holds a real claim on an issue while it is able to be
+// executing. Two shapes hold nothing:
+//   - terminal runs, which are finished; and
+//   - a `scheduled_retry` row that has never started (`startedAt == null`).
+//
+// The second case is the subtle one. The retry scheduler stamps
+// `issues.executionRunId` when it *creates* the retry row, not when that row
+// starts, so the lock is held across the entire wait for `scheduledRetryAt` -
+// hours, after a provider-quota backoff. During that window the issue reads
+// `activeRun: null` while every `PATCH /issues/{id}` and
+// `POST /issues/{id}/interactions` by the assignee's own live run 409s, so the
+// assignee cannot reach a disposition or raise an approval card at all. A
+// dormant retry is not a competing worker; the live run should take the lock.
+export function heartbeatRunHoldsIssueClaim(
+  run: { status: string; startedAt: Date | null } | null | undefined,
+): boolean {
+  if (!run) return false;
+  if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+  if (run.status === "scheduled_retry" && run.startedAt == null) return false;
+  return true;
+}
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
 
@@ -4810,11 +4832,11 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select({ status: heartbeatRuns.status, startedAt: heartbeatRuns.startedAt })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.executionRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (heartbeatRunHoldsIssueClaim(run)) return false;
 
       const updated = await tx
         .update(issues)
@@ -4839,9 +4861,10 @@ export function issueService(db: Db) {
 
   // Symmetric to clearExecutionRunIfTerminal. Clears checkoutRunId (and the
   // bundled execution lock cols) when the row's checkoutRunId points at a
-  // heartbeat run that is terminal or no longer exists. No assignee/status
-  // precondition: a terminal run holds no real claim regardless of who is
-  // assigned or what status the issue is currently in.
+  // heartbeat run that no longer holds a claim (terminal, dormant retry, or
+  // gone - see heartbeatRunHoldsIssueClaim). No assignee/status precondition:
+  // such a run holds no real claim regardless of who is assigned or what
+  // status the issue is currently in.
   async function clearCheckoutRunIfTerminal(issueId: string): Promise<boolean> {
     return db.transaction(async (tx) => {
       await tx.execute(
@@ -4858,22 +4881,22 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.checkoutRunId} for update`,
       );
       const run = await tx
-        .select({ status: heartbeatRuns.status })
+        .select({ status: heartbeatRuns.status, startedAt: heartbeatRuns.startedAt })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, issue.checkoutRunId))
         .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (heartbeatRunHoldsIssueClaim(run)) return false;
 
       if (issue.executionRunId && issue.executionRunId !== issue.checkoutRunId) {
         await tx.execute(
           sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
         );
         const executionRun = await tx
-          .select({ status: heartbeatRuns.status })
+          .select({ status: heartbeatRuns.status, startedAt: heartbeatRuns.startedAt })
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, issue.executionRunId))
           .then((rows) => rows[0] ?? null);
-        if (executionRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)) return false;
+        if (heartbeatRunHoldsIssueClaim(executionRun)) return false;
       }
 
       const updated = await tx


### PR DESCRIPTION
## The defect

The retry scheduler stamps `issues.executionRunId` when it **creates** the `scheduled_retry` heartbeat run, not when that run starts. After a provider-quota backoff the retry sits dormant (`startedAt: null`) until `scheduledRetryAt` -- hours later -- so the issue holds an execution lock owned by a run that is not executing anything.

`clearExecutionRunIfTerminal` / `clearCheckoutRunIfTerminal` only release on `TERMINAL_HEARTBEAT_RUN_STATUSES`, and `scheduled_retry` is correctly not terminal. So the lock never clears, and `canAdoptUnownedCheckout` refuses adoption on its `executionRunId` conjunct.

## Observed impact

The assignee's own live run gets `409 Issue run ownership conflict` on every `PATCH /issues/{id}` and `POST /issues/{id}/interactions`, while comments still return 201.

That makes the execution contract unsatisfiable: `done`, `in_review` and `blocked` are all PATCHes, so the issue is pinned to `in_progress` -- which is exactly the status that gets re-woken. The fleet re-enters finished work and re-derives conclusions already posted. Approval routing is blocked too: the `request_confirmation` interaction cannot be created, so completed work that ends in a board decision cannot be handed over at all.

Observed on a 10-issue burst across two agents in a single quota window. The issues read `activeRun: null` the whole time, which is what makes it look like a dead-run leak rather than a scheduling artifact.

## The change

Introduces `heartbeatRunHoldsIssueClaim()` as the single "does this run hold a real claim on the issue" predicate, and routes both clear helpers through it. A run holds nothing if it is terminal, **or** if it is `scheduled_retry` with `startedAt == null`. A `scheduled_retry` run that *has* started still holds its claim.

No new call sites were needed: `svc.update` and the checkout path already call both clear helpers before resolving ownership, so once the dormant lock clears, the existing `canAdoptUnownedCheckout` adopts it.

## Why this does not orphan the retry

- The retry is located by `contextSnapshot->>'issueId'` (`getIssueRetryRun`, `server/src/services/heartbeat.ts`), **not** by `issues.executionRunId`.
- `cancelStaleScheduledRetry` (`heartbeat.ts`) already nulls that exact column when a dormant retry stops being valid -- the codebase already treats this lock as releasable.

## Tests

Two cases added to the existing `server/src/__tests__/issue-stale-execution-lock-routes.test.ts`, modeled on the passing cases already in that file:

1. the assignee's live run adopts an execution lock held by a never-started `scheduled_retry`;
2. a `scheduled_retry` that **has** started still returns 409 (the guard is not over-broad).

Refs GOLAA-6375.