### PR TITLE
fix(recovery): suppress cancelled silent-run cards and prefer CEO owner

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -131,9 +131,12 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
+    /** When true, also seed a CEO and leave the running agent with no reportsTo (role fallback). */
+    preferRoleFallbackOwner?: boolean;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
+    const ceoId = randomUUID();
     const coderId = randomUUID();
     const issueId = randomUUID();
     const runId = randomUUID();
@@ -162,13 +165,26 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         runtimeConfig: {},
         permissions: {},
       },
+      ...(opts.preferRoleFallbackOwner
+        ? [{
+            id: ceoId,
+            companyId,
+            name: "CEO",
+            role: "ceo" as const,
+            status: "idle" as const,
+            adapterType: "codex_local",
+            adapterConfig: {},
+            runtimeConfig: {},
+            permissions: {},
+          }]
+        : []),
       {
         id: coderId,
         companyId,
         name: "Coder",
         role: "engineer",
         status: "running",
-        reportsTo: managerId,
+        reportsTo: opts.preferRoleFallbackOwner ? null : managerId,
         adapterType: "codex_local",
         adapterConfig: {},
         runtimeConfig: {},
@@ -253,7 +269,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         updatedAt: terminalEvidenceAt,
       });
     }
-    return { companyId, managerId, coderId, issueId, runId, issuePrefix };
+    return { companyId, managerId, ceoId, coderId, issueId, runId, issuePrefix };
   }
 
   it("creates one medium-priority evaluation issue for a suspicious silent run", async () => {
@@ -923,6 +939,58 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       .where(and(eq(heartbeatRunWatchdogDecisions.runId, runId), eq(heartbeatRunWatchdogDecisions.decision, "dismissed_false_positive")));
     expect(decisions).toHaveLength(1);
     expect(decisions[0].evaluationIssueId).toBe(evaluationIssueId);
+  });
+
+  it("suppresses repeat alerts when evaluation is cancelled without a watchdog decision", async () => {
+    // SAT-9895: cancel-fast previously re-created a card every scan (~1/min floods).
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const evaluationIssueId = first.evaluationIssueIds[0];
+    expect(evaluationIssueId).toBeTruthy();
+
+    await db.update(issues).set({ status: "cancelled" }).where(eq(issues.id, evaluationIssueId));
+
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(second.created).toBe(0);
+    expect(second.skipped).toBe(1);
+
+    const third = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(third.created).toBe(0);
+    expect(third.skipped).toBe(1);
+
+    const decisions = await db
+      .select()
+      .from(heartbeatRunWatchdogDecisions)
+      .where(and(eq(heartbeatRunWatchdogDecisions.runId, runId), eq(heartbeatRunWatchdogDecisions.decision, "dismissed_false_positive")));
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].evaluationIssueId).toBe(evaluationIssueId);
+  });
+
+  it("assigns silent-run evaluation to CEO when no nearer manager applies", async () => {
+    // SAT-9895: role fallback prefers ceo before cto.
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, ceoId, managerId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      preferRoleFallbackOwner: true,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const scan = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(scan.created).toBe(1);
+    const [evaluation] = await db
+      .select({ assigneeAgentId: issues.assigneeAgentId })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.assigneeAgentId).toBe(ceoId);
+    expect(evaluation?.assigneeAgentId).not.toBe(managerId);
   });
 
   it("still allows re-arm after continue decision even when issue was closed on board", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1397,15 +1397,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
-  // Returns a `done` stale-run evaluation issue for this run if one exists.
-  // Used to detect when a reviewer closed an alert directly on the board without going through
-  // the watchdog decision API — which would not leave a dismissed_false_positive decision record.
+  // Returns a terminal (done/cancelled) stale-run evaluation issue for this run if one exists.
+  // Used to detect when a reviewer closed or cancelled an alert without going through the
+  // watchdog decision API — which would not leave a dismissed_false_positive decision record.
   //
-  // Scoped to `done` only (not `cancelled`): cancellation is used by other system code paths
-  // and does not imply a reviewer's "false positive" verdict. `done` is the explicit
-  // board-close path used by reviewers acknowledging the alert. A cancelled evaluation is
-  // allowed to re-fire on the next scan; if a reviewer wants permanent suppression they
-  // should mark the alert done or record a watchdog decision.
+  // Both `done` and `cancelled` suppress re-fire for this origin. Cancel-fast agents previously
+  // re-created a card every scan (~1/min floods). Permanent suppression still auto-records
+  // dismissed_false_positive on the next scan (same path as board `done` closes).
   async function findClosedStaleRunEvaluation(companyId: string, runId: string) {
     const [row] = await db
       .select({ id: issues.id, identifier: issues.identifier, status: issues.status })
@@ -1416,7 +1414,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
           eq(issues.originId, runId),
           visibleIssueCondition(),
-          eq(issues.status, "done"),
+          inArray(issues.status, ["done", "cancelled"]),
         ),
       )
       .orderBy(desc(issues.updatedAt))
@@ -1831,11 +1829,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (sourceAssignee?.reportsTo) candidateIds.push(sourceAssignee.reportsTo);
     }
     if (input.runningAgent.reportsTo) candidateIds.push(input.runningAgent.reportsTo);
+    // Prefer CEO over CTO for silent-run evaluation ownership when no nearer manager applies.
     const roleCandidates = await db
       .select()
       .from(agents)
-      .where(and(eq(agents.companyId, input.run.companyId), inArray(agents.role, ["cto", "ceo"])))
-      .orderBy(sql`case when ${agents.role} = 'cto' then 0 else 1 end`, asc(agents.createdAt));
+      .where(and(eq(agents.companyId, input.run.companyId), inArray(agents.role, ["ceo", "cto"])))
+      .orderBy(sql`case when ${agents.role} = 'ceo' then 0 else 1 end`, asc(agents.createdAt));
     candidateIds.push(...roleCandidates.map((agent) => agent.id));
 
     const seen = new Set<string>();
@@ -2119,7 +2118,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       return { kind: "skipped" as const };
     }
 
-    // Dedup: if a prior evaluation issue for this run was closed `done` on the board
+    // Dedup: if a prior evaluation issue for this run was closed `done` or `cancelled` on the board
     // without going through the watchdog decision API, no dismissed_false_positive record exists
     // and the watchdog would re-fire every cycle. Auto-record the suppression now so future
     // cycles skip immediately via hasDismissedFalsePositiveDecision.


### PR DESCRIPTION
## Summary
- Treat `cancelled` like `done` in `findClosedStaleRunEvaluation` so cancel-fast no longer re-fires a `stale_active_run_evaluation` card every scan (~1/min floods).
- Prefer **CEO** over CTO in `resolveStaleRunOwnerAgentId` role fallback when no nearer manager applies.
- Existing watchdog `snooze` / `continue` / `dismissed_false_positive` APIs unchanged; board cancel/done still auto-records `dismissed_false_positive` on the next scan.

## Test plan
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` (20 passed)
- [x] New regression: cancelled evaluation suppresses re-file
- [x] New regression: CEO preferred over CTO when role fallback applies


Made with [Cursor](https://cursor.com)