### PR TITLE
fix(authz): allow current run checkout mutations

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -6,6 +6,7 @@ import {
   companies,
   companyMemberships,
   createDb,
+  heartbeatRuns,
   instanceUserRoles,
   issueComments,
   issues,
@@ -19,6 +20,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { authorizationService } from "../services/authorization.js";
+import { issueService } from "../services/issues.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -178,6 +180,7 @@ describeEmbeddedPostgres("authorization service", () => {
     await db.delete(companyMemberships);
     await db.delete(instanceUserRoles);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(projects);
     await db.delete(companies);
@@ -811,6 +814,78 @@ describeEmbeddedPostgres("authorization service", () => {
       allowed: false,
       code: "RESPONSIBLE_USER_UNAUTHORIZED",
       reason: "deny_unsupported_action",
+    });
+  });
+
+  it("allows a run-scoped agent to comment on and mutate its current checked-out issue", async () => {
+    const company = await createCompany(db, "RunScopedCurrentIssueMutation");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const currentIssue = await createIssue(db, company.id, {
+      title: "Current checked-out issue",
+      assigneeAgentId: actorAgent.id,
+      status: "todo",
+    });
+    const otherAssignedIssue = await createIssue(db, company.id, {
+      title: "Other assigned issue",
+      assigneeAgentId: actorAgent.id,
+    });
+    const [run] = await db.insert(heartbeatRuns).values({
+      companyId: company.id,
+      agentId: actorAgent.id,
+      status: "running",
+      contextSnapshot: { issueId: currentIssue.id },
+    }).returning();
+    const checkedOut = await issueService(db).checkout(
+      currentIssue.id,
+      actorAgent.id,
+      ["todo"],
+      run!.id,
+    );
+    expect(checkedOut).toMatchObject({
+      id: currentIssue.id,
+      status: "in_progress",
+      assigneeAgentId: actorAgent.id,
+      checkoutRunId: run!.id,
+    });
+
+    const actor = {
+      type: "agent" as const,
+      agentId: actorAgent.id,
+      companyId: company.id,
+      runId: run!.id,
+      onBehalfOfUserId: `missing-${randomUUID()}`,
+      source: "agent_jwt" as const,
+    };
+    const currentResource = {
+      type: "issue" as const,
+      companyId: company.id,
+      issueId: currentIssue.id,
+      assigneeAgentId: actorAgent.id,
+    };
+
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:comment",
+      resource: currentResource,
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_self" });
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:mutate",
+      resource: currentResource,
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_self" });
+
+    await expect(authorizationService(db).decide({
+      actor,
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: otherAssignedIssue.id,
+        assigneeAgentId: actorAgent.id,
+      },
+    })).resolves.toMatchObject({
+      allowed: false,
+      code: "RESPONSIBLE_USER_UNAVAILABLE",
     });
   });
 

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2230,6 +2230,35 @@ export function authorizationService(db: Db) {
       return agentDecision;
     }
 
+    // Checkout is deliberately available before issue-mutation authorization.
+    // Once this exact run has checked out its context issue, preserve that
+    // run-scoped ownership grant even if its responsible user is unavailable.
+    // Requiring all three persisted bindings keeps the carve-out from applying
+    // to another issue merely because it has the same assignee.
+    if (
+      agentDecision.reason === "allow_self" &&
+      (input.action === "issue:comment" || input.action === "issue:mutate") &&
+      input.resource.type === "issue" &&
+      input.resource.issueId &&
+      input.actor.agentId &&
+      input.actor.runId
+    ) {
+      const runIssueId = await loadRunIssueId(
+        input.actor.runId,
+        input.resource.companyId,
+        input.actor.agentId,
+      );
+      if (runIssueId === input.resource.issueId) {
+        const runIssue = await loadIssue(runIssueId);
+        if (
+          runIssue?.assigneeAgentId === input.actor.agentId &&
+          runIssue.checkoutRunId === input.actor.runId
+        ) {
+          return agentDecision;
+        }
+      }
+    }
+
     const companyId = companyIdForResource(input.resource);
     const snapshot = await getResponsibleUserSnapshot({
       actor: input.actor,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent work through issues and run-scoped credentials.
> - Issue checkout binds one agent run to one active issue.
> - The responsible-user intersection applies an additional authorization check to agent JWT writes.
> - Checkout did not use that write check, so checkout could succeed before the same run's issue update failed.
> - The repair must not authorize another issue that has the same assignee.
> - This pull request preserves the write grant only when the run context, assignee, and checkout lock all match the target issue.
> - The benefit is a consistent checkout-to-update workflow with no company-wide authority increase.

## Linked Issues or Issue Description

Refs #8906 as related work on bounded issue update authority. This change is narrower and applies only to the current checked-out run issue.

**What happened?**

A run-scoped agent could check out its assigned issue. A later comment or issue mutation could fail at the responsible-user authorization intersection.

**Expected behavior**

The same run can comment on and mutate the issue that it currently owns. Another issue with the same assignee remains outside this exception.

**Steps to reproduce**

1. Start a run JWT for an assigned `todo` issue.
2. Check out the issue with that run.
3. Use the same run JWT to add a comment or update the issue.
4. Observe that the authorization intersection rejects the write when its responsible user is unavailable.

**Paperclip version or commit**

The issue reproduces on v2026.722.0. The regression test runs on current `master`.

## What Changed

- Preserve `allow_self` for issue comments and mutations when the run context names the target issue.
- Require the stored assignee and checkout run to match the authenticated actor and run.
- Add a regression test that performs checkout and verifies comment and mutation authorization.
- Verify that another issue with the same assignee stays denied.

## Verification

- `pnpm exec vitest run server/src/__tests__/authorization-service.test.ts` — passed, 51 tests.
- `pnpm --filter @paperclipai/server typecheck` — blocked by stale local workspace dependency links. The plugin SDK cannot resolve its React type link.
- `pnpm exec tsc -p server/tsconfig.json --noEmit` — blocked by the same stale generated workspace package outputs. The errors are outside this two-file change.
- This repository has no `bin/ci` script.

## Risks

- Low risk. The exception requires the run issue ID, assignee ID, and checkout run ID to match persisted state.
- Responsible-user checks still apply to other assigned issues, peer issues, and non-issue actions.
- No schema or migration changes are included.

> This fix does not overlap with planned core work in `ROADMAP.md`.

## Model Used

- OpenAI Codex, GPT-5 agentic coding model, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run the focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation update is required for this internal authorization correction
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
