### PR TITLE
fix(cli): put Node.js on the service PATH so spawned agents can start

### DIFF
--- a/cli/src/__tests__/service-manager.test.ts
+++ b/cli/src/__tests__/service-manager.test.ts
@@ -8,6 +8,7 @@ import {
   LaunchdServiceManager,
   renderLaunchdPlist,
   renderSystemdUnit,
+  resolveServicePath,
   SystemdServiceManager,
   type CommandRunner,
   type ServiceManager,
@@ -62,6 +63,46 @@ describe("service definition generation", () => {
     expect(plist).toContain("<key>RunAtLoad</key><true/>");
     expect(plist).toContain("<key>KeepAlive</key><true/>");
     expect(plist).toContain("service.err.log");
+  });
+
+  it("puts the Node.js bin directory on the service PATH so `env node` shebangs resolve", () => {
+    // A supervised service inherits `/usr/bin:/bin:/usr/sbin:/sbin`, which holds no
+    // Node.js on a typical machine. The server survives that, because the managed
+    // shim calls Node by absolute path. The agents it spawns do not: their shebang
+    // is `#!/usr/bin/env node`, so each run dies with `env: node: No such file or
+    // directory` while the server keeps reporting healthy.
+    const servicePath = resolveServicePath({
+      shimPath: "/Users/alice/.local/bin/paperclipai",
+      execPath: "/Users/alice/.nvm/versions/node/v22.22.3/bin/node",
+    });
+
+    expect(servicePath.split(":")).toContain("/Users/alice/.nvm/versions/node/v22.22.3/bin");
+    expect(servicePath.split(":")).toContain("/Users/alice/.local/bin");
+    expect(servicePath.startsWith("/Users/alice/.nvm/versions/node/v22.22.3/bin:")).toBe(true);
+  });
+
+  it("keeps the service PATH free of duplicates so the definition stays byte-stable", () => {
+    // `doctor` compares the rendered definition against the on-disk copy to detect
+    // drift, so the same inputs must always render the same bytes.
+    const servicePath = resolveServicePath({ shimPath: "/usr/bin/paperclipai", execPath: "/usr/bin/node" });
+    const entries = servicePath.split(":");
+
+    expect(new Set(entries).size).toBe(entries.length);
+    expect(entries).toContain("/usr/bin");
+  });
+
+  it("exports the PATH in both service definitions", () => {
+    const shared = {
+      instanceId: "team-a",
+      shimPath: "/home/alice/.local/bin/paperclipai",
+      homeDir: "/home/alice/.paperclip",
+      servicePath: "/opt/node/bin:/usr/bin:/bin",
+    };
+
+    expect(renderSystemdUnit(shared)).toContain('Environment="PATH=/opt/node/bin:/usr/bin:/bin"');
+    expect(
+      renderLaunchdPlist({ ...shared, stdoutPath: "/tmp/out.log", stderrPath: "/tmp/err.log" }),
+    ).toContain("<key>PATH</key><string>/opt/node/bin:/usr/bin:/bin</string>");
   });
 });
 

--- a/cli/src/services/service-manager.ts
+++ b/cli/src/services/service-manager.ts
@@ -83,7 +83,32 @@ export function launchdServiceName(instanceId: string): string {
   return instanceId === "default" ? "ing.paperclip.paperclipai" : `ing.paperclip.paperclipai.${instanceId}`;
 }
 
-export function renderSystemdUnit(input: { instanceId: string; shimPath: string; homeDir: string }): string {
+// launchd hands a user agent `PATH=/usr/bin:/bin:/usr/sbin:/sbin`, and a systemd
+// user unit gets an equally bare default. Neither contains a Node.js install on a
+// typical machine — Node lives in a version manager's directory, Homebrew, or
+// `~/.local/bin`. The server itself survives that, because the managed shim
+// invokes Node by absolute path, but the agent binaries the server spawns start
+// with `#!/usr/bin/env node`, so every agent run dies with
+// `env: node: No such file or directory` while the server keeps reporting healthy.
+//
+// Both derived entries come from values the definition already carries, so the
+// rendered file stays byte-stable between runs. That matters: `doctor` compares
+// the rendered definition against the on-disk copy to detect drift, and seeding
+// this from the installing shell's own PATH would make every definition report as
+// drifted the moment that shell changed.
+const BASE_SERVICE_PATH = ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+export function resolveServicePath(input: { shimPath: string; execPath?: string }): string {
+  const candidates = [
+    path.dirname(input.execPath ?? process.execPath),
+    path.dirname(input.shimPath),
+    ...BASE_SERVICE_PATH,
+  ];
+  return candidates.filter((entry, index) => entry.length > 0 && candidates.indexOf(entry) === index).join(":");
+}
+
+export function renderSystemdUnit(input: { instanceId: string; shimPath: string; homeDir: string; servicePath?: string }): string {
+  const servicePath = input.servicePath ?? resolveServicePath({ shimPath: input.shimPath });
   return `[Unit]
 Description=Paperclip AI (${escapeSystemd(input.instanceId)})
 After=network.target
@@ -97,6 +122,7 @@ ExecStart="${escapeSystemd(input.shimPath)}" run --instance "${escapeSystemd(inp
 Environment="PAPERCLIP_SERVICE_MANAGED=1"
 Environment="PAPERCLIP_INSTANCE_ID=${escapeSystemd(input.instanceId)}"
 Environment="PAPERCLIP_HOME=${escapeSystemd(input.homeDir)}"
+Environment="PATH=${escapeSystemd(servicePath)}"
 WorkingDirectory=%h
 Restart=always
 RestartSec=5
@@ -107,8 +133,9 @@ WantedBy=default.target
 `;
 }
 
-export function renderLaunchdPlist(input: { instanceId: string; shimPath: string; homeDir: string; stdoutPath: string; stderrPath: string }): string {
+export function renderLaunchdPlist(input: { instanceId: string; shimPath: string; homeDir: string; stdoutPath: string; stderrPath: string; servicePath?: string }): string {
   const label = launchdServiceName(input.instanceId);
+  const servicePath = input.servicePath ?? resolveServicePath({ shimPath: input.shimPath });
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -123,6 +150,7 @@ export function renderLaunchdPlist(input: { instanceId: string; shimPath: string
     <key>PAPERCLIP_SERVICE_MANAGED</key><string>1</string>
     <key>PAPERCLIP_INSTANCE_ID</key><string>${escapeXml(input.instanceId)}</string>
     <key>PAPERCLIP_HOME</key><string>${escapeXml(input.homeDir)}</string>
+    <key>PATH</key><string>${escapeXml(servicePath)}</string>
   </dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The managed CLI can run an instance as a background service, through a launchd agent on macOS or a systemd user unit on Linux
> - A supervised process does not inherit the operator's shell environment. It inherits the supervisor's, and that PATH is bare
> - The service definitions do not set a PATH, so the service runs with `/usr/bin:/bin:/usr/sbin:/sbin`
> - The server itself is unaffected, because the managed shim calls Node.js by absolute path. Every agent it spawns is affected, because those binaries start with `#!/usr/bin/env node`
> - So the instance reports healthy while no agent can run at all — the worst shape for a defect, because the health surface says nothing is wrong
> - This pull request renders an explicit PATH into both service definitions, derived from values each definition already carries
> - The benefit is that a service-managed instance can actually execute agent work, and that the failure cannot recur silently

## Linked Issues or Issue Description

No existing issue. Describing it here, following `bug_report.yml`.

**What happened:**
After moving an instance from a foreground `pnpm dev` to `paperclipai service install`, every agent run failed. `service.err.log` filled with:

```
[acpx] spawning agent: ~/.paperclip/cli/installs/npm/<version>/node_modules/.bin/claude-agent-acp
env: node: No such file or directory
```

Meanwhile `paperclipai service status` reported `"health": { "ok": true }` and `paperclipai doctor` passed every check. The only other symptom was `GET /api/heartbeat-runs/<id>/log` answering 404, because the runs had produced no output.

**Expected behavior:**
An instance installed as a background service can spawn its agents.

**Steps to reproduce:**

1. Install Node.js somewhere other than `/usr/bin` — a version manager, Homebrew, or `~/.local/bin`. This is the normal case.
2. `paperclipai service install --instance <id>` and start it.
3. Trigger any agent run.
4. The run fails. `service.err.log` shows `env: node: No such file or directory`. `service status` still reports healthy.

Confirmed root cause, read off the running service:

```
$ ps eww <server-pid> | tr ' ' '\n' | grep ^PATH=
PATH=/usr/bin:/bin:/usr/sbin:/sbin

$ head -1 .../node_modules/.bin/claude-agent-acp
#!/usr/bin/env node

$ env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin /usr/bin/env node --version
env: node: No such file or directory
```

The rendered plist's `EnvironmentVariables` carries `PAPERCLIP_SERVICE_MANAGED`, `PAPERCLIP_INSTANCE_ID` and `PAPERCLIP_HOME`, and no `PATH`. `renderSystemdUnit` has the same gap.

**Paperclip version/commit:**
`2026.803.0-canary.4`; branch cut from `ba396c608`.

**Deployment mode:**
`local_trusted` / `private`, loopback, embedded PostgreSQL, launchd service on macOS 15 (arm64). The systemd path is the same code shape and is fixed here too, but I have not run it on Linux.

## What Changed

- Add `resolveServicePath({ shimPath, execPath })` to `cli/src/services/service-manager.ts`. It returns the directory of the running Node.js binary, then the directory of the managed shim, then `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`, de-duplicated.
- Render `Environment="PATH=..."` in `renderSystemdUnit`.
- Render `<key>PATH</key>` in `renderLaunchdPlist`.
- Both renderers accept an optional `servicePath` so the value can be injected in tests; they fall back to `resolveServicePath` otherwise. Existing callers need no change.
- Add three tests in `cli/src/__tests__/service-manager.test.ts`.

Both derived entries come from values the definition already carries. That is deliberate: `doctor` detects drift by comparing the rendered definition byte-for-byte against the on-disk copy, so seeding the PATH from the installing shell's own environment would mark every definition as drifted the moment that shell changed.

## Verification

### Tests

```sh
pnpm exec vitest run cli/src/__tests__/service-manager.test.ts
```

With this change: **22 passed**. With `cli/src/services/service-manager.ts` reverted to `origin/master`, the three new tests fail:

```
× puts the Node.js bin directory on the service PATH so `env node` shebangs resolve
× keeps the service PATH free of duplicates so the definition stays byte-stable
× exports the PATH in both service definitions
```

### In the field

The rendered plist was patched by hand on the affected machine with exactly the PATH this change produces, and the service reloaded. Before and after, against the real agent binary:

```
PATH=/usr/bin:/bin:/usr/sbin:/sbin   → env: node: No such file or directory
PATH with the Node.js bin directory  → 0.63.0
```

Agent runs resumed. `service.err.log` recorded no further `env: node` lines.

### Type checking

```sh
cd cli && ../node_modules/.bin/tsc --noEmit
```

The two changed files produce no TypeScript errors.

### Neighbouring suites

`service-health-check.test.ts` and `onboard-service.test.ts` pass. `doctor.test.ts` fails one test on my machine — it fails identically on an unmodified `origin/master`, and passes under `PAPERCLIP_SERVICE_MANAGED=1`, which short-circuits `serviceHealthChecks`. That test reads the machine's real service state rather than a fixture, so it fails on any machine that has a Paperclip service installed. It is not related to this change, and I have not tried to fix it here.

## Risks

Low risk.

- The definitions change, so `doctor` will report drift once for existing installs until `paperclipai service install` regenerates them. That is the intended repair path and the check already prints it.
- `/usr/local/bin` is added ahead of `/usr/bin`. On a machine where both hold a different Node.js, the service now prefers `/usr/local/bin` — but the directory of the running Node.js binary is placed first, so the resolved Node.js does not change.
- No public API, schema, or migration is affected.

## Model Used

Claude Opus 5 (`claude-opus-5`), through Claude Code. Extended thinking was on. The session used tool execution: it read the repository, inspected the environment of a running launchd service, reproduced the failing shebang resolution, ran the test suite and the type checker, and verified the fix against a live managed install.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass — the files this PR touches pass. `doctor.test.ts` has one unrelated pre-existing failure on my machine. See Verification.
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no documentation states the service environment
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — to confirm after the CI run
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
