### PR TITLE
feat(plugins): add human organization work plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
 COPY packages/plugins/sdk/package.json packages/plugins/sdk/
+COPY packages/plugins/plugin-human-org/package.json packages/plugins/plugin-human-org/
 COPY --parents packages/plugins/sandbox-providers/./*/package.json packages/plugins/sandbox-providers/
 COPY packages/plugins/paperclip-plugin-fake-sandbox/package.json packages/plugins/paperclip-plugin-fake-sandbox/
 COPY packages/plugins/plugin-llm-wiki/package.json packages/plugins/plugin-llm-wiki/

--- a/doc/HUMAN_ORG_MATTERMOST_TUTORIAL.md
+++ b/doc/HUMAN_ORG_MATTERMOST_TUTORIAL.md
@@ -1,0 +1,370 @@
+# Tutorial: Human organization charts, Paperclip tasks, and Mattermost
+
+**Plugin:** Human Org & Work (`paperclipai.plugin-human-org`)
+
+**Audience:** Paperclip instance administrators, operations leaders, and project managers
+**Outcome:** Import a human org chart, create or assign Paperclip work to people, manage that work on a Kanban board, and notify assignees in Mattermost.
+
+---
+
+## 1. What was added
+
+The **Human Org & Work** first-party plugin adds four connected features:
+
+1. **Human directory and org chart** — upload people with reporting lines, capabilities, and responsibilities.
+2. **Human work board** — a Kanban view backed by real Paperclip issues and their statuses.
+3. **Task assignment** — create a new task for an imported person or assign an existing issue from its detail page.
+4. **Mattermost notifications** — send a supported incoming-webhook message and `@username` mention when work is assigned.
+
+### Why Paperclip provides the board
+
+This implementation does **not** depend on Mattermost Boards/Focalboard APIs. Those APIs are not a stable integration surface in the current Mattermost ecosystem. Paperclip remains the task system of record; Mattermost is the notification and discussion surface. This avoids duplicated task state and synchronization conflicts.
+
+### Linked members versus external humans
+
+- **Linked Paperclip member:** if `paperclip_user_id` matches an active company member, the plugin also sets the issue's normal `assignee_user_id`. The issue appears in the normal Paperclip human-assignee workflow and in the Human Work board.
+- **External human:** if `paperclip_user_id` is blank, the plugin records the assignment in its company-scoped human-assignment store and displays it on the Human Work board. The normal Paperclip assignee remains empty. Mattermost notification still works when a username and webhook are configured.
+
+If `paperclip_user_id` is supplied but does not identify an active member of the same company, task creation or assignment is rejected rather than silently downgrading the person to an external assignment.
+
+The plugin never creates fake login accounts and never models humans as autonomous agents.
+
+---
+
+## 2. Prerequisites
+
+You need:
+
+- A self-hosted Paperclip checkout that includes `packages/plugins/plugin-human-org`.
+- Paperclip instance-admin access to install a plugin.
+- Company-admin or owner access to configure company secrets and plugin settings.
+- For Mattermost notifications: permission to create an incoming webhook in the destination Mattermost channel.
+
+### Release bundle compatibility
+
+The standalone plugin tarball expects the conflict-safe company-scoped plugin-entity, atomic entity-batch/insert-only claim, single-window issue-pagination, atomic issue-idempotency, and outbound-error redaction host contracts included in this Paperclip source snapshot. Its worker-side SDK runtime is bundled, so installation does not fetch `@paperclipai/plugin-sdk` from npm. If you are installing it into an older checkout, first apply `paperclip-human-org-core.patch` from the tutorial bundle at the repository root:
+
+```bash
+git apply --check paperclip-human-org-core.patch
+git apply paperclip-human-org-core.patch
+```
+
+Do not install the tarball into an older checkout if the compatibility patch does not apply cleanly. Update the checkout or review the conflicts instead; bypassing these core changes can break company isolation or omit issues beyond the first 500 records.
+
+---
+
+## 3. Build and verify the plugin
+
+From the Paperclip repository root:
+
+```bash
+pnpm --filter @paperclipai/plugin-human-org build
+pnpm --filter @paperclipai/plugin-human-org test
+```
+
+If `pnpm` is not available globally, use the repository's pinned version:
+
+```bash
+npm exec --yes pnpm@9.15.4 -- --filter @paperclipai/plugin-human-org build
+npm exec --yes pnpm@9.15.4 -- --filter @paperclipai/plugin-human-org test
+```
+
+Expected outputs include:
+
+- `packages/plugins/plugin-human-org/dist/worker.js`
+- `packages/plugins/plugin-human-org/dist/manifest.js`
+- `packages/plugins/plugin-human-org/dist/ui/index.js`
+- A passing Vitest suite.
+
+Paperclip can build an unbuilt bundled plugin during installation, but building first makes installation errors easier to diagnose.
+
+---
+
+## 4. Install the plugin
+
+1. Sign in to Paperclip as an instance administrator.
+2. Open **Company Settings → Plugin Manager**.
+3. Find **Human Org & Work** under **Available Plugins**.
+4. Select **Install**.
+5. Review the requested capabilities. They are limited to:
+   - reading projects and issues;
+   - creating and updating issues;
+   - reading company membership IDs for optional linking;
+   - resolving one configured secret reference;
+   - outbound HTTP for Mattermost;
+   - registering the page, sidebar link, and issue detail view;
+   - writing auditable activity entries.
+6. Confirm that the plugin status is **ready**.
+
+After installation, **Human Org & Work** appears in the Paperclip sidebar and as a panel on issue detail pages.
+
+---
+
+## 5. Configure Mattermost securely
+
+Mattermost notifications are optional. The org directory and Human Work board function without them.
+
+### 5.1 Create the incoming webhook
+
+1. In Mattermost, choose the destination channel.
+2. Open **Integrations → Incoming Webhooks → Add Incoming Webhook**.
+3. Select the channel and create the webhook.
+4. Copy the generated webhook URL.
+
+Treat that URL as a credential: anyone holding it can post to the configured channel.
+
+### 5.2 Store the URL as a Paperclip Secret
+
+1. In Paperclip, open the selected company's **Settings → Secrets**.
+2. Create a secret named, for example, `mattermost-human-work-webhook`.
+3. Paste the complete Mattermost webhook URL as the secret value.
+4. Save it.
+
+Do not put the webhook URL in the org CSV, documentation, issue text, or plugin logs.
+
+### 5.3 Bind the secret to the plugin
+
+1. Return to **Company Settings → Plugin Manager**.
+2. Open **Human Org & Work → Settings** for the selected company.
+3. For **Mattermost incoming webhook**, choose the secret created above.
+4. Set **Paperclip company URL** to the company URL users should open from Mattermost. Use the URL visible before an issue path, for example:
+
+   ```text
+   https://paperclip.example/QI
+   ```
+
+5. Keep **Notify Mattermost on assignment** enabled.
+6. Save the company configuration.
+
+The Human Org & Work page should show Mattermost as **Connected**. The plugin stores only a secret reference. It resolves the URL for a delivery and does not write the resolved value to plugin data or activity metadata.
+
+---
+
+## 6. Prepare the org chart
+
+Start with [`human-org-chart-sample.csv`](./examples/human-org-chart-sample.csv).
+
+### CSV columns
+
+| Column | Required | Meaning |
+|---|---:|---|
+| `external_id` | Yes | Stable unique ID from HRIS or your own directory. Do not reuse it for another person. |
+| `name` | Yes | Human-readable full name. |
+| `email` | No | Contact email; validated when present. |
+| `title` | No | Job title or role. |
+| `reports_to_external_id` | No | Manager's `external_id`. Leave blank for a root/leader. |
+| `capabilities` | No | `|`-separated skills, such as `rcm|payer-operations|analytics`. |
+| `responsibilities` | No | `|`-separated owned outcomes or duties. |
+| `mattermost_username` | No | Username without `@`; used for assignment mentions. |
+| `paperclip_user_id` | No | Existing active Paperclip user ID for native human assignment. Leave blank for external humans. |
+| `status` | No | `active` or `inactive`; defaults to `active`. |
+
+### Example
+
+```csv
+external_id,name,email,title,reports_to_external_id,capabilities,responsibilities,mattermost_username,paperclip_user_id,status
+exec-1,Asha Patel,asha@example.com,CEO,,strategy|budget,Set direction|Approve budget,asha,,active
+eng-1,Diego Ruiz,diego@example.com,Engineer,exec-1,typescript|aws,Build services|Review code,diego,,active
+```
+
+### Validation rules
+
+The complete upload is validated before any row is written. The import rejects:
+
+- missing `external_id` or `name`;
+- duplicate `external_id` values;
+- malformed email addresses;
+- status values other than `active` or `inactive`;
+- managers that are not included in a full replacement upload or the merged existing roster for an incremental upload;
+- a person reporting to themselves;
+- direct or indirect reporting cycles.
+- invalid or reserved Mattermost usernames (`all`, `channel`, `everyone`, and `here` are reserved);
+- imports over 2,000,000 characters or 5,000 people;
+- profile scalar fields over their documented implementation bounds, more than 100 capability/responsibility items, or list items over 200 characters.
+
+CSV quoted fields, escaped quotes, commas, and embedded newlines are supported. Unknown or duplicate headers, inconsistent column counts, and quotes inside unquoted fields are rejected.
+
+### JSON alternative
+
+You may upload a JSON array using camelCase or CSV-style field names:
+
+```json
+[
+  {
+    "externalId": "ops-1",
+    "name": "Maya Chen",
+    "title": "Revenue Cycle Lead",
+    "reportsToExternalId": "exec-1",
+    "capabilities": ["rcm", "payer-operations"],
+    "responsibilities": ["Own payer operations", "Escalate denials"],
+    "mattermostUsername": "maya",
+    "status": "active"
+  }
+]
+```
+
+---
+
+## 7. Import the org chart
+
+1. Open **Human Org & Work** from the Paperclip sidebar.
+2. Under **Import org chart**, select your `.csv` or `.json` file.
+3. Normally leave **Deactivate people omitted from this upload** unchecked. Existing profiles not in the file remain unchanged.
+4. For a full roster replacement, check that option. Existing active profiles omitted from the upload are marked inactive; historical assignments remain auditable.
+5. Select **Validate & import**.
+6. Confirm the imported count and inspect the rendered org tree.
+
+Imports are idempotent by `external_id`: importing the same file again updates existing profiles instead of creating duplicates. Profile updates and full-replacement deactivations commit in one database transaction, so a persistence failure does not leave a partial roster.
+
+---
+
+## 8. Create a new task for a human
+
+1. On **Human Org & Work**, open **Create human task**.
+2. Select the person. The dropdown includes name and title; inspect the org chart for capabilities and responsibilities.
+3. Optionally select a Paperclip project.
+4. Enter a concise title, description/acceptance criteria, and priority.
+5. Select **Create & assign task**.
+
+Paperclip creates a real issue in `todo`, records an insert-only pending human assignment, and only then attempts Mattermost delivery. The UI supplies a stable request ID; the host applies a company-scoped atomic issue idempotency key, the pending assignment doubles as a database-backed notification claim, and each worker also coalesces concurrent same-request actions. Concurrent retries across worker processes therefore produce one issue, one assignment, and at most one Mattermost delivery. If the assignment write fails, no orphan claim remains and a retry can safely persist the assignment before notifying. Reusing a request ID for another human is rejected. Direct action/API callers must supply their own unique `requestId` containing 1–128 letters, numbers, dots, underscores, colons, or hyphens. Task titles are limited to 500 characters and descriptions to 50,000 characters. The result line reports whether Mattermost was `sent`, `skipped`, `failed`, or `unknown`.
+
+Assignment is not rolled back when Mattermost is unavailable. The issue and assignment remain authoritative in Paperclip. A definite `failed` delivery can be retried by reassigning after the webhook is fixed. An `unknown` state means delivery may already have succeeded but the final state write failed; automatic task retries intentionally do not redeliver it. Inspect Mattermost before making any intentional manual reassignment.
+
+---
+
+## 9. Assign an existing issue
+
+1. Open any Paperclip issue.
+2. Find the **Human assignment** plugin panel.
+3. Select an imported person.
+4. Select **Assign & notify**.
+
+If the profile is linked to an active Paperclip member, the plugin clears agent ownership and sets that user as the core issue assignee. For an external person, agent ownership is cleared and the assignment is tracked on the Human Work board.
+
+Use **Remove** to remove the plugin-managed human assignment. If the linked user is still the issue's current core assignee, Paperclip clears that user assignment as well. If the plugin-assignment update fails, the core assignee is restored before the action reports failure.
+
+---
+
+## 10. Operate the Human Work board
+
+The board groups plugin-assigned issues by the live Paperclip status:
+
+- Backlog
+- To do
+- In progress
+- In review
+- Done
+- Cancelled
+
+Use the left and right controls on a card to update its Paperclip issue status. Select the card title to open the full issue for comments, attachments, dependencies, and review.
+
+The board does not copy issue content to a separate task database. It reads and updates the same Paperclip issue used by agents and projects.
+
+---
+
+## 11. Operating model
+
+A practical daily workflow is:
+
+1. Leaders maintain the roster from HRIS or a controlled CSV export.
+2. Project managers inspect capability/responsibility data before assigning work.
+3. Human owners receive a Mattermost mention with a Paperclip link.
+4. Humans or coordinators update status in Paperclip.
+5. Agents can continue to create related work, comments, or child issues without a second board sync.
+6. Re-import the roster when roles, managers, capabilities, or responsibilities change.
+
+### Recommended conventions
+
+- Use immutable HRIS IDs for `external_id`.
+- Keep capabilities short and reusable (`aws`, `typescript`, `rcm`, `credentialing`).
+- Phrase responsibilities as owned outcomes (`Approve releases`, `Own payer enrollment`).
+- Use one Mattermost channel for assignment notices per operating group.
+- Do not use the optional `paperclip_user_id` until the person has an active company membership.
+
+---
+
+## 12. Troubleshooting
+
+### Plugin is absent from Available Plugins
+
+Build the plugin, restart the Paperclip server if bundled-package discovery was already cached, and reload Plugin Manager:
+
+```bash
+pnpm --filter @paperclipai/plugin-human-org build
+```
+
+### Import says “Unknown manager”
+
+For an incremental import, the manager referenced by `reports_to_external_id` must exist either in the upload or in the current roster. For a full replacement, include the manager row in the same upload or remove the relationship.
+
+### Import says “Reporting cycle detected”
+
+Follow the manager chain for the listed IDs. At least one person indirectly reports back to themselves. Correct the source data and re-upload; no partial rows were saved.
+
+### Mattermost shows “setup required”
+
+Verify that:
+
+- the webhook URL is stored in Paperclip Secrets;
+- the plugin configuration binds the **secret**, not pasted plaintext;
+- notifications are enabled;
+- `paperclipBaseUrl` is set if you want clickable links.
+
+### Mattermost delivery is `skipped`
+
+Common reasons are no configured webhook, notifications disabled, or no `mattermost_username` on the selected profile.
+
+### Mattermost delivery is `failed`
+
+Regenerate or test the incoming webhook in Mattermost, verify outbound network access from the Paperclip server, and reassign the task to retry. The secret value is intentionally absent from logs.
+
+### Mattermost delivery is `unknown`
+
+The assignment was durable before delivery began, but Paperclip could not prove the final delivery state. Retrying the same task request returns the existing issue and does not send another webhook. Check Mattermost for the original notification before deliberately reassigning the task.
+
+### Task is not in the normal Paperclip “assigned to me” view
+
+The profile is external because `paperclip_user_id` is blank. It will still appear in the Human Work board. Link it to an active Paperclip member ID to use the native user-assignee workflow. If a nonblank ID is invalid or inactive, the plugin rejects assignment and reports the mapping error.
+
+---
+
+## 13. Security and audit behavior
+
+- All profile and assignment entities are scoped by Paperclip company ID.
+- Entity keys are internally namespaced by company, and every entity read is re-checked against its `scopeKind`/`scopeId` before use.
+- A company cannot read another company's roster through plugin data actions.
+- Import, task creation, assignment, status changes, and unassignment use Paperclip's immutable host actor context and require an active `owner`, `admin`, or `member` role. `viewer` memberships are read-only.
+- The Mattermost webhook is represented as a `secret-ref` configuration field.
+- Resolved webhook values are not persisted to entity data, activity metadata, or plugin logs.
+- Outbound HTTP validation and DNS failures use value-free host errors, so malformed secret-backed URLs are not reflected through RPC logs.
+- Invalid org charts are rejected before writes begin, and valid roster mutations commit atomically as one entity batch.
+- Assignment and import actions write activity records without storing private webhook content.
+- The plugin does not create authentication accounts or grant Paperclip permissions.
+
+---
+
+## 14. Verification performed for this implementation
+
+The repository change was verified with:
+
+- 36 plugin behavior tests covering strict CSV parsing and size limits, hierarchy validation, idempotent and incremental import, transactional roster rollback, identical-ID tenant isolation, viewer denial, active-member linking, external assignment, unassignment compensation, stale-assignment and live-assignee authority checks, atomic concurrent task creation with one assignment notification within and across worker processes, concurrent cross-human request-ID rejection, uncertain-notification reconciliation, pagination, Mattermost configuration/secret failure handling, Markdown/mention safety, and webhook non-disclosure;
+- 42 Paperclip plugin SDK regression tests, including unscoped entity-access denial, rejection of conflicting and batched company/scope identifiers, production worker-RPC forwarding of atomic entity primitives, and issue idempotency-key forwarding;
+- 264 plugin-related Paperclip server regression tests, including production entity tenant isolation, transactional batched upserts, insert-only entity claims, scoped API dispatch, worker-manager behavior, database-backed issue pagination beyond 500 records, atomic plugin issue idempotency, malformed outbound-URL redaction, static UI serving, installation, and auto-build;
+- plugin SDK and server TypeScript type checking;
+- manifest schema validation;
+- worker and UI production builds;
+- npm tarball generation confirming all install entrypoints are present and published metadata contains no `workspace:*` dependencies;
+- sample-import and archive-integrity smoke tests;
+- a static scan for hardcoded secrets and dangerous execution/XSS primitives.
+
+The source package is at:
+
+```text
+packages/plugins/plugin-human-org
+```
+
+The sample CSV is at:
+
+```text
+doc/examples/human-org-chart-sample.csv
+```

--- a/doc/examples/human-org-chart-sample.csv
+++ b/doc/examples/human-org-chart-sample.csv
@@ -1,0 +1,4 @@
+external_id,name,email,title,reports_to_external_id,capabilities,responsibilities,mattermost_username,paperclip_user_id,status
+exec-1,Asha Patel,asha@example.com,CEO,,strategy|budget,Set direction|Approve budget,asha,,active
+eng-1,Diego Ruiz,diego@example.com,Engineer,exec-1,typescript|aws,Build services|Review code,diego,,active
+ops-1,Maya Chen,maya@example.com,Revenue Cycle Lead,exec-1,rcm|payer-operations,Own payer operations|Escalate denials,maya,,active

--- a/packages/plugins/plugin-human-org/LICENSE
+++ b/packages/plugins/plugin-human-org/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Paperclip AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugins/plugin-human-org/README.md
+++ b/packages/plugins/plugin-human-org/README.md
@@ -1,0 +1,50 @@
+# Human Org & Work for Paperclip
+
+This first-party plugin adds an importable human organization directory, a human work board backed by real Paperclip issues, issue-level human assignment, and optional Mattermost notifications.
+
+## What it does
+
+- Imports CSV or JSON human org charts.
+- Stores reporting lines, capabilities, responsibilities, contact information, Mattermost usernames, and optional Paperclip user links.
+- Rejects unknown/duplicate CSV headers, inconsistent row widths, malformed quoting, duplicate IDs, unknown managers, self-reporting, invalid email addresses/statuses, unsafe Mattermost usernames, and reporting cycles before committing the roster; profile updates and replacement deactivations are one database transaction.
+- Creates and assigns Paperclip issues from a dedicated human work page.
+- Assigns an existing issue from its plugin detail panel.
+- Shows all imported-human work on a Kanban board driven by the issue's Paperclip status.
+- Sends secure Mattermost incoming-webhook notifications with `@username` mentions and task links.
+- Keeps webhook URLs in Paperclip Secrets rather than plugin data or logs.
+- Namespaces and re-filters stored entities by company, preventing collisions when organizations reuse the same `external_id`.
+- Uses Paperclip's immutable actor context for mutations: active owners, admins, and members can manage work; viewers are read-only.
+- Paginates complete rosters, projects, assignments, and issue boards rather than truncating at one host page.
+- Uses Paperclip's company-scoped atomic issue idempotency keys, a database-backed insert-only pending assignment as the notification claim, and same-worker in-flight request coalescing, so concurrent retries across worker processes produce one issue, one assignment, and at most one Mattermost delivery; request-ID reuse for another human is rejected. The pending assignment is durable before any webhook attempt, and a failed assignment write leaves no orphan claim, so a safe retry remains possible.
+- Records explicit `pending`/`unknown` notification states when delivery may have succeeded but the final state write did not; automatic retries never redeliver an uncertain webhook.
+- Enforces practical limits: 2,000,000 import characters, 5,000 people per import, bounded profile/list fields, 500-character task titles, and 50,000-character task descriptions.
+
+Task-creation action callers must provide a unique `requestId` (1–128 safe characters). The bundled UI creates and retains this ID automatically across retries.
+
+## Build
+
+From the Paperclip repository root:
+
+```bash
+pnpm --filter @paperclipai/plugin-human-org build
+pnpm --filter @paperclipai/plugin-human-org test
+```
+
+If `pnpm` is not installed globally:
+
+```bash
+npm exec --yes pnpm@9.15.4 -- --filter @paperclipai/plugin-human-org build
+npm exec --yes pnpm@9.15.4 -- --filter @paperclipai/plugin-human-org test
+```
+
+## Install
+
+Open **Company Settings → Plugin Manager**. Under **Available Plugins**, install **Human Org & Work**. For a source checkout, Paperclip discovers this package at `packages/plugins/plugin-human-org` and installs it as a local first-party plugin.
+
+### Host compatibility
+
+This release requires conflict-safe company-scoped plugin entities, single-window issue pagination, and plugin issue-create idempotency-key forwarding from the accompanying Paperclip source snapshot. The tutorial bundle includes `paperclip-human-org-core.patch` for older checkouts. Apply and review that patch before installing the tarball; do not bypass it if it does not apply cleanly.
+
+The release tarball bundles its worker-side plugin SDK runtime. It installs in a clean npm project without fetching the unpublished workspace package `@paperclipai/plugin-sdk`.
+
+See the [Human Org and Mattermost tutorial](https://github.com/paperclipai/paperclip/blob/master/doc/HUMAN_ORG_MATTERMOST_TUTORIAL.md) for complete setup, data format, usage, security, and troubleshooting instructions.

--- a/packages/plugins/plugin-human-org/package.json
+++ b/packages/plugins/plugin-human-org/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@paperclipai/plugin-human-org",
+  "version": "0.1.0",
+  "description": "Human org-chart import, capability directory, Paperclip human work board, and Mattermost assignment notifications",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "paperclipPlugin": {
+    "sdkRuntime": "bundled",
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "tsc && node ./scripts/build-worker.mjs && node ./scripts/build-ui.mjs",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "test": "vitest run",
+    "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../scripts/generate-plugin-package-json.mjs",
+    "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@paperclipai/shared": "workspace:*",
+    "@types/node": "^22.20.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.28.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.7.3",
+    "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  }
+}

--- a/packages/plugins/plugin-human-org/scripts/build-ui.mjs
+++ b/packages/plugins/plugin-human-org/scripts/build-ui.mjs
@@ -1,0 +1,17 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: ["react", "react-dom", "react/jsx-runtime", "@paperclipai/plugin-sdk/ui"],
+  logLevel: "info",
+});

--- a/packages/plugins/plugin-human-org/scripts/build-worker.mjs
+++ b/packages/plugins/plugin-human-org/scripts/build-worker.mjs
@@ -1,0 +1,13 @@
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/worker.ts"],
+  outfile: "dist/worker.js",
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node20",
+  sourcemap: true,
+  packages: "bundle",
+  logLevel: "info",
+});

--- a/packages/plugins/plugin-human-org/src/index.ts
+++ b/packages/plugins/plugin-human-org/src/index.ts
@@ -1,0 +1,3 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";
+export * from "./model.js";

--- a/packages/plugins/plugin-human-org/src/manifest.ts
+++ b/packages/plugins/plugin-human-org/src/manifest.ts
@@ -1,0 +1,91 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+export const PLUGIN_ID = "paperclipai.plugin-human-org";
+export const PLUGIN_VERSION = "0.1.0";
+export const PAGE_ROUTE = "human-org";
+
+export const SLOT_IDS = {
+  page: "human-org-page",
+  sidebar: "human-org-sidebar",
+  taskDetail: "human-org-task-detail",
+} as const;
+
+export const EXPORT_NAMES = {
+  page: "HumanOrgPage",
+  sidebar: "HumanOrgSidebarLink",
+  taskDetail: "HumanTaskDetailView",
+} as const;
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Human Org & Work",
+  description: "Import a human org chart with capabilities and responsibilities, assign Paperclip issues, track human work on a Kanban board, and notify people in Mattermost.",
+  author: "Paperclip",
+  categories: ["automation", "connector", "ui"],
+  capabilities: [
+    "projects.read",
+    "issues.read",
+    "issues.create",
+    "issues.update",
+    "access.members.read",
+    "http.outbound",
+    "secrets.read-ref",
+    "activity.log.write",
+    "ui.sidebar.register",
+    "ui.page.register",
+    "ui.detailTab.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  instanceConfigSchema: {
+    type: "object",
+    properties: {
+      mattermostWebhook: {
+        type: "string",
+        format: "secret-ref",
+        title: "Mattermost incoming webhook",
+        description: "Store the full incoming-webhook URL as a Paperclip Secret. The resolved URL is never written to plugin data or logs.",
+      },
+      paperclipBaseUrl: {
+        type: "string",
+        title: "Paperclip company URL",
+        description: "Base URL used in Mattermost task links, for example https://paperclip.example/RCM",
+      },
+      notifyMattermost: {
+        type: "boolean",
+        title: "Notify Mattermost on assignment",
+        default: true,
+      },
+    },
+  },
+  ui: {
+    slots: [
+      {
+        type: "page",
+        id: SLOT_IDS.page,
+        displayName: "Human Org & Work",
+        exportName: EXPORT_NAMES.page,
+        routePath: PAGE_ROUTE,
+      },
+      {
+        type: "sidebar",
+        id: SLOT_IDS.sidebar,
+        displayName: "Human Org & Work",
+        exportName: EXPORT_NAMES.sidebar,
+      },
+      {
+        type: "taskDetailView",
+        id: SLOT_IDS.taskDetail,
+        displayName: "Human assignment",
+        exportName: EXPORT_NAMES.taskDetail,
+        entityTypes: ["issue"],
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/plugin-human-org/src/model.ts
+++ b/packages/plugins/plugin-human-org/src/model.ts
@@ -1,0 +1,442 @@
+export type HumanProfileStatus = "active" | "inactive";
+
+export interface HumanOrgChartRow {
+  externalId: string;
+  name: string;
+  email?: string | null;
+  title?: string | null;
+  reportsToExternalId?: string | null;
+  capabilities?: string[];
+  responsibilities?: string[];
+  mattermostUsername?: string | null;
+  paperclipUserId?: string | null;
+  status?: HumanProfileStatus;
+}
+
+export interface HumanProfile {
+  externalId: string;
+  name: string;
+  email: string | null;
+  title: string | null;
+  reportsToExternalId: string | null;
+  capabilities: string[];
+  responsibilities: string[];
+  mattermostUsername: string | null;
+  paperclipUserId: string | null;
+  status: HumanProfileStatus;
+}
+
+export interface OrgChartValidationError {
+  code:
+    | "missing_external_id"
+    | "missing_name"
+    | "duplicate_external_id"
+    | "unknown_manager"
+    | "self_manager"
+    | "reporting_cycle"
+    | "invalid_email"
+    | "invalid_mattermost_username"
+    | "invalid_status"
+    | "input_limit";
+  row?: number;
+  externalId?: string;
+  message: string;
+}
+
+export const HUMAN_ORG_LIMITS = {
+  importCharacters: 2_000_000,
+  rows: 5_000,
+  externalId: 128,
+  name: 200,
+  email: 320,
+  title: 200,
+  paperclipUserId: 128,
+  listItems: 100,
+  listItem: 200,
+  taskTitle: 500,
+  taskDescription: 50_000,
+} as const;
+
+export interface OrgTreeNode {
+  profile: HumanProfile;
+  children: OrgTreeNode[];
+}
+
+const HEADER_ALIASES: Record<string, keyof HumanOrgChartRow> = {
+  external_id: "externalId",
+  externalid: "externalId",
+  id: "externalId",
+  name: "name",
+  email: "email",
+  title: "title",
+  role: "title",
+  reports_to_external_id: "reportsToExternalId",
+  reportstoexternalid: "reportsToExternalId",
+  manager_id: "reportsToExternalId",
+  manager: "reportsToExternalId",
+  capabilities: "capabilities",
+  skills: "capabilities",
+  responsibilities: "responsibilities",
+  mattermost_username: "mattermostUsername",
+  mattermostusername: "mattermostUsername",
+  paperclip_user_id: "paperclipUserId",
+  paperclipuserid: "paperclipUserId",
+  status: "status",
+};
+
+function cleanString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function stringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return [...new Set(value.map(cleanString).filter((item): item is string => item !== null))];
+  }
+  const text = cleanString(value);
+  if (!text) return [];
+  return [...new Set(text.split("|").map((item) => item.trim()).filter(Boolean))];
+}
+
+function normalizeStatus(value: unknown, strict: boolean): HumanProfileStatus {
+  const normalized = cleanString(value)?.toLowerCase();
+  if (!normalized || normalized === "active") return "active";
+  if (normalized === "inactive") return "inactive";
+  if (strict) throw new Error("status must be active or inactive");
+  return "active";
+}
+
+const RESERVED_MATTERMOST_MENTIONS = new Set(["all", "channel", "everyone", "here"]);
+
+function neutralizeMattermostBroadcastMentions(value: string): string {
+  return value.replace(/@(channel|all|here|everyone)\b/gi, "@\u200B$1");
+}
+
+function escapeMattermostMarkdown(value: string): string {
+  const markdownCharacters = new Set(["\\", "[", "]", "(", ")", "*", "_", "~", "`", ">"]);
+  return Array.from(neutralizeMattermostBroadcastMentions(value), (character) => (
+    markdownCharacters.has(character) ? `\\${character}` : character
+  )).join("");
+}
+
+function safeMattermostLink(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    return url.toString().replace(/\(/g, "%28").replace(/\)/g, "%29");
+  } catch {
+    return null;
+  }
+}
+
+function parseCsvMatrix(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+  let afterQuote = false;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (quoted) {
+      if (char === '"') {
+        if (input[index + 1] === '"') {
+          field += '"';
+          index += 1;
+        } else {
+          quoted = false;
+          afterQuote = true;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (afterQuote) {
+      if (char === ",") {
+        row.push(field);
+        field = "";
+        afterQuote = false;
+      } else if (char === "\n") {
+        row.push(field);
+        rows.push(row);
+        row = [];
+        field = "";
+        afterQuote = false;
+      } else if (char !== "\r") {
+        throw new Error("Malformed CSV quote: unexpected characters after a closing quote");
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      if (field.length > 0) throw new Error("Malformed CSV quote inside an unquoted field");
+      quoted = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else if (char !== "\r") {
+      field += char;
+    }
+  }
+
+  if (quoted) throw new Error("CSV contains an unclosed quoted field");
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows.filter((cells) => cells.some((cell) => cell.trim().length > 0));
+}
+
+function normalizeOrgChartRowInternal(input: Record<string, unknown>, strictStatus: boolean): HumanProfile {
+  return {
+    externalId: cleanString(input.externalId) ?? "",
+    name: cleanString(input.name) ?? "",
+    email: cleanString(input.email),
+    title: cleanString(input.title),
+    reportsToExternalId: cleanString(input.reportsToExternalId),
+    capabilities: stringList(input.capabilities),
+    responsibilities: stringList(input.responsibilities),
+    mattermostUsername: cleanString(input.mattermostUsername)?.replace(/^@/, "") ?? null,
+    paperclipUserId: cleanString(input.paperclipUserId),
+    status: normalizeStatus(input.status, strictStatus),
+  };
+}
+
+export function normalizeOrgChartRow(input: Record<string, unknown>): HumanProfile {
+  return normalizeOrgChartRowInternal(input, true);
+}
+
+export function normalizeOrgChartRows(input: unknown): HumanProfile[] {
+  if (!Array.isArray(input)) throw new Error("Org chart JSON must be an array of people");
+  if (input.length > HUMAN_ORG_LIMITS.rows) {
+    throw new Error(`Org chart imports are limited to ${HUMAN_ORG_LIMITS.rows.toLocaleString("en-US")} people`);
+  }
+  return input.map((row) => {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      return normalizeOrgChartRow({});
+    }
+    const source = row as Record<string, unknown>;
+    const mapped: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(source)) {
+      const alias = HEADER_ALIASES[key.trim().toLowerCase().replace(/[ -]/g, "_")] ?? key;
+      mapped[alias] = value;
+    }
+    return normalizeOrgChartRow(mapped);
+  });
+}
+
+export function parseOrgChartCsv(input: string): HumanProfile[] {
+  if (input.length > HUMAN_ORG_LIMITS.importCharacters) {
+    throw new Error(`Org chart imports are limited to ${HUMAN_ORG_LIMITS.importCharacters.toLocaleString("en-US")} characters`);
+  }
+  const matrix = parseCsvMatrix(input.replace(/^\uFEFF/, ""));
+  if (matrix.length < 2) throw new Error("CSV must include a header and at least one person");
+  if (matrix.length - 1 > HUMAN_ORG_LIMITS.rows) {
+    throw new Error(`Org chart imports are limited to ${HUMAN_ORG_LIMITS.rows.toLocaleString("en-US")} people`);
+  }
+  const rawHeaders = matrix[0]!;
+  const headers = rawHeaders.map((header) => {
+    const normalized = header.trim().toLowerCase().replace(/[ -]/g, "_");
+    return HEADER_ALIASES[normalized] ?? null;
+  });
+  const unknownHeaders = rawHeaders.filter((_header, index) => headers[index] === null);
+  if (unknownHeaders.length > 0) {
+    throw new Error(`Unknown CSV header: ${unknownHeaders.join(", ")}`);
+  }
+  const seenHeaders = new Set<keyof HumanOrgChartRow>();
+  for (const header of headers) {
+    if (!header) continue;
+    if (seenHeaders.has(header)) throw new Error(`Duplicate CSV header: ${header}`);
+    seenHeaders.add(header);
+  }
+  if (!headers.includes("externalId") || !headers.includes("name")) {
+    throw new Error("CSV requires external_id and name columns");
+  }
+
+  return matrix.slice(1).map((cells, rowIndex) => {
+    if (cells.length !== headers.length) {
+      throw new Error(`CSV row ${rowIndex + 2} has ${cells.length} cells; expected ${headers.length}`);
+    }
+    const row: Record<string, unknown> = {};
+    headers.forEach((header, index) => {
+      if (header) row[header] = cells[index] ?? "";
+    });
+    return normalizeOrgChartRow(row);
+  });
+}
+
+export function validateOrgChartRows(rows: HumanOrgChartRow[]): OrgChartValidationError[] {
+  if (rows.length > HUMAN_ORG_LIMITS.rows) {
+    return [{
+      code: "input_limit",
+      message: `Org chart imports are limited to ${HUMAN_ORG_LIMITS.rows.toLocaleString("en-US")} people`,
+    }];
+  }
+  const normalized = rows.map((row) => normalizeOrgChartRowInternal(row as unknown as Record<string, unknown>, false));
+  const errors: OrgChartValidationError[] = [];
+  const counts = new Map<string, number>();
+
+  normalized.forEach((row, index) => {
+    const scalarLimits: Array<[string, string | null, number]> = [
+      ["external_id", row.externalId, HUMAN_ORG_LIMITS.externalId],
+      ["name", row.name, HUMAN_ORG_LIMITS.name],
+      ["email", row.email, HUMAN_ORG_LIMITS.email],
+      ["title", row.title, HUMAN_ORG_LIMITS.title],
+      ["reports_to_external_id", row.reportsToExternalId, HUMAN_ORG_LIMITS.externalId],
+      ["paperclip_user_id", row.paperclipUserId, HUMAN_ORG_LIMITS.paperclipUserId],
+    ];
+    for (const [field, value, maximum] of scalarLimits) {
+      if (value && value.length > maximum) {
+        errors.push({
+          code: "input_limit",
+          row: index + 2,
+          externalId: row.externalId || undefined,
+          message: `${field} for ${row.externalId || `row ${index + 2}`} exceeds ${maximum} characters`,
+        });
+      }
+    }
+    for (const [field, values] of [
+      ["capabilities", row.capabilities],
+      ["responsibilities", row.responsibilities],
+    ] as const) {
+      if (values.length > HUMAN_ORG_LIMITS.listItems) {
+        errors.push({
+          code: "input_limit",
+          row: index + 2,
+          externalId: row.externalId || undefined,
+          message: `${field} for ${row.externalId || `row ${index + 2}`} exceeds ${HUMAN_ORG_LIMITS.listItems} items`,
+        });
+      }
+      if (values.some((value) => value.length > HUMAN_ORG_LIMITS.listItem)) {
+        errors.push({
+          code: "input_limit",
+          row: index + 2,
+          externalId: row.externalId || undefined,
+          message: `${field} for ${row.externalId || `row ${index + 2}`} contains an item exceeding ${HUMAN_ORG_LIMITS.listItem} characters`,
+        });
+      }
+    }
+    if (!row.externalId) {
+      errors.push({ code: "missing_external_id", row: index + 2, message: `Row ${index + 2} is missing external_id` });
+    } else {
+      counts.set(row.externalId, (counts.get(row.externalId) ?? 0) + 1);
+    }
+    if (!row.name) {
+      errors.push({ code: "missing_name", row: index + 2, externalId: row.externalId || undefined, message: `Row ${index + 2} is missing name` });
+    }
+    if (row.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(row.email)) {
+      errors.push({ code: "invalid_email", row: index + 2, externalId: row.externalId, message: `Invalid email for ${row.externalId || `row ${index + 2}`}` });
+    }
+    if (row.mattermostUsername && (
+      !/^[A-Za-z0-9._-]{1,64}$/.test(row.mattermostUsername)
+      || RESERVED_MATTERMOST_MENTIONS.has(row.mattermostUsername.toLowerCase())
+    )) {
+      errors.push({
+        code: "invalid_mattermost_username",
+        row: index + 2,
+        externalId: row.externalId,
+        message: `Invalid Mattermost username for ${row.externalId || `row ${index + 2}`}`,
+      });
+    }
+    const rawStatus = cleanString((rows[index] as HumanOrgChartRow | undefined)?.status)?.toLowerCase();
+    if (rawStatus && rawStatus !== "active" && rawStatus !== "inactive") {
+      errors.push({ code: "invalid_status", row: index + 2, externalId: row.externalId, message: `Status for ${row.externalId} must be active or inactive` });
+    }
+  });
+
+  for (const [externalId, count] of counts) {
+    if (count > 1) {
+      errors.push({ code: "duplicate_external_id", externalId, message: `Duplicate external_id: ${externalId}` });
+    }
+  }
+
+  const ids = new Set(normalized.map((row) => row.externalId).filter(Boolean));
+  for (const row of normalized) {
+    if (!row.externalId || !row.reportsToExternalId) continue;
+    if (row.reportsToExternalId === row.externalId) {
+      errors.push({ code: "self_manager", externalId: row.externalId, message: `${row.externalId} cannot report to itself` });
+    } else if (!ids.has(row.reportsToExternalId)) {
+      errors.push({ code: "unknown_manager", externalId: row.externalId, message: `Unknown manager ${row.reportsToExternalId} for ${row.externalId}` });
+    }
+  }
+
+  const managerById = new Map(normalized.map((row) => [row.externalId, row.reportsToExternalId]));
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const cycleMembers = new Set<string>();
+  function visit(id: string, path: string[]): void {
+    if (visiting.has(id)) {
+      const start = path.indexOf(id);
+      for (const member of path.slice(start)) cycleMembers.add(member);
+      return;
+    }
+    if (visited.has(id)) return;
+    visiting.add(id);
+    const manager = managerById.get(id);
+    if (manager && managerById.has(manager)) visit(manager, [...path, id]);
+    visiting.delete(id);
+    visited.add(id);
+  }
+  for (const id of ids) visit(id, []);
+  if (cycleMembers.size > 0) {
+    const members = [...cycleMembers].sort();
+    errors.push({ code: "reporting_cycle", externalId: members[0], message: `Reporting cycle detected: ${members.join(" → ")}` });
+  }
+  return errors;
+}
+
+export function buildOrgTree(profiles: HumanProfile[]): OrgTreeNode[] {
+  const active = profiles.filter((profile) => profile.status === "active");
+  const nodes = new Map(active.map((profile) => [profile.externalId, { profile, children: [] as OrgTreeNode[] }]));
+  const roots: OrgTreeNode[] = [];
+  for (const node of nodes.values()) {
+    const manager = node.profile.reportsToExternalId ? nodes.get(node.profile.reportsToExternalId) : null;
+    if (manager) manager.children.push(node);
+    else roots.push(node);
+  }
+  const sortNodes = (items: OrgTreeNode[]) => {
+    items.sort((left, right) => left.profile.name.localeCompare(right.profile.name));
+    items.forEach((item) => sortNodes(item.children));
+  };
+  sortNodes(roots);
+  return roots;
+}
+
+export function buildMattermostAssignmentPayload(input: {
+  humanName: string;
+  mattermostUsername?: string | null;
+  issueTitle: string;
+  issueIdentifier: string;
+  issueUrl: string;
+  priority?: string | null;
+}): { text: string; props: { card: string } } {
+  const mention = input.mattermostUsername ? `@${input.mattermostUsername.replace(/^@/, "")}` : input.humanName;
+  const priority = input.priority ? ` · priority **${input.priority}**` : "";
+  const safeHumanName = escapeMattermostMarkdown(input.humanName);
+  const safeMention = input.mattermostUsername ? mention : safeHumanName;
+  const safeIssueTitle = escapeMattermostMarkdown(input.issueTitle);
+  const label = `${escapeMattermostMarkdown(input.issueIdentifier)}: ${safeIssueTitle}`;
+  const url = safeMattermostLink(input.issueUrl);
+  const task = url ? `[${label}](${url})` : label;
+  const line = `${safeMention} — Paperclip assigned ${task}${priority}.`;
+  return {
+    text: line,
+    props: {
+      card: `### New Paperclip task\n${line}\n\nOpen the task in Paperclip to update status, add notes, or request help.`,
+    },
+  };
+}
+
+export const SAMPLE_ORG_CHART_CSV = `external_id,name,email,title,reports_to_external_id,capabilities,responsibilities,mattermost_username,paperclip_user_id,status
+exec-1,Asha Patel,asha@example.com,CEO,,strategy|budget,Set direction|Approve budget,asha,,active
+eng-1,Diego Ruiz,diego@example.com,Engineer,exec-1,typescript|aws,Build services|Review code,diego,,active
+ops-1,Maya Chen,maya@example.com,Revenue Cycle Lead,exec-1,rcm|payer-operations,Own payer operations|Escalate denials,maya,,active
+`;

--- a/packages/plugins/plugin-human-org/src/ui/index.tsx
+++ b/packages/plugins/plugin-human-org/src/ui/index.tsx
@@ -14,6 +14,36 @@ type IssueRecord = { id: string; identifier?: string | null; title: string; stat
 function createRequestId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
+
+export interface NewTaskRequestInput {
+  companyId: string;
+  humanExternalId: string;
+  projectId?: string;
+  title: string;
+  description: string;
+  priority: string;
+}
+
+export interface NewTaskRequestIdentity {
+  requestId: string;
+  input: NewTaskRequestInput;
+}
+
+export function resolveNewTaskRequestIdentity(
+  current: NewTaskRequestIdentity | null,
+  input: NewTaskRequestInput,
+  nextRequestId: () => string = createRequestId,
+): NewTaskRequestIdentity {
+  const unchanged = current
+    && current.input.companyId === input.companyId
+    && current.input.humanExternalId === input.humanExternalId
+    && current.input.projectId === input.projectId
+    && current.input.title === input.title
+    && current.input.description === input.description
+    && current.input.priority === input.priority;
+  return unchanged ? current : { requestId: nextRequestId(), input: { ...input } };
+}
+
 type AssignmentRecord = { issueId: string; humanExternalId: string; linkedUserId: string | null; notificationState: string };
 type WorkCard = { assignment: AssignmentRecord; human: HumanProfile; issue: IssueRecord };
 type RosterData = { profiles: HumanProfile[]; roots: OrgTreeNode[]; inactiveCount: number };
@@ -157,7 +187,7 @@ function NewTaskPanel({ companyId, profiles, projects, onCreated }: { companyId:
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const requestIdRef = useRef<string | null>(null);
+  const requestIdentityRef = useRef<NewTaskRequestIdentity | null>(null);
 
   async function submit(event: FormEvent) {
     event.preventDefault();
@@ -165,17 +195,20 @@ function NewTaskPanel({ companyId, profiles, projects, onCreated }: { companyId:
     setMessage(null);
     setError(null);
     try {
-      requestIdRef.current ??= createRequestId();
-      const result = await createTask({
+      const requestIdentity = resolveNewTaskRequestIdentity(requestIdentityRef.current, {
         companyId,
-        requestId: requestIdRef.current,
         humanExternalId,
         projectId: projectId || undefined,
         title,
         description,
         priority,
+      });
+      requestIdentityRef.current = requestIdentity;
+      const result = await createTask({
+        ...requestIdentity.input,
+        requestId: requestIdentity.requestId,
       }) as { issue?: IssueRecord; notification?: { state?: string; reason?: string } };
-      requestIdRef.current = null;
+      requestIdentityRef.current = null;
       setMessage(`Created ${result.issue?.identifier ?? result.issue?.id ?? "task"}. Mattermost: ${result.notification?.state ?? "skipped"}.`);
       setTitle("");
       setDescription("");

--- a/packages/plugins/plugin-human-org/src/ui/index.tsx
+++ b/packages/plugins/plugin-human-org/src/ui/index.tsx
@@ -1,0 +1,377 @@
+import { useMemo, useRef, useState, type CSSProperties, type FormEvent } from "react";
+import {
+  useHostContext,
+  useHostNavigation,
+  usePluginAction,
+  usePluginData,
+  type PluginPageProps,
+} from "@paperclipai/plugin-sdk/ui";
+import { HUMAN_ORG_LIMITS, SAMPLE_ORG_CHART_CSV, type HumanProfile, type OrgTreeNode } from "../model.js";
+
+type ProjectRecord = { id: string; name: string; status?: string };
+type IssueRecord = { id: string; identifier?: string | null; title: string; status: string; priority?: string | null; projectId?: string | null };
+
+function createRequestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+type AssignmentRecord = { issueId: string; humanExternalId: string; linkedUserId: string | null; notificationState: string };
+type WorkCard = { assignment: AssignmentRecord; human: HumanProfile; issue: IssueRecord };
+type RosterData = { profiles: HumanProfile[]; roots: OrgTreeNode[]; inactiveCount: number };
+type BoardData = { columns: Record<string, WorkCard[]>; total: number };
+type IntegrationStatus = { mattermostConfigured: boolean; notificationsEnabled: boolean; paperclipBaseUrlConfigured: boolean };
+type IssueAssignmentData = { assignment: AssignmentRecord | null; human: HumanProfile | null; profiles: HumanProfile[] };
+
+const pageStyle: CSSProperties = { display: "grid", gap: 20, padding: "4px 0 28px" };
+const cardStyle: CSSProperties = { border: "1px solid var(--border)", borderRadius: 4, padding: 16, background: "var(--card, transparent)" };
+const subtleStyle: CSSProperties = { border: "1px solid var(--border)", borderRadius: 4, padding: 12, background: "color-mix(in srgb, var(--card, transparent) 80%, transparent)" };
+const inputStyle: CSSProperties = { width: "100%", border: "1px solid var(--border)", borderRadius: 3, padding: "9px 10px", background: "transparent", color: "inherit", boxSizing: "border-box" };
+const buttonStyle: CSSProperties = { border: "1px solid var(--border)", borderRadius: 3, padding: "8px 12px", background: "transparent", color: "inherit", cursor: "pointer" };
+const primaryButtonStyle: CSSProperties = { ...buttonStyle, background: "var(--foreground)", color: "var(--background)", borderColor: "var(--foreground)" };
+const mutedStyle: CSSProperties = { opacity: 0.68, fontSize: 12, lineHeight: 1.5 };
+const rowStyle: CSSProperties = { display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" };
+const gridStyle: CSSProperties = { display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" };
+
+const STATUS_LABELS: Record<string, string> = {
+  backlog: "Backlog",
+  todo: "To do",
+  in_progress: "In progress",
+  in_review: "In review",
+  done: "Done",
+  cancelled: "Cancelled",
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function Section({ title, children, action }: { title: string; children: React.ReactNode; action?: React.ReactNode }) {
+  return (
+    <section style={cardStyle}>
+      <div style={{ ...rowStyle, justifyContent: "space-between", marginBottom: 14 }}>
+        <h2 style={{ margin: 0, fontSize: 16 }}>{title}</h2>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Pills({ values }: { values: string[] }) {
+  if (values.length === 0) return <span style={mutedStyle}>None listed</span>;
+  return (
+    <div style={rowStyle}>
+      {values.map((value) => (
+        <span key={value} style={{ border: "1px solid var(--border)", padding: "2px 7px", borderRadius: 999, fontSize: 11 }}>{value}</span>
+      ))}
+    </div>
+  );
+}
+
+function OrgNode({ node, depth = 0 }: { node: OrgTreeNode; depth?: number }) {
+  const profile = node.profile;
+  return (
+    <div style={{ display: "grid", gap: 8, marginLeft: depth === 0 ? 0 : 22, borderLeft: depth === 0 ? undefined : "1px solid var(--border)", paddingLeft: depth === 0 ? 0 : 12 }}>
+      <div style={subtleStyle}>
+        <div style={{ ...rowStyle, justifyContent: "space-between" }}>
+          <div>
+            <strong>{profile.name}</strong>
+            <div style={mutedStyle}>{profile.title || "No title"}{profile.email ? ` · ${profile.email}` : ""}</div>
+          </div>
+          <span style={{ fontSize: 11, opacity: 0.7 }}>{profile.paperclipUserId ? "Paperclip ID provided" : "External human"}</span>
+        </div>
+        <div style={{ display: "grid", gap: 7, marginTop: 10 }}>
+          <div><span style={mutedStyle}>Capabilities</span><Pills values={profile.capabilities} /></div>
+          <div><span style={mutedStyle}>Responsibilities</span><Pills values={profile.responsibilities} /></div>
+        </div>
+      </div>
+      {node.children.map((child) => <OrgNode key={child.profile.externalId} node={child} depth={depth + 1} />)}
+    </div>
+  );
+}
+
+function downloadSample(): void {
+  const blob = new Blob([SAMPLE_ORG_CHART_CSV], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "human-org-chart-sample.csv";
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function ImportPanel({ companyId, onImported }: { companyId: string; onImported: () => void }) {
+  const importOrgChart = usePluginAction("import-org-chart");
+  const [file, setFile] = useState<File | null>(null);
+  const [replace, setReplace] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!file) return;
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      if (file.size > HUMAN_ORG_LIMITS.importCharacters) {
+        throw new Error(`Org chart files are limited to ${HUMAN_ORG_LIMITS.importCharacters.toLocaleString("en-US")} bytes`);
+      }
+      const text = await file.text();
+      const payload = file.name.toLowerCase().endsWith(".json") ? { companyId, json: text, replace } : { companyId, csv: text, replace };
+      const response = await importOrgChart(payload) as { imported?: number; deactivated?: number };
+      setResult(`Imported ${response.imported ?? 0} people${response.deactivated ? `; deactivated ${response.deactivated}` : ""}.`);
+      onImported();
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} style={{ display: "grid", gap: 12 }}>
+      <div style={mutedStyle}>Upload CSV or JSON. Required columns are <code>external_id</code> and <code>name</code>. Use <code>|</code> between capabilities and responsibilities.</div>
+      <input type="file" accept=".csv,.json,text/csv,application/json" onChange={(event) => setFile(event.currentTarget.files?.[0] ?? null)} />
+      <label style={{ ...rowStyle, fontSize: 12 }}>
+        <input type="checkbox" checked={replace} onChange={(event) => setReplace(event.currentTarget.checked)} />
+        Deactivate people omitted from this upload
+      </label>
+      <div style={rowStyle}>
+        <button type="submit" style={primaryButtonStyle} disabled={!file || busy}>{busy ? "Importing…" : "Validate & import"}</button>
+        <button type="button" style={buttonStyle} onClick={downloadSample}>Download sample CSV</button>
+      </div>
+      {result ? <div style={{ color: "#22c55e", fontSize: 12 }}>{result}</div> : null}
+      {error ? <div role="alert" style={{ color: "#ef4444", fontSize: 12, whiteSpace: "pre-wrap" }}>{error}</div> : null}
+    </form>
+  );
+}
+
+function NewTaskPanel({ companyId, profiles, projects, onCreated }: { companyId: string; profiles: HumanProfile[]; projects: ProjectRecord[]; onCreated: () => void }) {
+  const createTask = usePluginAction("create-human-task");
+  const [humanExternalId, setHumanExternalId] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [priority, setPriority] = useState("medium");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef<string | null>(null);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setBusy(true);
+    setMessage(null);
+    setError(null);
+    try {
+      requestIdRef.current ??= createRequestId();
+      const result = await createTask({
+        companyId,
+        requestId: requestIdRef.current,
+        humanExternalId,
+        projectId: projectId || undefined,
+        title,
+        description,
+        priority,
+      }) as { issue?: IssueRecord; notification?: { state?: string; reason?: string } };
+      requestIdRef.current = null;
+      setMessage(`Created ${result.issue?.identifier ?? result.issue?.id ?? "task"}. Mattermost: ${result.notification?.state ?? "skipped"}.`);
+      setTitle("");
+      setDescription("");
+      onCreated();
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} style={{ display: "grid", gap: 10 }}>
+      <select style={inputStyle} value={humanExternalId} onChange={(event) => setHumanExternalId(event.currentTarget.value)} required>
+        <option value="">Select human owner</option>
+        {profiles.map((profile) => <option key={profile.externalId} value={profile.externalId}>{profile.name} — {profile.title || "No title"}</option>)}
+      </select>
+      <select style={inputStyle} value={projectId} onChange={(event) => setProjectId(event.currentTarget.value)}>
+        <option value="">No project</option>
+        {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
+      </select>
+      <input style={inputStyle} value={title} maxLength={HUMAN_ORG_LIMITS.taskTitle} onChange={(event) => setTitle(event.currentTarget.value)} placeholder="Task title" required />
+      <textarea style={{ ...inputStyle, minHeight: 90 }} value={description} maxLength={HUMAN_ORG_LIMITS.taskDescription} onChange={(event) => setDescription(event.currentTarget.value)} placeholder="Description and acceptance criteria" />
+      <select style={inputStyle} value={priority} onChange={(event) => setPriority(event.currentTarget.value)}>
+        <option value="critical">Critical</option><option value="high">High</option><option value="medium">Medium</option><option value="low">Low</option>
+      </select>
+      <button type="submit" style={primaryButtonStyle} disabled={busy || !humanExternalId || !title.trim()}>{busy ? "Creating…" : "Create & assign task"}</button>
+      {message ? <div style={{ color: "#22c55e", fontSize: 12 }}>{message}</div> : null}
+      {error ? <div role="alert" style={{ color: "#ef4444", fontSize: 12 }}>{error}</div> : null}
+    </form>
+  );
+}
+
+function HumanBoard({ companyId, board, onUpdated }: { companyId: string; board: BoardData; onUpdated: () => void }) {
+  const updateStatus = usePluginAction("update-human-task-status");
+  const navigation = useHostNavigation();
+  const [busyIssue, setBusyIssue] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const statusOrder = Object.keys(STATUS_LABELS);
+
+  async function move(issueId: string, status: string) {
+    setBusyIssue(issueId);
+    setError(null);
+    try {
+      await updateStatus({ companyId, issueId, status });
+      onUpdated();
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setBusyIssue(null);
+    }
+  }
+
+  return (
+    <>
+      {error ? <div role="alert" style={{ color: "#ef4444", fontSize: 12, marginBottom: 10 }}>{error}</div> : null}
+      <div style={{ display: "grid", gridTemplateColumns: `repeat(${statusOrder.length}, minmax(250px, 1fr))`, gap: 10, overflowX: "auto", paddingBottom: 6 }}>
+        {statusOrder.map((status, index) => {
+          const cards = board.columns[status] ?? [];
+          return (
+            <div key={status} style={{ ...subtleStyle, minHeight: 180 }}>
+              <div style={{ ...rowStyle, justifyContent: "space-between", marginBottom: 10 }}><strong style={{ fontSize: 12 }}>{STATUS_LABELS[status]}</strong><span style={mutedStyle}>{cards.length}</span></div>
+              <div style={{ display: "grid", gap: 8 }}>
+                {cards.map(({ issue, human, assignment }) => {
+                  const href = `/issues/${issue.identifier ?? issue.id}`;
+                  return (
+                    <article key={issue.id} style={{ ...cardStyle, padding: 11 }}>
+                      <a {...navigation.linkProps(href)} style={{ color: "inherit", textDecoration: "none", fontWeight: 600, fontSize: 13 }}>{issue.title}</a>
+                      <div style={{ ...mutedStyle, marginTop: 5 }}>{human.name} · {issue.priority ?? "medium"}</div>
+                      <div style={{ ...mutedStyle, marginTop: 3 }}>{assignment.linkedUserId ? "Paperclip member" : "External human"} · Mattermost {assignment.notificationState}</div>
+                      <div style={{ ...rowStyle, marginTop: 9 }}>
+                        {index > 0 ? <button style={buttonStyle} disabled={busyIssue === issue.id} onClick={() => void move(issue.id, statusOrder[index - 1]!)}>←</button> : null}
+                        {index < statusOrder.length - 1 ? <button style={buttonStyle} disabled={busyIssue === issue.id} onClick={() => void move(issue.id, statusOrder[index + 1]!)}>→</button> : null}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export function HumanOrgPage({ context }: PluginPageProps) {
+  const companyId = context.companyId;
+  const roster = usePluginData<RosterData>("human-roster", companyId ? { companyId } : undefined);
+  const board = usePluginData<BoardData>("human-work-board", companyId ? { companyId } : undefined);
+  const projects = usePluginData<ProjectRecord[]>("projects", companyId ? { companyId } : undefined);
+  const integration = usePluginData<IntegrationStatus>("integration-status", companyId ? { companyId } : undefined);
+  const profiles = roster.data?.profiles ?? [];
+  const capabilityCount = useMemo(() => new Set(profiles.flatMap((profile) => profile.capabilities)).size, [profiles]);
+
+  if (!companyId) return <div style={cardStyle}>Select a company to use Human Org & Work.</div>;
+  const refreshAll = () => { roster.refresh(); board.refresh(); projects.refresh(); integration.refresh(); };
+
+  return (
+    <main style={pageStyle}>
+      <header>
+        <h1 style={{ margin: 0, fontSize: 24 }}>Human Org & Work</h1>
+        <p style={{ ...mutedStyle, maxWidth: 760 }}>Import human reporting lines, capabilities, and responsibilities. Create real Paperclip issues, manage them on the human work board, and notify assignees in Mattermost.</p>
+      </header>
+
+      <div style={gridStyle}>
+        <div style={subtleStyle}><strong>{profiles.length}</strong><div style={mutedStyle}>Active people</div></div>
+        <div style={subtleStyle}><strong>{capabilityCount}</strong><div style={mutedStyle}>Unique capabilities</div></div>
+        <div style={subtleStyle}><strong>{board.data?.total ?? 0}</strong><div style={mutedStyle}>Human-assigned tasks</div></div>
+        <div style={subtleStyle}><strong>{integration.data?.mattermostConfigured ? "Connected" : "Not configured"}</strong><div style={mutedStyle}>Mattermost notifications</div></div>
+      </div>
+
+      <div style={{ ...subtleStyle, borderColor: integration.data?.mattermostConfigured ? "#22c55e" : "#d97706" }}>
+        <strong>Mattermost: {integration.data?.mattermostConfigured ? "ready" : "setup required"}</strong>
+        <div style={mutedStyle}>Configure the incoming webhook as a Secret in the plugin’s company configuration. Tasks remain authoritative in Paperclip; Mattermost is the notification and collaboration surface.</div>
+      </div>
+
+      <div style={gridStyle}>
+        <Section title="Import org chart"><ImportPanel companyId={companyId} onImported={refreshAll} /></Section>
+        <Section title="Create human task"><NewTaskPanel companyId={companyId} profiles={profiles} projects={projects.data ?? []} onCreated={refreshAll} /></Section>
+      </div>
+
+      <Section title="Human work board" action={<button style={buttonStyle} onClick={refreshAll}>Refresh</button>}>
+        {board.loading ? <div style={mutedStyle}>Loading board…</div> : board.data ? <HumanBoard companyId={companyId} board={board.data} onUpdated={refreshAll} /> : <div style={mutedStyle}>No human assignments yet.</div>}
+      </Section>
+
+      <Section title="Human org chart">
+        {roster.loading ? <div style={mutedStyle}>Loading roster…</div> : roster.data?.roots.length ? (
+          <div style={{ display: "grid", gap: 12 }}>{roster.data.roots.map((root) => <OrgNode key={root.profile.externalId} node={root} />)}</div>
+        ) : <div style={mutedStyle}>Upload a CSV or JSON org chart to begin.</div>}
+      </Section>
+    </main>
+  );
+}
+
+export function HumanOrgSidebarLink() {
+  const navigation = useHostNavigation();
+  return <a {...navigation.linkProps("/human-org")} style={{ color: "inherit", textDecoration: "none" }}>Human Org & Work</a>;
+}
+
+export function HumanTaskDetailView() {
+  const context = useHostContext();
+  const companyId = context.companyId;
+  const issueId = context.entityId;
+  const details = usePluginData<IssueAssignmentData>("issue-human-assignment", companyId && issueId ? { companyId, issueId } : undefined);
+  const assign = usePluginAction("assign-human-task");
+  const unassign = usePluginAction("unassign-human-task");
+  const [selected, setSelected] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!companyId || !issueId) return null;
+  const current = details.data?.human;
+  async function assignSelected() {
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await assign({ companyId, issueId, humanExternalId: selected });
+      setSelected("");
+      details.refresh();
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setBusy(false);
+    }
+  }
+  async function clearAssignment() {
+    setBusy(true);
+    setError(null);
+    try {
+      await unassign({ companyId, issueId });
+      details.refresh();
+    } catch (nextError) {
+      setError(errorMessage(nextError));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ ...cardStyle, display: "grid", gap: 10 }}>
+      <div>
+        <strong>Human assignment</strong>
+        <div style={mutedStyle}>{current ? `${current.name} · ${current.title || "No title"}` : "No imported human is assigned."}</div>
+      </div>
+      {current ? <Pills values={current.capabilities} /> : null}
+      <select style={inputStyle} value={selected} onChange={(event) => setSelected(event.currentTarget.value)}>
+        <option value="">Choose imported human</option>
+        {(details.data?.profiles ?? []).map((profile) => <option key={profile.externalId} value={profile.externalId}>{profile.name} — {profile.title || "No title"}</option>)}
+      </select>
+      <div style={rowStyle}>
+        <button style={primaryButtonStyle} disabled={!selected || busy} onClick={() => void assignSelected()}>{busy ? "Saving…" : "Assign & notify"}</button>
+        {current ? <button style={buttonStyle} disabled={busy} onClick={() => void clearAssignment()}>Remove</button> : null}
+      </div>
+      {error ? <div role="alert" style={{ color: "#ef4444", fontSize: 12 }}>{error}</div> : null}
+    </div>
+  );
+}

--- a/packages/plugins/plugin-human-org/src/worker.ts
+++ b/packages/plugins/plugin-human-org/src/worker.ts
@@ -1,0 +1,861 @@
+import {
+  definePlugin,
+  runWorker,
+  type EnvSecretRefBinding,
+  type PluginContext,
+  type PluginEntityRecord,
+  type PluginPerformActionContext,
+} from "@paperclipai/plugin-sdk";
+import type { Issue } from "@paperclipai/shared";
+import manifest from "./manifest.js";
+import {
+  buildMattermostAssignmentPayload,
+  buildOrgTree,
+  HUMAN_ORG_LIMITS,
+  normalizeOrgChartRows,
+  parseOrgChartCsv,
+  validateOrgChartRows,
+  type HumanProfile,
+} from "./model.js";
+
+const PROFILE_ENTITY = "human-profile";
+const ASSIGNMENT_ENTITY = "human-assignment";
+const TASK_ORIGIN_KIND = "plugin:paperclipai.plugin-human-org";
+const ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"] as const;
+const ENTITY_PAGE_SIZE = 500;
+
+type AssignmentRecord = {
+  issueId: string;
+  humanExternalId: string;
+  linkedUserId: string | null;
+  assignedAt: string;
+  assignedByUserId: string | null;
+  notificationState: "pending" | "sent" | "skipped" | "failed" | "unknown";
+};
+
+type HumanOrgConfig = {
+  mattermostWebhook?: unknown;
+  paperclipBaseUrl?: string;
+  notifyMattermost?: boolean;
+};
+
+function requiredCompanyId(params: Record<string, unknown>): string {
+  const companyId = typeof params.companyId === "string" ? params.companyId.trim() : "";
+  if (!companyId) throw new Error("companyId is required");
+  return companyId;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function scopedExternalId(companyId: string, externalId: string): string {
+  return `${companyId}:${externalId}`;
+}
+
+function belongsToCompany(entity: PluginEntityRecord, companyId: string): boolean {
+  return entity.scopeKind === "company" && entity.scopeId === companyId;
+}
+
+function isSecretRef(value: unknown): value is EnvSecretRefBinding {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && (value as { type?: unknown }).type === "secret_ref"
+    && typeof (value as { secretId?: unknown }).secretId === "string",
+  );
+}
+
+function profileFromEntity(entity: PluginEntityRecord): HumanProfile {
+  return normalizeOrgChartRows([{ ...entity.data, externalId: entity.data.externalId ?? entity.externalId }])[0]!;
+}
+
+function assignmentFromEntity(entity: PluginEntityRecord): AssignmentRecord | null {
+  const issueId = optionalString(entity.data.issueId) ?? entity.externalId ?? undefined;
+  const humanExternalId = optionalString(entity.data.humanExternalId);
+  if (!issueId || !humanExternalId) return null;
+  return {
+    issueId,
+    humanExternalId,
+    linkedUserId: optionalString(entity.data.linkedUserId) ?? null,
+    assignedAt: optionalString(entity.data.assignedAt) ?? entity.updatedAt,
+    assignedByUserId: optionalString(entity.data.assignedByUserId) ?? null,
+    notificationState: entity.data.notificationState === "pending"
+      || entity.data.notificationState === "sent"
+      || entity.data.notificationState === "failed"
+      || entity.data.notificationState === "unknown"
+      ? entity.data.notificationState
+      : "skipped",
+  };
+}
+
+async function listAllEntities(
+  ctx: PluginContext,
+  params: Omit<Parameters<PluginContext["entities"]["list"]>[0], "limit" | "offset">,
+): Promise<PluginEntityRecord[]> {
+  const records: PluginEntityRecord[] = [];
+  let offset = 0;
+  while (true) {
+    const page = await ctx.entities.list({ ...params, limit: ENTITY_PAGE_SIZE, offset });
+    records.push(...page);
+    if (page.length < ENTITY_PAGE_SIZE) return records;
+    offset += page.length;
+  }
+}
+
+async function listAllIssues(ctx: PluginContext, companyId: string): Promise<Issue[]> {
+  const issues: Issue[] = [];
+  let offset = 0;
+  while (true) {
+    const page = await ctx.issues.list({ companyId, limit: ENTITY_PAGE_SIZE, offset });
+    issues.push(...page);
+    if (page.length < ENTITY_PAGE_SIZE) return issues;
+    offset += page.length;
+  }
+}
+
+async function listAllProjects(ctx: PluginContext, companyId: string) {
+  const projects = [];
+  let offset = 0;
+  while (true) {
+    const page = await ctx.projects.list({ companyId, limit: ENTITY_PAGE_SIZE, offset });
+    projects.push(...page);
+    if (page.length < ENTITY_PAGE_SIZE) return projects;
+    offset += page.length;
+  }
+}
+
+async function listProfiles(ctx: PluginContext, companyId: string, includeInactive = false): Promise<HumanProfile[]> {
+  const records = await listAllEntities(ctx, {
+    entityType: PROFILE_ENTITY,
+    scopeKind: "company",
+    scopeId: companyId,
+  });
+  const profiles = records
+    .filter((record) => belongsToCompany(record, companyId))
+    .map(profileFromEntity);
+  return includeInactive ? profiles : profiles.filter((profile) => profile.status === "active");
+}
+
+async function getProfile(ctx: PluginContext, companyId: string, externalId: string): Promise<HumanProfile> {
+  const records = await ctx.entities.list({
+    entityType: PROFILE_ENTITY,
+    scopeKind: "company",
+    scopeId: companyId,
+    externalId: scopedExternalId(companyId, externalId),
+    limit: 2,
+    offset: 0,
+  });
+  const record = records.find((candidate) => belongsToCompany(candidate, companyId));
+  const profile = record ? profileFromEntity(record) : null;
+  if (!profile || profile.status !== "active") throw new Error(`Active human profile not found: ${externalId}`);
+  return profile;
+}
+
+async function listAssignments(ctx: PluginContext, companyId: string): Promise<AssignmentRecord[]> {
+  const records = await listAllEntities(ctx, {
+    entityType: ASSIGNMENT_ENTITY,
+    scopeKind: "company",
+    scopeId: companyId,
+  });
+  return records
+    .filter((record) => belongsToCompany(record, companyId) && record.status !== "inactive")
+    .map(assignmentFromEntity)
+    .filter((record): record is AssignmentRecord => record !== null);
+}
+
+async function getAssignmentEntity(
+  ctx: PluginContext,
+  companyId: string,
+  issueId: string,
+): Promise<PluginEntityRecord | null> {
+  const records = await ctx.entities.list({
+    entityType: ASSIGNMENT_ENTITY,
+    scopeKind: "company",
+    scopeId: companyId,
+    externalId: scopedExternalId(companyId, issueId),
+    limit: 2,
+    offset: 0,
+  });
+  return records.find((candidate) => belongsToCompany(candidate, companyId)) ?? null;
+}
+
+async function getAssignment(
+  ctx: PluginContext,
+  companyId: string,
+  issueId: string,
+): Promise<AssignmentRecord | null> {
+  const record = await getAssignmentEntity(ctx, companyId, issueId);
+  return record && record.status !== "inactive" ? assignmentFromEntity(record) : null;
+}
+
+async function resolveLinkedUserId(ctx: PluginContext, companyId: string, profile: HumanProfile): Promise<string | null> {
+  if (!profile.paperclipUserId) return null;
+  const members = await ctx.access.members.list({ companyId, includeArchived: false });
+  const linked = members.find((member) => (
+    member.principalType === "user"
+    && member.principalId === profile.paperclipUserId
+    && member.status === "active"
+  ));
+  if (!linked) {
+    throw new Error(`Linked Paperclip user ${profile.paperclipUserId} is not an active member of this company`);
+  }
+  return linked.principalId;
+}
+
+async function authorizeMutation(
+  ctx: PluginContext,
+  actionContext: PluginPerformActionContext,
+): Promise<{ companyId: string; userId: string }> {
+  const companyId = optionalString(actionContext.companyId);
+  const userId = actionContext.actor.type === "user" ? optionalString(actionContext.actor.userId) : undefined;
+  if (!companyId || !userId) throw new Error("A signed-in company member is required");
+  const members = await ctx.access.members.list({ companyId, includeArchived: false });
+  const actorMembership = members.find((member) => (
+    member.principalType === "user"
+    && member.principalId === userId
+    && member.status === "active"
+  ));
+  if (!actorMembership || !["owner", "admin", "member"].includes(actorMembership.membershipRole ?? "")) {
+    throw new Error("Active member role is required to manage human work");
+  }
+  return { companyId, userId };
+}
+
+function issueIdentifier(issue: Issue): string {
+  const record = issue as Issue & { identifier?: string | null };
+  return record.identifier || issue.id;
+}
+
+function issueLink(config: HumanOrgConfig, issue: Issue): string {
+  const base = optionalString(config.paperclipBaseUrl)?.replace(/\/$/, "");
+  if (!base) return issue.id;
+  return `${base}/issues/${encodeURIComponent(issueIdentifier(issue))}`;
+}
+
+async function notifyMattermost(
+  ctx: PluginContext,
+  companyId: string,
+  profile: HumanProfile,
+  issue: Issue,
+): Promise<{ state: "sent" | "skipped" | "failed"; reason?: string }> {
+  try {
+    const config = await ctx.config.get(companyId) as HumanOrgConfig;
+    if (config.notifyMattermost === false) return { state: "skipped", reason: "disabled" };
+    if (!profile.mattermostUsername) return { state: "skipped", reason: "no_mattermost_username" };
+    if (!isSecretRef(config.mattermostWebhook)) return { state: "skipped", reason: "webhook_not_configured" };
+    const webhookUrl = await ctx.secrets.resolve(config.mattermostWebhook, {
+      companyId,
+      configPath: "mattermostWebhook",
+    });
+    const payload = buildMattermostAssignmentPayload({
+      humanName: profile.name,
+      mattermostUsername: profile.mattermostUsername,
+      issueTitle: issue.title,
+      issueIdentifier: issueIdentifier(issue),
+      issueUrl: issueLink(config, issue),
+      priority: issue.priority,
+    });
+    const response = await ctx.http.fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) return { state: "failed", reason: `http_${response.status}` };
+    return { state: "sent" };
+  } catch {
+    return { state: "failed", reason: "delivery_error" };
+  }
+}
+
+async function persistAssignment(
+  ctx: PluginContext,
+  companyId: string,
+  issue: Issue,
+  profile: HumanProfile,
+  linkedUserId: string | null,
+  assignedByUserId: string | null,
+  notificationState: AssignmentRecord["notificationState"],
+  assignedAt = new Date().toISOString(),
+): Promise<AssignmentRecord> {
+  const assignment: AssignmentRecord = {
+    issueId: issue.id,
+    humanExternalId: profile.externalId,
+    linkedUserId,
+    assignedAt,
+    assignedByUserId,
+    notificationState,
+  };
+  await ctx.entities.upsert({
+    entityType: ASSIGNMENT_ENTITY,
+    scopeKind: "company",
+    scopeId: companyId,
+    externalId: scopedExternalId(companyId, issue.id),
+    title: `${profile.name}: ${issue.title}`,
+    status: "active",
+    data: assignment,
+  });
+  return assignment;
+}
+
+async function persistNotificationOutcome(
+  ctx: PluginContext,
+  companyId: string,
+  issue: Issue,
+  profile: HumanProfile,
+  assignment: AssignmentRecord,
+  notificationState: "sent" | "skipped" | "failed",
+): Promise<AssignmentRecord> {
+  try {
+    return await persistAssignment(
+      ctx,
+      companyId,
+      issue,
+      profile,
+      assignment.linkedUserId,
+      assignment.assignedByUserId,
+      notificationState,
+      assignment.assignedAt,
+    );
+  } catch {
+    const unknownAssignment: AssignmentRecord = { ...assignment, notificationState: "unknown" };
+    try {
+      return await persistAssignment(
+        ctx,
+        companyId,
+        issue,
+        profile,
+        assignment.linkedUserId,
+        assignment.assignedByUserId,
+        "unknown",
+        assignment.assignedAt,
+      );
+    } catch {
+      return unknownAssignment;
+    }
+  }
+}
+
+async function reconcilePendingNotification(
+  ctx: PluginContext,
+  companyId: string,
+  issue: Issue,
+  profile: HumanProfile,
+  assignment: AssignmentRecord,
+): Promise<AssignmentRecord> {
+  if (assignment.notificationState !== "pending") return assignment;
+  try {
+    return await persistAssignment(
+      ctx,
+      companyId,
+      issue,
+      profile,
+      assignment.linkedUserId,
+      assignment.assignedByUserId,
+      "unknown",
+      assignment.assignedAt,
+    );
+  } catch {
+    return { ...assignment, notificationState: "unknown" };
+  }
+}
+
+async function assignIssue(
+  ctx: PluginContext,
+  companyId: string,
+  issue: Issue,
+  profile: HumanProfile,
+  assignedBy: string | null,
+): Promise<{ issue: Issue; assignment: AssignmentRecord; notification: { state: string; reason?: string } }> {
+  const linkedUserId = await resolveLinkedUserId(ctx, companyId, profile);
+  const observedEntity = await getAssignmentEntity(ctx, companyId, issue.id);
+  let assignment: AssignmentRecord = {
+    issueId: issue.id,
+    humanExternalId: profile.externalId,
+    linkedUserId,
+    assignedAt: new Date().toISOString(),
+    assignedByUserId: assignedBy,
+    notificationState: "pending",
+  };
+  const transition = await ctx.issues.transitionAssigneeEntity({
+    issueId: issue.id,
+    companyId,
+    expectedAssigneeAgentId: issue.assigneeAgentId ?? null,
+    expectedAssigneeUserId: issue.assigneeUserId ?? null,
+    expectedEntity: {
+      id: observedEntity?.id ?? null,
+      updatedAt: observedEntity?.updatedAt ?? null,
+      status: observedEntity?.status ?? null,
+      data: observedEntity?.data ?? null,
+    },
+    assigneeAgentId: null,
+    assigneeUserId: linkedUserId,
+    entity: {
+      entityType: ASSIGNMENT_ENTITY,
+      scopeKind: "company",
+      scopeId: companyId,
+      externalId: scopedExternalId(companyId, issue.id),
+      title: `${profile.name}: ${issue.title}`,
+      status: "active",
+      data: assignment,
+    },
+    actor: assignedBy ? { actorUserId: assignedBy } : undefined,
+  });
+  const updatedIssue = transition.issue;
+  const notification = await notifyMattermost(ctx, companyId, profile, updatedIssue);
+  const notifiedAssignment: AssignmentRecord = {
+    ...assignment,
+    notificationState: notification.state,
+  };
+  try {
+    const outcome = await ctx.issues.transitionAssigneeEntity({
+      issueId: updatedIssue.id,
+      companyId,
+      expectedAssigneeAgentId: updatedIssue.assigneeAgentId ?? null,
+      expectedAssigneeUserId: updatedIssue.assigneeUserId ?? null,
+      expectedEntity: {
+        id: transition.entity.id,
+        updatedAt: transition.entity.updatedAt,
+        status: transition.entity.status,
+        data: transition.entity.data,
+      },
+      assigneeAgentId: updatedIssue.assigneeAgentId ?? null,
+      assigneeUserId: updatedIssue.assigneeUserId ?? null,
+      entity: {
+        entityType: ASSIGNMENT_ENTITY,
+        scopeKind: "company",
+        scopeId: companyId,
+        externalId: scopedExternalId(companyId, issue.id),
+        title: `${profile.name}: ${issue.title}`,
+        status: "active",
+        data: notifiedAssignment,
+      },
+      actor: assignedBy ? { actorUserId: assignedBy } : undefined,
+    });
+    assignment = assignmentFromEntity(outcome.entity) ?? notifiedAssignment;
+  } catch {
+    assignment = { ...assignment, notificationState: "unknown" };
+  }
+  await ctx.activity.log({
+    companyId,
+    message: `Assigned ${issueIdentifier(updatedIssue)} to human profile ${profile.name}`,
+    entityType: "issue",
+    entityId: updatedIssue.id,
+    metadata: {
+      humanExternalId: profile.externalId,
+      linkedToPaperclipUser: Boolean(linkedUserId),
+      mattermostNotification: notification.state,
+    },
+  });
+  return { issue: updatedIssue, assignment, notification };
+}
+
+function importRows(params: Record<string, unknown>): HumanProfile[] {
+  if (typeof params.csv === "string") return parseOrgChartCsv(params.csv);
+  if (typeof params.json === "string") {
+    if (params.json.length > HUMAN_ORG_LIMITS.importCharacters) {
+      throw new Error(`Org chart imports are limited to ${HUMAN_ORG_LIMITS.importCharacters.toLocaleString("en-US")} characters`);
+    }
+    return normalizeOrgChartRows(JSON.parse(params.json) as unknown);
+  }
+  if (params.rows !== undefined) return normalizeOrgChartRows(params.rows);
+  throw new Error("Provide csv, json, or rows");
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    const createTaskInFlight = new Map<string, {
+      humanExternalId: string;
+      promise: Promise<unknown>;
+    }>();
+    ctx.data.register("human-roster", async (params) => {
+      const companyId = requiredCompanyId(params);
+      const profiles = await listProfiles(ctx, companyId, true);
+      const activeProfiles = profiles.filter((profile) => profile.status === "active");
+      return {
+        profiles: activeProfiles,
+        roots: buildOrgTree(activeProfiles),
+        inactiveCount: profiles.length - activeProfiles.length,
+      };
+    });
+
+    ctx.data.register("projects", async (params) => {
+      const companyId = requiredCompanyId(params);
+      return await listAllProjects(ctx, companyId);
+    });
+
+    ctx.data.register("integration-status", async (params) => {
+      const companyId = requiredCompanyId(params);
+      const config = await ctx.config.get(companyId) as HumanOrgConfig;
+      return {
+        mattermostConfigured: isSecretRef(config.mattermostWebhook),
+        notificationsEnabled: config.notifyMattermost !== false,
+        paperclipBaseUrlConfigured: Boolean(optionalString(config.paperclipBaseUrl)),
+      };
+    });
+
+    ctx.data.register("human-work-board", async (params) => {
+      const companyId = requiredCompanyId(params);
+      const [profiles, assignments, issues] = await Promise.all([
+        listProfiles(ctx, companyId, true),
+        listAssignments(ctx, companyId),
+        listAllIssues(ctx, companyId),
+      ]);
+      const profilesById = new Map(profiles.map((profile) => [profile.externalId, profile]));
+      const issuesById = new Map(issues.map((issue) => [issue.id, issue]));
+      const columns: Record<string, Array<{ assignment: AssignmentRecord; human: HumanProfile; issue: Issue }>> = Object.fromEntries(
+        ISSUE_STATUSES.map((status) => [status, []]),
+      );
+      for (const assignment of assignments) {
+        const human = profilesById.get(assignment.humanExternalId);
+        const issue = issuesById.get(assignment.issueId);
+        if (!human || !issue) continue;
+        (columns[issue.status] ??= []).push({ assignment, human, issue });
+      }
+      for (const cards of Object.values(columns)) {
+        cards.sort((left, right) => left.issue.title.localeCompare(right.issue.title));
+      }
+      return { columns, total: assignments.length };
+    });
+
+    ctx.data.register("issue-human-assignment", async (params) => {
+      const companyId = requiredCompanyId(params);
+      const issueId = optionalString(params.issueId);
+      if (!issueId) throw new Error("issueId is required");
+      const [records, profiles] = await Promise.all([
+        ctx.entities.list({
+          entityType: ASSIGNMENT_ENTITY,
+          scopeKind: "company",
+          scopeId: companyId,
+          externalId: scopedExternalId(companyId, issueId),
+          limit: 2,
+          offset: 0,
+        }),
+        listProfiles(ctx, companyId),
+      ]);
+      const record = records.find((candidate) => belongsToCompany(candidate, companyId));
+      const assignment = record?.status === "inactive" ? null : (record ? assignmentFromEntity(record) : null);
+      return {
+        assignment,
+        human: assignment ? profiles.find((profile) => profile.externalId === assignment.humanExternalId) ?? null : null,
+        profiles,
+      };
+    });
+
+    ctx.actions.register("import-org-chart", async (params, actionContext) => {
+      const { companyId } = await authorizeMutation(ctx, actionContext);
+      const rows = importRows(params);
+      const existing = await listProfiles(ctx, companyId, true);
+      const replace = params.replace === true;
+      const incomingErrors = validateOrgChartRows(rows).filter(
+        (error) => replace || error.code !== "unknown_manager",
+      );
+      const mergedProfiles = replace
+        ? rows
+        : [...new Map([
+            ...existing.map((profile) => [profile.externalId, profile] as const),
+            ...rows.map((profile) => [profile.externalId, profile] as const),
+          ]).values()];
+      const errors = [...incomingErrors, ...validateOrgChartRows(mergedProfiles)]
+        .filter((error, index, all) => all.findIndex((candidate) => (
+          candidate.code === error.code
+          && candidate.externalId === error.externalId
+          && candidate.message === error.message
+        )) === index);
+      if (errors.length > 0) {
+        throw new Error(`Org chart validation failed: ${errors.map((error) => error.message).join("; ")}`);
+      }
+
+      const incomingIds = new Set(rows.map((row) => row.externalId));
+      const entityUpserts = rows.map((profile) => ({
+        entityType: PROFILE_ENTITY,
+        scopeKind: "company" as const,
+        scopeId: companyId,
+        externalId: scopedExternalId(companyId, profile.externalId),
+        title: profile.name,
+        status: profile.status,
+        data: { ...profile },
+      }));
+
+      let deactivated = 0;
+      if (params.replace === true) {
+        for (const profile of existing) {
+          if (incomingIds.has(profile.externalId) || profile.status === "inactive") continue;
+          const inactive = { ...profile, status: "inactive" as const };
+          entityUpserts.push({
+            entityType: PROFILE_ENTITY,
+            scopeKind: "company" as const,
+            scopeId: companyId,
+            externalId: scopedExternalId(companyId, inactive.externalId),
+            title: inactive.name,
+            status: "inactive",
+            data: inactive,
+          });
+          deactivated += 1;
+        }
+      }
+
+      await ctx.entities.upsertMany(entityUpserts);
+
+      await ctx.activity.log({
+        companyId,
+        message: `Imported ${rows.length} human org profiles`,
+        entityType: "company",
+        entityId: companyId,
+        metadata: { imported: rows.length, deactivated },
+      });
+      return { imported: rows.length, deactivated, errors: [] };
+    });
+
+    ctx.actions.register("create-human-task", async (params, actionContext) => {
+      const authorization = await authorizeMutation(ctx, actionContext);
+      const requestIdForLock = optionalString(params.requestId) ?? "";
+      const humanExternalIdForLock = optionalString(params.humanExternalId) ?? "";
+      const lockKey = JSON.stringify([
+        authorization.companyId,
+        requestIdForLock,
+      ]);
+      const inFlight = createTaskInFlight.get(lockKey);
+      if (inFlight) {
+        if (inFlight.humanExternalId !== humanExternalIdForLock) {
+          throw new Error("requestId was already used for a different human assignment");
+        }
+        return await inFlight.promise;
+      }
+      const run = Promise.resolve().then(async () => {
+      const { companyId, userId } = authorization;
+      const humanExternalId = optionalString(params.humanExternalId);
+      const title = optionalString(params.title);
+      if (!humanExternalId) throw new Error("humanExternalId is required");
+      if (!title) throw new Error("title is required");
+      const requestId = optionalString(params.requestId);
+      if (!requestId) throw new Error("requestId is required for idempotent task creation");
+      if (!/^[A-Za-z0-9._:-]{1,128}$/.test(requestId)) {
+        throw new Error("requestId must contain 1-128 letters, numbers, dots, underscores, colons, or hyphens");
+      }
+      if (humanExternalId.length > HUMAN_ORG_LIMITS.externalId) {
+        throw new Error(`humanExternalId exceeds ${HUMAN_ORG_LIMITS.externalId} characters`);
+      }
+      if (title.length > HUMAN_ORG_LIMITS.taskTitle) {
+        throw new Error(`title exceeds ${HUMAN_ORG_LIMITS.taskTitle} characters`);
+      }
+      const description = optionalString(params.description);
+      if (description && description.length > HUMAN_ORG_LIMITS.taskDescription) {
+        throw new Error(`description exceeds ${HUMAN_ORG_LIMITS.taskDescription.toLocaleString("en-US")} characters`);
+      }
+      const projectId = optionalString(params.projectId);
+      if (projectId && projectId.length > HUMAN_ORG_LIMITS.externalId) {
+        throw new Error(`projectId exceeds ${HUMAN_ORG_LIMITS.externalId} characters`);
+      }
+      const profile = await getProfile(ctx, companyId, humanExternalId);
+      const linkedUserId = await resolveLinkedUserId(ctx, companyId, profile);
+      const priority = params.priority === "critical" || params.priority === "high" || params.priority === "low"
+        ? params.priority
+        : "medium";
+      const originId = `human-task:${requestId}:${profile.externalId}`;
+      const idempotencyKey = `paperclipai.plugin-human-org:create:${requestId}`;
+      let issue = (await ctx.issues.list({
+        companyId,
+        originKind: TASK_ORIGIN_KIND,
+        originId,
+        limit: 2,
+        offset: 0,
+      }))[0];
+      if (issue) {
+        const assignment = await getAssignment(ctx, companyId, issue.id);
+        if (assignment) {
+          if (assignment.humanExternalId !== profile.externalId) {
+            throw new Error("requestId was already used for a different human assignment");
+          }
+          const deliveryUncertain = assignment.notificationState === "pending"
+            || assignment.notificationState === "unknown";
+          const reconciledAssignment = deliveryUncertain
+            ? await reconcilePendingNotification(ctx, companyId, issue, profile, assignment)
+            : assignment;
+          return {
+            issue,
+            assignment: reconciledAssignment,
+            notification: deliveryUncertain
+              ? { state: "unknown", reason: "duplicate_request_delivery_unknown" }
+              : { state: reconciledAssignment.notificationState, reason: "duplicate_request" },
+          };
+        }
+      } else {
+        issue = await ctx.issues.create({
+          companyId,
+          projectId,
+          title,
+          description,
+          status: "todo",
+          priority,
+          assigneeUserId: linkedUserId,
+          originKind: TASK_ORIGIN_KIND,
+          originId,
+          idempotencyKey,
+        });
+      }
+      if (issue.originId !== originId) {
+        throw new Error("requestId was already used for a different human task");
+      }
+      const assignedAt = new Date().toISOString();
+      const pendingAssignment: AssignmentRecord = {
+        issueId: issue.id,
+        humanExternalId: profile.externalId,
+        linkedUserId,
+        assignedAt,
+        assignedByUserId: userId,
+        notificationState: "pending",
+      };
+      const assignmentClaim = await ctx.entities.create({
+        entityType: ASSIGNMENT_ENTITY,
+        scopeKind: "company",
+        scopeId: companyId,
+        externalId: scopedExternalId(companyId, issue.id),
+        title: `${profile.name}: ${issueIdentifier(issue)}`,
+        status: "active",
+        data: pendingAssignment as unknown as Record<string, unknown>,
+      });
+      if (!assignmentClaim.created) {
+        const existingAssignment = assignmentFromEntity(assignmentClaim.entity);
+        if (!existingAssignment) {
+          throw new Error("Existing human assignment record is invalid");
+        }
+        if (existingAssignment.humanExternalId !== profile.externalId) {
+          throw new Error("requestId was already used for a different human assignment");
+        }
+        const deliveryUncertain = existingAssignment.notificationState === "pending"
+          || existingAssignment.notificationState === "unknown";
+        return {
+          issue,
+          assignment: existingAssignment,
+          notification: deliveryUncertain
+            ? { state: "unknown", reason: "concurrent_request_delivery_claimed" }
+            : { state: existingAssignment.notificationState, reason: "duplicate_request" },
+        };
+      }
+
+      let assignment = pendingAssignment;
+      const notification = await notifyMattermost(ctx, companyId, profile, issue);
+      assignment = await persistNotificationOutcome(
+        ctx,
+        companyId,
+        issue,
+        profile,
+        assignment,
+        notification.state,
+      );
+      await ctx.activity.log({
+        companyId,
+        message: `Created ${issueIdentifier(issue)} for ${profile.name}`,
+        entityType: "issue",
+        entityId: issue.id,
+        metadata: {
+          humanExternalId: profile.externalId,
+          linkedToPaperclipUser: Boolean(linkedUserId),
+          mattermostNotification: notification.state,
+        },
+      });
+      return { issue, assignment, notification };
+      });
+      createTaskInFlight.set(lockKey, { humanExternalId: humanExternalIdForLock, promise: run });
+      try {
+        return await run;
+      } finally {
+        if (createTaskInFlight.get(lockKey)?.promise === run) createTaskInFlight.delete(lockKey);
+      }
+    });
+
+    ctx.actions.register("assign-human-task", async (params, actionContext) => {
+      const { companyId, userId } = await authorizeMutation(ctx, actionContext);
+      const humanExternalId = optionalString(params.humanExternalId);
+      const issueId = optionalString(params.issueId);
+      if (!humanExternalId || !issueId) throw new Error("humanExternalId and issueId are required");
+      const [profile, issue] = await Promise.all([
+        getProfile(ctx, companyId, humanExternalId),
+        ctx.issues.get(issueId, companyId),
+      ]);
+      if (!issue) throw new Error(`Issue not found: ${issueId}`);
+      return await assignIssue(ctx, companyId, issue, profile, userId);
+    });
+
+    ctx.actions.register("update-human-task-status", async (params, actionContext) => {
+      const { companyId } = await authorizeMutation(ctx, actionContext);
+      const issueId = optionalString(params.issueId);
+      const status = optionalString(params.status);
+      if (!issueId || !status || !ISSUE_STATUSES.includes(status as (typeof ISSUE_STATUSES)[number])) {
+        throw new Error("A valid issueId and status are required");
+      }
+      const records = await ctx.entities.list({
+        entityType: ASSIGNMENT_ENTITY,
+        scopeKind: "company",
+        scopeId: companyId,
+        externalId: scopedExternalId(companyId, issueId),
+        limit: 2,
+        offset: 0,
+      });
+      const activeAssignment = records.find((record) => (
+        belongsToCompany(record, companyId)
+        && record.status !== "inactive"
+        && assignmentFromEntity(record) !== null
+      ));
+      const assignment = activeAssignment ? assignmentFromEntity(activeAssignment) : null;
+      if (!assignment) {
+        throw new Error(`Issue ${issueId} does not have an active human assignment`);
+      }
+      const issue = await ctx.issues.get(issueId, companyId);
+      if (!issue) throw new Error(`Issue not found: ${issueId}`);
+      if (
+        issue.assigneeAgentId !== null
+        || issue.assigneeUserId !== assignment.linkedUserId
+      ) {
+        throw new Error(`Human assignment no longer owns issue ${issueId}`);
+      }
+      return await ctx.issues.update(issueId, { status: status as Issue["status"] }, companyId);
+    });
+
+    ctx.actions.register("unassign-human-task", async (params, actionContext) => {
+      const { companyId, userId } = await authorizeMutation(ctx, actionContext);
+      const issueId = optionalString(params.issueId);
+      if (!issueId) throw new Error("issueId is required");
+      const [record, issue] = await Promise.all([
+        getAssignmentEntity(ctx, companyId, issueId),
+        ctx.issues.get(issueId, companyId),
+      ]);
+      const assignment = record && record.status !== "inactive" ? assignmentFromEntity(record) : null;
+      if (!assignment) return { unassigned: false };
+      if (!issue) throw new Error(`Issue not found: ${issueId}`);
+      const clearLinkedAssignee = Boolean(
+        assignment.linkedUserId && issue.assigneeUserId === assignment.linkedUserId,
+      );
+      await ctx.issues.transitionAssigneeEntity({
+        issueId,
+        companyId,
+        expectedAssigneeAgentId: issue.assigneeAgentId ?? null,
+        expectedAssigneeUserId: issue.assigneeUserId ?? null,
+        expectedEntity: {
+          id: record!.id,
+          updatedAt: record!.updatedAt,
+          status: record!.status,
+          data: record!.data,
+        },
+        assigneeAgentId: issue.assigneeAgentId ?? null,
+        assigneeUserId: clearLinkedAssignee ? null : (issue.assigneeUserId ?? null),
+        entity: {
+          entityType: ASSIGNMENT_ENTITY,
+          scopeKind: "company",
+          scopeId: companyId,
+          externalId: scopedExternalId(companyId, issueId),
+          title: record!.title ?? issueId,
+          status: "inactive",
+          data: assignment,
+        },
+        actor: { actorUserId: userId },
+      });
+      return { unassigned: true };
+    });
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/plugin-human-org/tests/model.spec.ts
+++ b/packages/plugins/plugin-human-org/tests/model.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMattermostAssignmentPayload,
+  normalizeOrgChartRows,
+  parseOrgChartCsv,
+  validateOrgChartRows,
+} from "../src/model.js";
+
+describe("human org-chart import model", () => {
+  it("parses CSV with quoted values and pipe-separated capabilities and responsibilities", () => {
+    const rows = parseOrgChartCsv([
+      "external_id,name,email,title,reports_to_external_id,capabilities,responsibilities,mattermost_username,paperclip_user_id,status",
+      'exec-1,"Asha, Patel",asha@example.com,CEO,,strategy|budget,"Set direction|Approve budget",asha,,active',
+      "eng-1,Diego Ruiz,diego@example.com,Engineer,exec-1,typescript|aws,Build services|Review code,diego,user-123,active",
+    ].join("\n"));
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        externalId: "exec-1",
+        name: "Asha, Patel",
+        capabilities: ["strategy", "budget"],
+        responsibilities: ["Set direction", "Approve budget"],
+        reportsToExternalId: null,
+      }),
+      expect.objectContaining({
+        externalId: "eng-1",
+        reportsToExternalId: "exec-1",
+        paperclipUserId: "user-123",
+      }),
+    ]);
+  });
+
+  it("rejects invalid statuses during CSV parsing instead of coercing them to active", () => {
+    expect(() => parseOrgChartCsv([
+      "external_id,name,status",
+      "person-1,Asha Patel,paused",
+    ].join("\n"))).toThrow("status must be active or inactive");
+  });
+
+  it.each([
+    ["unknown headers", "external_id,name,admin_flag\nperson-1,Asha,true", "Unknown CSV header"],
+    ["duplicate normalized headers", "external_id,externalId,name\nperson-1,duplicate,Asha", "Duplicate CSV header"],
+    ["inconsistent row widths", "external_id,name,status\nperson-1,Asha", "has 2 cells; expected 3"],
+    ["quotes inside unquoted fields", 'external_id,name\nperson-1,Ash"a', "Malformed CSV quote"],
+  ])("rejects %s", (_label, input, expectedMessage) => {
+    expect(() => parseOrgChartCsv(input)).toThrow(expectedMessage);
+  });
+
+  it("rejects oversized imports and profile fields", () => {
+    expect(() => parseOrgChartCsv("x".repeat(2_000_001))).toThrow("2,000,000 characters");
+    expect(() => normalizeOrgChartRows(Array.from({ length: 5_001 }, (_value, index) => ({
+      externalId: `person-${index}`,
+      name: `Person ${index}`,
+    })))).toThrow("5,000 people");
+    expect(validateOrgChartRows([{
+      externalId: "person-1",
+      name: "x".repeat(201),
+    }])).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "input_limit", externalId: "person-1" }),
+    ]));
+  });
+
+  it("rejects duplicate identities, missing managers, and reporting cycles", () => {
+    expect(validateOrgChartRows([
+      { externalId: "a", name: "A", reportsToExternalId: "missing" },
+      { externalId: "a", name: "Duplicate A", reportsToExternalId: null },
+    ])).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "duplicate_external_id", externalId: "a" }),
+      expect.objectContaining({ code: "unknown_manager", externalId: "a" }),
+    ]));
+
+    expect(validateOrgChartRows([
+      { externalId: "a", name: "A", reportsToExternalId: "b" },
+      { externalId: "b", name: "B", reportsToExternalId: "a" },
+    ])).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "reporting_cycle" }),
+    ]));
+
+    expect(validateOrgChartRows([
+      { externalId: "broadcast", name: "Broadcast", mattermostUsername: "channel" },
+    ])).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "invalid_mattermost_username", externalId: "broadcast" }),
+    ]));
+  });
+
+  it("builds a Mattermost payload with a direct mention and Paperclip issue link", () => {
+    expect(buildMattermostAssignmentPayload({
+      humanName: "Diego Ruiz",
+      mattermostUsername: "diego",
+      issueTitle: "Review payer integration",
+      issueIdentifier: "RCM-42",
+      issueUrl: "https://paperclip.example/RCM/issues/issue-42",
+      priority: "high",
+    })).toEqual(expect.objectContaining({
+      text: expect.stringContaining("@diego"),
+      props: expect.objectContaining({
+        card: expect.stringContaining("Review payer integration"),
+      }),
+    }));
+
+    const neutralized = buildMattermostAssignmentPayload({
+      humanName: "@here coordinator",
+      issueTitle: "Review with @channel",
+      issueIdentifier: "RCM-43",
+      issueUrl: "https://paperclip.example/RCM/issues/issue-43",
+    });
+    expect(neutralized.text).not.toContain("@here");
+    expect(neutralized.text).not.toContain("@channel");
+  });
+
+  it("escapes imported Markdown syntax in Mattermost assignment payloads", () => {
+    const payload = buildMattermostAssignmentPayload({
+      humanName: "Asha Patel",
+      mattermostUsername: "asha",
+      issueTitle: "Review ](https://evil.example) @channel",
+      issueIdentifier: "QI-42",
+      issueUrl: "https://paperclip.example/issues/QI-42",
+      priority: "high",
+    });
+
+    expect(payload.text).toContain("Review \\]\\(https://evil.example\\) @\u200Bchannel");
+    expect(payload.text).not.toContain("Review ](https://evil.example)");
+  });
+});

--- a/packages/plugins/plugin-human-org/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-human-org/tests/plugin.spec.ts
@@ -1,0 +1,942 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import { pluginManifestV1Schema } from "@paperclipai/shared";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const PROJECT_ID = "22222222-2222-4222-8222-222222222222";
+const ACTOR_USER_ID = "owner-user";
+const WEBHOOK_SECRET = { type: "secret_ref", secretId: "33333333-3333-4333-8333-333333333333", version: "latest" } as const;
+
+function activeMember(companyId: string, userId = ACTOR_USER_ID, membershipRole = "owner") {
+  return {
+    id: `member-${companyId}-${userId}`,
+    companyId,
+    principalType: "user" as const,
+    principalId: userId,
+    status: "active" as const,
+    membershipRole,
+    grants: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function actionOptions(companyId = COMPANY_ID, userId = ACTOR_USER_ID) {
+  return {
+    companyId,
+    actor: { type: "user" as const, userId, companyId },
+  };
+}
+
+const csv = [
+  "external_id,name,email,title,reports_to_external_id,capabilities,responsibilities,mattermost_username,paperclip_user_id,status",
+  "exec-1,Asha Patel,asha@example.com,CEO,,strategy|budget,Set direction|Approve budget,asha,,active",
+  "eng-1,Diego Ruiz,diego@example.com,Engineer,exec-1,typescript|aws,Build services|Review code,diego,user-123,active",
+].join("\n");
+
+describe("human org and work plugin", () => {
+  it("declares a roster page, issue task view, and secure outbound capabilities", () => {
+    expect(() => pluginManifestV1Schema.parse(manifest)).not.toThrow();
+    expect(manifest.capabilities).toEqual(expect.arrayContaining([
+      "issues.read",
+      "issues.create",
+      "issues.update",
+      "http.outbound",
+      "secrets.read-ref",
+      "ui.page.register",
+      "ui.detailTab.register",
+    ]));
+    expect(manifest.ui?.slots).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "page", routePath: "human-org" }),
+      expect.objectContaining({ type: "taskDetailView", entityTypes: ["issue"] }),
+    ]));
+    expect(manifest.instanceConfigSchema).toMatchObject({
+      properties: {
+        mattermostWebhook: { format: "secret-ref" },
+      },
+    });
+  });
+
+  it("imports a validated hierarchy idempotently and exposes it as a tree", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+
+    const first = await harness.performAction<{ imported: number }>("import-org-chart", {
+      csv,
+    }, actionOptions());
+    expect(first.imported).toBe(2);
+
+    const second = await harness.performAction<{ imported: number }>("import-org-chart", {
+      csv: csv.replace("Engineer", "Senior Engineer"),
+    }, actionOptions());
+    expect(second.imported).toBe(2);
+
+    const roster = await harness.getData<{
+      roots: Array<{ profile: { externalId: string }; children: Array<{ profile: { title: string } }> }>;
+      profiles: Array<{ externalId: string }>;
+    }>("human-roster", { companyId: COMPANY_ID });
+
+    expect(roster.profiles).toHaveLength(2);
+    expect(roster.roots).toEqual([
+      expect.objectContaining({
+        profile: expect.objectContaining({ externalId: "exec-1" }),
+        children: [expect.objectContaining({ profile: expect.objectContaining({ title: "Senior Engineer" }) })],
+      }),
+    ]);
+  });
+
+  it("does not leave a partial roster when atomic import persistence fails", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    const originalUpsert = harness.ctx.entities.upsert.bind(harness.ctx.entities);
+    let singleUpserts = 0;
+    harness.ctx.entities.upsert = async (input) => {
+      singleUpserts += 1;
+      if (singleUpserts === 2) throw new Error("simulated second profile failure");
+      return originalUpsert(input);
+    };
+    (harness.ctx.entities as typeof harness.ctx.entities & {
+      upsertMany: (inputs: unknown[]) => Promise<unknown[]>;
+    }).upsertMany = async () => {
+      throw new Error("simulated atomic batch failure");
+    };
+
+    await expect(harness.performAction("import-org-chart", {
+      rows: [
+        { externalId: "exec-1", name: "Asha Patel" },
+        { externalId: "eng-1", name: "Diego Ruiz", reportsToExternalId: "exec-1" },
+      ],
+    }, actionOptions())).rejects.toThrow("failure");
+
+    const stored = await harness.ctx.entities.list({
+      entityType: "human-profile",
+      scopeKind: "company",
+      scopeId: COMPANY_ID,
+      limit: 10,
+      offset: 0,
+    });
+    expect(stored).toHaveLength(0);
+  });
+
+  it("keeps the maximum 5,000-profile replacement within one 10,000-record transaction", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    const existing = Array.from({ length: 5_000 }, (_, index) => ({
+      externalId: `old-${index}`,
+      name: `Old Human ${index}`,
+    }));
+    await harness.performAction("import-org-chart", { rows: existing }, actionOptions());
+    const originalUpsertMany = harness.ctx.entities.upsertMany.bind(harness.ctx.entities);
+    const upsertMany = vi.fn(async (inputs: Parameters<typeof originalUpsertMany>[0]) => originalUpsertMany(inputs));
+    harness.ctx.entities.upsertMany = upsertMany;
+    const replacement = Array.from({ length: 5_000 }, (_, index) => ({
+      externalId: `new-${index}`,
+      name: `New Human ${index}`,
+    }));
+
+    await expect(harness.performAction("import-org-chart", {
+      rows: replacement,
+      replace: true,
+    }, actionOptions())).resolves.toMatchObject({ imported: 5_000, deactivated: 5_000 });
+    expect(upsertMany).toHaveBeenCalledTimes(1);
+    expect(upsertMany.mock.calls[0]?.[0]).toHaveLength(10_000);
+  }, 20_000);
+
+  it("validates incremental imports against the merged existing hierarchy", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+
+    await expect(harness.performAction("import-org-chart", {
+      replace: false,
+      rows: [{ externalId: "eng-1", name: "Diego Ruiz", reportsToExternalId: "exec-1" }],
+    }, actionOptions())).resolves.toMatchObject({ imported: 1 });
+
+    const roster = await harness.getData<{ profiles: Array<{ externalId: string }> }>("human-roster", {
+      companyId: COMPANY_ID,
+    });
+    expect(roster.profiles.map((profile) => profile.externalId).sort()).toEqual(["eng-1", "exec-1"]);
+  });
+
+  it("rejects cycles introduced by incremental updates before persisting them", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [
+        { externalId: "exec-1", name: "Asha Patel" },
+        { externalId: "eng-1", name: "Diego Ruiz", reportsToExternalId: "exec-1" },
+      ],
+    }, actionOptions());
+
+    await expect(harness.performAction("import-org-chart", {
+      replace: false,
+      rows: [{ externalId: "exec-1", name: "Asha Patel", reportsToExternalId: "eng-1" }],
+    }, actionOptions())).rejects.toThrow("Reporting cycle detected");
+
+    const roster = await harness.getData<{ profiles: Array<{ externalId: string; reportsToExternalId: string | null }> }>(
+      "human-roster",
+      { companyId: COMPANY_ID },
+    );
+    expect(roster.profiles.find((profile) => profile.externalId === "exec-1")?.reportsToExternalId).toBeNull();
+  });
+
+  it("creates a Paperclip issue, records the human assignment, and uses a linked Paperclip user when available", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      projects: [{ id: PROJECT_ID, companyId: COMPANY_ID, name: "RCM", description: null, status: "in_progress", color: "#2563eb", targetDate: null, leadAgentId: null, createdAt: new Date(), updatedAt: new Date() }],
+      accessMembers: [
+        activeMember(COMPANY_ID),
+        activeMember(COMPANY_ID, "user-123", "member"),
+      ],
+    });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", { csv }, actionOptions());
+
+    const result = await harness.performAction<{
+      issue: { id: string; title: string; assigneeUserId: string | null };
+      assignment: { humanExternalId: string };
+    }>("create-human-task", {
+      requestId: "create-linked-human",
+      humanExternalId: "eng-1",
+      projectId: PROJECT_ID,
+      title: "Review payer integration",
+      description: "Confirm field mappings.",
+      priority: "high",
+    }, actionOptions());
+
+    expect(result.issue).toMatchObject({
+      title: "Review payer integration",
+      assigneeUserId: "user-123",
+    });
+    expect(result.assignment.humanExternalId).toBe("eng-1");
+
+    const board = await harness.getData<{ columns: Record<string, Array<{ human: { externalId: string }; issue: { title: string } }>> }>(
+      "human-work-board",
+      { companyId: COMPANY_ID },
+    );
+    expect(board.columns.todo).toEqual([
+      expect.objectContaining({
+        human: expect.objectContaining({ externalId: "eng-1" }),
+        issue: expect.objectContaining({ title: "Review payer integration" }),
+      }),
+    ]);
+  });
+
+  it("deduplicates retried task creation requests", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+    const params = {
+      requestId: "request-123",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    };
+
+    const first = await harness.performAction<{ issue: { id: string } }>("create-human-task", params, actionOptions());
+    const second = await harness.performAction<{ issue: { id: string } }>("create-human-task", params, actionOptions());
+    expect(second.issue.id).toBe(first.issue.id);
+
+    const board = await harness.getData<{ columns: Record<string, unknown[]> }>(
+      "human-work-board",
+      { companyId: COMPANY_ID },
+    );
+    expect(Object.values(board.columns).flat()).toHaveLength(1);
+  });
+
+  it("atomically deduplicates concurrent task creation requests", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        mattermostWebhook: { type: "secret_ref", secretId: "mattermost-webhook" },
+        notifyMattermost: true,
+      },
+    });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    harness.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
+    harness.ctx.http.fetch = fetchSpy;
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" }],
+    }, actionOptions());
+    const params = {
+      requestId: "request-concurrent",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    };
+
+    const [first, second] = await Promise.all([
+      harness.performAction<{ issue: { id: string } }>("create-human-task", params, actionOptions()),
+      harness.performAction<{ issue: { id: string } }>("create-human-task", params, actionOptions()),
+    ]);
+
+    expect(second.issue.id).toBe(first.issue.id);
+    const issues = await harness.ctx.issues.list({
+      companyId: COMPANY_ID,
+      originKind: "plugin:paperclipai.plugin-human-org",
+      limit: 10,
+      offset: 0,
+    });
+    expect(issues).toHaveLength(1);
+    const board = await harness.getData<{ total: number }>("human-work-board", { companyId: COMPANY_ID });
+    expect(board.total).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the insert-only assignment record to deduplicate notifications across worker processes", async () => {
+    const options = {
+      manifest,
+      config: {
+        mattermostWebhook: { type: "secret_ref" as const, secretId: "mattermost-webhook" },
+        notifyMattermost: true,
+      },
+    };
+    const firstWorker = createTestHarness(options);
+    const secondWorker = createTestHarness(options);
+    firstWorker.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    secondWorker.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    (secondWorker.ctx as unknown as { entities: typeof firstWorker.ctx.entities }).entities = firstWorker.ctx.entities;
+    (secondWorker.ctx as unknown as { issues: typeof firstWorker.ctx.issues }).issues = firstWorker.ctx.issues;
+    const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
+    firstWorker.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    secondWorker.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    firstWorker.ctx.http.fetch = fetchSpy;
+    secondWorker.ctx.http.fetch = fetchSpy;
+    await plugin.definition.setup(firstWorker.ctx);
+    await plugin.definition.setup(secondWorker.ctx);
+    await firstWorker.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" }],
+    }, actionOptions());
+    const params = {
+      requestId: "request-cross-worker",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    };
+
+    const [first, second] = await Promise.all([
+      firstWorker.performAction<{ issue: { id: string } }>("create-human-task", params, actionOptions()),
+      secondWorker.performAction<{ issue: { id: string } }>("create-human-task", params, actionOptions()),
+    ]);
+
+    expect(second.issue.id).toBe(first.issue.id);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const assignments = await firstWorker.ctx.entities.list({
+      entityType: "human-assignment",
+      scopeKind: "company",
+      scopeId: COMPANY_ID,
+      limit: 10,
+      offset: 0,
+    });
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0]).toEqual(expect.objectContaining({
+      status: "active",
+      data: expect.objectContaining({
+        issueId: first.issue.id,
+        humanExternalId: "exec-1",
+        notificationState: "sent",
+      }),
+    }));
+  });
+
+  it("rejects concurrent reuse of one request ID across different humans", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        mattermostWebhook: { type: "secret_ref", secretId: "mattermost-webhook" },
+        notifyMattermost: true,
+      },
+    });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    harness.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
+    harness.ctx.http.fetch = fetchSpy;
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [
+        { externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" },
+        { externalId: "exec-2", name: "Diego Ruiz", mattermostUsername: "diego" },
+      ],
+    }, actionOptions());
+
+    const results = await Promise.allSettled([
+      harness.performAction("create-human-task", {
+        requestId: "request-shared",
+        humanExternalId: "exec-1",
+        title: "Approve Q4 budget",
+      }, actionOptions()),
+      harness.performAction("create-human-task", {
+        requestId: "request-shared",
+        humanExternalId: "exec-2",
+        title: "Approve Q4 budget",
+      }, actionOptions()),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejection = results.find((result) => result.status === "rejected");
+    expect(rejection).toMatchObject({
+      reason: expect.objectContaining({
+        message: "requestId was already used for a different human assignment",
+      }),
+    });
+    const issues = await harness.ctx.issues.list({ companyId: COMPANY_ID, limit: 10, offset: 0 });
+    expect(issues).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires a stable request ID for task creation", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+
+    await expect(harness.performAction("create-human-task", {
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    }, actionOptions())).rejects.toThrow("requestId is required");
+    await expect(harness.performAction("create-human-task", {
+      requestId: "oversized-task-title",
+      humanExternalId: "exec-1",
+      title: "x".repeat(501),
+    }, actionOptions())).rejects.toThrow("title exceeds 500 characters");
+  });
+
+  it("allows only one concurrent assignment transition from the same observed state", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        mattermostWebhook: { type: "secret_ref", secretId: "mattermost-webhook" },
+        notifyMattermost: true,
+      },
+    });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    harness.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
+    harness.ctx.http.fetch = fetchSpy;
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [
+        { externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" },
+        { externalId: "exec-2", name: "Diego Ruiz", mattermostUsername: "diego" },
+      ],
+    }, actionOptions());
+    const issue = await harness.ctx.issues.create({ companyId: COMPANY_ID, title: "Concurrent owner" });
+
+    const results = await Promise.allSettled([
+      harness.performAction("assign-human-task", {
+        humanExternalId: "exec-1",
+        issueId: issue.id,
+      }, actionOptions()),
+      harness.performAction("assign-human-task", {
+        humanExternalId: "exec-2",
+        issueId: issue.id,
+      }, actionOptions()),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const assignments = await harness.ctx.entities.list({
+      entityType: "human-assignment",
+      scopeKind: "company",
+      scopeId: COMPANY_ID,
+      externalId: `${COMPANY_ID}:${issue.id}`,
+      limit: 2,
+      offset: 0,
+    });
+    expect(assignments).toHaveLength(1);
+    const winner = (assignments[0]?.data as { humanExternalId?: string }).humanExternalId;
+    expect(["exec-1", "exec-2"]).toContain(winner);
+  });
+
+  it("leaves the prior Paperclip assignee unchanged if the atomic assignment transition fails", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+    const issue = await harness.ctx.issues.create({
+      companyId: COMPANY_ID,
+      title: "Existing agent task",
+      assigneeAgentId: "agent-1",
+    });
+    harness.ctx.issues.transitionAssigneeEntity = vi.fn(async () => {
+      throw new Error("simulated atomic transition failure");
+    });
+
+    await expect(harness.performAction("assign-human-task", {
+      humanExternalId: "exec-1",
+      issueId: issue.id,
+    }, actionOptions())).rejects.toThrow("simulated atomic transition failure");
+    await expect(harness.ctx.issues.get(issue.id, COMPANY_ID)).resolves.toEqual(expect.objectContaining({
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+    }));
+  });
+
+  it("does not notify Mattermost before a new task assignment is persisted", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        mattermostWebhook: { type: "secret_ref", secretId: "mattermost-webhook" },
+        notifyMattermost: true,
+      },
+    });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    harness.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
+    harness.ctx.http.fetch = fetchSpy;
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" }],
+    }, actionOptions());
+    const originalCreate = harness.ctx.entities.create.bind(harness.ctx.entities);
+    const originalUpsert = harness.ctx.entities.upsert.bind(harness.ctx.entities);
+    let failPendingAssignment = true;
+    const maybeFailPendingAssignment = (params: { entityType: string; data: Record<string, unknown> }) => {
+      if (
+        failPendingAssignment
+        && params.entityType === "human-assignment"
+        && params.data.notificationState === "pending"
+      ) {
+        failPendingAssignment = false;
+        throw new Error("simulated persistence failure");
+      }
+    };
+    harness.ctx.entities.create = vi.fn(async (params) => {
+      maybeFailPendingAssignment(params);
+      return await originalCreate(params);
+    });
+    harness.ctx.entities.upsert = vi.fn(async (params) => {
+      maybeFailPendingAssignment(params);
+      return await originalUpsert(params);
+    });
+
+    const params = {
+      requestId: "request-no-notify",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    };
+    await expect(harness.performAction("create-human-task", params, actionOptions())).rejects.toThrow("simulated persistence failure");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const [createdIssue] = await harness.ctx.issues.list({
+      companyId: COMPANY_ID,
+      originKind: "plugin:paperclipai.plugin-human-org",
+      originId: "human-task:request-no-notify:exec-1",
+      limit: 2,
+      offset: 0,
+    });
+    expect(createdIssue).toBeDefined();
+    const orphanedClaims = await harness.ctx.entities.list({
+      entityType: "human-notification-claim",
+      scopeKind: "company",
+      scopeId: COMPANY_ID,
+      limit: 10,
+      offset: 0,
+    });
+    expect(orphanedClaims).toHaveLength(0);
+
+    harness.ctx.entities.create = originalCreate;
+    harness.ctx.entities.upsert = originalUpsert;
+    const recovered = await harness.performAction<{
+      issue: { id: string };
+      assignment: { notificationState: string };
+      notification: { state: string };
+    }>("create-human-task", params, actionOptions());
+    expect(recovered.issue.id).toBe(createdIssue?.id);
+    expect(recovered.assignment.notificationState).toBe("sent");
+    expect(recovered.notification.state).toBe("sent");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a created task authoritative when Mattermost configuration lookup fails", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" }],
+    }, actionOptions());
+    harness.ctx.config.get = vi.fn().mockRejectedValue(new Error("simulated config failure"));
+
+    const result = await harness.performAction<{
+      issue: { id: string };
+      assignment: { issueId: string };
+      notification: { state: string; reason?: string };
+    }>("create-human-task", {
+      requestId: "config-failure-task",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    }, actionOptions());
+
+    expect(result.assignment.issueId).toBe(result.issue.id);
+    expect(result.notification).toEqual({ state: "failed", reason: "delivery_error" });
+    const board = await harness.getData<{ total: number }>("human-work-board", { companyId: COMPANY_ID });
+    expect(board.total).toBe(1);
+  });
+
+  it("does not redeliver Mattermost after delivery succeeds but the sent-state write fails", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        mattermostWebhook: { type: "secret_ref", secretId: "mattermost-webhook" },
+        notifyMattermost: true,
+      },
+    });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    harness.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://chat.example/hooks/secret-value");
+    const fetchSpy = vi.fn(async () => new Response("ok", { status: 200 }));
+    harness.ctx.http.fetch = fetchSpy;
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel", mattermostUsername: "asha" }],
+    }, actionOptions());
+    const originalUpsert = harness.ctx.entities.upsert;
+    let failedSentWrite = false;
+    harness.ctx.entities.upsert = vi.fn(async (params) => {
+      if (
+        params.entityType === "human-assignment"
+        && params.data.notificationState === "sent"
+        && !failedSentWrite
+      ) {
+        failedSentWrite = true;
+        throw new Error("simulated sent-state persistence failure");
+      }
+      return await originalUpsert(params);
+    });
+    const params = {
+      requestId: "request-ambiguous-notification",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    };
+
+    const first = await harness.performAction<{
+      issue: { id: string };
+      assignment: { notificationState: string };
+      notification: { state: string; reason?: string };
+    }>("create-human-task", params, actionOptions());
+    expect(first.notification.state).toBe("sent");
+    expect(first.assignment.notificationState).toBe("unknown");
+
+    const retried = await harness.performAction<{
+      issue: { id: string };
+      assignment: { notificationState: string };
+      notification: { state: string; reason?: string };
+    }>("create-human-task", params, actionOptions());
+    expect(retried.issue.id).toBe(first.issue.id);
+    expect(retried.assignment.notificationState).toBe("unknown");
+    expect(retried.notification).toEqual({ state: "unknown", reason: "duplicate_request_delivery_unknown" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an explicitly linked Paperclip user who is not an active company member", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "eng-1", name: "Diego Ruiz", paperclipUserId: "missing-user" }],
+    }, actionOptions());
+
+    await expect(harness.performAction("create-human-task", {
+      requestId: "inactive-linked-user",
+      humanExternalId: "eng-1",
+      title: "Review payer integration",
+    }, actionOptions())).rejects.toThrow("not an active member");
+
+    const board = await harness.getData<{ columns: Record<string, unknown[]> }>(
+      "human-work-board",
+      { companyId: COMPANY_ID },
+    );
+    expect(Object.values(board.columns).flat()).toHaveLength(0);
+  });
+
+  it("rejects board status changes after the human assignment is removed", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+    const created = await harness.performAction<{ issue: { id: string } }>("create-human-task", {
+      requestId: "status-after-unassign",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    }, actionOptions());
+    await harness.performAction("unassign-human-task", { issueId: created.issue.id }, actionOptions());
+
+    await expect(harness.performAction("update-human-task-status", {
+      issueId: created.issue.id,
+      status: "done",
+    }, actionOptions())).rejects.toThrow("active human assignment");
+  });
+
+  it("allows only one concurrent unassignment from the same observed state", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+    const created = await harness.performAction<{ issue: { id: string } }>("create-human-task", {
+      requestId: "concurrent-unassign",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    }, actionOptions());
+
+    const results = await Promise.allSettled([
+      harness.performAction("unassign-human-task", { issueId: created.issue.id }, actionOptions()),
+      harness.performAction("unassign-human-task", { issueId: created.issue.id }, actionOptions()),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const assignments = await harness.ctx.entities.list({
+      entityType: "human-assignment",
+      scopeKind: "company",
+      scopeId: COMPANY_ID,
+      externalId: `${COMPANY_ID}:${created.issue.id}`,
+      limit: 2,
+      offset: 0,
+    });
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0]?.status).toBe("inactive");
+  });
+
+  it("leaves the linked core assignee unchanged when atomic assignment deactivation fails", async () => {
+      const harness = createTestHarness({ manifest });
+      harness.seed({ accessMembers: [
+        activeMember(COMPANY_ID),
+        activeMember(COMPANY_ID, "linked-user", "member"),
+      ] });
+      await plugin.definition.setup(harness.ctx);
+      await harness.performAction("import-org-chart", {
+        rows: [{ externalId: "exec-1", name: "Asha Patel", paperclipUserId: "linked-user" }],
+      }, actionOptions());
+      const created = await harness.performAction<{ issue: { id: string } }>("create-human-task", {
+        requestId: "request-unassign-compensation",
+        humanExternalId: "exec-1",
+        title: "Approve Q4 budget",
+      }, actionOptions());
+      harness.ctx.issues.transitionAssigneeEntity = vi.fn(async () => {
+        throw new Error("simulated atomic transition failure");
+      });
+
+      await expect(harness.performAction("unassign-human-task", {
+        issueId: created.issue.id,
+      }, actionOptions())).rejects.toThrow("simulated atomic transition failure");
+
+      const issue = await harness.ctx.issues.get(created.issue.id, COMPANY_ID);
+      expect(issue?.assigneeUserId).toBe("linked-user");
+    });
+
+    it("does not let an inactive assignment clear a later manual core assignment", async () => {
+      const harness = createTestHarness({ manifest });
+      harness.seed({ accessMembers: [
+        activeMember(COMPANY_ID),
+        activeMember(COMPANY_ID, "linked-user", "member"),
+      ] });
+      await plugin.definition.setup(harness.ctx);
+      await harness.performAction("import-org-chart", {
+        rows: [{ externalId: "exec-1", name: "Asha Patel", paperclipUserId: "linked-user" }],
+      }, actionOptions());
+      const created = await harness.performAction<{ issue: { id: string } }>("create-human-task", {
+        requestId: "request-inactive-unassign",
+        humanExternalId: "exec-1",
+        title: "Approve Q4 budget",
+      }, actionOptions());
+      await harness.performAction("unassign-human-task", { issueId: created.issue.id }, actionOptions());
+      await harness.ctx.issues.update(created.issue.id, { assigneeUserId: "linked-user" }, COMPANY_ID);
+
+      await expect(harness.performAction("unassign-human-task", {
+        issueId: created.issue.id,
+      }, actionOptions())).resolves.toEqual({ unassigned: false });
+      const issue = await harness.ctx.issues.get(created.issue.id, COMPANY_ID);
+      expect(issue?.assigneeUserId).toBe("linked-user");
+    });
+
+    it("rejects status mutation after the core issue is reassigned outside the plugin", async () => {
+      const harness = createTestHarness({ manifest });
+      harness.seed({ accessMembers: [
+        activeMember(COMPANY_ID),
+        activeMember(COMPANY_ID, "linked-user", "member"),
+        activeMember(COMPANY_ID, "other-user", "member"),
+      ] });
+      await plugin.definition.setup(harness.ctx);
+      await harness.performAction("import-org-chart", {
+        rows: [{ externalId: "exec-1", name: "Asha Patel", paperclipUserId: "linked-user" }],
+      }, actionOptions());
+      const created = await harness.performAction<{ issue: { id: string } }>("create-human-task", {
+        requestId: "request-stale-status",
+        humanExternalId: "exec-1",
+        title: "Approve Q4 budget",
+      }, actionOptions());
+      await harness.ctx.issues.update(created.issue.id, { assigneeUserId: "other-user" }, COMPANY_ID);
+
+      await expect(harness.performAction("update-human-task-status", {
+        issueId: created.issue.id,
+        status: "done",
+      }, actionOptions())).rejects.toThrow("no longer owns");
+      const issue = await harness.ctx.issues.get(created.issue.id, COMPANY_ID);
+      expect(issue?.status).toBe("todo");
+    });
+
+    it("keeps external assignments off the core user-assignee field", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: {
+        mattermostWebhook: WEBHOOK_SECRET,
+        paperclipBaseUrl: "https://paperclip.example",
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    harness.ctx.secrets.resolve = vi.fn().mockResolvedValue("https://slack.quickintell.com/hooks/private-token");
+    harness.ctx.http.fetch = fetchMock;
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", { csv }, actionOptions());
+
+    const result = await harness.performAction<{ issue: { assigneeUserId: string | null } }>("create-human-task", {
+      requestId: "external-human-mattermost",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    }, actionOptions());
+
+    expect(result.issue.assigneeUserId).toBeNull();
+    expect(harness.ctx.secrets.resolve).toHaveBeenCalledWith(WEBHOOK_SECRET, {
+      companyId: COMPANY_ID,
+      configPath: "mattermostWebhook",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://slack.quickintell.com/hooks/private-token",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(JSON.stringify(harness.logs)).not.toContain("private-token");
+  });
+
+  it("rejects invalid hierarchy data without persisting partial rows", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(harness.performAction("import-org-chart", {
+      rows: [
+        { externalId: "a", name: "A", reportsToExternalId: "b" },
+        { externalId: "b", name: "B", reportsToExternalId: "a" },
+      ],
+    }, actionOptions())).rejects.toThrow("Reporting cycle detected");
+
+    const roster = await harness.getData<{ profiles: unknown[] }>("human-roster", { companyId: COMPANY_ID });
+    expect(roster.profiles).toHaveLength(0);
+  });
+
+  it("keeps identical external IDs isolated between companies", async () => {
+    const otherCompanyId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID), activeMember(otherCompanyId)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Company A person" }],
+    }, actionOptions());
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Company B person" }],
+    }, actionOptions(otherCompanyId));
+
+    const firstRoster = await harness.getData<{ profiles: Array<{ externalId: string; name: string }> }>("human-roster", {
+      companyId: COMPANY_ID,
+    });
+    const secondRoster = await harness.getData<{ profiles: Array<{ externalId: string; name: string }> }>("human-roster", {
+      companyId: otherCompanyId,
+    });
+    const stored = await harness.ctx.entities.list({ entityType: "human-profile", limit: 10, offset: 0 });
+
+    expect(firstRoster.profiles).toMatchObject([{ externalId: "exec-1", name: "Company A person" }]);
+    expect(secondRoster.profiles).toMatchObject([{ externalId: "exec-1", name: "Company B person" }]);
+    expect(stored.map((record) => record.externalId).sort()).toEqual([
+      `${COMPANY_ID}:exec-1`,
+      `${otherCompanyId}:exec-1`,
+    ].sort());
+  });
+
+  it("paginates the complete company roster beyond one thousand profiles", async () => {
+    const harness = createTestHarness({ manifest });
+    await plugin.definition.setup(harness.ctx);
+    await Promise.all(Array.from({ length: 1001 }, async (_value, index) => {
+      const externalId = `person-${String(index).padStart(4, "0")}`;
+      await harness.ctx.entities.upsert({
+        entityType: "human-profile",
+        scopeKind: "company",
+        scopeId: COMPANY_ID,
+        externalId: `${COMPANY_ID}:${externalId}`,
+        title: externalId,
+        status: "active",
+        data: {
+          companyId: COMPANY_ID,
+          externalId,
+          name: externalId,
+          email: null,
+          title: null,
+          reportsToExternalId: null,
+          capabilities: [],
+          responsibilities: [],
+          mattermostUsername: null,
+          paperclipUserId: null,
+          status: "active",
+        },
+      });
+    }));
+
+    const roster = await harness.getData<{ profiles: unknown[] }>("human-roster", { companyId: COMPANY_ID });
+    expect(roster.profiles).toHaveLength(1001);
+  });
+
+  it("paginates issues when building the human work board", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID)] });
+    await plugin.definition.setup(harness.ctx);
+    await harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions());
+    const created = await harness.performAction<{ issue: Record<string, unknown> }>("create-human-task", {
+      requestId: "pagination-human-task",
+      humanExternalId: "exec-1",
+      title: "Approve Q4 budget",
+    }, actionOptions());
+    const decoys = Array.from({ length: 500 }, (_value, index) => ({
+      ...created.issue,
+      id: `decoy-${index}`,
+      title: `Decoy ${index}`,
+    }));
+    harness.ctx.issues.list = vi.fn(async (params) => params.offset === 0 ? decoys : [created.issue as never]);
+
+    const board = await harness.getData<{ columns: Record<string, Array<{ issue: { id: string } }>> }>(
+      "human-work-board",
+      { companyId: COMPANY_ID },
+    );
+    expect(board.columns.todo.map((card) => card.issue.id)).toContain(created.issue.id);
+    expect(harness.ctx.issues.list).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects mutations from viewer memberships", async () => {
+    const viewerId = "viewer-user";
+    const harness = createTestHarness({ manifest });
+    harness.seed({ accessMembers: [activeMember(COMPANY_ID, viewerId, "viewer")] });
+    await plugin.definition.setup(harness.ctx);
+
+    await expect(harness.performAction("import-org-chart", {
+      rows: [{ externalId: "exec-1", name: "Asha Patel" }],
+    }, actionOptions(COMPANY_ID, viewerId))).rejects.toThrow("Active member role is required");
+  });
+});

--- a/packages/plugins/plugin-human-org/tests/ui.spec.ts
+++ b/packages/plugins/plugin-human-org/tests/ui.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import * as ui from "../src/ui/index.js";
+
+const taskInput = {
+  companyId: "company-1",
+  humanExternalId: "human-a",
+  projectId: "project-1",
+  title: "Review denials",
+  description: "Check the payer response.",
+  priority: "high",
+};
+
+describe("new human task request identity", () => {
+  it("creates a new request ID when the selected human changes", () => {
+    const resolveIdentity = (ui as Record<string, unknown>).resolveNewTaskRequestIdentity;
+    expect(typeof resolveIdentity).toBe("function");
+
+    const createId = vi.fn().mockReturnValue("request-2");
+    const previous = { requestId: "request-1", input: taskInput };
+    const next = (resolveIdentity as (
+      current: typeof previous,
+      input: typeof taskInput,
+      createRequestId: () => string,
+    ) => typeof previous)(
+      previous,
+      { ...taskInput, humanExternalId: "human-b" },
+      createId,
+    );
+
+    expect(next.requestId).toBe("request-2");
+    expect(next.input.humanExternalId).toBe("human-b");
+    expect(createId).toHaveBeenCalledOnce();
+  });
+
+  it("retains the request ID when an unchanged submission is retried", () => {
+    const resolveIdentity = (ui as Record<string, unknown>).resolveNewTaskRequestIdentity;
+    expect(typeof resolveIdentity).toBe("function");
+
+    const createId = vi.fn().mockReturnValue("request-2");
+    const previous = { requestId: "request-1", input: taskInput };
+    const next = (resolveIdentity as (
+      current: typeof previous,
+      input: typeof taskInput,
+      createRequestId: () => string,
+    ) => typeof previous)(previous, { ...taskInput }, createId);
+
+    expect(next).toBe(previous);
+    expect(createId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/plugin-human-org/tsconfig.json
+++ b/packages/plugins/plugin-human-org/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/plugins/plugin-human-org/vitest.config.ts
+++ b/packages/plugins/plugin-human-org/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.spec.ts"],
+  },
+});

--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -131,9 +131,11 @@ export interface HostServices {
     execute(params: WorkerToHostMethods["db.execute"][0]): Promise<WorkerToHostMethods["db.execute"][1]>;
   };
 
-  /** Provides `entities.upsert`, `entities.list`. */
+  /** Provides plugin-owned entity persistence. */
   entities: {
+    create(params: WorkerToHostMethods["entities.create"][0]): Promise<WorkerToHostMethods["entities.create"][1]>;
     upsert(params: WorkerToHostMethods["entities.upsert"][0]): Promise<WorkerToHostMethods["entities.upsert"][1]>;
+    upsertMany(params: WorkerToHostMethods["entities.upsertMany"][0]): Promise<WorkerToHostMethods["entities.upsertMany"][1]>;
     list(params: WorkerToHostMethods["entities.list"][0]): Promise<WorkerToHostMethods["entities.list"][1]>;
   };
 
@@ -227,6 +229,7 @@ export interface HostServices {
     get(params: WorkerToHostMethods["issues.get"][0]): Promise<WorkerToHostMethods["issues.get"][1]>;
     create(params: WorkerToHostMethods["issues.create"][0]): Promise<WorkerToHostMethods["issues.create"][1]>;
     update(params: WorkerToHostMethods["issues.update"][0]): Promise<WorkerToHostMethods["issues.update"][1]>;
+    transitionAssigneeEntity(params: WorkerToHostMethods["issues.transitionAssigneeEntity"][0]): Promise<WorkerToHostMethods["issues.transitionAssigneeEntity"][1]>;
     getRelations(params: WorkerToHostMethods["issues.relations.get"][0]): Promise<WorkerToHostMethods["issues.relations.get"][1]>;
     setBlockedBy(params: WorkerToHostMethods["issues.relations.setBlockedBy"][0]): Promise<WorkerToHostMethods["issues.relations.setBlockedBy"][1]>;
     addBlockers(params: WorkerToHostMethods["issues.relations.addBlockers"][0]): Promise<WorkerToHostMethods["issues.relations.addBlockers"][1]>;
@@ -391,7 +394,9 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
   "db.execute": "database.namespace.write",
 
   // Entities — no specific capability required (plugin-scoped by design)
+  "entities.create": null,
   "entities.upsert": null,
+  "entities.upsertMany": null,
   "entities.list": null,
 
   // Events
@@ -444,6 +449,7 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
   "issues.get": "issues.read",
   "issues.create": "issues.create",
   "issues.update": "issues.update",
+  "issues.transitionAssigneeEntity": "issues.update",
   "issues.relations.get": "issue.relations.read",
   "issues.relations.setBlockedBy": "issue.relations.write",
   "issues.relations.addBlockers": "issue.relations.write",
@@ -544,6 +550,7 @@ export function createHostClientHandlers(
   type CompanyScopeRequest =
     | { kind: "none" }
     | { kind: "single"; companyId: string }
+    | { kind: "conflict"; companyIds: string[] }
     | { kind: "all" };
 
   const noCompanyScope: CompanyScopeRequest = { kind: "none" };
@@ -563,20 +570,67 @@ export function createHostClientHandlers(
     if (method === "companies.list") return { kind: "all" };
     if (!isRecord(params)) return noCompanyScope;
 
+    const requestedCompanyIds: string[] = [];
+    if (method === "entities.upsertMany") {
+      if (!Array.isArray(params.inputs) || params.inputs.length === 0) return { kind: "all" };
+      for (const input of params.inputs) {
+        if (!isRecord(input)) return { kind: "all" };
+        if (input.scopeKind !== "company") continue;
+        const scopeId = readNonEmptyString(input.scopeId);
+        if (!scopeId) return { kind: "all" };
+        requestedCompanyIds.push(scopeId);
+      }
+    }
+    if (method === "issues.transitionAssigneeEntity") {
+      if (!isRecord(params.entity)) return { kind: "all" };
+      if (params.entity.scopeKind === "company") {
+        const scopeId = readNonEmptyString(params.entity.scopeId);
+        if (!scopeId) return { kind: "all" };
+        requestedCompanyIds.push(scopeId);
+      }
+    }
     const companyId = readNonEmptyString(params.companyId);
-    if (companyId) return { kind: "single", companyId };
+    if (companyId) requestedCompanyIds.push(companyId);
 
     if (params.scopeKind === "company") {
       const scopeId = readNonEmptyString(params.scopeId);
-      return scopeId ? { kind: "single", companyId: scopeId } : { kind: "all" };
+      if (!scopeId) return { kind: "all" };
+      requestedCompanyIds.push(scopeId);
+    }
+
+    if ((method === "entities.list" || method === "entities.upsert" || method === "entities.create") && !params.scopeKind && !companyId) {
+      return { kind: "all" };
     }
 
     if (method === "events.subscribe" && isRecord(params.filter)) {
       const filterCompanyId = readNonEmptyString(params.filter.companyId);
-      if (filterCompanyId) return { kind: "single", companyId: filterCompanyId };
+      if (filterCompanyId) requestedCompanyIds.push(filterCompanyId);
     }
 
+    const uniqueCompanyIds = [...new Set(requestedCompanyIds)];
+    if (uniqueCompanyIds.length > 1) return { kind: "conflict", companyIds: uniqueCompanyIds };
+    if (uniqueCompanyIds.length === 1) return { kind: "single", companyId: uniqueCompanyIds[0]! };
+
     return noCompanyScope;
+  }
+
+  function requestsNonCompanyScope(
+    method: WorkerToHostMethodName,
+    params: unknown,
+  ): boolean {
+    if (!isRecord(params)) return false;
+    if (method === "entities.upsertMany") {
+      return Array.isArray(params.inputs) && params.inputs.some((input) =>
+        isRecord(input) && input.scopeKind !== "company",
+      );
+    }
+    if (method === "issues.transitionAssigneeEntity") {
+      return !isRecord(params.entity) || params.entity.scopeKind !== "company";
+    }
+    return (
+      Object.prototype.hasOwnProperty.call(params, "scopeKind")
+      && params.scopeKind !== "company"
+    );
   }
 
   function requireInvocationCompanyScope(
@@ -585,6 +639,16 @@ export function createHostClientHandlers(
     context?: WorkerHostCallContext,
   ): void {
     const requested = requestedCompanyScope(method, params);
+    const allowedCompanyId = readNonEmptyString(context?.invocationScope?.companyId);
+
+    if (allowedCompanyId && requestsNonCompanyScope(method, params)) {
+      throw new InvocationScopeDeniedError(
+        pluginId,
+        method,
+        `the current invocation is scoped to company "${allowedCompanyId}"`,
+      );
+    }
+
     if (requested.kind === "none") return;
 
     if (context?.invalidInvocationScope) {
@@ -595,7 +659,13 @@ export function createHostClientHandlers(
       );
     }
 
-    const allowedCompanyId = readNonEmptyString(context?.invocationScope?.companyId);
+    if (requested.kind === "conflict") {
+      throw new InvocationScopeDeniedError(
+        pluginId,
+        method,
+        `conflicting company scopes were requested: ${requested.companyIds.join(", ")}`,
+      );
+    }
 
     if (requested.kind === "all") {
       if (method === "companies.list") return;
@@ -742,8 +812,14 @@ export function createHostClientHandlers(
     }),
 
     // Entities
+    "entities.create": gated("entities.create", async (params) => {
+      return services.entities.create(params);
+    }),
     "entities.upsert": gated("entities.upsert", async (params) => {
       return services.entities.upsert(params);
+    }),
+    "entities.upsertMany": gated("entities.upsertMany", async (params) => {
+      return services.entities.upsertMany(params);
     }),
     "entities.list": gated("entities.list", async (params) => {
       return services.entities.list(params);
@@ -870,6 +946,9 @@ export function createHostClientHandlers(
     }),
     "issues.update": gated("issues.update", async (params) => {
       return services.issues.update(params);
+    }),
+    "issues.transitionAssigneeEntity": gated("issues.transitionAssigneeEntity", async (params) => {
+      return services.issues.transitionAssigneeEntity(params);
     }),
     "issues.relations.get": gated("issues.relations.get", async (params) => {
       return services.issues.getRelations(params);

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -60,6 +60,8 @@ import type {
   PluginIssueAttachmentContent,
   PluginIssueWakeupBatchResult,
   PluginIssueWakeupResult,
+  PluginIssueAssigneeEntityTransitionInput,
+  PluginIssueAssigneeEntityTransitionResult,
   PluginJobContext,
   PluginExecutionWorkspaceMetadata,
   PluginWorkspace,
@@ -1164,6 +1166,32 @@ export interface WorkerToHostMethods {
   ];
 
   // Entities
+  "entities.create": [
+    params: {
+      entityType: string;
+      scopeKind: PluginStateScopeKind;
+      scopeId?: string;
+      externalId?: string;
+      title?: string;
+      status?: string;
+      data: Record<string, unknown>;
+    },
+    result: {
+      created: boolean;
+      entity: {
+        id: string;
+        entityType: string;
+        scopeKind: PluginStateScopeKind;
+        scopeId: string | null;
+        externalId: string | null;
+        title: string | null;
+        status: string | null;
+        data: Record<string, unknown>;
+        createdAt: string;
+        updatedAt: string;
+      };
+    },
+  ];
   "entities.upsert": [
     params: {
       entityType: string;
@@ -1186,6 +1214,31 @@ export interface WorkerToHostMethods {
       createdAt: string;
       updatedAt: string;
     },
+  ];
+  "entities.upsertMany": [
+    params: {
+      inputs: Array<{
+        entityType: string;
+        scopeKind: PluginStateScopeKind;
+        scopeId?: string;
+        externalId?: string;
+        title?: string;
+        status?: string;
+        data: Record<string, unknown>;
+      }>;
+    },
+    result: Array<{
+      id: string;
+      entityType: string;
+      scopeKind: PluginStateScopeKind;
+      scopeId: string | null;
+      externalId: string | null;
+      title: string | null;
+      status: string | null;
+      data: Record<string, unknown>;
+      createdAt: string;
+      updatedAt: string;
+    }>,
   ];
   "entities.list": [
     params: {
@@ -1416,6 +1469,7 @@ export interface WorkerToHostMethods {
       originKind?: string | null;
       originId?: string | null;
       originRunId?: string | null;
+      idempotencyKey?: string | null;
       blockedByIssueIds?: string[];
       labelIds?: string[];
       executionWorkspaceId?: string | null;
@@ -1434,6 +1488,10 @@ export interface WorkerToHostMethods {
       companyId: string;
     },
     result: Issue,
+  ];
+  "issues.transitionAssigneeEntity": [
+    params: PluginIssueAssigneeEntityTransitionInput,
+    result: PluginIssueAssigneeEntityTransitionResult,
   ];
   "issues.relations.get": [
     params: { issueId: string; companyId: string },

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -494,6 +494,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
   const routines = new Map<string, Routine>();
   const routineRuns = new Map<string, RoutineRun>();
   const issues = new Map<string, Issue>();
+  const issueIdempotencyIndex = new Map<string, string>();
   const blockedByIssueIds = new Map<string, string[]>();
   const issueComments = new Map<string, IssueComment[]>();
   const issueInteractions = new Map<string, IssueThreadInteraction[]>();
@@ -600,7 +601,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
     options?: TestHarnessPerformActionOptions,
   ): PluginPerformActionContext {
     const actorInput = options?.actor ?? null;
-    const companyId = stringOrNull(options?.companyId) ?? stringOrNull(actorInput?.companyId) ?? stringOrNull(params.companyId);
+    const companyId = stringOrNull(options?.companyId) ?? stringOrNull(actorInput?.companyId);
     const actor = Object.freeze({
       type: actorTypeOrSystem(actorInput?.type),
       userId: stringOrNull(actorInput?.userId),
@@ -934,6 +935,14 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
     },
     entities: {
+      async create(input: PluginEntityUpsert) {
+        if (!input.externalId) throw new Error("entities.create requires externalId");
+        const externalKey = `${input.entityType}|${input.scopeKind}|${input.scopeId ?? ""}|${input.externalId}`;
+        const existingId = entityExternalIndex.get(externalKey);
+        const existing = existingId ? entities.get(existingId) : undefined;
+        if (existing) return { created: false, entity: existing };
+        return { created: true, entity: await this.upsert(input) };
+      },
       async upsert(input: PluginEntityUpsert) {
         const externalKey = input.externalId
           ? `${input.entityType}|${input.scopeKind}|${input.scopeId ?? ""}|${input.externalId}`
@@ -974,6 +983,21 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         }
         if (externalKey) entityExternalIndex.set(externalKey, record.id);
         return record;
+      },
+      async upsertMany(inputs) {
+        const entitySnapshot = new Map(entities);
+        const externalIndexSnapshot = new Map(entityExternalIndex);
+        try {
+          const records = [];
+          for (const input of inputs) records.push(await this.upsert(input));
+          return records;
+        } catch (error) {
+          entities.clear();
+          for (const [key, value] of entitySnapshot) entities.set(key, value);
+          entityExternalIndex.clear();
+          for (const [key, value] of externalIndexSnapshot) entityExternalIndex.set(key, value);
+          throw error;
+        }
       },
       async list(query) {
         let out = [...entities.values()];
@@ -1584,6 +1608,12 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
       },
       async create(input) {
         requireCapability(manifest, capabilitySet, "issues.create");
+        const idempotencyKey = input.idempotencyKey?.trim();
+        if (idempotencyKey) {
+          const existingIssueId = issueIdempotencyIndex.get(`${input.companyId}:${idempotencyKey}`);
+          const existingIssue = existingIssueId ? issues.get(existingIssueId) : undefined;
+          if (existingIssue) return existingIssue;
+        }
         const now = new Date();
         const originKind = normalizePluginOriginKind(
           input.surfaceVisibility === "plugin_operation" && !input.originKind
@@ -1630,6 +1660,7 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           updatedAt: now,
         };
         issues.set(record.id, record);
+        if (idempotencyKey) issueIdempotencyIndex.set(`${input.companyId}:${idempotencyKey}`, record.id);
         if (input.blockedByIssueIds) blockedByIssueIds.set(record.id, [...new Set(input.blockedByIssueIds)]);
         return record;
       },
@@ -1651,6 +1682,70 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
           blockedByIssueIds.set(issueId, [...new Set(nextBlockedByIssueIds)]);
         }
         return updated;
+      },
+      async transitionAssigneeEntity(input) {
+        requireCapability(manifest, capabilitySet, "issues.update");
+        const record = issues.get(input.issueId);
+        if (!isInCompany(record, input.companyId)) throw new Error(`Issue not found: ${input.issueId}`);
+        if (
+          (record.assigneeAgentId ?? null) !== input.expectedAssigneeAgentId
+          || (record.assigneeUserId ?? null) !== input.expectedAssigneeUserId
+        ) {
+          throw new Error("Issue assignment changed concurrently");
+        }
+        if (
+          input.entity.scopeKind !== "company"
+          || input.entity.scopeId !== input.companyId
+        ) {
+          throw new Error("Assignment entity must use the issue company scope");
+        }
+        const externalKey = `${input.entity.entityType}|company|${input.companyId}|${input.entity.externalId}`;
+        const currentEntityId = entityExternalIndex.get(externalKey);
+        const currentEntity = currentEntityId ? entities.get(currentEntityId) : undefined;
+        if (
+          (currentEntity?.id ?? null) !== input.expectedEntity.id
+          || (currentEntity?.updatedAt ?? null) !== input.expectedEntity.updatedAt
+          || (currentEntity?.status ?? null) !== input.expectedEntity.status
+          || JSON.stringify(currentEntity?.data ?? null) !== JSON.stringify(input.expectedEntity.data)
+        ) {
+          throw new Error("Assignment entity changed concurrently");
+        }
+        const now = new Date();
+        const nowIso = now.toISOString();
+        const updatedIssue: Issue = {
+          ...record,
+          assigneeAgentId: input.assigneeAgentId,
+          assigneeUserId: input.assigneeUserId,
+          updatedAt: now,
+        };
+        const updatedEntity: PluginEntityRecord = currentEntity
+          ? {
+            ...currentEntity,
+            entityType: input.entity.entityType,
+            scopeKind: "company",
+            scopeId: input.companyId,
+            externalId: input.entity.externalId,
+            title: input.entity.title ?? null,
+            status: input.entity.status ?? null,
+            data: input.entity.data,
+            updatedAt: nowIso,
+          }
+          : {
+            id: randomUUID(),
+            entityType: input.entity.entityType,
+            scopeKind: "company",
+            scopeId: input.companyId,
+            externalId: input.entity.externalId,
+            title: input.entity.title ?? null,
+            status: input.entity.status ?? null,
+            data: input.entity.data,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          };
+        issues.set(input.issueId, updatedIssue);
+        entities.set(updatedEntity.id, updatedEntity);
+        entityExternalIndex.set(externalKey, updatedEntity.id);
+        return { issue: updatedIssue, entity: updatedEntity };
       },
       async assertCheckoutOwner(input) {
         requireCapability(manifest, capabilitySet, "issues.checkout");

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -801,6 +801,9 @@ export interface PluginStateClient {
  * @see PLUGIN_SPEC.md §21.3 `plugin_entities`
  */
 export interface PluginEntitiesClient {
+  /** Create an entity only if its scoped external ID does not already exist. */
+  create(input: PluginEntityUpsert): Promise<{ created: boolean; entity: PluginEntityRecord }>;
+
   /**
    * Create or update a plugin entity record (upsert by `externalId` within
    * the given scope, or by `id` if provided).
@@ -808,6 +811,9 @@ export interface PluginEntitiesClient {
    * @param input - Entity data to upsert
    */
   upsert(input: PluginEntityUpsert): Promise<PluginEntityRecord>;
+
+  /** Atomically apply all entity upserts, rolling back the whole batch on failure. */
+  upsertMany(inputs: PluginEntityUpsert[]): Promise<PluginEntityRecord[]>;
 
   /**
    * Query plugin entity records.
@@ -1335,6 +1341,28 @@ export interface PluginIssueAttachmentContent {
   contentBase64: string;
 }
 
+export interface PluginIssueAssigneeEntityTransitionInput {
+  issueId: string;
+  companyId: string;
+  expectedAssigneeAgentId: string | null;
+  expectedAssigneeUserId: string | null;
+  expectedEntity: {
+    id: string | null;
+    updatedAt: string | null;
+    status: string | null;
+    data: Record<string, unknown> | null;
+  };
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+  entity: PluginEntityUpsert & { externalId: string };
+  actor?: PluginIssueMutationActor;
+}
+
+export interface PluginIssueAssigneeEntityTransitionResult {
+  issue: Issue;
+  entity: PluginEntityRecord;
+}
+
 /**
  * `ctx.issues` — read and mutate issues plus comments.
  *
@@ -1388,6 +1416,8 @@ export interface PluginIssuesClient {
     originKind?: PluginIssueOriginKind;
     originId?: string | null;
     originRunId?: string | null;
+    /** Company-scoped key used by the host to atomically deduplicate issue creation. */
+    idempotencyKey?: string | null;
     blockedByIssueIds?: string[];
     labelIds?: string[];
     executionWorkspaceId?: string | null;
@@ -1420,6 +1450,13 @@ export interface PluginIssuesClient {
     companyId: string,
     actor?: PluginIssueMutationActor,
   ): Promise<Issue>;
+  /**
+   * Atomically compare-and-swap an issue assignee and one plugin-owned entity.
+   * The host rejects stale issue or entity observations and commits neither write.
+   */
+  transitionAssigneeEntity(
+    input: PluginIssueAssigneeEntityTransitionInput,
+  ): Promise<PluginIssueAssigneeEntityTransitionResult>;
   assertCheckoutOwner(input: {
     issueId: string;
     companyId: string;

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -657,6 +657,18 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
       },
 
       entities: {
+        async create(input) {
+          return callHost("entities.create", {
+            entityType: input.entityType,
+            scopeKind: input.scopeKind,
+            scopeId: input.scopeId,
+            externalId: input.externalId,
+            title: input.title,
+            status: input.status,
+            data: input.data,
+          });
+        },
+
         async upsert(input) {
           return callHost("entities.upsert", {
             entityType: input.entityType,
@@ -667,6 +679,10 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             status: input.status,
             data: input.data,
           });
+        },
+
+        async upsertMany(inputs) {
+          return callHost("entities.upsertMany", { inputs });
         },
 
         async list(query) {
@@ -824,6 +840,7 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             originKind: input.originKind,
             originId: input.originId,
             originRunId: input.originRunId,
+            idempotencyKey: input.idempotencyKey,
             blockedByIssueIds: input.blockedByIssueIds,
             labelIds: input.labelIds,
             executionWorkspaceId: input.executionWorkspaceId,
@@ -846,6 +863,10 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             },
             companyId,
           });
+        },
+
+        async transitionAssigneeEntity(input) {
+          return callHost("issues.transitionAssigneeEntity", input);
         },
 
         async assertCheckoutOwner(input) {

--- a/packages/plugins/sdk/tests/host-client-factory.test.ts
+++ b/packages/plugins/sdk/tests/host-client-factory.test.ts
@@ -146,6 +146,200 @@ describe("createHostClientHandlers invocation company scope", () => {
     expect(stateGet).not.toHaveBeenCalled();
   });
 
+  it("rejects a non-company state scope hidden behind a matching companyId", async () => {
+    const stateGet = vi.fn(async () => null);
+    const services = { state: { get: stateGet } } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["plugin.state.read"],
+      services,
+    });
+
+    await expect(
+      (handlers as Record<string, (input: unknown, context: unknown) => Promise<unknown>>)["state.get"](
+        {
+          companyId: "company-a",
+          scopeKind: "instance",
+          scopeId: "company-b",
+          stateKey: "settings",
+        },
+        { invocationScope: { companyId: "company-a" } },
+      ),
+    ).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(stateGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-company state scope without a companyId during a company invocation", async () => {
+    const stateGet = vi.fn(async () => null);
+    const services = { state: { get: stateGet } } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["plugin.state.read"],
+      services,
+    });
+
+    await expect(
+      handlers["state.get"](
+        { scopeKind: "instance", stateKey: "settings" },
+        { invocationScope: { companyId: "company-a" } },
+      ),
+    ).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(stateGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects unscoped entity reads instead of exposing every company", async () => {
+    const entitiesList = vi.fn(async () => []);
+    const services = {
+      entities: {
+        list: entitiesList,
+      },
+    } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: [],
+      services,
+    });
+
+    await expect(
+      handlers["entities.list"](
+        { entityType: "human-profile" },
+        { invocationScope: { companyId: "company-a" } },
+      ),
+    ).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(entitiesList).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["entities.list", "list", { entityType: "human-profile", limit: 10, offset: 0 }],
+    ["entities.upsert", "upsert", { entityType: "human-profile", externalId: "shared", title: "Cross tenant", data: {} }],
+  ] as const)("rejects conflicting companyId and scopeId for %s", async (method, delegateName, baseParams) => {
+    const entitiesList = vi.fn(async () => []);
+    const entitiesUpsert = vi.fn(async () => ({ id: "entity-1" }));
+    const services = {
+      entities: {
+        list: entitiesList,
+        upsert: entitiesUpsert,
+      },
+    } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: [],
+      services,
+    });
+
+    await expect(
+      (handlers as Record<string, (input: unknown, context: unknown) => Promise<unknown>>)[method](
+        {
+          ...baseParams,
+          companyId: "company-a",
+          scopeKind: "company",
+          scopeId: "company-b",
+        },
+        { invocationScope: { companyId: "company-a" } },
+      ),
+    ).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(delegateName === "list" ? entitiesList : entitiesUpsert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["entities.list", "list", { entityType: "human-profile", limit: 10, offset: 0 }],
+    ["entities.create", "create", { entityType: "human-profile", data: {} }],
+    ["entities.upsert", "upsert", { entityType: "human-profile", externalId: "shared", data: {} }],
+  ] as const)(
+    "rejects non-company entity scope hidden behind a matching companyId for %s",
+    async (method, delegateName, baseParams) => {
+      const delegates = {
+        list: vi.fn(async () => []),
+        create: vi.fn(async () => ({ created: true, entity: { id: "entity-1" } })),
+        upsert: vi.fn(async () => ({ id: "entity-1" })),
+      };
+      const services = { entities: delegates } as unknown as HostServices;
+      const handlers = createHostClientHandlers({
+        pluginId: "paperclip.test",
+        capabilities: [],
+        services,
+      });
+
+      await expect(
+        (handlers as Record<string, (input: unknown, context: unknown) => Promise<unknown>>)[method](
+          {
+            ...baseParams,
+            companyId: "company-a",
+            scopeKind: "instance",
+            scopeId: "company-b",
+          },
+          { invocationScope: { companyId: "company-a" } },
+        ),
+      ).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+      expect(delegates[delegateName]).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects batched entity mutations that mix company scopes", async () => {
+    const upsertMany = vi.fn(async () => []);
+    const services = { entities: { upsertMany } } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: [],
+      services,
+    });
+
+    await expect(handlers["entities.upsertMany"]({
+      inputs: [
+        { entityType: "human-profile", scopeKind: "company", scopeId: "company-a", data: {} },
+        { entityType: "human-profile", scopeKind: "company", scopeId: "company-b", data: {} },
+      ],
+    }, { invocationScope: { companyId: "company-a" } })).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(upsertMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-company entity scope hidden in a company-scoped batch", async () => {
+    const upsertMany = vi.fn(async () => []);
+    const services = { entities: { upsertMany } } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: [],
+      services,
+    });
+
+    await expect(handlers["entities.upsertMany"]({
+      inputs: [
+        { entityType: "human-profile", scopeKind: "company", scopeId: "company-a", data: {} },
+        { entityType: "human-profile", scopeKind: "instance", scopeId: "company-b", data: {} },
+      ],
+    }, { invocationScope: { companyId: "company-a" } })).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(upsertMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects an atomic issue/entity transition with a nested non-company decoy scope", async () => {
+    const transitionAssigneeEntity = vi.fn(async () => ({ issue: {}, entity: {} }));
+    const services = { issues: { transitionAssigneeEntity } } as unknown as HostServices;
+    const handlers = createHostClientHandlers({
+      pluginId: "paperclip.test",
+      capabilities: ["issues.update"],
+      services,
+    });
+
+    await expect(handlers["issues.transitionAssigneeEntity"]({
+      issueId: "issue-a",
+      companyId: "company-a",
+      expectedAssigneeAgentId: null,
+      expectedAssigneeUserId: null,
+      expectedEntity: { id: null, updatedAt: null, status: null, data: null },
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      entity: {
+        entityType: "human-assignment",
+        scopeKind: "instance",
+        scopeId: "company-a",
+        externalId: "issue-a",
+        status: "active",
+        data: {},
+      },
+    }, { invocationScope: { companyId: "company-a" } })).rejects.toBeInstanceOf(InvocationScopeDeniedError);
+    expect(transitionAssigneeEntity).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       "access.members.list",

--- a/packages/plugins/sdk/tests/testing-actions.test.ts
+++ b/packages/plugins/sdk/tests/testing-actions.test.ts
@@ -65,6 +65,23 @@ describe("createTestHarness action context", () => {
     expect(result.actorFrozen).toBe(true);
   });
 
+  it("does not derive trusted action context from caller-controlled params", async () => {
+    const harness = createTestHarness({ manifest });
+    harness.ctx.actions.register("inspect-untrusted", async (params, context) => ({
+      paramsCompanyId: params.companyId,
+      actorCompanyId: context.actor.companyId,
+      companyId: context.companyId,
+    }));
+
+    await expect(harness.performAction("inspect-untrusted", {
+      companyId: "spoofed-company",
+    })).resolves.toEqual({
+      paramsCompanyId: "spoofed-company",
+      actorCompanyId: null,
+      companyId: null,
+    });
+  });
+
   it("keeps existing one-argument action handlers compatible", async () => {
     const harness = createTestHarness({ manifest });
     harness.ctx.actions.register("legacy", async (params) => ({ ok: params.ok }));

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -297,6 +297,150 @@ describe("worker invocation scope propagation", () => {
   });
 });
 
+describe("worker issue RPC forwarding", () => {
+  it("forwards issue idempotency keys to the production host RPC", async () => {
+    const hostToWorker = new PassThrough();
+    const workerToHost = new PassThrough();
+    const hostReadline = createInterface({ input: workerToHost });
+    const pending = new Map<string, (response: JsonRpcResponse) => void>();
+    let nextRequestId = 1;
+    let capturedCreateParams: Record<string, unknown> | null = null;
+    const capturedEntityMethods: string[] = [];
+    const plugin = definePlugin({
+      async setup(ctx) {
+        ctx.actions.register("create-issue", async () => ctx.issues.create({
+          companyId: "company-a",
+          title: "Atomic human task",
+          originId: "human-task:req-1:exec-1",
+          idempotencyKey: "paperclipai.plugin-human-org:create:req-1",
+        }));
+        ctx.actions.register("entity-primitives", async () => ({
+          claim: await ctx.entities.create({
+            entityType: "claim",
+            scopeKind: "company",
+            scopeId: "company-a",
+            externalId: "claim-1",
+            data: {},
+          }),
+          batch: await ctx.entities.upsertMany([{
+            entityType: "profile",
+            scopeKind: "company",
+            scopeId: "company-a",
+            externalId: "profile-1",
+            data: {},
+          }]),
+        }));
+      },
+    });
+    const worker = startWorkerRpcHost({
+      plugin,
+      stdin: hostToWorker,
+      stdout: workerToHost,
+    });
+
+    function callWorker(method: string, params: unknown, invocation?: PluginInvocationContext) {
+      const id = `host-${nextRequestId++}`;
+      const request = {
+        ...createRequest(method, params, id),
+        ...(invocation ? { paperclipInvocation: invocation } : {}),
+      };
+      const result = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, (response) => {
+          if ("error" in response && response.error) {
+            reject(new Error(response.error.message));
+            return;
+          }
+          resolve((response as { result?: unknown }).result);
+        });
+      });
+      hostToWorker.write(serializeMessage(request));
+      return result;
+    }
+
+    hostReadline.on("line", (line) => {
+      const message = parseMessage(line);
+      if (isJsonRpcResponse(message)) {
+        pending.get(String(message.id))?.(message);
+        pending.delete(String(message.id));
+        return;
+      }
+      if (!isJsonRpcRequest(message)) return;
+      if (message.method === "issues.create") {
+        capturedCreateParams = message.params as Record<string, unknown>;
+        hostToWorker.write(serializeMessage(createSuccessResponse(message.id, {
+          id: "issue-1",
+          companyId: "company-a",
+          title: "Atomic human task",
+          status: "todo",
+          priority: "medium",
+        })));
+        return;
+      }
+      if (message.method !== "entities.create" && message.method !== "entities.upsertMany") return;
+      capturedEntityMethods.push(message.method);
+      const entity = {
+        id: "entity-1",
+        entityType: "claim",
+        scopeKind: "company",
+        scopeId: "company-a",
+        externalId: "claim-1",
+        title: null,
+        status: null,
+        data: {},
+        createdAt: "2026-08-03T00:00:00.000Z",
+        updatedAt: "2026-08-03T00:00:00.000Z",
+      };
+      hostToWorker.write(serializeMessage(createSuccessResponse(
+        message.id,
+        message.method === "entities.create" ? { created: true, entity } : [entity],
+      )));
+    });
+
+    try {
+      await callWorker("initialize", {
+        manifest: {
+          id: "paperclip.issue-forwarding-test",
+          apiVersion: 1,
+          version: "1.0.0",
+          displayName: "Issue forwarding test",
+          description: "Issue forwarding test",
+          author: "Paperclip",
+          categories: ["automation"],
+          capabilities: ["issues.create"],
+          entrypoints: { worker: "dist/worker.js" },
+        },
+        config: {},
+        instanceInfo: { instanceId: "test", hostVersion: "0.0.0" },
+        apiVersion: 1,
+      });
+
+      await callWorker(
+        "performAction",
+        { key: "create-issue", params: {} },
+        { id: "invocation-a", scope: { companyId: "company-a" } },
+      );
+
+      expect(capturedCreateParams).toMatchObject({
+        companyId: "company-a",
+        title: "Atomic human task",
+        originId: "human-task:req-1:exec-1",
+        idempotencyKey: "paperclipai.plugin-human-org:create:req-1",
+      });
+      await callWorker(
+        "performAction",
+        { key: "entity-primitives", params: {} },
+        { id: "invocation-a", scope: { companyId: "company-a" } },
+      );
+      expect(capturedEntityMethods).toEqual(["entities.create", "entities.upsertMany"]);
+    } finally {
+      worker.stop();
+      hostReadline.close();
+      hostToWorker.destroy();
+      workerToHost.destroy();
+    }
+  });
+});
+
 describe("worker configChanged cross-tenant guard", () => {
   // Spin up a worker-rpc-host wired to in-memory streams and expose a
   // request/response `callWorker` plus `initialize`/`stop` helpers.

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -787,8 +787,14 @@ export interface PluginCompanySettings {
  * Query filter for `ctx.entities.list`.
  */
 export interface PluginEntityQuery {
+  /** Optional tenant filter. `null` selects instance-scope records. */
+  companyId?: string | null;
   /** Optional filter by entity type (e.g. 'project', 'issue'). */
   entityType?: string;
+  /** Optional filter by entity scope kind. */
+  scopeKind?: PluginStateScopeKind;
+  /** Optional filter by entity scope ID. */
+  scopeId?: string;
   /** Optional filter by external system identifier. */
   externalId?: string;
   /** Maximum number of records to return. Defaults to 100. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,40 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
 
+  packages/plugins/plugin-human-org:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../sdk
+    devDependencies:
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
+
   packages/plugins/plugin-llm-wiki:
     dependencies:
       react:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,40 +592,6 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
 
-  packages/plugins/plugin-human-org:
-    dependencies:
-      '@paperclipai/plugin-sdk':
-        specifier: workspace:*
-        version: link:../sdk
-    devDependencies:
-      '@paperclipai/shared':
-        specifier: workspace:*
-        version: link:../../shared
-      '@types/node':
-        specifier: ^22.20.1
-        version: 22.20.1
-      '@types/react':
-        specifier: ^19.2.17
-        version: 19.2.17
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
-      esbuild:
-        specifier: ^0.28.1
-        version: 0.28.1
-      react:
-        specifier: ^19.2.7
-        version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.1))
-
   packages/plugins/plugin-llm-wiki:
     dependencies:
       react:

--- a/scripts/generate-plugin-package-json.mjs
+++ b/scripts/generate-plugin-package-json.mjs
@@ -17,10 +17,15 @@ if (!existsSync(packageJsonPath)) {
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 const sdkPackageJson = JSON.parse(readFileSync(sdkPackageJsonPath, "utf8"));
 const publishConfig = packageJson.publishConfig ?? {};
-const dependencies = {
-  ...(packageJson.dependencies ?? {}),
-  "@paperclipai/plugin-sdk": sdkPackageJson.version,
-};
+const sdkRuntimeBundled = packageJson.paperclipPlugin?.sdkRuntime === "bundled";
+const dependencies = sdkRuntimeBundled
+  ? Object.fromEntries(Object.entries(packageJson.dependencies ?? {}).filter(
+      ([, version]) => !String(version).startsWith("workspace:"),
+    ))
+  : {
+      ...(packageJson.dependencies ?? {}),
+      "@paperclipai/plugin-sdk": sdkPackageJson.version,
+    };
 
 const publishPackageJson = {
   name: packageJson.name,

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -22,6 +22,7 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  pluginEntities,
   pluginManagedResources,
   plugins,
   projects,
@@ -43,6 +44,7 @@ function createEventBusStub() {
       return {
         emit: async () => {},
         subscribe: () => {},
+        clear: () => {},
       };
     },
   } as any;
@@ -116,6 +118,7 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     await db.delete(issues);
     await db.delete(executionWorkspaces);
     await db.delete(pluginManagedResources);
+    await db.delete(pluginEntities);
     await db.delete(projects);
     await db.delete(plugins);
     await db.delete(companyMemberships);
@@ -155,6 +158,226 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     tempRoots.push(root);
     return root;
   }
+
+  it("returns successive issue pages without applying offset twice", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    await db.insert(issues).values(Array.from({ length: 501 }, (_value, index) => ({
+      companyId,
+      title: `Issue ${index}`,
+      status: "todo",
+      priority: "medium",
+    })));
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+
+    const firstPage = await services.issues.list({ companyId, limit: 500, offset: 0 });
+    const secondPage = await services.issues.list({ companyId, limit: 500, offset: 500 });
+
+    expect(firstPage).toHaveLength(500);
+    expect(secondPage).toHaveLength(1);
+    expect(new Set([...firstPage, ...secondPage].map((issue) => issue.id))).toHaveLength(501);
+    services.dispose();
+  });
+
+  it("atomically deduplicates concurrent plugin issue creation by idempotency key", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+    const input = {
+      companyId,
+      title: "Concurrent human task",
+      status: "todo" as const,
+      originId: "human-task:request-atomic:exec-1",
+      idempotencyKey: "paperclipai.plugin-human-org:create:request-atomic",
+    };
+
+    const [first, second] = await Promise.all([
+      services.issues.create(input),
+      services.issues.create(input),
+    ]);
+    const stored = await services.issues.list({
+      companyId,
+      originId: input.originId,
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(stored).toHaveLength(1);
+    services.dispose();
+  });
+
+  it("atomically rolls back batched plugin entity upserts", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const pluginId = randomUUID();
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "paperclip.human-org-batch",
+      packageName: "@paperclipai/plugin-human-org",
+      version: "0.1.0",
+      manifestJson: {},
+    });
+    const services = buildHostServices(db, pluginId, "paperclip.human-org-batch", createEventBusStub());
+    const entities = services.entities as typeof services.entities & {
+      upsertMany(inputs: Array<Record<string, unknown>>): Promise<unknown[]>;
+    };
+
+    await expect(entities.upsertMany([
+      {
+        entityType: "human-profile",
+        scopeKind: "company",
+        scopeId: companyId,
+        externalId: `${companyId}:exec-1`,
+        title: "Asha Patel",
+        status: "active",
+        data: { externalId: "exec-1" },
+      },
+      {
+        entityType: "human-profile",
+        scopeKind: "company",
+        scopeId: companyId,
+        externalId: `${companyId}:eng-1`,
+        title: "x".repeat(301),
+        status: "active",
+        data: { externalId: "eng-1" },
+      },
+    ])).rejects.toThrow();
+
+    const stored = await db.select().from(pluginEntities).where(eq(pluginEntities.pluginId, pluginId));
+    expect(stored).toHaveLength(0);
+    services.dispose();
+  });
+
+  it("atomically grants one durable plugin entity claim under concurrency", async () => {
+    const { companyId } = await seedCompanyAndAgent();
+    const pluginId = randomUUID();
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "paperclip.human-org-claim",
+      packageName: "@paperclipai/plugin-human-org",
+      version: "0.1.0",
+      manifestJson: {},
+    });
+    const services = buildHostServices(db, pluginId, "paperclip.human-org-claim", createEventBusStub());
+    const entities = services.entities as typeof services.entities & {
+      create(input: Record<string, unknown>): Promise<{ created: boolean }>;
+    };
+    const input = {
+      entityType: "human-notification-claim",
+      scopeKind: "company",
+      scopeId: companyId,
+      externalId: `${companyId}:issue-1`,
+      title: "Notification claim",
+      status: "claimed",
+      data: { issueId: "issue-1" },
+    };
+
+    const [first, second] = await Promise.all([
+      entities.create(input),
+      entities.create(input),
+    ]);
+    expect([first.created, second.created].sort()).toEqual([false, true]);
+    const stored = await db.select().from(pluginEntities).where(eq(pluginEntities.pluginId, pluginId));
+    expect(stored).toHaveLength(1);
+    services.dispose();
+  });
+
+  it("atomically transitions an issue assignee and its plugin-owned assignment entity", async () => {
+    const { companyId, agentId: firstAgentId } = await seedCompanyAndAgent();
+    const secondAgentId = randomUUID();
+    const pluginId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(agents).values({
+      id: secondAgentId,
+      companyId,
+      name: "Second engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: { command: "true" },
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "paperclip.human-org-transition",
+      packageName: "@paperclipai/plugin-human-org",
+      version: "0.1.0",
+      manifestJson: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Atomic assignment",
+      status: "todo",
+      priority: "medium",
+    });
+    const services = buildHostServices(db, pluginId, "paperclip.human-org-transition", createEventBusStub());
+    const transition = (assigneeAgentId: string, humanExternalId: string) =>
+      services.issues.transitionAssigneeEntity({
+        companyId,
+        issueId,
+        expectedAssigneeAgentId: null,
+        expectedAssigneeUserId: null,
+        expectedEntity: {
+          id: null,
+          updatedAt: null,
+          status: null,
+          data: null,
+        },
+        assigneeAgentId,
+        assigneeUserId: null,
+        entity: {
+          entityType: "human-assignment",
+          scopeKind: "company",
+          scopeId: companyId,
+          externalId: issueId,
+          title: "Atomic assignment",
+          status: "active",
+          data: { issueId, humanExternalId },
+        },
+      });
+
+    const results = await Promise.allSettled([
+      transition(firstAgentId, "exec-1"),
+      transition(secondAgentId, "exec-2"),
+    ]);
+    const storedIssue = await db.select().from(issues).where(eq(issues.id, issueId));
+    const storedEntities = await db
+      .select()
+      .from(pluginEntities)
+      .where(and(eq(pluginEntities.pluginId, pluginId), eq(pluginEntities.externalId, issueId)));
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect([firstAgentId, secondAgentId]).toContain(storedIssue[0]?.assigneeAgentId);
+    expect(storedEntities).toHaveLength(1);
+    const winningHuman = (storedEntities[0]?.data as { humanExternalId?: string }).humanExternalId;
+    expect(["exec-1", "exec-2"]).toContain(winningHuman);
+    expect(winningHuman).toBe(
+      storedIssue[0]?.assigneeAgentId === firstAgentId ? "exec-1" : "exec-2",
+    );
+    services.dispose();
+  });
+
+  it("does not reflect malformed outbound HTTP URLs in host errors", async () => {
+    const secretValue = "mattermost-webhook-secret-SHOULD-NOT-LEAK";
+    const services = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.http-redaction",
+      createEventBusStub(),
+    );
+
+    let errorMessage = "";
+    try {
+      await services.http.fetch({ url: secretValue });
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(errorMessage).toContain("Invalid outbound HTTP URL");
+    expect(errorMessage).not.toContain(secretValue);
+    services.dispose();
+  });
 
   it("returns plugin-safe execution workspace metadata scoped to the company", async () => {
     const { companyId } = await seedCompanyAndAgent();

--- a/server/src/__tests__/plugin-registry-batch-limit.test.ts
+++ b/server/src/__tests__/plugin-registry-batch-limit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { pluginRegistryService } from "../services/plugin-registry.js";
+
+function entity(index: number) {
+  return {
+    companyId: "11111111-1111-4111-8111-111111111111",
+    entityType: "human-profile",
+    scopeKind: "company" as const,
+    scopeId: "11111111-1111-4111-8111-111111111111",
+    externalId: `person-${index}`,
+    data: { index },
+  };
+}
+
+describe("plugin registry entity batch bounds", () => {
+  it("allows the 5,001-record transactional batch required by a bounded replacement import", async () => {
+    const transaction = vi.fn(async () => []);
+    const registry = pluginRegistryService({ transaction } as never);
+
+    await expect(
+      registry.upsertEntities("plugin-record-id", Array.from({ length: 5_001 }, (_value, index) => entity(index))),
+    ).resolves.toEqual([]);
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects batches above the 10,000-record replacement ceiling before opening a transaction", async () => {
+    const transaction = vi.fn(async () => []);
+    const registry = pluginRegistryService({ transaction } as never);
+
+    await expect(
+      registry.upsertEntities("plugin-record-id", Array.from({ length: 10_001 }, (_value, index) => entity(index))),
+    ).rejects.toThrow("exceeds 10000 records");
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/plugin-tenant-isolation.test.ts
+++ b/server/src/__tests__/plugin-tenant-isolation.test.ts
@@ -2,8 +2,10 @@ import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
+  activityLog,
   companies,
   createDb,
+  issues,
   pluginEntities,
   pluginJobs,
   pluginJobRuns,
@@ -13,6 +15,7 @@ import {
 } from "@paperclipai/db";
 import { buildHostServices, flushPluginLogBuffer } from "../services/plugin-host-services.js";
 import { pluginRegistryService } from "../services/plugin-registry.js";
+import { issueService } from "../services/issues.js";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -53,7 +56,9 @@ describeEmbeddedPostgres("plugin tenant isolation (company_id FK)", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(activityLog);
     await db.delete(pluginEntities);
+    await db.delete(issues);
     await db.delete(pluginJobRuns);
     await db.delete(pluginJobs);
     await db.delete(pluginLogs);
@@ -320,6 +325,123 @@ describeEmbeddedPostgres("plugin tenant isolation (company_id FK)", () => {
 
     const allRows = await db.select().from(pluginEntities);
     expect(allRows).toHaveLength(3);
+  });
+
+  it("plugin host entity services persist and list only the requested company scope", async () => {
+    const pluginId = await seedPlugin();
+    const companyA = await seedCompany();
+    const companyB = await seedCompany();
+    const services = buildHostServices(
+      db,
+      pluginId,
+      "paperclip.tenant-isolation-test",
+      createEventBusStub(),
+    );
+
+    await services.entities.upsert({
+      entityType: "human-profile",
+      scopeKind: "company",
+      scopeId: companyA,
+      externalId: "shared",
+      title: "Company A",
+      data: {},
+    });
+    await services.entities.upsert({
+      entityType: "human-profile",
+      scopeKind: "company",
+      scopeId: companyB,
+      externalId: "shared",
+      title: "Company B",
+      data: {},
+    });
+
+    const [companyARows, companyBRows, stored] = await Promise.all([
+      services.entities.list({
+        entityType: "human-profile",
+        scopeKind: "company",
+        scopeId: companyA,
+      }),
+      services.entities.list({
+        entityType: "human-profile",
+        scopeKind: "company",
+        scopeId: companyB,
+      }),
+      db.select().from(pluginEntities),
+    ]);
+
+    expect(companyARows).toMatchObject([{ title: "Company A", scopeId: companyA }]);
+    expect(companyBRows).toMatchObject([{ title: "Company B", scopeId: companyB }]);
+    expect(stored.map((row) => row.companyId).sort()).toEqual([companyA, companyB].sort());
+    services.dispose();
+  });
+
+  it("atomically serializes competing issue-assignee and plugin-entity transitions", async () => {
+    const pluginId = await seedPlugin();
+    const companyId = await seedCompany();
+    const services = buildHostServices(
+      db,
+      pluginId,
+      "paperclip.tenant-isolation-test",
+      createEventBusStub(),
+    );
+    const issue = await issueService(db).create(companyId, { title: "Concurrent human owner" });
+    const base = {
+      issueId: issue.id,
+      companyId,
+      expectedAssigneeAgentId: null,
+      expectedAssigneeUserId: null,
+      expectedEntity: { id: null, updatedAt: null, status: null, data: null },
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    } as const;
+    const assignment = (humanExternalId: string) => ({
+      entityType: "human-assignment",
+      scopeKind: "company" as const,
+      scopeId: companyId,
+      externalId: `${companyId}:${issue.id}`,
+      status: "active",
+      data: { issueId: issue.id, humanExternalId },
+    });
+
+    const assignResults = await Promise.allSettled([
+      services.issues.transitionAssigneeEntity({ ...base, entity: assignment("human-a") }),
+      services.issues.transitionAssigneeEntity({ ...base, entity: assignment("human-b") }),
+    ]);
+    expect(assignResults.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(assignResults.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const assigned = assignResults.find((result) => result.status === "fulfilled")!;
+    if (assigned.status !== "fulfilled") throw new Error("Expected one successful assignment");
+    const assignedEntity = assigned.value.entity as any;
+    const assignedIssue = assigned.value.issue;
+    const expectedAssignedEntity = {
+      id: assignedEntity.id,
+      updatedAt: assignedEntity.updatedAt.toISOString(),
+      status: assignedEntity.status,
+      data: assignedEntity.data,
+    };
+    const inactiveEntity = {
+      ...assignment((assignedEntity.data as { humanExternalId: string }).humanExternalId),
+      status: "inactive",
+    };
+    const unassignInput = {
+      issueId: issue.id,
+      companyId,
+      expectedAssigneeAgentId: assignedIssue.assigneeAgentId ?? null,
+      expectedAssigneeUserId: assignedIssue.assigneeUserId ?? null,
+      expectedEntity: expectedAssignedEntity,
+      assigneeAgentId: assignedIssue.assigneeAgentId ?? null,
+      assigneeUserId: assignedIssue.assigneeUserId ?? null,
+      entity: inactiveEntity,
+    };
+    const unassignResults = await Promise.allSettled([
+      services.issues.transitionAssigneeEntity(unassignInput),
+      services.issues.transitionAssigneeEntity(unassignInput),
+    ]);
+    expect(unassignResults.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(unassignResults.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const [storedEntity] = await db.select().from(pluginEntities).where(eq(pluginEntities.id, assignedEntity.id));
+    expect(storedEntity?.status).toBe("inactive");
+    services.dispose();
   });
 
   it("pluginRegistryService.getEntityByExternalId scopes by companyId — never returns another tenant's row", async () => {

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -9,6 +9,7 @@ import {
   heartbeatRuns,
   invites,
   issues as issuesTable,
+  pluginEntities,
   pluginLogs,
   principalPermissionGrants,
   projects as projectsTable,
@@ -44,6 +45,7 @@ import { approvalService } from "./approvals.js";
 import { getStorageService } from "../storage/index.js";
 import { subscribeCompanyLiveEvents } from "./live-events.js";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import path from "node:path";
 import { pluginRegistryService } from "./plugin-registry.js";
 import { pluginStateStore } from "./plugin-state-store.js";
@@ -78,6 +80,7 @@ import { getTelemetryClient } from "../telemetry.js";
 import { accessService } from "./access.js";
 import { authorizationService, type AuthorizationActor } from "./authorization.js";
 import { redactEventPayload, sanitizeRecord } from "../redaction.js";
+import { conflict } from "../errors.js";
 
 // ---------------------------------------------------------------------------
 // SSRF protection for plugin HTTP fetch
@@ -156,13 +159,11 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
   try {
     parsed = new URL(urlString);
   } catch {
-    throw new Error(`Invalid URL: ${urlString}`);
+    throw new Error("Invalid outbound HTTP URL");
   }
 
   if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
-    throw new Error(
-      `Disallowed protocol "${parsed.protocol}" — only http: and https: are permitted`,
-    );
+    throw new Error("Disallowed outbound HTTP URL protocol; only http: and https: are permitted");
   }
 
   // Resolve the hostname to an IP and check for private ranges.
@@ -176,7 +177,7 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
   const dnsPromise = dnsLookup(originalHostname, { all: true });
   const timeoutPromise = new Promise<never>((_, reject) => {
     setTimeout(
-      () => reject(new Error(`DNS lookup timed out after ${DNS_LOOKUP_TIMEOUT_MS}ms for ${originalHostname}`)),
+      () => reject(new Error("Outbound HTTP DNS lookup timed out")),
       DNS_LOOKUP_TIMEOUT_MS,
     );
   });
@@ -184,7 +185,7 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
   try {
     const results = await Promise.race([dnsPromise, timeoutPromise]);
     if (results.length === 0) {
-      throw new Error(`DNS resolution returned no results for ${originalHostname}`);
+      throw new Error("Outbound HTTP DNS resolution returned no results");
     }
 
     // Filter to only non-private IPs instead of rejecting the entire request
@@ -192,9 +193,7 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
     // to both private and public addresses.
     const safeResults = results.filter((entry) => !isPrivateIP(entry.address));
     if (safeResults.length === 0) {
-      throw new Error(
-        `All resolved IPs for ${originalHostname} are in private/reserved ranges`,
-      );
+      throw new Error("Outbound HTTP URL resolves only to private/reserved ranges");
     }
 
     const resolved = safeResults[0]!;
@@ -209,12 +208,8 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
     };
   } catch (err) {
     // Re-throw our own errors; wrap DNS failures
-    if (err instanceof Error && (
-      err.message.startsWith("All resolved IPs") ||
-      err.message.startsWith("DNS resolution returned") ||
-      err.message.startsWith("DNS lookup timed out")
-    )) throw err;
-    throw new Error(`DNS resolution failed for ${originalHostname}: ${(err as Error).message}`);
+    if (err instanceof Error && err.message.startsWith("Outbound HTTP")) throw err;
+    throw new Error("Outbound HTTP DNS resolution failed");
   }
 }
 
@@ -1340,11 +1335,33 @@ export function buildHostServices(
     },
 
     entities: {
+      async create(params) {
+        const companyId = params.scopeKind === "company"
+          ? ensureCompanyId(params.scopeId)
+          : null;
+        return registry.createEntity(pluginId, { ...params, companyId } as any) as any;
+      },
       async upsert(params) {
-        return registry.upsertEntity(pluginId, params as any) as any;
+        const companyId = params.scopeKind === "company"
+          ? ensureCompanyId(params.scopeId)
+          : null;
+        return registry.upsertEntity(pluginId, { ...params, companyId } as any) as any;
+      },
+      async upsertMany(params) {
+        if (params.inputs.length === 0 || params.inputs.length > 10_000) {
+          throw new Error("Plugin entity batches must contain between 1 and 10000 items");
+        }
+        const inputs = params.inputs.map((input) => ({
+          ...input,
+          companyId: input.scopeKind === "company" ? ensureCompanyId(input.scopeId) : null,
+        }));
+        return registry.upsertEntities(pluginId, inputs as any) as any;
       },
       async list(params) {
-        return registry.listEntities(pluginId, params as any) as any;
+        const companyId = params.scopeKind === "company"
+          ? ensureCompanyId(params.scopeId)
+          : null;
+        return registry.listEntities(pluginId, { ...params, companyId } as any) as any;
       },
     },
 
@@ -1685,7 +1702,7 @@ export function buildHostServices(
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
         assertReadableOriginFilter(params.originKind);
-        return applyWindow((await issues.list(companyId, params as any)) as Issue[], params);
+        return (await issues.list(companyId, params as any)) as Issue[];
       },
       async get(params) {
         const companyId = ensureCompanyId(params.companyId);
@@ -1765,6 +1782,107 @@ export function buildHostServices(
           },
         });
         return updated;
+      },
+      async transitionAssigneeEntity(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        if (
+          params.entity.scopeKind !== "company"
+          || params.entity.scopeId !== companyId
+        ) {
+          throw conflict("Assignment entity must use the issue company scope");
+        }
+        const actorAgentId = params.actor?.actorAgentId ?? null;
+        const actorUserId = params.actor?.actorUserId ?? null;
+        const actorRunId = params.actor?.actorRunId ?? null;
+        const transition = await db.transaction(async (tx) => {
+          const [currentIssue] = await tx
+            .select()
+            .from(issuesTable)
+            .where(and(eq(issuesTable.id, params.issueId), eq(issuesTable.companyId, companyId)))
+            .for("update");
+          if (!currentIssue) throw conflict("Issue assignment changed concurrently");
+          if (
+            (currentIssue.assigneeAgentId ?? null) !== params.expectedAssigneeAgentId
+            || (currentIssue.assigneeUserId ?? null) !== params.expectedAssigneeUserId
+          ) {
+            throw conflict("Issue assignment changed concurrently");
+          }
+
+          const [currentEntity] = await tx
+            .select()
+            .from(pluginEntities)
+            .where(and(
+              eq(pluginEntities.pluginId, pluginId),
+              eq(pluginEntities.companyId, companyId),
+              eq(pluginEntities.entityType, params.entity.entityType),
+              eq(pluginEntities.externalId, params.entity.externalId),
+            ))
+            .for("update");
+          if (
+            currentEntity
+            && (currentEntity.scopeKind !== "company" || currentEntity.scopeId !== companyId)
+          ) {
+            throw conflict("Assignment entity scope conflict");
+          }
+          if (
+            (currentEntity?.id ?? null) !== params.expectedEntity.id
+            || (currentEntity?.updatedAt.toISOString() ?? null) !== params.expectedEntity.updatedAt
+            || (currentEntity?.status ?? null) !== params.expectedEntity.status
+            || !isDeepStrictEqual(currentEntity?.data ?? null, params.expectedEntity.data)
+          ) {
+            throw conflict("Assignment entity changed concurrently");
+          }
+
+          const updatedIssue = await issues.update(params.issueId, {
+            assigneeAgentId: params.assigneeAgentId,
+            assigneeUserId: params.assigneeUserId,
+            actorAgentId,
+            actorUserId,
+          }, tx) as Issue;
+          const [updatedEntity] = currentEntity
+            ? await tx
+              .update(pluginEntities)
+              .set({
+                title: params.entity.title ?? null,
+                status: params.entity.status ?? null,
+                data: params.entity.data,
+                updatedAt: new Date(),
+              })
+              .where(eq(pluginEntities.id, currentEntity.id))
+              .returning()
+            : await tx
+              .insert(pluginEntities)
+              .values({
+                companyId,
+                pluginId,
+                entityType: params.entity.entityType,
+                scopeKind: "company",
+                scopeId: companyId,
+                externalId: params.entity.externalId,
+                title: params.entity.title ?? null,
+                status: params.entity.status ?? null,
+                data: params.entity.data,
+              })
+              .returning();
+          return { issue: updatedIssue, entity: updatedEntity! };
+        });
+        await logPluginActivity({
+          companyId,
+          action: "issue.updated",
+          entityType: "issue",
+          entityId: transition.issue.id,
+          actor: { actorAgentId, actorUserId, actorRunId },
+          details: {
+            identifier: transition.issue.identifier,
+            patch: {
+              assigneeAgentId: params.assigneeAgentId,
+              assigneeUserId: params.assigneeUserId,
+            },
+            atomicPluginEntityId: transition.entity.id,
+          },
+        });
+        return transition as any;
       },
       async getRelations(params) {
         const companyId = ensureCompanyId(params.companyId);

--- a/server/src/services/plugin-registry.ts
+++ b/server/src/services/plugin-registry.ts
@@ -19,6 +19,7 @@ import type {
   PluginCompanySettings,
   PluginEntityRecord,
   PluginEntityQuery,
+  PluginStateScopeKind,
   PluginJobRecord,
   PluginJobRunRecord,
   PluginWebhookDeliveryRecord,
@@ -28,6 +29,19 @@ import type {
   PluginWebhookDeliveryStatus,
 } from "@paperclipai/shared";
 import { conflict, notFound } from "../errors.js";
+
+type PluginEntityWrite = {
+  companyId?: string | null;
+  entityType: string;
+  scopeKind: PluginStateScopeKind;
+  scopeId?: string | null;
+  externalId?: string | null;
+  title?: string | null;
+  status?: string | null;
+  data: Record<string, unknown>;
+};
+
+type PluginEntityDb = Pick<Db, "select" | "insert" | "update">;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -86,6 +100,60 @@ export function pluginRegistryService(db: Db) {
       .select({ maxOrder: sql<number>`coalesce(max(${plugins.installOrder}), 0)` })
       .from(plugins);
     return (result[0]?.maxOrder ?? 0) + 1;
+  }
+
+  async function writeEntity(
+    executor: PluginEntityDb,
+    pluginId: string,
+    input: PluginEntityWrite,
+  ) {
+    let existing: typeof pluginEntities.$inferSelect | undefined;
+    if (input.externalId) {
+      [existing] = await executor
+        .select()
+        .from(pluginEntities)
+        .where(
+          and(
+            input.companyId == null
+              ? isNull(pluginEntities.companyId)
+              : eq(pluginEntities.companyId, input.companyId),
+            eq(pluginEntities.pluginId, pluginId),
+            eq(pluginEntities.entityType, input.entityType),
+            eq(pluginEntities.externalId, input.externalId),
+          ),
+        );
+    }
+
+    if (existing) {
+      const [updated] = await executor
+        .update(pluginEntities)
+        .set({
+          companyId: input.companyId ?? existing.companyId,
+          title: input.title ?? existing.title,
+          status: input.status ?? existing.status,
+          data: input.data,
+          updatedAt: new Date(),
+        })
+        .where(eq(pluginEntities.id, existing.id))
+        .returning();
+      return updated!;
+    }
+
+    const [created] = await executor
+      .insert(pluginEntities)
+      .values({
+        companyId: input.companyId ?? null,
+        pluginId,
+        entityType: input.entityType,
+        scopeKind: input.scopeKind,
+        scopeId: input.scopeId ?? null,
+        externalId: input.externalId ?? null,
+        title: input.title ?? null,
+        status: input.status ?? null,
+        data: input.data,
+      })
+      .returning();
+    return created!;
   }
 
   // -----------------------------------------------------------------------
@@ -482,7 +550,16 @@ export function pluginRegistryService(db: Db) {
      */
     listEntities: (pluginId: string, query?: PluginEntityQuery) => {
       const conditions = [eq(pluginEntities.pluginId, pluginId)];
+      if (query && "companyId" in query) {
+        conditions.push(
+          query.companyId == null
+            ? isNull(pluginEntities.companyId)
+            : eq(pluginEntities.companyId, query.companyId),
+        );
+      }
       if (query?.entityType) conditions.push(eq(pluginEntities.entityType, query.entityType));
+      if (query?.scopeKind) conditions.push(eq(pluginEntities.scopeKind, query.scopeKind));
+      if (query?.scopeId) conditions.push(eq(pluginEntities.scopeId, query.scopeId));
       if (query?.externalId) conditions.push(eq(pluginEntities.externalId, query.externalId));
 
       return db
@@ -533,63 +610,55 @@ export function pluginRegistryService(db: Db) {
         .then((rows) => rows[0] ?? null);
     },
 
-    /**
-     * Create or update a persistent mapping between a Paperclip object and an
-     * external entity.
-     *
-     * @param pluginId - The UUID of the plugin.
-     * @param input - The entity data to persist.
-     * @returns The newly created or updated `PluginEntityRecord`.
-     */
-    upsertEntity: async (
-      pluginId: string,
-      input: Omit<typeof pluginEntities.$inferInsert, "id" | "pluginId" | "createdAt" | "updatedAt">,
-    ) => {
-      // Drizzle doesn't support pg-specific onConflictDoUpdate easily in the insert() call
-      // with complex where clauses, so we do it manually.
-      // Match the per-tenant uniqueness of `plugin_entities_external_idx`
-      // (companyId, pluginId, entityType, externalId) with NULLS NOT DISTINCT
-      // semantics: two companies (and instance-scope NULLs across each other)
-      // may share the same (pluginId, entityType, externalId) tuple, so the
-      // lookup MUST scope by companyId — `isNull` for instance-scope, `eq`
-      // otherwise — to avoid returning and overwriting another tenant's row.
-      const companyIdPredicate =
-        input.companyId == null
-          ? isNull(pluginEntities.companyId)
-          : eq(pluginEntities.companyId, input.companyId);
-      const existing = await db
-        .select()
-        .from(pluginEntities)
-        .where(
-          and(
-            companyIdPredicate,
-            eq(pluginEntities.pluginId, pluginId),
-            eq(pluginEntities.entityType, input.entityType),
-            eq(pluginEntities.externalId, input.externalId ?? ""),
-          ),
-        )
-        .then((rows) => rows[0] ?? null);
-
-      if (existing) {
-        return db
-          .update(pluginEntities)
-          .set({
-            ...input,
-            updatedAt: new Date(),
-          })
-          .where(eq(pluginEntities.id, existing.id))
-          .returning()
-          .then((rows) => rows[0]);
-      }
-
-      return db
+    /** Create an entity only when its tenant-scoped external ID is unused. */
+    createEntity: async (pluginId: string, input: PluginEntityWrite) => {
+      if (!input.externalId) throw conflict("entities.create requires externalId");
+      const [created] = await db
         .insert(pluginEntities)
         .values({
-          ...input,
+          companyId: input.companyId ?? null,
           pluginId,
-        } as any)
-        .returning()
-        .then((rows) => rows[0]);
+          entityType: input.entityType,
+          scopeKind: input.scopeKind,
+          scopeId: input.scopeId ?? null,
+          externalId: input.externalId,
+          title: input.title ?? null,
+          status: input.status ?? null,
+          data: input.data,
+        } as typeof pluginEntities.$inferInsert)
+        .onConflictDoNothing()
+        .returning();
+      if (created) return { created: true, entity: created };
+
+      const companyIdPredicate = input.companyId == null
+        ? isNull(pluginEntities.companyId)
+        : eq(pluginEntities.companyId, input.companyId);
+      const [existing] = await db
+        .select()
+        .from(pluginEntities)
+        .where(and(
+          companyIdPredicate,
+          eq(pluginEntities.pluginId, pluginId),
+          eq(pluginEntities.entityType, input.entityType),
+          eq(pluginEntities.externalId, input.externalId),
+        ));
+      if (!existing) throw conflict("Entity claim conflict could not be resolved");
+      return { created: false, entity: existing };
+    },
+
+    /** Create or update one persistent plugin entity mapping. */
+    upsertEntity: async (pluginId: string, input: PluginEntityWrite) =>
+      writeEntity(db, pluginId, input),
+
+    /** Apply a set of entity upserts in one database transaction. */
+    upsertEntities: async (pluginId: string, inputs: PluginEntityWrite[]) => {
+      if (inputs.length === 0) return [];
+      if (inputs.length > 10_000) throw conflict("Entity upsert batch exceeds 10000 records");
+      return db.transaction(async (tx) => {
+        const records = [];
+        for (const input of inputs) records.push(await writeEntity(tx, pluginId, input));
+        return records;
+      });
     },
 
     /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI-agent companies.
> - The plugin system adds optional capabilities without making the control plane larger.
> - A company can include human workers who are not Paperclip agents or board users.
> - Operators need an imported human reporting tree, capability directory, and human work queue.
> - Human task assignment must keep the Paperclip issue and plugin assignment record consistent.
> - Concurrent assignment attempts must not overwrite each other.
> - This pull request adds a Human Org & Work plugin and the atomic host operations that it needs.
> - The benefit is a governed human-work flow with optional Mattermost notifications.

## Linked Issues or Issue Description

Refs #1110
Refs #2346
Refs #923
Refs #2759

**Subsystem affected**

`packages/plugins`, the plugin SDK, and the server plugin host services are affected.

**Problem or motivation**

Paperclip has no bundled plugin for imported human organization charts. It also has no plugin workflow that creates and assigns Paperclip issues to imported humans. A plugin cannot safely perform this operation with separate issue and entity writes because concurrent requests can both succeed and overwrite each other.

**Proposed solution**

Add a bundled Human Org & Work plugin. Import a bounded CSV or JSON roster. Show reporting lines and capabilities. Create real Paperclip issues for human work. Store the human assignment as a plugin entity. Perform issue-assignee and plugin-entity changes in one transaction with compare-and-swap preconditions. Send optional Mattermost webhook notifications after the authoritative transition succeeds.

**Alternatives considered**

A worker-local mutex would not protect multiple workers or server replicas. Generic entity upserts cannot protect a transition that also changes an issue. Two independent writes with rollback can still expose partial state. The host transaction is the smallest boundary that protects both records.

**Roadmap alignment**

`ROADMAP.md` says that plugins are the preferred path for optional product-specific capabilities. This change uses that path. It does not replace the core agent org chart or the company import and export feature.

**Additional context**

The duplicate search found related human-org and human-assignment work. It found no existing Human Org & Work plugin or Mattermost implementation. PR #10716 protects human-owned issues in the core executor. This pull request has a different scope and adds the plugin assignment workflow.

## What Changed

- Add the Human Org & Work plugin worker, UI, manifest, package, and documentation.
- Add bounded CSV and JSON roster import with hierarchy validation.
- Add a human capability directory, org tree, task form, work board, and issue detail assignment UI.
- Add optional Mattermost webhook notifications with safe mention and Markdown handling.
- Add tenant-scoped SDK and host operations for pagination, bulk persistence, and idempotent issue creation.
- Add `issues.transitionAssigneeEntity()` to change an issue assignee and plugin entity in one database transaction.
- Lock the issue row and compare the complete observed issue and entity state before each transition.
- Bind task retry identifiers to the submitted task fields. Generate a new identifier when a field changes.
- Add plugin, SDK, server, tenant-isolation, concurrency, batch-limit, and UI retry tests.
- Add a tutorial and sample organization-chart CSV.
- Exclude `pnpm-lock.yaml` because repository CI owns lockfile updates.

## Verification

- `/tmp/pnpm-tool/node_modules/.bin/pnpm --filter @paperclipai/plugin-human-org test` — 41 tests passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm exec vitest run packages/plugins/sdk/tests/host-client-factory.test.ts packages/plugins/sdk/tests/worker-rpc-host.test.ts packages/plugins/sdk/tests/testing-actions.test.ts` — 44 tests passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm exec vitest run --maxWorkers=1 server/src/__tests__/plugin-*.test.ts` — 268 tests passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm --filter @paperclipai/plugin-human-org typecheck` — passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm --filter @paperclipai/plugin-human-org build` — passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm --filter @paperclipai/plugin-sdk typecheck` — passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm --filter @paperclipai/plugin-sdk build` — passed.
- `/tmp/pnpm-tool/node_modules/.bin/pnpm -r typecheck` — passed before the focused UI follow-up. The plugin typecheck was rerun after that follow-up.
- `git diff --check` — passed.
- The release artifact builder verified 55 source and generated files by SHA-256.

A reviewer can import `doc/examples/human-org-chart-sample.csv`. The reviewer can then create a human task, retry an unchanged failed request, change the selected human, and confirm that the changed request uses a new idempotency key.

## Risks

- The new atomic host operation changes a shared plugin SDK contract. The protocol, RPC host, test harness, host client, and server service change together.
- The database transaction locks one issue row. Competing transitions return a conflict instead of using last-write-wins behavior.
- Mattermost delivery can be uncertain after a network timeout. Paperclip remains authoritative and records the notification outcome.
- A maximum replacement import can write 10,000 plugin-entity operations. The implementation applies explicit input and transaction bounds.
- The plugin package has no database migration. Rollback requires removal or disabling of the plugin and reversion of these commits.

> This change follows the plugin-system roadmap path for optional capabilities. The duplicate search found no existing Human Org & Work plugin.

## Model Used

- OpenAI Codex, exact model ID `gpt-5.6-sol`. The model used reasoning, tool calls, code execution, GitHub operations, and independent review agents. The runtime does not expose a context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket ID or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

