### PR TITLE
fix(gemini-local): decide the auth selector inside the target, not on the host

### DIFF
--- a/packages/adapters/gemini-local/src/server/acp.test.ts
+++ b/packages/adapters/gemini-local/src/server/acp.test.ts
@@ -16,7 +16,14 @@ import {
 // A local stand-in for a sandbox runner: runs the managed-runtime staging
 // scripts (mkdir/tar/find) as real child processes so the remote ACP lane can
 // be exercised end-to-end against the host filesystem.
-function createLocalSandboxRunner() {
+//
+// The commands are spawned with ONLY the env the caller passes. A real sandbox
+// does not inherit the host environment, and anything the host happens to
+// export must not silently satisfy an in-sandbox credential check, so the fake
+// has to isolate the same way or it stops modelling the thing under test.
+const SANDBOX_BASE_ENV = { PATH: process.env.PATH ?? "/usr/bin:/bin" };
+
+function createLocalSandboxRunner(injectedEnv: Record<string, string> = {}) {
   let counter = 0;
   return {
     execute: async (input: {
@@ -32,7 +39,18 @@ function createLocalSandboxRunner() {
       const command = input.command === "bash" ? "/bin/bash" : input.command;
       return await runChildProcess(`gemini-acp-sandbox-run-${counter}`, command, input.args ?? [], {
         cwd: input.cwd ?? process.cwd(),
-        env: input.env ?? {},
+        // runChildProcess merges process.env under the supplied env, so blank
+        // the credential vars the sandbox is not supposed to inherit rather
+        // than letting the host's leak in.
+        env: {
+          GEMINI_API_KEY: "",
+          GOOGLE_API_KEY: "",
+          ...SANDBOX_BASE_ENV,
+          ...(input.env ?? {}),
+          // Modelled last, the way a provider injects secrets into the sandbox
+          // itself rather than through the adapter's run env.
+          ...injectedEnv,
+        },
         stdin: input.stdin,
         timeoutSec: Math.max(1, Math.ceil((input.timeoutMs ?? 30_000) / 1000)),
         graceSec: 5,
@@ -558,11 +576,13 @@ describe("gemini_local ACP lane", () => {
     const hostHome = path.join(root, "home");
     await fs.mkdir(localCwd, { recursive: true });
     await fs.mkdir(remoteCwd, { recursive: true });
-    // The key exists ONLY in the host process env — never in the adapter-config env
-    // — so the remote sandbox (which does not inherit the host environment) will not
-    // receive it. Selecting api-key auth off this host-only signal would start
-    // headless Gemini with a credential it cannot see and fail authentication, so
-    // the seam must NOT persist a selector here.
+    // The key exists ONLY in the host process env — never in the adapter-config
+    // env and never injected into the sandbox — so the agent process cannot read
+    // it. Selecting api-key auth off this host-only signal would start headless
+    // Gemini with a credential it cannot see and fail authentication, so no
+    // selector may be persisted. The selector command tests the credential
+    // inside the target, so this now holds because the key is genuinely absent
+    // there, not because the host-side heuristic happened to guess right.
     const SECRET_KEY = "AIza-host-only-key-SENTINEL";
     process.env.HOME = hostHome;
     process.env.GEMINI_API_KEY = SECRET_KEY;
@@ -616,6 +636,78 @@ describe("gemini_local ACP lane", () => {
     for (const value of Object.values(meta[0]?.env ?? {})) {
       expect(String(value)).not.toContain(SECRET_KEY);
     }
+  });
+
+  it("persists an api-key auth selector for a credential injected straight into the sandbox", async () => {
+    const root = await makeTempRoot("paperclip-gemini-acp-injectedkey-");
+    const localCwd = path.join(root, "worktree");
+    const remoteCwd = path.join(root, "remote-workspace");
+    const hostHome = path.join(root, "home");
+    await fs.mkdir(localCwd, { recursive: true });
+    await fs.mkdir(remoteCwd, { recursive: true });
+    // The production shape this regressed on: a sandbox provider injects the key
+    // straight into the sandbox (the Kubernetes provider copies process.env
+    // values named by its per-adapter envKeys into the pod), so the key is
+    // readable by the agent but appears in NEITHER the adapter-config env nor
+    // any host-side signal the seam used to consult. Without a selector the
+    // Gemini CLI refuses the headless run and the ACP agent idles until the
+    // sandbox backstop fires hours later, so a selector MUST be persisted here.
+    const SECRET_KEY = "AIza-injected-key-SENTINEL";
+    process.env.HOME = hostHome;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+
+    const meta: AdapterInvocationMeta[] = [];
+    const runtime = new FakeRuntime({});
+    const execute = createGeminiAcpExecutor({
+      createRuntime: (options) => {
+        Object.assign(runtime.options, options);
+        return runtime as never;
+      },
+    });
+
+    const result = await execute(
+      buildContext(localCwd, {
+        config: {
+          engine: "acp",
+          cwd: localCwd,
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+          env: { HOME: hostHome },
+          promptTemplate: "Do the assigned work.",
+        },
+        context: {
+          issueId: "issue-1",
+          paperclipWorkspace: { cwd: localCwd, source: "project_workspace", workspaceId: "workspace-1" },
+        },
+        executionTarget: {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "fake-plugin",
+          remoteCwd,
+          runner: createLocalSandboxRunner({ GEMINI_API_KEY: SECRET_KEY }),
+        } as never,
+        authToken: "real-run-jwt",
+        onMeta: async (payload) => {
+          meta.push(payload);
+        },
+      }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const remappedHome = String(meta[0]?.env?.HOME ?? "");
+    expect(remappedHome).toContain(".paperclip-runtime");
+    // The selector IS written, because the credential is readable where the
+    // agent runs, and it carries no key bytes.
+    const settingsRaw = await fs.readFile(
+      path.join(remappedHome, ".gemini", "settings.json"),
+      "utf8",
+    );
+    expect(JSON.parse(settingsRaw)).toEqual({
+      selectedAuthType: "gemini-api-key",
+      security: { auth: { selectedType: "gemini-api-key" } },
+    });
+    expect(settingsRaw).not.toContain(SECRET_KEY);
   });
 
   it("falls back to the CLI lane for a runner-less sandbox even when the ACP command is set", async () => {

--- a/packages/adapters/gemini-local/src/server/acp.ts
+++ b/packages/adapters/gemini-local/src/server/acp.ts
@@ -32,6 +32,7 @@ import {
   parseObject,
 } from "@paperclipai/adapter-utils/server-utils";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "../index.js";
+import { buildGeminiAuthSelectorCommand } from "./auth-settings.js";
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRootDir = path.resolve(moduleDir, "../..");
@@ -194,33 +195,17 @@ async function prepareGeminiRemoteManagedHome(
     );
   }
 
-  // Pre-select api-key auth (file-only; no key bytes) so headless Gemini does not
-  // fail with "Invalid auth method selected". Only the credential's PRESENCE is
-  // used as a signal — no key bytes are written to settings.json.
-  //
-  // The presence check reads ONLY the resolved run `env` — the credential state
-  // this seam actually provisions into the sandbox (adapter-config env + resolved
-  // secret refs, repointed onto the in-sandbox HOME). A key that exists only in
-  // the host `process.env` is NOT a reliable signal: the remote sandbox does not
-  // inherit the host environment, so persisting a `gemini-api-key` selector off a
-  // host-only key would start headless Gemini with an auth method whose credential
-  // is unavailable in-sandbox and fail authentication. We therefore select api-key
-  // auth only when the key is present in the run env that reaches the sandbox. An
-  // existing settings.json (user-shipped via workspace) is left untouched.
-  const hasGeminiApiKey = Boolean(env.GEMINI_API_KEY || env.GOOGLE_API_KEY);
-  if (hasGeminiApiKey) {
-    const remoteSettingsPath = path.posix.join(managedRemoteHomeDir, ".gemini", "settings.json");
-    const authSettingsJson = JSON.stringify({
-      selectedAuthType: "gemini-api-key",
-      security: { auth: { selectedType: "gemini-api-key" } },
-    });
-    await runAdapterExecutionTargetShellCommand(
-      runId,
-      executionTarget,
-      `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSettingsPath))} && { [ -f ${JSON.stringify(remoteSettingsPath)} ] || printf '%s' ${JSON.stringify(authSettingsJson)} > ${JSON.stringify(remoteSettingsPath)}; }`,
-      shellOptions,
-    );
-  }
+  // Pre-select api-key auth (file-only; no key bytes) so headless Gemini does
+  // not fail with "Invalid auth method selected". The command decides inside
+  // the target, where the credential is actually readable, because neither the
+  // run env nor the host env is a reliable signal on its own. See
+  // buildGeminiAuthSelectorCommand.
+  await runAdapterExecutionTargetShellCommand(
+    runId,
+    executionTarget,
+    buildGeminiAuthSelectorCommand(managedRemoteHomeDir),
+    shellOptions,
+  );
 
   return { stagedRuntime };
 }

--- a/packages/adapters/gemini-local/src/server/auth-settings.test.ts
+++ b/packages/adapters/gemini-local/src/server/auth-settings.test.ts
@@ -1,0 +1,94 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { buildGeminiAuthSelectorCommand } from "./auth-settings.js";
+
+const execFileAsync = promisify(execFile);
+
+async function runInShell(command: string, env: Record<string, string>) {
+  // `env: {...}` only, never merged with process.env: that is the point of the
+  // command, and a leaked host key would silently invalidate these tests.
+  return await execFileAsync("/bin/sh", ["-c", command], { env });
+}
+
+async function makeHome() {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "gemini-auth-selector-"));
+}
+
+async function readSettings(home: string): Promise<string | null> {
+  return await fs
+    .readFile(path.join(home, ".gemini", "settings.json"), "utf8")
+    .catch(() => null);
+}
+
+describe("buildGeminiAuthSelectorCommand", () => {
+  it("writes the selector when GEMINI_API_KEY is set in the target environment", async () => {
+    const home = await makeHome();
+    await runInShell(buildGeminiAuthSelectorCommand(home), { GEMINI_API_KEY: "AIza-in-target" });
+
+    const raw = await readSettings(home);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual({
+      selectedAuthType: "gemini-api-key",
+      security: { auth: { selectedType: "gemini-api-key" } },
+    });
+  });
+
+  it("writes the selector when only GOOGLE_API_KEY is set", async () => {
+    const home = await makeHome();
+    await runInShell(buildGeminiAuthSelectorCommand(home), { GOOGLE_API_KEY: "AIza-in-target" });
+
+    expect(await readSettings(home)).not.toBeNull();
+  });
+
+  it("writes no selector when neither key is set in the target environment", async () => {
+    const home = await makeHome();
+    await runInShell(buildGeminiAuthSelectorCommand(home), {});
+
+    expect(await readSettings(home)).toBeNull();
+  });
+
+  it("writes no selector when the keys are set but empty", async () => {
+    const home = await makeHome();
+    await runInShell(buildGeminiAuthSelectorCommand(home), {
+      GEMINI_API_KEY: "",
+      GOOGLE_API_KEY: "",
+    });
+
+    expect(await readSettings(home)).toBeNull();
+  });
+
+  it("never writes key bytes into the settings file", async () => {
+    const home = await makeHome();
+    const secret = "AIza-secret-value-SENTINEL";
+    await runInShell(buildGeminiAuthSelectorCommand(home), { GEMINI_API_KEY: secret });
+
+    expect(await readSettings(home)).not.toContain(secret);
+  });
+
+  it("leaves an existing settings.json untouched", async () => {
+    const home = await makeHome();
+    await fs.mkdir(path.join(home, ".gemini"), { recursive: true });
+    const userSettings = '{"selectedAuthType":"oauth-personal"}';
+    await fs.writeFile(path.join(home, ".gemini", "settings.json"), userSettings, "utf8");
+
+    await runInShell(buildGeminiAuthSelectorCommand(home), { GEMINI_API_KEY: "AIza-in-target" });
+
+    expect(await readSettings(home)).toBe(userSettings);
+  });
+
+  it("succeeds rather than failing the run when no credential is present", async () => {
+    const home = await makeHome();
+    await expect(runInShell(buildGeminiAuthSelectorCommand(home), {})).resolves.toBeDefined();
+  });
+
+  it("creates the .gemini directory when the managed home is empty", async () => {
+    const home = await makeHome();
+    await runInShell(buildGeminiAuthSelectorCommand(home), { GEMINI_API_KEY: "AIza-in-target" });
+
+    await expect(fs.stat(path.join(home, ".gemini"))).resolves.toBeDefined();
+  });
+});

--- a/packages/adapters/gemini-local/src/server/auth-settings.ts
+++ b/packages/adapters/gemini-local/src/server/auth-settings.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+
+/**
+ * Gemini refuses headless runs unless an auth method is persisted in
+ * `$HOME/.gemini/settings.json` ("Invalid auth method selected."); the
+ * `GEMINI_DEFAULT_AUTH_TYPE` env var alone does not satisfy it. With a managed
+ * HOME the runtime root replaces the image home, so anything baked into the
+ * image is invisible and the selector has to be written per run.
+ *
+ * Whether to write it depends on one question: will an api key actually be
+ * readable by the agent process? That is not reliably knowable on the host.
+ * The adapter's run env misses keys that a sandbox provider injects directly
+ * into the sandbox (the Kubernetes provider copies `process.env` values named
+ * by its per-adapter `envKeys` into the pod), while the host `process.env`
+ * carries keys that never reach a remote target at all. Guessing from either
+ * one is wrong somewhere: guess low and headless Gemini hangs with no auth
+ * method selected, guess high and it starts with an auth method whose
+ * credential is absent.
+ *
+ * So do not guess. This command runs inside the target, so it tests the
+ * credential where the agent will actually read it, at the moment it matters.
+ *
+ * Writes no key bytes: only the selector. An existing settings.json
+ * (user-shipped via the workspace) is left untouched.
+ */
+export function buildGeminiAuthSelectorCommand(managedHomeDir: string): string {
+  const settingsPath = path.posix.join(managedHomeDir, ".gemini", "settings.json");
+  const settingsJson = JSON.stringify({
+    selectedAuthType: "gemini-api-key",
+    security: { auth: { selectedType: "gemini-api-key" } },
+  });
+  const quotedDir = JSON.stringify(path.posix.dirname(settingsPath));
+  const quotedPath = JSON.stringify(settingsPath);
+  const quotedJson = JSON.stringify(settingsJson);
+  // Skip when the file already exists, then skip when neither key is set in
+  // the target's own environment, otherwise write the selector. Every branch
+  // exits 0, so the command never fails a run over an absent credential.
+  return (
+    `mkdir -p ${quotedDir} && { [ -f ${quotedPath} ] || ` +
+    `[ -z "\${GEMINI_API_KEY:-}\${GOOGLE_API_KEY:-}" ] || ` +
+    `printf '%s' ${quotedJson} > ${quotedPath}; }`
+  );
+}

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -58,6 +58,7 @@ import {
   parseGeminiJsonl,
 } from "./parse.js";
 import { firstNonEmptyLine } from "./utils.js";
+import { buildGeminiAuthSelectorCommand } from "./auth-settings.js";
 import {
   createGeminiAcpExecutor,
   formatGeminiAcpFallbackMessage,
@@ -417,31 +418,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       // $HOME/.gemini/settings.json ("Invalid auth method selected."); env vars
       // alone (GEMINI_DEFAULT_AUTH_TYPE) do not satisfy it. With a managed HOME
       // the runtime root replaces the image home, so any settings baked into the
-      // image are invisible -- pre-select the api-key auth whenever an API key
-      // is provided. Both settings schema generations are written (legacy
-      // selectedAuthType + current security.auth.selectedType). An existing
-      // settings.json (user-shipped via workspace) is left untouched.
+      // image are invisible -- pre-select the api-key auth per run. Both
+      // settings schema generations are written (legacy selectedAuthType +
+      // current security.auth.selectedType). An existing settings.json
+      // (user-shipped via workspace) is left untouched.
       // Only the managed HOME (the per-run runtime root) is touched: on
       // non-managed remote targets remoteHomeDir is the user's real home, where
       // creating files is out of scope and existing settings remain visible.
-      // Key presence check spans the run env AND the host process env: in the
-      // managed sandbox path the key never enters the adapter's run env -- it
-      // reaches the agent pod via the provider's per-run secret (envKeys
-      // passthrough from the host env), so the host env is the signal here.
-      const hasGeminiApiKey = Boolean(
-        env.GEMINI_API_KEY || env.GOOGLE_API_KEY ||
-        process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY,
-      );
-      if (managedRemoteHomeDir && hasGeminiApiKey) {
-        const remoteSettingsPath = path.posix.join(managedRemoteHomeDir, ".gemini", "settings.json");
-        const authSettingsJson = JSON.stringify({
-          selectedAuthType: "gemini-api-key",
-          security: { auth: { selectedType: "gemini-api-key" } },
-        });
+      // The credential's presence is decided inside the target rather than
+      // guessed here: the run env misses keys a sandbox provider injects
+      // directly into the sandbox, and the host env carries keys that never
+      // reach a remote target. See buildGeminiAuthSelectorCommand.
+      if (managedRemoteHomeDir) {
         await runAdapterExecutionTargetShellCommand(
           runId,
           executionTarget,
-          `mkdir -p ${JSON.stringify(path.posix.dirname(remoteSettingsPath))} && { [ -f ${JSON.stringify(remoteSettingsPath)} ] || printf '%s' ${JSON.stringify(authSettingsJson)} > ${JSON.stringify(remoteSettingsPath)}; }`,
+          buildGeminiAuthSelectorCommand(managedRemoteHomeDir),
           { cwd, env, timeoutSec, graceSec, onLog },
         );
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs can execute on a managed sandbox target, where the runtime root replaces the image home, so anything the image baked into `$HOME` is invisible to the run
> - The Gemini CLI refuses a headless run unless an auth method is persisted in `$HOME/.gemini/settings.json`, so the adapter has to write that selector per run
> - Both gemini lanes write it, but each guesses differently about whether a credential will actually be readable, and the question is not answerable on the host at all
> - When the guess came out low the CLI got no auth method, never started a turn, and the run idled for the full four-hour sandbox backstop holding a live sandbox
> - This pull request stops guessing and lets the command that writes the file test the credential inside the target, where the agent will read it
> - The benefit is that provider-injected credentials work, host-only credentials still correctly write nothing, and there is no longer a host-side heuristic to keep in sync across two lanes

## Linked Issues or Issue Description

No existing issue. Describing it inline, following `.github/ISSUE_TEMPLATE/bug_report.yml`:

**What happened?**
`gemini_local` runs on a managed sandbox target sat in `running` for four hours, having emitted a single `run started` event, then died on the adapter backstop. They held a live sandbox pod the entire time. No error was ever surfaced, because nothing failed: the agent process was alive and idle.

**Expected behavior**
The run executes, or fails quickly with a real reason.

**Steps to reproduce**
1. Run a `gemini_local` agent on a managed sandbox target whose provider injects the API key into the sandbox rather than through the adapter's run env (the Kubernetes provider does this: `buildAdapterEnv` copies `process.env` values named by the per-adapter `envKeys`, which for gemini are `["GOOGLE_API_KEY","GEMINI_API_KEY"]`).
2. Let the run take the ACP lane, which is the default.
3. `prepareGeminiRemoteManagedHome` evaluates `Boolean(env.GEMINI_API_KEY || env.GOOGLE_API_KEY)` against the adapter's run env, which does not carry the key, so it writes no selector.
4. `gemini --acp` starts with no auth method selected and never completes a turn.
5. The run stays `running` until `DEFAULT_REMOTE_SANDBOX_ADAPTER_TIMEOUT_SEC` (4h).

**Paperclip version or commit**
`master` at 18f391ef0.

**Deployment mode**
Self-hosted multi-tenant deployment on a Kubernetes sandbox provider.

**Installation method**
Docker image built from source.

**Agent adapter(s) involved**
`gemini_local`, ACP lane. The CLI lane in `execute.ts` has the mirror-image version of the same guess.

**Database mode**
PostgreSQL.

**Access context**
Server-side adapter execution on a remote sandbox execution target.

**Node.js version**
22.

**Operating system**
Linux (container), gVisor-isolated pod.

**Relevant logs or output**
Probed inside a wedged sandbox pod, 4h24m into the run:
```
PID  ELAPSED   STAT COMMAND
 77  04:24:23  Sl   node /usr/bin/gemini --acp
110  04:24:20  Sl   /usr/bin/node /usr/bin/gemini --acp

cat: /home/paperclip/.gemini/settings.json: No such file or directory
```
The agent process is alive and idle, and the selector file it needs is absent.

**Relevant config**
Not config dependent. Any managed sandbox whose provider injects credentials into the sandbox rather than the run env hits this.

**Additional context**
The two lanes disagreed in code and in their comments. `execute.ts` reads run env plus host env, noting that in the managed sandbox path the key reaches the pod via the provider's per-run secret. `acp.ts` reads run env only, noting that a host-only key is unreliable because the sandbox does not inherit the host environment. Both observations are true; neither rule is correct on its own.

## What Changed

- Adds `buildGeminiAuthSelectorCommand(managedHomeDir)` in a new `auth-settings.ts`, returning a shell command that creates `$HOME/.gemini`, skips when a settings file already exists, skips when neither `GEMINI_API_KEY` nor `GOOGLE_API_KEY` is set **in the environment the command runs in**, and otherwise writes the selector. Every branch exits 0, so an absent credential can never fail a run.
- Uses it from both lanes, replacing the two divergent host-side checks with one rule.
- Writes no key bytes, and still leaves a user-shipped `settings.json` untouched.
- Isolates the acp test's fake sandbox runner from the host environment. It called `runChildProcess`, which merges `process.env`, so the fake did not model the env isolation that is the point of a sandbox and could silently satisfy an in-sandbox credential check from the host.

## Verification

- `npx vitest run packages/adapters/gemini-local/src/server/auth-settings.test.ts` — 8 tests running the real command through `/bin/sh` with an explicitly non-inherited env: writes on `GEMINI_API_KEY`, writes on `GOOGLE_API_KEY`, does not write with no keys, does not write with empty keys, never writes key bytes, leaves an existing file untouched, exits 0 with no credential, creates the directory.
- `npx vitest run packages/adapters/gemini-local/src/server/acp.test.ts` — 13 passed, including a new regression test for the production shape (credential injected into the sandbox, absent from the run env) which **fails on `master` and passes with this change**.
- The pre-existing `does not persist an api-key auth selector from a host-only credential` test still passes, and now for the right reason: the key is genuinely absent in the target rather than a host-side heuristic guessing correctly.
- Full package: 55 passed, 1 pre-existing unrelated failure (`pre-selects gemini-api-key auth in the managed HOME for sandbox execution`, which fails identically on an unmodified `master` checkout on this machine because the test's fake shell does not answer a remote file-size probe).

## Risks

Low, and it narrows behaviour rather than widening it. The selector is now written strictly when a credential is readable where the agent runs, which is a subset of "either env has it" and a superset of "the run env has it". The case that changes is exactly the broken one: a provider-injected credential now gets a selector instead of an idling agent.

One thing worth naming: the command relies on the target's shell seeing the same environment the agent process will. That holds for the sandbox transports here, where both the staging commands and the agent run in the same sandbox. If a future transport ran staging commands somewhere other than where the agent executes, this check would need to move with it.

## Model Used

Claude Opus 5 (claude-opus-5, 1M context), extended thinking, with tool use and code execution. Diagnosed from a live deployment: the run records showed hangs with no output, and a probe inside the wedged sandbox pod showed the ACP process alive and idle with the selector file absent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
