### PR TITLE
fix(claude-local): back off to the real reset when an account usage window is refused

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -11,7 +11,20 @@ import {
   isClaudeUnknownSessionError,
   isClaudeImageProcessingError,
   isClaudeModelNotFoundError,
+  readClaudeRateLimitRejection,
 } from "./parse.js";
+
+// A stream-json run refused by the account-level seven-day usage window. The CLI
+// reports the refusal three ways in one stream — the structured rate_limit_event,
+// the synthetic assistant message, and the result event — and this fixture keeps
+// all three so the classifier is exercised against the shape it really sees.
+// `resetsAt` 1785866400 is 2026-08-04T18:00:00Z, i.e. 7pm Europe/London.
+const WEEKLY_LIMIT_STDOUT = [
+  '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1785866400,"rateLimitType":"seven_day","overageStatus":"allowed","isUsingOverage":false},"uuid":"a1","session_id":"s1"}',
+  '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1785866400,"rateLimitType":"seven_day","overageStatus":"rejected","overageDisabledReason":"out_of_credits","isUsingOverage":false},"uuid":"a2","session_id":"s1"}',
+  '{"type":"assistant","message":{"model":"<synthetic>","role":"assistant","content":[{"type":"text","text":"You\'ve hit your weekly limit · resets 7pm (Europe/London)"}]},"session_id":"s1","error":"rate_limit","is_api_error_message":true}',
+  '{"type":"result","subtype":"success","is_error":true,"terminal_reason":"api_error","api_error_status":429,"result":"You\'ve hit your weekly limit · resets 7pm (Europe/London)","total_cost_usd":0,"session_id":"s1"}',
+].join("\n");
 
 describe("detectClaudeLoginRequired", () => {
   it("classifies Claude's invalid API key login prompt as auth required", () => {
@@ -365,6 +378,79 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+
+  it("prefers the structured rate_limit_event reset over the wall-clock prose", () => {
+    const now = new Date("2026-08-04T11:15:16.000Z");
+    expect(
+      extractClaudeRetryNotBefore({ stdout: WEEKLY_LIMIT_STDOUT }, now)?.toISOString(),
+    ).toBe("2026-08-04T18:00:00.000Z");
+  });
+
+  it("falls back to the prose reset when the structured reset is already past", () => {
+    // A stale resetsAt must not park the retry in the past; the prose clock
+    // rolls forward to the next occurrence instead.
+    const now = new Date("2026-08-05T11:15:16.000Z");
+    expect(
+      extractClaudeRetryNotBefore({ stdout: WEEKLY_LIMIT_STDOUT }, now)?.toISOString(),
+    ).toBe("2026-08-05T18:00:00.000Z");
+  });
+});
+
+describe("readClaudeRateLimitRejection", () => {
+  it("reads the rejected account window and its exact reset epoch", () => {
+    expect(readClaudeRateLimitRejection({ stdout: WEEKLY_LIMIT_STDOUT })).toEqual({
+      resetsAt: new Date("2026-08-04T18:00:00.000Z"),
+      rateLimitType: "seven_day",
+    });
+  });
+
+  it("ignores allowed rate-limit events emitted during healthy runs", () => {
+    const stdout =
+      '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1785866400,"rateLimitType":"seven_day"},"uuid":"a1"}';
+    expect(readClaudeRateLimitRejection({ stdout })).toBeNull();
+  });
+
+  it("returns null when the stream carries no rate-limit event", () => {
+    expect(readClaudeRateLimitRejection({ stdout: '{"type":"result","subtype":"success"}' })).toBeNull();
+  });
+});
+
+describe("claude subscription window classification (weekly-limit regression)", () => {
+  // Regression: "You've hit your weekly limit" matched neither the quota nor the
+  // reset wording, so the run was tagged claude_transient_upstream with no
+  // retryNotBefore and replayed on the short bounded backoff for the entire
+  // length of the window — every replay refused, every one costing a run.
+  const errorMessage = "You've hit your weekly limit · resets 7pm (Europe/London)";
+
+  it("classifies the weekly-limit wording as provider quota, not transient upstream", () => {
+    expect(isClaudeProviderQuotaError({ errorMessage })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(false);
+  });
+
+  it("classifies the 5-hour-limit wording as provider quota", () => {
+    expect(
+      isClaudeProviderQuotaError({ errorMessage: "You've hit your 5-hour limit · resets 3pm (Europe/London)" }),
+    ).toBe(true);
+  });
+
+  it("extracts the reset time from the weekly-limit prose alone", () => {
+    const now = new Date("2026-08-04T11:15:16.000Z");
+    expect(extractClaudeRetryNotBefore({ errorMessage }, now)?.toISOString()).toBe(
+      "2026-08-04T18:00:00.000Z",
+    );
+  });
+
+  it("classifies the real refused stream as quota even though it also looks like a 429", () => {
+    // The raw stream contains `"error":"rate_limit"` and `api_error_status: 429`,
+    // which is what previously won the classification race.
+    expect(isClaudeProviderQuotaError({ stdout: WEEKLY_LIMIT_STDOUT })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ stdout: WEEKLY_LIMIT_STDOUT })).toBe(false);
+  });
+
+  it("still treats a plain overload as transient rather than quota", () => {
+    expect(isClaudeProviderQuotaError({ stderr: "HTTP 529: overloaded_error" })).toBe(false);
+    expect(isClaudeTransientUpstreamError({ stderr: "HTTP 529: overloaded_error" })).toBe(true);
   });
 });
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -11,12 +11,33 @@ const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
-const CLAUDE_PROVIDER_QUOTA_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+// Subscription usage-window wording emitted by the Claude CLI. The CLI phrases
+// the same condition several ways depending on which window was hit — "You've
+// hit your session limit", "You've hit your weekly limit", "5-hour limit
+// reached" — so match the shared shape rather than enumerating one window at a
+// time (an unlisted window silently degrades to a generic transient retry).
+const CLAUDE_USAGE_LIMIT_WORDING = [
+  "you(?:'|’)ve\\s+hit\\s+your\\s+[^\\n.·]{0,40}?\\blimit\\b",
+  "(?:session|weekly|5[-\\s]?hour|seven[-\\s]?day)\\s+limit\\b",
+  "usage\\s+limit\\s+(?:reached|exceeded)",
+  "usage\\s+cap\\s+reached",
+  "claude\\s+usage\\s+limit\\s+reached",
+  "out\\s+of\\s+extra\\s+usage",
+  "extra\\s+usage\\b",
+  "servicequotaexceededexception",
+].join("|");
+const CLAUDE_PROVIDER_QUOTA_RE = new RegExp(`(?:${CLAUDE_USAGE_LIMIT_WORDING})`, "i");
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
-const CLAUDE_EXTRA_USAGE_RESET_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,120}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+const CLAUDE_EXTRA_USAGE_RESET_RE = new RegExp(
+  // The haystack includes raw stream-json lines, where the prose is embedded in a
+  // JSON string — so `"` and `,` terminate the hint just as `.` and a newline do.
+  `(?:${CLAUDE_USAGE_LIMIT_WORDING})[\\s\\S]{0,120}?\\bresets?\\s+(?:at\\s+)?([^\\n()]+?)(?:\\s*\\(([^)]+)\\))?(?:[.!,"]|\\n|$)`,
+  "i",
+);
+// A reset further out than this is almost certainly a misparse; fall back to the
+// caller's normal backoff rather than parking a run for months.
+const MAX_CLAUDE_RATE_LIMIT_RESET_HORIZON_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Sum the per-model usage ledger from a Claude CLI result event. The result
@@ -445,6 +466,68 @@ function parseClaudeResetClockTime(clockText: string, now: Date, timeZoneHint?: 
   return retryAt;
 }
 
+function epochSecondsToDate(value: unknown): Date | null {
+  const seconds =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+      ? Number.parseFloat(value)
+      : Number.NaN;
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  const date = new Date(seconds * 1000);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export interface ClaudeRateLimitRejection {
+  resetsAt: Date | null;
+  rateLimitType: string | null;
+}
+
+/**
+ * Read the Claude CLI's structured usage-window rejection off the stream-json
+ * stdout:
+ *
+ *   {"type":"rate_limit_event","rate_limit_info":{"status":"rejected",
+ *     "resetsAt":1785866400,"rateLimitType":"seven_day",...}}
+ *
+ * This is the only authoritative reset time available. The human-facing prose
+ * ("You've hit your weekly limit · resets 7pm (Europe/London)") carries a wall
+ * clock with no date, so a multi-day window parses to *tonight* — which is why a
+ * weekly limit used to be retried every few minutes for days. `resetsAt` is
+ * epoch seconds and is exact.
+ *
+ * Only `status: "rejected"` counts: the CLI also emits `allowed` events during
+ * healthy runs.
+ */
+export function readClaudeRateLimitRejection(input: {
+  stdout?: string | null;
+  stderr?: string | null;
+}): ClaudeRateLimitRejection | null {
+  let latest: ClaudeRateLimitRejection | null = null;
+
+  for (const source of [input.stdout ?? "", input.stderr ?? ""]) {
+    if (!source.includes("rate_limit_event")) continue;
+    for (const rawLine of source.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line.startsWith("{") || !line.includes("rate_limit_event")) continue;
+      const event = parseJson(line);
+      if (!event || asString(event.type, "") !== "rate_limit_event") continue;
+
+      const info = parseObject(event.rate_limit_info);
+      if (asString(info.status, "").trim().toLowerCase() !== "rejected") continue;
+
+      // Keep the last rejection in the stream: a run can be refused more than
+      // once and the newest event carries the freshest reset time.
+      latest = {
+        resetsAt: epochSecondsToDate(info.resetsAt ?? info.resets_at),
+        rateLimitType: asString(info.rateLimitType ?? info.rate_limit_type, "").trim() || null,
+      };
+    }
+  }
+
+  return latest;
+}
+
 export function extractClaudeRetryNotBefore(
   input: {
     parsed?: Record<string, unknown> | null;
@@ -454,6 +537,16 @@ export function extractClaudeRetryNotBefore(
   },
   now = new Date(),
 ): Date | null {
+  // Structured event first — it is the only source that survives a multi-day
+  // window (see readClaudeRateLimitRejection).
+  const structuredResetsAt = readClaudeRateLimitRejection(input)?.resetsAt ?? null;
+  if (structuredResetsAt) {
+    const deltaMs = structuredResetsAt.getTime() - now.getTime();
+    if (deltaMs > 0 && deltaMs <= MAX_CLAUDE_RATE_LIMIT_RESET_HORIZON_MS) {
+      return structuredResetsAt;
+    }
+  }
+
   const haystack = buildClaudeTransientHaystack(input);
   const match = haystack.match(CLAUDE_EXTRA_USAGE_RESET_RE);
   if (!match) return null;
@@ -500,6 +593,11 @@ export function isClaudeProviderQuotaError(input: {
     stderr: input.stderr ?? "",
   });
   if (loginMeta.requiresLogin) return false;
+
+  // A structured rejection is unambiguous — the CLI told us the account-level
+  // window is refused. Trust it before falling back to prose matching, which
+  // cannot cover every wording the CLI may adopt.
+  if (readClaudeRateLimitRejection(input)) return true;
 
   const haystack = buildClaudeTransientHaystack(input);
   if (!haystack) return false;

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -28,6 +28,7 @@ import {
 import {
   describeClaudeFailure,
   detectClaudeLoginRequired,
+  isClaudeProviderQuotaError,
   isClaudeTransientUpstreamError,
   parseClaudeStreamJson,
 } from "./parse.js";
@@ -428,11 +429,13 @@ export async function testEnvironment(
           (stdoutFallback ? truncateDetail(stdoutFallback) : "") ||
           detail ||
           "";
-        const transient = isClaudeTransientUpstreamError({
-          parsed,
-          stdout: probe.stdout,
-          stderr: probe.stderr,
-        });
+        // A usage-limit refusal is a wait-and-retry condition for the operator
+        // exactly like an overload, so it belongs in the same warning bucket.
+        // isClaudeTransientUpstreamError deliberately yields to the quota
+        // classifier, so check both or quota reads as a hard probe failure.
+        const probeInput = { parsed, stdout: probe.stdout, stderr: probe.stderr };
+        const transient =
+          isClaudeTransientUpstreamError(probeInput) || isClaudeProviderQuotaError(probeInput);
         checks.push(
           transient
             ? {

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -92,4 +92,50 @@ describe("classifyAdapterFailureForRecovery", () => {
       resultJson: null,
     })).toBeNull();
   });
+
+  // Regression: a claude_local run refused by the account-level weekly window
+  // reported "You've hit your weekly limit · resets 7pm (Europe/London)". That
+  // matched neither the quota wording nor the "try again at" reset clock, so it
+  // fell through to the ordinary bounded transient backoff and was replayed
+  // every few minutes for the whole length of the window.
+  it("classifies the Claude weekly-limit wording and its 'resets' clock", () => {
+    const now = new Date("2026-08-04T11:15:16.000Z");
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "You've hit your weekly limit · resets 7pm (Europe/London)",
+      resultJson: null,
+    }, now)).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date("2026-08-04T18:00:00.000Z"),
+      parsedResetTime: true,
+    });
+  });
+
+  it("classifies the Claude 5-hour-limit wording", () => {
+    const now = new Date("2026-08-04T11:15:16.000Z");
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "You've hit your 5-hour limit · resets 3pm (UTC)",
+      resultJson: null,
+    }, now)).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date("2026-08-04T15:00:00.000Z"),
+      parsedResetTime: true,
+    });
+  });
+
+  it("prefers the adapter's persisted retryNotBefore over the wall-clock prose", () => {
+    // The adapter reads the exact epoch off the CLI's structured
+    // rate_limit_event; a multi-day window cannot be recovered from prose.
+    const now = new Date("2026-08-02T07:00:00.000Z");
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "provider_quota",
+      error: "You've hit your weekly limit · resets 7pm (Europe/London)",
+      resultJson: { retryNotBefore: "2026-08-04T18:00:00.000Z" },
+    }, now)).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date("2026-08-04T18:00:00.000Z"),
+      parsedResetTime: true,
+    });
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -381,8 +381,13 @@ const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
+// Defence in depth for runs whose adapter did not tag `errorFamily`. Covers the
+// Claude CLI's per-window phrasings ("You've hit your weekly limit", "5-hour
+// limit") as well as the generic quota wording; without them a standing
+// account-level limit reads as an ordinary transient failure and gets retried on
+// the short bounded backoff for as long as the window lasts.
 const PROVIDER_QUOTA_ERROR_RE =
-  /(?:you(?:'|’)ve hit your usage limit|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
+  /(?:you(?:'|’)ve hit your [^\n.·]{0,40}?\blimit\b|(?:session|weekly|5[-\s]?hour|seven[-\s]?day) limit\b|usage limit(?: reached| exceeded)?|provider quota|quota (?:limit )?exceeded|model (?:is )?at capacity)/i;
 const CONFIGURATION_INCOMPLETE_ERROR_RE =
   /(?:model_not_found|model [^\n]{0,120} not found|missing (?:api )?(?:key|credentials?)|credentials? (?:are |is )?missing|no (?:api )?(?:key|credentials?) (?:was |were )?(?:found|configured|provided)|api key (?:is )?(?:not set|unavailable))/i;
 
@@ -391,9 +396,15 @@ export type AdapterFailureRecoveryClassification =
   | { kind: "configuration_incomplete" }
   | null;
 
+// The Claude CLI says "resets 7pm (Europe/London)" where the API says "try again
+// at ...". Both are wall-clock hints with no date, so a multi-day window resolves
+// to the next occurrence of that clock time rather than the true reset — still
+// far better than the 1h default backoff, and self-correcting because the next
+// attempt re-reads a fresh reset. Exact reset times come from the adapter's
+// persisted retryNotBefore (structured rate_limit_event), checked before this.
 function parseProviderQuotaClockReset(error: string, now: Date) {
   const match = error.match(
-    /try again at\s+(\d{1,2})(?::(\d{2}))?\s*(?:([ap])\.?\s*m\.?)?(?:\s*\(([^)]+)\)|\s+([A-Z]{2,5}))?/i,
+    /(?:try again at|\bresets?\b(?:\s+at)?)\s+(\d{1,2})(?::(\d{2}))?\s*(?:([ap])\.?\s*m\.?)?(?:\s*\(([^)]+)\)|\s+([A-Z]{2,5}))?/i,
   );
   if (!match) return null;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The `claude-local` adapter runs the Claude CLI and classifies its failures. The server uses that classification to decide when to retry a run.
> - The platform already has the correct contract for a provider quota: `errorFamily: provider_quota` plus a `retryNotBefore` timestamp. `heartbeat.ts` honours that timestamp and overrides its normal bounded backoff.
> - Nothing populated that contract for an account-level usage window, because nothing recognised the error. The CLI wording did not match the adapter's quota patterns.
> - The run was therefore classified as an ordinary transient upstream error. It retried on a 2m/10m/30m/2h backoff against a window that can last for days.
> - Every one of those retries is refused before it reaches the model. It consumes a run, returns zero tokens, and makes no progress.
> - This pull request classifies the refusal correctly and reads the exact reset time from the structured event the CLI already sends.
> - The benefit is that a task waits once until the real reset, instead of retrying every few minutes for the length of the window.

## Linked Issues or Issue Description

No public issue exists for this. The problem is described inline below, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

Related open work, for reviewer context — neither fixes this case:

- Refs #3425 — earlier work on Claude usage-limit detection in the same adapter. It is unmerged and has not been updated since April. This PR targets what is on `master` today.
- Refs #9011 — the sibling problem in `codex-local`: a usage-limit error with no reset clock. Same class of bug in a different adapter.

**What happened?**

The Claude CLI refuses a run when an account-level usage window is exhausted. It reports:

```
You've hit your weekly limit · resets 7pm (Europe/London)
```

The adapter does not recognise this wording as a quota error.

| Pattern | Knows | Matches the wording above? |
|---|---|---|
| `CLAUDE_PROVIDER_QUOTA_RE` | `You've hit your **session** limit`, `weekly limit **reached**` | No |
| `CLAUDE_EXTRA_USAGE_RESET_RE` | the same prefix list | No, so no reset time is extracted |

Because quota is not recognised, the raw stream wins the classification race instead. The stream contains `"error":"rate_limit"` and `api_error_status: 429`. The run is filed as `claude_transient_upstream` with no `retryNotBefore`. It then retries on the bounded 2m/10m/30m/2h backoff.

This is the worst possible response to a standing multi-day window. The window refuses every attempt before it reaches the model. Each attempt burns a run and returns zero tokens. The retry loop simply repeats for the entire length of the window.

**Expected behavior**

The adapter must classify an account-level usage-window refusal as `provider_quota`. It must set `retryNotBefore` to the true reset time. The run must then wait once until that reset, instead of retrying every few minutes.

**Steps to reproduce**

1. Run a `claude_local` agent with a Claude subscription whose weekly usage window is exhausted.
2. Observe that the CLI refuses the run and emits `"You've hit your weekly limit · resets <clock> (<tz>)"`.
3. Inspect the recorded failure. Before this change it is `claude_transient_upstream` with no `retryNotBefore`.
4. Observe that the run retries within about 2 minutes and is refused again. The loop continues until the window expires on its own.

You do not need an exhausted account to see the classification bug. Pass the refused stdout to `isClaudeProviderQuotaError` directly. The added tests do exactly this, and they fail on `master`.

**Paperclip version or commit**

Reproduced on `master`. The branch is rebased on current `master`.

**Deployment mode**

Local / self-hosted.

**Agent adapter(s) involved**

Claude Code (`claude-local`). The server-side change in `recovery/service.ts` is adapter-independent.

## Root cause

The CLI already hands us the answer. It sends a structured event on its stream-json stdout:

```json
{"type":"rate_limit_event","rate_limit_info":{"status":"rejected",
  "resetsAt":1785866400,"rateLimitType":"seven_day",
  "overageStatus":"rejected","overageDisabledReason":"out_of_credits"}}
```

`resetsAt` is epoch seconds and it is exact. The adapter discarded this event and matched the prose instead.

That distinction matters beyond convenience. The prose carries a wall clock with no date. A multi-day window therefore parses to *tonight* rather than to the true reset. Only the structured field survives a window longer than 24 hours.

## What Changed

- Added `readClaudeRateLimitRejection()`. It reads the last `status: "rejected"` event from stdout. `isClaudeProviderQuotaError` trusts that event outright. `extractClaudeRetryNotBefore` prefers it whenever it gives a sane future time (30 days or less), and falls back to the prose otherwise. It ignores `status: "allowed"` events, which the CLI also emits during healthy runs.
- Widened the prose match, which is now the fallback. The per-window phrasings share one `CLAUDE_USAGE_LIMIT_WORDING` alternation. It matches the *shape* `you've hit your <window> limit` instead of listing windows one at a time. A window that the CLI adds later can no longer degrade silently to a generic transient retry. This generalisation is the real guardrail. The structured event is the belt.
- Made the reset hint terminate on `"` and `,`, as well as on `.` and a newline. The haystack includes raw stream-json lines. There the prose sits inside a JSON string, so it never matched at all.
- Added the same wording to `PROVIDER_QUOTA_ERROR_RE` server-side, and taught `parseProviderQuotaClockReset` the `resets 7pm (TZ)` form alongside the API's `try again at ...`. This is defence in depth for a run whose adapter did not tag `errorFamily`. Exact reset times still come from the adapter's persisted `retryNotBefore`, which is checked first.
- Fixed a pre-existing failure in `test.probe.test.ts`. The hello probe called only `isClaudeTransientUpstreamError`, which deliberately yields to the quota classifier. A usage-limit refusal therefore surfaced as a hard "probe failed" instead of the wait-and-retry warning that the test asserts. It now checks both. Happy to split this out if you prefer it separate.

## Verification

Replay a refused run's stdout through the classifier:

| | before | after |
|---|---|---|
| `errorCode` | `claude_transient_upstream` | `provider_quota` |
| `retryNotBefore` | none | the exact reset epoch |
| next retry | +2 min | +405 min |

New tests fail on `master` and pass on this branch. I confirmed this by reverting only the source files to `master` and keeping the new tests in place:

```
$ git checkout origin/master -- packages/adapters/claude-local/src/server/parse.ts \
    packages/adapters/claude-local/src/server/test.ts \
    server/src/services/recovery/service.ts

$ npx vitest run src/server/parse.test.ts            # in packages/adapters/claude-local
  Tests  9 failed | 40 passed (49)

$ npx vitest run src/services/recovery/provider-failure-classification.test.ts   # in server
  Tests  2 failed | 10 passed (12)
```

With the fix restored, both suites are green: 49/49 and 12/12.

`parse.test.ts` gains a fixture that carries all three refusal shapes the CLI emits in one stream: the `rate_limit_event`, the assistant message, and the result event. It asserts that the classifier returns quota and the exact epoch reset, and not a 2-minute transient retry.

Wider suites: claude-local 89/90, server recovery 47/47, heartbeat-retry-scheduling 30/30, adapter typecheck clean. The one remaining adapter failure is `execute.remote.test.ts` (`syncDirectoryToSsh` called twice, not once). It reproduces unchanged on clean `master`. It is pre-existing and unrelated, so I left it alone.

## Risks

Low risk, but there are two behaviour changes worth review:

- **A wider quota match.** `CLAUDE_USAGE_LIMIT_WORDING` now matches the shape `you've hit your <window> limit` rather than a fixed list. The `<window>` part is bounded to 40 characters and must not cross a newline or a `.` or a `·`. A false positive would make a run wait for a reset instead of retrying quickly. I judged that safer than the current failure, which retries a dead session for days. The negative test for a plain `529 overloaded_error` still asserts transient, not quota.
- **A longer wait.** A correctly classified run now waits until the real reset instead of retrying in 2 minutes. That is the intent. The 30-day horizon in `extractClaudeRetryNotBefore` guards against a misparse parking a run indefinitely, and falls back to the caller's normal backoff.

No migration. No schema change. No API change. The structured-event path is additive: if the event is absent, behaviour falls back to the prose path.

## Model Used

Claude Opus 5 (`claude-opus-5`, 1M context variant), with extended thinking, tool use, and local test execution. Running as an autonomous agent under Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation describes this classification behaviour, so there was nothing to update
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending on this push
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending first review
- [x] I will address all Greptile and reviewer comments before requesting merge
