### PR TITLE
fix(server): surface interaction decline/cancel reasons as issue comments and reject whitespace-only comment bodies

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -539,7 +539,7 @@ export const updateIssueSchema = createIssueBaseSchema.omit({
 }).partial().extend({
   requestDepth: issueRequestDepthInputSchema.optional(),
   assigneeAgentId: z.string().trim().min(1).optional().nullable(),
-  comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
+  comment: multilineTextSchema.pipe(z.string().trim().min(1)).optional(),
   reviewRequest: issueReviewRequestSchema.optional().nullable(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
@@ -644,7 +644,7 @@ export const issueCommentMetadataSchema = z.object({
 export type IssueCommentMetadata = z.infer<typeof issueCommentMetadataSchema>;
 
 export const addIssueCommentSchema = z.object({
-  body: multilineTextSchema.pipe(z.string().min(1)),
+  body: multilineTextSchema.pipe(z.string().trim().min(1)),
   authorType: issueCommentAuthorTypeSchema.optional(),
   presentation: issueCommentPresentationSchema.nullable().optional(),
   metadata: issueCommentMetadataSchema.nullable().optional(),

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -565,6 +565,15 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       summaryMarkdown: null,
     });
 
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    const reasonComment = comments.find((comment) => comment.body.includes("Questions cancelled"));
+    expect(reasonComment).toBeDefined();
+    expect(reasonComment?.body).toContain("Not needed anymore");
+    expect(reasonComment?.authorType).toBe("user");
+
     await expect(interactionsSvc.answerQuestions({
       id: issueId,
       companyId,
@@ -573,6 +582,78 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     }, {
       userId: "local-board",
     })).rejects.toThrow("Interaction has already been resolved");
+  });
+
+  it("records a confirmation decline reason as an issue comment", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Decline reason comment");
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Proceed with the plan?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const rejected = await interactionsSvc.rejectInteraction({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      reason: "Budget not approved",
+    }, {
+      userId: "local-board",
+    });
+
+    expect(rejected.status).toBe("rejected");
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    const reasonComment = comments.find((comment) => comment.body.includes("Confirmation declined"));
+    expect(reasonComment).toBeDefined();
+    expect(reasonComment?.body).toContain("Budget not approved");
+    expect(reasonComment?.authorType).toBe("user");
+
+    const withoutReason = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Second confirmation",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    await interactionsSvc.rejectInteraction({
+      id: issueId,
+      companyId,
+    }, withoutReason.id, {}, {
+      userId: "local-board",
+    });
+
+    const after = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(after.filter((comment) => comment.body.includes("Confirmation declined"))).toHaveLength(1);
+  });
+
+  it("rejects whitespace-only comment bodies at the service layer", async () => {
+    const { issueId } = await seedConfirmationIssue("Whitespace comment guard");
+
+    await expect(
+      issuesSvc.addComment(issueId, "   \n\t  ", { userId: "local-board" }),
+    ).rejects.toThrow("Comment body cannot be empty");
   });
 
   it("expires ask_user_questions interactions by default when a user comments after creation", async () => {

--- a/server/src/routes/board-chat.ts
+++ b/server/src/routes/board-chat.ts
@@ -357,7 +357,7 @@ export function boardChatRoutes(
       // Persist the board's reply under the "board-concierge" sentinel so the
       // UI renders it as an assistant bubble (see BoardChat `isUser` check).
       const cleanedResponse = stripActionSignals(fullResponse);
-      if (cleanedResponse) {
+      if (cleanedResponse.trim()) {
         try {
           await issueSvc.addComment(resolvedIssueId, cleanedResponse, {
             userId: "board-concierge",

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -52,6 +52,7 @@ import {
 } from "@paperclipai/shared";
 import { z } from "zod";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { logger } from "../middleware/logger.js";
 import { getTelemetryClient } from "../telemetry.js";
 import { issueService, runWorkspaceIsFinalized } from "./issues.js";
 
@@ -1135,6 +1136,33 @@ export function issueThreadInteractionService(db: Db) {
     return result;
   }
 
+  async function recordResolutionReasonComment(args: {
+    issue: { id: string; companyId: string };
+    actor: InteractionActor;
+    interactionId: string;
+    label: string;
+    reason: string | null | undefined;
+  }): Promise<void> {
+    const reason = args.reason?.trim();
+    if (!reason) {
+      return;
+    }
+    try {
+      await issueService(db).addComment(
+        args.issue.id,
+        `**${args.label}** (interaction ${args.interactionId.slice(0, 8)}): ${reason}`,
+        { agentId: args.actor.agentId ?? undefined, userId: args.actor.userId ?? undefined },
+      );
+    } catch (error) {
+      // The resolution itself has already committed; failing to surface the
+      // reason as a comment must not fail the resolution.
+      logger.warn(
+        { issueId: args.issue.id, interactionId: args.interactionId, error },
+        "failed to record interaction resolution reason as issue comment",
+      );
+    }
+  }
+
   async function rejectRequestConfirmation(args: {
     issue: { id: string; companyId: string };
     current: IssueThreadInteractionRow;
@@ -1180,6 +1208,13 @@ export function issueThreadInteractionService(db: Db) {
       throw conflict("Interaction has already been resolved");
     }
     await touchIssue(db, args.issue.id);
+    await recordResolutionReasonComment({
+      issue: args.issue,
+      actor: args.actor,
+      interactionId: updated.id,
+      label: "Confirmation declined",
+      reason,
+    });
     const rejected = hydrateInteraction(updated);
     await emitInteractionResolvedTelemetry(db, rejected);
     return rejected;
@@ -1692,6 +1727,13 @@ export function issueThreadInteractionService(db: Db) {
       }
 
       await touchIssue(db, issue.id);
+      await recordResolutionReasonComment({
+        issue,
+        actor,
+        interactionId: updated.id,
+        label: "Suggested tasks declined",
+        reason: input.reason,
+      });
       const rejected = hydrateInteraction(updated);
       await emitInteractionResolvedTelemetry(db, rejected);
       return rejected;
@@ -2218,6 +2260,13 @@ export function issueThreadInteractionService(db: Db) {
       }
 
       await touchIssue(db, issue.id);
+      await recordResolutionReasonComment({
+        issue,
+        actor,
+        interactionId: updated.id,
+        label: "Questions cancelled",
+        reason,
+      });
       const cancelled = hydrateInteraction(updated);
       await emitInteractionResolvedTelemetry(db, cancelled);
       return cancelled;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8150,6 +8150,9 @@ export function issueService(db: Db) {
       },
       dbOrTx: any = db,
     ) => {
+      if (body.trim().length === 0) {
+        throw unprocessable("Comment body cannot be empty");
+      }
       const issue = await dbOrTx
         .select({ companyId: issues.companyId })
         .from(issues)


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Boards and agents coordinate through issue-thread interactions: confirmations, suggested tasks, and questions
> - When a board declines a confirmation, rejects suggested tasks, or cancels questions, the reason text is stored only in the interaction's result JSONB
> - Nothing surfaces that reason on the issue thread, so the assignee's next wake context never sees why the request was declined - the guidance is silently lost
> - Separately, whitespace-only comment bodies pass validation (`min(1)` without trim) and create empty comments that wake agents with no content
> - This PR records decline/cancel reasons as first-class issue comments at resolution time, and rejects whitespace-only comment bodies at both the schema and service layers
> - The benefit is that resolution guidance reliably reaches the assignee's context, and empty-content comment wakes disappear

## What Changed

- `server/src/services/issue-thread-interactions.ts`: new `recordResolutionReasonComment` helper, called from `rejectRequestConfirmation` (covers `request_confirmation` and `request_checkbox_confirmation`), `rejectSuggestedTasks`, and `cancelQuestions` when a non-empty reason is present. Best-effort: a failed comment insert logs a warning and never fails the already-committed resolution.
- `packages/shared/src/validators/issue.ts`: `addIssueCommentSchema.body` and `updateIssueSchema.comment` now `.trim()` before `.min(1)`, so whitespace-only submissions are rejected.
- `server/src/services/issues.ts`: `addComment` throws 422 `Comment body cannot be empty` for whitespace-only bodies - defense in depth for internal callers that bypass route validation.
- `server/src/routes/board-chat.ts`: skip persisting a board reply whose cleaned response is whitespace-only.
- `server/src/__tests__/issue-thread-interactions-service.test.ts`: new test for decline-reason comments (with a reason, and asserting no comment when the reason is omitted), new test for the whitespace guard, and the existing `cancelQuestions` test now asserts the cancellation-reason comment.

## Verification

- `pnpm --filter @paperclipai/shared typecheck && pnpm --filter @paperclipai/server typecheck` - clean
- `pnpm exec vitest run server/src/__tests__/issue-thread-interactions-service.test.ts` - 42 passed (embedded postgres)
- `pnpm exec vitest run packages/shared/src/validators/issue.test.ts server/src/__tests__/issue-comment-redaction.test.ts` - 32 passed
- Manual: decline a pending confirmation with a reason (board UI or the reject endpoint); a `**Confirmation declined** (interaction <id8>): <reason>` comment appears on the issue thread attributed to the declining user/agent. POST an issue comment whose body is only whitespace; the API returns 422.

## Risks

- Behavioral shift: resolutions that carry a reason now add a visible issue comment authored by the resolving user/agent. Resolution-time comments do not trigger comment-created side effects such as confirmation supersede-on-comment - those fire from the comment routes, not from `issueService.addComment`.
- Whitespace-only comments now fail with 422 where they previously created empty comments. No in-repo caller posts blank bodies through `addComment`; deleted-comment tombstones render `body: ""` through a different path and are unaffected (covered by the redaction suite, which passes).
- No migrations, no schema changes. Low risk overall; the reason comment is wrapped best-effort so a comment failure can never fail the resolution.

## Model Used

- Claude Fable 5 (Anthropic), model ID `claude-fable-5`, running in Claude Code - agentic session with extended thinking and tool use (repo search, file edits, local `tsc` and `vitest` runs against an embedded-postgres test database).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (n/a - no UI change)
- [ ] I have updated relevant documentation to reflect my changes (n/a - no existing doc surface describes comment validation or interaction resolution side effects)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
