### PR TITLE
fix(claude-local): classify prompt overflow as deterministic, not transient upstream

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -68,6 +68,9 @@ export interface AdapterRuntimeServiceReport {
 export type AdapterExecutionErrorFamily =
   | "transient_upstream"
   | "provider_quota"
+  // Deterministic: the prompt is the same size on the next attempt, so a plain
+  // retry cannot succeed. Deliberately not part of the transient contract.
+  | "context_overflow"
   | "model_refusal"
   | "refresh_token_reused"
   | "refresh_token_expired"

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -69,6 +69,7 @@ import {
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  isClaudeContextOverflowError,
 } from "./parse.js";
 import {
   materializeRemoteClaudeConfig,
@@ -1109,12 +1110,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderr: proc.stderr,
         errorMessage,
       });
+    // Deterministic: the same prompt is the same size next time. Must be
+    // decided before the transient branch — the transient haystack reads the
+    // whole stdout, and the CLI stream carries `rate_limit_info` on every run.
+    const contextOverflow = failed && isClaudeContextOverflowError(parsed);
     const transientUpstream =
       failed &&
       !loginMeta.requiresLogin &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
       !providerQuota &&
+      !contextOverflow &&
       isClaudeTransientUpstreamError({
         parsed,
         stdout: proc.stdout,
@@ -1142,6 +1148,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? "max_turns_exhausted"
       : failed && poisonedPreviousMessageId
       ? "claude_poisoned_previous_message_id"
+      : contextOverflow
+      ? "claude_context_overflow"
       : providerQuota
       ? "provider_quota"
       : transientUpstream
@@ -1149,7 +1157,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : claudeRefusal
       ? "claude_refusal"
       : null;
-    const errorFamily = providerQuota
+    const errorFamily = contextOverflow
+      ? "context_overflow"
+      : providerQuota
       ? "provider_quota"
       : transientUpstream
       ? "transient_upstream"

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -11,6 +11,7 @@ import {
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  isClaudeContextOverflowError,
 } from "./parse.js";
 
 describe("detectClaudeLoginRequired", () => {
@@ -51,6 +52,54 @@ describe("isClaudeModelNotFoundError", () => {
     expect(isClaudeModelNotFoundError({
       errorMessage: "API Error: 503 service unavailable",
     })).toBe(false);
+  });
+});
+
+describe("isClaudeContextOverflowError", () => {
+  // Verbatim from a failed run on a production host: the CLI reports the
+  // overflow as a *successful* result subtype, so `subtype` cannot be used to
+  // detect it — only the result text can.
+  const overflowResult = { subtype: "success", result: "Prompt is too long" };
+
+  it("classifies the CLI's prompt overflow result", () => {
+    expect(isClaudeContextOverflowError(overflowResult)).toBe(true);
+  });
+
+  it("classifies the API-shaped context limit errors", () => {
+    expect(
+      isClaudeContextOverflowError({
+        result: "input length and `max_tokens` exceed context limit: 203241 + 32000 > 204698",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeContextOverflowError({ errors: [{ message: "context_length_exceeded" }] }),
+    ).toBe(true);
+  });
+
+  it("does not claim usage-limit failures", () => {
+    expect(
+      isClaudeContextOverflowError({
+        result: "You've hit your weekly limit · resets Aug 3, 7am (Europe/Zurich)",
+      }),
+    ).toBe(false);
+    expect(isClaudeContextOverflowError(null)).toBe(false);
+  });
+
+  it("keeps prompt overflow out of the transient bucket even when the stream carries rate-limit telemetry", () => {
+    // Every Claude CLI stream carries a `rate_limit_info` block, and
+    // `rateLimitType` alone matches CLAUDE_TRANSIENT_UPSTREAM_RE. Because the
+    // transient haystack reads the whole stdout, an overflow used to be
+    // reclassified as a transient upstream blip and retried until the attempt
+    // budget was gone. Measured on a real host: 617 runs, all retried.
+    const stdout = JSON.stringify({
+      type: "result",
+      rate_limit_info: { status: "rejected", rateLimitType: "seven_day" },
+    });
+
+    expect(isClaudeTransientUpstreamError({ parsed: overflowResult, stdout })).toBe(false);
+    // The contamination itself is real and out of scope here: without a
+    // deterministic classifier in front, the same stdout still decides.
+    expect(isClaudeTransientUpstreamError({ parsed: { result: "disk full" }, stdout })).toBe(true);
   });
 });
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -13,6 +13,8 @@ const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+const CLAUDE_CONTEXT_OVERFLOW_RE =
+  /(?:prompt\s+is\s+too\s+long|input\s+length\s+and\s+`?max_tokens`?\s+exceed\s+context\s+limit|context[\s_-]?length[\s_-]?exceeded|maximum\s+context\s+length)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
@@ -278,6 +280,29 @@ export function isClaudePoisonedPreviousMessageIdError(parsed: Record<string, un
   );
 }
 
+/**
+ * Prompt overflow is deterministic: the same prompt is the same size on the
+ * next attempt, so a plain retry cannot succeed. It needs its own classifier
+ * because the transient haystack below reads the whole `stdout`, and the
+ * Claude CLI stream carries a `rate_limit_info` block on every run —
+ * `rateLimitType` alone matches CLAUDE_TRANSIENT_UPSTREAM_RE. Without this
+ * classifier running first, an overflow is retried as a transient upstream
+ * blip until the attempt budget is gone.
+ *
+ * Like the other deterministic classifiers, this one reads only the parsed
+ * result payload, never `stdout` — that is what keeps it immune to whatever
+ * the run happened to print.
+ */
+export function isClaudeContextOverflowError(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) => CLAUDE_CONTEXT_OVERFLOW_RE.test(msg));
+}
+
 export function isClaudeImageProcessingError(parsed: Record<string, unknown>): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
@@ -468,7 +493,7 @@ export function isClaudeTransientUpstreamError(input: {
 }): boolean {
   const parsed = input.parsed ?? null;
   // Deterministic failures are handled by their own classifiers.
-  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed))) {
+  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed) || isClaudeContextOverflowError(parsed))) {
     return false;
   }
   const loginMeta = detectClaudeLoginRequired({
@@ -491,7 +516,7 @@ export function isClaudeProviderQuotaError(input: {
   errorMessage?: string | null;
 }): boolean {
   const parsed = input.parsed ?? null;
-  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed))) {
+  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed) || isClaudeContextOverflowError(parsed))) {
     return false;
   }
   const loginMeta = detectClaudeLoginRequired({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - A `claude_local` agent that outgrows its context window fails with `Prompt is too long`.
> - That failure is deterministic: the same prompt is the same size on the next attempt.
> - The adapter had no classifier for it, so the run was retried as a transient upstream blip.
> - Measured on one host, those retries burned 617 runs without a chance of succeeding.
> - Giving the failure its own deterministic error code keeps it off the transient retry path.
> - The benefit is that an overflowing agent stops spending its attempt budget on a retry that cannot work.

## Linked Issues or Issue Description

Refs #7733.

## What Changed

- Add `isClaudeContextOverflowError()` to the claude-local parser. Like the other
  deterministic classifiers in that file it reads only the parsed result payload,
  never `stdout`.
- Decide it **before** the transient branch in the parsed classification ladder,
  and add it to the deterministic guard list inside
  `isClaudeTransientUpstreamError()` and `isClaudeProviderQuotaError()`.
- Emit error code `claude_context_overflow` and error family `context_overflow`,
  and add that family to `AdapterExecutionErrorFamily`.

## Why the ordering is the actual fix

The obvious reading is that `Prompt is too long` falls into a generic transient
bucket because nothing classifies it. That is not what happens —
`CLAUDE_TRANSIENT_UPSTREAM_RE` does not match the text:

```js
RE.test("Claude run failed: subtype=success: Prompt is too long")  // false
```

`buildClaudeTransientHaystack()` folds the whole `stdout` into the search text,
and every Claude CLI stream carries its own rate-limit telemetry:

```json
"rate_limit_info":{"status":"rejected","resetsAt":...,"rateLimitType":"seven_day"}
```

`rateLimitType` alone matches `rate[-\s]?limit`. Sampled over the real run logs
on one host: **40 of 40** carry that token. Feeding a real 60 kB `stdout` to the
shipped predicate (`paperclipai@2026.609.0`, `dist/server/parse.js`):

| result text | `isClaudeTransientUpstreamError` |
| --- | --- |
| `Prompt is too long` | true |
| `disk full` | true |
| `syntax error in config` | true |

So a new error class on its own would still lose to the contaminated haystack.
It has to be decided first — which is what this change does.

That wider contamination affects **every** error class, not just this one, so it
is deliberately left alone here and belongs in its own change.

## Why the retry actually stops

`readTransientRecoveryContractFromRun()` builds a retry contract only for the
families `transient_upstream` and `provider_quota`. `context_overflow` is
neither, so no `transient_failure` retry is scheduled.

## Verification

- `npx vitest run packages/adapters/claude-local/src/server/parse.test.ts`
  → **43 passed** (4 new).
- Whole package before/after, same tree, same links:
  baseline **71 passed / 9 failed (80)**, with this change **75 passed / 9 failed (84)**.
  The 9 failures are pre-existing in this environment (`Cannot find package 'acpx/runtime'`
  and a remote-exec call-count assertion); the delta is exactly the 4 new tests.
- `npx tsc --noEmit` in `packages/adapters/claude-local`: no diagnostics in the
  changed files. (This is what caught the missing `AdapterExecutionErrorFamily`
  member.) The remaining output is pre-existing `@types/node` resolution noise
  in this sandbox.
- Red-before is measured against the **shipped** artifact, not a hand-rolled
  stub: the table above is the old behaviour.

## Note on scope

The overflow classifier reads the parsed payload only, so a run that dies
without emitting a parseable result JSON is not covered. In every failure
measured here the CLI did emit one (`subtype=success`, `result="Prompt is too
long"`), and keeping deterministic classifiers off `stdout` is exactly what
stops the contamination described above.
