### PR TITLE
fix(interactions): retry accepts during workspace sync

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,6 +35,7 @@ export {
   ensureLinuxSharedLibraryAliases,
   prepareEmbeddedPostgresNativeRuntime,
 } from "./embedded-postgres-native.js";
+export { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 export { issueRelations } from "./schema/issue_relations.js";
 export { issueReferenceMentions } from "./schema/issue_reference_mentions.js";
 export * from "./schema/index.js";

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -78,11 +78,32 @@ async function main() {
     }
   }
 
+  let afterCount = beforeCount;
+  if (!dryRun) {
+    afterCount = 0;
+    for (const company of companyRows) {
+      const remainingCandidates = await db
+        .select({ issueId: issues.id })
+        .from(issues)
+        .leftJoin(agents, eq(issues.assigneeAgentId, agents.id))
+        .where(
+          and(
+            eq(issues.companyId, company.id),
+            inArray(issues.status, OPEN_ISSUE_STATUSES),
+            isNotNull(issues.assigneeAgentId),
+            or(eq(agents.status, "terminated"), isNull(agents.id)),
+          ),
+        );
+      afterCount += remainingCandidates.length;
+    }
+  }
+
   console.log(`${dryRun ? "Dry run: " : ""}terminated-assignee backfill counts`);
   console.log(`before=${beforeCount}`);
   console.log(`released_to_manager=${releasedToManager}`);
   console.log(`released_to_unassigned_queue=${releasedToQueue}`);
-  console.log(`after=${dryRun ? beforeCount : 0}`);
+  console.log(`after=${afterCount}`);
+  await db.$client.end({ timeout: 1 });
 }
 
 void main().catch((error) => {

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray, isNotNull, isNull, or, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
+import { isAgentStatusAssignableToWork } from "../packages/shared/src/agent-eligibility.js";
 import { loadConfig } from "../server/src/config.js";
 
 const OPEN_ISSUE_STATUSES = ["todo", "in_progress", "in_review", "blocked"] as const;
@@ -55,7 +56,7 @@ async function main() {
           .where(and(eq(agents.id, candidate.managerId), eq(agents.companyId, company.id)))
           .then((rows) => rows[0] ?? null)
         : null;
-      const assigneeAgentId = manager && manager.status !== "terminated" ? manager.id : null;
+      const assigneeAgentId = manager && isAgentStatusAssignableToWork(manager.status) ? manager.id : null;
       if (assigneeAgentId) releasedToManager += 1;
       else releasedToQueue += 1;
 

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -1,0 +1,91 @@
+import { and, eq, inArray, isNotNull, isNull, or, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
+import { loadConfig } from "../server/src/config.js";
+
+const OPEN_ISSUE_STATUSES = ["todo", "in_progress", "in_review", "blocked"] as const;
+
+function parseFlag(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  if (index < 0) return null;
+  const value = process.argv[index + 1];
+  return value && !value.startsWith("--") ? value : null;
+}
+
+async function main() {
+  const config = loadConfig();
+  const dbUrl =
+    process.env.DATABASE_URL?.trim()
+    || config.databaseUrl
+    || `postgres://paperclip:paperclip@127.0.0.1:${config.embeddedPostgresPort}/paperclip`;
+  const companyId = parseFlag("--company");
+  const dryRun = process.argv.includes("--dry-run");
+  const db = createDb(dbUrl);
+  const companyRows = companyId
+    ? [{ id: companyId }]
+    : await db.select({ id: companies.id }).from(companies);
+
+  let beforeCount = 0;
+  let releasedToManager = 0;
+  let releasedToQueue = 0;
+
+  for (const company of companyRows) {
+    const candidates = await db
+      .select({
+        issueId: issues.id,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeStatus: agents.status,
+        managerId: agents.reportsTo,
+      })
+      .from(issues)
+      .leftJoin(agents, eq(issues.assigneeAgentId, agents.id))
+      .where(
+        and(
+          eq(issues.companyId, company.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNotNull(issues.assigneeAgentId),
+          or(eq(agents.status, "terminated"), isNull(agents.id)),
+        ),
+      );
+
+    beforeCount += candidates.length;
+    for (const candidate of candidates) {
+      const manager = candidate.managerId
+        ? await db
+          .select({ id: agents.id, status: agents.status })
+          .from(agents)
+          .where(and(eq(agents.id, candidate.managerId), eq(agents.companyId, company.id)))
+          .then((rows) => rows[0] ?? null)
+        : null;
+      const assigneeAgentId = manager && manager.status !== "terminated" ? manager.id : null;
+      if (assigneeAgentId) releasedToManager += 1;
+      else releasedToQueue += 1;
+
+      if (dryRun) continue;
+      await db.transaction(async (tx) => {
+        await tx
+          .update(issues)
+          .set({ assigneeAgentId, updatedAt: new Date() })
+          .where(and(eq(issues.id, candidate.issueId), eq(issues.companyId, company.id)));
+        await tx.insert(issueComments).values({
+          companyId: company.id,
+          issueId: candidate.issueId,
+          authorType: "system",
+          body: assigneeAgentId
+            ? "System backfill: released an assignment held by a terminated agent to its manager."
+            : "System backfill: released an assignment held by a terminated or missing agent to the unassigned queue.",
+        });
+      });
+    }
+  }
+
+  console.log(`${dryRun ? "Dry run: " : ""}terminated-assignee backfill counts`);
+  console.log(`before=${beforeCount}`);
+  console.log(`released_to_manager=${releasedToManager}`);
+  console.log(`released_to_unassigned_queue=${releasedToQueue}`);
+  console.log(`after=${dryRun ? beforeCount : 0}`);
+}
+
+void main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Terminated-assignee backfill failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -8,6 +8,8 @@ import {
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueComments,
+  issues,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -34,9 +36,11 @@ describeEmbeddedPostgres("agent service clearError", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueComments);
     await db.delete(heartbeatRunEvents);
     await db.delete(agentRuntimeState);
     await db.delete(heartbeatRuns);
+    await db.delete(issues);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -234,5 +238,67 @@ describeEmbeddedPostgres("agent service clearError", () => {
       status: 409,
       message: "Pending approval agents cannot have errors cleared",
     });
+  });
+
+  it("releases open work to the terminated agent's manager and detaches direct reports", async () => {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const directReportId = randomUUID();
+    const openIssueId = randomUUID();
+    const terminalIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      { id: managerId, companyId, name: "Manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: managerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: directReportId, companyId, name: "Report", role: "engineer", reportsTo: terminatedAgentId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values([
+      { id: openIssueId, companyId, title: "Open work", status: "in_progress", priority: "high", assigneeAgentId: terminatedAgentId },
+      { id: terminalIssueId, companyId, title: "Done work", status: "done", priority: "high", assigneeAgentId: terminatedAgentId },
+    ]);
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    const [terminalIssue] = await db.select().from(issues).where(eq(issues.id, terminalIssueId));
+    const [directReport] = await db.select().from(agents).where(eq(agents.id, directReportId));
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, openIssueId));
+
+    expect(openIssue?.assigneeAgentId).toBe(managerId);
+    expect(terminalIssue?.assigneeAgentId).toBe(terminatedAgentId);
+    expect(directReport?.reportsTo).toBe(managerId);
+    expect(comments).toHaveLength(1);
+    expect(comments[0]).toMatchObject({ authorType: "system" });
+  });
+
+  it("releases open work to the unassigned queue when a terminated agent has no manager", async () => {
+    const companyId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const openIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {},
+    });
+    await db.insert(issues).values({
+      id: openIssueId, companyId, title: "Open work", status: "blocked", priority: "high", assigneeAgentId: terminatedAgentId,
+    });
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    expect(openIssue?.assigneeAgentId).toBeNull();
   });
 });

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { eq } from "drizzle-orm";
+import request from "supertest";
 import {
   agents,
   agentRuntimeState,
+  activityLog,
   companies,
   createDb,
   heartbeatRunEvents,
@@ -16,9 +19,27 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { agentService } from "../services/agents.ts";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+vi.mock("../services/issue-assignment-wakeup.js", () => ({
+  queueIssueAssignmentWakeup: vi.fn(),
+}));
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function issuePatchApp(db: ReturnType<typeof createDb>, companyId: string, agentId: string, runId: string) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = { type: "agent", agentId, companyId, runId, source: "agent_jwt" };
+    next();
+  });
+  app.use("/api", issueRoutes(db, {} as any));
+  app.use(errorHandler);
+  return app;
+}
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -36,6 +57,7 @@ describeEmbeddedPostgres("agent service clearError", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(activityLog);
     await db.delete(issueComments);
     await db.delete(heartbeatRunEvents);
     await db.delete(agentRuntimeState);
@@ -278,6 +300,48 @@ describeEmbeddedPostgres("agent service clearError", () => {
     expect(comments[0]).toMatchObject({ authorType: "system" });
   });
 
+  it("allows the released manager to PATCH work after terminating its assignee", async () => {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const openIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      { id: managerId, companyId, name: "Manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: managerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values({
+      id: openIssueId,
+      companyId,
+      title: "Open work",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: terminatedAgentId,
+    });
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [managerRun] = await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId: managerId,
+      status: "running",
+      contextSnapshot: { issueId: openIssueId },
+    }).returning();
+
+    const res = await request(issuePatchApp(db, companyId, managerId, managerRun!.id))
+      .patch(`/api/issues/${openIssueId}`)
+      .send({ title: "Manager resumed released work" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ id: openIssueId, assigneeAgentId: managerId, title: "Manager resumed released work" });
+  });
+
   it("releases open work to the unassigned queue when a terminated agent has no manager", async () => {
     const companyId = randomUUID();
     const terminatedAgentId = randomUUID();
@@ -294,6 +358,57 @@ describeEmbeddedPostgres("agent service clearError", () => {
     });
     await db.insert(issues).values({
       id: openIssueId, companyId, title: "Open work", status: "blocked", priority: "high", assigneeAgentId: terminatedAgentId,
+    });
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    expect(openIssue?.assigneeAgentId).toBeNull();
+  });
+
+  it("releases open work to the unassigned queue when the terminated agent's manager is pending approval", async () => {
+    const companyId = randomUUID();
+    const pendingManagerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const openIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: pendingManagerId,
+        companyId,
+        name: "Pending manager",
+        role: "manager",
+        status: "pending_approval",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: terminatedAgentId,
+        companyId,
+        name: "Leaving",
+        role: "engineer",
+        reportsTo: pendingManagerId,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: openIssueId,
+      companyId,
+      title: "Open work",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: terminatedAgentId,
     });
 
     await agentService(db).terminate(terminatedAgentId);

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1586,6 +1586,21 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("another company");
   });
 
+  it("allows a manager to mutate an issue assigned to a direct report", async () => {
+    const company = await createCompany(db, "ManagerIssueMutation");
+    const manager = await createAgent(db, company.id, { role: "manager" });
+    const report = await createAgent(db, company.id, { reportsTo: manager.id });
+    const issue = await createIssue(db, company.id, { assigneeAgentId: report.id });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: manager.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource: { type: "issue", companyId: company.id, issueId: issue.id, assigneeAgentId: report.id },
+    });
+
+    expect(decision).toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+  });
+
   it("allows scoped assignment inside a granted project and denies other projects", async () => {
     const company = await createCompany(db, "ProjectScope");
     const project = await createProject(db, company.id, "Allowed");

--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -121,4 +121,29 @@ describe("errorHandler", () => {
       code: "RESPONSIBLE_USER_UNAUTHORIZED",
     });
   });
+
+  it("serializes workspace sync pending conflicts with a stable code and details", () => {
+    const req = makeReq();
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    const details = {
+      code: "workspace_sync_pending",
+      executionWorkspaceId: "workspace-1",
+      sourceRunId: "run-1",
+    };
+
+    errorHandler(
+      new HttpError(409, "Cannot accept interaction: workspace sync is still pending", details),
+      req,
+      res,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Cannot accept interaction: workspace sync is still pending",
+      code: "workspace_sync_pending",
+      details,
+    });
+  });
 });

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -2325,7 +2325,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
         message: expect.stringContaining(
           "the run that created this interaction has not finished syncing its workspace",
         ),
-        details: { executionWorkspaceId, sourceRunId },
+        details: { code: "workspace_sync_pending", executionWorkspaceId, sourceRunId },
       });
 
       const row = await db
@@ -2453,7 +2453,39 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
         message: expect.stringContaining(
           "the run that created this interaction has not finished syncing its workspace",
         ),
-        details: { executionWorkspaceId, sourceRunId },
+        details: { code: "workspace_sync_pending", executionWorkspaceId, sourceRunId },
+      });
+    });
+
+    it("persists request_confirmation rejection while a workspace_finalize is running", async () => {
+      const { companyId, executionWorkspaceId, issueId, interactionId, sourceRunId } =
+        await seedAcceptGateFixture({ sourceRunStatus: "running" });
+
+      await db.insert(workspaceOperations).values({
+        companyId,
+        executionWorkspaceId,
+        heartbeatRunId: sourceRunId,
+        phase: "workspace_finalize",
+        status: "running",
+        startedAt: new Date("2026-05-23T22:05:00.000Z"),
+      });
+
+      const rejected = await interactionsSvc.rejectInteraction(
+        { id: issueId, companyId },
+        interactionId,
+        { reason: "Please revise this plan." },
+        { userId: "local-board" },
+      );
+
+      expect(rejected).toMatchObject({
+        id: interactionId,
+        kind: "request_confirmation",
+        status: "rejected",
+        result: {
+          outcome: "rejected",
+          reason: "Please revise this plan.",
+        },
+        resolvedByUserId: "local-board",
       });
     });
 
@@ -2547,7 +2579,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
         message: expect.stringContaining(
           "the run that created this interaction has not finished syncing its workspace",
         ),
-        details: { executionWorkspaceId, sourceRunId },
+        details: { code: "workspace_sync_pending", executionWorkspaceId, sourceRunId },
       });
 
       await db.insert(workspaceOperations).values({

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -709,21 +709,68 @@ export function agentService(db: Db) {
       const existing = await getById(id);
       if (!existing) return null;
 
-      await db
-        .update(agents)
-        .set({
-          status: "terminated",
-          pauseReason: null,
-          pausedAt: null,
-          errorReason: null,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, id));
+      await db.transaction(async (tx) => {
+        const now = new Date();
+        const manager = existing.reportsTo
+          ? await tx
+            .select({ id: agents.id, status: agents.status })
+            .from(agents)
+            .where(and(eq(agents.id, existing.reportsTo), eq(agents.companyId, existing.companyId)))
+            .then((rows) => rows[0] ?? null)
+          : null;
+        const replacementAssigneeId = manager && manager.status !== "terminated" ? manager.id : null;
+        const releasableIssues = await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.assigneeAgentId, id),
+              inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+            ),
+          );
 
-      await db
-        .update(agentApiKeys)
-        .set({ revokedAt: new Date() })
-        .where(eq(agentApiKeys.agentId, id));
+        await tx
+          .update(agents)
+          .set({
+            status: "terminated",
+            pauseReason: null,
+            pausedAt: null,
+            errorReason: null,
+            updatedAt: now,
+          })
+          .where(eq(agents.id, id));
+        await tx
+          .update(agents)
+          .set({ reportsTo: replacementAssigneeId, updatedAt: now })
+          .where(eq(agents.reportsTo, id));
+        await tx
+          .update(issues)
+          .set({ assigneeAgentId: replacementAssigneeId, updatedAt: now })
+          .where(
+            and(
+              eq(issues.assigneeAgentId, id),
+              inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+            ),
+          );
+        if (releasableIssues.length > 0) {
+          await tx.insert(issueComments).values(
+            releasableIssues.map((issue) => ({
+              companyId: existing.companyId,
+              issueId: issue.id,
+              authorType: "system" as const,
+              body: replacementAssigneeId
+                ? "System: assignment released because the prior agent was terminated; reassigned to its manager."
+                : "System: assignment released because the prior agent was terminated; moved to the unassigned queue.",
+              createdAt: now,
+              updatedAt: now,
+            })),
+          );
+        }
+        await tx
+          .update(agentApiKeys)
+          .set({ revokedAt: now })
+          .where(eq(agentApiKeys.agentId, id));
+      });
 
       return getById(id);
     },

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -19,6 +19,7 @@ import {
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   getAgentWorkEligibility,
+  isAgentStatusAssignableToWork,
   isUuidLike,
   normalizeAgentApiKeyScope,
   normalizeAgentUrlKey,
@@ -718,7 +719,7 @@ export function agentService(db: Db) {
             .where(and(eq(agents.id, existing.reportsTo), eq(agents.companyId, existing.companyId)))
             .then((rows) => rows[0] ?? null)
           : null;
-        const replacementAssigneeId = manager && manager.status !== "terminated" ? manager.id : null;
+        const replacementAssigneeId = manager && isAgentStatusAssignableToWork(manager.status) ? manager.id : null;
         const releasableIssues = await tx
           .select({ id: issues.id })
           .from(issues)

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2094,7 +2094,7 @@ export function authorizationService(db: Db) {
     }
 
     if (
-      input.action === "tasks:manage_active_checkouts" &&
+      (input.action === "tasks:manage_active_checkouts" || input.action === "issue:mutate") &&
       input.resource.type === "issue" &&
       input.resource.assigneeAgentId &&
       await isManagerOf(companyId, actorAgentId, input.resource.assigneeAgentId)

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1007,7 +1007,11 @@ export function issueThreadInteractionService(db: Db) {
     throw conflict(
       "Cannot accept interaction: the run that created this interaction has not finished syncing its workspace. "
         + "Retry once the local worktree has finished syncing.",
-      { executionWorkspaceId, sourceRunId: args.sourceRunId },
+      {
+        code: "workspace_sync_pending",
+        executionWorkspaceId,
+        sourceRunId: args.sourceRunId,
+      },
     );
   }
 

--- a/ui/src/components/AttentionInteractionResolver.tsx
+++ b/ui/src/components/AttentionInteractionResolver.tsx
@@ -126,6 +126,7 @@ export function AttentionInteractionResolver({
       onAcceptInteraction={(target, selectedClientKeys, selectedOptionIds) =>
         acceptMutation.mutateAsync({ interaction: target, selectedClientKeys, selectedOptionIds }).then(() => undefined)
       }
+      onRefreshInteraction={invalidate}
       onRejectInteraction={(target, reason) =>
         rejectMutation.mutateAsync({ interactionId: target.id, reason }).then(() => undefined)
       }

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -214,6 +214,7 @@ interface IssueChatMessageContext {
     selectedClientKeys?: string[],
     selectedOptionIds?: string[],
   ) => Promise<void> | void;
+  onRefreshInteraction?: () => Promise<void> | void;
   onRejectInteraction?: (
     interaction:
       | SuggestTasksInteraction
@@ -526,6 +527,7 @@ interface IssueChatThreadProps {
     selectedClientKeys?: string[],
     selectedOptionIds?: string[],
   ) => Promise<void> | void;
+  onRefreshInteraction?: () => Promise<void> | void;
   onRejectInteraction?: (
     interaction:
       | SuggestTasksInteraction
@@ -2242,6 +2244,7 @@ function ExpiredRequestConfirmationActivity({
     currentUserId,
     userLabelMap,
     onAcceptInteraction,
+    onRefreshInteraction,
     onRejectInteraction,
     onCancelInteraction,
     onUploadImage,
@@ -2323,6 +2326,7 @@ function ExpiredRequestConfirmationActivity({
             currentUserId={currentUserId}
             userLabelMap={userLabelMap}
             onAcceptInteraction={onAcceptInteraction}
+            onRefreshInteraction={onRefreshInteraction}
             onRejectInteraction={onRejectInteraction}
             onCancelInteraction={onCancelInteraction}
             onUploadImage={onUploadImage}
@@ -2844,6 +2848,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
     currentUserId,
     userLabelMap,
     onAcceptInteraction,
+    onRefreshInteraction,
     onRejectInteraction,
     onSubmitInteractionAnswers,
     onCancelInteraction,
@@ -2903,6 +2908,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
             currentUserId={currentUserId}
             userLabelMap={userLabelMap}
             onAcceptInteraction={onAcceptInteraction}
+            onRefreshInteraction={onRefreshInteraction}
             onRejectInteraction={onRejectInteraction}
             onSubmitInteractionAnswers={onSubmitInteractionAnswers}
             onCancelInteraction={onCancelInteraction}
@@ -4358,6 +4364,7 @@ export function IssueChatThread({
   stoppingRunId = null,
   onImageClick,
   onAcceptInteraction,
+  onRefreshInteraction,
   onRejectInteraction,
   onSubmitInteractionAnswers,
   onCancelInteraction,
@@ -4892,6 +4899,7 @@ export function IssueChatThread({
   const stableOnDeleteComment = useStableEvent(onDeleteComment);
   const stableOnImageClick = useStableEvent(onImageClick);
   const stableOnAcceptInteraction = useStableEvent(onAcceptInteraction);
+  const stableOnRefreshInteraction = useStableEvent(onRefreshInteraction);
   const stableOnRejectInteraction = useStableEvent(onRejectInteraction);
   const stableOnSubmitInteractionAnswers = useStableEvent(onSubmitInteractionAnswers);
   const stableOnCancelInteraction = useStableEvent(onCancelInteraction);
@@ -4917,6 +4925,7 @@ export function IssueChatThread({
       onDeleteComment: stableOnDeleteComment,
       onImageClick: stableOnImageClick,
       onAcceptInteraction: stableOnAcceptInteraction,
+      onRefreshInteraction: stableOnRefreshInteraction,
       onRejectInteraction: stableOnRejectInteraction,
       onSubmitInteractionAnswers: stableOnSubmitInteractionAnswers,
       onCancelInteraction: stableOnCancelInteraction,

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -5,6 +5,7 @@ import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IssueThreadInteractionCard } from "./IssueThreadInteractionCard";
+import { ApiError } from "../api/client";
 import { ThemeProvider } from "../context/ThemeContext";
 import { TooltipProvider } from "./ui/tooltip";
 import {
@@ -397,6 +398,104 @@ describe("IssueThreadInteractionCard", () => {
     expect(onAcceptInteraction).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "request_confirmation" }),
     );
+  });
+
+  it("waits for workspace sync and retries a gated confirmation", async () => {
+    vi.useFakeTimers();
+    try {
+      const syncGateError = new ApiError(
+        "Cannot accept interaction: the run that created this interaction has not finished syncing its workspace.",
+        409,
+        {
+          code: "workspace_sync_pending",
+          details: { executionWorkspaceId: "workspace-1", sourceRunId: "run-1" },
+        },
+      );
+      const onAcceptInteraction = vi.fn()
+        .mockRejectedValueOnce(syncGateError)
+        .mockResolvedValueOnce(undefined);
+      const onRefreshInteraction = vi.fn(async () => undefined);
+      const host = renderCard({
+        interaction: pendingRequestConfirmationInteraction,
+        onAcceptInteraction,
+        onRefreshInteraction,
+      });
+
+      const confirmButton = Array.from(host.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Approve plan"),
+      );
+      await act(async () => {
+        confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+      });
+
+      expect(host.textContent).toContain("Waiting for workspace sync");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(onAcceptInteraction).toHaveBeenCalledTimes(2);
+      expect(onRefreshInteraction).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds automatic retries when workspace sync never resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const syncGateError = new ApiError(
+        "Cannot accept interaction: the run that created this interaction has not finished syncing its workspace.",
+        409,
+        {
+          code: "workspace_sync_pending",
+          details: { executionWorkspaceId: "workspace-1", sourceRunId: "run-1" },
+        },
+      );
+      const onAcceptInteraction = vi.fn().mockRejectedValue(syncGateError);
+      const host = renderCard({
+        interaction: pendingRequestConfirmationInteraction,
+        onAcceptInteraction,
+      });
+
+      const confirmButton = Array.from(host.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes("Approve plan"),
+      );
+      await act(async () => {
+        confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(1000 + 2000 + 4000 + 8000 + 16000);
+      });
+
+      expect(onAcceptInteraction).toHaveBeenCalledTimes(6);
+      expect(host.textContent).toContain("Workspace sync is still in progress. Automatic retries stopped");
+      expect(host.textContent).toContain("Retry");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refetches instead of retrying when the interaction was already resolved", async () => {
+    const onAcceptInteraction = vi.fn().mockRejectedValue(
+      new ApiError("Interaction has already been resolved", 409, {}),
+    );
+    const onRefreshInteraction = vi.fn(async () => undefined);
+    const host = renderCard({
+      interaction: pendingRequestConfirmationInteraction,
+      onAcceptInteraction,
+      onRefreshInteraction,
+    });
+
+    const confirmButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Approve plan"),
+    );
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(onAcceptInteraction).toHaveBeenCalledTimes(1);
+    expect(onRefreshInteraction).toHaveBeenCalledTimes(1);
+    expect(host.textContent).not.toContain("Try again");
   });
 
   it("does not expose continuation wake policy labels in the card header", () => {

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -10,6 +10,10 @@ import {
   getCheckboxConfirmationSelectedLabels,
   getItemVerdictProgress,
   getQuestionAnswerLabels,
+  interactionSyncGateRetryDelayMs,
+  INTERACTION_SYNC_GATE_MAX_RETRIES,
+  isInteractionAlreadyResolvedConflict,
+  isInteractionWorkspaceSyncConflict,
   normalizeRequestConfirmationTargetHref,
   type AskUserQuestionsAnswer,
   type AskUserQuestionsInteraction,
@@ -58,6 +62,8 @@ interface IssueThreadInteractionCardProps {
       | RequestCheckboxConfirmationInteraction,
     reason?: string,
   ) => Promise<void> | void;
+  /** Refresh the interaction after a workspace-sync gate clears. */
+  onRefreshInteraction?: () => Promise<void> | void;
   onSubmitInteractionAnswers?: (
     interaction: AskUserQuestionsInteraction,
     answers: AskUserQuestionsAnswer[],
@@ -73,6 +79,57 @@ interface IssueThreadInteractionCardProps {
   ) => Promise<void> | void;
   onUploadImage?: (file: File) => Promise<string>;
   externalReferences?: MarkdownExternalReferenceMap;
+}
+
+function useSyncGateAccept() {
+  const [syncWaiting, setSyncWaiting] = useState(false);
+  const [syncRetryExhausted, setSyncRetryExhausted] = useState(false);
+
+  async function acceptWithSyncRetry(
+    accept: () => Promise<void> | void,
+    onRefreshInteraction?: () => Promise<void> | void,
+  ) {
+    let retryNumber = 0;
+    setSyncRetryExhausted(false);
+    while (true) {
+      try {
+        await accept();
+        setSyncWaiting(false);
+        setSyncRetryExhausted(false);
+        // The accept response is authoritative, but a refetch also pulls in
+        // any continuation state written immediately after resolution.
+        await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
+        return;
+      } catch (error) {
+        if (isInteractionAlreadyResolvedConflict(error)) {
+          setSyncWaiting(false);
+          setSyncRetryExhausted(false);
+          await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
+          return;
+        }
+        if (!isInteractionWorkspaceSyncConflict(error) || retryNumber >= INTERACTION_SYNC_GATE_MAX_RETRIES) {
+          setSyncWaiting(false);
+          setSyncRetryExhausted(isInteractionWorkspaceSyncConflict(error));
+          throw error;
+        }
+        retryNumber += 1;
+        setSyncWaiting(true);
+        await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
+        await new Promise<void>((resolve) => {
+          window.setTimeout(resolve, interactionSyncGateRetryDelayMs(retryNumber));
+        });
+      }
+    }
+  }
+
+  return { acceptWithSyncRetry, syncWaiting, syncRetryExhausted };
+}
+
+function interactionActionError(error: unknown, fallback: string): string {
+  if (isInteractionWorkspaceSyncConflict(error)) {
+    return "Workspace sync is still in progress. Automatic retries stopped; try again manually once the workspace finishes syncing.";
+  }
+  return error instanceof Error && error.message.trim() ? error.message : fallback;
 }
 
 function resolveActorLabel(args: {
@@ -584,6 +641,7 @@ function SuggestTasksCard({
   userLabelMap,
   onAcceptInteraction,
   onRejectInteraction,
+  onRefreshInteraction,
 }: {
   interaction: SuggestTasksInteraction;
   agentMap?: Map<string, Agent>;
@@ -597,6 +655,7 @@ function SuggestTasksCard({
     interaction: SuggestTasksInteraction,
     reason?: string,
   ) => Promise<void> | void;
+  onRefreshInteraction?: () => Promise<void> | void;
 }) {
   const [rejecting, setRejecting] = useState(false);
   const [working, setWorking] = useState<"accept" | "reject" | null>(null);
@@ -663,6 +722,7 @@ function SuggestTasksCard({
     setWorking("reject");
     try {
       await onRejectInteraction(interaction, rejectReason.trim() || undefined);
+      await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
       setRejecting(false);
     } finally {
       setWorking(null);
@@ -1664,6 +1724,7 @@ function RequestToolActionCard({
   requestedByLabel,
   onAcceptInteraction,
   onRejectInteraction,
+  onRefreshInteraction,
   externalReferences,
 }: {
   interaction: RequestConfirmationInteraction;
@@ -1677,6 +1738,7 @@ function RequestToolActionCard({
     interaction: RequestConfirmationInteraction,
     reason?: string,
   ) => Promise<void> | void;
+  onRefreshInteraction?: () => Promise<void> | void;
   externalReferences?: MarkdownExternalReferenceMap;
 }) {
   const payload = interaction.payload.toolAction!;
@@ -1684,6 +1746,7 @@ function RequestToolActionCard({
   const [rejectReason, setRejectReason] = useState("");
   const [working, setWorking] = useState<"accept" | "reject" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const { acceptWithSyncRetry, syncWaiting, syncRetryExhausted } = useSyncGateAccept();
   const [nowMs, setNowMs] = useState(() => Date.now());
   const isPending = state === "pending";
   const isDestructive = payload.risk === "destructive";
@@ -1706,9 +1769,12 @@ function RequestToolActionCard({
     setWorking("accept");
     setActionError(null);
     try {
-      await onAcceptInteraction(interaction);
-    } catch {
-      setActionError("Couldn't submit. Try again.");
+      await acceptWithSyncRetry(
+        () => onAcceptInteraction(interaction),
+        onRefreshInteraction,
+      );
+    } catch (error) {
+      setActionError(interactionActionError(error, "Couldn't submit. Try again."));
     } finally {
       setWorking(null);
     }
@@ -1720,9 +1786,10 @@ function RequestToolActionCard({
     setActionError(null);
     try {
       await onRejectInteraction(interaction, rejectReason.trim() || undefined);
+      await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
       setRejecting(false);
-    } catch {
-      setActionError("Couldn't submit. Try again.");
+    } catch (error) {
+      setActionError(interactionActionError(error, "Couldn't submit. Try again."));
     } finally {
       setWorking(null);
     }
@@ -1764,7 +1831,14 @@ function RequestToolActionCard({
                 disabled={!onAcceptInteraction || working !== null}
                 onClick={() => void handleAccept()}
               >
-                {working === "accept" ? (
+                {syncWaiting ? (
+                  <>
+                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    Waiting for workspace sync…
+                  </>
+                ) : syncRetryExhausted ? (
+                  "Retry"
+                ) : working === "accept" ? (
                   <>
                     <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
                     Approving…
@@ -1785,6 +1859,12 @@ function RequestToolActionCard({
                 Approving runs this action now.
               </span>
             </div>
+
+            {syncWaiting ? (
+              <p className="text-sm text-muted-foreground">
+                Waiting for the agent&apos;s workspace to sync — your response will apply automatically.
+              </p>
+            ) : null}
 
             {rejecting ? (
               <div className="space-y-3 rounded-sm border border-border/70 bg-background/75 p-3">
@@ -1847,6 +1927,7 @@ function RequestConfirmationCard({
   primaryActionOnRight = false,
   onAcceptInteraction,
   onRejectInteraction,
+  onRefreshInteraction,
   onUploadImage,
   externalReferences,
 }: {
@@ -1860,6 +1941,7 @@ function RequestConfirmationCard({
     interaction: RequestConfirmationInteraction,
     reason?: string,
   ) => Promise<void> | void;
+  onRefreshInteraction?: () => Promise<void> | void;
   onUploadImage?: (file: File) => Promise<string>;
   externalReferences?: MarkdownExternalReferenceMap;
 }) {
@@ -1871,6 +1953,7 @@ function RequestConfirmationCard({
   const [shots, setShots] = useState<{ name: string; url: string }[]>([]);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const { acceptWithSyncRetry, syncWaiting, syncRetryExhausted } = useSyncGateAccept();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // Screenshots ride along in the decline reason as markdown image refs so the
   // board can attach images when sending a plan back — no schema change needed.
@@ -1929,9 +2012,12 @@ function RequestConfirmationCard({
     setWorking("accept");
     setActionError(null);
     try {
-      await onAcceptInteraction(interaction);
-    } catch {
-      setActionError("Try again");
+      await acceptWithSyncRetry(
+        () => onAcceptInteraction(interaction),
+        onRefreshInteraction,
+      );
+    } catch (error) {
+      setActionError(interactionActionError(error, "Try again"));
     } finally {
       setWorking(null);
     }
@@ -1944,9 +2030,10 @@ function RequestConfirmationCard({
     setActionError(null);
     try {
       await onRejectInteraction(interaction, composeReason());
+      await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
       setRejecting(false);
-    } catch {
-      setActionError("Try again");
+    } catch (error) {
+      setActionError(interactionActionError(error, "Try again"));
     } finally {
       setWorking(null);
     }
@@ -1985,7 +2072,14 @@ function RequestConfirmationCard({
               disabled={!onAcceptInteraction || working !== null}
               onClick={() => void handleAccept()}
             >
-              {working === "accept" ? (
+              {syncWaiting ? (
+                <>
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                  Waiting for workspace sync…
+                </>
+              ) : syncRetryExhausted ? (
+                "Retry"
+              ) : working === "accept" ? (
                 <>
                   <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
                   Confirming...
@@ -2010,6 +2104,12 @@ function RequestConfirmationCard({
               {interaction.payload.rejectLabel ?? "Decline"}
             </Button>
           </div>
+
+          {syncWaiting ? (
+            <p className="text-sm text-muted-foreground">
+              Waiting for the agent&apos;s workspace to sync — your response will apply automatically.
+            </p>
+          ) : null}
 
           {rejecting ? (
             <div className="space-y-3 rounded-sm border border-border/70 bg-background/75 p-3">
@@ -2258,6 +2358,7 @@ function RequestCheckboxConfirmationCard({
   interaction,
   onAcceptInteraction,
   onRejectInteraction,
+  onRefreshInteraction,
   externalReferences,
 }: {
   interaction: RequestCheckboxConfirmationInteraction;
@@ -2270,6 +2371,7 @@ function RequestCheckboxConfirmationCard({
     interaction: RequestCheckboxConfirmationInteraction,
     reason?: string,
   ) => Promise<void> | void;
+  onRefreshInteraction?: () => Promise<void> | void;
   externalReferences?: MarkdownExternalReferenceMap;
 }) {
   const options = interaction.payload.options;
@@ -2293,6 +2395,7 @@ function RequestCheckboxConfirmationCard({
   const [rejectAttempted, setRejectAttempted] = useState(false);
   const [acceptAttempted, setAcceptAttempted] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const { acceptWithSyncRetry, syncWaiting, syncRetryExhausted } = useSyncGateAccept();
 
   const optionSeed = useMemo(() => optionIds.join("\n"), [optionIds]);
 
@@ -2360,9 +2463,12 @@ function RequestCheckboxConfirmationCard({
     setWorking("accept");
     setActionError(null);
     try {
-      await onAcceptInteraction(interaction, undefined, [...selectedOptionIds]);
-    } catch {
-      setActionError("Try again");
+      await acceptWithSyncRetry(
+        () => onAcceptInteraction(interaction, undefined, [...selectedOptionIds]),
+        onRefreshInteraction,
+      );
+    } catch (error) {
+      setActionError(interactionActionError(error, "Try again"));
     } finally {
       setWorking(null);
     }
@@ -2375,9 +2481,10 @@ function RequestCheckboxConfirmationCard({
     setActionError(null);
     try {
       await onRejectInteraction(interaction, trimmedRejectReason || undefined);
+      await Promise.resolve(onRefreshInteraction?.()).catch(() => undefined);
       setRejecting(false);
-    } catch {
-      setActionError("Try again");
+    } catch (error) {
+      setActionError(interactionActionError(error, "Try again"));
     } finally {
       setWorking(null);
     }
@@ -2473,7 +2580,14 @@ function RequestCheckboxConfirmationCard({
             disabled={!onAcceptInteraction || working !== null}
             onClick={() => void handleAccept()}
           >
-            {working === "accept" ? (
+            {syncWaiting ? (
+              <>
+                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                Waiting for workspace sync…
+              </>
+            ) : syncRetryExhausted ? (
+              "Retry"
+            ) : working === "accept" ? (
               <>
                 <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
                 Confirming...
@@ -2498,6 +2612,12 @@ function RequestCheckboxConfirmationCard({
             {interaction.payload.rejectLabel ?? "Request changes"}
           </Button>
         </div>
+
+        {syncWaiting ? (
+          <p className="text-sm text-muted-foreground">
+            Waiting for the agent&apos;s workspace to sync — your response will apply automatically.
+          </p>
+        ) : null}
 
         {rejecting ? (
           <div className="space-y-3 rounded-sm border border-border/70 bg-background/75 p-3">
@@ -3052,6 +3172,7 @@ export function IssueThreadInteractionCard({
   userLabelMap,
   onAcceptInteraction,
   onRejectInteraction,
+  onRefreshInteraction,
   onSubmitInteractionAnswers,
   onCancelInteraction,
   primaryActionOnRight,
@@ -3155,6 +3276,7 @@ export function IssueThreadInteractionCard({
             userLabelMap={userLabelMap}
             onAcceptInteraction={onAcceptInteraction}
             onRejectInteraction={onRejectInteraction}
+            onRefreshInteraction={onRefreshInteraction}
           />
         ) : interaction.kind === "ask_user_questions" ? (
           <AskUserQuestionsCard
@@ -3168,6 +3290,7 @@ export function IssueThreadInteractionCard({
             interaction={interaction}
             onAcceptInteraction={onAcceptInteraction}
             onRejectInteraction={onRejectInteraction}
+            onRefreshInteraction={onRefreshInteraction}
             externalReferences={externalReferences}
           />
         ) : isToolAction && interaction.kind === "request_confirmation" && toolActionState ? (
@@ -3178,6 +3301,7 @@ export function IssueThreadInteractionCard({
             requestedByLabel={createdByLabel}
             onAcceptInteraction={onAcceptInteraction}
             onRejectInteraction={onRejectInteraction}
+            onRefreshInteraction={onRefreshInteraction}
             externalReferences={externalReferences}
           />
         ) : interaction.kind === "request_item_verdicts" ? (
@@ -3193,6 +3317,7 @@ export function IssueThreadInteractionCard({
             primaryActionOnRight={primaryActionOnRight}
             onAcceptInteraction={onAcceptInteraction}
             onRejectInteraction={onRejectInteraction}
+            onRefreshInteraction={onRefreshInteraction}
             onUploadImage={onUploadImage}
             externalReferences={externalReferences}
           />

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -81,6 +81,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     currentAssigneeValue,
     issueStatus,
     onAcceptInteraction,
+    onRefreshInteraction,
     onRejectInteraction,
     onSubmitInteractionAnswers,
     onCancelInteraction,
@@ -335,6 +336,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
         currentUserId={currentUserId}
         userLabelMap={userLabelMap}
         onAcceptInteraction={onAcceptInteraction}
+        onRefreshInteraction={onRefreshInteraction}
         onRejectInteraction={onRejectInteraction}
         onSubmitInteractionAnswers={onSubmitInteractionAnswers}
         onCancelInteraction={onCancelInteraction}
@@ -348,6 +350,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
       currentUserId,
       userLabelMap,
       onAcceptInteraction,
+      onRefreshInteraction,
       onRejectInteraction,
       onSubmitInteractionAnswers,
       onCancelInteraction,

--- a/ui/src/lib/issue-thread-interactions.ts
+++ b/ui/src/lib/issue-thread-interactions.ts
@@ -52,6 +52,58 @@ import type {
   SuggestTasksResultCreatedTask,
 } from "@paperclipai/shared";
 
+export const INTERACTION_SYNC_GATE_MAX_RETRIES = 5;
+export const INTERACTION_SYNC_GATE_RETRY_DELAYS_MS = [1000, 2000, 4000, 8000, 16000] as const;
+
+/**
+ * Accepting a confirmation is intentionally blocked while its source run is
+ * still syncing the execution workspace. Keep this classification narrow so
+ * other 409 conflicts remain visible to the operator instead of being retried.
+ */
+export function isInteractionWorkspaceSyncConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    status?: unknown;
+    message?: unknown;
+    body?: unknown;
+  };
+  if (candidate.status !== 409) return false;
+
+  const message = typeof candidate.message === "string" ? candidate.message : "";
+  if (message.includes("has not finished syncing its workspace")) return true;
+
+  const body = candidate.body;
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  const nestedDetails = record.details && typeof record.details === "object"
+    ? record.details as Record<string, unknown>
+    : null;
+  const code = record.code ?? nestedDetails?.code;
+  if (code === "workspace_sync_pending") return true;
+  if (typeof code === "string") return false;
+  return typeof record.executionWorkspaceId === "string"
+    && typeof record.sourceRunId === "string";
+}
+
+export function isInteractionAlreadyResolvedConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { status?: unknown; message?: unknown; body?: unknown };
+  if (candidate.status !== 409) return false;
+  const message = typeof candidate.message === "string" ? candidate.message : "";
+  if (message.includes("already been resolved")) return true;
+  if (!candidate.body || typeof candidate.body !== "object") return false;
+  const record = candidate.body as Record<string, unknown>;
+  const details = record.details && typeof record.details === "object"
+    ? record.details as Record<string, unknown>
+    : null;
+  return record.code === "interaction_already_resolved" || details?.code === "interaction_already_resolved";
+}
+
+export function interactionSyncGateRetryDelayMs(retryNumber: number): number {
+  const index = Math.max(0, Math.min(retryNumber - 1, INTERACTION_SYNC_GATE_RETRY_DELAYS_MS.length - 1));
+  return INTERACTION_SYNC_GATE_RETRY_DELAYS_MS[index];
+}
+
 export interface SuggestedTaskTreeNode {
   task: SuggestedTaskDraft;
   children: SuggestedTaskTreeNode[];

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -24,6 +24,7 @@ const mockIssuesApi = vi.hoisted(() => ({
   listComments: vi.fn(),
   listAttachments: vi.fn(),
   listWorkProducts: vi.fn(),
+  listInteractions: vi.fn(),
   listFeedbackVotes: vi.fn(),
   markRead: vi.fn(),
   update: vi.fn(),
@@ -257,6 +258,7 @@ vi.mock("../components/IssueChatThread", () => ({
       onSelect: (runId: string) => Promise<void> | void;
     }[];
     footer?: ReactNode;
+    onRefreshInteraction?: () => Promise<void> | void;
   }) => {
     mockIssueChatThreadRender(props);
     return (
@@ -982,6 +984,7 @@ describe("IssueDetail", () => {
     mockIssuesApi.listComments.mockResolvedValue([]);
     mockIssuesApi.listAttachments.mockResolvedValue([]);
     mockIssuesApi.listWorkProducts.mockResolvedValue([]);
+    mockIssuesApi.listInteractions.mockResolvedValue([]);
     mockIssuesApi.listFeedbackVotes.mockResolvedValue([]);
     mockIssuesApi.markRead.mockResolvedValue({ id: "issue-1", lastReadAt: new Date().toISOString() });
     mockIssuesApi.archiveFromInbox.mockResolvedValue({ id: "issue-1", archivedAt: new Date() });
@@ -1057,6 +1060,32 @@ describe("IssueDetail", () => {
         String(call[0]).includes("React has detected a change in the order of Hooks"),
       ),
     ).toBe(false);
+  });
+
+  it("passes the interaction refresh callback through to the issue chat thread", async () => {
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const props = mockIssueChatThreadRender.mock.calls.at(-1)?.[0] as {
+      onRefreshInteraction?: () => Promise<void> | void;
+    };
+    expect(props.onRefreshInteraction).toEqual(expect.any(Function));
+
+    mockIssuesApi.listInteractions.mockClear();
+    await act(async () => {
+      await props.onRefreshInteraction?.();
+    });
+
+    expect(mockIssuesApi.listInteractions).toHaveBeenCalledWith("PAP-1");
   });
 
   it("updates status and priority from the task header controls", async () => {

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1279,6 +1279,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
         stopRunVariant="pause"
         runFinalizationActions={runFinalizationActions}
         onAcceptInteraction={onAcceptInteraction}
+        onRefreshInteraction={onRefreshInteraction}
         onRejectInteraction={onRejectInteraction}
         onSubmitInteractionAnswers={(interaction, answers) =>
           onSubmitInteractionAnswers(interaction, answers)

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -950,6 +950,7 @@ type IssueDetailChatTabProps = {
     selectedClientKeys?: string[],
     selectedOptionIds?: string[],
   ) => Promise<void>;
+  onRefreshInteraction: () => Promise<void> | void;
   onRejectInteraction: (interaction: ActionableIssueThreadInteraction, reason?: string) => Promise<void>;
   onSubmitInteractionAnswers: (
     interaction: IssueThreadInteraction,
@@ -1032,6 +1033,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   pausingWorkRunId,
   onImageClick,
   onAcceptInteraction,
+  onRefreshInteraction,
   onRejectInteraction,
   onSubmitInteractionAnswers,
   onCancelInteraction,
@@ -1685,7 +1687,7 @@ export function IssueDetail() {
       }),
     [comments.length, commentsLoading, commentsLoadingOlder, detailTab, hasOlderComments],
   );
-  const { data: interactions = [] } = useQuery({
+  const { data: interactions = [], refetch: refetchInteractions } = useQuery({
     queryKey: queryKeys.issues.interactions(issueId!),
     queryFn: () => issuesApi.listInteractions(issueId!),
     enabled: !!issueId,
@@ -4962,6 +4964,7 @@ export function IssueDetail() {
               pausingWorkRunId={pauseIssueWorkRun.isPending ? pauseIssueWorkRun.variables?.runId ?? null : null}
               onImageClick={handleChatImageClick}
               onAcceptInteraction={handleAcceptInteraction}
+              onRefreshInteraction={() => refetchInteractions().then(() => undefined)}
               onRejectInteraction={handleRejectInteraction}
               onSubmitInteractionAnswers={handleSubmitInteractionAnswers}
               onCancelInteraction={handleCancelInteraction}

--- a/ui/src/pages/Pipelines.tsx
+++ b/ui/src/pages/Pipelines.tsx
@@ -3327,6 +3327,7 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
                     return updateConversationWorkMode(nextMode);
                   }}
                   onAcceptInteraction={handleAcceptConversationInteraction}
+                  onRefreshInteraction={invalidateConversation}
                   onRejectInteraction={handleRejectConversationInteraction}
                   onSubmitInteractionAnswers={handleSubmitConversationInteractionAnswers}
                   onCancelInteraction={handleCancelConversationInteraction}

--- a/ui/src/pages/SkillStudio.tsx
+++ b/ui/src/pages/SkillStudio.tsx
@@ -3372,6 +3372,9 @@ function InteractionSection({
                 key={summary.id}
                 interaction={full}
                 agentMap={agentMap}
+                onRefreshInteraction={async () => {
+                  await Promise.all([fullQuery.refetch(), Promise.resolve(onAnswered())]);
+                }}
                 onAcceptInteraction={async (interaction, _keys, optionIds) => {
                   await accept.mutateAsync({ interaction, optionIds });
                 }}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue-thread interactions record board decisions and resume agent work.
> - A confirmation accept must wait while its source workspace is still syncing.
> - The server returns a conflict during that short wait.
> - The UI hid that conflict behind a generic error and did not refresh all card surfaces.
> - This pull request gives the conflict a stable code and adds bounded client retry and refetch behavior.
> - The benefit is that the board response applies after sync and the card shows the real server state.

## Linked Issues or Issue Description

No public GitHub issue exists for this bug.

Related alternative: Refs #9520. That pull request removes the server sync gate and selects a fresh worktree. This pull request preserves the gate and makes the client wait, retry, and refetch.

**What happened?**

The board could accept or reject an issue-thread confirmation card. An accept during source-workspace sync returned HTTP 409. The card showed a generic error and could stay in the pending state. Some card surfaces also did not refetch after the interaction resolved.

**Expected behavior**

The card must show a sync-wait state for the transient conflict. It must retry for a bounded period. It must refetch after accept, reject, or an already-resolved response. Hard failures must keep their server message.

**Steps to reproduce**

1. Create a confirmation interaction from a run that uses an execution workspace.
2. Accept the interaction while the source workspace finalize operation is still active.
3. Observe the HTTP 409 response and the pending card state.

**Paperclip version or commit**

Reproduced on `42d0ddcb`, the current `master` head when this branch was prepared.

**Deployment mode**

Local development and self-hosted server.

## What Changed

- Add `details.code = "workspace_sync_pending"` to the gated accept conflict.
- Confirm that the HTTP error body carries the stable code.
- Show an explicit workspace-sync wait state in confirmation cards.
- Retry transient accepts with bounded exponential backoff.
- Stop retrying on hard conflicts and show the server message with a manual retry action.
- Refetch on successful accept or reject and on an already-resolved conflict.
- Wire refresh behavior through Issue Detail, Pipelines, Attention, Task Chat, and Skill Studio.
- Add server and UI regression tests for accept, reject, retry, and refetch behavior.

## Verification

- `pnpm exec vitest run server/src/__tests__/error-handler.test.ts server/src/__tests__/issue-thread-interactions-service.test.ts ui/src/components/IssueThreadInteractionCard.test.tsx` → 81 tests passed.
- `pnpm --filter @paperclipai/server typecheck` → passed.
- `pnpm --filter @paperclipai/ui typecheck` → passed.
- `pnpm check:token-gates` → all gates clean.
- `git diff --check origin/master...HEAD` → clean.
- The focused commit replayed cleanly on current `origin/master`.

## Risks

- Low to moderate risk. The change affects interaction-card state and timing.
- Retry is limited to the stable sync-pending code and has a fixed attempt cap.
- Other HTTP 409 responses do not enter the retry loop.
- Refetch callbacks are optional so existing card callers remain compatible.
- No database migration or API status change is included.

> This is a focused bug fix. `ROADMAP.md` does not contain a competing planned item.

## Model Used

- OpenAI Codex model `gpt-5.6-luna` produced and reviewed the implementation with reasoning, tool use, and code execution.
- OpenAI Codex model `gpt-5.6-sol` prepared the clean `master` branch and pull request with reasoning, tool use, and code execution.
- The Codex runtime managed the context windows.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation update is required for this error-handling bug fix
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
