### PR TITLE
docs(guides): add BuyWhere MCP agent example

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,7 +68,8 @@
               "guides/agent-developer/task-workflow",
               "guides/agent-developer/comments-and-communication",
               "guides/agent-developer/handling-approvals",
-              "guides/agent-developer/cost-reporting"
+              "guides/agent-developer/cost-reporting",
+              "guides/agent-developer/buywhere-agent-example"
             ]
           }
         ]

--- a/docs/guides/agent-developer/buywhere-agent-example.md
+++ b/docs/guides/agent-developer/buywhere-agent-example.md
@@ -1,0 +1,183 @@
+---
+title: BuyWhere Agent Example
+summary: Use BuyWhere's MCP server to add product search, deals, and price comparison to your Paperclip agent
+---
+
+This guide shows how to configure a Paperclip agent to use [BuyWhere](https://buywhere.ai), an MCP server that provides real-time product search and price comparison across Singapore, Southeast Asia, and the US.
+
+## What BuyWhere Provides
+
+BuyWhere exposes an MCP server with 8 tools over one JSON-RPC endpoint:
+
+| Tool | Description |
+|------|-------------|
+| `search_products` | Full-text search across Shopee, Lazada, Amazon SG, Amazon US, Walmart, and 20+ more platforms |
+| `lookup_product` | Get detailed product info by URL or ID |
+| `compare_prices` | Compare prices for the same product across multiple retailers |
+| `get_deals` | Products with the biggest current discounts |
+| `price_history` | Historical price chart for a product |
+| `list_categories` | Browse available product categories |
+| `subscribe_price_alert` | Monitor price drops on specific products |
+| `list_merchants` | See all retailers indexed by BuyWhere |
+
+## Prerequisites
+
+- A Paperclip company with at least one agent configured
+- A BuyWhere API key ([get one free](https://buywhere.ai) — free tier: 1,000 calls/month)
+
+## Setup
+
+### 1. Install the BuyWhere MCP Server
+
+In your agent's execution environment, install the BuyWhere MCP server:
+
+```sh
+npm install -g @buywhere/mcp-server
+# or
+npx @buywhere/mcp-server --help
+```
+
+### 2. Configure Your Paperclip Agent
+
+Set these environment variables on your agent (via the Paperclip UI → Agent → Settings → Environment, or via the API):
+
+```env
+BUYWHERE_API_KEY=bw_live_your_api_key_here
+```
+
+### 3. Connect via MCP (if your adapter supports MCP)
+
+If your adapter supports MCP servers natively (e.g., Claude Code with MCP configured), add this to your `mcp_servers.json`:
+
+```json
+{
+  "mcpServers": {
+    "buywhere": {
+      "command": "npx",
+      "args": ["-y", "@buywhere/mcp-server"],
+      "env": {
+        "BUYWHERE_API_KEY": "${BUYWHERE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### 4. Or Use the HTTP Endpoint Directly
+
+Paperclip agents can call the BuyWhere HTTP API directly without MCP:
+
+```typescript
+const response = await fetch("https://api.buywhere.ai/mcp", {
+  method: "POST",
+  headers: {
+    "Authorization": `Bearer ${process.env.BUYWHERE_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "search_products",
+      arguments: { query: "wireless headphones singapore", limit: 10 }
+    }
+  })
+});
+const data = await response.json();
+```
+
+## Example: Product Research Agent
+
+Here's a complete agent instruction set for a product research agent that uses BuyWhere:
+
+```
+You are a product research agent. When given a product category or specific product,
+use the BuyWhere tools to:
+
+1. Search for the product across multiple retailers
+2. Compare prices to find the best deal
+3. Check current discount/deal listings
+4. Look up historical pricing to identify if now is a good time to buy
+5. Report your findings in a structured format
+
+Always cite the specific retailer and price for each finding. Flag any products
+with unusual price swings or especially good deals.
+
+When searching:
+- Use search_products for general queries
+- Use get_deals when asked about discounts or "best deals"
+- Use compare_prices when you have a specific product URL or model
+- Use price_history when checking if a price is good or inflated
+
+Format your final report as:
+- Summary table: product | best price | retailer | deal %
+- Top 3 picks with reasoning
+- Any price alerts worth setting
+```
+
+## Example: Shopping Assistant Skill
+
+You can package BuyWhere integration as a Paperclip skill:
+
+```typescript
+// skills/buywhere-search/SKILL.md
+export const description = `Search products across Singapore, SEA, and US retailers`;
+
+// The agent calls these tools via the MCP server or HTTP API:
+export const tools = {
+  search_products: {
+    description: "Full-text product search",
+    parameters: {
+      query: "string",
+      limit: "number (default: 10)",
+      region: "sg | sea | us (default: sg)"
+    }
+  },
+  get_deals: {
+    description: "Current top discounts",
+    parameters: {
+      category: "string (optional)",
+      limit: "number (default: 10)"
+    }
+  }
+};
+```
+
+## Verification
+
+After setup, test that your agent can reach BuyWhere:
+
+```typescript
+// In your agent's execution context
+const test = await fetch("https://api.buywhere.ai/mcp", {
+  method: "POST",
+  headers: { "Authorization": `Bearer ${process.env.BUYWHERE_API_KEY}` },
+  body: JSON.stringify({
+    jsonrpc: "2.0", id: 1,
+    method: "tools/call",
+    params: { name: "list_categories", arguments: {} }
+  })
+});
+const result = await test.json();
+console.log("BuyWhere connected:", result.result?.content?.[0]?.text ?? "OK");
+```
+
+Expected output: a JSON list of product categories.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | Invalid or missing API key | Set `BUYWHERE_API_KEY` env var |
+| `429 Too Many Requests` | Rate limit exceeded | Upgrade plan or add delay between calls |
+| `500 Internal Server Error` | BuyWhere API issue | Check status at buywhere.ai and retry |
+| `ENOTFOUND api.buywhere.ai` | DNS/network issue | Verify internet connectivity from agent environment |
+
+## See Also
+
+- [BuyWhere MCP Server on npm](https://www.npmjs.com/package/@buywhere/mcp-server)
+- [BuyWhere Documentation](https://buywhere.ai/docs)
+- [GitHub: BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp)
+- [How Agents Work](/guides/agent-developer/how-agents-work)
+- [Writing a Skill](/guides/agent-developer/writing-a-skill)

--- a/docs/guides/agent-developer/buywhere-agent-example.md
+++ b/docs/guides/agent-developer/buywhere-agent-example.md
@@ -118,31 +118,41 @@ Format your final report as:
 
 ## Example: Shopping Assistant Skill
 
-You can package BuyWhere integration as a Paperclip skill:
+You can package BuyWhere integration as a Paperclip skill. A skill is a `SKILL.md` file with YAML frontmatter (see [Writing a Skill](/guides/agent-developer/writing-a-skill) for the full format):
 
-```typescript
-// skills/buywhere-search/SKILL.md
-export const description = `Search products across Singapore, SEA, and US retailers`;
+```markdown
+---
+name: buywhere-search
+description: >
+  Search products and find deals across Singapore, SEA, and US retailers using
+  the BuyWhere MCP server. Use when the user asks to search for products,
+  compare prices, find discounts, or browse categories. Do not use for
+  non-shopping queries.
+---
 
-// The agent calls these tools via the MCP server or HTTP API:
-export const tools = {
-  search_products: {
-    description: "Full-text product search",
-    parameters: {
-      query: "string",
-      limit: "number (default: 10)",
-      region: "sg | sea | us (default: sg)"
-    }
-  },
-  get_deals: {
-    description: "Current top discounts",
-    parameters: {
-      category: "string (optional)",
-      limit: "number (default: 10)"
-    }
-  }
-};
+# BuyWhere Product Search
+
+Call the BuyWhere tools exposed by the MCP server (or the HTTP API) to answer
+shopping queries.
+
+## Available tools
+
+- `search_products` — full-text search. Arguments: `query` (string),
+  `limit` (number, default 10), `region` (`sg` | `sea` | `us`, default `sg`).
+- `get_deals` — current top discounts. Arguments: `category` (string,
+  optional), `limit` (number, default 10).
+- `compare_prices` — compare one product across retailers.
+- `price_history` — historical price chart for a product.
+
+## How to use
+
+1. For a general query, call `search_products` with the user's terms.
+2. If the user wants discounts, call `get_deals`.
+3. For a specific product URL or model, call `compare_prices`.
+4. Always cite the retailer and price in your answer.
 ```
+
+Place this at `skills/buywhere-search/SKILL.md` in your agent's working directory.
 
 ## Verification
 
@@ -160,7 +170,10 @@ const test = await fetch("https://api.buywhere.ai/mcp", {
   })
 });
 const result = await test.json();
-console.log("BuyWhere connected:", result.result?.content?.[0]?.text ?? "OK");
+if (!test.ok || result.error || !result.result) {
+  throw new Error(`BuyWhere connection failed: ${JSON.stringify(result.error ?? result)}`);
+}
+console.log("BuyWhere connected:", result.result.content?.[0]?.text ?? JSON.stringify(result.result));
 ```
 
 Expected output: a JSON list of product categories.


### PR DESCRIPTION
<!-- Written in Simplified Technical English (ASD-STE100). -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents become more useful when they can take real-world actions through external tools and MCP servers
> - The Agent Developer guides show how to build and configure agents, but there is no end-to-end example of connecting an external MCP server as a sample agent capability
> - This gap makes it harder for new users to see how an MCP-based tool integrates with a Paperclip agent
> - This pull request adds a new Agent Developer guide that uses the BuyWhere MCP server (product search and price comparison) as a sample agent example
> - The benefit is a concrete, copy-paste reference for wiring an MCP server into a Paperclip agent, which the existing guides do not yet provide

## Linked Issues or Issue Description

No public GitHub issue exists for this change.

- **What is broken / missing:** The Agent Developer guides do not include a worked example of connecting an external MCP server to a Paperclip agent.
- **Expected behavior:** A reader can follow a single guide to install an MCP server, set the agent environment, configure the MCP client, and test the connection.
- **Steps to reproduce the gap:** Open the Agent Developer guides and search for an MCP integration example; none exists.
- **Paperclip version/commit:** master at commit bd7a13e.
- **Deployment mode:** Documentation (no runtime).

## What Changed

- Added `docs/guides/agent-developer/buywhere-agent-example.md`, a new guide that shows how to use the BuyWhere MCP server as a sample agent capability in Paperclip.
- Added `guides/agent-developer/buywhere-agent-example` to the `Agent Developer` group in `docs/docs.json` so the page appears in the navigation.

The guide covers:
- The eight BuyWhere MCP tools (search, lookup, compare, deals, history, categories, alerts, merchants).
- Prerequisites (a Paperclip company with one agent, and a BuyWhere API key).
- Setup steps: install the MCP server package, set the `BUYWHERE_API_KEY` environment variable on the agent, and add the server to `mcp_servers.json`.
- A direct HTTP API call alternative for adapters that do not use MCP.
- A full product-research agent instruction set.
- A packaged skill example.
- A verification snippet and an error-handling table.

## Verification

- `docs/docs.json` is valid JSON: `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"` passes.
- The new page path in `docs/docs.json` matches the file path `docs/guides/agent-developer/buywhere-agent-example.md`.
- The BuyWhere endpoints referenced in the guide are live (verified before writing): `https://api.buywhere.ai/mcp` and `https://buywhere.ai` both return HTTP 200.
- This is a documentation-only change. No tests or build steps are affected. A reviewer can confirm the page renders by running the docs preview (Mintlify) and opening the new guide.

## Risks

- Low risk. This change adds one markdown file and one line in a JSON nav file. It does not change any runtime code, configuration, or behavior.
- The BuyWhere MCP server and API are external third-party services. If BuyWhere changes its endpoint or tool names, the guide will need an update. The guide links to the BuyWhere docs and GitHub repo so the source of truth stays external.
- This is an integration example, not a core feature. It does not overlap with the Paperclip roadmap.

> Checked ROADMAP.md. This is a docs integration example, not core feature work, so it does not duplicate planned core work.

## Model Used

- **Provider:** Anthropic
- **Model ID/version:** flow-1 (Claude family)
- **Context window:** large (200K+)
- **Reasoning mode:** standard
- **Capability details:** tool use (git, curl, file edits)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`docs/buywhere-agent-example`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (docs-only change; no test suite affected)
- [x] I have added or updated tests where applicable (n/a for docs)
- [x] I have updated relevant documentation to reflect my changes (this PR is the documentation)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (will monitor after open)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address after review)
- [x] I will address all Greptile and reviewer comments before requesting merge
