### PR TITLE
fix(claude-local): honor explicit CLAUDE_CONFIG_DIR in local sandboxed runs

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for honoring an explicit `adapterConfig.env.CLAUDE_CONFIG_DIR`
+// in the local sandboxed execution path. Before the fix, the sandbox bind mount and
+// the in-sandbox `CLAUDE_CONFIG_DIR` both resolved against `process.env` (the shared
+// directory), ignoring the per-agent value. A version that wires only one of the two
+// looks correct from inside the sandbox until something tries to write, so this test
+// asserts on both.
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  executeClaudeAcp,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+} = vi.hoisted(() => ({
+  ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+  ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+  // Force the ACP lane to fail so execute() falls back to the local CLI runner,
+  // which is the path that builds the filesystem sandbox.
+  executeClaudeAcp: vi.fn(async () => {
+    throw new Error('Transform failed with 1 error: execute.ts:818:0: ERROR: Unexpected "<<"');
+  }),
+  resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "claude"),
+  runAdapterExecutionTargetProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: "claude-session-1",
+        message: { content: [{ type: "text", text: "hello" }] },
+      }),
+      JSON.stringify({
+        type: "result",
+        session_id: "claude-session-1",
+        result: "hello",
+        usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+}));
+
+vi.mock("./acp.js", () => ({
+  createClaudeAcpExecutor: () => executeClaudeAcp,
+  formatClaudeAcpFallbackMessage: (reason: string) =>
+    `[paperclip] Claude ACP default unavailable; falling back to Claude CLI. ${reason} Set engine=acp to require ACP or engine=cli to silence this fallback.\n`,
+  resolveClaudeExecutionEngineForRun: async (ctx: { config: Record<string, unknown> }) =>
+    ctx.config.engine === "acp"
+      ? { engine: "acp", explicit: true }
+      : { engine: "acp", explicit: false },
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function buildContext(config: Record<string, unknown> = {}) {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Claude Coder",
+      adapterType: "claude_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config,
+    context: {},
+    onLog: vi.fn(async () => {}),
+  };
+}
+
+describe("claude_local local sandbox honors adapterConfig.env.CLAUDE_CONFIG_DIR", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("points both the writable bind mount and the in-sandbox env at the explicit value", async () => {
+    // The shared directory implied by process.env must differ from the per-agent
+    // value so the assertion can distinguish them.
+    const sharedDir = "/var/tmp/paperclip-claude-shared-process-env";
+    const explicitDir = "/var/tmp/paperclip-claude-explicit-adapter-env";
+    vi.stubEnv("CLAUDE_CONFIG_DIR", sharedDir);
+
+    const ctx = buildContext({
+      filesystemScope: "workspace",
+      env: { CLAUDE_CONFIG_DIR: explicitDir },
+    });
+
+    await execute(ctx as never);
+
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+    const options = (runAdapterExecutionTargetProcess as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![4] as {
+        env: Record<string, string | undefined>;
+        localProcessSandbox: { managedPaths: Array<{ path: string; access: string }> };
+      };
+
+    // The in-sandbox environment variable follows the explicit per-agent value...
+    expect(options.env.CLAUDE_CONFIG_DIR).toBe(explicitDir);
+    // ...and so does the writable bind mount that backs it.
+    expect(options.localProcessSandbox.managedPaths).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: explicitDir, access: "rw" }),
+      ]),
+    );
+    // Neither surface should still point at the shared process.env directory.
+    expect(options.env.CLAUDE_CONFIG_DIR).not.toBe(sharedDir);
+    expect(
+      options.localProcessSandbox.managedPaths.some((entry) => entry.path === sharedDir),
+    ).toBe(false);
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -525,7 +525,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     servers: runtimeMcpServers,
   });
   const localMcpConfigDir = path.dirname(localMcpConfigPath);
-  const sharedClaudeConfigDir = resolveSharedClaudeConfigDir(process.env);
+  const sharedClaudeConfigDir = resolveSharedClaudeConfigDir(
+    hasExplicitClaudeConfigDir
+      ? { ...process.env, CLAUDE_CONFIG_DIR: String(configEnv.CLAUDE_CONFIG_DIR) }
+      : process.env,
+  );
   const networkScope = parseLocalProcessNetworkScope(config.networkScope);
   const filesystemScope = parseLocalProcessFilesystemScope(config.filesystemScope);
   const localProcessSandbox: LocalProcessSandboxOptions | null =


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The claude_local adapter runs Claude CLI inside a local sandbox when filesystem or network scope is set.
> - The sandbox bind-mounts the Claude config directory and sets CLAUDE_CONFIG_DIR so Claude can read its settings and write transcripts.
> - Today the local sandbox always resolves that directory from process.env, so every local agent of one instance shares the same ~/.claude directory.
> - adapterConfig.env.CLAUDE_CONFIG_DIR is already read for remote runs and for deciding whether to prepare a managed config seed.
> - The local path never consults that explicit value, so an agent that sets its own CLAUDE_CONFIG_DIR still gets the shared directory.
> - This pull request makes the local sandbox resolve the config directory from adapterConfig.env.CLAUDE_CONFIG_DIR when it is set, falling back to the shared directory when it is not.
> - The benefit is that agents can have isolated Claude profiles, session transcripts no longer leak across agents, and the behavior matches the remote path.

## Linked Issues or Issue Description

Fixes: #10686
Refs: #6882, #10754

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts` now resolves the local sandbox `CLAUDE_CONFIG_DIR` from `adapterConfig.env.CLAUDE_CONFIG_DIR` when that key is explicitly set.
- When no explicit value is set, the existing shared `~/.claude` behavior is unchanged.
- The resolved directory is used for the sandbox bind mount and for the in-sandbox `CLAUDE_CONFIG_DIR` environment variable.
- Adds `execute.claude-config-dir.test.ts`, a regression test that asserts both the writable bind mount and the in-sandbox environment follow the explicit value. It fails before this change and passes after.

## Verification

- `pnpm -C packages/adapters/claude-local typecheck` passes.
- `pnpm -r typecheck` passes for the full workspace.
- A local reproduction with two `claude_local` agents each setting a different `CLAUDE_CONFIG_DIR` now shows each run pointing to its own directory.
- `vitest run packages/adapters/claude-local/src/server/execute.claude-config-dir.test.ts` passes with the fix. With the `execute.ts` hunk reverted, the same test fails on both the bind-mount path and the in-sandbox variable (the two surfaces are set in different places, so both are asserted).
- The pre-existing `execute.remote.test.ts` fails on this host on an unrelated remote SSH sync assertion (`syncDirectoryToSsh` / `managedRemoteWorkspace`); it does not touch the local sandbox path and references no `CLAUDE_CONFIG_DIR` symbol.

## Risks

- Low. The change only activates when an agent explicitly sets `adapterConfig.env.CLAUDE_CONFIG_DIR`.
- Agents that do not set it keep the current shared `~/.claude` directory.
- PR #6882 works in the same area but addresses a different problem: it pins the default config directory to the agent home. This change does not overlap with that logic.
- Downstream consumer: once directories become per-agent, the `clean-poisoned-claude-sessions` maintenance script (`#10754`) resolves every row against one global directory and can silently misclassify healthy sessions of other agents as missing. That fix is tracked in `#10754` and should land alongside or before this change so the maintenance path stays correct.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Cognition Devin CLI, model SWE-1.7 Max, 262K context, tool use enabled. Assisted with code change, verification, and pull request authoring. The regression test was added during review follow-up and verified locally. Commit authored as Santhi Prakash.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
