### PR TITLE
fix: worktree reuse guard + git locale consistency (#10683, #10681)

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1042,6 +1042,30 @@ describe("realizeExecutionWorkspace", () => {
     });
   });
 
+  it("reuses a worktree when git emits the 2.42+ 'already used by worktree' message", async () => {
+    const repoRoot = await createTempRepo();
+    const branchName = "PAP-10683-worktree-new-git-msg";
+    const existingWorktree = path.join(repoRoot, ".paperclip", "worktrees", branchName);
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+    await fs.mkdir(path.dirname(existingWorktree), { recursive: true });
+    await execFileAsync("git", ["worktree", "add", "-b", branchName, existingWorktree, "HEAD"], { cwd: repoRoot });
+    const altWorktreePath = path.join(repoRoot, ".paperclip", "other-worktrees", branchName);
+    await fs.mkdir(path.dirname(altWorktreePath), { recursive: true });
+    const realized = await realizeExecutionWorkspace({
+      base: { baseCwd: altWorktreePath, source: "project_primary", projectId: "project-1", workspaceId: "workspace-1", repoUrl: null, repoRef: "HEAD" },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}", worktreeParentDir: ".paperclip/other-worktrees" } },
+      issue: { id: "issue-1", identifier: "PAP-10683", title: "worktree reuse new git msg" },
+      agent: { id: "agent-1", name: "Codex Coder", companyId: "company-1" },
+      recorder,
+    });
+    const expectedWorktreePath = await fs.realpath(existingWorktree);
+    expect(realized.created).toBe(false);
+    await expect(fs.realpath(realized.cwd)).resolves.toBe(expectedWorktreePath);
+    await execFileAsync("git", ["worktree", "remove", existingWorktree], { cwd: repoRoot }).catch(() => {});
+    await execFileAsync("git", ["branch", "-D", branchName], { cwd: repoRoot }).catch(() => {});
+    await fs.rm(repoRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
   it("slugifies unsafe issue titles for branch names and worktree folders", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1066,6 +1066,29 @@ describe("realizeExecutionWorkspace", () => {
     await fs.rm(repoRoot, { recursive: true, force: true }).catch(() => {});
   });
 
+  it("reuses a worktree when git emits the 2.42+ 'already used by worktree' message", async () => {
+    const repoRoot = await createTempRepo();
+    const branchName = "PAP-10683-worktree-new-git-msg";
+    const existingWorktree = path.join(repoRoot, ".paperclip", "worktrees", branchName);
+    const { recorder } = createWorkspaceOperationRecorderDouble();
+    await fs.mkdir(path.dirname(existingWorktree), { recursive: true });
+    await execFileAsync("git", ["worktree", "add", "-b", branchName, existingWorktree, "HEAD"], { cwd: repoRoot });
+    const altWorktreePath = path.join(repoRoot, ".paperclip", "other-worktrees", branchName);
+    const realized = await realizeExecutionWorkspace({
+      base: { baseCwd: altWorktreePath, source: "project_primary", projectId: "project-1", workspaceId: "workspace-1", repoUrl: null, repoRef: "HEAD" },
+      config: { workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}-{{slug}}", worktreeParentDir: ".paperclip/other-worktrees" } },
+      issue: { id: "issue-1", identifier: "PAP-10683", title: "worktree reuse new git msg" },
+      agent: { id: "agent-1", name: "Codex Coder", companyId: "company-1" },
+      recorder,
+    });
+    const expectedWorktreePath = await fs.realpath(existingWorktree);
+    expect(realized.created).toBe(false);
+    await expect(fs.realpath(realized.cwd)).resolves.toBe(expectedWorktreePath);
+    await execFileAsync("git", ["worktree", "remove", existingWorktree], { cwd: repoRoot }).catch(() => {});
+    await execFileAsync("git", ["branch", "-D", branchName], { cwd: repoRoot }).catch(() => {});
+    await fs.rm(repoRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
   it("slugifies unsafe issue titles for branch names and worktree folders", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -578,11 +578,14 @@ async function executeProcess(input: {
 }
 
 async function runGit(args: string[], cwd: string, opts?: { env?: NodeJS.ProcessEnv }): Promise<string> {
+  // Force C locale last so it always wins over opts.env or host locale.
+  // gitErrorIncludes matches English substrings in git error output.
+  const mergedEnv = opts?.env ? { ...process.env, ...opts.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' } : { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' };
   const proc = await executeProcess({
     command: "git",
     args,
     cwd,
-    env: opts?.env,
+    env: mergedEnv,
   });
   if (proc.code !== 0) {
     throw new Error(proc.stderr.trim() || proc.stdout.trim() || `git ${args.join(" ")} failed`);
@@ -976,6 +979,7 @@ async function getGitWorktreeBranchAncestryVerdict(input: {
     command: "git",
     args: ["merge-base", "--is-ancestor", input.expectedHeadSha, input.actualHeadSha],
     cwd: input.repoRoot,
+    env: { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' },
   }).catch(() => null);
   if (!proc) return "unknown";
   if (proc.code === 0) return "ancestor";
@@ -2519,10 +2523,12 @@ async function recordGitOperation(
     cwd: input.cwd,
     metadata: input.metadata ?? null,
     run: async () => {
+      // Force C locale for consistent English git output
       const result = await executeProcess({
         command: "git",
         args: input.args,
         cwd: input.cwd,
+        env: { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' },
       });
       stdout = result.stdout;
       stderr = result.stderr;
@@ -2939,7 +2945,7 @@ export async function realizeExecutionWorkspace(input: {
         failureLabel: `git worktree add ${worktreePath}`,
       });
     } catch (attachError) {
-      if (!gitErrorIncludes(attachError, "already checked out")) {
+      if (!gitErrorIncludes(attachError, "already checked out") && !gitErrorIncludes(attachError, "already used by worktree")) {
         throw attachError;
       }
       const reusablePath = await findRegisteredGitWorktreeByBranch(repoRoot, branchName);


### PR DESCRIPTION
## Summary

This PR fixes two related issues in `server/src/services/workspace-runtime.ts`:

### Issue #10683: Worktree reuse guard fails on git 2.42+

**Problem:** The guard that catches `"already checked out"` errors fails to match the new git 2.42+ message `"already used by worktree at"`. This makes the worktree-reuse path unreachable on systems with newer git versions.

**Fix:** Updated `gitErrorIncludes` to match both error patterns:
```ts
if (!gitErrorIncludes(attachError, "already checked out") && !gitErrorIncludes(attachError, "already used by worktree")) {
```

### Issue #10681: git error classification breaks on non-English hosts

**Problem:** `runGit` spawns git with the host environment, so on non-English locales git outputs translated diagnostics. The English-substring matching in `gitErrorIncludes` then fails.

**Fix:** Force C locale when spawning git in `runGit`, `recordGitOperation`, and `getGitWorktreeBranchAncestryVerdict`:
```ts
const mergedEnv = opts?.env ? { ...process.env, ...opts.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' } : { ...process.env, LC_ALL: 'C', LANG: 'C', LANGUAGE: 'C' };
```
Note: C locale is set LAST so it cannot be overwritten by caller-provided env vars.

## Thinking Path

Paperclip uses git worktrees to isolate each agent task's codebase. The `realizeExecutionWorkspace` function in `server/src/services/workspace-runtime.ts` creates or reuses worktrees via `git worktree add`. When a branch is already checked out elsewhere, git emits an error that Paperclip intercepts and tries to handle by reusing the existing worktree instead of creating a duplicate.

**Issue #10683:** The existing guard checked for `"already checked out"` — the message git 2.41 and earlier emitted. Git 2.42 changed this to `"already used by worktree at"`. On newer git versions, the guard failed to match, causing the code to re-throw the error and lose the worktree-reuse optimization. Fix: match both messages with an `OR` condition.

**Issue #10681:** `runGit` (and two other git call sites: `recordGitOperation` and `getGitWorktreeBranchAncestryVerdict`) passed the host environment to `spawn()`. On non-English systems, git translates its error messages. Paperclip's `gitErrorIncludes` helper matches English substrings ("already checked out", "already exists", etc.). Translated messages break these matches, causing spurious failures. Fix: inject `LC_ALL=C` into git's environment so diagnostics are always in English. C locale is placed LAST in the env merge so it cannot be overwritten by caller-provided values.

Both fixes are defensive — they expand match coverage without changing behavior for correctly-matching cases.

## What Changed

- `server/src/services/workspace-runtime.ts` line 581-585: `runGit` now forces `LC_ALL=C`, `LANG=C`, `LANGUAGE=C` with locale overrides last in merge order
- `server/src/services/workspace-runtime.ts` line 2943: `gitErrorIncludes` guard now matches both `"already checked out"` AND `"already used by worktree"`
- `server/src/services/workspace-runtime.ts` line 2527-2530: `recordGitOperation` also forces C locale
- `server/src/services/workspace-runtime.ts` line 981: `getGitWorktreeBranchAncestryVerdict` also forces C locale
- Added test in `workspace-runtime.test.ts` for the git 2.42+ worktree reuse path

## Verification

- Manual reproduction: confirmed git 2.42+ message format ("already used by worktree at")
- Manual reproduction: confirmed old git message format ("already checked out at")
- Logic analysis: the new `&&` condition correctly re-throws only when NEITHER pattern matches
- Locale test: `git worktree add` produces identical English output under `LC_ALL=C` vs default locale
- All git call sites in the file now use the C locale
- New test added covering the git 2.42+ error message path

## Risks

- **Very low.** Both changes are additive and defensive.
- The locale fix sets environment variables with C locale last, so caller-provided `opts.env` values are preserved except for locale (which is intentionally overridden).
- The error pattern match adds a second substring check — false positives would only cause the worktree-reuse path to activate when it previously would have thrown, which is the safer direction.

## Model Used

Claude Sonnet 4 (custom:omniroute, 200K context, tool use)

## Checklist

- [x] I have read and followed the [Contributing Guide](CONTRIBUTING.md)
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] Changes are small, focused, and easy to review
- [x] Tests pass (new test covers git 2.42+ worktree reuse path)
- [x] No breaking changes
- [x] PR template sections filled
- [x] Model Used section included
