### PR TITLE
fix(claude-local): classify prompt overflow as deterministic, not transient upstream

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -68,6 +68,9 @@ export interface AdapterRuntimeServiceReport {
 export type AdapterExecutionErrorFamily =
   | "transient_upstream"
   | "provider_quota"
+  // Deterministic: the prompt is the same size on the next attempt, so a plain
+  // retry cannot succeed. Deliberately not part of the transient contract.
+  | "context_overflow"
   | "model_refusal"
   | "refresh_token_reused"
   | "refresh_token_expired"

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -69,6 +69,7 @@ import {
   isClaudePoisonedPreviousMessageIdError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  isClaudeContextOverflowError,
 } from "./parse.js";
 import {
   materializeRemoteClaudeConfig,
@@ -1109,12 +1110,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderr: proc.stderr,
         errorMessage,
       });
+    // Deterministic: the same prompt is the same size next time. Must be
+    // decided before the transient branch — the transient haystack reads the
+    // whole stdout, and the CLI stream carries `rate_limit_info` on every run.
+    const contextOverflow = failed && isClaudeContextOverflowError(parsed);
     const transientUpstream =
       failed &&
       !loginMeta.requiresLogin &&
       !clearSessionForMaxTurns &&
       !poisonedPreviousMessageId &&
       !providerQuota &&
+      !contextOverflow &&
       isClaudeTransientUpstreamError({
         parsed,
         stdout: proc.stdout,
@@ -1142,6 +1148,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ? "max_turns_exhausted"
       : failed && poisonedPreviousMessageId
       ? "claude_poisoned_previous_message_id"
+      : contextOverflow
+      ? "claude_context_overflow"
       : providerQuota
       ? "provider_quota"
       : transientUpstream
@@ -1149,7 +1157,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : claudeRefusal
       ? "claude_refusal"
       : null;
-    const errorFamily = providerQuota
+    const errorFamily = contextOverflow
+      ? "context_overflow"
+      : providerQuota
       ? "provider_quota"
       : transientUpstream
       ? "transient_upstream"

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -11,6 +11,7 @@ import {
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  isClaudeContextOverflowError,
 } from "./parse.js";
 
 describe("detectClaudeLoginRequired", () => {
@@ -51,6 +52,54 @@ describe("isClaudeModelNotFoundError", () => {
     expect(isClaudeModelNotFoundError({
       errorMessage: "API Error: 503 service unavailable",
     })).toBe(false);
+  });
+});
+
+describe("isClaudeContextOverflowError", () => {
+  // Verbatim from a failed run on a production host: the CLI reports the
+  // overflow as a *successful* result subtype, so `subtype` cannot be used to
+  // detect it — only the result text can.
+  const overflowResult = { subtype: "success", result: "Prompt is too long" };
+
+  it("classifies the CLI's prompt overflow result", () => {
+    expect(isClaudeContextOverflowError(overflowResult)).toBe(true);
+  });
+
+  it("classifies the API-shaped context limit errors", () => {
+    expect(
+      isClaudeContextOverflowError({
+        result: "input length and `max_tokens` exceed context limit: 203241 + 32000 > 204698",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeContextOverflowError({ errors: [{ message: "context_length_exceeded" }] }),
+    ).toBe(true);
+  });
+
+  it("does not claim usage-limit failures", () => {
+    expect(
+      isClaudeContextOverflowError({
+        result: "You've hit your weekly limit · resets Aug 3, 7am (Europe/Zurich)",
+      }),
+    ).toBe(false);
+    expect(isClaudeContextOverflowError(null)).toBe(false);
+  });
+
+  it("keeps prompt overflow out of the transient bucket even when the stream carries rate-limit telemetry", () => {
+    // Every Claude CLI stream carries a `rate_limit_info` block, and
+    // `rateLimitType` alone matches CLAUDE_TRANSIENT_UPSTREAM_RE. Because the
+    // transient haystack reads the whole stdout, an overflow used to be
+    // reclassified as a transient upstream blip and retried until the attempt
+    // budget was gone. Measured on a real host: 617 runs, all retried.
+    const stdout = JSON.stringify({
+      type: "result",
+      rate_limit_info: { status: "rejected", rateLimitType: "seven_day" },
+    });
+
+    expect(isClaudeTransientUpstreamError({ parsed: overflowResult, stdout })).toBe(false);
+    // The contamination itself is real and out of scope here: without a
+    // deterministic classifier in front, the same stdout still decides.
+    expect(isClaudeTransientUpstreamError({ parsed: { result: "disk full" }, stdout })).toBe(true);
   });
 });
 

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -65,6 +65,46 @@ describe("isClaudeContextOverflowError", () => {
     expect(isClaudeContextOverflowError(overflowResult)).toBe(true);
   });
 
+  it("classifies the full result payload the CLI actually emits", () => {
+    // Captured verbatim from a run log. Two fields matter: `subtype` is
+    // "success" — so it carries no signal — and `is_error` is true, which is
+    // what puts the run behind execute.ts's `failed` gate in the first place.
+    expect(
+      isClaudeContextOverflowError({
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        stop_reason: "stop_sequence",
+        terminal_reason: "blocking_limit",
+        num_turns: 1,
+        total_cost_usd: 0,
+        result: "Prompt is too long",
+      }),
+    ).toBe(true);
+  });
+
+  it("reads free-form result text and therefore must stay behind the failure gate", () => {
+    // This classifier is text-only by design — like the sibling deterministic
+    // classifiers, it never reads stdout, which is what keeps it immune to the
+    // rate-limit telemetry below. The price is that it cannot tell an overflow
+    // apart from an agent *writing about* an overflow, so execute.ts only
+    // consults it once the run has already failed.
+    //
+    // The gate costs nothing in coverage: every payload carrying
+    // `is_error: true` already makes `failed` true, so the only shape it
+    // excludes is a run the CLI reported as fully clean (exit 0, is_error
+    // false) — where the result text is the agent's own message, not an error.
+    // Not hypothetical: in a 1000-run sample from one fleet, 7 *succeeded*
+    // runs had this phrase in their final message.
+    expect(
+      isClaudeContextOverflowError({
+        subtype: "success",
+        result:
+          "The no-comment streak was caused by a session-pin loop (`Prompt is too long`), not genuine inactivity.",
+      }),
+    ).toBe(true);
+  });
+
   it("classifies the API-shaped context limit errors", () => {
     expect(
       isClaudeContextOverflowError({

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -13,6 +13,8 @@ const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
   /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+const CLAUDE_CONTEXT_OVERFLOW_RE =
+  /(?:prompt\s+is\s+too\s+long|input\s+length\s+and\s+`?max_tokens`?\s+exceed\s+context\s+limit|context[\s_-]?length[\s_-]?exceeded|maximum\s+context\s+length)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
@@ -278,6 +280,29 @@ export function isClaudePoisonedPreviousMessageIdError(parsed: Record<string, un
   );
 }
 
+/**
+ * Prompt overflow is deterministic: the same prompt is the same size on the
+ * next attempt, so a plain retry cannot succeed. It needs its own classifier
+ * because the transient haystack below reads the whole `stdout`, and the
+ * Claude CLI stream carries a `rate_limit_info` block on every run —
+ * `rateLimitType` alone matches CLAUDE_TRANSIENT_UPSTREAM_RE. Without this
+ * classifier running first, an overflow is retried as a transient upstream
+ * blip until the attempt budget is gone.
+ *
+ * Like the other deterministic classifiers, this one reads only the parsed
+ * result payload, never `stdout` — that is what keeps it immune to whatever
+ * the run happened to print.
+ */
+export function isClaudeContextOverflowError(parsed: Record<string, unknown> | null | undefined): boolean {
+  if (!parsed) return false;
+  const resultText = asString(parsed.result, "").trim();
+  const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
+    .map((msg) => msg.trim())
+    .filter(Boolean);
+
+  return allMessages.some((msg) => CLAUDE_CONTEXT_OVERFLOW_RE.test(msg));
+}
+
 export function isClaudeImageProcessingError(parsed: Record<string, unknown>): boolean {
   const resultText = asString(parsed.result, "").trim();
   const allMessages = [resultText, ...extractClaudeErrorMessages(parsed)]
@@ -468,7 +493,7 @@ export function isClaudeTransientUpstreamError(input: {
 }): boolean {
   const parsed = input.parsed ?? null;
   // Deterministic failures are handled by their own classifiers.
-  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed))) {
+  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed) || isClaudeContextOverflowError(parsed))) {
     return false;
   }
   const loginMeta = detectClaudeLoginRequired({
@@ -491,7 +516,7 @@ export function isClaudeProviderQuotaError(input: {
   errorMessage?: string | null;
 }): boolean {
   const parsed = input.parsed ?? null;
-  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed))) {
+  if (parsed && (isClaudeMaxTurnsResult(parsed) || isClaudeUnknownSessionError(parsed) || isClaudePoisonedPreviousMessageIdError(parsed) || isClaudeImageProcessingError(parsed) || isClaudeContextOverflowError(parsed))) {
     return false;
   }
   const loginMeta = detectClaudeLoginRequired({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - A `claude_local` agent that outgrows its context window fails with `Prompt is too long`.
> - That failure is deterministic: the same prompt is the same size on the next attempt.
> - The adapter had no classifier for it, so the run was retried as a transient upstream blip.
> - Measured on one host, those retries burned 617 runs without a chance of succeeding.
> - Giving the failure its own deterministic error code keeps it off the transient retry path.
> - The benefit is that an overflowing agent stops spending its attempt budget on a retry that cannot work.

## Linked Issues or Issue Description

Refs #7733.

## What Changed

- Add `isClaudeContextOverflowError()` to the claude-local parser. Like the other
  deterministic classifiers in that file it reads only the parsed result payload,
  never `stdout`.
- Decide it **before** the transient branch in the parsed classification ladder,
  and add it to the deterministic guard list inside
  `isClaudeTransientUpstreamError()` and `isClaudeProviderQuotaError()`.
- Emit error code `claude_context_overflow` and error family `context_overflow`,
  and add that family to `AdapterExecutionErrorFamily`.

## Why the ordering is the actual fix

The obvious reading is that `Prompt is too long` falls into a generic transient
bucket because nothing classifies it. That is not what happens —
`CLAUDE_TRANSIENT_UPSTREAM_RE` does not match the text:

```js
RE.test("Claude run failed: subtype=success: Prompt is too long")  // false
```

`buildClaudeTransientHaystack()` folds the whole `stdout` into the search text,
and every Claude CLI stream carries its own rate-limit telemetry:

```json
"rate_limit_info":{"status":"rejected","resetsAt":...,"rateLimitType":"seven_day"}
```

`rateLimitType` alone matches `rate[-\s]?limit`. Sampled over the real run logs
on one host: **40 of 40** carry that token. Feeding a real 60 kB `stdout` to the
shipped predicate (`paperclipai@2026.609.0`, `dist/server/parse.js`):

| result text | `isClaudeTransientUpstreamError` |
| --- | --- |
| `Prompt is too long` | true |
| `disk full` | true |
| `syntax error in config` | true |

So a new error class on its own would still lose to the contaminated haystack.
It has to be decided first — which is what this change does.

That wider contamination affects **every** error class, not just this one, so it
is deliberately left alone here and belongs in its own change.

## Why the retry actually stops

`readTransientRecoveryContractFromRun()` builds a retry contract only for the
families `transient_upstream` and `provider_quota`. `context_overflow` is
neither, so no `transient_failure` retry is scheduled.

## Verification

- `npx vitest run packages/adapters/claude-local/src/server/parse.test.ts`
  → **45 passed** (6 new).
- Whole package before/after, same tree, same links:
  baseline **71 passed / 9 failed (80)**, with this change **75 passed / 9 failed (84)**.
  The 9 failures are pre-existing in this environment (`Cannot find package 'acpx/runtime'`
  and a remote-exec call-count assertion); the delta is exactly the 4 new tests.
- `npx tsc --noEmit` in `packages/adapters/claude-local`: no diagnostics in the
  changed files. (This is what caught the missing `AdapterExecutionErrorFamily`
  member.) The remaining output is pre-existing `@types/node` resolution noise
  in this sandbox.
- Red-before is measured against the **shipped** artifact, not a hand-rolled
  stub: the table above is the old behaviour.

## Note on scope

The overflow classifier reads the parsed payload only, so a run that dies
without emitting a parseable result JSON is not covered. In every failure
measured here the CLI did emit one (`subtype=success`, `result="Prompt is too
long"`), and keeping deterministic classifiers off `stdout` is exactly what
stops the contamination described above.

## Risks

Low risk, and deliberately narrow.

- **Behavioural shift, intended:** a `claude_local` run failing with a context
  overflow is no longer retried as a transient upstream failure. That is the
  point of the change; the retries could not succeed.
- **No change for anything else.** The new predicate reads only the parsed
  result payload and matches context-length phrasings, so runs that do not
  overflow classify exactly as before. The whole-package test suite shows the
  same 9 pre-existing failures before and after (80 → 84 tests, +4 new).
- **New enum member.** `context_overflow` is added to
  `AdapterExecutionErrorFamily`. Consumers switch on the two families that
  carry a retry contract (`transient_upstream`, `provider_quota`) and fall
  through otherwise, so the new member is inert for them.
- **Deliberately not fixed here:** the transient haystack reads the whole
  `stdout` and is therefore matched by the CLI's own `rate_limit_info` block on
  essentially every run. That affects all error classes and needs its own
  change; this PR only makes sure overflow is decided before it.
- **Known gap, stated rather than papered over:** a run that dies without
  emitting a parseable result JSON is not classified. Keeping deterministic
  classifiers off `stdout` is what makes them trustworthy, so widening them was
  the wrong trade here.

## Review round 1

Greptile raised a P1 on the `failed` gate in `execute.ts`: a
`{ subtype: "success", result: "Prompt is too long" }` payload *without*
`is_error` would skip the classifier. Measured against real run logs, the gate
is load-bearing and stays:

- The payload the CLI actually emits carries `is_error: true` alongside
  `subtype: "success"`. `is_error: true` alone makes `parsedSucceeded` false and
  `failed` true regardless of exit code, so every payload of this shape is
  already classified — 129 of 129 runs that failed with this text on one host
  came out with an `errorCode` set, which is only reachable through `failed`.
- Dropping the gate would misclassify *successful* runs. The classifier reads
  `result`, which on a clean run is the agent's free-form final message. In a
  1000-run sample from the same fleet, **7 succeeded runs** contain the phrase
  because the agents were writing about this defect; each would have been
  stamped `claude_context_overflow` and had its result discarded.
- The gate costs nothing in coverage: since `is_error: true` implies `failed`,
  the only shape it excludes is a run the CLI reported as fully clean — exit 0
  *and* `is_error` false — where there is no error to classify.

Commit `00523eb9` pins both halves as regression tests: the full captured
payload, and an assertion that the classifier *does* fire on prose mentioning
the phrase, so the reason the gate exists is explicit rather than incidental.

`failed` swallowing a non-zero exit code when `subtype: "success"` and
`is_error` is absent is a real pre-existing hole, but it is not specific to
overflow — it would hide `provider_quota` the same way. Left out to keep this
PR to one concern.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, with tool use
and code execution (repository search, local vitest/tsc runs, and direct
measurement against real run logs and the shipped `paperclipai@2026.609.0`
artifact).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above — closest is #10471, which was closed unmerged by its author because it targeted this repo while their fleet runs a fork; it never landed here, and `origin/master` still has no overflow classification
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs cover adapter error codes; the reasoning is carried in code comments and this description
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — one flake on the first run (`heartbeat-workspace-busy`, unrelated to this diff: the *same* commit passed that shard in the sibling run); re-running on the review-round commit
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — one P1 raised and answered inline with measured evidence (see *Review round 1*); awaiting re-review
- [x] I will address all Greptile and reviewer comments before requesting merge

## Related

Supersedes my own #10760, which was opened from a branch whose name carried an
internal ticket id. Same commit, same tree.