### PR TITLE
test(e2e): deflake applications Connections list against the health sweep

### DIFF
--- a/tests/e2e/applications-crud.spec.ts
+++ b/tests/e2e/applications-crud.spec.ts
@@ -84,26 +84,29 @@ test.describe.serial("applications lifecycle", () => {
 
     await gotoApps(page, seed.prefix);
 
-    // The status pill ("Healthy" / "Not connected") is derived from two separate
-    // react-query fetches (applications + connections). A row can paint as soon as
-    // the applications fetch resolves, but the pill only renders once the
-    // connections fetch also settles. Under CI load that second fetch can land
-    // after Playwright's default 5s assertion timeout, so give the pill
-    // assertions the same generous window used by the rest of this spec — this is
-    // a polling wait on the real rendered label, not a fixed sleep, so coverage of
-    // the exact status text is preserved.
+    // The connected app starts with a "Healthy" pill and an "Open" action. A
+    // background health sweep then probes the connection endpoint. The test
+    // endpoint is an unreachable fixture URL, so the probe fails and the pill
+    // becomes "Needs attention" and the action becomes "Reconnect". Both are
+    // connected states that navigate to the same connection detail. This test
+    // proves the connected-vs-not-connected split, not the transient health
+    // label, so accept either connected state instead of the racy exact label.
+    // The pill is derived from two react-query fetches (applications +
+    // connections), so keep the same generous window the rest of this spec uses.
     const connectedRow = page.locator("tbody tr", { hasText: connectedName });
     await expect(connectedRow).toBeVisible();
-    await expect(connectedRow.getByText("Healthy")).toBeVisible({ timeout: 30_000 });
-    await expect(connectedRow.getByRole("button", { name: "Open" })).toBeVisible();
+    await expect(connectedRow.getByText(/^(Healthy|Needs attention)$/)).toBeVisible({ timeout: 30_000 });
+    await expect(connectedRow.getByRole("button", { name: /^(Open|Reconnect)$/ })).toBeVisible();
 
+    // The not-connected app has no connection, so the health sweep never touches
+    // it and its "Not connected" pill and "Connect" action stay deterministic.
     const notConnectedRow = page.locator("tbody tr", { hasText: notConnectedName });
     await expect(notConnectedRow).toBeVisible();
     await expect(notConnectedRow.getByText("Not connected")).toBeVisible({ timeout: 30_000 });
     await expect(notConnectedRow.getByRole("button", { name: "Connect" })).toBeVisible();
     await page.screenshot({ path: `${SCREENSHOT_DIR}/applications-crud-current-list.png`, fullPage: true });
 
-    await connectedRow.getByRole("button", { name: "Open" }).click();
+    await connectedRow.getByRole("button", { name: /^(Open|Reconnect)$/ }).click();
     await expect(page).toHaveURL(new RegExp(`/${seed.prefix}/apps/${connected.id}`), { timeout: 20_000 });
 
     await gotoApps(page, seed.prefix);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The applications page shows connected services and their status
> - The e2e suite covers the Connections row on that page
> - The server runs a periodic connection health sweep during the test
> - The sweep can change the connected row label and action after the first render
> - This pull request accepts both connected states on that row
> - The benefit is the test checks the real user path without a sweep race

## Linked Issues or Issue Description

No public issue exists. This pull request fixes a race in the applications Connections e2e test.

**Bug:** The test pinned the exact connected-state pill and action.

**Expected:** The test should accept both connected states for the same connection row.

**Impact:** The health sweep can change the label between assertions.

**Fix:** The test now accepts either label and action on the connected row.

## What Changed

- Allowed the connected row pill to match `Healthy` or `Needs attention`.
- Allowed the connected row action to match `Open` or `Reconnect`.
- Kept the not-connected row exact.

## Verification

- `git diff --check origin/master..origin/test/deflake-applications-crud-health-sweep`
- `git show --stat --summary --oneline 9785785a5d41cd13ee5a0f8aeb73f389cdbdac2e`
- Local Playwright e2e did not run in this worktree.
- CI on this pull request should provide the full proof.

## Risks

- Low risk. The change only widens the expected labels for the connected row.
- If the UI adds a new state, the test may need another update.

## Model Used

OpenAI GPT-5, tool use, context window not exposed in this shell session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
