### PR TITLE
fix(authz): admit the mention grant to a blocker-only issue PATCH

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -75,6 +75,7 @@ async function createIssue(
     projectId?: string | null;
     parentId?: string | null;
     assigneeAgentId?: string | null;
+    createdByAgentId?: string | null;
     originKind?: string | null;
     originId?: string | null;
   } = {},
@@ -90,6 +91,7 @@ async function createIssue(
       projectId: input.projectId ?? null,
       parentId: input.parentId ?? null,
       assigneeAgentId: input.assigneeAgentId ?? null,
+      createdByAgentId: input.createdByAgentId ?? null,
       originKind: input.originKind ?? "manual",
       originId: input.originId ?? null,
     })
@@ -1265,6 +1267,219 @@ describeEmbeddedPostgres("authorization service", () => {
       allowed: true,
       reason: "allow_issue_mention_grant",
     });
+  });
+
+  // The boundary that withholds the mention grant from `issue:mutate` exists at
+  // two independent sites: the low-trust boundary (phrased in the negative) and
+  // the ordinary boundary. A blocker-edge mutation has to clear both, so each is
+  // covered here with its own no-scope negative control.
+  it("admits a low-trust mentioned agent to a blocker-edge issue:mutate, and withholds it without the scope", async () => {
+    const company = await createCompany(db, "BlockerEdgeLowTrust");
+    const allowedProject = await createProject(db, company.id, "BlockerEdgeLowTrustAllowed");
+    const targetProject = await createProject(db, company.id, "BlockerEdgeLowTrustTarget");
+    const assigneeAgent = await createAgent(db, company.id, { role: "coach" });
+    const mentionedAgent = await createAgent(db, company.id, {
+      role: "qa",
+      permissions: {
+        trustPreset: LOW_TRUST_REVIEW_PRESET,
+        authorizationPolicy: {
+          trustBoundary: {
+            mode: LOW_TRUST_REVIEW_PRESET,
+            companyId: company.id,
+            projectIds: [allowedProject.id],
+          },
+        },
+      },
+    });
+    const issue = await createIssue(db, company.id, {
+      title: "Low-trust blocker-edge target",
+      projectId: targetProject.id,
+      assigneeAgentId: assigneeAgent.id,
+    });
+    const blocker = await createIssue(db, company.id, {
+      title: "Low-trust blocker",
+      projectId: targetProject.id,
+    });
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      authorAgentId: assigneeAgent.id,
+      authorType: "agent",
+      body: `[@QA](agent://${mentionedAgent.id}) please state the ordering on this issue.`,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: mentionedAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: assigneeAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: { blockerEdgeOnly: true, addedBlockerIssueIds: [blocker.id], blockerEdgeRemovesExisting: false },
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_issue_mention_grant" });
+
+    // Negative control: same actor, same mention, no blocker-edge scope.
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({ allowed: false });
+  });
+
+  it("admits a standard-trust mentioned agent to a blocker-edge issue:mutate on another agent's issue", async () => {
+    const company = await createCompany(db, "BlockerEdgeStandard");
+    const project = await createProject(db, company.id, "BlockerEdgeStandardProject");
+    const assigneeAgent = await createAgent(db, company.id, { role: "coach" });
+    const mentionedAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Standard-trust blocker-edge target",
+      projectId: project.id,
+      assigneeAgentId: assigneeAgent.id,
+    });
+    const blocker = await createIssue(db, company.id, { title: "Standard blocker", projectId: project.id });
+    await db.insert(issueComments).values({
+      companyId: company.id,
+      issueId: issue.id,
+      authorAgentId: assigneeAgent.id,
+      authorType: "agent",
+      body: `[@Engineer](agent://${mentionedAgent.id}) please state the ordering on this issue.`,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: mentionedAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: assigneeAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: { blockerEdgeOnly: true, addedBlockerIssueIds: [blocker.id], blockerEdgeRemovesExisting: false },
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_issue_mention_grant" });
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+    })).resolves.toMatchObject({ allowed: false });
+  });
+
+  it("admits a blocker-edge issue:mutate on the strength of owning every added blocker", async () => {
+    const company = await createCompany(db, "BlockerEdgeOwnership");
+    const project = await createProject(db, company.id, "BlockerEdgeOwnershipProject");
+    const assigneeAgent = await createAgent(db, company.id, { role: "coach" });
+    const orderingAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "Ownership blocker-edge target",
+      projectId: project.id,
+      assigneeAgentId: assigneeAgent.id,
+    });
+    // No mention anywhere on the target issue — ownership of the blocker is the
+    // only basis under test.
+    const ownedByCreation = await createIssue(db, company.id, {
+      title: "Blocker the actor created",
+      projectId: project.id,
+      createdByAgentId: orderingAgent.id,
+    });
+    const ownedByAssignment = await createIssue(db, company.id, {
+      title: "Blocker the actor is assigned",
+      projectId: project.id,
+      assigneeAgentId: orderingAgent.id,
+    });
+    const unowned = await createIssue(db, company.id, {
+      title: "Blocker owned by someone else",
+      projectId: project.id,
+      assigneeAgentId: assigneeAgent.id,
+    });
+
+    const authorization = authorizationService(db);
+    const actor = { type: "agent", agentId: orderingAgent.id, companyId: company.id, source: "agent_key" } as const;
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      projectId: issue.projectId,
+      assigneeAgentId: assigneeAgent.id,
+      status: issue.status,
+    } as const;
+
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: {
+        blockerEdgeOnly: true,
+        addedBlockerIssueIds: [ownedByCreation.id, ownedByAssignment.id],
+        blockerEdgeRemovesExisting: false,
+      },
+    })).resolves.toMatchObject({ allowed: true, reason: "allow_issue_blocker_edge_grant" });
+
+    // One unowned blocker in the set denies the whole write — the check is
+    // "every added blocker", not "any".
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: {
+        blockerEdgeOnly: true,
+        addedBlockerIssueIds: [ownedByCreation.id, unowned.id],
+        blockerEdgeRemovesExisting: false,
+      },
+    })).resolves.toMatchObject({ allowed: false });
+
+    // Dropping an existing blocker is not an ordering the actor owns.
+    await expect(authorization.decide({
+      actor,
+      action: "issue:mutate",
+      resource,
+      scope: {
+        blockerEdgeOnly: true,
+        addedBlockerIssueIds: [ownedByCreation.id],
+        blockerEdgeRemovesExisting: true,
+      },
+    })).resolves.toMatchObject({ allowed: false });
+  });
+
+  it("does not let the blocker-edge scope widen a non-blocker issue:mutate", async () => {
+    const company = await createCompany(db, "BlockerEdgeNoSmuggle");
+    const project = await createProject(db, company.id, "BlockerEdgeNoSmuggleProject");
+    const assigneeAgent = await createAgent(db, company.id, { role: "coach" });
+    const orderingAgent = await createAgent(db, company.id, { role: "engineer" });
+    const issue = await createIssue(db, company.id, {
+      title: "No-smuggle target",
+      projectId: project.id,
+      assigneeAgentId: assigneeAgent.id,
+    });
+
+    // An empty added set has nothing to establish ownership over, so the
+    // ownership basis cannot fire and the mention basis is absent.
+    await expect(authorizationService(db).decide({
+      actor: { type: "agent", agentId: orderingAgent.id, companyId: company.id, source: "agent_key" },
+      action: "issue:mutate",
+      resource: {
+        type: "issue",
+        companyId: company.id,
+        issueId: issue.id,
+        projectId: issue.projectId,
+        assigneeAgentId: assigneeAgent.id,
+        status: issue.status,
+      },
+      scope: { blockerEdgeOnly: true, addedBlockerIssueIds: [], blockerEdgeRemovesExisting: false },
+    })).resolves.toMatchObject({ allowed: false });
   });
 
   it("does not grant mention-scoped issue access from self-authored or unauthorized-author comments", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -9,6 +9,29 @@ const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
+const blockerIssueId = "88888888-8888-4888-8888-888888888888";
+const existingBlockerIssueId = "99999999-9999-4999-8999-999999999999";
+
+// Mirrors the shape the real authorization service produces for a blocker-edge
+// mutation: `issue:mutate` is denied as usual unless the caller proved the body
+// was narrowed to blockedByIssueIds and set the scope flag.
+async function blockerEdgeAwareDecide(input: { action: string; scope?: Record<string, unknown> | null }) {
+  const blockerEdge = input.action === "issue:mutate" && input.scope?.blockerEdgeOnly === true;
+  if (blockerEdge) {
+    return {
+      allowed: true,
+      action: input.action,
+      reason: "allow_issue_blocker_edge_grant",
+      explanation: "Allowed by a blocker-edge grant over issues the actor owns.",
+    };
+  }
+  return {
+    allowed: input.action === "issue:read",
+    action: input.action,
+    reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+    explanation: input.action === "issue:read" ? "Allowed by test read grant." : "Missing permission.",
+  };
+}
 
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
@@ -800,6 +823,83 @@ describe("agent issue mutation checkout ownership", () => {
       expect.any(Object),
       expect.any(Object),
     );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a peer agent a blockedByIssueIds-only PATCH under a blocker-edge grant", async () => {
+    mockAccessService.decide.mockImplementation(blockerEdgeAwareDecide);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [blockerIssueId] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({
+        blockerEdgeOnly: true,
+        addedBlockerIssueIds: [blockerIssueId],
+        blockerEdgeRemovesExisting: false,
+      }),
+    }));
+  });
+
+  // Item 4 — the load-bearing guard. A body carrying anything besides
+  // blockedByIssueIds must never reach the authorization layer with the
+  // widened scope, or the ordering verb becomes a way to smuggle a content
+  // edit onto another agent's row.
+  it("withholds the blocker-edge grant when the PATCH body carries any other field", async () => {
+    mockAccessService.decide.mockImplementation(blockerEdgeAwareDecide);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [blockerIssueId], title: "smuggled content edit" });
+
+    // The widened scope is never set, so `issue:mutate` is decided on the
+    // ordinary boundary and refused there — before the ownership branch.
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(expect.objectContaining({
+      scope: expect.objectContaining({ blockerEdgeOnly: true }),
+    }));
+  });
+
+  it("flags a blocker-edge PATCH that drops an existing blocker", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: existingBlockerIssueId }],
+      blocks: [],
+    });
+    mockAccessService.decide.mockImplementation(blockerEdgeAwareDecide);
+
+    await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [blockerIssueId] });
+
+    expect(mockAccessService.decide).toHaveBeenCalledWith(expect.objectContaining({
+      action: "issue:mutate",
+      scope: expect.objectContaining({
+        blockerEdgeOnly: true,
+        addedBlockerIssueIds: [blockerIssueId],
+        blockerEdgeRemovesExisting: true,
+      }),
+    }));
+  });
+
+  it("still refuses a blocker-edge PATCH the authorization layer denies", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read",
+      action: input.action,
+      reason: input.action === "issue:read" ? "allow_explicit_grant" : "deny_missing_grant",
+      explanation: input.action === "issue:read" ? "Allowed by test read grant." : "Missing permission.",
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [blockerIssueId] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3703,6 +3703,45 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     };
   }
 
+  // A blocker write authorized outside the write transaction carries the set it
+  // was authorized against. The replacement is whole-set, so without this the
+  // caller silently deletes any edge that landed in between — including one it
+  // was never allowed to remove.
+  it("refuses a blocker replacement whose authorization snapshot went stale", async () => {
+    const seeded = await seedSharedWorkspaceDependency();
+    const concurrentBlockerId = randomUUID();
+    await db.insert(issues).values({
+      id: concurrentBlockerId,
+      companyId: seeded.companyId,
+      projectId: seeded.projectId,
+      identifier: "PAP-15901",
+      title: "Concurrently added blocker",
+      status: "todo",
+      priority: "medium",
+    });
+
+    // A concurrent writer adds an edge after the stale snapshot was taken.
+    await svc.update(seeded.dependentId, {
+      blockedByIssueIds: [seeded.blockerId, concurrentBlockerId],
+    });
+
+    await expect(svc.update(seeded.dependentId, {
+      blockedByIssueIds: [seeded.blockerId],
+      expectedCurrentBlockerIssueIds: [seeded.blockerId],
+    })).rejects.toMatchObject({ status: 409 });
+
+    const afterRefusal = await svc.getRelationSummaries(seeded.dependentId);
+    expect(afterRefusal.blockedBy.map((relation) => relation.id).sort())
+      .toEqual([seeded.blockerId, concurrentBlockerId].sort());
+
+    // The same write succeeds once the precondition matches what is on the row.
+    const applied = await svc.update(seeded.dependentId, {
+      blockedByIssueIds: [seeded.blockerId],
+      expectedCurrentBlockerIssueIds: [concurrentBlockerId, seeded.blockerId],
+    });
+    expect(applied?.blockedByIssueIds).toEqual([seeded.blockerId]);
+  });
+
   it("returns authoritative update receipts for row fields and blocker relations", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3661,7 +3661,7 @@ export function issueRoutes(
     // not contend with the assignee's content edits, and refusing it while the
     // target is in_progress would defeat the grant in its primary case.
     if (blockerEdge && isIssueBlockerEdgeGrantDecision(boundaryDecision)) {
-      return true;
+      return { admittedByBlockerEdgeGrant: true };
     }
     if (issue.assigneeAgentId === null) {
       return true;
@@ -7897,7 +7897,17 @@ export function issueRoutes(
         priorRelationsForBlockerEdge.blockedBy.map((relation) => relation.id),
       )
       : null;
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing, blockerEdgeScope))) return;
+    const mutationAllowed = await assertAgentIssueMutationAllowed(req, res, existing, blockerEdgeScope);
+    if (!mutationAllowed) return;
+    // A grant-admitted blocker write is authorized against the snapshot read
+    // above, outside the write transaction. Carry that snapshot down as a
+    // precondition so the whole-set replacement refuses rather than silently
+    // clobbering an edge that landed in between — the removal guard is only
+    // meaningful if the set it was computed against is still the set on the row.
+    const expectedCurrentBlockerIssueIds =
+      mutationAllowed !== true && mutationAllowed.admittedByBlockerEdgeGrant && priorRelationsForBlockerEdge
+        ? priorRelationsForBlockerEdge.blockedBy.map((relation) => relation.id)
+        : null;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -8286,6 +8296,7 @@ export function issueRoutes(
     const postCommitActivityPublications: ActivityPublication[] = [];
     const issueUpdateData = {
       ...updateFields,
+      ...(expectedCurrentBlockerIssueIds ? { expectedCurrentBlockerIssueIds } : {}),
       actorAgentId: actor.agentId ?? null,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
     };

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3426,6 +3426,39 @@ export function issueRoutes(
     await assertCanAssignTasks(req, companyId, assignmentScope);
   }
 
+  type BlockerEdgeMutationScope = {
+    addedBlockerIssueIds: string[];
+    removesExistingBlockers: boolean;
+  };
+
+  // Item 4 — the load-bearing guard for the widened blocker-edge grant.
+  //
+  // The grant is available ONLY when the request body mutates the blocker set
+  // and nothing else. Narrowing is proven here, at the one place that can see
+  // the whole body, so the ordering verb cannot smuggle a content edit
+  // alongside it. Anything this function does not positively recognise returns
+  // null, which leaves the ordinary `issue:mutate` boundary untouched.
+  function resolveBlockerEdgeMutationScope(
+    body: Record<string, unknown>,
+    currentBlockedByIssueIds: string[],
+  ): BlockerEdgeMutationScope | null {
+    const keys = Object.keys(body);
+    if (keys.length !== 1 || keys[0] !== "blockedByIssueIds") return null;
+    const requested = body.blockedByIssueIds;
+    if (!Array.isArray(requested)) return null;
+    if (!requested.every((value) => typeof value === "string" && value.length > 0)) return null;
+    const requestedIds = [...new Set(requested as string[])];
+    const current = new Set(currentBlockedByIssueIds);
+    return {
+      addedBlockerIssueIds: requestedIds.filter((id) => !current.has(id)),
+      // `blockedByIssueIds` is a whole-set replacement, so a caller adding one
+      // edge must resend the edges already there. Dropping an existing blocker
+      // is a different act from stating an ordering, and the ownership basis
+      // refuses it — see agentOwnsProposedBlockerIssues in authorization.ts.
+      removesExistingBlockers: currentBlockedByIssueIds.some((id) => !requestedIds.includes(id)),
+    };
+  }
+
   async function decideIssueAccess(
     req: Request,
     issue: {
@@ -3438,6 +3471,7 @@ export function issueRoutes(
       status: string;
     },
     action: "issue:comment" | "issue:read" | "issue:mutate",
+    blockerEdge?: BlockerEdgeMutationScope | null,
   ) {
     return access.decide({
       actor: req.actor,
@@ -3458,6 +3492,13 @@ export function issueRoutes(
         parentIssueId: issue.parentId,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
+        ...(blockerEdge
+          ? {
+            blockerEdgeOnly: true,
+            addedBlockerIssueIds: blockerEdge.addedBlockerIssueIds,
+            blockerEdgeRemovesExisting: blockerEdge.removesExistingBlockers,
+          }
+          : {}),
       },
     });
   }
@@ -3515,6 +3556,13 @@ export function issueRoutes(
     return decision !== true && decision.reason === "allow_issue_mention_grant";
   }
 
+  // Either grant basis admits a blocker-edge write across the ownership
+  // boundary: the mention grant, and the ownership-of-the-added-blockers grant.
+  function isIssueBlockerEdgeGrantDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {
+    return decision !== true
+      && (decision.reason === "allow_issue_mention_grant" || decision.reason === "allow_issue_blocker_edge_grant");
+  }
+
   function isDirectParentReportDecision(decision: true | Awaited<ReturnType<typeof decideIssueAccess>>) {
     return decision !== true && decision.reason === "allow_direct_parent_report";
   }
@@ -3566,6 +3614,7 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
     },
+    blockerEdge?: BlockerEdgeMutationScope | null,
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3596,10 +3645,23 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
-    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
+    const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate", blockerEdge);
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
       return false;
+    }
+    // A blocker-edge write admitted by the mention or ownership grant is, by
+    // construction, a write onto *another* agent's row — that is the whole point
+    // of the grant. The assignee-ownership boundary below would refuse exactly
+    // the case the grant exists to permit, so it is skipped here and only here.
+    // Nothing else is skipped: the body was already narrowed to
+    // `blockedByIssueIds` (resolveBlockerEdgeMutationScope), and the blocker
+    // validation, cycle checks and low-trust control-plane guard in the handler
+    // still run. The checked-out 409 is skipped with it: an ordering edge does
+    // not contend with the assignee's content edits, and refusing it while the
+    // target is in_progress would defeat the grant in its primary case.
+    if (blockerEdge && isIssueBlockerEdgeGrantDecision(boundaryDecision)) {
+      return true;
     }
     if (issue.assigneeAgentId === null) {
       return true;
@@ -7821,7 +7883,21 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    // Resolve the blocker-edge seam before the mutation gate: the gate needs to
+    // know whether this body is a pure ordering write in order to admit the
+    // mention/ownership grant for it. A body carrying anything else resolves to
+    // null and takes the ordinary `issue:mutate` path unchanged.
+    const priorRelationsForBlockerEdge =
+      Array.isArray(req.body.blockedByIssueIds) && Object.keys(req.body).length === 1
+        ? await svc.getRelationSummaries(existing.id)
+        : null;
+    const blockerEdgeScope = priorRelationsForBlockerEdge
+      ? resolveBlockerEdgeMutationScope(
+        req.body as Record<string, unknown>,
+        priorRelationsForBlockerEdge.blockedBy.map((relation) => relation.id),
+      )
+      : null;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, blockerEdgeScope))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -7835,7 +7911,7 @@ export function issueRoutes(
     const titleOrDescriptionChanged = req.body.title !== undefined || req.body.description !== undefined;
     const existingRelations =
       Array.isArray(req.body.blockedByIssueIds)
-        ? await svc.getRelationSummaries(existing.id)
+        ? priorRelationsForBlockerEdge ?? await svc.getRelationSummaries(existing.id)
         : null;
     const {
       comment: commentBody,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -105,6 +105,7 @@ export type AuthorizationDecision = {
     | "allow_consented_change"
     | "allow_legacy_agent_creator"
     | "allow_issue_mention_grant"
+    | "allow_issue_blocker_edge_grant"
     | "allow_direct_parent_report"
     | "allow_self"
     | "allow_company_agent"
@@ -517,6 +518,25 @@ function activeResponsibleUserCanAuthorizeAgentGrantedSkillChange(
 
 function scopeBoolean(scope: Record<string, unknown> | null | undefined, key: string) {
   return scope?.[key] === true;
+}
+
+function scopeIssueIdList(scope: Record<string, unknown> | null | undefined, key: string) {
+  const raw = scope?.[key];
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.filter((value): value is string => typeof value === "string" && value.length > 0))];
+}
+
+// A blocker-edge mutation is an `issue:mutate` whose request body was already
+// narrowed by the caller to the single `blockedByIssueIds` field. It is a
+// routing/ordering write, not a content edit, so it may be admitted by the
+// mention grant that `issue:mutate` is otherwise withheld from. The caller is
+// responsible for proving the narrowing before setting this scope flag — see
+// `assertAgentIssueMutationAllowed` in routes/issues.ts.
+function isBlockerEdgeOnlyIssueMutation(
+  action: AuthorizationAction,
+  scope: Record<string, unknown> | null | undefined,
+) {
+  return action === "issue:mutate" && scopeBoolean(scope, "blockerEdgeOnly");
 }
 
 export function authorizationDeniedDetails(decision: AuthorizationDecision) {
@@ -949,6 +969,7 @@ export function authorizationService(db: Db) {
     resource: AuthorizationResource;
     resolution: TrustPresetResolution;
     directParentReportTarget: boolean;
+    scope?: Record<string, unknown> | null;
   }): Promise<AuthorizationDecision | null> {
     if (input.resolution.kind === "standard") return null;
     if (input.resolution.kind === "denied") {
@@ -1033,18 +1054,27 @@ export function authorizationService(db: Db) {
       if (await issueResourceWithinLowTrustBoundary(boundary, input.resource)) {
         return lowTrustAllow("Allowed inside the low-trust issue boundary.");
       }
+      // `issue:mutate` is withheld from the mention grant here because a content
+      // edit is not something a mention can license. A blocker-edge-only mutate
+      // is not a content edit, so it is admitted on the same footing as
+      // `issue:comment` — the caller has already proven the body carries no
+      // other field.
+      const blockerEdgeOnly = isBlockerEdgeOnlyIssueMutation(input.action, input.scope);
       if (
-        input.action !== "issue:mutate" &&
-        input.resource.issueId &&
-        await agentHasMentionGrantOnIssue({
+        (input.action !== "issue:mutate" || blockerEdgeOnly) &&
+        input.resource.issueId
+      ) {
+        const basis = await resolveIssueMentionScopedGrant({
           action: input.action,
           companyId: boundary.companyId,
           issueId: input.resource.issueId,
           issueAssigneeAgentId: input.resource.assigneeAgentId ?? null,
           actorAgentId: input.actorAgentId,
-        })
-      ) {
-        return allowIssueMentionGrant(input.action);
+          blockerEdgeOnly,
+          addedBlockerIssueIds: scopeIssueIdList(input.scope, "addedBlockerIssueIds"),
+          removesExistingBlockers: scopeBoolean(input.scope, "blockerEdgeRemovesExisting"),
+        });
+        if (basis) return allowIssueMentionGrant(input.action, basis);
       }
       return lowTrustDeny("Issue is outside this low-trust boundary.");
     }
@@ -1388,7 +1418,90 @@ export function authorizationService(db: Db) {
     return false;
   }
 
-  function allowIssueMentionGrant(action: AuthorizationAction): AuthorizationDecision {
+  // Second basis for a blocker-edge write: the actor already owns every issue it
+  // is proposing to add as a blocker. Pointing your own work at another agent's
+  // row states an ordering; it cannot edit that row's content, and it cannot add
+  // a blocker the actor does not own. Removals are never admitted on this basis
+  // — dropping someone else's blocker is not an ordering you own.
+  async function agentOwnsProposedBlockerIssues(input: {
+    companyId: string;
+    actorAgentId: string;
+    addedBlockerIssueIds: string[];
+    removesExistingBlockers: boolean;
+  }) {
+    if (input.removesExistingBlockers) return false;
+    if (input.addedBlockerIssueIds.length === 0) return false;
+    const rows = await db
+      .select({
+        id: issues.id,
+        assigneeAgentId: issues.assigneeAgentId,
+        createdByAgentId: issues.createdByAgentId,
+      })
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, input.companyId),
+        inArray(issues.id, input.addedBlockerIssueIds),
+      ));
+    // Every proposed blocker must resolve, inside this company, to an issue the
+    // actor created or is assigned. A blocker that does not resolve fails the
+    // count check below, so an unreadable or cross-company id denies rather than
+    // silently dropping out of the set.
+    if (rows.length !== input.addedBlockerIssueIds.length) return false;
+    return rows.every((row) =>
+      row.assigneeAgentId === input.actorAgentId || row.createdByAgentId === input.actorAgentId
+    );
+  }
+
+  // Resolves the grant basis that admits a mention-scoped issue write, or null.
+  // `blockerEdgeOnly` widens the set of admissible bases; it never narrows it.
+  async function resolveIssueMentionScopedGrant(input: {
+    action: AuthorizationAction;
+    companyId: string;
+    issueId: string;
+    issueAssigneeAgentId: string | null;
+    actorAgentId: string;
+    blockerEdgeOnly: boolean;
+    addedBlockerIssueIds: string[];
+    removesExistingBlockers: boolean;
+  }): Promise<"mention" | "blocker_edge" | null> {
+    if (await agentHasMentionGrantOnIssue({
+      action: input.action,
+      companyId: input.companyId,
+      issueId: input.issueId,
+      issueAssigneeAgentId: input.issueAssigneeAgentId,
+      actorAgentId: input.actorAgentId,
+    })) {
+      return "mention";
+    }
+    if (input.blockerEdgeOnly && await agentOwnsProposedBlockerIssues({
+      companyId: input.companyId,
+      actorAgentId: input.actorAgentId,
+      addedBlockerIssueIds: input.addedBlockerIssueIds,
+      removesExistingBlockers: input.removesExistingBlockers,
+    })) {
+      logger.info({
+        actorAgentId: input.actorAgentId,
+        issueId: input.issueId,
+        companyId: input.companyId,
+        grantedAction: input.action,
+        grant: "issue_blocker_edge",
+      }, "authorized issue blocker-edge grant");
+      return "blocker_edge";
+    }
+    return null;
+  }
+
+  function allowIssueMentionGrant(
+    action: AuthorizationAction,
+    basis: "mention" | "blocker_edge" = "mention",
+  ): AuthorizationDecision {
+    if (basis === "blocker_edge") {
+      return allow({
+        action,
+        reason: "allow_issue_blocker_edge_grant",
+        explanation: "Allowed by a blocker-edge grant over issues the actor owns.",
+      });
+    }
     return allow({
       action,
       reason: "allow_issue_mention_grant",
@@ -1791,6 +1904,7 @@ export function authorizationService(db: Db) {
       resource: input.resource,
       resolution: trustResolution,
       directParentReportTarget,
+      scope: input.scope,
     });
     if (lowTrustDecision) {
       if (!lowTrustDecision.allowed) return lowTrustDecision;
@@ -2017,18 +2131,22 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
+      const blockerEdgeOnly = isBlockerEdgeOnlyIssueMutation(input.action, input.scope);
       if (
-        input.action === "issue:comment" &&
-        resource?.issueId &&
-        await agentHasMentionGrantOnIssue({
+        (input.action === "issue:comment" || blockerEdgeOnly) &&
+        resource?.issueId
+      ) {
+        const basis = await resolveIssueMentionScopedGrant({
           action: input.action,
           companyId,
           issueId: resource.issueId,
           issueAssigneeAgentId: resource.assigneeAgentId ?? null,
           actorAgentId,
-        })
-      ) {
-        return allowIssueMentionGrant(input.action);
+          blockerEdgeOnly,
+          addedBlockerIssueIds: scopeIssueIdList(input.scope, "addedBlockerIssueIds"),
+          removesExistingBlockers: scopeBoolean(input.scope, "blockerEdgeRemovesExisting"),
+        });
+        if (basis) return allowIssueMentionGrant(input.action, basis);
       }
     }
     if (

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4664,28 +4664,59 @@ export function issueService(db: Db) {
     blockedByIssueIds: string[],
     actor: { agentId?: string | null; userId?: string | null } = {},
     dbOrTx: any = db,
+    // Optimistic-concurrency precondition. When supplied, the blocker set read
+    // by the caller's authorization check must still be the set on the row at
+    // write time. This write is a whole-set replacement, so without the check a
+    // caller authorized against a stale snapshot can delete an edge that landed
+    // in between — including one the caller was never allowed to remove.
+    expectedCurrentBlockerIssueIds?: string[] | null,
   ) {
     const deduped = [...new Set(blockedByIssueIds)];
     if (deduped.some((candidate) => candidate === issueId)) {
       throw unprocessable("Issue cannot be blocked by itself");
     }
 
-    if (deduped.length > 0) {
-      const lockedIssueIds = [issueId, ...deduped].sort();
+    if (deduped.length > 0 || expectedCurrentBlockerIssueIds) {
+      const lockedIssueIds = [...new Set([issueId, ...deduped])].sort();
       await dbOrTx.execute(
         sql`SELECT ${issues.id} FROM ${issues}
             WHERE ${and(eq(issues.companyId, companyId), inArray(issues.id, lockedIssueIds))}
             ORDER BY ${issues.id}
             FOR UPDATE`,
       );
-      const relatedIssues = await dbOrTx
-        .select({ id: issues.id })
-        .from(issues)
-        .where(and(eq(issues.companyId, companyId), inArray(issues.id, deduped)));
-      if (relatedIssues.length !== deduped.length) {
-        throw unprocessable("Blocked-by issues must belong to the same company");
+      if (expectedCurrentBlockerIssueIds) {
+        // Read under the lock taken above, so this reflects the set the
+        // replacement below is about to overwrite.
+        const currentRows = await dbOrTx
+          .select({ blockerIssueId: issueRelations.issueId })
+          .from(issueRelations)
+          .where(and(
+            eq(issueRelations.companyId, companyId),
+            eq(issueRelations.relatedIssueId, issueId),
+            eq(issueRelations.type, "blocks"),
+          ));
+        const observed: string[] = [
+          ...new Set(currentRows.map((row: { blockerIssueId: string }) => row.blockerIssueId)),
+        ].sort() as string[];
+        const expected = [...new Set(expectedCurrentBlockerIssueIds)].sort();
+        if (observed.length !== expected.length || observed.some((id: string, index: number) => id !== expected[index])) {
+          throw conflict("Blocked-by issues changed since this request was authorized", {
+            code: "blocked_by_precondition_failed",
+            issueId,
+          });
+        }
       }
-      await assertNoBlockingCycles(companyId, issueId, deduped, dbOrTx);
+
+      if (deduped.length > 0) {
+        const relatedIssues = await dbOrTx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(and(eq(issues.companyId, companyId), inArray(issues.id, deduped)));
+        if (relatedIssues.length !== deduped.length) {
+          throw unprocessable("Blocked-by issues must belong to the same company");
+        }
+        await assertNoBlockingCycles(companyId, issueId, deduped, dbOrTx);
+      }
     }
 
     await dbOrTx
@@ -7099,6 +7130,7 @@ export function issueService(db: Db) {
       data: Partial<typeof issues.$inferInsert> & {
         labelIds?: string[];
         blockedByIssueIds?: string[];
+        expectedCurrentBlockerIssueIds?: string[] | null;
         actorAgentId?: string | null;
         actorUserId?: string | null;
       },
@@ -7117,6 +7149,7 @@ export function issueService(db: Db) {
       const {
         labelIds: nextLabelIds,
         blockedByIssueIds,
+        expectedCurrentBlockerIssueIds,
         actorAgentId,
         actorUserId,
         ...issueData
@@ -7365,6 +7398,7 @@ export function issueService(db: Db) {
               userId: actorUserId ?? null,
             },
             tx,
+            expectedCurrentBlockerIssueIds ?? null,
           );
         }
         if (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents coordinate through issues. Ordering between issues is recorded with the `blockedByIssueIds` field, which the scheduler reads to decide what is ready to run
> - An agent that is mentioned on another agent's issue receives a mention-scoped grant. That grant is admitted for `issue:comment` and withheld from `issue:mutate`
> - `blockedByIssueIds` is reachable only through `issue:mutate`. So a mentioned agent can say "this must wait for that" in a comment, and cannot write the edge that makes the scheduler honour it
> - The ordering is then carried only as prose in issue descriptions, which drift apart. `POST /issues` already accepts `blockedByIssueIds` at create time, so the field itself was never the sensitive part
> - This pull request admits the mention grant to a PATCH whose body carries `blockedByIssueIds` and nothing else, at both boundary sites that withhold it
> - The benefit is that an ordering an agent is allowed to state, it is also allowed to record

## Linked Issues or Issue Description

No public issue exists. The defect is described below, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**
An agent that holds a mention-scoped grant on an issue it is not assigned can post a comment on that issue, but receives `403` when it sends `PATCH /api/issues/:id` with only `blockedByIssueIds`. The same bearer, on the same issue, in the same minute, gets `201` for the comment and `403` for the blocker write.

**Expected behavior**
An actor that may state an ordering in a comment on an issue should also be able to record that ordering as a blocker edge on the same issue. Writing a blocker edge is a routing act, not a content edit.

**Steps to reproduce**
1. Create issue A assigned to agent 1, and issue B assigned to agent 2.
2. As agent 1, post a comment on issue A that mentions agent 2. This creates the mention-scoped grant.
3. As agent 2, `POST /api/issues/<A>/comments` — succeeds with `201`.
4. As agent 2, `PATCH /api/issues/<A>` with body `{"blockedByIssueIds": ["<B>"]}` — fails with `403`.

**Paperclip version or commit**
Reproduced on `master`. The two conjuncts responsible are `input.action !== "issue:mutate"` in `decideLowTrustAccess` and `input.action === "issue:comment"` in `decideBase`, both in `server/src/services/authorization.ts`.

**Deployment mode**
Not deployment-specific. The check is in the authorization service and applies to every mode.

**Access context**
Agent actor authenticated with an agent key, acting on an issue assigned to a different agent. Reproduces under both the standard trust preset and the low-trust review preset.

Related open pull requests, found while searching for duplicates. None of them change who may write a blocker edge, so there is no overlap in behaviour:

- Refs #10475 — rejects unknown issue PATCH fields. Adjacent to the body-narrowing guard here.
- Refs #8459 — lets recovery owners clear stale blockers. A different actor and a different basis.
- Refs #10269 — stops an implicit reopen when the same PATCH wires blockers.

## What Changed

- Added an `allow_issue_blocker_edge_grant` decision reason, so a blocker write stays distinguishable from a comment in the audit trail.
- Admitted the mention grant to `issue:mutate` at **both** sites that withheld it: `decideLowTrustAccess` (written in the negative, `action !== "issue:mutate"`) and `decideBase` (written in the positive, `action === "issue:comment"`). A blocker-edge mutation must clear both, so fixing one alone changes nothing observable.
- Qualified the request through the existing authorization `scope` channel rather than adding a new action verb. `scope.blockerEdgeOnly` is read by a single helper, `isBlockerEdgeOnlyIssueMutation`.
- Added a second grant basis: an actor that created or is assigned **every** issue it proposes to add as a blocker may record that ordering. The check is "every added blocker", not "any". A request that also drops an existing blocker is refused on this basis.
- Added the route seam. `PATCH /issues/:id` resolves the narrowing before the mutation gate, and passes the added-blocker set and a removal flag to the authorization layer.
- Skipped the assignee-ownership refusal for a blocker-edge write that the grant admitted. That refusal would otherwise deny exactly the case the grant exists to permit.
- Added tests for both boundary sites, both grant bases, and the body-narrowing guard.

### On not adding an `issue:block` verb

A new action was the obvious shape and was rejected on the merits. `PermissionKey` is re-enumerated at about ten sites, each a list of the form `action === "issue:read" || action === "issue:comment" || action === "issue:mutate"`. An action missing from one of those lists does not fail loudly — it falls through to that branch's default, and the defaults differ per site. The failure direction is unknown per site and would not be visible in review.

Reusing the existing `issue:comment` action for the narrowed PATCH was also considered and rejected. `issue:comment` carries a second, unrelated allow path: `allow_direct_parent_report` admits a comment on the current run issue's direct parent under the standard trust preset, with no mention grant at all. Asserting `issue:comment` for a blocker write would silently hand every agent the ability to rewrite its parent issue's blocker edges. That widening is invisible in the diff, because it appears as a narrowing from `issue:mutate` to `issue:comment`.

The scope channel avoids both. It adds no action to enumerate, inherits no unrelated allow path, and keeps the audit action as `issue:mutate`.

### The three `agentHasMentionGrantOnIssue` call sites after this change

| site | what it does now |
|---|---|
| `decideLowTrustAccess`, direct-parent report branch | Unchanged. Still `issue:comment` only; this is the low-trust direct-parent reporting path and has nothing to do with blocker edges. |
| `decideLowTrustAccess`, boundary branch | Now also admits `issue:mutate` when the caller proved the body is blocker-only. Reached through `resolveIssueMentionScopedGrant`. |
| `decideBase`, ordinary issue branch | Same change, at the ordinary boundary. Reached through `resolveIssueMentionScopedGrant`. |

## Verification

```
pnpm --filter @paperclipai/server typecheck
npx vitest run server/src/__tests__/authorization-service.test.ts
npx vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
```

New tests, all passing:

- `authorization-service.test.ts` — a low-trust mentioned agent is admitted to a blocker-edge `issue:mutate`, and the same actor with the same mention is denied without the scope. This negative control is what proves the low-trust site is load-bearing.
- `authorization-service.test.ts` — the same pair at the ordinary boundary, under the standard trust preset.
- `authorization-service.test.ts` — the ownership basis: admitted when the actor created or is assigned every added blocker; denied when one added blocker is owned by someone else; denied when the request also drops an existing blocker.
- `authorization-service.test.ts` — an empty added-blocker set cannot establish the ownership basis.
- `issue-agent-mutation-ownership-routes.test.ts` — a peer agent completes a blocker-only PATCH on another agent's active checkout, and the widened scope reaches the authorization layer.
- `issue-agent-mutation-ownership-routes.test.ts` — a PATCH carrying `blockedByIssueIds` **and** `title` is refused, and the widened scope is never set. This is the guard that stops an ordering write from smuggling a content edit.

Regression run over the suites that touch this path — `low-trust-red-team-routes`, `issue-dependency-wakeups-routes`, `issues-service`, `issue-comment-reopen-routes`, `issue-activity-events-routes` — 215 tests, all passing.

## Risks

Moderate. This widens an authorization boundary, so the guards are the load-bearing part.

- The widened grant is reachable only when the PATCH body has exactly one key, `blockedByIssueIds`, holding an array of non-empty strings. Anything else resolves to `null` and takes the ordinary `issue:mutate` path unchanged. The narrowing is proven in the route, at the one place that can see the whole body.
- The assignee-ownership refusal is skipped only for a request that was both narrowed and admitted by one of the two grant bases. Blocker validation, cycle checks and the low-trust control-plane guard in the handler all still run.
- The checked-out `409` is skipped along with it. An ordering edge does not contend with the assignee's content edits, and refusing it while the target is `in_progress` would defeat the grant in its main case. This is a deliberate behavioural change and the one most worth a reviewer's attention.
- The ownership basis refuses removals, so it cannot be used to drop another agent's blocker. The mention basis still permits removals, which matches what that grant already licenses.
- No migration. No schema change. The new decision reason is additive.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use and code execution. The measurements quoted above — the boundary sites, the enumeration sites, and the test runs — were produced by running the commands, not from memory.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no shipped documentation describes this authorization boundary (searched `docs/`, `doc/`, `DESIGN.md`), so the behaviour is recorded in code comments and in this PR body
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
