### PR TITLE
fix(server): fail-closed hot-restart continuity for ACPX local adapters (PAP-16219)

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -148,6 +148,42 @@ look like a zero-loss restart.
 
 A healthy guarded deploy must compare the report against `/api/health` (`version` or `serverVersion`) and treat any `lostRunIds` entry as a continuity failure that needs recovery before marking deployment complete.
 
+#### Two continuity lanes: adoption vs. session-resume (ACPX local adapters)
+
+Local heartbeat adapters run their agent through one of two lanes, and the two
+lanes have different, deliberate restart behavior. The persisted
+`processGroupId` on the run distinguishes them:
+
+- **Detached direct-spawn lane (`processGroupId` is non-null).** The agent runs
+  in its own process group, survives the old server, and is re-signalable by
+  group. These runs are *left alive* across a hot restart and **adopted** live by
+  the new server (`adoptedRunIds`).
+- **ACP-engine lane — `codex_local`, `claude_local`, `gemini_local` on their
+  default path (`processGroupId` is null).** The agent is driven over an
+  in-process stdio JSON-RPC transport owned by the server process. When the
+  server exits, the agent gets stdin EOF and dies, and the transport **cannot be
+  reattached** — there is no safe way to adopt it. Rather than falsely promise
+  adoption and then lose the run, the new server **fails closed**: it finalizes
+  the original run (`finalized_while_down`, run `errorCode` /report `reason`
+  `acp_transport_not_reattachable`) and queues a retry that **resumes the
+  persisted ACP session** on the new server. Continuity for this lane is
+  therefore session-store resume, not process adoption.
+
+  Tradeoff: the in-flight turn that was mid-flight at restart is not preserved at
+  the process level; the retry re-enters the agent and resumes its saved session
+  (transcript, working state) from the last checkpoint the ACP session store
+  persisted. This is the honest outcome — the null `processGroupId` is a
+  load-bearing signal, not a gap. Do **not** make the ACP lane report a synthetic
+  process group (e.g. by detaching the agent spawn) to force adoption: the stdio
+  transport still dies with the server, so that would only restore the false
+  promise the fix removed. See `isReattachableHotRestartRun` in
+  `server/src/services/heartbeat.ts` and the invariant note on `onAgentSpawn` in
+  `packages/adapter-utils/src/acpx-engine/execute.ts`.
+
+For an ACP-engine local heartbeat, a zero-loss restart therefore records the
+original run in `finalizedWhileDownRunIds` (not `adoptedRunIds`), keeps
+`lostRunIds` empty, and leaves a `retryOfRunId` continuation queued.
+
 ### Recovering a deploy blocked by missing process metadata
 
 If the currently installed version already has a running local-agent heartbeat
@@ -183,9 +219,15 @@ jq -e --arg run "$RUN_ID" \
   "$PAPERCLIP_HOME/hot-restart-report.json"
 ```
 
-An alive child appears in `adoptedRunIds`; a child that completed during the
-restart window appears in `finalizedWhileDownRunIds`. Either is continuous. A
-`lostRunIds` entry remains a failed deploy and must not be waived.
+An alive, reattachable child (detached lane, non-null `processGroupId`) appears in
+`adoptedRunIds`; a child that completed during the restart window appears in
+`finalizedWhileDownRunIds`. An ACP-engine local run (`codex_local` /
+`claude_local` / `gemini_local`, null `processGroupId`) also appears in
+`finalizedWhileDownRunIds` — finalized fail-closed with a session-resume retry
+queued (see "Two continuity lanes" above), so for that lane the check above is
+satisfied by the `finalizedWhileDownRunIds` branch, not `adoptedRunIds`. All
+three are continuous. A `lostRunIds` entry remains a failed deploy and must not
+be waived.
 
 Tailscale/private-auth dev mode:
 

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -3109,6 +3109,17 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         : undefined,
       onAgentSpawn: async (meta) => {
         processIdentitySink.latest = meta;
+        // `processGroupId: null` is a deliberate, load-bearing invariant, not a
+        // gap. The ACP agent is spawned in THIS process's group and driven over
+        // an in-process stdio JSON-RPC transport owned by this server, so it
+        // cannot be reattached across a `paperclip.service` restart (it dies on
+        // stdin EOF when the server exits). The server relies on a null group id
+        // to fail-close hot-restart adoption for this lane and instead resume the
+        // persisted ACP session on retry — see `isReattachableHotRestartRun` in
+        // `server/src/services/heartbeat.ts`. Do NOT report a synthetic group id
+        // here (e.g. by detaching the spawn) without also teaching the server a
+        // separate reattachability signal, or hot restart will silently promise
+        // an adoption it cannot honor.
         await processIdentitySink.current?.({
           pid: meta.pid,
           processGroupId: null,
@@ -3229,6 +3240,9 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
       // not emit another spawn event. Persist its known identity on this run
       // before the next prompt starts so every running heartbeat is adoptable.
       if (handle && cached && processIdentitySink.latest && ctx.onSpawn) {
+        // Same invariant as the spawn hook above: a warm-handle reuse re-persists
+        // the in-process ACP agent's identity with a null group id, keeping the
+        // run fail-closed for hot-restart adoption. See the note on `onAgentSpawn`.
         await ctx.onSpawn({
           pid: processIdentitySink.latest.pid,
           processGroupId: null,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1491,13 +1491,17 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   });
 
   it("adopts an old-server legacy snapshot written for a new instance-scoped marker", async () => {
-    const child = spawnAliveProcess();
-    childProcesses.add(child);
-    expect(child.pid).toBeGreaterThan(0);
+    // A genuinely reattachable run: the detached direct-spawn lane leaves the
+    // agent in its own process group, so the group survives this server and can
+    // be adopted. (The ACP-engine lane with a null group id is fail-closed
+    // instead — covered by the dedicated regressions below.)
+    const group = await spawnOrphanedProcessGroup();
+    cleanupPids.add(group.descendantPid);
+    expect(group.processGroupId).toBeGreaterThan(0);
     const { companyId, agentId, issueId, runId } = await seedRunFixture({
       agentStatus: "running",
-      processPid: child.pid ?? null,
-      processGroupId: null,
+      processPid: group.processPid,
+      processGroupId: group.processGroupId,
     });
 
     await withTempPaperclipHome(async (home) => {
@@ -1523,8 +1527,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           agentId,
           adapterType: "codex_local",
           status: "running",
-          processPid: child.pid,
-          processGroupId: null,
+          processPid: group.processPid,
+          processGroupId: group.processGroupId,
           issueId,
         }],
       };
@@ -1534,7 +1538,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       expect(mergedIntent).toMatchObject({
         preflightActiveRunIds: [runId],
         shutdownSnapshot: {
-          activeRuns: [expect.objectContaining({ runId, processPid: child.pid })],
+          activeRuns: [expect.objectContaining({ runId, processGroupId: group.processGroupId })],
         },
       });
 
@@ -1637,7 +1641,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
-  it("persists codex_local spawn identity before hot restart and never loses the live run for missing metadata", async () => {
+  it("persists codex_local ACP spawn identity (pid, null process group) for the live run", async () => {
     let releaseAdapter: (() => void) | null = null;
     let spawnedPid: number | null = null;
     const adapterStarted = new Promise<void>((resolve) => {
@@ -1696,6 +1700,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           return row?.status === "running" && row.processPid ? row : null;
         }),
     );
+    // The ACP-engine lane records the agent pid but a null process group: the
+    // agent runs behind an in-process stdio transport, not a detached group. This
+    // null group id is the load-bearing signal the hot-restart reconciler uses to
+    // fail-close adoption for this lane (see the dedicated regressions below).
     expect(running).toMatchObject({
       id: runId,
       status: "running",
@@ -1704,118 +1712,98 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       processStartedAt: new Date("2026-07-30T07:00:00.000Z"),
     });
 
-    await withTempPaperclipHome(async (home) => {
-      await writeHotRestartIntent({
-        previousServerPid: process.pid,
-        previousServerVersion: "old-version",
-        requestedAt: new Date("2026-07-30T07:01:00.000Z"),
-      });
-      await heartbeat.prepareHotRestartShutdown(
-        "SIGTERM",
-        new Date("2026-07-30T07:02:00.000Z"),
-      );
-
-      const adoption = await heartbeat.reconcileHotRestartAdoption(
-        new Date("2026-07-30T07:03:00.000Z"),
-      );
-      expect(adoption).toMatchObject({
-        mode: "reported",
-        adoptedRunIds: [runId],
-        finalizedWhileDownRunIds: [],
-        lostRunIds: [],
-      });
-      const report = JSON.parse(
-        await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
-      ) as { runs?: Array<Record<string, unknown>> };
-      expect(report.runs).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            runId,
-            classification: "adopted",
-            reason: "process_pid_alive",
-          }),
-        ]),
-      );
-      expect(report.runs).not.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ runId, reason: "missing_process_metadata" }),
-        ]),
-      );
-    });
-
     if (!releaseAdapter) throw new Error("Adapter release handle was not captured");
     releaseAdapter();
     const settled = await waitForRunToSettle(heartbeat, runId, 5_000);
     expect(settled?.status).toBe("succeeded");
   });
 
-  it("reports adopted hot-restart runs before startup reap can mark them process_lost", async () => {
-    const child = spawnAliveProcess();
-    childProcesses.add(child);
-    expect(child.pid).toBeGreaterThan(0);
-    const { runId } = await seedRunFixture({
-      agentStatus: "running",
-      processPid: child.pid ?? null,
-      processGroupId: null,
-    });
-
-    await withTempPaperclipHome(async (home) => {
-      const heartbeat = heartbeatService(db);
-      await writeHotRestartIntent({
-        previousServerPid: process.pid,
-        previousServerVersion: "old-version",
-        requestedAt: new Date("2026-03-19T00:05:00.000Z"),
-      });
-      await heartbeat.prepareHotRestartShutdown(
-        "SIGTERM",
-        new Date("2026-03-19T00:06:00.000Z"),
-      );
-
-      const adoption = await heartbeat.reconcileHotRestartAdoption(
-        new Date("2026-03-19T00:07:00.000Z"),
-      );
-      expect(adoption).toMatchObject({
-        mode: "reported",
-        adoptedRunIds: [runId],
-        finalizedWhileDownRunIds: [],
-        lostRunIds: [],
-        skippedRunIds: [],
+  // PAP-16219: an ACP-engine local run (null process group) cannot be reattached
+  // across a restart. It must be finalized fail-closed (never `lost`, never a
+  // bare-pid `adopted`) with a session-resume retry queued — for both codex_local
+  // and claude_local. A live child pid is deliberately still alive here to prove
+  // we do NOT adopt by bare pid (which would also risk latching a recycled pid).
+  for (const adapterType of ["codex_local", "claude_local"] as const) {
+    it(`finalizes a live ${adapterType} ACP run fail-closed on hot restart and queues a session-resume retry`, async () => {
+      const child = spawnAliveProcess();
+      childProcesses.add(child);
+      expect(child.pid).toBeGreaterThan(0);
+      const { agentId, runId, issueId } = await seedRunFixture({
+        adapterType,
+        agentStatus: "idle",
+        processPid: child.pid ?? null,
+        processGroupId: null,
       });
 
-      const report = JSON.parse(
-        await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
-      ) as Record<string, unknown>;
-      expect(report).toMatchObject({
-        previousServerPid: process.pid,
-        newServerPid: process.pid,
-        previousServerVersion: "old-version",
-        adoptedRunIds: [runId],
-        finalizedWhileDownRunIds: [],
-        lostRunIds: [],
-      });
-      expect(typeof report.newServerVersion).toBe("string");
-
-      const reap = await heartbeat.reapOrphanedRuns();
-      expect(reap).toEqual({ reaped: 0, runIds: [] });
-      const adopted = await db
-        .select()
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, runId))
-        .then((rows) => rows[0] ?? null);
-      expect(adopted?.status).toBe("running");
-      expect(adopted?.errorCode).not.toBe("process_lost");
-      expect(adopted?.resultJson).toMatchObject({
-        hotRestart: {
-          adopted: true,
-          adoptedAt: "2026-03-19T00:07:00.000Z",
+      await withTempPaperclipHome(async (home) => {
+        const heartbeat = heartbeatService(db);
+        await writeHotRestartIntent({
           previousServerPid: process.pid,
-          newServerPid: process.pid,
           previousServerVersion: "old-version",
-          processPid: child.pid,
-        },
+          requestedAt: new Date("2026-03-19T00:05:00.000Z"),
+          preflightActiveRunIds: [runId],
+        });
+        await heartbeat.prepareHotRestartShutdown(
+          "SIGTERM",
+          new Date("2026-03-19T00:06:00.000Z"),
+        );
+
+        const adoption = await heartbeat.reconcileHotRestartAdoption(
+          new Date("2026-03-19T00:07:00.000Z"),
+        );
+        // Success condition: empty lostRunIds; the original run recorded in
+        // finalizedWhileDownRunIds; nothing falsely adopted.
+        expect(adoption).toMatchObject({
+          mode: "reported",
+          adoptedRunIds: [],
+          finalizedWhileDownRunIds: [runId],
+          lostRunIds: [],
+          skippedRunIds: [],
+        });
+
+        const report = JSON.parse(
+          await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
+        ) as { runs?: Array<Record<string, unknown>> };
+        expect(report.runs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              runId,
+              adapterType,
+              classification: "finalized_while_down",
+              reason: "acp_transport_not_reattachable",
+              // Usable persisted process identity is retained on the report.
+              processPid: child.pid,
+            }),
+          ]),
+        );
+
+        // The run is honestly finalized (not left "running" under a false
+        // adoption promise) and is not marked lost/process_lost.
+        const finalized = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        expect(finalized?.status).toBe("interrupted");
+        expect(finalized?.errorCode).toBe("acp_transport_not_reattachable");
+        expect(finalized?.processPid).toBe(child.pid);
+
+        // The durable handoff: a retry is queued so the persisted ACP session
+        // resumes on the new server.
+        const retryRuns = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(and(eq(heartbeatRuns.agentId, agentId), eq(heartbeatRuns.retryOfRunId, runId)));
+        expect(retryRuns).toHaveLength(1);
+        expect(["queued", "running"]).toContain(retryRuns[0]?.status);
+
+        // A subsequent startup reap does not double-handle the finalized run.
+        const reap = await heartbeat.reapOrphanedRuns();
+        expect(reap.runIds).not.toContain(runId);
+        expect(issueId).toBeTruthy();
       });
     });
-  });
+  }
 
   it.skipIf(process.platform === "win32")("keeps process-group-only hot-restart adoptions out of process_lost reaping", async () => {
     const orphan = await spawnOrphanedProcessGroup();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5783,6 +5783,39 @@ function isTrackedLocalChildProcessAdapter(adapterType: string) {
   return SESSIONED_LOCAL_ADAPTERS.has(adapterType);
 }
 
+/**
+ * Whether a tracked local run keeps a child process that can be safely
+ * *reattached* — i.e. adopted live — across a `paperclip.service` restart.
+ *
+ * The only lane that qualifies is the detached direct-spawn lane
+ * (`runChildProcess` in adapter-utils), which launches the agent in its own
+ * process group (recorded as a non-null `processGroupId`). Such a child outlives
+ * this server, stays re-signalable by group, and reports its result out-of-band,
+ * so the new server can genuinely adopt it.
+ *
+ * The ACP-engine lane (`claude_local` / `codex_local` / `gemini_local` on their
+ * default path) drives the agent over an *in-process* stdio JSON-RPC transport
+ * owned by THIS server process, and spawns the agent in the server's own process
+ * group — so it records `processGroupId: null`. When the server exits, the agent
+ * gets stdin EOF / stdout EPIPE and dies, and the transport cannot be
+ * reattached. A null `processGroupId` on a tracked local run is therefore a
+ * load-bearing signal: the run has no reattachable process and must be finalized
+ * fail-closed on hot restart (and resumed from its persisted ACP session on
+ * retry) rather than promised a bare-pid adoption we cannot honor — which would
+ * also risk adopting a recycled pid. See `acpx-engine/execute.ts` for the
+ * spawn-side invariant.
+ */
+function isReattachableHotRestartRun(input: {
+  adapterType: string;
+  processGroupId: number | null;
+}): boolean {
+  return (
+    isTrackedLocalChildProcessAdapter(input.adapterType)
+    && typeof input.processGroupId === "number"
+    && input.processGroupId > 0
+  );
+}
+
 function isHeartbeatRunTerminalStatus(
   status: string | null | undefined,
 ): status is (typeof HEARTBEAT_RUN_TERMINAL_STATUSES)[number] {
@@ -10030,14 +10063,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       capturedAt: now,
     });
 
-    for (const { run } of activeRuns) {
+    // Record an honest per-run continuity note. A reattachable run (detached
+    // direct-spawn lane, real `processGroupId`) is genuinely left alive for the
+    // new server to adopt. A non-reattachable run (ACP-engine lane, null
+    // `processGroupId`) is NOT promised adoption — its in-process transport dies
+    // with this server; startup reconciliation finalizes it fail-closed and
+    // resumes its persisted ACP session on retry. Emitting the false
+    // "leaving child alive for startup adoption" promise for the latter is the
+    // exact behavior PAP-16219 repairs.
+    for (const { run, adapterType } of activeRuns) {
+      const reattachable = isReattachableHotRestartRun({
+        adapterType,
+        processGroupId: run.processGroupId ?? null,
+      });
       await appendRunEvent(run, await nextRunEventSeq(run.id), {
         eventType: "lifecycle",
         stream: "system",
         level: "info",
-        message: "Hot restart requested; leaving child process alive for startup adoption",
+        message: reattachable
+          ? "Hot restart requested; leaving child process alive for startup adoption"
+          : "Hot restart requested; ACP transport is not reattachable — run will be finalized and resumed on the new server",
         payload: {
           signal,
+          reattachable,
           previousServerPid: intent.previousServerPid,
           previousServerVersion: intentWithVersion.previousServerVersion,
           processPid: run.processPid ?? null,
@@ -10056,6 +10104,82 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       skipDrain: true as const,
       activeRunIds: snapshotRuns.map((run) => run.runId),
     };
+  }
+
+  // Fail-closed finalization for a tracked local run whose ACP stdio transport
+  // cannot be reattached across a restart (null `processGroupId`). Mirrors the
+  // shutdown drain's per-run body: mark the run interrupted, resolve its wakeup,
+  // release its environment/issue leases, and enqueue a process-loss retry that
+  // resumes the persisted ACP session on this server. Returns the interrupted run
+  // (or the unchanged run when it already left `running`, e.g. a graceful drain
+  // beat us to it). Never leaves the run `running` under a false adoption.
+  async function finalizeNonReattachableHotRestartRun(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    agent: typeof agents.$inferSelect;
+    intent: NonNullable<Awaited<ReturnType<typeof readHotRestartIntent>>>;
+    now: Date;
+  }): Promise<typeof heartbeatRuns.$inferSelect> {
+    const { run, agent, intent, now } = input;
+    if (run.status !== "running") return run;
+
+    const message =
+      "ACP transport is not reattachable across a paperclip.service restart; "
+      + "finalized while the server was down and queued a session-resume retry";
+    const interruptedStatus = await setRunStatusIfRunning(run.id, "interrupted", {
+      finishedAt: now,
+      error: message,
+      errorCode: "acp_transport_not_reattachable",
+      resultJson: mergeRunStopMetadataForAgent(agent, "interrupted", {
+        resultJson: parseObject(run.resultJson),
+        errorCode: "acp_transport_not_reattachable",
+        errorMessage: message,
+      }),
+    });
+    if (!interruptedStatus.updated || !interruptedStatus.run) {
+      // Another path (graceful drain, a racing reconcile) already finalized it.
+      return interruptedStatus.run ?? run;
+    }
+    let interrupted = interruptedStatus.run;
+
+    await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+      finishedAt: now,
+      error: null,
+    });
+    interrupted =
+      (await classifyAndPersistRunLiveness(interrupted, parseObject(interrupted.resultJson)))
+      ?? interrupted;
+
+    await releaseEnvironmentLeasesForRun({
+      runId: interrupted.id,
+      companyId: interrupted.companyId,
+      agentId: interrupted.agentId,
+      status: interrupted.status,
+      failureReason: interrupted.error ?? undefined,
+    });
+
+    const retry = await enqueueProcessLossRetry(interrupted, agent, now);
+    if (!retry) {
+      await releaseIssueExecutionAndPromote(interrupted);
+    }
+
+    await appendRunEvent(interrupted, await nextRunEventSeq(interrupted.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message,
+      payload: {
+        previousServerPid: intent.previousServerPid,
+        newServerPid: process.pid,
+        ...(run.processPid ? { processPid: run.processPid } : {}),
+        ...(retry ? { retryRunId: retry.id } : {}),
+      },
+    });
+
+    await finalizeAgentStatus(run.agentId, "interrupted", message, {
+      wasFirstHeartbeat: timerClaimWasFirstHeartbeat(run),
+    });
+
+    return interrupted;
   }
 
   async function reconcileHotRestartAdoption(now = new Date()) {
@@ -10100,7 +10224,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ? await db
         .select({
           run: heartbeatRuns,
-          adapterType: agents.adapterType,
+          agent: agents,
         })
         .from(heartbeatRuns)
         .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
@@ -10135,7 +10259,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         continue;
       }
 
-      const candidate = toHotRestartIntentRun(current);
+      const candidate = toHotRestartIntentRun({
+        run: current.run,
+        adapterType: current.agent.adapterType,
+      });
       if (current.run.status !== "running") {
         classify(candidate, "finalized_while_down", `run_status_${current.run.status}`);
       } else {
@@ -10157,12 +10284,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         continue;
       }
 
-      const { run, adapterType } = current;
+      const { run, agent } = current;
+      const adapterType = agent.adapterType;
+      const processPid = run.processPid ?? candidate.processPid;
+      const processGroupId = run.processGroupId ?? candidate.processGroupId;
       const patch = {
         adapterType,
         status: run.status,
-        processPid: run.processPid ?? candidate.processPid,
-        processGroupId: run.processGroupId ?? candidate.processGroupId,
+        processPid,
+        processGroupId,
       };
 
       if (run.status !== "running") {
@@ -10180,8 +10310,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         continue;
       }
 
-      const processPid = run.processPid ?? candidate.processPid;
-      const processGroupId = run.processGroupId ?? candidate.processGroupId;
+      // Fail-closed hot-restart contract for the ACP-engine local lane. A tracked
+      // local run with a null `processGroupId` drives its agent over an in-process
+      // stdio JSON-RPC transport that died with the previous server (stdin EOF).
+      // It cannot be adopted: the agent is gone, and "adopting" a bare pid would
+      // either promise a live run we cannot talk to or, worse, latch onto a
+      // recycled pid. Finalize it honestly as finalized_while_down and requeue a
+      // retry that resumes the persisted ACP session on this server — the durable
+      // handoff. Never classify it `lost` and never falsely `adopted`.
+      if (!isReattachableHotRestartRun({ adapterType, processGroupId })) {
+        const finalized = await finalizeNonReattachableHotRestartRun({
+          run,
+          agent,
+          intent,
+          now,
+        });
+        classify(candidate, "finalized_while_down", "acp_transport_not_reattachable", {
+          ...patch,
+          status: finalized?.status ?? run.status,
+        });
+        continue;
+      }
+
       const processPidAlive = isProcessAlive(processPid);
       const processGroupAlive = isProcessGroupAlive(processGroupId);
       if (!processPid && !processGroupId) {


### PR DESCRIPTION
## Summary

Repairs Paperclip hot-restart continuity for local ACPX-backed adapters (`codex_local`, `claude_local`, and the `gemini_local` default path) so a `paperclip.service` restart no longer falsely promises adoption and then loses live runs (the PAP-16215 incident: `lostRunIds` = 4, `adoptedRunIds`/`finalizedWhileDownRunIds` empty).

### Root cause

The ACP-engine lane drives its agent over an **in-process stdio JSON-RPC transport** owned by the server process and spawns the agent in the server's own process group, so it persists `processGroupId: null`. On restart the agent gets stdin EOF / stdout EPIPE and dies; the transport **cannot be reattached**. The previously-merged path nonetheless emitted "leaving child process alive for startup adoption" and then classified the dead run as `lost`. Adopting by bare pid is also unsafe (pid recycling).

The detached direct-spawn lane (`runChildProcess`) is different: it launches the agent in its own process group (non-null `processGroupId`), survives the server, and is genuinely adoptable. **The persisted `processGroupId` is therefore a clean per-run signal of which lane a run used** — no external spawn-behavior change needed.

### Change (fail-closed, per the issue's sanctioned path)

- **`reconcileHotRestartAdoption`** — a tracked local run with a null `processGroupId` is finalized `finalized_while_down` (reason `acp_transport_not_reattachable`), never `lost`, never bare-pid `adopted`, and a process-loss retry is queued so the **persisted ACP session resumes** on the new server (the durable handoff). Reattachable detached-lane runs (real `processGroupId`) still adopt live exactly as before.
- **`prepareHotRestartShutdown`** — stops emitting the false "leaving child alive for adoption" promise for null-pgid runs; emits an honest continuity note instead.
- **`acpx-engine/execute.ts`** — documents that `processGroupId: null` is a load-bearing invariant (do **not** detach the ACP spawn to force adoption — the stdio transport still dies with the server, so that only restores the false promise).
- **`doc/DEVELOPING.md`** — documents the two continuity lanes and the exact tradeoff.

### Success condition

A controlled hot restart with a live ACPX heartbeat now yields **empty `lostRunIds`**, records the original run in **`finalizedWhileDownRunIds`** with usable persisted process identity, and queues a session-resume retry.

## Tests

- New focused regressions for **both `codex_local` and `claude_local`** (real spawned-process boundary): fail-closed → `finalized_while_down`, empty `lostRunIds`, run `interrupted`, retry queued, no double-reap.
- Reattachable (detached-group) adoption path retained/covered.
- Updated the two tests that encoded the flawed bare-pid adoption.
- `git diff --check` clean; full **server `tsc --noEmit`** clean; suites: 119 (heartbeat-process-recovery + hot-restart + shutdown) + 100 (acpx-engine execute) pass.

## Notes

- Does **not** touch the live deployment / `/srv/paperclip/app`. Do not merge before review.
- The parent deploy **PAP-16215** stays blocked until this reaches `origin/master` and the live continuity test passes (that live test is a post-merge step owned by the deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)