### PR TITLE
fix(server): unassign issues on agent termination so they do not become immutable

### DIFF
--- a/server/src/__tests__/agents-service-terminate-unassign.test.ts
+++ b/server/src/__tests__/agents-service-terminate-unassign.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { agentApiKeys, agents, companies, createDb, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agent service terminate", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-terminate-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(agentApiKeys);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(companyId: string, name: string) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  it("unassigns the terminated agent's issues so they stay mutable", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, "Retired");
+
+    const openIssueId = randomUUID();
+    const reviewIssueId = randomUUID();
+    const doneIssueId = randomUUID();
+
+    await db.insert(issues).values([
+      { id: openIssueId, companyId, title: "Open work", status: "todo", assigneeAgentId: agentId },
+      { id: reviewIssueId, companyId, title: "In review", status: "in_review", assigneeAgentId: agentId },
+      { id: doneIssueId, companyId, title: "Finished work", status: "done", assigneeAgentId: agentId },
+    ]);
+
+    const terminated = await agentService(db).terminate(agentId);
+    expect(terminated).toMatchObject({ id: agentId, status: "terminated" });
+
+    const rows = await db.select().from(issues).where(eq(issues.companyId, companyId));
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.assigneeAgentId).toBeNull();
+    }
+
+    // Statuses must survive. Termination detaches ownership; it does not
+    // reopen, close, or otherwise move the work.
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    expect(byId.get(openIssueId)?.status).toBe("todo");
+    expect(byId.get(reviewIssueId)?.status).toBe("in_review");
+    expect(byId.get(doneIssueId)?.status).toBe("done");
+  });
+
+  it("leaves other agents' issues untouched", async () => {
+    const companyId = await seedCompany();
+    const terminatedAgentId = await seedAgent(companyId, "Retired");
+    const survivingAgentId = await seedAgent(companyId, "Active");
+
+    const keptIssueId = randomUUID();
+    await db.insert(issues).values([
+      { companyId, title: "Retired agent work", status: "todo", assigneeAgentId: terminatedAgentId },
+      { id: keptIssueId, companyId, title: "Active agent work", status: "todo", assigneeAgentId: survivingAgentId },
+    ]);
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [kept] = await db.select().from(issues).where(eq(issues.id, keptIssueId));
+    expect(kept?.assigneeAgentId).toBe(survivingAgentId);
+
+    const [survivor] = await db.select().from(agents).where(eq(agents.id, survivingAgentId));
+    expect(survivor?.status).toBe("idle");
+  });
+
+  it("keeps authorship attribution and still revokes api keys", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, "Retired");
+
+    const authoredIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: authoredIssueId,
+      companyId,
+      title: "Authored by the retired agent",
+      status: "todo",
+      assigneeAgentId: agentId,
+      createdByAgentId: agentId,
+    });
+
+    await db.insert(agentApiKeys).values({
+      agentId,
+      companyId,
+      name: "default",
+      keyHash: "hash",
+    });
+
+    await agentService(db).terminate(agentId);
+
+    const [authored] = await db.select().from(issues).where(eq(issues.id, authoredIssueId));
+    expect(authored?.assigneeAgentId).toBeNull();
+    // The agent row survives termination, so authorship remains a valid
+    // reference. Only `remove` clears it.
+    expect(authored?.createdByAgentId).toBe(agentId);
+
+    const keys = await db.select().from(agentApiKeys).where(eq(agentApiKeys.agentId, agentId));
+    expect(keys).toHaveLength(1);
+    expect(keys[0]?.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it("returns null for an unknown agent", async () => {
+    expect(await agentService(db).terminate(randomUUID())).toBeNull();
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -709,21 +709,34 @@ export function agentService(db: Db) {
       const existing = await getById(id);
       if (!existing) return null;
 
-      await db
-        .update(agents)
-        .set({
-          status: "terminated",
-          pauseReason: null,
-          pausedAt: null,
-          errorReason: null,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, id));
+      await db.transaction(async (tx) => {
+        // A terminated agent is not invokable, so it can never act on its own
+        // issues again. Authorization grants `issue:mutate` only to the current
+        // assignee, so leaving the assignment in place makes those rows
+        // permanently immutable for every other actor. Detach them here, the
+        // same way `remove` does. Only the assignee link is cleared: unlike
+        // `remove`, the agent row survives, so authorship stays valid.
+        await tx
+          .update(issues)
+          .set({ assigneeAgentId: null, updatedAt: new Date() })
+          .where(eq(issues.assigneeAgentId, id));
 
-      await db
-        .update(agentApiKeys)
-        .set({ revokedAt: new Date() })
-        .where(eq(agentApiKeys.agentId, id));
+        await tx
+          .update(agents)
+          .set({
+            status: "terminated",
+            pauseReason: null,
+            pausedAt: null,
+            errorReason: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(agents.id, id));
+
+        await tx
+          .update(agentApiKeys)
+          .set({ revokedAt: new Date() })
+          .where(eq(agentApiKeys.agentId, id));
+      });
 
       return getById(id);
     },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators retire an agent with the `terminate` verb. Deletion is often blocked by foreign keys, so termination is the supported way to retire an agent.
> - `terminate()` sets the agent status and revokes the agent API keys. It leaves every issue still pointing at that agent through `assigneeAgentId`.
> - Authorization grants `issue:mutate` only to the current assignee, or to any company agent when the issue has no agent assignee. A terminated agent is not invokable, so it can never act again.
> - The issues it still owns therefore become immutable for every actor. Even an un-assign request is rejected.
> - `remove()` in the same file already clears `assigneeAgentId`. `terminate()` never got the same treatment.
> - This pull request clears `assigneeAgentId` for the agent's issues inside the termination transaction.
> - The benefit is that retiring an agent no longer strands its work in a state that no actor can repair through the API.

## Linked Issues or Issue Description

`Refs #10508` — *"Issues assigned to a terminated agent become fully immutable; terminated refs linger in execution_state participants and recovery-action owners"*.

This PR addresses the first defect in that issue. It does not address the other two. Please see "Scope limits" below before you re-tag it. I used `Refs` instead of `Closes` on purpose, so the issue stays open for the remaining work. Re-tag it if you prefer.

Prior art: the same fix was proposed in #1279 by @mikefreno in March. That PR received no review comments, and the author closed it himself in May. Thanks to @mikefreno for finding this first. I re-propose it against a filed issue, with a reproduction and a regression test.

I also describe the defect here, so you do not need to leave the PR.

**What happened?**

`terminate()` writes only the `agents` row and the `agentApiKeys` rows. Issues assigned to the agent keep the terminated `assigneeAgentId`. Those issues then reject every `PATCH /api/issues/:id`, including a plain un-assign.

Three parts of the codebase combine to make this permanent:

1. **The intended behaviour already exists a few lines below.** `remove()` in `server/src/services/agents.ts` already runs `update(issues).set({ assigneeAgentId: null, ... })`. `terminate()` does not.
2. **The reconciler built for stranded issues declines these rows.** `reconcileStrandedAssignedIssues` in `server/src/services/recovery/service.ts` calls `isAgentInvokable(agent)`. A terminated agent returns `invokable: false`, so the function increments `skipped` and moves on. `terminate` creates the stranded row, and the sweeper steps over it.
3. **Authorization has no exception for a terminated assignee.** In `server/src/services/authorization.ts`, `issue:mutate` is allowed when the actor is the assignee, or when the issue has no agent assignee. The mention grant is the only other path, and it is gated to `issue:comment`. So `issue:mutate` has no third path.

The rule keys on assignee identity, not on agent health. A `paused` or `pending_approval` assignee blocks the same writes. That makes this a class of defect rather than one missing line. This PR does not widen the diff to cover those states. I note it as follow-up work.

**Expected behavior**

Termination detaches the agent from its issues, in the same way `remove()` does. The issues stay mutable, and an operator can reassign them through the API.

**Steps to reproduce**

1. Assign an issue to an agent. Leave the issue in a non-terminal status.
2. Terminate that agent.
3. Send `PATCH /api/issues/:id` with `{"assigneeAgentId": null}`.

Result: `403 {"error":"Issue is outside this actor's authorization boundary"}`. The request fails even for an agent that holds the broadest permissions available, because the rule tests assignee identity only.

**Paperclip version or commit**

Reproduced on `2026.722.0`. Code inspected and patched at `bc5c392`.

**Deployment mode**

Self-hosted.

## What Changed

- `terminate()` in `server/src/services/agents.ts` now clears `assigneeAgentId` on the issues assigned to the agent.
- The three writes (issue detach, agent status, key revocation) now run in one `db.transaction`. A partial failure can no longer leave the agent terminated while its issues stay bound.
- Added `server/src/__tests__/agents-service-terminate-unassign.test.ts`. It covers the detach, the isolation of other agents' issues, the preserved authorship, and the unknown-agent case.

Deliberate asymmetry with `remove()`: this change clears `assigneeAgentId` only. `remove()` also clears `createdByAgentId` and deletes the agent's `issueComments`, because it deletes the agent row. Termination keeps the agent row, so authorship stays a valid reference and history is preserved. A test asserts this.

## Verification

Automated. Run from `server/`:

```
pnpm vitest run src/__tests__/agents-service-terminate-unassign.test.ts
```

Result: 4 passed.

I confirmed the test detects the defect. With the `terminate()` change reverted and the test kept, the run gives **2 failed / 2 passed**. The two failures are the assertions that the issues get detached:

```
AssertionError: expected '…' to be null
 ❯ src/__tests__/agents-service-terminate-unassign.test.ts:143
```

The two tests that still pass are the isolation guard and the unknown-agent case. Neither depends on the new behaviour, so that split is correct.

Regression runs. All suites that reference agent termination or issue assignment:

```
pnpm vitest run src/__tests__/agents-service-terminate-unassign.test.ts \
  src/__tests__/agents-service-clear-error.test.ts \
  src/__tests__/agent-invokability.test.ts \
  src/__tests__/agent-shortname-collision.test.ts \
  src/__tests__/built-in-agents.test.ts \
  src/__tests__/issues-service.test.ts \
  src/__tests__/issue-liveness.test.ts \
  src/__tests__/companies-service.test.ts
```

Result: 8 files, 195 passed.

```
pnpm vitest run src/__tests__/access-service.test.ts \
  src/__tests__/agent-permissions-routes.test.ts \
  src/__tests__/heartbeat-archived-company-guard.test.ts \
  src/__tests__/issue-watchdogs-routes.test.ts \
  src/__tests__/resource-memberships-routes.test.ts \
  src/__tests__/routines-service.test.ts \
  src/__tests__/tool-access-service.test.ts
```

Result: 7 files, 264 passed.

Type check. `pnpm typecheck` in `server/` exits 0 with no errors.

The tests use the embedded Postgres helper, in the same pattern as `agents-service-clear-error.test.ts`. They skip on a host that cannot start it.

## Risks

Low risk, with two behaviour changes to note.

- **Terminal issues are detached too.** The update matches every issue assigned to the agent, including `done` and `cancelled`. This matches `remove()`, and it keeps terminated rows re-openable. The trade-off is that a completed issue no longer shows the retired agent as assignee. `createdByAgentId` still records the agent, so the attribution is not lost. I chose parity with `remove()` over a status filter, because a status filter adds a new policy decision and leaves terminal rows immutable.
- **`updatedAt` moves on the detached issues.** This follows the issue service, which bumps `updatedAt` when it clears `assigneeAgentId`. Clients that sort or sync on `updatedAt` will see the affected issues change position once, at termination.
- No migration. No schema change. No API surface change.
- The new transaction wraps writes that already ran unconditionally and in this order, so it does not change the outcome of a successful termination.

**Scope limits**, stated plainly so the issue is not closed early:

- This change stops the defect at the source. It does not repair issues already stranded by an agent that was terminated before the upgrade. Those rows still need a data fix, or removal of the agent.
- It does not clear `execution_state.currentParticipant`, and it does not repoint recovery-action `owner` fields. #10508 also asks for both.
- It does not change the authorization rule. `paused` and `pending_approval` assignees still block `issue:mutate`.

## Model Used

Claude Opus (Anthropic), model id `claude-opus-5`, run through Claude Code with extended reasoning and tool use. The model read the code at `bc5c392`, wrote the change and the test, and ran the verification commands quoted above. A human reviewed the result and the scope decisions before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — not applicable. This is a bug fix with no documented behaviour change.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending. CI has not run yet at submission time. I will fix anything it reports.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending first review.
- [x] I will address all Greptile and reviewer comments before requesting merge
