### PR TITLE
fix(recovery): suppress wakes after terminal disposition

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -436,6 +436,37 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(run!.id)).toBe(1);
   });
 
+  it.each(["done", "cancelled"] as const)(
+    "does not create a recovery run when the locked source issue is terminal (%s)",
+    async (terminalStatus) => {
+      const { companyId, agentId } = await seedCompanyAndAgent();
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Terminal recovery source",
+        status: terminalStatus,
+        priority: "high",
+        assigneeAgentId: agentId,
+      });
+
+      const run = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_continuation_needed",
+        payload: { issueId },
+        contextSnapshot: { issueId, retryReason: "issue_continuation_needed" },
+        requestedByActorType: "system",
+        suppressIfIssueTerminal: true,
+      });
+
+      expect(run).toBeNull();
+      expect(mockAdapterExecute).not.toHaveBeenCalled();
+      await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
+      await expect(db.select().from(heartbeatRuns)).resolves.toHaveLength(0);
+    },
+  );
+
   it("allows legacy generic timer wakes by default when no skip policy is set", async () => {
     const { agentId } = await seedCompanyAndAgent({
       heartbeatConfig: {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -328,7 +328,50 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       sourceIssueId: sourceIssue.id,
       recoveryCause: "stranded_assigned_issue",
     });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ suppressIfIssueTerminal: true }),
+    );
   });
+
+  it.each(["done", "cancelled"] as const)(
+    "does not create a source recovery action or wake after the source reaches terminal status %s",
+    async (terminalStatus) => {
+      const { companyId, coderId, sourceIssue } = await seedCompany();
+      const enqueueWakeup = vi.fn(async () => null);
+      const recovery = recoveryService(db, { enqueueWakeup });
+      const latestRun = {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      } as const;
+
+      // Simulate reconciliation holding a pre-terminal snapshot while the
+      // source run persists its final disposition before recovery schedules.
+      await db.update(issues).set({ status: terminalStatus }).where(eq(issues.id, sourceIssue.id));
+
+      await expect(recovery.escalateStrandedAssignedIssue({
+        issue: sourceIssue,
+        previousStatus: "in_progress",
+        latestRun,
+        comment: "Automatic continuation recovery failed.",
+      })).resolves.toBeNull();
+
+      const [currentSource, actions, wakeups] = await Promise.all([
+        db.select({ status: issues.status }).from(issues).where(eq(issues.id, sourceIssue.id)),
+        db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id)),
+        db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, companyId)),
+      ]);
+      expect(currentSource[0]?.status).toBe(terminalStatus);
+      expect(actions).toHaveLength(0);
+      expect(wakeups).toHaveLength(0);
+      expect(enqueueWakeup).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ["process_lost", undefined, "coder"],

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2431,6 +2431,10 @@ interface WakeupOptions {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  // Automatic recovery must not enqueue a new run after the source task has
+  // reached a final disposition. Keep this opt-in so an authorized explicit
+  // resume can still reopen a terminal issue through its route-level flow.
+  suppressIfIssueTerminal?: boolean;
 }
 
 type UsageTotals = {
@@ -17195,6 +17199,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             idempotencyKey: opts.idempotencyKey ?? null,
             finishedAt: new Date(),
           });
+          return { kind: "skipped" as const };
+        }
+
+        // Re-check under the same issue-row lock used to enqueue the run. This
+        // closes the gap between recovery reconciliation's source read and the
+        // scheduler write, without changing explicit resume behavior.
+        if (opts.suppressIfIssueTerminal && (issue.status === "done" || issue.status === "cancelled")) {
           return { kind: "skipped" as const };
         }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2884,6 +2884,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause?: StrandedRecoveryCause;
     recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
+    recoveryActions?: ReturnType<typeof issueRecoveryActionService>;
   }) {
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
     const routing = await resolveStrandedRecoveryRouting({
@@ -2894,7 +2895,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
     const ownerAgentId = routing.ownerAgentId;
     const now = new Date();
-    const action = await recoveryActionsSvc.upsertSourceScoped({
+    const action = await (input.recoveryActions ?? recoveryActionsSvc).upsertSourceScoped({
       companyId: input.issue.companyId,
       sourceIssueId: input.issue.id,
       kind: strandedRecoveryActionKind(recoveryCause),
@@ -3322,17 +3323,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
-    // Reconciliation may hold an in-progress snapshot while the run completes
-    // its final disposition. Do not create a recovery action from that stale
-    // snapshot; the scheduler also rechecks under its enqueue lock.
-    const currentSource = await db
-      .select({ status: issues.status })
-      .from(issues)
-      .where(and(eq(issues.id, input.issue.id), eq(issues.companyId, input.issue.companyId)))
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-    if (!currentSource || currentSource.status === "done" || currentSource.status === "cancelled") return null;
-
     if (isStrandedIssueRecoveryIssue(input.issue)) {
       return escalateStrandedRecoveryIssueInPlace({
         issue: input.issue,
@@ -3342,14 +3332,47 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const recoveryCause = resolveStrandedRecoveryCause(input.latestRun, input.recoveryCause);
-    const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
-      issue: input.issue,
-      previousStatus: input.previousStatus,
-      latestRun: input.latestRun,
-      recoveryCause,
-      recoveryOwnerAgentId: input.recoveryOwnerAgentId,
-      successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
+    // Keep terminal disposition and recovery side effects in one source-row
+    // transaction. A final disposition that commits first makes this a no-op;
+    // one that races later observes the recovery transaction before the
+    // scheduler's terminal re-check.
+    const claimed = await db.transaction(async (tx) => {
+      await tx.execute(sql`
+        select id from issues
+        where id = ${input.issue.id} and company_id = ${input.issue.companyId}
+        for update
+      `);
+      const currentSource = await tx
+        .select({ status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.id, input.issue.id), eq(issues.companyId, input.issue.companyId)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (!currentSource || currentSource.status === "done" || currentSource.status === "cancelled") return null;
+
+      const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
+        issue: input.issue,
+        previousStatus: input.previousStatus,
+        latestRun: input.latestRun,
+        recoveryCause,
+        recoveryOwnerAgentId: input.recoveryOwnerAgentId,
+        successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+        recoveryActions: issueRecoveryActionService(tx as unknown as Db),
+      });
+      const [updated] = await tx
+        .update(issues)
+        .set({
+          status: "blocked",
+          assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
+          updatedAt: new Date(),
+        })
+        .where(and(eq(issues.id, input.issue.id), eq(issues.companyId, input.issue.companyId)))
+        .returning();
+      return updated ? { recoveryAction, updated } : null;
     });
+    if (!claimed) return null;
+    const { recoveryAction, updated } = claimed;
     const isProviderQuotaWait = recoveryCause === "provider_quota" &&
       !recoveryAction.ownerAgentId &&
       Boolean(recoveryAction.returnOwnerAgentId);
@@ -3361,13 +3384,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         agentId: recoveryAction.returnOwnerAgentId,
       });
     }
-    const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
-    const updated = await issuesSvc.update(input.issue.id, {
-      status: "blocked",
-      blockedByIssueIds: blockerIds,
-      assigneeAgentId: recoveryAction.ownerAgentId ?? input.issue.assigneeAgentId,
-    });
-    if (!updated) return null;
     if (isProviderQuotaWait) return updated;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -120,6 +120,7 @@ type RecoveryWakeupOptions = {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  suppressIfIssueTerminal?: boolean;
 };
 
 type RecoveryWakeup = (
@@ -1147,6 +1148,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       source: "automation",
       triggerDetail: "system",
       reason: input.reason,
+      suppressIfIssueTerminal: true,
       payload: withRecoveryModelProfileHint({
         issueId: input.issueId,
         ...(input.retryOfRunId ? { retryOfRunId: input.retryOfRunId } : {}),
@@ -2980,6 +2982,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       source: "assignment",
       triggerDetail: "system",
       reason: "source_scoped_recovery_action",
+      suppressIfIssueTerminal: true,
       idempotencyKey: `source_scoped_recovery_action:${input.action.id}:${input.action.attemptCount}`,
       payload: withRecoveryModelProfileHint({
         issueId: input.issue.id,
@@ -3319,6 +3322,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryOwnerAgentId?: string | null;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
+    // Reconciliation may hold an in-progress snapshot while the run completes
+    // its final disposition. Do not create a recovery action from that stale
+    // snapshot; the scheduler also rechecks under its enqueue lock.
+    const currentSource = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(and(eq(issues.id, input.issue.id), eq(issues.companyId, input.issue.companyId)))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!currentSource || currentSource.status === "done" || currentSource.status === "cancelled") return null;
+
     if (isStrandedIssueRecoveryIssue(input.issue)) {
       return escalateStrandedRecoveryIssueInPlace({
         issue: input.issue,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent work through issue status and heartbeat runs.
> - The recovery service creates automatic follow-up work for stranded issues.
> - Terminal source issues must not receive automatic follow-up work.
> - A final disposition can occur after recovery reconciliation reads a source issue.
> - This pull request checks terminal state before recovery side effects.
> - It also checks terminal state in the scheduler transaction before a run exists.
> - The benefit is that automatic recovery stops for terminal issues while an authorized resume flow remains available.

## Linked Issues or Issue Description

Related public pull requests: #6465, #5706.

**What happened?**

Automatic recovery could use a stale non-terminal issue snapshot. A source issue could then become done or cancelled before recovery created an action or scheduled a wake.

**Expected behavior**

Automatic recovery must create no recovery action, wake request, or heartbeat run for a source issue with a final status. An authorized explicit resume remains eligible through its existing route.

**Steps to reproduce**

1. Start automatic stranded-issue recovery from an in-progress source issue.
2. Persist `done` or `cancelled` on the source before recovery side effects run.
3. Observe the old check-then-write path create follow-up recovery work.

**Paperclip version or commit**

Built from the pull request head.

**Deployment mode**

Local development.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

## What Changed

- Re-read the company-scoped source issue before a source-scoped recovery action is created.
- Add an opt-in terminal-source guard to automatic recovery wake requests.
- Re-check the source state under the heartbeat enqueue transaction before a wake request or run is created.
- Cover stale source snapshots and scheduler suppression for both `done` and `cancelled`.

## Verification

- Focused recovery, scheduler, and explicit-resume tests: 147 passed.
- `git diff --check origin/master...HEAD` passed.
- Server typecheck reaches unrelated current-master errors in adapter-utils for `spawnCwd` and an implicit `chunk` type. This pull request does not change that package.

## Risks

Low risk. The new guard applies only to automatic recovery paths. It can suppress a stale automatic wake after terminal disposition. It does not change the explicit resume route. No migration or schema change exists. A server restart or deploy is required for the new guard.

## Model Used

OpenAI Codex, `gpt-5.6-terra`, with repository tools and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (not needed for this internal guard)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
