### PR TITLE
Allow managers to update subordinate-owned issues

### DIFF
--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -1586,6 +1586,70 @@ describeEmbeddedPostgres("authorization service", () => {
     expect(decision.explanation).toContain("another company");
   });
 
+  it("allows reporting-chain managers to comment on and mutate subordinate-owned issues", async () => {
+    const company = await createCompany(db, "ManagerIssueMutation");
+    const managerAgent = await createAgent(db, company.id, { role: "cto" });
+    const childAgent = await createAgent(db, company.id, { reportsTo: managerAgent.id });
+    const grandchildAgent = await createAgent(db, company.id, { reportsTo: childAgent.id });
+    const peerAgent = await createAgent(db, company.id);
+    const issue = await createIssue(db, company.id, {
+      title: "Subordinate-owned issue",
+      assigneeAgentId: grandchildAgent.id,
+    });
+    const authorization = authorizationService(db);
+    const resource = {
+      type: "issue",
+      companyId: company.id,
+      issueId: issue.id,
+      assigneeAgentId: grandchildAgent.id,
+      status: issue.status,
+    } as const;
+
+    for (const action of ["issue:comment", "issue:mutate"] as const) {
+      await expect(authorization.decide({
+        actor: { type: "agent", agentId: managerAgent.id, companyId: company.id, source: "agent_key" },
+        action,
+        resource,
+      })).resolves.toMatchObject({ allowed: true, reason: "allow_manager_chain" });
+
+      await expect(authorization.decide({
+        actor: { type: "agent", agentId: peerAgent.id, companyId: company.id, source: "agent_key" },
+        action,
+        resource,
+      })).resolves.toMatchObject({ allowed: false, reason: "deny_missing_grant" });
+    }
+  });
+
+  it("does not extend manager-chain issue mutation across company boundaries", async () => {
+    const managerCompany = await createCompany(db, "ManagerBoundarySource");
+    const targetCompany = await createCompany(db, "ManagerBoundaryTarget");
+    const managerAgent = await createAgent(db, managerCompany.id, { role: "cto" });
+    const targetAgent = await createAgent(db, targetCompany.id, { reportsTo: managerAgent.id });
+    const issue = await createIssue(db, targetCompany.id, {
+      title: "Foreign subordinate-looking issue",
+      assigneeAgentId: targetAgent.id,
+    });
+
+    for (const action of ["issue:comment", "issue:mutate"] as const) {
+      await expect(authorizationService(db).decide({
+        actor: {
+          type: "agent",
+          agentId: managerAgent.id,
+          companyId: managerCompany.id,
+          source: "agent_key",
+        },
+        action,
+        resource: {
+          type: "issue",
+          companyId: targetCompany.id,
+          issueId: issue.id,
+          assigneeAgentId: targetAgent.id,
+          status: issue.status,
+        },
+      })).resolves.toMatchObject({ allowed: false, reason: "deny_company_boundary" });
+    }
+  });
+
   it("allows scoped assignment inside a granted project and denies other projects", async () => {
     const company = await createCompany(db, "ProjectScope");
     const project = await createProject(db, company.id, "Allowed");

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -820,6 +820,53 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("lets a reporting-chain manager comment, patch status and blockers, and create work products", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed:
+        input.action === "issue:comment" ||
+        input.action === "issue:mutate" ||
+        input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason:
+        input.action === "issue:comment" ||
+        input.action === "issue:mutate" ||
+        input.action === "tasks:manage_active_checkouts"
+          ? "allow_manager_chain"
+          : "deny_missing_grant",
+      explanation: "Allowed because the actor manages the issue assignee in the reporting chain.",
+    }));
+    const app = await createApp(peerActor());
+
+    await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Manager update" })
+      .expect(201);
+    await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "blocked", blockedByIssueIds: [] })
+      .expect(200);
+    await request(app)
+      .post(`/api/issues/${issueId}/work-products`)
+      .send({ type: "artifact", provider: "test", title: "Manager artifact" })
+      .expect(201);
+
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Manager update",
+      expect.any(Object),
+      expect.any(Object),
+    );
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "blocked", blockedByIssueIds: [] }),
+    );
+    expect(mockWorkProductService.createForIssue).toHaveBeenCalledWith(
+      issueId,
+      companyId,
+      expect.objectContaining({ title: "Manager artifact" }),
+    );
+  });
+
   it("rejects peer agents from listing comments when issue read is outside their boundary", async () => {
     mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
       allowed: false,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -2017,6 +2017,13 @@ export function authorizationService(db: Db) {
           explanation: "Allowed because the issue has no agent assignee.",
         });
       }
+      if (await isManagerOf(companyId, actorAgentId, resource.assigneeAgentId)) {
+        return allow({
+          action: input.action,
+          reason: "allow_manager_chain",
+          explanation: "Allowed because the actor manages the issue assignee in the reporting chain.",
+        });
+      }
       if (
         input.action === "issue:comment" &&
         resource?.issueId &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The authorization service controls agent access to company issues.
> - Issue ownership protects active work from unrelated agents.
> - A reporting-chain manager already has authority to manage a subordinate's active checkout.
> - The base issue boundary denied that manager before the route could apply the existing manager authority.
> - This pull request aligns issue comment and mutation access with the reporting chain.
> - The benefit is that managers can coordinate subordinate work while peers remain denied.

## Linked Issues or Issue Description

Refs #9707, which covers manager comments but intentionally leaves mutation denied. This pull request includes that comment behavior and adds the manager mutation behavior required for status, blocker, and work-product updates.

**What happened?**

A reporting-chain manager could not comment on or update an issue after a subordinate became the assignee. The base authorization decision denied access before the route checked the existing active-checkout manager override.

**Expected behavior**

A same-company reporting-chain manager can comment on and mutate a subordinate-owned issue. A peer cannot do either action.

**Steps to reproduce**

1. Create a manager and a subordinate in one company.
2. Assign an active issue to the subordinate.
3. Authenticate as the manager.
4. Post a comment or patch the issue.
5. Observe a forbidden response before this change.

**Paperclip version or commit**

Reproduced on `master` before commit `3765ed0793e85b04745d6c29c375dc131617aa5f`.

## What Changed

- Allowed `issue:comment` and `issue:mutate` when the actor manages the assignee in the same-company reporting tree.
- Reused the existing `allow_manager_chain` decision and reporting-subtree lookup.
- Added service tests for transitive manager access, peer denial, and company-boundary denial.
- Added route tests for manager comments, status and blocker patches, and work-product creation.
- Preserved active-checkout conflict behavior for unrelated agents.

## Verification

- `pnpm vitest run server/src/__tests__/authorization-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
  - Passed: 2 files and 124 tests.
- `pnpm -r typecheck`
  - Passed.
- `pnpm test:run`
  - Server passed: 306 files and 3,344 tests; 2 skipped.
  - UI had two unrelated timezone-sensitive failures under `Europe/Warsaw`: `src/lib/attention.test.ts` and `src/components/IssueProperties.test.tsx` expect UTC day or clock values.
- `pnpm build`
  - Passed.
- This repository has no `bin/ci` entrypoint.

## Risks

- Moderate authorization risk because this adds manager mutation authority.
- The allow is restricted to the same-company reporting subtree.
- Existing route checks still protect active checkouts from peers and unrelated agents.
- Rollback is a revert of commit `3765ed0793e85b04745d6c29c375dc131617aa5f`.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5 family, with reasoning, repository file access, shell command execution, test execution, and GitHub CLI access. The exact context-window size was not exposed to this worker.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
