### PR TITLE
fix(ui): follow managed sign-out redirects

### DIFF
--- a/ui/src/api/auth.test.ts
+++ b/ui/src/api/auth.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authApi } from "./auth";
+
+describe("authApi.signOut", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the managed deployment redirect from the response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, redirectTo: "/cloud/logout" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(authApi.signOut()).resolves.toEqual({
+      success: true,
+      redirectTo: "/cloud/logout",
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/sign-out", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+  });
+});

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -15,6 +15,11 @@ type AuthErrorBody =
   }
   | null;
 
+export interface SignOutResult {
+  success?: boolean;
+  redirectTo?: string;
+}
+
 export class AuthApiError extends Error {
   status: number;
   code: string | null;
@@ -105,7 +110,7 @@ function logAuthHttpError(method: string, path: string, status: number, statusTe
   });
 }
 
-async function authPost(path: string, body: Record<string, unknown>) {
+async function authPost(path: string, body: Record<string, unknown>): Promise<unknown> {
   let res: Response;
   try {
     res = await fetch(`/api/auth${path}`, {
@@ -180,7 +185,14 @@ export const authApi = {
   updateProfile: async (input: UpdateCurrentUserProfile): Promise<CurrentUserProfile> =>
     authPatch("/profile", input, (payload) => currentUserProfileSchema.parse(payload)),
 
-  signOut: async () => {
-    await authPost("/sign-out", {});
+  signOut: async (): Promise<SignOutResult | null> => {
+    const payload = await authPost("/sign-out", {});
+    if (!payload || typeof payload !== "object") return null;
+
+    const result = payload as Record<string, unknown>;
+    return {
+      ...(typeof result.success === "boolean" ? { success: result.success } : {}),
+      ...(typeof result.redirectTo === "string" ? { redirectTo: result.redirectTo } : {}),
+    };
   },
 };

--- a/ui/src/components/SidebarAccountMenu.test.tsx
+++ b/ui/src/components/SidebarAccountMenu.test.tsx
@@ -19,9 +19,14 @@ const mockInstanceSettingsApi = vi.hoisted(() => ({
 }));
 const mockToggleTheme = vi.hoisted(() => vi.fn());
 const mockSetSidebarOpen = vi.hoisted(() => vi.fn());
+const mockNavigateTopLevel = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api/auth", () => ({
   authApi: mockAuthApi,
+}));
+
+vi.mock("@/lib/browserNavigation", () => ({
+  navigateTopLevel: mockNavigateTopLevel,
 }));
 
 vi.mock("@/api/instanceSettings", () => ({
@@ -86,7 +91,7 @@ describe("SidebarAccountMenu", () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableIsolatedWorkspaces: false,
     });
-    mockAuthApi.signOut.mockResolvedValue(undefined);
+    mockAuthApi.signOut.mockResolvedValue({ success: true, redirectTo: "/cloud/logout" });
   });
 
   afterEach(() => {
@@ -162,7 +167,38 @@ describe("SidebarAccountMenu", () => {
     await flushReact();
 
     expect(mockAuthApi.signOut).toHaveBeenCalledOnce();
-    expect(queryClient.getQueryState(queryKeys.health)?.isInvalidated).toBe(true);
+    expect(mockNavigateTopLevel).toHaveBeenCalledWith("/cloud/logout");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("falls back to the managed logout route when sign-out omits a redirect", async () => {
+    mockAuthApi.signOut.mockResolvedValue({ success: true });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <SidebarAccountMenu deploymentMode="authenticated" open />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const signOutButton = Array.from(document.body.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Sign out"),
+    );
+    await act(async () => {
+      signOutButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(mockNavigateTopLevel).toHaveBeenCalledWith("/cloud/logout");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -12,6 +12,7 @@ import type { DeploymentMode, ServerGitInfo } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
 import { authApi } from "@/api/auth";
 import { queryKeys } from "@/lib/queryKeys";
+import { navigateTopLevel } from "@/lib/browserNavigation";
 import { useSidebar } from "../context/SidebarContext";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -24,6 +25,7 @@ const PROFILE_SETTINGS_PATH = "/company/settings/instance/profile";
 const DOCS_URL = "https://docs.paperclip.ing/";
 const FEEDBACK_URL = "https://paperclip.ing/feedback";
 const SOURCE_REPOSITORY_URL = "https://github.com/paperclipai/paperclip";
+const MANAGED_SIGN_OUT_PATH = "/cloud/logout";
 const SOURCE_VERSION_RE = /\+\d+\.git\.([0-9a-f]{7,40})(?:\.dirty)?$/i;
 
 interface SidebarAccountMenuProps {
@@ -130,8 +132,12 @@ export function SidebarAccountMenu({
 
   const signOutMutation = useMutation({
     mutationFn: () => authApi.signOut(),
-    onSuccess: async () => {
+    onSuccess: async (result) => {
       setOpen(false);
+      if (deploymentMode === "authenticated") {
+        navigateTopLevel(result?.redirectTo?.trim() || MANAGED_SIGN_OUT_PATH);
+        return;
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
       await queryClient.invalidateQueries({ queryKey: queryKeys.health });
     },

--- a/ui/src/lib/browserNavigation.ts
+++ b/ui/src/lib/browserNavigation.ts
@@ -1,0 +1,3 @@
+export function navigateTopLevel(target: string) {
+  window.location.assign(target);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The tenant UI provides account actions for managed deployments
> - The sign-out API can return a deployment-owned redirect target
> - The account menu did not follow that target after the server cleared the session
> - Managed users could remain on a stale tenant page after sign-out
> - This pull request follows the returned redirect and uses `/cloud/logout` as the managed fallback
> - The benefit is a complete managed sign-out flow from the tenant account menu

## Linked Issues or Issue Description

**What happened?**

The managed tenant account menu cleared the server session but stayed on the tenant page after users selected Sign out.

**Expected behavior**

The browser must navigate to the redirect returned by the sign-out API. Managed deployments must fall back to `/cloud/logout` when the response omits the redirect.

**Steps to reproduce**

1. Open an authenticated managed tenant.
2. Open the account menu.
3. Select Sign out.
4. Observe that the old implementation did not navigate to the cloud logout route.

**Paperclip version or commit**

The defect is present on master before commit `f417afe22cfa869a38c93c3d24b6e47354ffc6f0`.

**Deployment mode**

Managed deployment.

## What Changed

- Return the parsed sign-out response from the auth API.
- Navigate managed deployments to the response redirect or `/cloud/logout`.
- Add focused API and account-menu tests.

## Verification

- `pnpm exec vitest run ui/src/api/auth.test.ts ui/src/components/SidebarAccountMenu.test.tsx`
- Result: 2 test files passed and 4 tests passed.

## Risks

- Low risk. The navigation change is limited to authenticated managed deployments.
- Self-hosted deployments keep the existing query invalidation flow.

## Model Used

- OpenAI Codex based on GPT-5, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
