### PR TITLE
fix(approvals): bind agent secrets on hire approval (COD-362)

### DIFF
--- a/server/src/__tests__/approvals-service.test.ts
+++ b/server/src/__tests__/approvals-service.test.ts
@@ -5,12 +5,21 @@ const mockAgentService = vi.hoisted(() => ({
   activatePendingApproval: vi.fn(),
   create: vi.fn(),
   terminate: vi.fn(),
+  getById: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  syncEnvBindingsForTarget: vi.fn(),
 }));
 
 const mockNotifyHireApproved = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/agents.js", () => ({
   agentService: vi.fn(() => mockAgentService),
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: vi.fn(() => mockSecretService),
 }));
 
 vi.mock("../services/hire-hook.js", () => ({
@@ -26,13 +35,13 @@ type ApprovalRecord = {
   requestedByAgentId: string | null;
 };
 
-function createApproval(status: string): ApprovalRecord {
+function createApproval(status: string, payload: Record<string, unknown> = { agentId: "agent-1" }): ApprovalRecord {
   return {
     id: "approval-1",
     companyId: "company-1",
     type: "hire_agent",
     status,
-    payload: { agentId: "agent-1" },
+    payload,
     requestedByAgentId: "requester-1",
   };
 }
@@ -61,6 +70,8 @@ describe("approvalService resolution idempotency", () => {
     mockAgentService.activatePendingApproval.mockResolvedValue(undefined);
     mockAgentService.create.mockResolvedValue({ id: "agent-1" });
     mockAgentService.terminate.mockResolvedValue(undefined);
+    mockAgentService.getById.mockResolvedValue({ id: "agent-1", adapterConfig: {} });
+    mockSecretService.syncEnvBindingsForTarget.mockResolvedValue([]);
     mockNotifyHireApproved.mockResolvedValue(undefined);
   });
 
@@ -103,5 +114,85 @@ describe("approvalService resolution idempotency", () => {
     expect(result.applied).toBe(true);
     expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1");
     expect(mockNotifyHireApproved).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("approvalService hire secret bindings (COD-362)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentService.activatePendingApproval.mockResolvedValue(undefined);
+    mockAgentService.create.mockResolvedValue({ id: "agent-created" });
+    mockAgentService.terminate.mockResolvedValue(undefined);
+    mockSecretService.syncEnvBindingsForTarget.mockResolvedValue([]);
+    mockNotifyHireApproved.mockResolvedValue(undefined);
+  });
+
+  it("writes secret bindings on the activatePendingApproval branch (approval carries an agentId)", async () => {
+    const approved = createApproval("approved", { agentId: "agent-1" });
+    const dbStub = createDbStub([[createApproval("pending")]], [approved]);
+
+    const env = { OMNI_KEY: { type: "secret_ref", secretId: "sec-omni", version: "latest" } };
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-1",
+      adapterConfig: { env },
+    });
+
+    const svc = approvalService(dbStub.db as any);
+    const result = await svc.approve("approval-1", "board", "ship it");
+
+    expect(result.applied).toBe(true);
+    expect(mockAgentService.activatePendingApproval).toHaveBeenCalledWith("agent-1");
+    expect(mockAgentService.getById).toHaveBeenCalledWith("agent-1");
+    expect(mockSecretService.syncEnvBindingsForTarget).toHaveBeenCalledTimes(1);
+    expect(mockSecretService.syncEnvBindingsForTarget).toHaveBeenCalledWith(
+      "company-1",
+      { targetType: "agent", targetId: "agent-1" },
+      env,
+    );
+  });
+
+  it("writes secret bindings on the create branch (approval has no agentId)", async () => {
+    const approved = createApproval("approved", {
+      name: "New Agent",
+      role: "general",
+      adapterType: "claude_local",
+    });
+    const dbStub = createDbStub([[createApproval("pending")]], [approved]);
+
+    const env = { OMNI_KEY: { type: "secret_ref", secretId: "sec-omni", version: "latest" } };
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-created",
+      companyId: "company-1",
+      adapterConfig: { env },
+    });
+
+    const svc = approvalService(dbStub.db as any);
+    const result = await svc.approve("approval-1", "board", "ship it");
+
+    expect(result.applied).toBe(true);
+    expect(mockAgentService.create).toHaveBeenCalledTimes(1);
+    expect(mockAgentService.getById).toHaveBeenCalledWith("agent-created");
+    expect(mockSecretService.syncEnvBindingsForTarget).toHaveBeenCalledWith(
+      "company-1",
+      { targetType: "agent", targetId: "agent-created" },
+      env,
+    );
+  });
+
+  it("does not call the secret sync when the hired agent has no env", async () => {
+    const approved = createApproval("approved", { agentId: "agent-1" });
+    const dbStub = createDbStub([[createApproval("pending")]], [approved]);
+
+    mockAgentService.getById.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-1",
+      adapterConfig: {},
+    });
+
+    const svc = approvalService(dbStub.db as any);
+    await svc.approve("approval-1", "board", "ship it");
+
+    expect(mockSecretService.syncEnvBindingsForTarget).not.toHaveBeenCalled();
   });
 });

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -7,11 +7,19 @@ import { agentService } from "./agents.js";
 import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
+import { secretService } from "./secrets.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
 
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
   const budgets = budgetService(db);
   const instanceSettings = instanceSettingsService(db);
+  const secretsSvc = secretService(db);
   const canResolveStatuses = new Set(["pending", "revision_requested"]);
   const resolvableStatuses = Array.from(canResolveStatuses);
   type ApprovalRecord = typeof approvals.$inferSelect;
@@ -141,6 +149,22 @@ export function approvalService(db: Db) {
           hireApprovedAgentId = created?.id ?? null;
         }
         if (hireApprovedAgentId) {
+          // Persist the secret bindings for the freshly hired agent. Both the
+          // activatePendingApproval and create branches leave secret_ref values
+          // in adapterConfig.env without writing company_secret_bindings rows,
+          // so without this the agent fails every run with "Secret is not bound
+          // to ..." (binding_missing). Read the env back from the persisted
+          // agent so we sync exactly what was stored. See COD-362.
+          const hiredAgent = await agentsSvc.getById(hireApprovedAgentId);
+          const agentEnv = asRecord(hiredAgent?.adapterConfig)?.env;
+          if (agentEnv) {
+            await secretsSvc.syncEnvBindingsForTarget?.(
+              updated.companyId,
+              { targetType: "agent", targetId: hireApprovedAgentId },
+              agentEnv,
+            );
+          }
+
           const budgetMonthlyCents =
             typeof payload.budgetMonthlyCents === "number" ? payload.budgetMonthlyCents : 0;
           if (budgetMonthlyCents > 0) {


### PR DESCRIPTION
## Problem

Agents hired via the **approval flow** (`POST /companies/:id/agent-hires` → `approve`) are persisted with `secret_ref` values in `adapterConfig.env` but **no rows in `company_secret_bindings`**. `assertBindingContext()` then rejects every run with `Secret is not bound to ...` (`binding_missing`), so the agent can never start — it lands in `status: error` and its issues self-block with an empty `blockedBy`.

Direct creation (`POST /companies/:id/agents`, `routes/agents.ts:2318`) and `PATCH /agents/:id` (`routes/agents.ts:2803`, when `touchesAdapterConfiguration`) already call `syncEnvBindingsForTarget`. But neither branch of `approve()` for `hire_agent` in `services/approvals.ts` — `agentsSvc.create(...)` nor `activatePendingApproval()` — wrote bindings.

## Fix

Call `syncEnvBindingsForTarget` at the activation point in `services/approvals.ts`, after `hireApprovedAgentId` is resolved. This covers **both** branches. The env is read back from the persisted agent (`agentsSvc.getById`), mirroring the working `POST`/`PATCH` paths — `sanitizeRecord` preserves `secret_ref` bindings intact (`redaction.ts` `sanitizeValue`: `if (isSecretRefBinding(value)) return value`).

## Tests

Extended `__tests__/approvals-service.test.ts` with 3 regression tests asserting `syncEnvBindingsForTarget` is called with the agent env on both the `activatePendingApproval` and `create` branches, and skipped when the agent has no env. All 6 tests in the file pass (`vitest run`, Node 24). No new typecheck errors in `approvals.ts`.

Fixes COD-362.
