### PR TITLE
fix(heartbeat): defer contended routine-execution lock claim instead of failing the run

### DIFF
--- a/server/src/__tests__/heartbeat-routine-execution-lock-contention.test.ts
+++ b/server/src/__tests__/heartbeat-routine-execution-lock-contention.test.ts
@@ -1,0 +1,338 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+// Regression coverage for routine execution-lock contention. A routine with
+// concurrencyPolicy=always_enqueue can have a later fire's execution issue claimed
+// while a prior fire's execution issue still holds the routine execution lock
+// (execution_run_id set). The null->set lock stamp then collides with the
+// issues_open_routine_execution_uq partial unique index. Before the fix this raised
+// an unhandled 23505 ("Failed query") that killed the run and dropped the digest
+// with no visible error; now the contended run is left queued and retried once the
+// prior lock frees.
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Routine execution-lock contention test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping routine execution-lock contention tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return fn();
+}
+
+describeEmbeddedPostgres("heartbeat routine execution-lock contention", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  const countExecuteCallsForRun = (runId: string) =>
+    mockAdapterExecute.mock.calls.filter(([context]) => context?.runId === runId).length;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-routine-exec-lock-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockReset();
+    mockAdapterExecute.mockImplementation(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "Routine execution-lock contention test run.",
+      provider: "test",
+      model: "test-model",
+    }));
+    runningProcesses.clear();
+    await heartbeat.drainActiveRunExecutions();
+    await db.execute(sql.raw(`
+      TRUNCATE TABLE
+        "issues",
+        "heartbeat_run_events",
+        "cost_events",
+        "activity_log",
+        "heartbeat_runs",
+        "agent_wakeup_requests",
+        "agent_runtime_state",
+        "agents",
+        "companies"
+      RESTART IDENTITY CASCADE
+    `));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Scheduled Sweeper",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          // Allow a free concurrency slot so claimQueuedRun actually runs for the
+          // contended fire (the lock holder below is a terminal run, so it does not
+          // consume a slot).
+          maxConcurrentRuns: 2,
+        },
+      },
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  // Seeds an open routine-execution issue for a routine identity. When a lock
+  // holder run id is provided the issue holds the routine execution lock.
+  async function seedRoutineExecutionIssue(input: {
+    companyId: string;
+    agentId: string;
+    originId: string;
+    originFingerprint: string;
+    lockHeldByRunId?: string | null;
+  }) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: input.companyId,
+      title: "Scheduled sweep — 3x daily",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: input.agentId,
+      originKind: "routine_execution",
+      originId: input.originId,
+      originFingerprint: input.originFingerprint,
+      executionRunId: input.lockHeldByRunId ?? null,
+      executionAgentNameKey: input.lockHeldByRunId ? "scheduled-sweeper" : null,
+      executionLockedAt: input.lockHeldByRunId ? new Date() : null,
+    });
+    return issueId;
+  }
+
+  async function seedQueuedRun(input: { companyId: string; agentId: string; issueId: string }) {
+    const wakeupRequestId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: input.issueId },
+      status: "queued",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId,
+      contextSnapshot: { issueId: input.issueId, wakeReason: "issue_assigned" },
+    });
+    await db
+      .update(agentWakeupRequests)
+      .set({ runId })
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+    return { runId, wakeupRequestId };
+  }
+
+  // Terminal heartbeat run that a stale routine execution lock points at.
+  async function seedLockHolderRun(input: { companyId: string; agentId: string }) {
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      createdAt: new Date(),
+      startedAt: new Date(),
+      finishedAt: new Date(),
+      contextSnapshot: {},
+    });
+    return runId;
+  }
+
+  it("defers a contended routine-execution fire instead of failing it", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const originId = randomUUID();
+    const originFingerprint = randomUUID();
+
+    // Prior fire's execution issue still holds the routine lock.
+    const holderRunId = await seedLockHolderRun({ companyId, agentId });
+    const priorIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+      lockHeldByRunId: holderRunId,
+    });
+
+    // Next fire's execution issue + its queued run.
+    const nextIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+    });
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId: nextIssueId,
+    });
+
+    await heartbeat.resumeQueuedRuns();
+    // Give any (incorrect) background execution a chance to surface.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const [run] = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    const [nextIssue] = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, nextIssueId));
+    const [priorIssue] = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, priorIssueId));
+    const [wakeup] = await db
+      .select({ status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId));
+
+    // Contended fire is left queued for retry, not failed/cancelled.
+    expect(run?.status).toBe("queued");
+    expect(run?.errorCode).toBeNull();
+    // The lock was not stolen from the prior issue, and the next issue never
+    // acquired it.
+    expect(nextIssue?.executionRunId).toBeNull();
+    expect(priorIssue?.executionRunId).toBe(holderRunId);
+    // No adapter execution happened for the deferred run.
+    expect(countExecuteCallsForRun(runId)).toBe(0);
+    // The wakeup is still pending (queued), not skipped/failed.
+    expect(wakeup?.status).toBe("queued");
+  });
+
+  it("runs the deferred fire once the prior routine lock is released", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const originId = randomUUID();
+    const originFingerprint = randomUUID();
+
+    const holderRunId = await seedLockHolderRun({ companyId, agentId });
+    const priorIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+      lockHeldByRunId: holderRunId,
+    });
+    const nextIssueId = await seedRoutineExecutionIssue({
+      companyId,
+      agentId,
+      originId,
+      originFingerprint,
+    });
+    const { runId } = await seedQueuedRun({ companyId, agentId, issueId: nextIssueId });
+
+    // First pass: contended, deferred (stays queued).
+    await heartbeat.resumeQueuedRuns();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const [deferred] = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(deferred?.status).toBe("queued");
+
+    // Prior fire completes and releases the routine lock.
+    await db
+      .update(issues)
+      .set({ status: "done", executionRunId: null, executionAgentNameKey: null, executionLockedAt: null })
+      .where(eq(issues.id, priorIssueId));
+
+    // Second pass: the deferred run now claims the lock and executes.
+    await heartbeat.resumeQueuedRuns();
+    await waitForCondition(async () => {
+      const [run] = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId));
+      return run?.status === "succeeded";
+    });
+
+    const [run] = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
+    expect(countExecuteCallsForRun(runId)).toBe(1);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6265,6 +6265,35 @@ function normalizeAgentNameKey(value: string | null | undefined) {
   return normalized.length > 0 ? normalized : null;
 }
 
+// Detects the Postgres unique-violation (23505) raised by the
+// `issues_open_routine_execution_uq` partial unique index, which enforces at most
+// one *locked* (execution_run_id set) open routine-execution issue per routine
+// identity (companyId, originKind, originId, originFingerprint). The error can
+// arrive as the raw pg error or wrapped by Drizzle's query error, so we walk the
+// cause chain. See routines.ts for the sibling detection on the dispatch path.
+function isOpenRoutineExecutionLockConflict(error: unknown): boolean {
+  const constraint = "issues_open_routine_execution_uq";
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === "object"; depth += 1) {
+    // node-postgres surfaces the index on `constraint`; the porsager `postgres`
+    // driver used here surfaces it on `constraint_name`. Match either.
+    const candidate = current as {
+      code?: unknown;
+      constraint?: unknown;
+      constraint_name?: unknown;
+      cause?: unknown;
+    };
+    if (
+      candidate.code === "23505" &&
+      (candidate.constraint === constraint || candidate.constraint_name === constraint)
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
 const defaultSessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     const asObj = parseObject(raw);
@@ -12183,6 +12212,55 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueContext: issueId ? await getIssueExecutionContext(run.companyId, issueId) : null,
       routineEnvContext: { routineId: null, env: null, responsibleUserId: null },
     });
+
+    // Fix A (lazy locking): stamp executionRunId at claim time (not at queue time).
+    // Guard is idempotent — safe if called more than once.
+    //
+    // This runs BEFORE flipping the run to "running" so a routine-execution lock
+    // contention leaves the run cleanly queued for a later tick instead of failing
+    // the fire. The issues_open_routine_execution_uq partial unique index
+    // permits only one *locked* open routine-execution issue per routine identity;
+    // under always_enqueue a later fire can be claimed while a prior fire's
+    // execution issue still holds the lock, and the null->set transition then hits
+    // that index. Previously the unhandled 23505 surfaced as "Failed query" and
+    // killed the run, dropping the digest with no visible error. We now serialize:
+    // leave this run queued and retry once the prior execution issue completes or
+    // the stale-lock backstop sweeper clears the lock.
+    const wakeReason = readNonEmptyString(context.wakeReason);
+    if (issueId && wakeReason !== "source_scoped_recovery_action") {
+      const claimedAgent = await getAgent(run.agentId);
+      try {
+        await db
+          .update(issues)
+          .set({
+            executionRunId: run.id,
+            executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
+            executionLockedAt: claimedAt,
+            updatedAt: claimedAt,
+          })
+          .where(
+            and(
+              eq(issues.id, issueId),
+              eq(issues.companyId, run.companyId),
+              // Mention/context runs can touch an issue, but only the current assignee
+              // owns the issue execution lock shown as the active run.
+              eq(issues.assigneeAgentId, run.agentId),
+              or(isNull(issues.executionRunId), eq(issues.executionRunId, run.id)),
+            ),
+          );
+      } catch (error) {
+        if (!isOpenRoutineExecutionLockConflict(error)) throw error;
+        // Another open execution issue for the same routine identity currently
+        // holds the lock. Leave this run queued (do not flip to "running") so a
+        // later tick retries it once the lock frees, instead of failing the fire.
+        logger.info(
+          { runId: run.id, issueId, agentId: run.agentId },
+          "claimQueuedRun: deferred routine execution run; routine lock held by a concurrent execution",
+        );
+        return null;
+      }
+    }
+
     const claimed = await db
       .update(heartbeatRuns)
       .set({
@@ -12214,33 +12292,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     publishRunLifecyclePluginEvent(claimed);
 
     await setWakeupStatus(claimed.wakeupRequestId, "claimed", { claimedAt });
-
-    // Fix A (lazy locking): stamp executionRunId now that the run is actually running,
-    // not at queue time. Guard is idempotent — safe if called more than once.
-    const claimedContext = parseObject(claimed.contextSnapshot);
-    const claimedIssueId = readNonEmptyString(claimedContext.issueId);
-    const claimedWakeReason = readNonEmptyString(claimedContext.wakeReason);
-    if (claimedIssueId && claimedWakeReason !== "source_scoped_recovery_action") {
-      const claimedAgent = await getAgent(claimed.agentId);
-      await db
-        .update(issues)
-        .set({
-          executionRunId: claimed.id,
-          executionAgentNameKey: normalizeAgentNameKey(claimedAgent?.name),
-          executionLockedAt: claimedAt,
-          updatedAt: claimedAt,
-        })
-        .where(
-          and(
-            eq(issues.id, claimedIssueId),
-            eq(issues.companyId, claimed.companyId),
-            // Mention/context runs can touch an issue, but only the current assignee
-            // owns the issue execution lock shown as the active run.
-            eq(issues.assigneeAgentId, claimed.agentId),
-            or(isNull(issues.executionRunId), eq(issues.executionRunId, claimed.id)),
-          ),
-        );
-    }
 
     return claimed;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Routines are the scheduling subsystem. Each fire creates an execution issue, and an agent picks that issue up on its next heartbeat.
> - A partial unique index keeps at most one *locked* open routine-execution issue per routine identity. The lock itself is stamped lazily, when the run is claimed.
> - Under `concurrencyPolicy: always_enqueue` each fire creates its own execution issue. A later fire can therefore be claimed while an earlier fire still holds the routine lock.
> - That collision raises a Postgres `23505` unique violation inside the claim path. The exception was unhandled, so it killed the whole run.
> - The fire is then lost silently. There is no execution issue, no output, and no surfaced error. It appears only later as a gap.
> - This pull request catches that specific violation and leaves the run queued instead of destroying it.
> - The benefit is that `always_enqueue` serialises cleanly under contention, rather than dropping fires.

## Linked Issues or Issue Description

No public issue exists for this. The problem is described inline below, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

Related prior work, for reviewer context:

- Refs #3825 — closed and never merged. It addressed the same index from the dispatch-time create path and added stale-lock repair. This PR fixes the *claim-time* lock stamp, which is a different code path. I mention it so a reviewer can judge whether the two should be reconciled.

**What happened?**

A routine fire is dropped silently. There is no execution issue, no output, and no surfaced error. It becomes visible only as a gap, when someone notices the routine did not run. Two consecutive contended fires produce a multi-hour hole.

The underlying error is a Postgres unique violation in the claim path:

```
code: '23505'
constraint_name: 'issues_open_routine_execution_uq'
query: 'update "issues" set "execution_run_id" = $1, ... where ...'
```

The failure mode is the bad part. Contention on the lock is a normal and expected condition under `always_enqueue`. The response was to destroy the fire instead of waiting for the lock.

**Expected behavior**

A contended fire must wait for the lock and then run. It must not be dropped. `always_enqueue` must serialise fires rather than lose them.

**Steps to reproduce**

1. Configure a routine with `concurrencyPolicy: always_enqueue`.
2. Let a fire create an execution issue and hold the routine execution lock. Either let it run, or leave a stale lock that the sweeper has not yet cleared.
3. Fire the routine again, so a second execution issue is created and its run is claimed while the first still holds the lock.
4. The claim-time `UPDATE` that stamps `execution_run_id` raises `23505` on `issues_open_routine_execution_uq`. The run dies and no execution issue is produced.

The added test reproduces this against embedded Postgres, so no live instance is needed.

**Paperclip version or commit**

Reproduced on `master`. The branch is rebased on current `master`.

**Deployment mode**

Local / self-hosted.

**Agent adapter(s) involved**

Not adapter-specific. This is a core routines/heartbeat bug.

## Root cause

The partial unique index `issues_open_routine_execution_uq` (`packages/db/src/schema/issues.ts`) enforces at most one *locked* open routine-execution issue per routine identity `(companyId, originKind, originId, originFingerprint)`. It only activates when `execution_run_id is not null`.

Under `always_enqueue` each fire creates its own execution issue, and `claimQueuedRun` stamps the lock lazily at claim time. When a later fire's run is claimed while an earlier fire's execution issue is still open and still holds its lock, the `execution_run_id` null-to-set stamp flips the new row into that index. Postgres then raises `23505`.

That exception was unhandled in the claim path, so it terminated the run.

## What Changed

- Moved the lock stamp in `claimQueuedRun` to *before* the run flips to `running`, and wrapped it in a targeted catch for that specific unique violation.
- On contention the run is left queued, and the function returns `null`. A later tick retries it once the prior execution issue completes, or once the stale-lock backstop sweeper clears the lock.
- Made the conflict detector walk the error `cause` chain and match both driver shapes. `node-postgres` exposes the index name as `constraint`. The porsager `postgres` driver uses `constraint_name`. Matching only one shape silently misses the violation under the other driver.
- Added `server/src/__tests__/heartbeat-routine-execution-lock-contention.test.ts`.

## Verification

The new test uses embedded Postgres and reproduces the exact failure: the same `UPDATE`, and the same `issues_open_routine_execution_uq` / `23505`. It then asserts that the contended fire is deferred, and that it self-heals once the prior lock is released.

It fails before the change and passes after. I confirmed this by reverting only `heartbeat.ts` to `master` and keeping the test in place:

```
$ git checkout origin/master -- server/src/services/heartbeat.ts
$ npx vitest run src/__tests__/heartbeat-routine-execution-lock-contention.test.ts

  × defers a contended routine-execution fire instead of failing it
  × runs the deferred fire once the prior routine lock is released
    PostgresError: duplicate key value violates unique constraint
      "issues_open_routine_execution_uq"
      code: '23505'
  Tests  2 failed (2)
```

With the fix restored, both pass (2/2), and the deferral is visible in the log:

```
claimQueuedRun: deferred routine execution run; routine lock held by a concurrent execution
```

## Risks

Low risk, and the change is narrow.

- **A deferred run is now returned as `null`.** Callers must treat that as "nothing to claim this tick", which is the existing contract for an unclaimable run. The run stays queued, so a later tick picks it up. The pre-existing stale-lock sweeper is what guarantees this terminates if the holder died.
- **The catch is deliberately narrow.** It matches only `23505` on `issues_open_routine_execution_uq`. Any other error still propagates, so this does not mask unrelated failures.
- **A behaviour change under contention only.** On the uncontended path the lock stamp simply happens slightly earlier in the same function. Ordering the stamp before the `running` flip is what makes the failure recoverable, because the run has not yet been marked started.

No migration. No schema change. No API change.

## Note for maintainers

`routines.ts` has a similar `23505` check on the dispatch-time create path, and it matches only `.constraint`. Under the porsager driver it therefore likely misses the violation entirely. I have not touched it here, to keep this PR to one fix. It looks like the same latent gap and may deserve a follow-up.

## Model Used

Claude Opus 5 (`claude-opus-5`, 1M context variant), with extended thinking, tool use, and local test execution. Running as an autonomous agent under Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation describes this locking behaviour, so there was nothing to update
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending on this push
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending first review
- [x] I will address all Greptile and reviewer comments before requesting merge
