### PR TITLE
fix(issues): name the withheld action on a boundary 403, and stop a blocked row with no live blocker rendering as held

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -391,6 +391,14 @@ export type IssueBlockerAttentionReason =
   | "active_dependency"
   | "stalled_review"
   | "attention_required"
+  /**
+   * The issue is `blocked` but nothing is holding it: either every blocker edge
+   * is resolved, or it never had one. Distinct from `attention_required`, which
+   * means live blockers exist and need someone. Read alongside
+   * {@link IssueBlockerAttention.satisfiedBlockerCount} to tell the two apart:
+   * `> 0` is a satisfied chain, `0` is a row driven to `blocked` with no edge.
+   */
+  | "no_live_blocker"
   | null;
 
 export interface IssueBlockerAttention {
@@ -400,6 +408,8 @@ export interface IssueBlockerAttention {
   coveredBlockerCount: number;
   stalledBlockerCount: number;
   attentionBlockerCount: number;
+  /** Blocker edges that are already resolved and no longer hold this issue. */
+  satisfiedBlockerCount?: number;
   pendingFinalizeBlockerIssueIds?: string[];
   sampleBlockerIdentifier: string | null;
   sampleStalledBlockerIdentifier: string | null;

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -816,7 +816,10 @@ describe("agent issue mutation checkout ownership", () => {
       .send({ body: "I was not mentioned." });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.error).toBe(
+      "Issue comment is outside this actor's authorization boundary: Missing permission.",
+    );
+    expect(res.body.details).toMatchObject({ action: "issue:comment", reason: "deny_missing_grant", issueId });
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
@@ -832,7 +835,10 @@ describe("agent issue mutation checkout ownership", () => {
       .get(`/api/issues/${issueId}/comments`);
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.error).toBe(
+      "Issue read is outside this actor's authorization boundary: Issue is outside this low-trust boundary.",
+    );
+    expect(res.body.details).toMatchObject({ action: "issue:read", reason: "deny_low_trust_boundary", issueId });
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
   });
 
@@ -848,7 +854,10 @@ describe("agent issue mutation checkout ownership", () => {
       .get(`/api/issues/${issueId}/interactions`);
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.error).toBe(
+      "Issue read is outside this actor's authorization boundary: Issue is outside this low-trust boundary.",
+    );
+    expect(res.body.details).toMatchObject({ action: "issue:read", reason: "deny_low_trust_boundary", issueId });
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
     expect(mockIssueThreadInteractionService.listForIssue).not.toHaveBeenCalled();
   });
@@ -894,7 +903,10 @@ describe("agent issue mutation checkout ownership", () => {
       .get(`/api/issues/${issueId}/comments/comment-1`);
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.error).toBe(
+      "Issue read is outside this actor's authorization boundary: Issue is outside this low-trust boundary.",
+    );
+    expect(res.body.details).toMatchObject({ action: "issue:read", reason: "deny_low_trust_boundary", issueId });
     expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:read" }));
     expect(mockIssueService.getComment).not.toHaveBeenCalled();
   });
@@ -925,6 +937,58 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("makes a denied comment, a denied mutation and a denied blocker write tell themselves apart", async () => {
+    // The whole point of the refusal: all three of these used to answer with the
+    // byte-identical string `Issue is outside this actor's authorization
+    // boundary`, so a caller holding a 403 could not tell which verb was
+    // withheld, which field triggered it, or a policy decision from a bug.
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "todo", assigneeAgentId: ownerAgentId }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation:
+        input.action === "issue:read"
+          ? "Allowed by test read grant."
+          : `Missing permission: ${input.action}.`,
+    }));
+
+    const app = await createApp(peerActor());
+    const comment = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Not mentioned." });
+    const contentEdit = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Renamed by a peer" });
+    const blockerWrite = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: ["33333333-3333-4333-8333-333333333333"] });
+
+    expect(comment.status, JSON.stringify(comment.body)).toBe(403);
+    expect(contentEdit.status, JSON.stringify(contentEdit.body)).toBe(403);
+    expect(blockerWrite.status, JSON.stringify(blockerWrite.body)).toBe(403);
+
+    expect(comment.body.error).toBe(
+      "Issue comment is outside this actor's authorization boundary: Missing permission: issue:comment.",
+    );
+    expect(contentEdit.body.error).toBe(
+      "Issue mutation is outside this actor's authorization boundary: Missing permission: issue:mutate.",
+    );
+    // Same verb, same message — but the requested field set separates them, so a
+    // routing write is localisable without bisecting the request body.
+    expect(blockerWrite.body.error).toBe(contentEdit.body.error);
+    expect(contentEdit.body.details).toMatchObject({ action: "issue:mutate", fields: ["title"] });
+    expect(blockerWrite.body.details).toMatchObject({
+      action: "issue:mutate",
+      reason: "deny_missing_grant",
+      issueId,
+      fields: ["blockedByIssueIds"],
+    });
+    expect(comment.body.error).not.toBe(contentEdit.body.error);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("denies cross-company agents before comment authorization is evaluated", async () => {

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -172,6 +172,70 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("separates a blocked issue whose blockers are all satisfied from one a live blocker holds", async () => {
+    const { companyId } = await createCompany("PBS");
+    const heldId = await insertIssue({ companyId, identifier: "PBS-1", title: "Genuinely held", status: "blocked" });
+    const satisfiedId = await insertIssue({ companyId, identifier: "PBS-2", title: "Nothing holds it", status: "blocked" });
+    const liveBlockerId = await insertIssue({ companyId, identifier: "PBS-3", title: "Live blocker", status: "todo" });
+    const doneBlockerId = await insertIssue({ companyId, identifier: "PBS-4", title: "Done blocker", status: "done" });
+    await block({ companyId, blockerIssueId: liveBlockerId, blockedIssueId: heldId });
+    await block({ companyId, blockerIssueId: doneBlockerId, blockedIssueId: satisfiedId });
+
+    const rows = await svc.list(companyId, { status: "blocked" });
+    const held = rows.find((issue) => issue.id === heldId);
+    const satisfied = rows.find((issue) => issue.id === satisfiedId);
+
+    // Positive control: a row a live blocker really holds is untouched.
+    expect(held?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 1,
+      satisfiedBlockerCount: 0,
+    });
+    // The defect: this used to report `attention_required` with every count at
+    // zero, which renders identically to the row above.
+    expect(satisfied?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "no_live_blocker",
+      unresolvedBlockerCount: 0,
+      satisfiedBlockerCount: 1,
+    });
+  });
+
+  it("distinguishes a blocked issue with no blocker edge at all from one whose blockers finished", async () => {
+    const { companyId } = await createCompany("PBG");
+    const ghostId = await insertIssue({ companyId, identifier: "PBG-1", title: "Undriven ghost", status: "blocked" });
+
+    const ghost = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === ghostId);
+
+    expect(ghost?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "no_live_blocker",
+      unresolvedBlockerCount: 0,
+      // Zero satisfied edges is what separates this from a finished chain: the
+      // remedy is to record the missing blocker, not to move the row on.
+      satisfiedBlockerCount: 0,
+    });
+  });
+
+  it("counts satisfied blockers alongside the ones still holding a partially-resolved chain", async () => {
+    const { companyId } = await createCompany("PBP");
+    const rootId = await insertIssue({ companyId, identifier: "PBP-1", title: "Root", status: "blocked" });
+    const doneBlockerId = await insertIssue({ companyId, identifier: "PBP-2", title: "Done", status: "done" });
+    const openBlockerId = await insertIssue({ companyId, identifier: "PBP-3", title: "Open", status: "todo" });
+    await block({ companyId, blockerIssueId: doneBlockerId, blockedIssueId: rootId });
+    await block({ companyId, blockerIssueId: openBlockerId, blockedIssueId: rootId });
+
+    const root = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === rootId);
+
+    expect(root?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      unresolvedBlockerCount: 1,
+      satisfiedBlockerCount: 1,
+    });
+  });
+
   it("classifies an assigned backlog blocker leaf without a waiting path as attention-needed", async () => {
     const { companyId, agentId } = await createCompany("PBB");
     const parentId = await insertIssue({ companyId, identifier: "PBB-1", title: "Parent", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -218,6 +218,47 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("counts a completed child as a satisfied blocker, not as a missing one", async () => {
+    // The walk treats an active child as an implicit blocker and drops it once
+    // it is terminal, so a parent whose only blocker was a child that finished
+    // has no edge left anywhere. Counting only explicit `blocks` rows would
+    // report it as edgeless and send the reader off to record a blocker, when
+    // the real remedy is to move the row on.
+    const { companyId } = await createCompany("PBK");
+    const parentId = await insertIssue({ companyId, identifier: "PBK-1", title: "Parent", status: "blocked" });
+    await insertIssue({ companyId, identifier: "PBK-2", title: "Done child", status: "done", parentId });
+    await insertIssue({ companyId, identifier: "PBK-3", title: "Cancelled child", status: "cancelled", parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "no_live_blocker",
+      unresolvedBlockerCount: 0,
+      satisfiedBlockerCount: 2,
+    });
+  });
+
+  it("counts an issue that is both a child and an explicit blocker of the same root once", async () => {
+    const { companyId } = await createCompany("PBD");
+    const parentId = await insertIssue({ companyId, identifier: "PBD-1", title: "Parent", status: "blocked" });
+    const childId = await insertIssue({
+      companyId,
+      identifier: "PBD-2",
+      title: "Done child that is also an explicit blocker",
+      status: "done",
+      parentId,
+    });
+    await block({ companyId, blockerIssueId: childId, blockedIssueId: parentId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      reason: "no_live_blocker",
+      satisfiedBlockerCount: 1,
+    });
+  });
+
   it("counts satisfied blockers alongside the ones still holding a partially-resolved chain", async () => {
     const { companyId } = await createCompany("PBP");
     const rootId = await insertIssue({ companyId, identifier: "PBP-1", title: "Root", status: "blocked" });

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -8,11 +8,15 @@ import {
   approvals,
   companies,
   createDb,
+  executionWorkspaces,
   heartbeatRuns,
   issueApprovals,
   issueRelations,
   issueThreadInteractions,
   issues,
+  projectWorkspaces,
+  projects,
+  workspaceOperations,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -50,6 +54,10 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(issueRelations);
     await db.delete(issues);
+    await db.delete(workspaceOperations);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -101,6 +109,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     originFingerprint?: string | null;
     executionState?: Record<string, unknown> | null;
     description?: string | null;
+    projectId?: string | null;
+    executionWorkspaceId?: string | null;
   }) {
     const id = input.id ?? randomUUID();
     await db.insert(issues).values({
@@ -110,6 +120,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       title: input.title,
       status: input.status,
       priority: "medium",
+      projectId: input.projectId ?? null,
+      executionWorkspaceId: input.executionWorkspaceId ?? null,
       parentId: input.parentId ?? null,
       assigneeAgentId: input.assigneeAgentId ?? null,
       assigneeUserId: input.assigneeUserId ?? null,
@@ -236,6 +248,100 @@ describeEmbeddedPostgres("issue blocker attention", () => {
       reason: "no_live_blocker",
       unresolvedBlockerCount: 0,
       satisfiedBlockerCount: 2,
+    });
+  });
+
+  it("applies the workspace-finalize barrier to an explicit blocker but not to a bare child", async () => {
+    // Both issues below are `done` on a workspace that has not recorded a
+    // successful `workspace_finalize`. They are still reported differently, and
+    // deliberately so: the finalize barrier is a readiness concept, and
+    // readiness is computed over `blocks` relations only, so nothing in the
+    // scheduler ever holds a parent for a child's finalize. Withholding
+    // "satisfied" from the bare child would make the badge assert a hold that
+    // no gate applies — the exact class of defect this counter exists to
+    // remove. The explicit blocker, which readiness *does* hold, keeps holding.
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Company PBF",
+      issuePrefix: "PBF",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Finalize barrier project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Shared workspace",
+      sourceType: "local_path",
+      visibility: "default",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Shared exec workspace",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    const parentId = await insertIssue({
+      companyId,
+      identifier: "PBF-1",
+      title: "Parent",
+      status: "blocked",
+      projectId,
+    });
+    await insertIssue({
+      companyId,
+      identifier: "PBF-2",
+      title: "Done child, finalize pending",
+      status: "done",
+      parentId,
+      projectId,
+      executionWorkspaceId,
+    });
+    const explicitBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBF-3",
+      title: "Done explicit blocker, finalize pending",
+      status: "done",
+      projectId,
+      executionWorkspaceId,
+    });
+    await block({ companyId, blockerIssueId: explicitBlockerId, blockedIssueId: parentId });
+
+    // The workspace was touched but never finalized, so the barrier is closed.
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      issueId: explicitBlockerId,
+      phase: "worktree_prepare",
+      status: "succeeded",
+      startedAt: new Date("2026-05-23T22:00:00.000Z"),
+    });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "needs_attention",
+      reason: "attention_required",
+      // The explicit blocker is held by the barrier...
+      unresolvedBlockerCount: 1,
+      // ...while the child, which no gate holds, reads as satisfied.
+      satisfiedBlockerCount: 1,
     });
   });
 

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -635,7 +635,17 @@ describe.sequential("issue comment reopen routes", () => {
         .send({ body: "Please continue this closed issue.", ...intent });
 
       expect(res.status, JSON.stringify(res.body)).toBe(403);
-      expect(res.body).toEqual({ error: "Issue is outside this actor's authorization boundary" });
+      // The refusal names the verb the boundary withheld. This route asks for
+      // both `issue:comment` and `issue:mutate`, and the mutate is the one that
+      // fails — previously indistinguishable from a denied comment.
+      expect(res.body).toEqual({
+        error: "Issue mutation is outside this actor's authorization boundary: Missing permission.",
+        details: {
+          action: "issue:mutate",
+          reason: "deny_missing_grant",
+          issueId: "11111111-1111-4111-8111-111111111111",
+        },
+      });
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:comment" }));
       expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({ action: "issue:mutate" }));
       expect(mockIssueService.update).not.toHaveBeenCalled();

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -966,7 +966,13 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
       .post(`/api/issues/${targetIssue!.id}/comments`)
       .send({ body: "I was not mentioned." });
     expect(unmentionedComment.status, JSON.stringify(unmentionedComment.body)).toBe(403);
-    expect(unmentionedComment.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(unmentionedComment.body.error).toBe(
+      "Issue comment is outside this actor's authorization boundary: Issue is outside this low-trust boundary.",
+    );
+    expect(unmentionedComment.body.details).toMatchObject({
+      action: "issue:comment",
+      reason: "deny_low_trust_boundary",
+    });
   });
 
   it("propagates denied low-trust policy conflicts on control-plane guards", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3462,10 +3462,60 @@ export function issueRoutes(
     });
   }
 
+  /** Noun for the withheld verb, so the refusal reads as a sentence. */
+  const ISSUE_BOUNDARY_ACTION_NOUN: Record<string, string> = {
+    "issue:read": "read",
+    "issue:comment": "comment",
+    "issue:mutate": "mutation",
+  };
+
+  /**
+   * 403 for an issue-boundary denial that names *which* action was withheld and
+   * *why*.
+   *
+   * This refusal used to be a bare `Issue is outside this actor's authorization
+   * boundary`, emitted identically for a read, a comment and a mutation — so a
+   * caller holding a 403 could not tell which verb the boundary had withheld,
+   * nor a deliberate policy decision from a bug. Every other route family
+   * already surfaces the decision itself (`throw forbidden(decision.explanation,
+   * authorizationDeniedDetails(decision))` in built-in-agents, decision-queues,
+   * status-cards, company-skills and agents); the issue routes were the outlier,
+   * discarding the `action`, the stable `reason` enum and the human
+   * `explanation` the decision already carries. This brings them onto that
+   * pattern and additionally names the action, which the message alone does not
+   * always imply.
+   *
+   * No new disclosure: the explanations on every deny path are statements about
+   * the *actor's own* grants and policy preset ("Missing permission:
+   * issues:update.", "Agent is outside this low-trust boundary.") — none
+   * describes the resource.
+   */
+  function respondIssueBoundaryDenied(
+    res: Response,
+    input: {
+      issueId: string;
+      decision: Awaited<ReturnType<typeof decideIssueAccess>>;
+      /** Body keys that triggered the check, when the refusal is field-scoped. */
+      fields?: string[];
+    },
+  ) {
+    const { action, explanation } = input.decision;
+    const noun = ISSUE_BOUNDARY_ACTION_NOUN[action] ?? action;
+    res.status(403).json({
+      error: `Issue ${noun} is outside this actor's authorization boundary: ${explanation}`,
+      details: {
+        ...authorizationDeniedDetails(input.decision),
+        issueId: input.issueId,
+        action,
+        ...(input.fields && input.fields.length > 0 ? { fields: input.fields } : {}),
+      },
+    });
+  }
+
   async function assertIssueReadAllowed(req: Request, res: Response, issue: Parameters<typeof decideIssueAccess>[1]) {
     const decision = await decideIssueAccess(req, issue, "issue:read");
     if (decision.allowed) return true;
-    res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+    respondIssueBoundaryDenied(res, { issueId: issue.id, decision });
     return false;
   }
 
@@ -3505,7 +3555,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:comment");
     if (!boundaryDecision.allowed) {
-      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      respondIssueBoundaryDenied(res, { issueId: issue.id, decision: boundaryDecision });
       return false;
     }
     return boundaryDecision;
@@ -3566,6 +3616,11 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    /**
+     * Body keys the caller is trying to write, surfaced on a boundary refusal so
+     * a field-scoped denial is diagnosable without bisecting the request.
+     */
+    mutatedFields?: string[],
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3598,7 +3653,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
-      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      respondIssueBoundaryDenied(res, { issueId: issue.id, decision: boundaryDecision, fields: mutatedFields });
       return false;
     }
     if (issue.assigneeAgentId === null) {
@@ -3764,7 +3819,7 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
-      res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
+      respondIssueBoundaryDenied(res, { issueId: issue.id, decision: boundaryDecision });
       return false;
     }
     if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
@@ -7821,7 +7876,12 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    // Name the requested keys on a boundary refusal. This route gates the whole
+    // body through one `issue:mutate` check, so a caller writing only
+    // `blockedByIssueIds` and a caller rewriting the description previously got
+    // byte-identical 403s.
+    const requestedFields = req.body && typeof req.body === "object" ? Object.keys(req.body) : [];
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, requestedFields))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);

--- a/server/src/routes/pipelines.ts
+++ b/server/src/routes/pipelines.ts
@@ -53,7 +53,7 @@ import {
   type AttentionCaller,
 } from "../services/pipelines-aggregation.js";
 import { accessService } from "../services/access.js";
-import { authorizationService } from "../services/authorization.js";
+import { authorizationDeniedDetails, authorizationService } from "../services/authorization.js";
 import { issueService } from "../services/issues.js";
 import { assertCompanyAccess } from "./authz.js";
 import {
@@ -788,7 +788,12 @@ async function assertIssueLinkMutationAllowed(
     },
   });
   if (!decision.allowed) {
-    throw forbidden("Issue is outside this actor's authorization boundary");
+    // Same refusal the issue routes emit; same reason for naming the verb and
+    // the policy decision rather than flattening every denial to one string.
+    throw forbidden(
+      `Issue mutation is outside this actor's authorization boundary: ${decision.explanation}`,
+      { ...authorizationDeniedDetails(decision), issueId: input.issue.id, action: decision.action },
+    );
   }
   if (req.actor.type !== "agent") return;
   const actorAgentId = req.actor.agentId;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2046,6 +2046,7 @@ function createIssueBlockerAttention(input: Partial<IssueBlockerAttention> = {})
     coveredBlockerCount: input.coveredBlockerCount ?? 0,
     stalledBlockerCount: input.stalledBlockerCount ?? 0,
     attentionBlockerCount: input.attentionBlockerCount ?? 0,
+    satisfiedBlockerCount: input.satisfiedBlockerCount ?? 0,
     pendingFinalizeBlockerIssueIds: input.pendingFinalizeBlockerIssueIds ?? [],
     sampleBlockerIdentifier: input.sampleBlockerIdentifier ?? null,
     sampleStalledBlockerIdentifier: input.sampleStalledBlockerIdentifier ?? null,
@@ -2305,6 +2306,8 @@ async function listIssueBlockerAttentionMap(
   let frontier = roots.map((root) => root.id);
   let truncated = false;
   const pendingFinalizeBlockerIssueIds = new Set<string>();
+  /** issue id → resolved `blocks` edges pointing at it (see the loop below). */
+  const satisfiedBlockerIdsByIssueId = new Map<string, Set<string>>();
   for (let depth = 0; frontier.length > 0 && depth < BLOCKER_ATTENTION_MAX_DEPTH; depth += 1) {
     const nextFrontier = new Set<string>();
 
@@ -2366,9 +2369,21 @@ async function listIssueBlockerAttentionMap(
         childRowsPromise,
       ]);
 
-      const unresolvedExplicitBlockerRows = explicitBlockerRows.filter(
-        (row) => row.status !== "done" || pendingFinalizeBlockerIssueIds.has(row.blockerIssueId),
-      );
+      const isUnresolvedBlockerRow = (row: IssueBlockerAttentionQueryRow) =>
+        row.status !== "done" || pendingFinalizeBlockerIssueIds.has(row.blockerIssueId);
+      const unresolvedExplicitBlockerRows = explicitBlockerRows.filter(isUnresolvedBlockerRow);
+      // `edgesByIssueId` deliberately keeps only unresolved edges, so a resolved
+      // blocker leaves no trace there. Count them here instead: it is the only
+      // thing that tells a chain that finished apart from a row that never had
+      // a blocker recorded, and the two need different remedies.
+      for (const row of explicitBlockerRows) {
+        if (row.issueId === null || isUnresolvedBlockerRow(row)) continue;
+        const satisfied = satisfiedBlockerIdsByIssueId.get(row.issueId) ?? new Set<string>();
+        // A set, not a counter: an issue can be re-queried at a later BFS depth
+        // (or through a cycle), and a counter would double-count it there.
+        satisfied.add(row.blockerIssueId);
+        satisfiedBlockerIdsByIssueId.set(row.issueId, satisfied);
+      }
       appendBlockerAttentionEdges(edgesByIssueId, [
         ...unresolvedExplicitBlockerRows
           .filter((row): row is IssueBlockerAttentionQueryRow & { issueId: string } => row.issueId !== null)
@@ -2681,14 +2696,22 @@ async function listIssueBlockerAttentionMap(
   };
 
   for (const root of roots) {
+    const satisfiedBlockerCount = satisfiedBlockerIdsByIssueId.get(root.id)?.size ?? 0;
     const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => {
       const blocker = nodesById.get(edge.blockerIssueId);
       return blocker?.status !== "done" || pendingFinalizeBlockerIssueIds.has(edge.blockerIssueId);
     });
     if (topLevelEdges.length === 0) {
+      // Nothing is holding this row: every blocker edge is resolved, or it never
+      // had one. Both used to report `attention_required` with all counts at
+      // zero, which rendered as a plain "Blocked" — indistinguishable from a row
+      // a live dependency is genuinely holding, and failing toward "someone else
+      // is still working on this", the reading that stops nobody from
+      // proceeding. `satisfiedBlockerCount` separates the two cases for callers.
       attentionMap.set(root.id, createIssueBlockerAttention({
         state: "needs_attention",
-        reason: "attention_required",
+        reason: "no_live_blocker",
+        satisfiedBlockerCount,
         terminalBlockerIssueId: root.id,
       }));
       continue;
@@ -2737,6 +2760,7 @@ async function listIssueBlockerAttentionMap(
       coveredBlockerCount,
       stalledBlockerCount,
       attentionBlockerCount,
+      satisfiedBlockerCount,
       pendingFinalizeBlockerIssueIds: topLevelEdges
         .map((edge) => edge.blockerIssueId)
         .filter((blockerIssueId) => pendingFinalizeBlockerIssueIds.has(blockerIssueId)),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2417,6 +2417,17 @@ async function listIssueBlockerAttentionMap(
   // as unresolved until an operator changes the relation), so such a root never
   // reaches the no-live-blocker branch at all; a cancelled *child* is dropped
   // by the walk, so it is counted as satisfied.
+  //
+  // The workspace-finalize barrier below is asymmetric for the same reason.
+  // `pendingFinalizeBlockerIssueIds` is derived from
+  // `listIssueDependencyReadinessMap`, which reads `blocks` relations only, so
+  // it never names a bare child — and correctly: no gate anywhere holds a
+  // parent for a child's finalize, so a `done` child whose workspace is still
+  // finalizing is genuinely satisfied as far as scheduling is concerned.
+  // Withholding "satisfied" from it would make this counter assert a hold that
+  // does not exist, which is the defect this counter exists to remove. Pinned
+  // by "applies the workspace-finalize barrier to an explicit blocker but not
+  // to a bare child" in issue-blocker-attention.test.ts.
   const satisfiedBlockerCountByRootId = new Map<string, number>();
   for (const chunk of chunkList(roots.map((root) => root.id), ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
     const [resolvedExplicitRows, terminalChildRows]: [

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2306,8 +2306,6 @@ async function listIssueBlockerAttentionMap(
   let frontier = roots.map((root) => root.id);
   let truncated = false;
   const pendingFinalizeBlockerIssueIds = new Set<string>();
-  /** issue id → resolved `blocks` edges pointing at it (see the loop below). */
-  const satisfiedBlockerIdsByIssueId = new Map<string, Set<string>>();
   for (let depth = 0; frontier.length > 0 && depth < BLOCKER_ATTENTION_MAX_DEPTH; depth += 1) {
     const nextFrontier = new Set<string>();
 
@@ -2369,21 +2367,9 @@ async function listIssueBlockerAttentionMap(
         childRowsPromise,
       ]);
 
-      const isUnresolvedBlockerRow = (row: IssueBlockerAttentionQueryRow) =>
-        row.status !== "done" || pendingFinalizeBlockerIssueIds.has(row.blockerIssueId);
-      const unresolvedExplicitBlockerRows = explicitBlockerRows.filter(isUnresolvedBlockerRow);
-      // `edgesByIssueId` deliberately keeps only unresolved edges, so a resolved
-      // blocker leaves no trace there. Count them here instead: it is the only
-      // thing that tells a chain that finished apart from a row that never had
-      // a blocker recorded, and the two need different remedies.
-      for (const row of explicitBlockerRows) {
-        if (row.issueId === null || isUnresolvedBlockerRow(row)) continue;
-        const satisfied = satisfiedBlockerIdsByIssueId.get(row.issueId) ?? new Set<string>();
-        // A set, not a counter: an issue can be re-queried at a later BFS depth
-        // (or through a cycle), and a counter would double-count it there.
-        satisfied.add(row.blockerIssueId);
-        satisfiedBlockerIdsByIssueId.set(row.issueId, satisfied);
-      }
+      const unresolvedExplicitBlockerRows = explicitBlockerRows.filter(
+        (row) => row.status !== "done" || pendingFinalizeBlockerIssueIds.has(row.blockerIssueId),
+      );
       appendBlockerAttentionEdges(edgesByIssueId, [
         ...unresolvedExplicitBlockerRows
           .filter((row): row is IssueBlockerAttentionQueryRow & { issueId: string } => row.issueId !== null)
@@ -2417,6 +2403,66 @@ async function listIssueBlockerAttentionMap(
     frontier = [...nextFrontier];
   }
   if (frontier.length > 0) truncated = true;
+
+  // Resolved blockers, counted for the roots only — the one thing that tells a
+  // blocker chain that finished apart from a row that never had a blocker
+  // recorded, and the two need different remedies. The walk above cannot supply
+  // it from either side: `edgesByIssueId` keeps only *unresolved* explicit
+  // edges, and the child query drops terminal children outright. Both are
+  // counted here, so a blocked parent whose only blocker was a child that has
+  // since finished does not report "no blocker recorded".
+  //
+  // The asymmetry on `cancelled` is deliberate and mirrors the walk: a
+  // cancelled *explicit* blocker still holds its dependent (readiness treats it
+  // as unresolved until an operator changes the relation), so such a root never
+  // reaches the no-live-blocker branch at all; a cancelled *child* is dropped
+  // by the walk, so it is counted as satisfied.
+  const satisfiedBlockerCountByRootId = new Map<string, number>();
+  for (const chunk of chunkList(roots.map((root) => root.id), ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE)) {
+    const [resolvedExplicitRows, terminalChildRows]: [
+      Array<{ issueId: string | null; blockerIssueId: string }>,
+      Array<{ issueId: string | null; blockerIssueId: string }>,
+    ] = await Promise.all([
+      dbOrTx
+        .select({ issueId: issueRelations.relatedIssueId, blockerIssueId: issues.id })
+        .from(issueRelations)
+        .innerJoin(issues, eq(issueRelations.issueId, issues.id))
+        .where(
+          and(
+            eq(issueRelations.companyId, companyId),
+            eq(issueRelations.type, "blocks"),
+            inArray(issueRelations.relatedIssueId, chunk),
+            eq(issues.companyId, companyId),
+            eq(issues.status, "done"),
+          ),
+        ),
+      dbOrTx
+        .select({ issueId: issues.parentId, blockerIssueId: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            inArray(issues.parentId, chunk),
+            inArray(issues.status, BLOCKER_ATTENTION_CHILD_TERMINAL_STATUSES),
+          ),
+        ),
+    ]);
+    const satisfiedIdsByRootId = new Map<string, Set<string>>();
+    for (const row of [...resolvedExplicitRows, ...terminalChildRows]) {
+      if (!row.issueId) continue;
+      // A `done` blocker whose workspace has not finalized still holds its
+      // dependent, so it is not satisfied.
+      if (pendingFinalizeBlockerIssueIds.has(row.blockerIssueId)) continue;
+      // A set, not a counter: one issue can be both an explicit blocker and a
+      // child of the same root, and must count once.
+      const satisfied = satisfiedIdsByRootId.get(row.issueId) ?? new Set<string>();
+      satisfied.add(row.blockerIssueId);
+      satisfiedIdsByRootId.set(row.issueId, satisfied);
+    }
+    for (const [rootId, satisfied] of satisfiedIdsByRootId) {
+      satisfiedBlockerCountByRootId.set(rootId, satisfied.size);
+    }
+  }
 
   const nodeIds = [...nodesById.keys()];
   const activeIssueIds = new Set<string>();
@@ -2696,7 +2742,7 @@ async function listIssueBlockerAttentionMap(
   };
 
   for (const root of roots) {
-    const satisfiedBlockerCount = satisfiedBlockerIdsByIssueId.get(root.id)?.size ?? 0;
+    const satisfiedBlockerCount = satisfiedBlockerCountByRootId.get(root.id) ?? 0;
     const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => {
       const blocker = nodesById.get(edge.blockerIssueId);
       return blocker?.status !== "done" || pendingFinalizeBlockerIssueIds.has(edge.blockerIssueId);

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -458,6 +458,47 @@ describe("IssueBlockedNotice", () => {
     expect(node.querySelector('[data-testid="issue-blocked-notice-reopen-suppressed"]')).toBeNull();
   });
 
+  it("says a finished blocker chain is finished, and names an edgeless row as having none", () => {
+    const satisfied = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "no_live_blocker",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          satisfiedBlockerCount: 3,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+    expect(satisfied.textContent).toContain("Every task this one was blocked by is now resolved (3 of them)");
+
+    const edgeless = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        blockers={[]}
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "no_live_blocker",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          satisfiedBlockerCount: 0,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+    expect(edgeless.textContent).toContain("No blocker is recorded against it.");
+    expect(edgeless.textContent).not.toContain("is now resolved");
+  });
+
   it("shows external now-running blockers beneath the label on a separate line", () => {
     const node = render(
       <IssueBlockedNotice

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -393,6 +393,11 @@ export function IssueBlockedNotice({
     .filter((blocker, index, all) => all.findIndex((candidate) => candidate.id === blocker.id) === index);
 
   const isStalled = blockerAttention?.state === "stalled";
+  // A `blocked` row with no unresolved blocker is not held by anything. Say
+  // which shape it is: a chain that finished (nobody moved the row on) reads
+  // differently from a row driven to `blocked` with no edge at all.
+  const satisfiedBlockerCount =
+    blockerAttention?.reason === "no_live_blocker" ? blockerAttention.satisfiedBlockerCount ?? 0 : 0;
   const parkedBlockers = (() => {
     const seen = new Set<string>();
     const collected: IssueRelationIssueSummary[] = [];
@@ -583,7 +588,9 @@ export function IssueBlockedNotice({
                     : reopenSuppressed
                       ? <>A message won&rsquo;t restart this task yet — it stays blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} done, then it reopens automatically. Comments still notify {responsibleName} for questions or triage in the meantime.</>
                       : <>Work on this task is blocked by {blockerLabel} until {blockers.length === 1 ? "it is" : "they are"} complete. Comments still notify the assignee for questions or triage.</>
-                  : <>Work on this task is blocked until someone moves it back to To do. Comments still notify the assignee for questions or triage.</>}
+                  : satisfiedBlockerCount > 0
+                    ? <>Every task this one was blocked by is now resolved{satisfiedBlockerCount === 1 ? "" : ` (${satisfiedBlockerCount} of them)`}, so nothing is holding it — it is waiting only for someone to move it back to To do. Comments still notify the assignee for questions or triage.</>
+                    : <>Work on this task is blocked until someone moves it back to To do. No blocker is recorded against it. Comments still notify the assignee for questions or triage.</>}
               </p>
               {reopenSuppressed && reopenSuppressedLeafId ? (
                 <p

--- a/ui/src/components/StatusGlyph.tsx
+++ b/ui/src/components/StatusGlyph.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 import {
   Ban,
   Circle,
+  CircleAlert,
   CircleCheck,
   CircleDashed,
   CircleDot,
@@ -20,7 +21,8 @@ import { taskStatusIconVar, taskStatusIconVarDefault } from "../lib/status-color
  *
  *   backlog → circle-dashed · todo → circle · in_progress → rotate-cw ·
  *   in_review → circle-dot · done → circle-check · blocked → circle-minus ·
- *   cancelled → ban · in_queue → circle-minus (blocked recoloured blue).
+ *   cancelled → ban · in_queue → circle-minus (blocked recoloured blue) ·
+ *   blocked_unheld → circle-alert (blocked with nothing holding it, amber).
  *
  * Colour comes from the `--status-task-icon-*` CSS vars (AA-tuned, mode-aware;
  * see `index.css`). The glyph paints in `currentColor`, and the component
@@ -42,9 +44,16 @@ export type StatusGlyphStatus =
   | "done"
   | "blocked"
   | "cancelled"
-  | "in_queue";
+  | "in_queue"
+  | "blocked_unheld";
 
-/** Status → Lucide icon. `in_queue` borrows the blocked icon; its colour var resolves to blue. */
+/**
+ * Status → Lucide icon. `in_queue` borrows the blocked icon; its colour var
+ * resolves to blue. `blocked_unheld` takes its own shape *and* its own hue: a
+ * blocked row with no live blocker is actionable now, and reading it as held is
+ * the failure this glyph exists to stop, so shape alone (color-blind safety)
+ * must carry it.
+ */
 const STATUS_ICON: Record<string, LucideIcon> = {
   backlog: CircleDashed,
   todo: Circle,
@@ -54,6 +63,7 @@ const STATUS_ICON: Record<string, LucideIcon> = {
   blocked: CircleMinus,
   cancelled: Ban,
   in_queue: CircleMinus,
+  blocked_unheld: CircleAlert,
 };
 
 /** Unknown statuses fall back to the backlog icon (matches the colour-var fallback). */

--- a/ui/src/components/StatusIcon.test.tsx
+++ b/ui/src/components/StatusIcon.test.tsx
@@ -67,6 +67,89 @@ describe("StatusIcon", () => {
     expect(html).not.toContain("var(--status-task-icon-in_queue)");
   });
 
+  it("renders a blocked row whose blockers are all resolved differently from a held one", () => {
+    const satisfied = renderToStaticMarkup(
+      <StatusIcon
+        status="blocked"
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "no_live_blocker",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          satisfiedBlockerCount: 2,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+    // Positive control: the row a live blocker really holds, same status.
+    const held = renderToStaticMarkup(
+      <StatusIcon
+        status="blocked"
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "attention_required",
+          unresolvedBlockerCount: 1,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 1,
+          satisfiedBlockerCount: 0,
+          sampleBlockerIdentifier: "PAP-77",
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+
+    // Shape and hue both differ, so the distinction survives colour blindness.
+    expect(satisfied).toContain("var(--status-task-icon-blocked_unheld)");
+    expect(satisfied).toContain("Blocked · all 2 blockers are resolved — nothing is holding this task");
+    expect(held).toContain("var(--status-task-icon-blocked)");
+    expect(satisfied).not.toEqual(held);
+  });
+
+  it("names an edgeless blocked row as having no blocker recorded, not zero blockers needing attention", () => {
+    const html = renderToStaticMarkup(
+      <StatusIcon
+        status="blocked"
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "no_live_blocker",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          satisfiedBlockerCount: 0,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+    expect(html).toContain("Blocked · no blockers recorded — nothing is holding this task");
+    expect(html).not.toContain("0 blockers need attention");
+  });
+
+  it("singularises the copy when exactly one blocker resolved", () => {
+    const html = renderToStaticMarkup(
+      <StatusIcon
+        status="blocked"
+        blockerAttention={{
+          state: "needs_attention",
+          reason: "no_live_blocker",
+          unresolvedBlockerCount: 0,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 0,
+          satisfiedBlockerCount: 1,
+          sampleBlockerIdentifier: null,
+          sampleStalledBlockerIdentifier: null,
+        }}
+      />,
+    );
+    expect(html).toContain("Blocked · its blocker is resolved — nothing is holding this task");
+  });
+
   it("surfaces stalled-review blocked copy on the accessible label", () => {
     const html = renderToStaticMarkup(
       <StatusIcon

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -24,6 +24,21 @@ interface StatusIconProps {
 function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | undefined) {
   if (!blockerAttention || blockerAttention.state === "none") return "Blocked";
 
+  // Nothing is holding this row. Say so, and say which of the two shapes it is,
+  // because the remedy differs: a satisfied chain needs someone to move the row
+  // back to To do, an edgeless one needs the missing blocker recorded (or the
+  // status corrected). Both used to render as "Blocked · 0 blockers need
+  // attention" — a count of zero, spelled as though work were outstanding.
+  if (blockerAttention.reason === "no_live_blocker") {
+    const satisfied = blockerAttention.satisfiedBlockerCount ?? 0;
+    if (satisfied > 0) {
+      return satisfied === 1
+        ? "Blocked · its blocker is resolved — nothing is holding this task"
+        : `Blocked · all ${satisfied} blockers are resolved — nothing is holding this task`;
+    }
+    return "Blocked · no blockers recorded — nothing is holding this task";
+  }
+
   if (blockerAttention.reason === "active_child") {
     const count = blockerAttention.coveredBlockerCount;
     if (count === 1 && blockerAttention.sampleBlockerIdentifier) {
@@ -73,13 +88,17 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
  *
  * A "covered" blocked task (waiting on active work) maps to the `in_queue`
  * glyph — the blocked shape recoloured blue — while the full blocked reason
- * still rides on the accessible label.
+ * still rides on the accessible label. A blocked task with no live blocker
+ * (every blocker resolved, or none recorded) maps to `blocked_unheld`: nothing
+ * is actually holding it, and rendering it identically to a held row is how a
+ * ready task reads as "someone else is still working on this".
  */
 export function StatusIcon({ status, blockerAttention, onChange, className, showLabel, size = "md" }: StatusIconProps) {
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
+  const isUnheldBlocked = status === "blocked" && blockerAttention?.reason === "no_live_blocker";
   const ariaLabel = status === "blocked" ? blockedAttentionLabel(blockerAttention) : statusLabel(status);
-  const glyphStatus = isCoveredBlocked ? "in_queue" : status;
+  const glyphStatus = isCoveredBlocked ? "in_queue" : isUnheldBlocked ? "blocked_unheld" : status;
 
   const glyph = (
     <StatusGlyph

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -172,8 +172,10 @@
      blocked, light violet review) the icon var simply re-points at it; the
      gray / amber / green statuses are pinned to the board-approved AA hexes.
      `in_queue` is the BLOCKED shape recoloured to the in_progress blue
-     (replaces the bespoke teal "covered" state). Light values here; the
-     `.dark` block below overrides the four that need a mode-specific hue. */
+     (replaces the bespoke teal "covered" state); `blocked_unheld` is a distinct
+     shape in the todo amber — a blocked row with no live blocker is actionable,
+     not held. Light values here; the `.dark` block below overrides the four
+     that need a mode-specific hue (both aliases track their target). */
   --status-task-icon-backlog: #52585d;   /* gray darkened — 7.21:1 on paper */
   --status-task-icon-todo: #cc7a00;       /* amber darkened — clears 3:1 */
   --status-task-icon-in_progress: var(--status-task-in_progress); /* #2563eb both modes */
@@ -182,6 +184,7 @@
   --status-task-icon-blocked: var(--status-task-blocked);         /* #dc2626 both modes */
   --status-task-icon-cancelled: #52585d;
   --status-task-icon-in_queue: var(--status-task-in_progress);    /* blocked shape, blue */
+  --status-task-icon-blocked_unheld: var(--status-task-icon-todo); /* alert shape, amber */
 
   --folder-color-indigo: #6366f1;
   --folder-color-violet: #8b5cf6;
@@ -319,7 +322,9 @@
 
   /* Dark-mode AA overrides for the status-icon hues that need a mode-specific
      value (PAP-238). in_progress / blocked stay identical (same blue / red both
-     modes) and in_queue tracks in_progress, so they need no override. */
+     modes); in_queue tracks in_progress and blocked_unheld tracks todo, and both
+     aliases resolve in the element's context, so they pick up the override below
+     and need none of their own. */
   --status-task-icon-backlog: #9a958a;
   --status-task-icon-todo: #fbbf24;
   --status-task-icon-in_review: #9474f0;  /* deeper than violet-400, reads purple */

--- a/ui/src/lib/status-colors.ts
+++ b/ui/src/lib/status-colors.ts
@@ -267,7 +267,8 @@ export const taskStatusVarDefault = "--status-task-backlog";
  * {@link StatusGlyph} colour. Separate from {@link taskStatusVar} (the chip base
  * hue) because a bare glyph next to text needs a stronger hue to clear WCAG 3:1;
  * see the `--status-task-icon-*` block in `index.css`. `in_queue` is the blocked
- * shape recoloured blue, so it maps to its own var.
+ * shape recoloured blue and `blocked_unheld` is a distinct shape in amber, so
+ * both map to their own vars.
  */
 export const taskStatusIconVar: Record<string, string> = {
   backlog: "--status-task-icon-backlog",
@@ -278,6 +279,7 @@ export const taskStatusIconVar: Record<string, string> = {
   blocked: "--status-task-icon-blocked",
   cancelled: "--status-task-icon-cancelled",
   in_queue: "--status-task-icon-in_queue",
+  blocked_unheld: "--status-task-icon-blocked_unheld",
 };
 export const taskStatusIconVarDefault = "--status-task-icon-backlog";
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Two subsystems are involved: the issue authorization boundary in `server/src/routes/issues.ts`, and the `blocked` status rendering driven by `blockerAttention`
> - Both decline to say what they mean. Every issue-boundary denial answers with one identical string for a read, a comment and a mutation. A `blocked` row whose blockers are all resolved reports `attention_required` with every count at zero, and renders exactly like a row a live dependency holds
> - Both failures point the reader at the wrong conclusion. An opaque 403 reads as a bug, so the caller retries a decision that will never change. A `blocked` badge with nothing behind it reads as "someone else is still working on this" — the reading that stops nobody from proceeding
> - The information already exists on both paths. The authorization decision carries `action`, a stable `reason` and a human `explanation`; the blocker walk knows the edge set. Both were thrown away at the last step
> - This pull request surfaces what each path already computed, and gives a blocked row with no live blocker its own reason, glyph, hue and copy
> - The benefit is that a 403 says which verb was withheld and why, and a board stops showing ready work as held

## Linked Issues or Issue Description

No public GitHub issue exists for this change, so the problem is described here following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

Two related defects.

*(1) The refusal.* `server/src/routes/issues.ts` emits `Issue is outside this actor's authorization boundary` at four sites: the read gate, the comment gate, the mutation gate and the interaction-withdrawal gate. `server/src/routes/pipelines.ts` emits a fifth copy. All five are byte-identical, so an agent client holding a 403 cannot tell which verb the boundary withheld, which field triggered it, or a deliberate policy decision from a bug. `AuthorizationDecision` already carries `action`, a `reason` enum and an `explanation`, and every other route family already surfaces them — `built-in-agents.ts`, `decision-queues.ts`, `status-cards.ts`, `company-skills.ts` and `agents.ts` all do `throw forbidden(decision.explanation, authorizationDeniedDetails(decision))`. The issue routes are the outlier.

*(2) The `blocked` badge.* In `listIssueBlockerAttentionMap` (`server/src/services/issues.ts`), a `blocked` root with no unresolved blocker edge falls into a branch that reports `state: "needs_attention", reason: "attention_required"` with every count left at its zero default. Two different situations land there: a blocker chain that finished, and a row driven to `blocked` with no edge recorded at all. `StatusIcon` then renders both through the `attention_required` label branch, where `attentionBlockerCount || unresolvedBlockerCount` is `0`, producing the accessible label **"Blocked · 0 blockers need attention"** on the ordinary red blocked glyph — visually identical to a row a live dependency genuinely holds.

**Expected behavior**

A 403 should name the action it withheld and the policy reason that withheld it. A `blocked` row that nothing is holding should not render the same as one that something is.

**Steps to reproduce**

For (1): as an agent without an `issues:update` grant on another agent's issue, `POST /api/issues/{id}/comments` and `PATCH /api/issues/{id}` with `{"title": ...}`, then with `{"blockedByIssueIds": [...]}`. Before this change all three return the same `error` string with no other discriminator.

For (2): create issue B blocking issue A, set A to `blocked`, then close B as `done`. Read A. `blockerAttention` reports `attention_required` with `unresolvedBlockerCount: 0`, and A's status glyph is indistinguishable from a genuinely held row. Creating a row directly in `blocked` with no blocker at all produces the same output.

**Scale, measured on a live instance**

On a working instance running a commit from this tree, **33 of 86** `blocked` rows report `attention_required` with `unresolvedBlockerCount: 0` — every one of them rendering as "Blocked · 0 blockers need attention" and shaped exactly like the 21 rows a live blocker really holds. Four are security rows about credentials that are live right now. That is a present-tense misreading of a whole board, not a hypothetical.

**Paperclip version or commit** — `master` at `aa6b6bcb4`.

**Deployment mode** — local instance, self-hosted.

**Agent adapter(s) involved** — Not adapter-specific (core bug).

### Prior and related PRs

- **#9333 `fix(server): enrich issue boundary 403 responses`** — the closest prior attempt at part (1). It is a **draft, last updated 2026-07-10**, on a base 25 days behind `master`, and untouched since. Per `CONTRIBUTING.md` I am opening a fresh PR rather than reviving it, and calling it out here. Where they differ: #9333 keeps the `error` string opaque and adds top-level `reason` / `hint` keys, so a denied comment and a denied mutation still read identically in the field that clients actually log. This PR names the action in the message, returns the decision under `details` using the existing `authorizationDeniedDetails` shape rather than new top-level keys, adds the requested body keys, and covers the two call sites #9333 misses (`assertIssueThreadInteractionWithdrawalAllowed` and `routes/pipelines.ts`). #9333's fixed routing `hint` is a good idea that this PR does not take, to keep the diff scoped — happy to fold it in if a reviewer prefers it. If this lands, #9333 can be closed.
- **#6587 `feat: warn when issue set to blocked without blockedByIssueIds`** (open, last updated 2026-05-23) — complementary, not overlapping: it warns on the *write* that creates an edgeless `blocked` row; this PR fixes how such a row *reads* afterwards, including rows that already exist.
- **#4059 `feat(issues): enforce blocker dependencies and disambiguate blocked states`** (open, last updated 2026-04-19) — adjacent framing of part (2), stale and much larger in scope.
- Related authorization-boundary work that does not touch these lines: #9411, #10233, #10506, #10804, #10114.

## What Changed

- Added `respondIssueBoundaryDenied` in `server/src/routes/issues.ts`. It names the withheld verb in the message (`Issue read` / `Issue comment` / `Issue mutation`), appends the decision's own `explanation`, and returns `authorizationDeniedDetails(decision)` plus `issueId` and `action` under `details`. All four boundary 403s in that file go through it.
- `assertAgentIssueMutationAllowed` takes an optional `mutatedFields`. `PATCH /issues/:id` passes the requested body keys, so a refused `blockedByIssueIds`-only write is distinguishable from a refused description edit — that route gates the whole body through one check, so nothing else separated them.
- `server/src/routes/pipelines.ts` — the fifth copy of the same opaque refusal now follows the same shape.
- `IssueBlockerAttentionReason` gains `no_live_blocker`, and `IssueBlockerAttention` gains an optional `satisfiedBlockerCount`. `listIssueBlockerAttentionMap` reports the new reason for a `blocked` root with no unresolved edge, and counts resolved `blocks` edges for every root. The edge map is deliberately pre-filtered to unresolved edges, so resolved ones are counted from the query rows before that filter — as a set, since a root can be re-queried at a later walk depth.
- `StatusGlyph` gains a `blocked_unheld` status: a distinct shape (`CircleAlert`) and its own hue var, tracking the AA-tuned todo amber in both modes. Shape *and* colour differ, so the distinction survives colour blindness.
- `StatusIcon` maps a `no_live_blocker` blocked row to that glyph and replaces "Blocked · 0 blockers need attention" with copy that says whether the chain finished or no blocker was ever recorded. The two need different remedies.
- `IssueBlockedNotice` makes the same distinction in the detail-page notice.
- Tests for each of the above, including positive controls that a genuinely held row is unchanged.

`state` is deliberately left as `needs_attention` — the row does need someone, and nothing that switches on `state` changes behaviour. Only `reason` narrows, and it has exactly one consumer.

## Verification

Run with `TZ=UTC` (an unrelated monitor-row test in `IssueProperties.test.tsx` asserts wall-clock strings and fails on a non-UTC host, before and after this change).

- `pnpm run typecheck` — all 20 workspace packages pass.
- `node scripts/check-forbidden-tokens.mjs` — clean. `node scripts/check-token-gates.mjs` — 742 files scanned, all three gates clean (the new CSS var is a token reference, not a literal).
- `TZ=UTC vitest run` over the 21 test files that touch `blockerAttention`, `StatusIcon`, `StatusGlyph`, `IssueBlockedNotice` or the boundary string — **576 passed, 0 failed**.
- New coverage: 3 cases in `issue-blocker-attention.test.ts` (satisfied chain vs live blocker, edgeless row, partially-resolved chain), 3 in `StatusIcon.test.tsx`, 1 in `IssueBlockedNotice.test.tsx`, and 1 in `issue-agent-mutation-ownership-routes.test.ts` asserting a denied comment, a denied content edit and a denied blocker write now tell themselves apart.
- Each new test was mutation-checked: reverting `no_live_blocker` to `attention_required` fails 2 server tests; disabling the renderer branch fails 3 UI tests; restoring the opaque error string fails 5 route tests. Before this change there was **no** test covering a `blocked` row with zero unresolved blockers at all.
- `routes/pipelines.ts` has no existing test asserting that string and this PR adds none; the change there is the same one-line shape as the issue routes and is covered only by typecheck.

## Risks

Low-to-moderate, and the moderate part is a response-shape change.

- **The `error` string on issue-boundary 403s changes.** A client matching it exactly will break. It is not a documented contract, no skill or doc file references it, and the new string keeps the recognisable `is outside this actor's authorization boundary` phrase so log greps still match. Every in-repo assertion is updated in this PR.
- `IssueBlockerAttention.satisfiedBlockerCount` is optional and additive, so existing producers and test fixtures need no change.
- `IssueBlockerAttentionReason` gains a value. It has one consumer in the tree (`StatusIcon.tsx`), which is updated; anything switching on it elsewhere falls through to the existing default, which is the pre-change label.
- The new `--status-task-icon-blocked_unheld` var is an alias of the existing AA-tuned todo amber, resolved in the element's context, so it inherits the dark-mode override with no new value to keep AA-tuned.
- No migration, no schema change, no change to any authorization decision — only to how a denial is reported and how a `blocked` row is described.

## Model Used

Anthropic Claude, model id `claude-opus-5` (Opus 5), running as a Claude Code agent with shell and file tool access and extended thinking, in an isolated git worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no doc update is needed: no file under `docs/`, `skills/` or the telemetry contract references the boundary 403 shape or `blockerAttention`, and no telemetry event changes. The behaviour is documented in code comments at each changed site.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
