### PR TITLE
fix(logger): redact credentials sent in unsupported auth headers

### DIFF
--- a/server/src/__tests__/http-log-redaction.test.ts
+++ b/server/src/__tests__/http-log-redaction.test.ts
@@ -15,6 +15,8 @@ describe("HTTP logger redaction", () => {
     expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-csrf-token"]');
     expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-xsrf-token"]');
     expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-api-key"]');
+    expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["api-key"]');
+    expect(HTTP_LOG_REDACT_PATHS).toContain('req.headers["x-auth-token"]');
   });
 
   it("redacts request and response header secrets from pino-http output", async () => {
@@ -82,5 +84,72 @@ describe("HTTP logger redaction", () => {
     expect(log.req.headers.cookie).toBe("[Redacted]");
     expect(log.req.headers["set-cookie"]).toBe("[Redacted]");
     expect(log.res.headers["set-cookie"]).toBe("[Redacted]");
+  });
+
+  it("redacts credentials sent in unsupported auth headers", async () => {
+    const chunks: string[] = [];
+    const stream = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk.toString());
+        callback();
+      },
+    });
+    const logger = pino({ redact: [...HTTP_LOG_REDACT_PATHS] }, stream);
+    const httpLogger = pinoHttp({ logger });
+    const server = createServer((req, res) => {
+      httpLogger(req, res);
+      // The request carries no supported credential, so it is rejected — but
+      // the HTTP logger still writes the request headers on that path.
+      res.statusCode = 401;
+      res.end("unauthorized");
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => resolve());
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected server to listen on an ephemeral TCP port");
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const client = request(
+          {
+            hostname: "127.0.0.1",
+            port: address.port,
+            path: "/unsupported-auth-header",
+            headers: {
+              "x-api-key": "x-api-key-secret",
+              "api-key": "api-key-secret",
+              "x-auth-token": "x-auth-token-secret",
+            },
+          },
+          (res) => {
+            res.resume();
+            res.on("end", resolve);
+          },
+        );
+        client.on("error", reject);
+        client.end();
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+
+    const output = chunks.join("");
+    expect(output).not.toMatch(/x-api-key-secret|api-key-secret|x-auth-token-secret/);
+
+    const log = JSON.parse(output.trim()) as {
+      req: { headers: Record<string, string> };
+    };
+    expect(log.req.headers["x-api-key"]).toBe("[Redacted]");
+    expect(log.req.headers["api-key"]).toBe("[Redacted]");
+    expect(log.req.headers["x-auth-token"]).toBe("[Redacted]");
   });
 });

--- a/server/src/middleware/http-log-redaction.ts
+++ b/server/src/middleware/http-log-redaction.ts
@@ -9,5 +9,11 @@ export const HTTP_LOG_REDACT_PATHS = [
   // Credential- and session-paired headers with no debugging value.
   'req.headers["x-csrf-token"]',
   'req.headers["x-xsrf-token"]',
+  // Auth-shaped headers the server does not accept as credentials. They are
+  // still logged with the request, including on the rejected response, so a
+  // credential a caller put in the wrong header would otherwise be written
+  // out in clear text.
   'req.headers["x-api-key"]',
+  'req.headers["api-key"]',
+  'req.headers["x-auth-token"]',
 ] as const;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server logs every HTTP request through `pino-http`, and `HTTP_LOG_REDACT_PATHS` (`server/src/middleware/http-log-redaction.ts`) is the single place that says which headers must never reach the log
> - That list covers `authorization`, `cookie`, the CSRF pair and `x-api-key` — but not `api-key` and not `x-auth-token`
> - Neither of those is accepted as a credential, so a request carrying one is never authenticated; but the HTTP logger writes request headers regardless of the response status, so a caller who reaches for the wrong header name has their credential persisted to the request log in clear text
> - This is a plain gap in an existing allow-list, not a behaviour change: the two names sit next to `x-api-key`, which is already redacted for exactly this reason
> - This pull request adds the two missing paths and extends the existing round-trip test to assert all three are redacted on a request that is answered with a 401
> - The benefit is that a mistyped credential no longer survives in the request log

## Linked Issues or Issue Description

No existing issue — describing it here as a bug report.

**What happened:** A request sent with `api-key: <secret>` or `x-auth-token: <secret>` has that value written verbatim into the HTTP request log.

**What I expected:** The value is replaced with `[Redacted]`, the same way `x-api-key` already is.

**Reproduction** — before this change, against `server/src/__tests__/http-log-redaction.test.ts` extended with the new case:

```
{"req":{"method":"GET","url":"/unsupported-auth-header","headers":{
  "x-api-key":"[Redacted]",
  "api-key":"api-key-secret",
  "x-auth-token":"x-auth-token-secret", ...}},
 "res":{"statusCode":401}, "msg":"request completed"}
```

`x-api-key` is redacted; the other two are not.

**Version:** `master` (verified at `18f391ef0`; the touched files are byte-identical between this PR's base and that commit).

Refs #10430 — that PR rejects the same three header names in `actorMiddleware`. It is independent of this one: it touches `server/src/middleware/auth.ts` only, this one touches `http-log-redaction.ts` only, and the two do not overlap. The leak fixed here exists whether or not #10430 lands, because the logger writes the headers on the rejected path too. If #10430 merges, folding the two lists into one shared constant would be a reasonable small follow-up.

## What Changed

- `server/src/middleware/http-log-redaction.ts`: add `req.headers["api-key"]` and `req.headers["x-auth-token"]` to `HTTP_LOG_REDACT_PATHS`, with a comment explaining why these auth-shaped-but-unsupported headers belong on the list.
- `server/src/__tests__/http-log-redaction.test.ts`: assert both new paths are present, and add a `pino-http` round-trip case that sends all three headers on a request answered with a 401 and asserts each is `[Redacted]` and that no secret value appears anywhere in the log output.

Additions only — 75 inserted lines, 0 deleted.

## Verification

```
cd server && npx vitest run src/__tests__/http-log-redaction.test.ts
```

- Against unmodified `http-log-redaction.ts`: **2 failed, 1 passed** — the constant test fails on `api-key`, and the round-trip test fails with the plaintext log line quoted above.
- With the change: **3 passed**.

The redaction paths use the same bracketed `req.headers["…"]` form `pino` already requires for the hyphenated names on the list, so the round-trip test (not just the `toContain` assertion) is what proves the paths are actually effective.

## Risks

Low risk. The change is two additional entries in a redaction allow-list. It cannot reject or alter a request; the only observable effect is that two header values are written as `[Redacted]` instead of their raw value. There is no debugging value in the raw value of a header the server does not accept as a credential.

Note on the base commit: this branch is based on `4eace88f6` rather than the current `master` tip. My GitHub token has no `workflow` scope, so a branch based on the tip cannot be pushed to my fork. The three files involved (`http-log-redaction.ts`, its test, and `logger.ts`) are unchanged between `4eace88f6` and `master`, so this merges cleanly — but a maintainer with `workflow` scope will need to click "Update branch" if CI requires a current base.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, with tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no user-facing docs describe this list; the rationale is carried in a code comment
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
