### PR TITLE
feat(projects): add permanent deletion with managed cleanup

### DIFF
--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agents,
@@ -16,6 +16,8 @@ import {
   issueExecutionDecisions,
   issueReadStates,
   issues,
+  projects,
+  projectWorkspaces,
   routines,
 } from "@paperclipai/db";
 import {
@@ -24,6 +26,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { agentService } from "../services/agents.ts";
 import { companyService } from "../services/companies.ts";
+import { projectService } from "../services/projects.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -55,6 +58,8 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(routines);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -109,6 +114,28 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     });
 
     return { agentId, companyId, issueId, runId };
+  }
+
+  async function seedProjectFixture() {
+    const { companyId } = await seedFixture();
+    const projectId = randomUUID();
+    const workspaceCwd = `/tmp/paperclip-managed/${companyId}/${projectId}`;
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Disposable project",
+      status: "backlog",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: randomUUID(),
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: workspaceCwd,
+      isPrimary: true,
+    });
+    return { companyId, projectId, workspaceCwd };
   }
 
   it("removes agent-owned issue comments and run-linked activity before deleting the agent", async () => {
@@ -278,5 +305,43 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(routines).where(eq(routines.id, routineId))).resolves.toHaveLength(0);
     await expect(db.select().from(agents).where(eq(agents.id, agentId))).resolves.toHaveLength(0);
     await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("deletes project-managed files only when explicitly requested", async () => {
+    const { companyId, projectId, workspaceCwd } = await seedProjectFixture();
+    const removeManagedFiles = vi.fn().mockResolvedValue(undefined);
+
+    const removed = await projectService(db, { removeManagedFiles }).remove(projectId, {
+      deleteFiles: true,
+    });
+
+    expect(removeManagedFiles).toHaveBeenCalledWith({
+      companyId,
+      projectId,
+      workspaceCwds: [workspaceCwd],
+    });
+    expect(removed?.fileCleanup).toBe("succeeded");
+  });
+
+  it("does not delete project-managed files by default", async () => {
+    const { projectId } = await seedProjectFixture();
+    const removeManagedFiles = vi.fn().mockResolvedValue(undefined);
+
+    const removed = await projectService(db, { removeManagedFiles }).remove(projectId);
+
+    expect(removeManagedFiles).not.toHaveBeenCalled();
+    expect(removed?.fileCleanup).toBe("not_requested");
+  });
+
+  it("reports project cleanup failure after completing database deletion", async () => {
+    const { projectId } = await seedProjectFixture();
+    const removeManagedFiles = vi.fn().mockRejectedValue(new Error("permission denied"));
+
+    const removed = await projectService(db, { removeManagedFiles }).remove(projectId, {
+      deleteFiles: true,
+    });
+
+    expect(removed?.fileCleanup).toBe("failed");
+    await expect(db.select().from(projects).where(eq(projects.id, projectId))).resolves.toHaveLength(0);
   });
 });

--- a/server/src/__tests__/project-goal-telemetry-routes.test.ts
+++ b/server/src/__tests__/project-goal-telemetry-routes.test.ts
@@ -22,6 +22,7 @@ const mockAccessService = vi.hoisted(() => ({
   decide: vi.fn(),
 }));
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockHeartbeatService = vi.hoisted(() => ({ cancelRun: vi.fn() }));
 const mockSecretService = vi.hoisted(() => ({
   normalizeEnvBindingsForPersistence: vi.fn(),
 }));
@@ -39,6 +40,7 @@ vi.mock("../telemetry.js", () => ({
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
   environmentService: () => mockEnvironmentService,
+  heartbeatService: () => mockHeartbeatService,
   goalService: () => mockGoalService,
   logActivity: mockLogActivity,
   projectService: () => mockProjectService,
@@ -48,6 +50,7 @@ vi.mock("../services/index.js", () => ({
 
 vi.mock("../services/workspace-runtime.js", () => ({
   startRuntimeServicesForWorkspaceControl: vi.fn(),
+  stopRuntimeServicesForExecutionWorkspace: vi.fn(),
   stopRuntimeServicesForProjectWorkspace: vi.fn(),
 }));
 
@@ -59,6 +62,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     accessService: () => mockAccessService,
     environmentService: () => mockEnvironmentService,
+    heartbeatService: () => mockHeartbeatService,
     goalService: () => mockGoalService,
     logActivity: mockLogActivity,
     projectService: () => mockProjectService,
@@ -68,6 +72,7 @@ function registerModuleMocks() {
 
   vi.doMock("../services/workspace-runtime.js", () => ({
     startRuntimeServicesForWorkspaceControl: vi.fn(),
+    stopRuntimeServicesForExecutionWorkspace: vi.fn(),
     stopRuntimeServicesForProjectWorkspace: vi.fn(),
   }));
 }

--- a/server/src/__tests__/project-goal-telemetry-routes.test.ts
+++ b/server/src/__tests__/project-goal-telemetry-routes.test.ts
@@ -22,7 +22,10 @@ const mockAccessService = vi.hoisted(() => ({
   decide: vi.fn(),
 }));
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
-const mockHeartbeatService = vi.hoisted(() => ({ cancelRun: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelRun: vi.fn(),
+  waitForRunExecutionDrain: vi.fn(),
+}));
 const mockSecretService = vi.hoisted(() => ({
   normalizeEnvBindingsForPersistence: vi.fn(),
 }));

--- a/server/src/__tests__/project-managed-file-cleanup.test.ts
+++ b/server/src/__tests__/project-managed-file-cleanup.test.ts
@@ -15,7 +15,7 @@ describe("project managed-file cleanup", () => {
     await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
-  it("removes the managed project root without touching an external workspace", async () => {
+  it("removes the managed project root without touching external or sibling workspaces", async () => {
     const paperclipHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-project-cleanup-"));
     tempRoots.push(paperclipHome);
     process.env.PAPERCLIP_HOME = paperclipHome;
@@ -28,19 +28,27 @@ describe("project managed-file cleanup", () => {
       repoName: "repo",
     });
     const externalWorkspace = path.join(paperclipHome, "external-workspace");
+    const siblingWorkspace = resolveManagedProjectWorkspaceDir({
+      companyId,
+      projectId: "33333333-3333-4333-8333-333333333333",
+      repoName: "sibling",
+    });
     await mkdir(managedWorkspace, { recursive: true });
     await mkdir(externalWorkspace, { recursive: true });
+    await mkdir(siblingWorkspace, { recursive: true });
     await writeFile(path.join(managedWorkspace, "managed.txt"), "managed");
     await writeFile(path.join(externalWorkspace, "external.txt"), "external");
+    await writeFile(path.join(siblingWorkspace, "sibling.txt"), "sibling");
 
     await removeProjectManagedFiles({
       companyId,
       projectId,
-      workspaceCwds: [externalWorkspace],
+      workspaceCwds: [externalWorkspace, siblingWorkspace],
     });
 
     await expect(access(managedWorkspace)).rejects.toThrow();
     await expect(access(path.join(externalWorkspace, "external.txt"))).resolves.toBeUndefined();
+    await expect(access(path.join(siblingWorkspace, "sibling.txt"))).resolves.toBeUndefined();
   });
 
   it("rejects unsafe path segments", async () => {

--- a/server/src/__tests__/project-managed-file-cleanup.test.ts
+++ b/server/src/__tests__/project-managed-file-cleanup.test.ts
@@ -1,0 +1,55 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveManagedProjectWorkspaceDir } from "../home-paths.ts";
+import { removeProjectManagedFiles } from "../services/projects.ts";
+
+describe("project managed-file cleanup", () => {
+  const originalPaperclipHome = process.env.PAPERCLIP_HOME;
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = originalPaperclipHome;
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("removes the managed project root without touching an external workspace", async () => {
+    const paperclipHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-project-cleanup-"));
+    tempRoots.push(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+
+    const companyId = "11111111-1111-4111-8111-111111111111";
+    const projectId = "22222222-2222-4222-8222-222222222222";
+    const managedWorkspace = resolveManagedProjectWorkspaceDir({
+      companyId,
+      projectId,
+      repoName: "repo",
+    });
+    const externalWorkspace = path.join(paperclipHome, "external-workspace");
+    await mkdir(managedWorkspace, { recursive: true });
+    await mkdir(externalWorkspace, { recursive: true });
+    await writeFile(path.join(managedWorkspace, "managed.txt"), "managed");
+    await writeFile(path.join(externalWorkspace, "external.txt"), "external");
+
+    await removeProjectManagedFiles({
+      companyId,
+      projectId,
+      workspaceCwds: [externalWorkspace],
+    });
+
+    await expect(access(managedWorkspace)).rejects.toThrow();
+    await expect(access(path.join(externalWorkspace, "external.txt"))).resolves.toBeUndefined();
+  });
+
+  it("rejects unsafe path segments", async () => {
+    await expect(
+      removeProjectManagedFiles({
+        companyId: "../outside",
+        projectId: "project-id",
+        workspaceCwds: [],
+      }),
+    ).rejects.toThrow("Invalid company or project id");
+  });
+});

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -21,6 +21,7 @@ const mockEnvironmentService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockHeartbeatService = vi.hoisted(() => ({ cancelRun: vi.fn() }));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
 const mockAccessService = vi.hoisted(() => ({
@@ -34,6 +35,7 @@ vi.mock("../telemetry.js", () => ({
 vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
   environmentService: () => mockEnvironmentService,
+  heartbeatService: () => mockHeartbeatService,
   logActivity: mockLogActivity,
   projectService: () => mockProjectService,
   secretService: () => mockSecretService,
@@ -50,6 +52,7 @@ vi.mock("../services/secrets.js", () => ({
 
 vi.mock("../services/workspace-runtime.js", () => ({
   startRuntimeServicesForWorkspaceControl: vi.fn(),
+  stopRuntimeServicesForExecutionWorkspace: vi.fn(),
   stopRuntimeServicesForProjectWorkspace: vi.fn(),
 }));
 
@@ -61,6 +64,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     accessService: () => mockAccessService,
     environmentService: () => mockEnvironmentService,
+    heartbeatService: () => mockHeartbeatService,
     logActivity: mockLogActivity,
     projectService: () => mockProjectService,
     secretService: () => mockSecretService,
@@ -77,6 +81,7 @@ function registerModuleMocks() {
 
   vi.doMock("../services/workspace-runtime.js", () => ({
     startRuntimeServicesForWorkspaceControl: vi.fn(),
+    stopRuntimeServicesForExecutionWorkspace: vi.fn(),
     stopRuntimeServicesForProjectWorkspace: vi.fn(),
   }));
 }

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -21,7 +21,10 @@ const mockEnvironmentService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
-const mockHeartbeatService = vi.hoisted(() => ({ cancelRun: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelRun: vi.fn(),
+  waitForRunExecutionDrain: vi.fn(),
+}));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
 const mockAccessService = vi.hoisted(() => ({

--- a/server/src/__tests__/workspace-runtime-routes-authz.test.ts
+++ b/server/src/__tests__/workspace-runtime-routes-authz.test.ts
@@ -26,7 +26,10 @@ const mockEnvironmentService = vi.hoisted(() => ({
 }));
 
 const mockWorkspaceOperationService = vi.hoisted(() => ({}));
-const mockHeartbeatService = vi.hoisted(() => ({}));
+const mockHeartbeatService = vi.hoisted(() => ({
+  cancelRun: vi.fn(),
+  waitForRunExecutionDrain: vi.fn(),
+}));
 const mockLogActivity = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
 const mockAccessService = vi.hoisted(() => ({

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2527,7 +2527,10 @@ registry.registerPath({
   path: "/api/projects/{id}",
   tags: ["projects"],
   summary: "Delete a project",
-  request: { params: z.object({ id: z.string() }) },
+  request: {
+    params: z.object({ id: z.string() }),
+    query: z.object({ deleteFiles: z.enum(["true", "false", "1", "0"]).optional() }),
+  },
   responses: { 200: r.ok(), 401: r.unauthorized },
 });
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2531,7 +2531,19 @@ registry.registerPath({
     params: z.object({ id: z.string() }),
     query: z.object({ deleteFiles: z.enum(["true", "false", "1", "0"]).optional() }),
   },
-  responses: { 200: r.ok(), 401: r.unauthorized },
+  responses: {
+    200: r.ok(
+      z
+        .object({
+          id: z.string(),
+          companyId: z.string(),
+          name: z.string(),
+          fileCleanup: z.enum(["not_requested", "succeeded", "failed"]),
+        })
+        .passthrough(),
+    ),
+    401: r.unauthorized,
+  },
 });
 
 registry.registerPath({

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
-import type { Db } from "@paperclipai/db";
+import { executionWorkspaces, heartbeatRuns, issues, type Db } from "@paperclipai/db";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   createProjectSchema,
   createProjectWorkspaceSchema,
@@ -13,7 +14,13 @@ import {
 import type { WorkspaceRuntimeDesiredState, WorkspaceRuntimeServiceStateMap } from "@paperclipai/shared";
 import { trackProjectCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { accessService, projectService, logActivity, workspaceOperationService } from "../services/index.js";
+import {
+  accessService,
+  heartbeatService,
+  projectService,
+  logActivity,
+  workspaceOperationService,
+} from "../services/index.js";
 import { conflict, forbidden } from "../errors.js";
 import { externalObjectService } from "../services/external-objects.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
@@ -23,6 +30,7 @@ import {
   listConfiguredRuntimeServiceEntries,
   runWorkspaceJobForControl,
   startRuntimeServicesForWorkspaceControl,
+  stopRuntimeServicesForExecutionWorkspace,
   stopRuntimeServicesForProjectWorkspace,
 } from "../services/workspace-runtime.js";
 import {
@@ -43,6 +51,7 @@ const SHARED_WORKSPACE_STOP_AND_RESTART_ACTIONS = new Set(["stop", "restart"]);
 export function projectRoutes(db: Db) {
   const router = Router();
   const svc = projectService(db);
+  const heartbeat = heartbeatService(db);
   const access = accessService(db);
   const secretsSvc = secretService(db);
   const workspaceOperations = workspaceOperationService(db);
@@ -58,6 +67,65 @@ export function projectRoutes(db: Db) {
     await assertEnvironmentSelectionForCompany(environmentsSvc, companyId, environmentId, {
       allowedDrivers: ["local", "ssh", "sandbox"],
     });
+  }
+
+  async function stopProjectDeletionActivity(project: Awaited<ReturnType<typeof svc.getById>>) {
+    if (!project) return;
+
+    const issueRunRefs = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.projectId, project.id));
+    const referencedRunIds = Array.from(
+      new Set(
+        issueRunRefs.flatMap((row) => [row.checkoutRunId, row.executionRunId]).filter(Boolean),
+      ),
+    ) as string[];
+    const referencedActiveRuns =
+      referencedRunIds.length > 0
+        ? await db
+            .select({ id: heartbeatRuns.id })
+            .from(heartbeatRuns)
+            .where(
+              and(
+                inArray(heartbeatRuns.id, referencedRunIds),
+                inArray(heartbeatRuns.status, ["queued", "running"]),
+              ),
+            )
+        : [];
+    const contextualActiveRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.companyId, project.companyId),
+        inArray(heartbeatRuns.status, ["queued", "running"]),
+        sql`${heartbeatRuns.contextSnapshot} ->> 'projectId' = ${project.id}`,
+      ));
+
+    const activeRunIds = new Set([
+      ...referencedActiveRuns.map((row) => row.id),
+      ...contextualActiveRuns.map((row) => row.id),
+    ]);
+    for (const runId of activeRunIds) {
+      await heartbeat.cancelRun(runId, "Cancelled because the project was deleted");
+    }
+    for (const workspace of project.workspaces) {
+      await stopRuntimeServicesForProjectWorkspace({
+        db,
+        projectWorkspaceId: workspace.id,
+      });
+    }
+    const projectExecutionWorkspaces = await db
+      .select({ id: executionWorkspaces.id, cwd: executionWorkspaces.cwd })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.projectId, project.id));
+    for (const workspace of projectExecutionWorkspaces) {
+      await stopRuntimeServicesForExecutionWorkspace({
+        db,
+        executionWorkspaceId: workspace.id,
+        workspaceCwd: workspace.cwd,
+      });
+    }
   }
 
   function readProjectPolicyEnvironmentId(policy: unknown): string | null | undefined {
@@ -667,8 +735,12 @@ export function projectRoutes(db: Db) {
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Project not found");
     if (!existing) return;
-    const project = await svc.remove(id, {
-      deleteFiles: req.query.deleteFiles === "true" || req.query.deleteFiles === "1",
+    const deleteFiles = req.query.deleteFiles === "true" || req.query.deleteFiles === "1";
+    if (deleteFiles) {
+      await stopProjectDeletionActivity(existing);
+    }
+    const project = await svc.remove(existing.id, {
+      deleteFiles,
     });
     if (!project) {
       res.status(404).json({ error: "Project not found" });

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -108,6 +108,7 @@ export function projectRoutes(db: Db) {
     ]);
     for (const runId of activeRunIds) {
       await heartbeat.cancelRun(runId, "Cancelled because the project was deleted");
+      await heartbeat.waitForRunExecutionDrain(runId);
     }
     for (const workspace of project.workspaces) {
       await stopRuntimeServicesForProjectWorkspace({

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -667,7 +667,9 @@ export function projectRoutes(db: Db) {
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Project not found");
     if (!existing) return;
-    const project = await svc.remove(id);
+    const project = await svc.remove(id, {
+      deleteFiles: req.query.deleteFiles === "true" || req.query.deleteFiles === "1",
+    });
     if (!project) {
       res.status(404).json({ error: "Project not found" });
       return;

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,3 +1,5 @@
+import { rm } from "node:fs/promises";
+import path from "node:path";
 import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -31,7 +33,47 @@ import {
 import { listCurrentRuntimeServicesForProjectWorkspaces } from "./workspace-runtime-read-model.js";
 import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
 import { mergeProjectWorkspaceRuntimeConfig, readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
-import { resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { resolveManagedProjectWorkspaceDir, resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { logger } from "../middleware/logger.js";
+
+export type FileCleanupStatus = "not_requested" | "succeeded" | "failed";
+
+const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9_-]+$/;
+
+function isPathInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+export async function removeProjectManagedFiles(input: {
+  companyId: string;
+  projectId: string;
+  workspaceCwds: string[];
+}): Promise<void> {
+  if (!SAFE_PATH_SEGMENT.test(input.companyId) || !SAFE_PATH_SEGMENT.test(input.projectId)) {
+    throw new Error("Invalid company or project id for managed-file cleanup");
+  }
+
+  const projectsRoot = path.resolve(resolvePaperclipInstanceRoot(), "projects");
+  const managedProjectRoot = path.dirname(
+    resolveManagedProjectWorkspaceDir({
+      companyId: input.companyId,
+      projectId: input.projectId,
+      repoName: "_default",
+    }),
+  );
+  const targets = new Set([managedProjectRoot]);
+  for (const cwd of input.workspaceCwds) {
+    const resolved = path.resolve(cwd);
+    if (isPathInside(projectsRoot, resolved)) targets.add(resolved);
+  }
+
+  const results = await Promise.allSettled(
+    [...targets].map((target) => rm(target, { recursive: true, force: true })),
+  );
+  const failure = results.find((result) => result.status === "rejected");
+  if (failure?.status === "rejected") throw failure.reason;
+}
 
 type ProjectRow = typeof projects.$inferSelect;
 type ProjectWorkspaceRow = typeof projectWorkspaces.$inferSelect;
@@ -540,7 +582,16 @@ async function ensureSinglePrimaryWorkspace(
     );
 }
 
-export function projectService(db: Db) {
+export function projectService(
+  db: Db,
+  options: {
+    removeManagedFiles?: (input: {
+      companyId: string;
+      projectId: string;
+      workspaceCwds: string[];
+    }) => Promise<void>;
+  } = {},
+) {
   const createProject = async (
     companyId: string,
     data: Omit<typeof projects.$inferInsert, "companyId"> & { goalIds?: string[] },
@@ -865,16 +916,48 @@ export function projectService(db: Db) {
       return cleared;
     },
 
-    remove: (id: string) =>
-      db
-        .delete(projects)
-        .where(eq(projects.id, id))
-        .returning()
-        .then((rows) => {
-          const row = rows[0] ?? null;
-          if (!row) return null;
-          return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
-        }),
+    remove: async (id: string, removeOptions: { deleteFiles?: boolean } = {}) => {
+      const result = await db.transaction(async (tx) => {
+        const workspaceRows = removeOptions.deleteFiles
+          ? await tx
+              .select({ cwd: projectWorkspaces.cwd })
+              .from(projectWorkspaces)
+              .where(eq(projectWorkspaces.projectId, id))
+          : [];
+        const rows = await tx.delete(projects).where(eq(projects.id, id)).returning();
+        return {
+          row: rows[0] ?? null,
+          workspaceCwds: workspaceRows
+            .map(({ cwd }) => cwd)
+            .filter((cwd): cwd is string => typeof cwd === "string" && cwd.length > 0),
+        };
+      });
+      if (!result.row) return null;
+
+      let fileCleanup: FileCleanupStatus = "not_requested";
+      if (removeOptions.deleteFiles) {
+        try {
+          await (options.removeManagedFiles ?? removeProjectManagedFiles)({
+            companyId: result.row.companyId,
+            projectId: result.row.id,
+            workspaceCwds: result.workspaceCwds,
+          });
+          fileCleanup = "succeeded";
+        } catch (err) {
+          fileCleanup = "failed";
+          logger.warn(
+            { err, companyId: result.row.companyId, projectId: result.row.id },
+            "project deleted but managed-file cleanup failed",
+          );
+        }
+      }
+
+      return {
+        ...result.row,
+        urlKey: deriveProjectUrlKey(result.row.name, result.row.id),
+        fileCleanup,
+      };
+    },
 
     listWorkspaces: async (projectId: string): Promise<ProjectWorkspace[]> => {
       const rows = await db

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -54,7 +54,6 @@ export async function removeProjectManagedFiles(input: {
     throw new Error("Invalid company or project id for managed-file cleanup");
   }
 
-  const projectsRoot = path.resolve(resolvePaperclipInstanceRoot(), "projects");
   const managedProjectRoot = path.dirname(
     resolveManagedProjectWorkspaceDir({
       companyId: input.companyId,
@@ -65,7 +64,7 @@ export async function removeProjectManagedFiles(input: {
   const targets = new Set([managedProjectRoot]);
   for (const cwd of input.workspaceCwds) {
     const resolved = path.resolve(cwd);
-    if (isPathInside(projectsRoot, resolved)) targets.add(resolved);
+    if (isPathInside(managedProjectRoot, resolved)) targets.add(resolved);
   }
 
   const results = await Promise.allSettled(

--- a/ui/src/api/projects.ts
+++ b/ui/src/api/projects.ts
@@ -7,6 +7,8 @@ import type {
 import { api } from "./client";
 import { sanitizeWorkspaceRuntimeControlTarget } from "./workspace-runtime-control";
 
+export type FileCleanupStatus = "not_requested" | "succeeded" | "failed";
+
 function withCompanyScope(path: string, companyId?: string) {
   if (!companyId) return path;
   const separator = path.includes("?") ? "&" : "?";
@@ -62,5 +64,11 @@ export const projectsApi = {
     ),
   removeWorkspace: (projectId: string, workspaceId: string, companyId?: string) =>
     api.delete<ProjectWorkspace>(projectPath(projectId, companyId, `/workspaces/${encodeURIComponent(workspaceId)}`)),
-  remove: (id: string, companyId?: string) => api.delete<Project>(projectPath(id, companyId)),
+  remove: (id: string, options: { companyId?: string; deleteFiles?: boolean } = {}) =>
+    api.delete<Project & { fileCleanup: FileCleanupStatus }>(
+      withCompanyScope(
+        `/projects/${encodeURIComponent(id)}${options.deleteFiles ? "?deleteFiles=true" : ""}`,
+        options.companyId,
+      ),
+    ),
 };

--- a/ui/src/components/ProjectProperties.concurrency.test.tsx
+++ b/ui/src/components/ProjectProperties.concurrency.test.tsx
@@ -74,12 +74,22 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function render(project: Project, onFieldUpdate: (field: string, data: Record<string, unknown>) => void) {
+function render(
+  project: Project,
+  onFieldUpdate: (field: string, data: Record<string, unknown>) => void,
+  onDelete?: (deleteFiles: boolean) => void,
+) {
   act(() => {
     root.render(
       <QueryClientProvider client={primedClient()}>
         <TooltipProvider>
-          <ProjectProperties project={project} onFieldUpdate={onFieldUpdate} getFieldSaveState={() => "idle"} onArchive={noop} />
+          <ProjectProperties
+            project={project}
+            onFieldUpdate={onFieldUpdate}
+            getFieldSaveState={() => "idle"}
+            onArchive={noop}
+            onDelete={onDelete}
+          />
         </TooltipProvider>
       </QueryClientProvider>,
     );
@@ -125,5 +135,42 @@ describe("ProjectProperties — shared workspace concurrency select", () => {
         executionWorkspacePolicy: expect.objectContaining({ sharedWorkspaceConcurrency: "allow" }),
       }),
     );
+  });
+});
+
+describe("ProjectProperties — permanent deletion", () => {
+  function clickButton(label: string) {
+    const button = [...container.querySelectorAll("button")].find((candidate) =>
+      candidate.textContent?.includes(label),
+    );
+    if (!button) throw new Error(`Button not found: ${label}`);
+    act(() => button.click());
+  }
+
+  it("requires confirmation and forwards the managed-file opt-in", () => {
+    const onDelete = vi.fn();
+    render(makeProject(), vi.fn(), onDelete);
+
+    clickButton("Delete project");
+    const checkbox = container.querySelector<HTMLElement>('[role="checkbox"]');
+    if (!checkbox) throw new Error("Managed-file checkbox not found");
+    act(() => checkbox.click());
+    clickButton("Confirm delete");
+
+    expect(onDelete).toHaveBeenCalledWith(true);
+  });
+
+  it("resets the managed-file opt-in when the project changes", () => {
+    render(makeProject(), vi.fn(), vi.fn());
+    clickButton("Delete project");
+    const firstCheckbox = container.querySelector<HTMLElement>('[role="checkbox"]');
+    if (!firstCheckbox) throw new Error("Managed-file checkbox not found");
+    act(() => firstCheckbox.click());
+    expect(firstCheckbox.getAttribute("aria-checked")).toBe("true");
+
+    render(makeProject({ id: "project-2", urlKey: "project-2", name: "Second project" }), vi.fn(), vi.fn());
+    clickButton("Delete project");
+    const secondCheckbox = container.querySelector<HTMLElement>('[role="checkbox"]');
+    expect(secondCheckbox?.getAttribute("aria-checked")).toBe("false");
   });
 });

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -23,6 +23,7 @@ import { DraftInput } from "./agent-config-primitives";
 import { InlineEditor } from "./InlineEditor";
 import { EnvironmentVariablesEditor } from "./environment-variables-editor";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 
 const PROJECT_STATUSES = [
   { value: "backlog", label: "Backlog" },
@@ -39,6 +40,8 @@ interface ProjectPropertiesProps {
   getFieldSaveState?: (field: ProjectConfigFieldKey) => ProjectFieldSaveState;
   onArchive?: (archived: boolean) => void;
   archivePending?: boolean;
+  onDelete?: (deleteFiles: boolean) => void;
+  deletePending?: boolean;
 }
 
 export type ProjectFieldSaveState = "idle" | "saving" | "saved" | "error";
@@ -246,7 +249,70 @@ function ArchiveDangerZone({
   );
 }
 
-export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSaveState, onArchive, archivePending }: ProjectPropertiesProps) {
+function DeleteDangerZone({
+  project,
+  onDelete,
+  deletePending,
+}: {
+  project: Project;
+  onDelete: (deleteFiles: boolean) => void;
+  deletePending?: boolean;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [deleteFiles, setDeleteFiles] = useState(false);
+
+  return (
+    <div className="space-y-3 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-4">
+      <p className="text-sm text-muted-foreground">
+        Permanently delete this project and its database records. This cannot be undone.
+      </p>
+      {confirming ? (
+        <div className="space-y-3">
+          <label className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Checkbox
+              checked={deleteFiles}
+              onCheckedChange={(checked) => setDeleteFiles(checked === true)}
+              disabled={deletePending}
+            />
+            Also delete Paperclip-managed project workspace files
+          </label>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-destructive font-medium">
+              Delete &ldquo;{project.name}&rdquo; permanently?
+            </span>
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => onDelete(deleteFiles)}
+              disabled={deletePending}
+            >
+              {deletePending ? (
+                <><Loader2 className="h-3 w-3 animate-spin mr-1" />Deleting...</>
+              ) : "Confirm delete"}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setConfirming(false);
+                setDeleteFiles(false);
+              }}
+              disabled={deletePending}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button size="sm" variant="destructive" onClick={() => setConfirming(true)}>
+          <Trash2 className="h-3 w-3 mr-1" />Delete project
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSaveState, onArchive, archivePending, onDelete, deletePending }: ProjectPropertiesProps) {
   const { selectedCompanyId } = useCompany();
   const queryClient = useQueryClient();
   const [goalOpen, setGoalOpen] = useState(false);
@@ -1268,18 +1334,28 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
 
       </div>
 
-      {onArchive && (
+      {(onArchive || onDelete) && (
         <>
           <Separator className="my-4" />
           <div className="space-y-4 py-4">
             <div className="text-xs font-medium text-destructive uppercase tracking-wide">
               Danger Zone
             </div>
-            <ArchiveDangerZone
-              project={project}
-              onArchive={onArchive}
-              archivePending={archivePending}
-            />
+            {onArchive && (
+              <ArchiveDangerZone
+                project={project}
+                onArchive={onArchive}
+                archivePending={archivePending}
+              />
+            )}
+            {onDelete && (
+              <DeleteDangerZone
+                key={project.id}
+                project={project}
+                onDelete={onDelete}
+                deletePending={deletePending}
+              />
+            )}
           </div>
         </>
       )}

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -510,6 +510,32 @@ export function ProjectDetail() {
     },
   });
 
+  const deleteProject = useMutation({
+    mutationFn: (deleteFiles: boolean) =>
+      projectsApi.remove(projectLookupRef, {
+        companyId: resolvedCompanyId ?? lookupCompanyId,
+        deleteFiles,
+      }),
+    onSuccess: (deletedProject) => {
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(resolvedCompanyId) });
+      }
+      if (deletedProject.fileCleanup === "failed") {
+        pushToast({
+          title: `"${deletedProject.name}" was deleted, but file cleanup failed`,
+          body: "Some Paperclip-managed project files may need to be removed manually.",
+          tone: "warn",
+        });
+      } else {
+        pushToast({ title: `"${deletedProject.name}" has been deleted`, tone: "success" });
+      }
+      navigate("/projects");
+    },
+    onError: () => {
+      pushToast({ title: "Failed to delete project", tone: "error" });
+    },
+  });
+
   const uploadImage = useMutation({
     mutationFn: async (file: File) => {
       if (!resolvedCompanyId) throw new Error("No company selected");
@@ -939,6 +965,8 @@ export function ProjectDetail() {
             getFieldSaveState={(field) => fieldSaveStates[field] ?? "idle"}
             onArchive={(archived) => archiveProject.mutate(archived)}
             archivePending={archiveProject.isPending}
+            onDelete={(deleteFiles) => deleteProject.mutate(deleteFiles)}
+            deletePending={deleteProject.isPending}
           />
         </div>
       )}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Projects group work, configuration, and execution workspaces.
> - The server can delete a project, but the project UI only supports archive and unarchive.
> - Managed workspace files can remain after database deletion.
> - File removal must be explicit and limited to Paperclip-managed paths.
> - This pull request adds a guarded delete flow to Project Configuration.
> - The benefit is complete project lifecycle control without risking external workspaces.

## Linked Issues or Issue Description

Fixes: #7800

Refs: #4487

## What Changed

- Add a permanent project delete control to the existing Configuration danger zone.
- Require a second confirmation before deletion.
- Add an opt-in checkbox for Paperclip-managed project workspace cleanup.
- Add a `deleteFiles` query parameter to the existing project delete endpoint.
- Remove the managed project root and only workspace paths inside Paperclip's managed projects tree.
- Return `not_requested`, `succeeded`, or `failed` cleanup status.
- Log cleanup failures and keep the database deletion successful.
- Warn the user when database deletion succeeds but file cleanup fails.
- Reset destructive opt-in state when the project changes.
- Add service, path-boundary, and component tests.
- Update the OpenAPI request contract.

## Verification

- `pnpm exec vitest run server/src/__tests__/cleanup-removal-service.test.ts server/src/__tests__/project-managed-file-cleanup.test.ts --reporter=dot` (9 tests passed).
- `pnpm exec vitest run ui/src/components/ProjectProperties.concurrency.test.tsx --reporter=dot` (5 tests passed; the file has existing React `act` warnings).
- `pnpm --filter @paperclipai/ui typecheck` passed.
- `pnpm check:token-gates` passed.
- Server typecheck reached an unrelated dependency mismatch in the reused local dependency tree: upstream `spawnCwd` is absent from the installed `PaperclipAcpRuntimeOptions`. CI will install dependencies from this branch lockfile.

## Risks

- Database deletion completes before optional file cleanup. A filesystem failure can leave managed files behind. The API reports `failed`, the server logs the error, and the UI warns the user.
- Cleanup intentionally leaves workspace paths outside Paperclip's managed projects tree untouched.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, exact model ID `gpt-5.6-sol`. The platform manages the context window and does not expose its exact size. Reasoning, tool use, code execution, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
