### PR TITLE
Don't give hosted users credential advice they cannot act on

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -318,6 +318,25 @@ export interface AdapterEnvironmentTestContext {
    * Surfaced in check messages so users see which environment the probe ran in.
    */
   environmentName?: string | null;
+  /**
+   * Whether the person reading this probe's result can reach the Paperclip
+   * host's shell and filesystem.
+   *
+   * Defaults to `true`, which is the single-operator install every adapter was
+   * written for: the host is the user's own machine, so "run `codex login`" or
+   * "run `claude login`" is advice they can act on, and a credential file
+   * sitting in `~/.codex` is theirs.
+   *
+   * Set to `false` for a hosted multi-tenant deployment, where BOTH halves of
+   * that assumption are wrong. The user has no shell on the host, so host-login
+   * advice is unfollowable and reads as a broken product; and any credential
+   * that does sit on the host belongs to the operator or another tenant, so
+   * reporting it as "you are authenticated" would be actively misleading.
+   * Adapters must then confine themselves to credentials the user can supply
+   * through Paperclip: an API key, or a subscription token they mint on their
+   * own machine and paste in.
+   */
+  callerControlsHost?: boolean;
   deployment?: {
     mode?: "local_trusted" | "authenticated";
     exposure?: "private" | "public";

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -300,6 +300,25 @@ export interface AdapterEnvironmentTestContext {
    * Surfaced in check messages so users see which environment the probe ran in.
    */
   environmentName?: string | null;
+  /**
+   * Whether the person reading this probe's result can reach the Paperclip
+   * host's shell and filesystem.
+   *
+   * Defaults to `true`, which is the single-operator install every adapter was
+   * written for: the host is the user's own machine, so "run `codex login`" or
+   * "run `claude login`" is advice they can act on, and a credential file
+   * sitting in `~/.codex` is theirs.
+   *
+   * Set to `false` for a hosted multi-tenant deployment, where BOTH halves of
+   * that assumption are wrong. The user has no shell on the host, so host-login
+   * advice is unfollowable and reads as a broken product; and any credential
+   * that does sit on the host belongs to the operator or another tenant, so
+   * reporting it as "you are authenticated" would be actively misleading.
+   * Adapters must then confine themselves to credentials the user can supply
+   * through Paperclip: an API key, or a subscription token they mint on their
+   * own machine and paste in.
+   */
+  callerControlsHost?: boolean;
   deployment?: {
     mode?: "local_trusted" | "authenticated";
     exposure?: "private" | "public";

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -676,6 +676,7 @@ export async function testClaudeAcpEnvironment(
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
+  const callerControlsHost = ctx.callerControlsHost !== false;
 
   checks.push({
     code: "claude_engine_selected",
@@ -786,6 +787,15 @@ export async function testClaudeAcpEnvironment(
       message:
         "CLAUDE_CODE_OAUTH_TOKEN is set. Claude ACP will authenticate with the configured subscription token; no stored login is needed on the execution target.",
       detail: `Detected in ${source}.`,
+    });
+  } else if (!callerControlsHost) {
+    // ACP-lane mirror of the CLI-lane branch in test.ts: name the token route,
+    // which the user can actually complete from their own machine.
+    checks.push({
+      code: "claude_acp_subscription_mode_possible",
+      level: "info",
+      message: "No Claude credentials are configured for this agent yet.",
+      hint: "Add an Anthropic API key, or use your Claude Pro or Max plan by running `claude setup-token` on your own computer and pasting the token it prints.",
     });
   } else if (!targetIsRemote) {
     checks.push({

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -437,6 +437,7 @@ export async function testClaudeAcpEnvironment(
   const config = parseObject(ctx.config);
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
+  const callerControlsHost = ctx.callerControlsHost !== false;
 
   checks.push({
     code: "claude_engine_selected",
@@ -524,6 +525,15 @@ export async function testClaudeAcpEnvironment(
       message: "ANTHROPIC_API_KEY is set. Claude ACP will use API-key auth instead of subscription credentials.",
       detail: `Detected in ${source}.`,
       hint: "Unset ANTHROPIC_API_KEY if you want subscription-based Claude login behavior.",
+    });
+  } else if (!callerControlsHost) {
+    // ACP-lane mirror of the CLI-lane branch in test.ts: name the token route,
+    // which the user can actually complete from their own machine.
+    checks.push({
+      code: "claude_acp_subscription_mode_possible",
+      level: "info",
+      message: "No Claude credentials are configured for this agent yet.",
+      hint: "Add an Anthropic API key, or use your Claude Pro or Max plan by running `claude setup-token` on your own computer and pasting the token it prints.",
     });
   } else if (!targetIsRemote) {
     checks.push({

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -87,6 +87,7 @@ export async function testEnvironment(
   const command = asString(config.command, "claude");
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
+  const callerControlsHost = ctx.callerControlsHost !== false;
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
   const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
   const runId = `claude-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -222,6 +223,18 @@ export async function testEnvironment(
       message:
         "CLAUDE_CODE_OAUTH_TOKEN is set. Claude will authenticate with the configured subscription token; no stored login is needed on the execution target.",
       detail: `Detected in ${source}.`,
+    });
+  } else if (!callerControlsHost) {
+    // Hosted multi-tenant: "if Claude is logged in" refers to a host login the
+    // user cannot perform. Unlike Codex, there IS a real subscription route
+    // here, so name it rather than pushing them to an API key: the token is
+    // minted on their own machine and pasted in, which is exactly the thing
+    // they were looking for when they picked this adapter.
+    checks.push({
+      code: "claude_subscription_mode_possible",
+      level: "info",
+      message: "No Claude credentials are configured for this agent yet.",
+      hint: "Add an Anthropic API key, or use your Claude Pro or Max plan by running `claude setup-token` on your own computer and pasting the token it prints.",
     });
   } else if (!targetIsRemote) {
     checks.push({

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -111,6 +111,7 @@ export async function testEnvironment(
   const command = asString(config.command, "claude");
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
+  const callerControlsHost = ctx.callerControlsHost !== false;
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
   const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
   const targetLabel = targetIsRemote
@@ -277,6 +278,18 @@ export async function testEnvironment(
         "ANTHROPIC_API_KEY is set. Claude will use API-key auth instead of subscription credentials.",
       detail: `Detected in ${source}.`,
       hint: "Unset ANTHROPIC_API_KEY if you want subscription-based Claude login behavior.",
+    });
+  } else if (!callerControlsHost) {
+    // Hosted multi-tenant: "if Claude is logged in" refers to a host login the
+    // user cannot perform. Unlike Codex, there IS a real subscription route
+    // here, so name it rather than pushing them to an API key: the token is
+    // minted on their own machine and pasted in, which is exactly the thing
+    // they were looking for when they picked this adapter.
+    checks.push({
+      code: "claude_subscription_mode_possible",
+      level: "info",
+      message: "No Claude credentials are configured for this agent yet.",
+      hint: "Add an Anthropic API key, or use your Claude Pro or Max plan by running `claude setup-token` on your own computer and pasting the token it prints.",
     });
   } else if (!targetIsRemote) {
     checks.push({

--- a/packages/adapters/codex-local/src/server/acp.hosted-credentials.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.hosted-credentials.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testCodexAcpEnvironment } from "./acp.js";
+
+// Regression guard for advice a hosted user cannot act on.
+//
+// The probe used to answer a missing credential with "run `codex login` for the
+// same OS user that runs the Paperclip server". On a self-hosted install that is
+// fine: the host is the user's own machine. On a hosted multi-tenant install it
+// is a dead end, and a customer who picked Codex expecting his ChatGPT plan to
+// work followed that hint until he gave up and asked for a refund.
+//
+// The subtler half is credential *reporting*. Readiness falls back to
+// `codexHomeHasUsableAuth(sharedSourceHome)`, i.e. the server's own Codex home.
+// On a hosted install that credential belongs to the operator or another
+// tenant, so a tenant could be told they were authenticated by someone else's
+// login. The hosted branch therefore sits above every host-derived signal.
+//
+// `callerControlsHost: false` is how the server says "this person is a tenant,
+// not the operator". These tests pin both directions.
+
+const baseConfig = {
+  engine: "acp",
+  // Deliberately not "codex": keeps the probe on the credential branch instead
+  // of resolving and spawning a real ACP server on the test machine.
+  agentCommand: "/nonexistent/codex-acp",
+  env: {},
+};
+
+let hostHome: string;
+
+beforeEach(async () => {
+  // Point the "server's own Codex home" at a directory we control, so these
+  // assertions describe the code and not whether the machine running them
+  // happens to have a real ~/.codex. Without this the suite passes on CI and
+  // fails on any developer laptop with Codex logged in.
+  hostHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-hosttest-"));
+  vi.stubEnv("CODEX_HOME", path.join(hostHome, "codex"));
+  vi.stubEnv("HOME", hostHome);
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await fs.rm(hostHome, { recursive: true, force: true }).catch(() => {});
+});
+
+/** Gives the server host a usable Codex credential, as a logged-in operator would. */
+async function seedHostCredential() {
+  const home = path.join(hostHome, "codex");
+  await fs.mkdir(home, { recursive: true });
+  await fs.writeFile(
+    path.join(home, "auth.json"),
+    // Shape `hasUsableAuthPayload` accepts for subscription auth: a token
+    // bundle carrying an account id, which is what `codex login` writes.
+    JSON.stringify({
+      tokens: { account_id: "acct-operator", access_token: "at", refresh_token: "rt" },
+    }),
+  );
+}
+
+describe("Codex ACP credential advice on a hosted install", () => {
+  it("tells a tenant to add a key, never to run `codex login`", async () => {
+    const result = await testCodexAcpEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: baseConfig,
+      callerControlsHost: false,
+    });
+
+    const missing = result.checks.find((check) => check.code === "codex_acp_credentials_missing");
+    expect(missing).toBeTruthy();
+    expect(missing?.hint).toContain("Add an OpenAI API key");
+    // The plan question is the one they actually arrived with. Leaving it
+    // unanswered is what sent the customer looking for a route that is not there.
+    expect(missing?.hint).toContain("ChatGPT Plus or Pro plan cannot be used here");
+    // `codex login` may still be NAMED as the reason a plan cannot work, but
+    // never issued as something to go and do on the server.
+    expect(missing?.hint).not.toContain("run `codex login`");
+  });
+
+  it("never reports the host's own credential as the tenant's", async () => {
+    // The operator is logged in on the server. That is not this tenant's login,
+    // and claiming otherwise would send them off to debug a working-looking
+    // agent that fails on its first real run.
+    await seedHostCredential();
+
+    const result = await testCodexAcpEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: baseConfig,
+      callerControlsHost: false,
+    });
+
+    expect(result.checks.some((check) => check.code === "codex_acp_native_auth_detected")).toBe(false);
+    expect(result.checks.some((check) => check.code === "codex_acp_credentials_missing")).toBe(true);
+  });
+
+  it("still accepts a key configured on the agent itself", async () => {
+    // The hosted branch must not swallow the tenant's OWN credential, which is
+    // the one thing that does work here.
+    const result = await testCodexAcpEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { ...baseConfig, env: { OPENAI_API_KEY: "sk-proj-test" } },
+      callerControlsHost: false,
+    });
+
+    expect(result.checks.some((check) => check.code === "codex_acp_credentials_missing")).toBe(false);
+    expect(result.checks.some((check) => check.code === "codex_acp_openai_api_key_detected")).toBe(true);
+  });
+
+  it("keeps host advice and host credential reporting for a self-hosted operator", async () => {
+    // Default (field omitted) is the single-operator install, where the host
+    // really is the user's machine: their login counts and `codex login` is the
+    // right thing to tell them.
+    await seedHostCredential();
+    const detected = await testCodexAcpEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: baseConfig,
+    });
+    expect(detected.checks.some((check) => check.code === "codex_acp_native_auth_detected")).toBe(true);
+
+    await fs.rm(path.join(hostHome, "codex"), { recursive: true, force: true });
+    const missing = await testCodexAcpEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: baseConfig,
+    });
+    const check = missing.checks.find((c) => c.code === "codex_acp_credentials_missing");
+    expect(check).toBeTruthy();
+    expect(check?.hint).toContain("codex login");
+  });
+});

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -492,6 +492,7 @@ export async function testCodexAcpEnvironment(
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
+  const callerControlsHost = ctx.callerControlsHost !== false;
 
   checks.push({
     code: "codex_engine_selected",
@@ -577,6 +578,23 @@ export async function testCodexAcpEnvironment(
         level: "info",
         message: "OPENAI_API_KEY is set for Codex ACP authentication.",
         detail: `Detected in ${configApiKey ? "adapter config env" : "server environment"}.`,
+      });
+    } else if (!callerControlsHost) {
+      // Hosted multi-tenant. This branch sits directly after the api-key case
+      // deliberately: an API key came from this agent's own config, but every
+      // readiness signal below it is derived from the SERVER's Codex home
+      // (`codexHomeHasUsableAuth(sharedSourceHome)`). On a hosted install that
+      // home belongs to the operator or another tenant, so falling through
+      // would tell this user they are authenticated by someone else's login,
+      // and the final `else` would tell them to run `codex login` on a machine
+      // they have no shell on. Both are dead ends; answer with the one thing
+      // they can act on, and settle the plan question rather than leaving a
+      // subscriber hunting for an option that does not exist.
+      checks.push({
+        code: "codex_acp_credentials_missing",
+        level: "warn",
+        message: "No Codex credentials are configured for this agent.",
+        hint: "Add an OpenAI API key to this agent's credentials. A ChatGPT Plus or Pro plan cannot be used here: it signs in through a local `codex login`, which only works on your own machine.",
       });
     } else if (credentialReadiness.ready && !credentialReadiness.managed) {
       checks.push({

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -499,6 +499,7 @@ export async function testCodexAcpEnvironment(
   const config = parseObject(ctx.config);
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
+  const callerControlsHost = ctx.callerControlsHost !== false;
 
   checks.push({
     code: "codex_engine_selected",
@@ -584,6 +585,23 @@ export async function testCodexAcpEnvironment(
         level: "info",
         message: "OPENAI_API_KEY is set for Codex ACP authentication.",
         detail: `Detected in ${configApiKey ? "adapter config env" : "server environment"}.`,
+      });
+    } else if (!callerControlsHost) {
+      // Hosted multi-tenant. This branch sits directly after the api-key case
+      // deliberately: an API key came from this agent's own config, but every
+      // readiness signal below it is derived from the SERVER's Codex home
+      // (`codexHomeHasUsableAuth(sharedSourceHome)`). On a hosted install that
+      // home belongs to the operator or another tenant, so falling through
+      // would tell this user they are authenticated by someone else's login,
+      // and the final `else` would tell them to run `codex login` on a machine
+      // they have no shell on. Both are dead ends; answer with the one thing
+      // they can act on, and settle the plan question rather than leaving a
+      // subscriber hunting for an option that does not exist.
+      checks.push({
+        code: "codex_acp_credentials_missing",
+        level: "warn",
+        message: "No Codex credentials are configured for this agent.",
+        hint: "Add an OpenAI API key to this agent's credentials. A ChatGPT Plus or Pro plan cannot be used here: it signs in through a local `codex login`, which only works on your own machine.",
       });
     } else if (credentialReadiness.ready && !credentialReadiness.managed) {
       checks.push({

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -218,6 +218,7 @@ export async function testEnvironment(
   const command = asString(config.command, "codex");
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
+  const callerControlsHost = ctx.callerControlsHost !== false;
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
   const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
   const targetLabel = targetIsRemote
@@ -293,6 +294,19 @@ export async function testEnvironment(
       level: "info",
       message: "OPENAI_API_KEY is set for Codex authentication.",
       detail: `Detected in ${source}.`,
+    });
+  } else if (!callerControlsHost) {
+    // Hosted multi-tenant: the host's auth.json is not this user's and
+    // `codex auth` is not a command they can run, so both halves of the advice
+    // in the local branch below would be dead ends. Skipping the auth-file
+    // read matters as much as the wording: a credential that IS on the host
+    // belongs to the operator or another tenant, and reporting it as this
+    // user's would be worse than saying nothing.
+    checks.push({
+      code: "codex_openai_api_key_missing",
+      level: "warn",
+      message: "No OpenAI API key is configured for this agent. Codex runs will fail until one is added.",
+      hint: "Add an OpenAI API key to this agent's credentials. A ChatGPT Plus or Pro plan cannot be used here: it signs in through a local `codex login`, which only works on your own machine.",
     });
   } else if (!targetIsRemote) {
     // Local-only auth file check. On remote targets, the probe will surface
@@ -421,7 +435,9 @@ export async function testEnvironment(
             ...(detail ? { detail } : {}),
             hint: probeApiKey
               ? "OPENAI_API_KEY was provided but Codex still rejected the request. Verify the key is valid for the OpenAI Responses API (e.g. `curl -H \"Authorization: Bearer $OPENAI_API_KEY\" https://api.openai.com/v1/models`), or run `codex login` and seed `~/.codex/auth.json`."
-              : "Codex CLI does not read OPENAI_API_KEY from the environment; set OPENAI_API_KEY in this adapter's config (so Paperclip writes it to `$CODEX_HOME/auth.json`) or run `codex login` on the host first.",
+              : callerControlsHost
+                ? "Codex CLI does not read OPENAI_API_KEY from the environment; set OPENAI_API_KEY in this adapter's config (so Paperclip writes it to `$CODEX_HOME/auth.json`) or run `codex login` on the host first."
+                : "Add an OpenAI API key to this agent's credentials. A ChatGPT Plus or Pro plan cannot be used here: it signs in through a local `codex login`, which only works on your own machine.",
           });
           if (targetIsSandbox) {
             // Emit the neutral canonical check so the user interface can decide

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -217,6 +217,7 @@ export async function testEnvironment(
   const command = asString(config.command, "codex");
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
+  const callerControlsHost = ctx.callerControlsHost !== false;
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
   const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
   const targetLabel = targetIsRemote
@@ -292,6 +293,19 @@ export async function testEnvironment(
       level: "info",
       message: "OPENAI_API_KEY is set for Codex authentication.",
       detail: `Detected in ${source}.`,
+    });
+  } else if (!callerControlsHost) {
+    // Hosted multi-tenant: the host's auth.json is not this user's and
+    // `codex auth` is not a command they can run, so both halves of the advice
+    // in the local branch below would be dead ends. Skipping the auth-file
+    // read matters as much as the wording: a credential that IS on the host
+    // belongs to the operator or another tenant, and reporting it as this
+    // user's would be worse than saying nothing.
+    checks.push({
+      code: "codex_openai_api_key_missing",
+      level: "warn",
+      message: "No OpenAI API key is configured for this agent. Codex runs will fail until one is added.",
+      hint: "Add an OpenAI API key to this agent's credentials. A ChatGPT Plus or Pro plan cannot be used here: it signs in through a local `codex login`, which only works on your own machine.",
     });
   } else if (!targetIsRemote) {
     // Local-only auth file check. On remote targets, the probe will surface
@@ -420,7 +434,9 @@ export async function testEnvironment(
             ...(detail ? { detail } : {}),
             hint: probeApiKey
               ? "OPENAI_API_KEY was provided but Codex still rejected the request. Verify the key is valid for the OpenAI Responses API (e.g. `curl -H \"Authorization: Bearer $OPENAI_API_KEY\" https://api.openai.com/v1/models`), or run `codex login` and seed `~/.codex/auth.json`."
-              : "Codex CLI does not read OPENAI_API_KEY from the environment; set OPENAI_API_KEY in this adapter's config (so Paperclip writes it to `$CODEX_HOME/auth.json`) or run `codex login` on the host first.",
+              : callerControlsHost
+                ? "Codex CLI does not read OPENAI_API_KEY from the environment; set OPENAI_API_KEY in this adapter's config (so Paperclip writes it to `$CODEX_HOME/auth.json`) or run `codex login` on the host first."
+                : "Add an OpenAI API key to this agent's credentials. A ChatGPT Plus or Pro plan cannot be used here: it signs in through a local `codex login`, which only works on your own machine.",
           });
         } else {
           checks.push({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3134,6 +3134,12 @@ export function agentRoutes(
           config: effectiveAdapterConfig,
           executionTarget,
           environmentName,
+          // A cloud tenant reaches this server through the gateway and has no
+          // shell on it, so adapters must not answer with host-login advice
+          // ("run `codex login`") or report a host credential file as theirs.
+          // Every other actor source is a local/self-hosted operator for whom
+          // the host genuinely is their own machine.
+          callerControlsHost: req.actor?.source !== "cloud_tenant",
         });
 
         const prefixChecks = [

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1862,6 +1862,12 @@ export function agentRoutes(
           config: runtimeAdapterConfig,
           executionTarget,
           environmentName,
+          // A cloud tenant reaches this server through the gateway and has no
+          // shell on it, so adapters must not answer with host-login advice
+          // ("run `codex login`") or report a host credential file as theirs.
+          // Every other actor source is a local/self-hosted operator for whom
+          // the host genuinely is their own machine.
+          callerControlsHost: req.actor?.source !== "cloud_tenant",
         });
 
         if (result.status === "fail") releaseStatus = "failed";


### PR DESCRIPTION
## Problem

The adapter environment probe assumes the Paperclip host is the user's own machine. On a multi-tenant deployment that assumption fails in two distinct ways.

**1. Unfollowable advice.** A missing Codex credential is answered with:

> Set OPENAI_API_KEY in the agent adapter env, set it in the Paperclip server environment, or run `codex login` for the same OS user that runs the Paperclip server

A tenant has no shell on that server. All three routes are dead ends, so a missing key reads as a broken product. The Claude lanes have the same shape ("subscription-based auth can be used if Claude is logged in").

**2. Cross-tenant credential reporting.** This is the sharper one. `evaluateCodexCredentialReadiness` falls back to `codexHomeHasUsableAuth(sharedSourceHome)` — the *server's* Codex home. Where the operator is logged in, every tenant is told `codex_acp_native_auth_detected`, i.e. "you are authenticated", by someone else's credential. They then watch the agent fail on its first real run with no clue why.

## Motivation

A paying customer hit exactly this. Telemetry shows him running the probe, receiving the `codex login` hint, clicking it repeatedly, then stopping. He wrote in asking for a refund because he felt misled. He had never stored a credential or completed a run.

He was also right on the substance: a ChatGPT plan genuinely cannot work on a hosted install, because it authenticates only through that local login. Nothing said so.

## Change

`callerControlsHost` on `AdapterEnvironmentTestContext`, **defaulting to `true`** so every existing caller keeps today's behaviour byte for byte. The agents route derives it from `req.actor.source`, which already distinguishes `cloud_tenant` from a local operator.

When `false`:
- codex lanes name the credential the user can actually supply, and state that a ChatGPT Plus/Pro plan cannot be used here. A bare "set OPENAI_API_KEY" leaves a subscriber hunting for the plan option instead of buying the credit the key needs.
- claude lanes point at `claude setup-token`, which genuinely does let a Pro/Max plan drive the agent and is minted on the user's own machine.
- the branch is ordered **directly after the api-key case**, so no host-derived readiness signal can reach a tenant. The agent's own configured key still works exactly as before.

## Tests

New `acp.hosted-credentials.test.ts`. It stubs `CODEX_HOME`/`HOME` rather than reading whatever the machine has, so it describes the code instead of the developer's laptop (the first draft passed on CI and failed locally for precisely that reason). Pins all four directions: hosted gets no login imperative, hosted never sees a seeded host credential, the agent's own key still registers, and self-hosted keeps both the host credential reporting and the `codex login` hint.

codex-local: 22 files / 223 pass. Two failures in claude-local (`execute.remote`, `test.probe`) reproduce unmodified on `origin/master` and are unrelated to this change.