### PR TITLE
fix(adapters): stop benign CLI banners masking the real run error

### DIFF
--- a/packages/adapter-utils/src/benign-stderr.test.ts
+++ b/packages/adapter-utils/src/benign-stderr.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { firstMeaningfulStderrLine, isBenignAdapterStderrLine } from "./benign-stderr.js";
+
+const YOLO = "YOLO mode is enabled. All tool calls will be automatically approved.";
+
+describe("isBenignAdapterStderrLine", () => {
+  it("treats the approvals-bypass banner as benign", () => {
+    expect(isBenignAdapterStderrLine(YOLO)).toBe(true);
+  });
+
+  it("treats adapter-injected diagnostics as benign", () => {
+    expect(isBenignAdapterStderrLine("[paperclip] Confining the agent to the workspace.")).toBe(true);
+  });
+
+  it("never treats a real failure as benign", () => {
+    expect(isBenignAdapterStderrLine("Error: boom")).toBe(false);
+    expect(
+      isBenignAdapterStderrLine(
+        "GEMINI_SANDBOX is true but failed to determine command for sandbox; install docker or podman",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("firstMeaningfulStderrLine", () => {
+  it("skips banners to reach the real error", () => {
+    expect(firstMeaningfulStderrLine(`${YOLO}\nError: boom`)).toBe("Error: boom");
+  });
+
+  it("skips the exact production stack of banners", () => {
+    const stderr = [
+      "[paperclip] Adapter execution timeout: timeoutSec=14400 (sandbox default).",
+      "[paperclip] Gemini ACP default unavailable; falling back to Gemini CLI.",
+      YOLO,
+      "GEMINI_SANDBOX is true but failed to determine command for sandbox; install docker or podman",
+    ].join("\n");
+    expect(firstMeaningfulStderrLine(stderr)).toBe(
+      "GEMINI_SANDBOX is true but failed to determine command for sandbox; install docker or podman",
+    );
+  });
+
+  it("falls back to the first line when every line is benign", () => {
+    expect(firstMeaningfulStderrLine(`${YOLO}\n[paperclip] note\n`)).toBe(YOLO);
+  });
+
+  it("returns an empty string for empty or whitespace input", () => {
+    expect(firstMeaningfulStderrLine("")).toBe("");
+    expect(firstMeaningfulStderrLine(" \n\t\n")).toBe("");
+  });
+
+  it("strips ANSI colour codes before matching", () => {
+    expect(firstMeaningfulStderrLine(`${YOLO}\n[31mError: boom[0m`)).toBe("Error: boom");
+  });
+});

--- a/packages/adapter-utils/src/benign-stderr.ts
+++ b/packages/adapter-utils/src/benign-stderr.ts
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------
+// Benign adapter stderr lines
+//
+// When a CLI agent exits non-zero without a structured error, adapters fall
+// back to the first stderr line as the user-facing run error. That line is
+// often a startup banner the adapter itself provoked (the approvals-bypass
+// warning it enabled, or a "[paperclip] ..." diagnostic it injected), which
+// then masks the real cause. Production spent weeks reporting "YOLO mode is
+// enabled" as the failure of every Gemini run whose real error was a sandbox
+// misconfiguration two lines lower.
+//
+// Keep this list conservative: a pattern listed here can hide a real error.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_RE = /\[[0-9;]*m/g;
+
+const BENIGN_STDERR_LINE_RES: readonly RegExp[] = [
+  // Every adapter that runs unattended passes an approvals-bypass flag, so the
+  // agent CLI always prints this. It is never the reason a run failed.
+  /^YOLO mode is enabled\b/i,
+  // Diagnostics the adapter itself wrote (ACP fallback notes, timeout notes,
+  // sandbox suppression notes).
+  /^\[paperclip\]/,
+];
+
+function normalizeStderrLine(line: string): string {
+  return line.replace(ANSI_ESCAPE_RE, "").trim();
+}
+
+export function isBenignAdapterStderrLine(line: string): boolean {
+  const normalized = normalizeStderrLine(line);
+  if (!normalized) return true;
+  return BENIGN_STDERR_LINE_RES.some((re) => re.test(normalized));
+}
+
+/**
+ * The first stderr line that could plausibly explain a failure. Falls back to
+ * the first non-empty line when every line is a benign banner, so a run whose
+ * only output is a banner still reports something rather than nothing.
+ */
+export function firstMeaningfulStderrLine(text: string): string {
+  const lines = text.split(/\r?\n/).map(normalizeStderrLine).filter(Boolean);
+  return lines.find((line) => !isBenignAdapterStderrLine(line)) ?? lines[0] ?? "";
+}

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -69,6 +69,10 @@ export {
   redactCommandText,
   redactDiagnosticText,
 } from "./command-redaction.js";
+export {
+  firstMeaningfulStderrLine,
+  isBenignAdapterStderrLine,
+} from "./benign-stderr.js";
 export { buildSandboxNpmInstallCommand } from "./sandbox-install-command.js";
 export {
   buildAdapterEnvConfig,

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -64,6 +64,10 @@ export {
   REDACTED_COMMAND_TEXT_VALUE,
   redactCommandText,
 } from "./command-redaction.js";
+export {
+  firstMeaningfulStderrLine,
+  isBenignAdapterStderrLine,
+} from "./benign-stderr.js";
 export { buildSandboxNpmInstallCommand } from "./sandbox-install-command.js";
 export { createRuntimeProgressReporter } from "./runtime-progress.js";
 export type {

--- a/packages/adapters/codex-local/src/server/execute.stderr-error.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.stderr-error.test.ts
@@ -76,7 +76,8 @@ vi.mock("./runtime-config.js", async () => {
   };
 });
 
-import { execute, firstMeaningfulStderrLine } from "./execute.js";
+import { firstMeaningfulStderrLine } from "@paperclipai/adapter-utils";
+import { execute } from "./execute.js";
 
 function mockFailedProcess(stderr: string) {
   runAdapterExecutionTargetProcess.mockImplementation(async () => ({

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import {
@@ -125,38 +130,6 @@ function stripCodexRolloutNoise(text: string): string {
     kept.push(part);
   }
   return kept.join("\n");
-}
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
-
-// Benign stderr lines that never explain a nonzero exit and must not be
-// surfaced as the run error: Codex always prints the YOLO approvals warning
-// because this adapter passes the approvals-bypass flag itself, and
-// "[paperclip] ..." lines are diagnostics the adapter injected (e.g. ACP
-// fallback notes). Keep this list conservative so real errors are never
-// skipped.
-const BENIGN_CODEX_STDERR_LINE_RES: readonly RegExp[] = [
-  /^YOLO mode is enabled\b/i,
-  /^\[paperclip\]/,
-];
-
-function isBenignCodexStderrLine(line: string): boolean {
-  return BENIGN_CODEX_STDERR_LINE_RES.some((re) => re.test(line));
-}
-
-export function firstMeaningfulStderrLine(text: string): string {
-  const meaningful = text
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line && !isBenignCodexStderrLine(line));
-  return meaningful ?? firstNonEmptyLine(text);
 }
 
 function signalCodexChild(

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import {
@@ -117,15 +122,6 @@ function stripCodexRolloutNoise(text: string): string {
     kept.push(part);
   }
   return kept.join("\n");
-}
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
 }
 
 function signalCodexChild(
@@ -1354,7 +1350,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         } as Record<string, unknown>)
         : null;
       const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const fallbackErrorMessage =
         parsedError ||
         stderrLine ||

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -57,15 +62,6 @@ import { hasCursorTrustBypassArg } from "../shared/trust.js";
 import { resolveCursorSkillsHome } from "./skills.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
@@ -709,7 +705,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         } as Record<string, unknown>)
       : null;
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
     const fallbackErrorMessage =
       parsedError ||
       stderrLine ||

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -52,15 +57,6 @@ import { normalizeCursorStreamLine } from "../shared/stream.js";
 import { hasCursorTrustBypassArg } from "../shared/trust.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
@@ -697,7 +693,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         } as Record<string, unknown>)
       : null;
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
     const fallbackErrorMessage =
       parsedError ||
       stderrLine ||

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -3,6 +3,7 @@ import type { Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { firstMeaningfulStderrLine } from "@paperclipai/adapter-utils";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -61,7 +62,6 @@ import {
   isGeminiSessionUnrecoverableError,
   parseGeminiJsonl,
 } from "./parse.js";
-import { firstNonEmptyLine } from "./utils.js";
 import {
   createGeminiAcpExecutor,
   formatGeminiAcpFallbackMessage,
@@ -678,7 +678,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
 
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
     const structuredFailure = attempt.parsed.resultEvent
       ? describeGeminiFailure(attempt.parsed.resultEvent)
       : null;

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -3,6 +3,7 @@ import type { Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { firstMeaningfulStderrLine } from "@paperclipai/adapter-utils";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -57,7 +58,6 @@ import {
   isGeminiSessionUnrecoverableError,
   parseGeminiJsonl,
 } from "./parse.js";
-import { firstNonEmptyLine } from "./utils.js";
 import {
   createGeminiAcpExecutor,
   formatGeminiAcpFallbackMessage,
@@ -663,7 +663,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
 
     const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
     const structuredFailure = attempt.parsed.resultEvent
       ? describeGeminiFailure(attempt.parsed.resultEvent)
       : null;

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { firstMeaningfulStderrLine } from "@paperclipai/adapter-utils";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -46,15 +47,6 @@ import { resolveManagedGrokHomeDir, stageGrokHomeForSync } from "./grok-home.js"
 import { isGrokUnknownSessionError, parseGrokJsonl } from "./parse.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
@@ -576,7 +568,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
       const failed = (attempt.proc.exitCode ?? 0) !== 0;
       const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const fallbackErrorMessage =
         parsedError ||
         stderrLine ||

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { firstMeaningfulStderrLine } from "@paperclipai/adapter-utils";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
@@ -43,15 +44,6 @@ import { DEFAULT_GROK_LOCAL_MODEL } from "../index.js";
 import { isGrokUnknownSessionError, parseGrokJsonl } from "./parse.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
   const raw = env[key];
@@ -511,7 +503,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
       const failed = (attempt.proc.exitCode ?? 0) !== 0;
       const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const fallbackErrorMessage =
         parsedError ||
         stderrLine ||

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -672,7 +677,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         : null;
 
       const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
       const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
       const fallbackErrorMessage =

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -653,7 +658,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         : null;
 
       const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
       const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
       const fallbackErrorMessage =

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -60,15 +65,6 @@ const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 const PAPERCLIP_SESSIONS_DIR = path.join(os.homedir(), ".pi", "paperclips");
 const PI_AGENT_SKILLS_DIR = path.join(os.homedir(), ".pi", "agent", "skills");
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function parseModelProvider(model: string | null): string | null {
   if (!model) return null;
@@ -773,7 +769,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           }
         : null;
 
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
       const parsedError = attempt.parsed.errors.find((error) => error.trim().length > 0) ?? "";
       const effectiveExitCode = (rawExitCode ?? 0) === 0 && parsedError ? 1 : rawExitCode;

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -2,7 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  firstMeaningfulStderrLine,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -56,15 +61,6 @@ const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
 const PAPERCLIP_SESSIONS_DIR = path.join(os.homedir(), ".pi", "paperclips");
 const PI_AGENT_SKILLS_DIR = path.join(os.homedir(), ".pi", "agent", "skills");
-
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
-  );
-}
 
 function parseModelProvider(model: string | null): string | null {
   if (!model) return null;
@@ -762,7 +758,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           }
         : null;
 
-      const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+      const stderrLine = firstMeaningfulStderrLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
       const parsedError = attempt.parsed.errors.find((error) => error.trim().length > 0) ?? "";
       const effectiveExitCode = (rawExitCode ?? 0) === 0 && parsedError ? 1 : rawExitCode;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each `*-local` adapter shells out to an agent CLI and turns the exit into a run result the user reads in the UI
> - When the CLI exits non-zero without a structured error, the adapters fall back to `firstNonEmptyLine(stderr)` as the user-facing error
> - Line 1 of stderr is very often a startup banner the adapter itself provoked, so the banner is reported as the failure and the real cause never reaches anyone
> - This pull request adds a shared `firstMeaningfulStderrLine` that skips known-benign banners, and adopts it in the six adapters that derive a fallback error this way
> - The benefit is that a failed run reports the line that actually explains it, which is the difference between a user fixing their config and a user filing a support ticket

## Linked Issues or Issue Description

No existing issue. Describing it inline, following `.github/ISSUE_TEMPLATE/bug_report.yml`:

**What happened?**
Every failed `gemini_local` run reported its cause as `YOLO mode is enabled. All tool calls will be automatically approved.` That sentence is a startup banner the Gemini CLI prints because the adapter passes `--approval-mode yolo` itself. It is never a failure reason. The line that actually explained the failure was two lines lower in stderr and never reached a user.

**Expected behavior**
A failed run reports the stderr line that plausibly explains the failure, not a startup banner the adapter provoked.

**Steps to reproduce**
1. Configure a `gemini_local` agent so its run will fail at CLI startup (for example on a target with no container runtime and `adapterConfig.sandbox` set, which makes the CLI exit non-zero with a sandbox error).
2. Dispatch a run and let it fail.
3. Read the run's error in the UI or in `heartbeat_runs.error`.
4. Observe the error is the YOLO banner. The real cause is only visible in the full stderr.

**Paperclip version or commit**
`master` at 18f391ef0. Also present in every released version that carries these adapters.

**Deployment mode**
Reproduced on a self-hosted multi-tenant deployment; the code path is deployment independent.

**Installation method**
Docker image built from source.

**Agent adapter(s) involved**
`gemini_local` observed; `grok_local`, `opencode_local`, `cursor`, `pi_local` share the identical fallback. `codex_local` already carried a private filter.

**Database mode**
PostgreSQL.

**Access context**
Server-side adapter execution.

**Node.js version**
22.

**Operating system**
Linux (container).

**Relevant logs or output**
```
[paperclip] Gemini ACP default unavailable; falling back to Gemini CLI.
YOLO mode is enabled. All tool calls will be automatically approved.
GEMINI_SANDBOX is true but failed to determine command for sandbox; install docker or podman
```
Reported run error: `YOLO mode is enabled. All tool calls will be automatically approved.`
Actual cause: line 3.

**Relevant config**
Not config dependent. Any non-zero exit without a structured error hits this path.

**Additional context**
The banner is unavoidable: adapters pass the approvals-bypass flag themselves, so the CLI prints it on every unattended run.

## What Changed

- Adds `packages/adapter-utils/src/benign-stderr.ts` with `isBenignAdapterStderrLine` and `firstMeaningfulStderrLine`: the first stderr line that is not a known-benign banner, falling back to the first non-empty line when every line is benign, so a run whose only output is a banner still reports something rather than nothing.
- Strips ANSI SGR codes before matching, since agent CLIs colour their fatal errors.
- Keeps the benign list to two conservative patterns (the approvals banner, and adapter-injected `[paperclip] ...` diagnostics), because anything listed here can hide a real error.
- Re-exports both from the package index.
- Adopts the selector in `codex`, `gemini`, `grok`, `opencode`, `cursor` and `pi`, at the single call site in each that derives the user-facing fallback error. Other `firstNonEmptyLine` uses (probe details and similar) are untouched.
- Removes the now-dead local helpers, including `codex-local`'s private version.

## Verification

- `npx vitest run packages/adapter-utils/src/benign-stderr.test.ts` — 8 tests covering benign filtering, reaching the real error, the exact production stderr stack above, the all-benign fallback, empty and whitespace input, and ANSI stripping.
- `npx vitest run packages/adapters/codex-local/src/server/execute.stderr-error.test.ts` — codex-local's pre-existing regression suite passes **unchanged**, which is the evidence that the shared helper is behaviour-compatible with the private one it replaces.
- Full suites for all six adapters plus `adapter-utils` run clean against the pre-existing baseline on this machine (the same set of platform-gated `local-process-sandbox` failures appears with and without this change).

## Risks

Low, with one thing to watch: the benign list decides which stderr line a user sees, so a pattern that is too broad could hide a real error. It is deliberately limited to two anchored patterns that no genuine failure message starts with, and the all-benign fallback means the selector can never return less information than the previous behaviour did. Structured-error precedence (`parsedError` and friends) is untouched in every adapter, so this only affects the fallback path.

## Model Used

Claude Opus 5 (claude-opus-5, 1M context), extended thinking, with tool use and code execution. The production stderr in this PR came from querying a live deployment; the gemini-cli behaviour referenced was reproduced locally against `@google/gemini-cli@0.53.1`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
