### PR TITLE
feat: add company-scoped wiki sync and plugin lifecycle health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ tests/storybook-visual/playwright-report/
 .superpowers/
 .claude/worktrees/
 .herenow
+
+# Notion-wiki-sync plugin runtime output (not source)
+/wiki/

--- a/packages/plugins/plugin-llm-wiki/README.md
+++ b/packages/plugins/plugin-llm-wiki/README.md
@@ -22,6 +22,105 @@ The alpha surface includes:
 - Paperclip-derived distillation maintains `wiki/projects/<slug>/standup.md` as the executive current-state view for each represented project, alongside durable `wiki/projects/<slug>/index.md` knowledge pages
 - wiki page writes with plugin path validation, atomic local-folder writes, metadata/revision rows, backlink extraction, and optional stale-hash protection
 - wiki tools for search/read/write/propose patch/source/log/index/backlinks workflows
+- agent-free Notion <-> Wiki sync job (`notion-wiki-sync`) on `*/15 * * * *`
+- agent-free Notion Strategy Poll job (`notion-strategy-poll`) on `0 * * * *`
+
+## Notion <-> Wiki Sync
+
+The plugin declares a native scheduled job, `notion-wiki-sync`, that runs in the
+plugin worker every 15 minutes. It does not create or wake an agent.
+
+Configuration:
+
+- Notion token: `notionToken` plugin config, `NOTION_TOKEN`, or
+  `~/.paperclip/instances/default/secrets/notion-token.txt`.
+- Default Notion create parent: `notionTasksDatabaseId` plugin config,
+  `NOTION_TASKS_DATABASE_ID`, or
+  `~/.paperclip/instances/default/secrets/notion-tasks-database-id.txt`.
+- Wiki target defaults to `wikiId=default`, `spaceSlug=default`; override with
+  `notionSyncWikiId` and `notionSyncSpaceSlug`.
+- `notionSyncCompanyIds` must contain the explicit company ids this scheduled job
+  may process. An empty or missing list skips the run; the plugin never falls back
+  to instance-wide company discovery.
+- Set `notionSyncEnabled=false` to disable the job without removing it.
+
+Data shape and behavior:
+
+- Source API: Notion API v1, `Notion-Version: 2022-06-28`.
+- Scope: all pages returned by Notion `/search` with `object=page`, i.e. all
+  pages visible to the integration token. Empty search results are logged as a
+  gap, not filled with placeholders.
+- Notion -> Wiki writes pages under `wiki/notion/<title>-<pageid>.md`.
+- Wiki frontmatter includes `source: notion`, `notion_page_id`,
+  `notion_last_edited_time`, `notion_content_hash`, `notion_sync: true`, and
+  `notion_url` when available.
+- Wiki -> Notion writeback is opt-in: wiki pages must have
+  `notion_sync: true`. Pages with `notion_page_id` replace that Notion page's
+  child blocks. Pages without `notion_page_id` create a new Notion page under
+  the configured Tasks database when that database id is available.
+- Cursors are persisted in `notion_sync_cursors` with Notion last edit time,
+  Notion content hash, wiki content hash, origin, and last sync time.
+- Each run inserts one `wiki_operations` row with `operation_type=notion-sync`,
+  status, counts, warnings, affected pages, and the plugin job run id.
+- Conflict policy: Notion is authority for Notion-origin pages; Wiki is authority
+  for Wiki-origin pages. Conflicts are appended to `wiki/log.md` and recorded in
+  operation warnings; they are not silently overwritten.
+- Notion 429/5xx responses retry with exponential backoff inside the run. Partial
+  page failures do not abort the whole cycle.
+
+Manual verification can run the same code path with the plugin action
+`run-notion-sync`. Deploy still requires the board/operator to upgrade the
+installed plugin package so the host loads the rebuilt `dist/manifest.js` and
+`dist/worker.js`.
+
+## Notion Strategy Poll
+
+The plugin declares a native scheduled job, `notion-strategy-poll`, that runs in
+the plugin worker hourly (`0 * * * *`). It is agent-free: empty polls create zero
+Paperclip issues and do not create routine execution issues.
+
+Configuration:
+
+- Source API: Notion API v1 at `https://api.notion.com`,
+  `Notion-Version: 2022-06-28`.
+- Notion token: `notionStrategyPollToken`, `notionToken`, `NOTION_TOKEN`, or
+  `~/.paperclip/instances/default/secrets/notion-token.txt`.
+- Tasks database id: `notionStrategyPollTasksDatabaseId`,
+  `notionTasksDatabaseId`, `NOTION_TASKS_DATABASE_ID`, or
+  `~/.paperclip/instances/default/secrets/notion-tasks-database-id.txt`.
+  Pilars Tasks DB: `26a3a489-a9ca-81a5-90a5-db6e196213ce`.
+- Target CRO: `notionStrategyPollCroAgentId`, `PAPERCLIP_CRO_AGENT_ID`, or the
+  Pilars CRO id `fb0272a1-0b64-42c6-bebf-835c6ea22903`.
+- `notionStrategyPollCompanyIds` contains the explicit company ids this poll may
+  process. When omitted it inherits `notionSyncCompanyIds`; when both are empty,
+  the poll skips without attempting instance-wide company discovery.
+- Set `notionStrategyPollEnabled=false` to disable the job without removing it.
+
+Data shape and behavior:
+
+- Queries the Tasks database via `POST /v1/databases/{databaseId}/query`, sorted
+  by `last_edited_time` ascending, with a strict `last_edited_time after`
+  watermark after the first successful processed delta.
+- Reads each Notion page as `{ id, url, archived, last_edited_time, properties }`.
+  The poller uses title from `Task name`, `Name`, or the first title property;
+  status from `Status` (`status` or `select`); tags from `Tags.multi_select`.
+- Strategy detection is intentionally the legacy Notion poller heuristic: skip
+  Done/Cancelled/Canceled/Archived and archived pages; require at least one tag;
+  then match when title contains `стратег`/`strategy` or tags include
+  `Research` plus `BTC` or `Metrics`.
+- Idempotency is persisted in `notion_strategy_poll_cursors`, keyed by the full
+  normalized Notion page id plus exact `last_edited_time`. No 8-character page id
+  prefixes are used.
+- On a genuine new or changed strategy delta, the worker creates exactly one
+  Paperclip issue assigned to CRO. Issue creation uses the plugin host bridge
+  `ctx.issues.create` under the manifest `issues.create` capability, not an
+  out-of-band cron or agent run.
+- Each poll writes one `wiki_operations` row with
+  `operation_type=notion-strategy-poll`, status, counts, warnings, emitted issue
+  identifiers, and the plugin job run id.
+- Notion 429/5xx responses retry with exponential backoff inside the run. Auth,
+  schema, and API failures are recorded as operation warnings and do not create
+  placeholder/proxy issues.
 
 ## Phase 5 Security Gate
 

--- a/packages/plugins/plugin-llm-wiki/migrations/004_notion_sync.sql
+++ b/packages/plugins/plugin-llm-wiki/migrations/004_notion_sync.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS plugin_llm_wiki_8f50da974f.notion_sync_cursors (
+  id uuid PRIMARY KEY,
+  company_id uuid NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  wiki_id text NOT NULL,
+  space_id uuid NOT NULL REFERENCES plugin_llm_wiki_8f50da974f.wiki_spaces(id) ON DELETE CASCADE,
+  notion_page_id text NOT NULL,
+  wiki_path text NOT NULL,
+  notion_last_edited_time timestamptz,
+  notion_content_hash text,
+  wiki_content_hash text,
+  origin text NOT NULL DEFAULT 'notion',
+  last_synced_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (company_id, wiki_id, space_id, notion_page_id),
+  UNIQUE (company_id, wiki_id, space_id, wiki_path)
+);
+
+CREATE INDEX IF NOT EXISTS notion_sync_cursors_company_wiki_idx
+  ON plugin_llm_wiki_8f50da974f.notion_sync_cursors (company_id, wiki_id, space_id, updated_at DESC);

--- a/packages/plugins/plugin-llm-wiki/migrations/005_notion_strategy_poll.sql
+++ b/packages/plugins/plugin-llm-wiki/migrations/005_notion_strategy_poll.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS plugin_llm_wiki_8f50da974f.notion_strategy_poll_cursors (
+  id uuid PRIMARY KEY,
+  company_id uuid NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  wiki_id text NOT NULL,
+  space_id uuid NOT NULL REFERENCES plugin_llm_wiki_8f50da974f.wiki_spaces(id) ON DELETE CASCADE,
+  notion_page_id text NOT NULL,
+  notion_page_id_normalized text NOT NULL,
+  notion_last_edited_time timestamptz NOT NULL,
+  emitted_issue_id uuid REFERENCES public.issues(id) ON DELETE SET NULL,
+  emitted_issue_identifier text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (company_id, wiki_id, space_id, notion_page_id_normalized, notion_last_edited_time)
+);
+
+CREATE INDEX IF NOT EXISTS notion_strategy_poll_cursor_watermark_idx
+  ON plugin_llm_wiki_8f50da974f.notion_strategy_poll_cursors
+  (company_id, wiki_id, space_id, notion_last_edited_time DESC);

--- a/packages/plugins/plugin-llm-wiki/src/manifest.ts
+++ b/packages/plugins/plugin-llm-wiki/src/manifest.ts
@@ -15,6 +15,8 @@ export const WIKI_PROJECT_KEY = "llm-wiki";
 export const CURSOR_WINDOW_ROUTINE_KEY = "cursor-window-processing";
 export const NIGHTLY_LINT_ROUTINE_KEY = "nightly-wiki-lint";
 export const INDEX_REFRESH_ROUTINE_KEY = "index-refresh";
+export const NOTION_SYNC_JOB_KEY = "notion-wiki-sync";
+export const NOTION_STRATEGY_POLL_JOB_KEY = "notion-strategy-poll";
 export const DEFAULT_MAX_SOURCE_BYTES = 250000;
 export const DEFAULT_MAX_PAPERCLIP_ISSUE_SOURCE_CHARS = 12000;
 export const DEFAULT_MAX_PAPERCLIP_CURSOR_WINDOW_CHARS = 60000;
@@ -88,6 +90,8 @@ const manifest: PaperclipPluginManifestV1 = {
   categories: ["automation", "ui"],
   capabilities: [
     "events.subscribe",
+    "jobs.schedule",
+    "http.outbound",
     "api.routes.register",
     "database.namespace.migrate",
     "database.namespace.read",
@@ -126,6 +130,20 @@ const manifest: PaperclipPluginManifestV1 = {
     worker: "./dist/worker.js",
     ui: "./dist/ui"
   },
+  jobs: [
+    {
+      jobKey: NOTION_SYNC_JOB_KEY,
+      displayName: "Notion Wiki Sync",
+      description: "Agent-free Notion <-> LLM Wiki sync. Enumerates all Notion pages visible to the configured integration token, syncs changed Notion pages into wiki/notion/, and writes opted-in wiki changes back to Notion.",
+      schedule: "*/15 * * * *"
+    },
+    {
+      jobKey: NOTION_STRATEGY_POLL_JOB_KEY,
+      displayName: "Notion Strategy Poll",
+      description: "Agent-free Notion Tasks DB poll. Routes genuine new or changed strategy deltas to CRO and suppresses empty polls by construction.",
+      schedule: "0 * * * *"
+    }
+  ],
   database: {
     namespaceSlug: "llm_wiki",
     migrationsDir: "migrations",

--- a/packages/plugins/plugin-llm-wiki/src/notion-strategy-poll.ts
+++ b/packages/plugins/plugin-llm-wiki/src/notion-strategy-poll.ts
@@ -1,0 +1,571 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { Company, PluginContext, PluginJobContext } from "@paperclipai/plugin-sdk";
+import { WIKI_ROOT_FOLDER_KEY } from "./manifest.js";
+import { DEFAULT_SPACE_SLUG, DEFAULT_WIKI_ID, resolveSpace, type WikiSpace } from "./wiki.js";
+
+const NOTION_API_BASE = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+const DEFAULT_NOTION_TOKEN_PATH = "~/.paperclip/instances/default/secrets/notion-token.txt";
+const DEFAULT_NOTION_TASKS_DATABASE_ID_PATH = "~/.paperclip/instances/default/secrets/notion-tasks-database-id.txt";
+const DEFAULT_CRO_AGENT_ID = "fb0272a1-0b64-42c6-bebf-835c6ea22903";
+const MAX_PAGINATION_ITERATIONS = 50;
+
+const STRATEGY_TITLE_MARKERS = ["\u0441\u0442\u0440\u0430\u0442\u0435\u0433", "strategy"] as const;
+const STRATEGY_RESEARCH_TAG = "research";
+const STRATEGY_DOMAIN_TAGS = new Set(["btc", "metrics"]);
+const SKIP_STATUSES = new Set(["done", "cancelled", "canceled", "archived"]);
+
+type NotionStrategyPollConfig = {
+  enabled: boolean;
+  wikiId: string;
+  spaceSlug: string;
+  tokenPath: string;
+  tasksDatabaseIdPath: string;
+  token?: string | null;
+  tasksDatabaseId?: string | null;
+  croAgentId: string;
+  /**
+   * Companies this job fans out over. The host never grants a plugin a wildcard
+   * ("all companies") scope on a proactive worker-to-host call, so the job must
+   * name each company explicitly and issue one company-scoped call per entry.
+   */
+  companyIds: string[];
+};
+
+type NotionPage = {
+  id: string;
+  object: "page";
+  url?: string;
+  archived?: boolean;
+  last_edited_time?: string;
+  properties?: Record<string, unknown>;
+};
+
+type PollCounts = {
+  companies: number;
+  pagesFetched: number;
+  pagesSkipped: number;
+  pagesMatched: number;
+  issuesCreated: number;
+  alreadyProcessed: number;
+  failures: number;
+};
+
+type CompanyPollResult = {
+  companyId: string;
+  wikiId: string;
+  spaceSlug: string;
+  status: "succeeded" | "failed" | "partial";
+  counts: PollCounts;
+  warnings: string[];
+  emittedIssues: string[];
+};
+
+function tableName(namespace: string, table: string): string {
+  return `${namespace}.${table}`;
+}
+
+function jsonParam(value: unknown): string {
+  return JSON.stringify(value ?? {});
+}
+
+function expandHome(path: string): string {
+  if (path === "~") return process.env.HOME ?? "";
+  if (path.startsWith("~/")) return `${process.env.HOME ?? ""}${path.slice(1)}`;
+  return path;
+}
+
+function readSecretFile(path: string): string | null {
+  try {
+    const value = readFileSync(expandHome(path), "utf8").trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function plainText(richText: unknown): string {
+  if (!Array.isArray(richText)) return "";
+  return richText
+    .map((part) => typeof part === "object" && part != null && "plain_text" in part ? String(part.plain_text ?? "") : "")
+    .join("");
+}
+
+function normalizePageId(id: string): string {
+  return id.replace(/-/g, "");
+}
+
+function extractTitle(page: NotionPage): string {
+  const properties = page.properties ?? {};
+  for (const name of ["Task name", "Name"]) {
+    const prop = properties[name];
+    if (typeof prop === "object" && prop != null && (prop as { type?: string }).type === "title") {
+      const title = plainText((prop as { title?: unknown }).title).trim();
+      if (title) return title;
+    }
+  }
+  for (const prop of Object.values(properties)) {
+    if (typeof prop === "object" && prop != null && (prop as { type?: string }).type === "title") {
+      const title = plainText((prop as { title?: unknown }).title).trim();
+      if (title) return title;
+    }
+  }
+  return "";
+}
+
+function extractStatus(page: NotionPage): string {
+  const prop = page.properties?.Status;
+  if (typeof prop !== "object" || prop == null) return "";
+  const typed = prop as { type?: string; status?: { name?: unknown } | null; select?: { name?: unknown } | null };
+  if (typed.type === "status") return stringField(typed.status?.name) ?? "";
+  if (typed.type === "select") return stringField(typed.select?.name) ?? "";
+  return "";
+}
+
+function extractTags(page: NotionPage): string[] {
+  const prop = page.properties?.Tags;
+  if (typeof prop !== "object" || prop == null) return [];
+  const tags = (prop as { multi_select?: unknown }).multi_select;
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .map((tag) => typeof tag === "object" && tag != null ? stringField((tag as { name?: unknown }).name)?.toLowerCase() : null)
+    .filter((tag): tag is string => Boolean(tag));
+}
+
+export function isNotionStrategyPage(page: NotionPage): { match: boolean; reason: string } {
+  if (page.archived === true) return { match: false, reason: "skip: archived page" };
+  const title = extractTitle(page).toLowerCase();
+  const status = extractStatus(page).toLowerCase();
+  const tags = new Set(extractTags(page));
+  if (SKIP_STATUSES.has(status)) return { match: false, reason: `skip: status=${JSON.stringify(status)}` };
+  if (tags.size === 0) return { match: false, reason: "no tags (likely template sub-page)" };
+
+  const titleHit = STRATEGY_TITLE_MARKERS.some((marker) => title.includes(marker));
+  const domainHit = [...tags].filter((tag) => STRATEGY_DOMAIN_TAGS.has(tag));
+  const tagHit = tags.has(STRATEGY_RESEARCH_TAG) && domainHit.length > 0;
+  if (tagHit && titleHit) return { match: true, reason: `title strategy + research + ${JSON.stringify(domainHit.sort())}` };
+  if (tagHit) return { match: true, reason: `research + ${JSON.stringify(domainHit.sort())}` };
+  if (titleHit) {
+    return {
+      match: false,
+      reason: `title mentions strategy but missing required tags (needs 'research' + one of ${JSON.stringify([...STRATEGY_DOMAIN_TAGS].sort())}; tags=${JSON.stringify([...tags].sort())})`,
+    };
+  }
+  return { match: false, reason: `not a strategy (status=${JSON.stringify(status)} tags=${JSON.stringify([...tags].sort())})` };
+}
+
+async function notionRequest<T>(
+  ctx: PluginContext,
+  token: string,
+  path: string,
+  init: RequestInit = {},
+  attempt = 0,
+): Promise<T> {
+  const response = await ctx.http.fetch(`${NOTION_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "Notion-Version": NOTION_VERSION,
+      ...(init.headers ?? {}),
+    },
+  });
+  if ((response.status === 429 || response.status >= 500) && attempt < 3) {
+    const retryAfter = Number(response.headers.get("retry-after"));
+    const delayMs = Number.isFinite(retryAfter) && retryAfter > 0
+      ? retryAfter * 1000
+      : 250 * 2 ** attempt;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return notionRequest<T>(ctx, token, path, init, attempt + 1);
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Notion ${init.method ?? "GET"} ${path} failed: HTTP ${response.status}${body ? ` ${body.slice(0, 500)}` : ""}`);
+  }
+  return await response.json() as T;
+}
+
+async function queryTasksDatabase(ctx: PluginContext, token: string, databaseId: string, sinceIso: string | null): Promise<NotionPage[]> {
+  const pages: NotionPage[] = [];
+  let startCursor: string | undefined;
+  const seenCursors = new Set<string>();
+  for (let i = 0; i < MAX_PAGINATION_ITERATIONS; i += 1) {
+    if (startCursor) {
+      if (seenCursors.has(startCursor)) {
+        throw new Error(`Notion pagination cursor repeated (${startCursor}); aborting to avoid an infinite loop.`);
+      }
+      seenCursors.add(startCursor);
+    }
+    const body: Record<string, unknown> = {
+      page_size: 100,
+      sorts: [{ timestamp: "last_edited_time", direction: "ascending" }],
+    };
+    if (sinceIso) {
+      body.filter = { timestamp: "last_edited_time", last_edited_time: { after: sinceIso } };
+    }
+    if (startCursor) body.start_cursor = startCursor;
+
+    const payload = await notionRequest<{ results?: unknown[]; has_more?: boolean; next_cursor?: string | null }>(
+      ctx,
+      token,
+      `/databases/${databaseId}/query`,
+      { method: "POST", body: JSON.stringify(body) },
+    );
+    for (const row of payload.results ?? []) {
+      if (typeof row === "object" && row != null && (row as { object?: string }).object === "page") {
+        pages.push(row as NotionPage);
+      }
+    }
+    if (!payload.has_more) return pages;
+    startCursor = payload.next_cursor ?? undefined;
+    if (!startCursor) return pages;
+  }
+  throw new Error(`Notion pagination exceeded ${MAX_PAGINATION_ITERATIONS} iterations; aborting.`);
+}
+
+function stringArrayField(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const out = value
+    .map((entry) => stringField(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return out.length > 0 ? out : null;
+}
+
+async function readConfig(ctx: PluginContext): Promise<NotionStrategyPollConfig> {
+  const config = await ctx.config.get();
+  return {
+    enabled: config.notionStrategyPollEnabled !== false,
+    wikiId: stringField(config.notionStrategyPollWikiId) ?? stringField(config.notionSyncWikiId) ?? DEFAULT_WIKI_ID,
+    spaceSlug: stringField(config.notionStrategyPollSpaceSlug) ?? stringField(config.notionSyncSpaceSlug) ?? DEFAULT_SPACE_SLUG,
+    token: stringField(config.notionStrategyPollToken) ?? stringField(config.notionToken) ?? process.env.NOTION_TOKEN ?? null,
+    tokenPath: stringField(config.notionStrategyPollTokenPath) ?? stringField(config.notionTokenPath) ?? process.env.NOTION_TOKEN_PATH ?? DEFAULT_NOTION_TOKEN_PATH,
+    tasksDatabaseId: stringField(config.notionStrategyPollTasksDatabaseId) ?? stringField(config.notionTasksDatabaseId) ?? process.env.NOTION_TASKS_DATABASE_ID ?? null,
+    tasksDatabaseIdPath: stringField(config.notionStrategyPollTasksDatabaseIdPath) ?? stringField(config.notionTasksDatabaseIdPath) ?? process.env.NOTION_TASKS_DATABASE_ID_PATH ?? DEFAULT_NOTION_TASKS_DATABASE_ID_PATH,
+    croAgentId: stringField(config.notionStrategyPollCroAgentId) ?? process.env.PAPERCLIP_CRO_AGENT_ID ?? DEFAULT_CRO_AGENT_ID,
+    companyIds:
+      stringArrayField(config.notionStrategyPollCompanyIds) ??
+      stringArrayField(config.notionSyncCompanyIds) ??
+      [],
+  };
+}
+
+function resolveToken(config: NotionStrategyPollConfig): string {
+  const token = config.token ?? readSecretFile(config.tokenPath);
+  if (!token) {
+    throw new Error(`Notion token missing. Configure notionStrategyPollToken/notionStrategyPollTokenPath, notionToken/notionTokenPath, or create ${config.tokenPath}.`);
+  }
+  return token;
+}
+
+function resolveTasksDatabaseId(config: NotionStrategyPollConfig): string {
+  const databaseId = config.tasksDatabaseId ?? readSecretFile(config.tasksDatabaseIdPath);
+  if (!databaseId) {
+    throw new Error(`Notion Tasks database id missing. Configure notionStrategyPollTasksDatabaseId/notionStrategyPollTasksDatabaseIdPath, notionTasksDatabaseId/notionTasksDatabaseIdPath, or create ${config.tasksDatabaseIdPath}.`);
+  }
+  return databaseId;
+}
+
+async function latestWatermark(ctx: PluginContext, input: { companyId: string; wikiId: string; spaceId: string }): Promise<string | null> {
+  const rows = await ctx.db.query<Record<string, unknown>>(
+    `SELECT max(notion_last_edited_time)::text AS watermark
+       FROM ${tableName(ctx.db.namespace, "notion_strategy_poll_cursors")}
+      WHERE company_id = $1 AND wiki_id = $2 AND space_id = $3`,
+    [input.companyId, input.wikiId, input.spaceId],
+  );
+  return stringField(rows[0]?.watermark);
+}
+
+async function alreadyProcessed(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  spaceId: string;
+  notionPageIdNormalized: string;
+  lastEditedTime: string;
+}): Promise<boolean> {
+  const rows = await ctx.db.query<Record<string, unknown>>(
+    `SELECT 1
+       FROM ${tableName(ctx.db.namespace, "notion_strategy_poll_cursors")}
+      WHERE company_id = $1
+        AND wiki_id = $2
+        AND space_id = $3
+        AND notion_page_id_normalized = $4
+        AND notion_last_edited_time = $5::timestamptz
+      LIMIT 1`,
+    [input.companyId, input.wikiId, input.spaceId, input.notionPageIdNormalized, input.lastEditedTime],
+  );
+  return rows.length > 0;
+}
+
+async function recordProcessed(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  spaceId: string;
+  notionPageId: string;
+  lastEditedTime: string;
+  issueId: string | null;
+  issueIdentifier: string | null;
+  metadata: Record<string, unknown>;
+}) {
+  await ctx.db.execute(
+    `INSERT INTO ${tableName(ctx.db.namespace, "notion_strategy_poll_cursors")}
+       (id, company_id, wiki_id, space_id, notion_page_id, notion_page_id_normalized, notion_last_edited_time,
+        emitted_issue_id, emitted_issue_identifier, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz, $8, $9, $10::jsonb)
+     ON CONFLICT (company_id, wiki_id, space_id, notion_page_id_normalized, notion_last_edited_time)
+     DO UPDATE SET emitted_issue_id = EXCLUDED.emitted_issue_id,
+                   emitted_issue_identifier = EXCLUDED.emitted_issue_identifier,
+                   metadata = EXCLUDED.metadata,
+                   updated_at = now()`,
+    [
+      randomUUID(),
+      input.companyId,
+      input.wikiId,
+      input.spaceId,
+      input.notionPageId,
+      normalizePageId(input.notionPageId),
+      input.lastEditedTime,
+      input.issueId ?? null,
+      input.issueIdentifier,
+      jsonParam(input.metadata),
+    ],
+  );
+}
+
+async function recordOperation(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  spaceId: string;
+  operationId: string;
+  runId: string;
+  status: "succeeded" | "failed" | "partial";
+  warnings: string[];
+  metadata: Record<string, unknown>;
+}) {
+  await ctx.db.execute(
+    `INSERT INTO ${tableName(ctx.db.namespace, "wiki_operations")}
+       (id, company_id, wiki_id, space_id, operation_type, status, run_ids, cost_cents, warnings, affected_pages, metadata)
+     VALUES ($1, $2, $3, $4, 'notion-strategy-poll', $5, $6::jsonb, 0, $7::jsonb, '[]'::jsonb, $8::jsonb)`,
+    [
+      input.operationId,
+      input.companyId,
+      input.wikiId,
+      input.spaceId,
+      input.status,
+      jsonParam([input.runId]),
+      jsonParam(input.warnings),
+      jsonParam(input.metadata),
+    ],
+  );
+}
+
+function buildCroIssue(input: {
+  companyId: string;
+  croAgentId: string;
+  page: NotionPage;
+  reason: string;
+}) {
+  const title = extractTitle(input.page) || "(untitled Notion task)";
+  const status = extractStatus(input.page);
+  const tags = extractTags(input.page);
+  const edited = input.page.last_edited_time ?? "";
+  const notionId = input.page.id;
+  const url = input.page.url ?? "";
+  return {
+    companyId: input.companyId,
+    title: `Research: ${title}`,
+    description: [
+      "Research task auto-created by plugin-native Notion Strategy Poll.",
+      "",
+      `**Source:** ${url ? `[${title}](${url})` : title}`,
+      `**Notion id:** \`${notionId}\``,
+      `**Notion status:** ${status || "n/a"}`,
+      `**Tags:** ${tags.length > 0 ? tags.join(", ") : "n/a"}`,
+      `**Last edited:** ${edited || "n/a"}`,
+      `**Detection:** ${input.reason}`,
+      "",
+      "Please analyse this strategy, document assumptions, and propose a backtest or paper-trade plan. Escalate to CTO if data dependencies are unclear.",
+    ].join("\n"),
+    status: "todo" as const,
+    priority: "medium" as const,
+    assigneeAgentId: input.croAgentId,
+    originKind: "plugin:llm-wiki:notion-strategy-poll" as const,
+    originId: `notion:${normalizePageId(notionId)}:${edited}`,
+    originRunId: null,
+  };
+}
+
+async function syncCompany(ctx: PluginContext, company: Company, job: PluginJobContext): Promise<CompanyPollResult> {
+  const config = await readConfig(ctx);
+  const counts: PollCounts = {
+    companies: 1,
+    pagesFetched: 0,
+    pagesSkipped: 0,
+    pagesMatched: 0,
+    issuesCreated: 0,
+    alreadyProcessed: 0,
+    failures: 0,
+  };
+  const warnings: string[] = [];
+  const emittedIssues: string[] = [];
+  const wikiId = config.wikiId;
+
+  const folderStatus = await ctx.localFolders.status(company.id, WIKI_ROOT_FOLDER_KEY);
+  if (!folderStatus.configured || !folderStatus.readable) {
+    return {
+      companyId: company.id,
+      wikiId,
+      spaceSlug: config.spaceSlug,
+      status: "succeeded",
+      counts,
+      warnings: ["Skipped: wiki-root local folder is not configured for this company."],
+      emittedIssues,
+    };
+  }
+
+  const space = await resolveSpace(ctx, { companyId: company.id, wikiId, spaceSlug: config.spaceSlug });
+  const operationId = randomUUID();
+  try {
+    if (!config.enabled) {
+      warnings.push("Notion strategy poll disabled by plugin config.");
+      await recordOperation(ctx, {
+        companyId: company.id,
+        wikiId,
+        spaceId: space.id,
+        operationId,
+        runId: job.runId,
+        status: "succeeded",
+        warnings,
+        metadata: { skipped: true, reason: "disabled" },
+      });
+      return { companyId: company.id, wikiId, spaceSlug: space.slug, status: "succeeded", counts, warnings, emittedIssues };
+    }
+
+    const token = resolveToken(config);
+    const tasksDatabaseId = resolveTasksDatabaseId(config);
+    const since = await latestWatermark(ctx, { companyId: company.id, wikiId, spaceId: space.id });
+    const pages = await queryTasksDatabase(ctx, token, tasksDatabaseId, since);
+    counts.pagesFetched = pages.length;
+
+    for (const page of pages) {
+      const edited = page.last_edited_time;
+      if (!edited) {
+        counts.pagesSkipped += 1;
+        warnings.push(`Skipped Notion page ${page.id}: missing last_edited_time.`);
+        continue;
+      }
+      const pageIdNormalized = normalizePageId(page.id);
+      if (await alreadyProcessed(ctx, {
+        companyId: company.id,
+        wikiId,
+        spaceId: space.id,
+        notionPageIdNormalized: pageIdNormalized,
+        lastEditedTime: edited,
+      })) {
+        counts.alreadyProcessed += 1;
+        continue;
+      }
+      const decision = isNotionStrategyPage(page);
+      if (!decision.match) {
+        counts.pagesSkipped += 1;
+        await recordProcessed(ctx, {
+          companyId: company.id,
+          wikiId,
+          spaceId: space.id,
+          notionPageId: page.id,
+          lastEditedTime: edited,
+          issueId: null,
+          issueIdentifier: null,
+          metadata: {
+            title: extractTitle(page),
+            notionUrl: page.url ?? null,
+            skipped: true,
+            skipReason: decision.reason,
+            jobRunId: job.runId,
+          },
+        });
+        continue;
+      }
+      counts.pagesMatched += 1;
+      const issue = await ctx.issues.create(buildCroIssue({
+        companyId: company.id,
+        croAgentId: config.croAgentId,
+        page,
+        reason: decision.reason,
+      }));
+      await recordProcessed(ctx, {
+        companyId: company.id,
+        wikiId,
+        spaceId: space.id,
+        notionPageId: page.id,
+        lastEditedTime: edited,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier ?? null,
+        metadata: {
+          title: extractTitle(page),
+          notionUrl: page.url ?? null,
+          detectionReason: decision.reason,
+          jobRunId: job.runId,
+        },
+      });
+      emittedIssues.push(issue.identifier ?? issue.id);
+      counts.issuesCreated += 1;
+    }
+  } catch (error) {
+    counts.failures += 1;
+    warnings.push(error instanceof Error ? error.message : String(error));
+  }
+
+  const status = counts.failures > 0 && counts.issuesCreated > 0 ? "partial" : counts.failures > 0 ? "failed" : "succeeded";
+  await recordOperation(ctx, {
+    companyId: company.id,
+    wikiId,
+    spaceId: space.id,
+    operationId,
+    runId: job.runId,
+    status,
+    warnings,
+    metadata: { counts, emittedIssues, scheduledAt: job.scheduledAt, trigger: job.trigger },
+  });
+  await ctx.metrics.write("notion_strategy_poll.run", 1, { status, trigger: job.trigger });
+  return { companyId: company.id, wikiId, spaceSlug: space.slug, status, counts, warnings, emittedIssues };
+}
+
+export async function runNotionStrategyPoll(ctx: PluginContext, job: PluginJobContext) {
+  const { companyIds } = await readConfig(ctx);
+  if (companyIds.length === 0) {
+    ctx.logger.warn("Notion Strategy Poll skipped: no notionStrategyPollCompanyIds configured", {
+      jobKey: job.jobKey,
+      runId: job.runId,
+    });
+    return { status: "skipped", results: [] as CompanyPollResult[] };
+  }
+  const companies: Company[] = [];
+  for (const companyId of companyIds) {
+    const company = await ctx.companies.get(companyId);
+    if (!company) {
+      ctx.logger.warn("Notion Strategy Poll: configured company not found or not authorized", {
+        jobKey: job.jobKey,
+        runId: job.runId,
+        companyId,
+      });
+      continue;
+    }
+    companies.push(company);
+  }
+  const results: CompanyPollResult[] = [];
+  for (const company of companies) {
+    results.push(await syncCompany(ctx, company, job));
+  }
+  ctx.logger.info("Notion Strategy Poll job completed", {
+    jobKey: job.jobKey,
+    runId: job.runId,
+    companyCount: companies.length,
+    statuses: results.map((result) => ({ companyId: result.companyId, status: result.status, counts: result.counts })),
+  });
+  return { status: "ok", results };
+}

--- a/packages/plugins/plugin-llm-wiki/src/notion-sync.ts
+++ b/packages/plugins/plugin-llm-wiki/src/notion-sync.ts
@@ -1,0 +1,884 @@
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { Company, PluginContext, PluginJobContext } from "@paperclipai/plugin-sdk";
+import { WIKI_ROOT_FOLDER_KEY } from "./manifest.js";
+import { DEFAULT_SPACE_SLUG, DEFAULT_WIKI_ID, resolveSpace, writeWikiPage, type WikiSpace } from "./wiki.js";
+
+const NOTION_API_BASE = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+const DEFAULT_NOTION_TOKEN_PATH = "~/.paperclip/instances/default/secrets/notion-token.txt";
+const DEFAULT_NOTION_TASKS_DATABASE_ID_PATH = "~/.paperclip/instances/default/secrets/notion-tasks-database-id.txt";
+const MAX_NOTION_BLOCK_CHILDREN = 100;
+
+type NotionSyncConfig = {
+  enabled: boolean;
+  wikiId: string;
+  spaceSlug: string;
+  tokenPath: string;
+  tasksDatabaseIdPath: string;
+  token?: string | null;
+  tasksDatabaseId?: string | null;
+  /**
+   * Companies this job fans out over. The host never grants a plugin a wildcard
+   * ("all companies") scope on a proactive worker-to-host call, so the job must
+   * name each company explicitly and issue one company-scoped call per entry.
+   */
+  companyIds: string[];
+};
+
+type SyncCursor = {
+  notionPageId: string;
+  wikiPath: string;
+  notionLastEditedTime: string | null;
+  notionContentHash: string | null;
+  wikiContentHash: string | null;
+  origin: "notion" | "wiki" | string;
+};
+
+type NotionPage = {
+  id: string;
+  object: "page";
+  url?: string;
+  archived?: boolean;
+  last_edited_time?: string;
+  created_time?: string;
+  properties?: Record<string, unknown>;
+  parent?: Record<string, unknown>;
+};
+
+type NotionBlock = {
+  id: string;
+  type: string;
+  has_children?: boolean;
+  [key: string]: unknown;
+};
+
+type SyncCounts = {
+  companies: number;
+  notionPagesSeen: number;
+  notionPagesWritten: number;
+  notionPagesSkipped: number;
+  wikiPagesSeen: number;
+  wikiPagesPushed: number;
+  conflicts: number;
+  failures: number;
+};
+
+type CompanySyncResult = {
+  companyId: string;
+  wikiId: string;
+  spaceSlug: string;
+  status: "succeeded" | "failed" | "partial";
+  counts: SyncCounts;
+  warnings: string[];
+  affectedPages: string[];
+};
+
+function contentHash(contents: string): string {
+  return createHash("sha256").update(contents, "utf8").digest("hex");
+}
+
+function tableName(namespace: string, table: string): string {
+  return `${namespace}.${table}`;
+}
+
+function jsonParam(value: unknown): string {
+  return JSON.stringify(value ?? {});
+}
+
+function expandHome(path: string): string {
+  if (path === "~") return process.env.HOME ?? "";
+  if (path.startsWith("~/")) return `${process.env.HOME ?? ""}${path.slice(1)}`;
+  return path;
+}
+
+function readSecretFile(path: string): string | null {
+  try {
+    const value = readFileSync(expandHome(path), "utf8").trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+const CYRILLIC_TRANSLIT: Record<string, string> = {
+  "\u0430": "a", "\u0431": "b", "\u0432": "v", "\u0433": "g", "\u0434": "d",
+  "\u0435": "e", "\u0451": "e", "\u0436": "zh", "\u0437": "z", "\u0438": "i",
+  "\u0439": "i", "\u043a": "k", "\u043b": "l", "\u043c": "m", "\u043d": "n",
+  "\u043e": "o", "\u043f": "p", "\u0440": "r", "\u0441": "s", "\u0442": "t",
+  "\u0443": "u", "\u0444": "f", "\u0445": "h", "\u0446": "ts", "\u0447": "ch",
+  "\u0448": "sh", "\u0449": "shch", "\u044a": "", "\u044b": "y", "\u044c": "",
+  "\u044d": "e", "\u044e": "yu", "\u044f": "ya",
+};
+
+function transliterate(value: string): string {
+  let out = "";
+  for (const ch of value) {
+    out += CYRILLIC_TRANSLIT[ch] ?? ch;
+  }
+  return out;
+}
+
+const MAX_SLUG_LENGTH = 80;
+
+function slugify(value: string): string {
+  const slug = transliterate(value.trim().toLowerCase())
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+  return slug || "untitled";
+}
+
+function normalizePageId(id: string): string {
+  return id.replace(/-/g, "");
+}
+
+function notionPagePath(page: NotionPage, title: string): string {
+  return `wiki/notion/${slugify(title)}-${normalizePageId(page.id)}.md`;
+}
+
+function frontmatterValue(value: string): string {
+  return JSON.stringify(value);
+}
+
+function buildFrontmatter(input: {
+  title: string;
+  pageId: string;
+  lastEditedTime: string;
+  url?: string | null;
+  contentHash: string;
+}) {
+  const lines = [
+    "---",
+    `title: ${frontmatterValue(input.title)}`,
+    "source: notion",
+    `notion_page_id: ${frontmatterValue(input.pageId)}`,
+    `notion_last_edited_time: ${frontmatterValue(input.lastEditedTime)}`,
+    `notion_content_hash: ${frontmatterValue(input.contentHash)}`,
+    "notion_sync: true",
+    input.url ? `notion_url: ${frontmatterValue(input.url)}` : null,
+    "---",
+    "",
+  ].filter((line): line is string => line !== null);
+  return lines.join("\n");
+}
+
+function parseFrontmatter(contents: string): { frontmatter: Record<string, string | boolean>; body: string } {
+  if (!contents.startsWith("---\n")) return { frontmatter: {}, body: contents };
+  const end = contents.indexOf("\n---", 4);
+  if (end === -1) return { frontmatter: {}, body: contents };
+  const raw = contents.slice(4, end).split(/\r?\n/);
+  const frontmatter: Record<string, string | boolean> = {};
+  for (const line of raw) {
+    const match = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    const trimmed = rawValue.trim();
+    if (trimmed === "true") {
+      frontmatter[key] = true;
+    } else if (trimmed === "false") {
+      frontmatter[key] = false;
+    } else if (trimmed.startsWith("\"")) {
+      try {
+        frontmatter[key] = JSON.parse(trimmed) as string;
+      } catch {
+        frontmatter[key] = trimmed;
+      }
+    } else {
+      frontmatter[key] = trimmed;
+    }
+  }
+  return { frontmatter, body: contents.slice(end + "\n---".length).replace(/^\r?\n/, "") };
+}
+
+function serializeFrontmatter(frontmatter: Record<string, string | boolean>, body: string): string {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(frontmatter)) {
+    lines.push(`${key}: ${typeof value === "boolean" ? String(value) : frontmatterValue(value)}`);
+  }
+  lines.push("---", "", body.replace(/^\r?\n/, "").trimEnd(), "");
+  return lines.join("\n");
+}
+
+function plainText(richText: unknown): string {
+  if (!Array.isArray(richText)) return "";
+  return richText
+    .map((part) => typeof part === "object" && part != null && "plain_text" in part ? String(part.plain_text ?? "") : "")
+    .join("");
+}
+
+function titleFromPage(page: NotionPage): string {
+  for (const property of Object.values(page.properties ?? {})) {
+    if (typeof property !== "object" || property == null) continue;
+    const maybe = property as { type?: string; title?: unknown };
+    if (maybe.type === "title") {
+      const title = plainText(maybe.title);
+      if (title.trim()) return title.trim();
+    }
+  }
+  return `Notion page ${normalizePageId(page.id).slice(0, 8)}`;
+}
+
+function renderBlock(block: NotionBlock): string {
+  const value = block[block.type];
+  const payload = typeof value === "object" && value != null ? value as Record<string, unknown> : {};
+  const text = plainText(payload.rich_text);
+  switch (block.type) {
+    case "heading_1":
+      return `# ${text}`;
+    case "heading_2":
+      return `## ${text}`;
+    case "heading_3":
+      return `### ${text}`;
+    case "bulleted_list_item":
+      return `- ${text}`;
+    case "numbered_list_item":
+      return `1. ${text}`;
+    case "to_do":
+      return `- [${payload.checked === true ? "x" : " "}] ${text}`;
+    case "quote":
+      return `> ${text}`;
+    case "code":
+      return `\`\`\`${stringField(payload.language) ?? ""}\n${text}\n\`\`\``;
+    case "divider":
+      return "---";
+    case "paragraph":
+      return text;
+    case "child_page":
+      return `[[${stringField(payload.title) ?? "Child page"}]]`;
+    default:
+      return text.trim() ? text : `<!-- unsupported Notion block: ${block.type} -->`;
+  }
+}
+
+function markdownToNotionBlocks(markdown: string): Array<Record<string, unknown>> {
+  const blocks: Array<Record<string, unknown>> = [];
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  let paragraph: string[] = [];
+  const flushParagraph = () => {
+    const text = paragraph.join("\n").trim();
+    paragraph = [];
+    if (!text) return;
+    for (const chunk of chunkText(text)) {
+      blocks.push({ object: "block", type: "paragraph", paragraph: { rich_text: richText(chunk) } });
+    }
+  };
+  for (const line of lines) {
+    if (!line.trim()) {
+      flushParagraph();
+      continue;
+    }
+    const heading = /^(#{1,3})\s+(.+)$/.exec(line);
+    const bullet = /^[-*]\s+(.+)$/.exec(line);
+    const todo = /^[-*]\s+\[( |x|X)\]\s+(.+)$/.exec(line);
+    if (heading) {
+      flushParagraph();
+      const level = heading[1].length;
+      const type = `heading_${level}`;
+      blocks.push({ object: "block", type, [type]: { rich_text: richText(heading[2]) } });
+    } else if (todo) {
+      flushParagraph();
+      blocks.push({ object: "block", type: "to_do", to_do: { checked: todo[1].toLowerCase() === "x", rich_text: richText(todo[2]) } });
+    } else if (bullet) {
+      flushParagraph();
+      blocks.push({ object: "block", type: "bulleted_list_item", bulleted_list_item: { rich_text: richText(bullet[1]) } });
+    } else {
+      paragraph.push(line);
+    }
+    if (blocks.length >= MAX_NOTION_BLOCK_CHILDREN) break;
+  }
+  flushParagraph();
+  return blocks.slice(0, MAX_NOTION_BLOCK_CHILDREN);
+}
+
+function richText(text: string): Array<Record<string, unknown>> {
+  return chunkText(text).map((content) => ({ type: "text", text: { content } }));
+}
+
+function chunkText(text: string): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += 1900) chunks.push(text.slice(i, i + 1900));
+  return chunks.length > 0 ? chunks : [""];
+}
+
+async function notionRequest<T>(
+  ctx: PluginContext,
+  token: string,
+  path: string,
+  init: RequestInit = {},
+  attempt = 0,
+): Promise<T> {
+  const response = await ctx.http.fetch(`${NOTION_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "Notion-Version": NOTION_VERSION,
+      ...(init.headers ?? {}),
+    },
+  });
+  if ((response.status === 429 || response.status >= 500) && attempt < 3) {
+    const retryAfter = Number(response.headers.get("retry-after"));
+    const delayMs = Number.isFinite(retryAfter) && retryAfter > 0
+      ? retryAfter * 1000
+      : 250 * 2 ** attempt;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return notionRequest<T>(ctx, token, path, init, attempt + 1);
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Notion ${init.method ?? "GET"} ${path} failed: HTTP ${response.status}${body ? ` ${body.slice(0, 500)}` : ""}`);
+  }
+  return await response.json() as T;
+}
+
+async function listAccessiblePages(ctx: PluginContext, token: string): Promise<NotionPage[]> {
+  const pages: NotionPage[] = [];
+  let startCursor: string | undefined;
+  do {
+    const payload = await notionRequest<{ results?: unknown[]; has_more?: boolean; next_cursor?: string | null }>(ctx, token, "/search", {
+      method: "POST",
+      body: JSON.stringify({
+        filter: { property: "object", value: "page" },
+        page_size: 100,
+        start_cursor: startCursor,
+      }),
+    });
+    for (const row of payload.results ?? []) {
+      if (typeof row === "object" && row != null && (row as { object?: string }).object === "page") {
+        pages.push(row as NotionPage);
+      }
+    }
+    startCursor = payload.has_more ? payload.next_cursor ?? undefined : undefined;
+  } while (startCursor);
+  return pages.filter((page) => page.archived !== true);
+}
+
+async function listPageBlocks(ctx: PluginContext, token: string, pageId: string): Promise<NotionBlock[]> {
+  const blocks: NotionBlock[] = [];
+  let startCursor: string | undefined;
+  do {
+    const suffix = new URLSearchParams({ page_size: "100" });
+    if (startCursor) suffix.set("start_cursor", startCursor);
+    const payload = await notionRequest<{ results?: unknown[]; has_more?: boolean; next_cursor?: string | null }>(
+      ctx,
+      token,
+      `/blocks/${pageId}/children?${suffix.toString()}`,
+    );
+    for (const row of payload.results ?? []) {
+      if (typeof row === "object" && row != null && typeof (row as { type?: unknown }).type === "string") {
+        blocks.push(row as NotionBlock);
+      }
+    }
+    startCursor = payload.has_more ? payload.next_cursor ?? undefined : undefined;
+  } while (startCursor);
+  return blocks;
+}
+
+async function replacePageBlocks(ctx: PluginContext, token: string, pageId: string, blocks: Array<Record<string, unknown>>) {
+  const current = await listPageBlocks(ctx, token, pageId);
+  for (const block of current) {
+    await notionRequest(ctx, token, `/blocks/${block.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ archived: true }),
+    });
+  }
+  if (blocks.length === 0) return;
+  await notionRequest(ctx, token, `/blocks/${pageId}/children`, {
+    method: "PATCH",
+    body: JSON.stringify({ children: blocks.slice(0, MAX_NOTION_BLOCK_CHILDREN) }),
+  });
+}
+
+async function titlePropertyName(ctx: PluginContext, token: string, databaseId: string): Promise<string> {
+  const database = await notionRequest<{ properties?: Record<string, { type?: string }> }>(ctx, token, `/databases/${databaseId}`);
+  for (const [name, property] of Object.entries(database.properties ?? {})) {
+    if (property?.type === "title") return name;
+  }
+  return "Name";
+}
+
+async function createNotionPage(ctx: PluginContext, token: string, databaseId: string, title: string, markdown: string): Promise<NotionPage> {
+  const titleProp = await titlePropertyName(ctx, token, databaseId);
+  return await notionRequest<NotionPage>(ctx, token, "/pages", {
+    method: "POST",
+    body: JSON.stringify({
+      parent: { database_id: databaseId },
+      properties: {
+        [titleProp]: { title: richText(title) },
+      },
+      children: markdownToNotionBlocks(markdown),
+    }),
+  });
+}
+
+function stringArrayField(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  const out = value
+    .map((entry) => stringField(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return out.length > 0 ? out : null;
+}
+
+async function readConfig(ctx: PluginContext): Promise<NotionSyncConfig> {
+  const config = await ctx.config.get();
+  return {
+    enabled: config.notionSyncEnabled !== false,
+    wikiId: stringField(config.notionSyncWikiId) ?? DEFAULT_WIKI_ID,
+    spaceSlug: stringField(config.notionSyncSpaceSlug) ?? DEFAULT_SPACE_SLUG,
+    token: stringField(config.notionToken) ?? process.env.NOTION_TOKEN ?? null,
+    tokenPath: stringField(config.notionTokenPath) ?? process.env.NOTION_TOKEN_PATH ?? DEFAULT_NOTION_TOKEN_PATH,
+    tasksDatabaseId: stringField(config.notionTasksDatabaseId) ?? process.env.NOTION_TASKS_DATABASE_ID ?? null,
+    tasksDatabaseIdPath: stringField(config.notionTasksDatabaseIdPath) ?? process.env.NOTION_TASKS_DATABASE_ID_PATH ?? DEFAULT_NOTION_TASKS_DATABASE_ID_PATH,
+    companyIds: stringArrayField(config.notionSyncCompanyIds) ?? [],
+  };
+}
+
+function resolveToken(config: NotionSyncConfig): string {
+  const token = config.token ?? readSecretFile(config.tokenPath);
+  if (!token) {
+    throw new Error(`Notion token missing. Configure notionToken/notionTokenPath or create ${config.tokenPath}.`);
+  }
+  return token;
+}
+
+function resolveTasksDatabaseId(config: NotionSyncConfig): string | null {
+  return config.tasksDatabaseId ?? readSecretFile(config.tasksDatabaseIdPath);
+}
+
+async function readCursor(ctx: PluginContext, input: { companyId: string; wikiId: string; spaceId: string; notionPageId?: string; wikiPath?: string }): Promise<SyncCursor | null> {
+  const byPage = input.notionPageId
+    ? await ctx.db.query<Record<string, unknown>>(
+        `SELECT notion_page_id, wiki_path, notion_last_edited_time::text AS notion_last_edited_time,
+                notion_content_hash, wiki_content_hash, origin
+           FROM ${tableName(ctx.db.namespace, "notion_sync_cursors")}
+          WHERE company_id = $1 AND wiki_id = $2 AND space_id = $3 AND notion_page_id = $4
+          LIMIT 1`,
+        [input.companyId, input.wikiId, input.spaceId, input.notionPageId],
+      )
+    : [];
+  const byPath = !byPage[0] && input.wikiPath
+    ? await ctx.db.query<Record<string, unknown>>(
+        `SELECT notion_page_id, wiki_path, notion_last_edited_time::text AS notion_last_edited_time,
+                notion_content_hash, wiki_content_hash, origin
+           FROM ${tableName(ctx.db.namespace, "notion_sync_cursors")}
+          WHERE company_id = $1 AND wiki_id = $2 AND space_id = $3 AND wiki_path = $4
+          LIMIT 1`,
+        [input.companyId, input.wikiId, input.spaceId, input.wikiPath],
+      )
+    : [];
+  const row = byPage[0] ?? byPath[0];
+  return row ? {
+    notionPageId: String(row.notion_page_id),
+    wikiPath: String(row.wiki_path),
+    notionLastEditedTime: stringField(row.notion_last_edited_time),
+    notionContentHash: stringField(row.notion_content_hash),
+    wikiContentHash: stringField(row.wiki_content_hash),
+    origin: stringField(row.origin) ?? "notion",
+  } : null;
+}
+
+async function upsertCursor(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  spaceId: string;
+  notionPageId: string;
+  wikiPath: string;
+  notionLastEditedTime?: string | null;
+  notionContentHash?: string | null;
+  wikiContentHash?: string | null;
+  origin: "notion" | "wiki";
+  metadata?: Record<string, unknown>;
+}) {
+  await ctx.db.execute(
+    `INSERT INTO ${tableName(ctx.db.namespace, "notion_sync_cursors")} AS notion_sync_cursors
+       (id, company_id, wiki_id, space_id, notion_page_id, wiki_path, notion_last_edited_time,
+        notion_content_hash, wiki_content_hash, origin, last_synced_at, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz, $8, $9, $10, now(), $11::jsonb)
+     ON CONFLICT (company_id, wiki_id, space_id, notion_page_id)
+     DO UPDATE SET wiki_path = EXCLUDED.wiki_path,
+                   notion_last_edited_time = EXCLUDED.notion_last_edited_time,
+                   notion_content_hash = EXCLUDED.notion_content_hash,
+                   wiki_content_hash = EXCLUDED.wiki_content_hash,
+                   origin = EXCLUDED.origin,
+                   last_synced_at = now(),
+                   metadata = EXCLUDED.metadata,
+                   updated_at = now()`,
+    [
+      randomUUID(),
+      input.companyId,
+      input.wikiId,
+      input.spaceId,
+      input.notionPageId,
+      input.wikiPath,
+      input.notionLastEditedTime ?? null,
+      input.notionContentHash ?? null,
+      input.wikiContentHash ?? null,
+      input.origin,
+      jsonParam(input.metadata ?? {}),
+    ],
+  );
+}
+
+async function recordOperation(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  spaceId: string;
+  operationId: string;
+  runId: string;
+  status: "succeeded" | "failed" | "partial";
+  warnings: string[];
+  affectedPages: string[];
+  metadata: Record<string, unknown>;
+}) {
+  await ctx.db.execute(
+    `INSERT INTO ${tableName(ctx.db.namespace, "wiki_operations")}
+       (id, company_id, wiki_id, space_id, operation_type, status, run_ids, cost_cents, warnings, affected_pages, metadata)
+     VALUES ($1, $2, $3, $4, 'notion-sync', $5, $6::jsonb, 0, $7::jsonb, $8::jsonb, $9::jsonb)`,
+    [
+      input.operationId,
+      input.companyId,
+      input.wikiId,
+      input.spaceId,
+      input.status,
+      jsonParam([input.runId]),
+      jsonParam(input.warnings),
+      jsonParam(input.affectedPages),
+      jsonParam(input.metadata),
+    ],
+  );
+}
+
+async function appendWikiLog(ctx: PluginContext, companyId: string, space: WikiSpace, entry: string) {
+  let current = "";
+  try {
+    current = await ctx.localFolders.readText(companyId, WIKI_ROOT_FOLDER_KEY, space.pathPrefix ? `${space.pathPrefix}/wiki/log.md` : "wiki/log.md");
+  } catch {
+    current = "# Log\n\nAppend-only chronological record of wiki operations.\n";
+  }
+  const path = space.pathPrefix ? `${space.pathPrefix}/wiki/log.md` : "wiki/log.md";
+  await ctx.localFolders.writeTextAtomic(companyId, WIKI_ROOT_FOLDER_KEY, path, `${current.trimEnd()}\n\n- ${new Date().toISOString()} ${entry}\n`);
+}
+
+async function readExistingWikiContents(ctx: PluginContext, companyId: string, space: WikiSpace, path: string): Promise<string | null> {
+  try {
+    return await ctx.localFolders.readText(companyId, WIKI_ROOT_FOLDER_KEY, space.pathPrefix ? `${space.pathPrefix}/${path}` : path);
+  } catch {
+    return null;
+  }
+}
+
+async function listWikiSyncPages(ctx: PluginContext, companyId: string, space: WikiSpace): Promise<Array<{ path: string; contents: string }>> {
+  const prefix = space.pathPrefix ? `${space.pathPrefix}/wiki` : "wiki";
+  const listing = await ctx.localFolders.list(companyId, WIKI_ROOT_FOLDER_KEY, { relativePath: prefix, recursive: true, maxEntries: 5000 });
+  const pages: Array<{ path: string; contents: string }> = [];
+  for (const entry of listing.entries) {
+    if (entry.kind !== "file" || !entry.path.endsWith(".md")) continue;
+    const relativePath = space.pathPrefix && entry.path.startsWith(`${space.pathPrefix}/`)
+      ? entry.path.slice(space.pathPrefix.length + 1)
+      : entry.path;
+    const contents = await ctx.localFolders.readText(companyId, WIKI_ROOT_FOLDER_KEY, entry.path);
+    const { frontmatter } = parseFrontmatter(contents);
+    if (frontmatter.notion_sync === true) pages.push({ path: relativePath, contents });
+  }
+  return pages;
+}
+
+async function syncNotionToWiki(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  space: WikiSpace;
+  token: string;
+  counts: SyncCounts;
+  warnings: string[];
+  affectedPages: string[];
+}) {
+  const pages = await listAccessiblePages(ctx, input.token);
+  input.counts.notionPagesSeen += pages.length;
+  if (pages.length === 0) {
+    input.warnings.push("Notion search returned zero accessible pages; check integration share settings.");
+  }
+  for (const page of pages) {
+    try {
+      const title = titleFromPage(page);
+      const path = notionPagePath(page, title);
+      const cursor = await readCursor(ctx, {
+        companyId: input.companyId,
+        wikiId: input.wikiId,
+        spaceId: input.space.id,
+        notionPageId: page.id,
+      });
+      if (cursor?.notionLastEditedTime === page.last_edited_time) {
+        input.counts.notionPagesSkipped += 1;
+        continue;
+      }
+      const blocks = await listPageBlocks(ctx, input.token, page.id);
+      const body = blocks.map(renderBlock).join("\n\n").trimEnd();
+      const notionHash = contentHash(body);
+      const existingWikiContents = await readExistingWikiContents(ctx, input.companyId, input.space, path);
+      const existingWikiHash = existingWikiContents ? contentHash(existingWikiContents) : null;
+      const contents = `${buildFrontmatter({
+        title,
+        pageId: page.id,
+        lastEditedTime: page.last_edited_time ?? new Date().toISOString(),
+        url: page.url,
+        contentHash: notionHash,
+      })}${body}\n`;
+      const wikiHash = contentHash(contents);
+      if (cursor && existingWikiHash && cursor.wikiContentHash && existingWikiHash !== cursor.wikiContentHash && cursor.notionContentHash !== notionHash && cursor.origin === "notion") {
+        input.counts.conflicts += 1;
+        input.warnings.push(`Conflict on ${path}: Notion changed and wiki changed since last sync; Notion authority applied.`);
+        await appendWikiLog(ctx, input.companyId, input.space, `Notion sync conflict on ${path}; Notion authority applied for notion-origin page ${page.id}.`);
+      }
+      await writeWikiPage(ctx, {
+        companyId: input.companyId,
+        wikiId: input.wikiId,
+        spaceSlug: input.space.slug,
+        path,
+        contents,
+        summary: `Sync Notion page ${page.id}`,
+        sourceRefs: [{ type: "notion", pageId: page.id, url: page.url ?? null, lastEditedTime: page.last_edited_time ?? null }],
+        writer: "board_ui",
+      });
+      await upsertCursor(ctx, {
+        companyId: input.companyId,
+        wikiId: input.wikiId,
+        spaceId: input.space.id,
+        notionPageId: page.id,
+        wikiPath: path,
+        notionLastEditedTime: page.last_edited_time ?? null,
+        notionContentHash: notionHash,
+        wikiContentHash: wikiHash,
+        origin: "notion",
+        metadata: { title, notionUrl: page.url ?? null },
+      });
+      input.affectedPages.push(path);
+      input.counts.notionPagesWritten += 1;
+    } catch (error) {
+      input.counts.failures += 1;
+      input.warnings.push(`Failed Notion->Wiki page ${page.id}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+
+async function syncWikiToNotion(ctx: PluginContext, input: {
+  companyId: string;
+  wikiId: string;
+  space: WikiSpace;
+  token: string;
+  tasksDatabaseId: string | null;
+  counts: SyncCounts;
+  warnings: string[];
+  affectedPages: string[];
+}) {
+  const pages = await listWikiSyncPages(ctx, input.companyId, input.space);
+  input.counts.wikiPagesSeen += pages.length;
+  for (const page of pages) {
+    try {
+      const parsed = parseFrontmatter(page.contents);
+      const bodyHash = contentHash(parsed.body.trimEnd());
+      const notionPageId = stringField(parsed.frontmatter.notion_page_id);
+      const cursor = await readCursor(ctx, {
+        companyId: input.companyId,
+        wikiId: input.wikiId,
+        spaceId: input.space.id,
+        notionPageId: notionPageId ?? undefined,
+        wikiPath: page.path,
+      });
+      const wikiHash = contentHash(page.contents);
+      if (cursor?.wikiContentHash === wikiHash) continue;
+      const targetNotionPageId = notionPageId ?? (cursor?.origin === "wiki" ? cursor.notionPageId : null);
+
+      if (targetNotionPageId) {
+        if (cursor?.origin !== "wiki") {
+          input.counts.conflicts += 1;
+          input.warnings.push(`Conflict on ${page.path}: Notion-origin page changed in wiki; Notion remains authority and writeback skipped.`);
+          await appendWikiLog(ctx, input.companyId, input.space, `Notion sync conflict on ${page.path}; skipped wiki writeback because Notion is authority for notion-origin page ${targetNotionPageId}.`);
+          continue;
+        }
+        await replacePageBlocks(ctx, input.token, targetNotionPageId, markdownToNotionBlocks(parsed.body));
+        let contentsForCursor = page.contents;
+        if (!notionPageId) {
+          contentsForCursor = serializeFrontmatter({
+            ...parsed.frontmatter,
+            notion_page_id: targetNotionPageId,
+            notion_sync: true,
+          }, parsed.body);
+          await writeWikiPage(ctx, {
+            companyId: input.companyId,
+            wikiId: input.wikiId,
+            spaceSlug: input.space.slug,
+            path: page.path,
+            contents: contentsForCursor,
+            summary: `Persist Notion page id ${targetNotionPageId}`,
+            sourceRefs: [{ type: "notion", pageId: targetNotionPageId }],
+            writer: "board_ui",
+          });
+        }
+        await upsertCursor(ctx, {
+          companyId: input.companyId,
+          wikiId: input.wikiId,
+          spaceId: input.space.id,
+          notionPageId: targetNotionPageId,
+          wikiPath: page.path,
+          notionLastEditedTime: stringField(parsed.frontmatter.notion_last_edited_time),
+          notionContentHash: bodyHash,
+          wikiContentHash: contentHash(contentsForCursor),
+          origin: "wiki",
+          metadata: { pushedFromWiki: true },
+        });
+      } else {
+        if (!input.tasksDatabaseId) {
+          input.warnings.push(`Wiki page ${page.path} has notion_sync=true but no notion_page_id and no Tasks DB id configured; create skipped.`);
+          continue;
+        }
+        const created = await createNotionPage(ctx, input.token, input.tasksDatabaseId, String(parsed.frontmatter.title ?? page.path), parsed.body);
+        const contentsWithNotionId = serializeFrontmatter({
+          ...parsed.frontmatter,
+          notion_page_id: created.id,
+          notion_last_edited_time: created.last_edited_time ?? new Date().toISOString(),
+          notion_url: created.url ?? "",
+          notion_sync: true,
+        }, parsed.body);
+        await writeWikiPage(ctx, {
+          companyId: input.companyId,
+          wikiId: input.wikiId,
+          spaceSlug: input.space.slug,
+          path: page.path,
+          contents: contentsWithNotionId,
+          summary: `Persist created Notion page ${created.id}`,
+          sourceRefs: [{ type: "notion", pageId: created.id, url: created.url ?? null, lastEditedTime: created.last_edited_time ?? null }],
+          writer: "board_ui",
+        });
+        await upsertCursor(ctx, {
+          companyId: input.companyId,
+          wikiId: input.wikiId,
+          spaceId: input.space.id,
+          notionPageId: created.id,
+          wikiPath: page.path,
+          notionLastEditedTime: created.last_edited_time ?? null,
+          notionContentHash: bodyHash,
+          wikiContentHash: contentHash(contentsWithNotionId),
+          origin: "wiki",
+          metadata: { createdFromWiki: true, notionUrl: created.url ?? null },
+        });
+      }
+      input.affectedPages.push(page.path);
+      input.counts.wikiPagesPushed += 1;
+    } catch (error) {
+      input.counts.failures += 1;
+      input.warnings.push(`Failed Wiki->Notion page ${page.path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+}
+
+async function syncCompany(ctx: PluginContext, company: Company, job: PluginJobContext): Promise<CompanySyncResult> {
+  const config = await readConfig(ctx);
+  const counts: SyncCounts = {
+    companies: 1,
+    notionPagesSeen: 0,
+    notionPagesWritten: 0,
+    notionPagesSkipped: 0,
+    wikiPagesSeen: 0,
+    wikiPagesPushed: 0,
+    conflicts: 0,
+    failures: 0,
+  };
+  const warnings: string[] = [];
+  const affectedPages: string[] = [];
+  const wikiId = config.wikiId;
+
+  const folderStatus = await ctx.localFolders.status(company.id, WIKI_ROOT_FOLDER_KEY);
+  if (!folderStatus.configured || !folderStatus.readable) {
+    return {
+      companyId: company.id,
+      wikiId,
+      spaceSlug: config.spaceSlug,
+      status: "succeeded",
+      counts,
+      warnings: ["Skipped: wiki-root local folder is not configured for this company."],
+      affectedPages,
+    };
+  }
+
+  const space = await resolveSpace(ctx, { companyId: company.id, wikiId, spaceSlug: config.spaceSlug });
+  const operationId = randomUUID();
+  try {
+    if (!config.enabled) {
+      warnings.push("Notion sync disabled by plugin config.");
+      await recordOperation(ctx, {
+        companyId: company.id,
+        wikiId,
+        spaceId: space.id,
+        operationId,
+        runId: job.runId,
+        status: "succeeded",
+        warnings,
+        affectedPages,
+        metadata: { skipped: true, reason: "disabled" },
+      });
+      return { companyId: company.id, wikiId, spaceSlug: space.slug, status: "succeeded", counts, warnings, affectedPages };
+    }
+    const token = resolveToken(config);
+    const tasksDatabaseId = resolveTasksDatabaseId(config);
+    await syncNotionToWiki(ctx, { companyId: company.id, wikiId, space, token, counts, warnings, affectedPages });
+    await syncWikiToNotion(ctx, { companyId: company.id, wikiId, space, token, tasksDatabaseId, counts, warnings, affectedPages });
+  } catch (error) {
+    counts.failures += 1;
+    warnings.push(error instanceof Error ? error.message : String(error));
+  }
+  const status = counts.failures > 0 && (counts.notionPagesWritten > 0 || counts.wikiPagesPushed > 0) ? "partial" : counts.failures > 0 ? "failed" : "succeeded";
+  await recordOperation(ctx, {
+    companyId: company.id,
+    wikiId,
+    spaceId: space.id,
+    operationId,
+    runId: job.runId,
+    status,
+    warnings,
+    affectedPages,
+    metadata: { counts, scheduledAt: job.scheduledAt, trigger: job.trigger },
+  });
+  await ctx.metrics.write("notion_sync.run", 1, { status, trigger: job.trigger });
+  return { companyId: company.id, wikiId, spaceSlug: space.slug, status, counts, warnings, affectedPages };
+}
+
+export async function runNotionWikiSync(ctx: PluginContext, job: PluginJobContext) {
+  const { companyIds } = await readConfig(ctx);
+  if (companyIds.length === 0) {
+    ctx.logger.warn("Notion Wiki sync skipped: no notionSyncCompanyIds configured", {
+      jobKey: job.jobKey,
+      runId: job.runId,
+    });
+    return { status: "skipped", results: [] as CompanySyncResult[] };
+  }
+  const companies: Company[] = [];
+  for (const companyId of companyIds) {
+    const company = await ctx.companies.get(companyId);
+    if (!company) {
+      ctx.logger.warn("Notion Wiki sync: configured company not found or not authorized", {
+        jobKey: job.jobKey,
+        runId: job.runId,
+        companyId,
+      });
+      continue;
+    }
+    companies.push(company);
+  }
+  const results: CompanySyncResult[] = [];
+  for (const company of companies) {
+    results.push(await syncCompany(ctx, company, job));
+  }
+  ctx.logger.info("Notion Wiki sync job completed", {
+    jobKey: job.jobKey,
+    runId: job.runId,
+    companyCount: companies.length,
+    statuses: results.map((result) => ({ companyId: result.companyId, status: result.status, counts: result.counts })),
+  });
+  return { status: "ok", results };
+}

--- a/packages/plugins/plugin-llm-wiki/src/worker.ts
+++ b/packages/plugins/plugin-llm-wiki/src/worker.ts
@@ -6,11 +6,16 @@ import {
   type PluginManagedRoutineDeclaration,
   type PluginManagedRoutineResolution,
 } from "@paperclipai/plugin-sdk";
+import { randomUUID } from "node:crypto";
 import {
   PAPERCLIP_DISTILL_SKILL_KEY,
+  NOTION_SYNC_JOB_KEY,
+  NOTION_STRATEGY_POLL_JOB_KEY,
   WIKI_MAINTENANCE_ROUTINE_KEYS,
   WIKI_ROOT_FOLDER_KEY,
 } from "./manifest.js";
+import { runNotionWikiSync } from "./notion-sync.js";
+import { runNotionStrategyPoll } from "./notion-strategy-poll.js";
 import {
   bootstrapWikiRoot,
   bootstrapSpace,
@@ -188,6 +193,14 @@ const plugin = definePlugin({
     activeContext = ctx;
     await registerWikiTools(ctx);
 
+    ctx.jobs.register(NOTION_SYNC_JOB_KEY, async (job) => {
+      await runNotionWikiSync(ctx, job);
+    });
+
+    ctx.jobs.register(NOTION_STRATEGY_POLL_JOB_KEY, async (job) => {
+      await runNotionStrategyPoll(ctx, job);
+    });
+
     for (const eventName of PAPERCLIP_EVENT_INGESTION_EVENTS) {
       ctx.events.on(eventName, async (event) => {
         const result = await handlePaperclipEventIngestion(ctx, event);
@@ -213,6 +226,15 @@ const plugin = definePlugin({
       return companyId
         ? getOverview(ctx, companyId)
         : { status: "ok", checkedAt: new Date().toISOString(), message: "LLM Wiki worker is running" };
+    });
+
+    ctx.actions.register("run-notion-sync", async (params) => {
+      return runNotionWikiSync(ctx, {
+        jobKey: NOTION_SYNC_JOB_KEY,
+        runId: stringField(params.runId) ?? randomUUID(),
+        trigger: "manual",
+        scheduledAt: new Date().toISOString(),
+      });
     });
 
     ctx.actions.register("bootstrap-root", async (params) => {

--- a/packages/plugins/plugin-llm-wiki/tests/notion-strategy-poll.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/notion-strategy-poll.spec.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import type { Company, Issue, PluginContext, PluginJobContext } from "@paperclipai/plugin-sdk";
+import { isNotionStrategyPage, runNotionStrategyPoll } from "../src/notion-strategy-poll.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const SPACE_ID = "22222222-2222-4222-8222-222222222222";
+
+type CursorRow = {
+  notionPageId: string;
+  notionPageIdNormalized: string;
+  notionLastEditedTime: string;
+  emittedIssueId: string;
+  emittedIssueIdentifier: string | null;
+};
+
+function makeJob(): PluginJobContext {
+  return {
+    jobKey: "notion-strategy-poll",
+    runId: "test-run",
+    trigger: "manual",
+    scheduledAt: "2026-07-03T00:00:00.000Z",
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makePage(input: {
+  id?: string;
+  title?: string;
+  status?: string;
+  tags?: string[];
+  lastEditedTime?: string;
+}) {
+  const id = input.id ?? "26a3a489-a9ca-8033-8b5c-e8b7e5a2fba0";
+  return {
+    id,
+    object: "page",
+    url: `https://notion.test/${id}`,
+    last_edited_time: input.lastEditedTime ?? "2026-07-03T00:00:00.000Z",
+    properties: {
+      "Task name": { type: "title", title: [{ plain_text: input.title ?? "BTC strategy idea" }] },
+      Status: { type: "status", status: { name: input.status ?? "In progress" } },
+      Tags: { type: "multi_select", multi_select: (input.tags ?? ["Research", "BTC"]).map((name) => ({ name })) },
+    },
+  };
+}
+
+function makeContext(input: {
+  notionPages?: Array<Record<string, unknown>>;
+  companyIds?: string[];
+}) {
+  const cursors: CursorRow[] = [];
+  const operations: Array<Record<string, unknown>> = [];
+  const issues: Issue[] = [];
+  const requests: Array<{ method: string; path: string; body: unknown }> = [];
+  const company = {
+    id: COMPANY_ID,
+    name: "Test Company",
+    slug: "test-company",
+    createdAt: "2026-07-03T00:00:00.000Z",
+    updatedAt: "2026-07-03T00:00:00.000Z",
+  } as unknown as Company;
+
+  const ctx = {
+    manifest: {},
+    config: {
+      async get() {
+        return {
+          notionStrategyPollToken: "test-token",
+          notionStrategyPollTasksDatabaseId: "tasks-db",
+          notionStrategyPollCroAgentId: "cro-agent-id",
+          notionStrategyPollCompanyIds: input.companyIds ?? [COMPANY_ID],
+        };
+      },
+    },
+    companies: {
+      async get(companyId: string) {
+        return companyId === COMPANY_ID ? company : null;
+      },
+    },
+    http: {
+      async fetch(url: string | URL, init?: RequestInit) {
+        const parsed = new URL(String(url));
+        const body = typeof init?.body === "string" ? JSON.parse(init.body) as unknown : null;
+        const method = init?.method ?? "GET";
+        requests.push({ method, path: parsed.pathname, body });
+        if (parsed.pathname === "/v1/databases/tasks-db/query") {
+          return jsonResponse({ results: input.notionPages ?? [], has_more: false, next_cursor: null });
+        }
+        return jsonResponse({ ok: true });
+      },
+    },
+    localFolders: {
+      async status() {
+        return { configured: true, readable: true };
+      },
+    },
+    issues: {
+      async create(issueInput: Record<string, unknown>) {
+        const issue = {
+          id: `issue-${issues.length + 1}`,
+          identifier: `PILA-T${issues.length + 1}`,
+          title: String(issueInput.title),
+          description: String(issueInput.description ?? ""),
+          status: issueInput.status,
+          priority: issueInput.priority,
+          assigneeAgentId: issueInput.assigneeAgentId,
+          companyId: issueInput.companyId,
+        } as unknown as Issue;
+        issues.push(issue);
+        return issue;
+      },
+    },
+    db: {
+      namespace: "test_llm_wiki",
+      async query<T = Record<string, unknown>>(sql: string, params?: unknown[]) {
+        if (sql.includes("FROM test_llm_wiki.wiki_spaces")) {
+          return [{
+            id: SPACE_ID,
+            company_id: COMPANY_ID,
+            wiki_id: "default",
+            slug: "default",
+            display_name: "default",
+            space_type: "local_folder",
+            folder_mode: "managed_subfolder",
+            root_folder_key: "wiki-root",
+            path_prefix: null,
+            configured_root_path: null,
+            access_scope: "shared",
+            owner_user_id: null,
+            owner_agent_id: null,
+            team_key: null,
+            settings: {},
+            status: "active",
+            created_at: null,
+            updated_at: null,
+          }] as T[];
+        }
+        if (sql.includes("max(notion_last_edited_time)")) {
+          const latest = cursors
+            .map((cursor) => cursor.notionLastEditedTime)
+            .sort()
+            .at(-1);
+          return [{ watermark: latest ?? null }] as T[];
+        }
+        if (sql.includes("FROM test_llm_wiki.notion_strategy_poll_cursors")) {
+          const normalized = String(params?.[3] ?? "");
+          const edited = String(params?.[4] ?? "");
+          return cursors.some((cursor) =>
+            cursor.notionPageIdNormalized === normalized &&
+            cursor.notionLastEditedTime === edited
+          ) ? [{ "?column?": 1 }] as T[] : [];
+        }
+        return [];
+      },
+      async execute(sql: string, params?: unknown[]) {
+        if (sql.includes("INTO test_llm_wiki.notion_strategy_poll_cursors")) {
+          cursors.push({
+            notionPageId: String(params?.[4]),
+            notionPageIdNormalized: String(params?.[5]),
+            notionLastEditedTime: String(params?.[6]),
+            emittedIssueId: String(params?.[7]),
+            emittedIssueIdentifier: params?.[8] == null ? null : String(params[8]),
+          });
+        }
+        if (sql.includes("INTO test_llm_wiki.wiki_operations")) {
+          operations.push({
+            status: params?.[4],
+            runIds: params?.[5],
+            warnings: params?.[6],
+            metadata: params?.[7],
+          });
+        }
+        return { rowCount: 1 };
+      },
+    },
+    metrics: {
+      async write() {
+        return undefined;
+      },
+    },
+    logger: {
+      info() {
+        return undefined;
+      },
+      warn() {
+        return undefined;
+      },
+      error() {
+        return undefined;
+      },
+      debug() {
+        return undefined;
+      },
+    },
+  } as unknown as PluginContext;
+
+  return { ctx, cursors, issues, operations, requests };
+}
+
+describe("Notion Strategy Poll", () => {
+  it("ports the legacy strategy heuristic", () => {
+    expect(isNotionStrategyPage(makePage({ title: "Template strategy page", tags: [] }) as never)).toMatchObject({
+      match: false,
+      reason: "no tags (likely template sub-page)",
+    });
+    expect(isNotionStrategyPage(makePage({ title: "BTC idea", tags: ["Research", "Metrics"] }) as never)).toMatchObject({
+      match: true,
+    });
+    expect(isNotionStrategyPage(makePage({ title: "Strategy draft", status: "Done", tags: ["Research", "BTC"] }) as never)).toMatchObject({
+      match: false,
+    });
+  });
+
+  it("records an operation but creates zero Paperclip issues on an empty poll", async () => {
+    const { ctx, issues, operations } = makeContext({ notionPages: [] });
+
+    await runNotionStrategyPoll(ctx, makeJob());
+
+    expect(issues).toHaveLength(0);
+    expect(operations).toHaveLength(1);
+    expect(JSON.parse(String(operations[0].metadata))).toMatchObject({
+      counts: expect.objectContaining({ pagesFetched: 0, issuesCreated: 0 }),
+      emittedIssues: [],
+    });
+  });
+
+  it("fails closed without an explicit company allowlist", async () => {
+    const { ctx, issues, operations, requests } = makeContext({ companyIds: [] });
+
+    const result = await runNotionStrategyPoll(ctx, makeJob());
+
+    expect(result).toEqual({ status: "skipped", results: [] });
+    expect(issues).toHaveLength(0);
+    expect(operations).toHaveLength(0);
+    expect(requests).toHaveLength(0);
+  });
+
+  it("creates one CRO issue for a matching delta and suppresses unchanged re-polls by full normalized page id", async () => {
+    const page = makePage({
+      id: "26a3a489-a9ca-8033-8b5c-e8b7e5a2fba0",
+      title: "BTC Strategy: metrics breakout",
+      tags: ["Research", "BTC"],
+    });
+    const { ctx, cursors, issues, requests } = makeContext({ notionPages: [page] });
+
+    await runNotionStrategyPoll(ctx, makeJob());
+    await runNotionStrategyPoll(ctx, { ...makeJob(), runId: "test-run-2" });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      assigneeAgentId: "cro-agent-id",
+      title: "Research: BTC Strategy: metrics breakout",
+    });
+    expect(issues[0].description).toContain("**Notion id:** `26a3a489-a9ca-8033-8b5c-e8b7e5a2fba0`");
+    expect(cursors).toHaveLength(1);
+    expect(cursors[0].notionPageIdNormalized).toBe("26a3a489a9ca80338b5ce8b7e5a2fba0");
+    expect(cursors[0].notionPageIdNormalized).toHaveLength(32);
+    expect(requests.filter((request) => request.method === "POST" && request.path === "/v1/databases/tasks-db/query")).toHaveLength(2);
+  });
+});

--- a/packages/plugins/plugin-llm-wiki/tests/notion-sync.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/notion-sync.spec.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from "vitest";
+import type { Company, PluginContext, PluginJobContext } from "@paperclipai/plugin-sdk";
+import { runNotionWikiSync } from "../src/notion-sync.js";
+
+const COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+const SPACE_ID = "22222222-2222-4222-8222-222222222222";
+
+type CursorRow = {
+  notionPageId: string;
+  wikiPath: string;
+  notionLastEditedTime: string | null;
+  notionContentHash: string | null;
+  wikiContentHash: string | null;
+  origin: string;
+};
+
+function makeJob(): PluginJobContext {
+  return {
+    jobKey: "notion-wiki-sync",
+    runId: "test-run",
+    trigger: "manual",
+    scheduledAt: "2026-06-24T00:00:00.000Z",
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeContext(input: {
+  files?: Record<string, string>;
+  notionPages?: Array<Record<string, unknown>>;
+  blocksByPage?: Record<string, Array<Record<string, unknown>>>;
+  companyIds?: string[];
+}) {
+  const files = { ...(input.files ?? {}) };
+  const cursors: CursorRow[] = [];
+  const operations: Array<Record<string, unknown>> = [];
+  const requests: Array<{ method: string; path: string; body: unknown }> = [];
+  let createdCount = 0;
+  const company = {
+    id: COMPANY_ID,
+    name: "Test Company",
+    slug: "test-company",
+    createdAt: "2026-06-24T00:00:00.000Z",
+    updatedAt: "2026-06-24T00:00:00.000Z",
+  } as unknown as Company;
+
+  const ctx = {
+    manifest: {},
+    config: {
+      async get() {
+        return {
+          notionToken: "test-token",
+          notionTasksDatabaseId: "tasks-db",
+          notionSyncCompanyIds: input.companyIds ?? [COMPANY_ID],
+        };
+      },
+    },
+    companies: {
+      async get(companyId: string) {
+        return companyId === COMPANY_ID ? company : null;
+      },
+    },
+    http: {
+      async fetch(url: string | URL, init?: RequestInit) {
+        const parsed = new URL(String(url));
+        const body = typeof init?.body === "string" ? JSON.parse(init.body) as unknown : null;
+        const method = init?.method ?? "GET";
+        requests.push({ method, path: parsed.pathname, body });
+        if (parsed.pathname === "/v1/search") {
+          return jsonResponse({ results: input.notionPages ?? [], has_more: false, next_cursor: null });
+        }
+        if (parsed.pathname === "/v1/databases/tasks-db") {
+          return jsonResponse({ properties: { "Task name": { type: "title" } } });
+        }
+        if (parsed.pathname === "/v1/pages" && method === "POST") {
+          createdCount += 1;
+          return jsonResponse({
+            id: `created-page-${createdCount}`,
+            object: "page",
+            url: `https://notion.test/created-page-${createdCount}`,
+            last_edited_time: "2026-06-24T00:01:00.000Z",
+          });
+        }
+        const blockChildrenMatch = /^\/v1\/blocks\/([^/]+)\/children$/.exec(parsed.pathname);
+        if (blockChildrenMatch && method === "GET") {
+          return jsonResponse({ results: input.blocksByPage?.[blockChildrenMatch[1]] ?? [], has_more: false, next_cursor: null });
+        }
+        if (blockChildrenMatch && method === "PATCH") {
+          return jsonResponse({ ok: true });
+        }
+        const blockPatchMatch = /^\/v1\/blocks\/([^/]+)$/.exec(parsed.pathname);
+        if (blockPatchMatch && method === "PATCH") {
+          return jsonResponse({ ok: true });
+        }
+        return jsonResponse({ ok: true });
+      },
+    },
+    localFolders: {
+      async status(_companyId: string, folderKey: string) {
+        return {
+          folderKey,
+          configured: true,
+          path: "/tmp/wiki-root",
+          realPath: "/tmp/wiki-root",
+          access: "readWrite",
+          readable: true,
+          writable: true,
+          requiredDirectories: [],
+          requiredFiles: [],
+          missingDirectories: [],
+          missingFiles: [],
+          healthy: true,
+          problems: [],
+          checkedAt: new Date().toISOString(),
+        };
+      },
+      async list(_companyId: string, _folderKey: string, options?: { relativePath?: string; recursive?: boolean; maxEntries?: number }) {
+        const prefix = options?.relativePath ? `${options.relativePath.replace(/\/$/, "")}/` : "";
+        return {
+          folderKey: "wiki-root",
+          relativePath: options?.relativePath ?? null,
+          truncated: false,
+          entries: Object.keys(files)
+            .filter((path) => !prefix || path.startsWith(prefix))
+            .map((path) => ({
+              path,
+              name: path.split("/").pop() ?? path,
+              kind: "file" as const,
+              size: files[path].length,
+              modifiedAt: null,
+            })),
+        };
+      },
+      async readText(_companyId: string, _folderKey: string, path: string) {
+        if (!(path in files)) throw new Error(`missing file ${path}`);
+        return files[path];
+      },
+      async writeTextAtomic(_companyId: string, _folderKey: string, path: string, contents: string) {
+        files[path] = contents;
+        return {} as never;
+      },
+    },
+    db: {
+      namespace: "test_llm_wiki",
+      async query<T = Record<string, unknown>>(sql: string, params?: unknown[]) {
+        if (sql.includes("FROM test_llm_wiki.wiki_spaces")) {
+          return [{
+            id: SPACE_ID,
+            company_id: COMPANY_ID,
+            wiki_id: "default",
+            slug: "default",
+            display_name: "default",
+            space_type: "local_folder",
+            folder_mode: "managed_subfolder",
+            root_folder_key: "wiki-root",
+            path_prefix: null,
+            configured_root_path: null,
+            access_scope: "shared",
+            owner_user_id: null,
+            owner_agent_id: null,
+            team_key: null,
+            settings: {},
+            status: "active",
+            created_at: null,
+            updated_at: null,
+          }] as T[];
+        }
+        if (sql.includes("FROM test_llm_wiki.notion_sync_cursors")) {
+          const notionPageId = typeof params?.[3] === "string" && sql.includes("notion_page_id = $4") ? params[3] : null;
+          const wikiPath = typeof params?.[3] === "string" && sql.includes("wiki_path = $4") ? params[3] : null;
+          const cursor = cursors.find((row) =>
+            (notionPageId && row.notionPageId === notionPageId) ||
+            (wikiPath && row.wikiPath === wikiPath)
+          );
+          return cursor ? [{
+            notion_page_id: cursor.notionPageId,
+            wiki_path: cursor.wikiPath,
+            notion_last_edited_time: cursor.notionLastEditedTime,
+            notion_content_hash: cursor.notionContentHash,
+            wiki_content_hash: cursor.wikiContentHash,
+            origin: cursor.origin,
+          }] as T[] : [];
+        }
+        return [];
+      },
+      async execute(sql: string, params?: unknown[]) {
+        if (sql.includes("INTO test_llm_wiki.notion_sync_cursors")) {
+          const next: CursorRow = {
+            notionPageId: String(params?.[4]),
+            wikiPath: String(params?.[5]),
+            notionLastEditedTime: params?.[6] == null ? null : String(params[6]),
+            notionContentHash: params?.[7] == null ? null : String(params[7]),
+            wikiContentHash: params?.[8] == null ? null : String(params[8]),
+            origin: String(params?.[9] ?? "notion"),
+          };
+          const index = cursors.findIndex((row) => row.notionPageId === next.notionPageId);
+          if (index >= 0) cursors[index] = next;
+          else cursors.push(next);
+        }
+        if (sql.includes("INTO test_llm_wiki.wiki_operations")) {
+          operations.push({
+            status: params?.[4],
+            runIds: params?.[5],
+            warnings: params?.[6],
+            affectedPages: params?.[7],
+            metadata: params?.[8],
+          });
+        }
+        return { rowCount: 1 };
+      },
+    },
+    metrics: {
+      async write() {
+        return undefined;
+      },
+    },
+    logger: {
+      info() {
+        return undefined;
+      },
+      warn() {
+        return undefined;
+      },
+      error() {
+        return undefined;
+      },
+      debug() {
+        return undefined;
+      },
+    },
+  } as unknown as PluginContext;
+
+  return { ctx, files, cursors, operations, requests };
+}
+
+describe("Notion Wiki sync", () => {
+  it("fails closed without an explicit company allowlist", async () => {
+    const { ctx, operations, requests } = makeContext({ companyIds: [] });
+
+    const result = await runNotionWikiSync(ctx, makeJob());
+
+    expect(result).toEqual({ status: "skipped", results: [] });
+    expect(operations).toHaveLength(0);
+    expect(requests).toHaveLength(0);
+  });
+
+  it("does not fall back to a wildcard when a configured company is unavailable", async () => {
+    const { ctx, operations, requests } = makeContext({ companyIds: ["unknown-company"] });
+
+    const result = await runNotionWikiSync(ctx, makeJob());
+
+    expect(result.results).toEqual([]);
+    expect(operations).toHaveLength(0);
+    expect(requests).toHaveLength(0);
+  });
+
+  it("imports changed Notion pages into wiki/notion with cursor and operation rows", async () => {
+    const { ctx, files, cursors, operations } = makeContext({
+      notionPages: [{
+        id: "page-1",
+        object: "page",
+        url: "https://notion.test/page-1",
+        last_edited_time: "2026-06-24T00:00:00.000Z",
+        properties: {
+          Name: { type: "title", title: [{ plain_text: "Strategy Note" }] },
+        },
+      }],
+      blocksByPage: {
+        "page-1": [{
+          id: "block-1",
+          type: "paragraph",
+          paragraph: { rich_text: [{ plain_text: "Imported body" }] },
+        }],
+      },
+    });
+
+    await runNotionWikiSync(ctx, makeJob());
+
+    const path = Object.keys(files).find((key) => key.startsWith("wiki/notion/strategy-note-"));
+    expect(path).toBeTruthy();
+    expect(files[path ?? ""]).toContain("notion_page_id: \"page-1\"");
+    expect(files[path ?? ""]).toContain("Imported body");
+    expect(cursors).toHaveLength(1);
+    expect(cursors[0]).toMatchObject({ notionPageId: "page-1", origin: "notion" });
+    expect(operations).toHaveLength(1);
+    expect(JSON.parse(String(operations[0].metadata))).toMatchObject({
+      counts: expect.objectContaining({ notionPagesSeen: 1, notionPagesWritten: 1 }),
+    });
+  });
+
+  it("uses the full Notion page id in wiki paths so same-title pages do not collide", async () => {
+    const { ctx, files, cursors, operations } = makeContext({
+      notionPages: [
+        {
+          id: "26a3a489-a9ca-8033-8b5c-e8b7e5a2fba0",
+          object: "page",
+          url: "https://notion.test/page-a",
+          last_edited_time: "2026-06-24T00:00:00.000Z",
+          properties: {},
+        },
+        {
+          id: "26a3a489-a9ca-8049-9bcf-c9a8794f3eec",
+          object: "page",
+          url: "https://notion.test/page-b",
+          last_edited_time: "2026-06-24T00:00:00.000Z",
+          properties: {},
+        },
+      ],
+      blocksByPage: {
+        "26a3a489-a9ca-8033-8b5c-e8b7e5a2fba0": [],
+        "26a3a489-a9ca-8049-9bcf-c9a8794f3eec": [],
+      },
+    });
+
+    await runNotionWikiSync(ctx, makeJob());
+
+    expect(files["wiki/notion/notion-page-26a3a489-26a3a489a9ca80338b5ce8b7e5a2fba0.md"]).toBeTruthy();
+    expect(files["wiki/notion/notion-page-26a3a489-26a3a489a9ca80499bcfc9a8794f3eec.md"]).toBeTruthy();
+    expect(cursors.map((cursor) => cursor.wikiPath).sort()).toEqual([
+      "wiki/notion/notion-page-26a3a489-26a3a489a9ca80338b5ce8b7e5a2fba0.md",
+      "wiki/notion/notion-page-26a3a489-26a3a489a9ca80499bcfc9a8794f3eec.md",
+    ]);
+    expect(operations).toHaveLength(1);
+    expect(JSON.parse(String(operations[0].metadata))).toMatchObject({
+      counts: expect.objectContaining({ failures: 0, notionPagesWritten: 2 }),
+    });
+  });
+
+  it("persists created Notion ids into wiki frontmatter and does not duplicate on later edits", async () => {
+    const { ctx, files, requests } = makeContext({
+      files: {
+        "wiki/custom.md": [
+          "---",
+          "title: \"Custom Wiki Page\"",
+          "notion_sync: true",
+          "---",
+          "",
+          "Initial body",
+          "",
+        ].join("\n"),
+      },
+      notionPages: [],
+      blocksByPage: {
+        "created-page-1": [],
+      },
+    });
+
+    await runNotionWikiSync(ctx, makeJob());
+
+    expect(files["wiki/custom.md"]).toContain("notion_page_id: \"created-page-1\"");
+    expect(requests.filter((request) => request.method === "POST" && request.path === "/v1/pages")).toHaveLength(1);
+
+    files["wiki/custom.md"] = files["wiki/custom.md"].replace("Initial body", "Edited body");
+    await runNotionWikiSync(ctx, makeJob());
+
+    expect(requests.filter((request) => request.method === "POST" && request.path === "/v1/pages")).toHaveLength(1);
+    expect(requests.some((request) => request.method === "PATCH" && request.path === "/v1/blocks/created-page-1/children")).toBe(true);
+  });
+});

--- a/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
+++ b/packages/plugins/plugin-llm-wiki/tests/plugin.spec.ts
@@ -3,11 +3,12 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
-import type { Agent, Issue, PluginManagedRoutineResolution, Project } from "@paperclipai/plugin-sdk";
+import type { Agent, Company, Issue, PluginManagedRoutineResolution, Project } from "@paperclipai/plugin-sdk";
 import manifest, {
   CURSOR_WINDOW_ROUTINE_KEY,
   INDEX_REFRESH_ROUTINE_KEY,
   NIGHTLY_LINT_ROUTINE_KEY,
+  NOTION_SYNC_JOB_KEY,
   PAPERCLIP_DISTILL_SKILL_KEY,
   WIKI_MAINTAINER_AGENT_KEY,
   WIKI_MAINTAINER_SKILL_CANONICAL_KEY,
@@ -679,6 +680,12 @@ describe("LLM Wiki plugin scaffold", () => {
     expect(manifest.agents?.[0]?.instructions?.files?.["AGENTS.md"]).toContain("{{localFolders.wiki-root.path}}");
     expect(manifest.agents?.[0]?.instructions?.assetPath).toBe("agents/wiki-maintainer");
     expect(manifest.projects?.[0]?.projectKey).toBe("llm-wiki");
+    expect(manifest.capabilities).toContain("jobs.schedule");
+    expect(manifest.capabilities).toContain("http.outbound");
+    expect(manifest.jobs).toContainEqual(expect.objectContaining({
+      jobKey: NOTION_SYNC_JOB_KEY,
+      schedule: "*/15 * * * *",
+    }));
     expect(manifest.routines?.map((routine) => routine.routineKey)).toEqual([
       CURSOR_WINDOW_ROUTINE_KEY,
       NIGHTLY_LINT_ROUTINE_KEY,
@@ -734,6 +741,30 @@ describe("LLM Wiki plugin scaffold", () => {
     expect(packageJson.devDependencies?.["react-dom"]).toBeDefined();
     expect(packageJson.devDependencies?.["@types/react-dom"]).toBeDefined();
     expect(packageJson.peerDependencies?.react).toBe(">=18");
+  });
+
+  it("registers the Notion sync job handler without requiring an agent", async () => {
+    const harness = createTestHarness({
+      manifest,
+      config: { notionSyncCompanyIds: [COMPANY_ID] },
+    });
+    harness.seed({
+      companies: [{
+        id: COMPANY_ID,
+        name: "Test Company",
+        slug: "test-company",
+        createdAt: "2026-06-24T00:00:00.000Z",
+        updatedAt: "2026-06-24T00:00:00.000Z",
+      } as unknown as Company],
+    });
+    await plugin.definition.setup(harness.ctx);
+    await harness.runJob(NOTION_SYNC_JOB_KEY, {
+      runId: "notion-sync-test-run",
+      trigger: "manual",
+      scheduledAt: "2026-06-24T00:00:00.000Z",
+    });
+
+    expect(harness.logs.some((entry) => entry.message === "Notion Wiki sync job completed")).toBe(true);
   });
 
   it("renders a host-aligned sidebar link with an open-book icon", () => {

--- a/server/src/__tests__/access-routes-permissions-upgrade.test.ts
+++ b/server/src/__tests__/access-routes-permissions-upgrade.test.ts
@@ -27,7 +27,12 @@ const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : 
 
 type Db = ReturnType<typeof createDb>;
 
-async function createApp(db: Db, companyId: string, userId: string) {
+async function createApp(
+  db: Db,
+  companyId: string,
+  userId: string,
+  opts?: { restrictedSession?: boolean },
+) {
   process.env.PAPERCLIP_LOG_DIR = "/tmp/paperclip-test-home/logs";
   process.env.PAPERCLIP_IN_WORKTREE = "false";
   const { accessRoutes } = await import("../routes/access.js");
@@ -37,10 +42,11 @@ async function createApp(db: Db, companyId: string, userId: string) {
     req.actor = {
       type: "board",
       userId,
-      source: "local_implicit",
+      source: opts?.restrictedSession ? "session" : "local_implicit",
+      sessionId: opts?.restrictedSession ? `session-${userId}` : undefined,
       companyIds: [companyId],
       memberships: [{ companyId, membershipRole: "owner", status: "active" }],
-      isInstanceAdmin: true,
+      isInstanceAdmin: !opts?.restrictedSession,
     };
     next();
   });
@@ -163,5 +169,104 @@ describeEmbeddedPostgres("access routes permissions upgrade compatibility", () =
       scope: customScope,
       grantedByUserId: owner.principalId,
     });
+  });
+
+  it("allows a board owner to update explicit grants for an agent membership", async () => {
+    const { company, owner } = await createCompanyWithOwner(db);
+    const agentMember = await db
+      .insert(companyMemberships)
+      .values({
+        companyId: company.id,
+        principalType: "agent",
+        principalId: randomUUID(),
+        status: "active",
+        membershipRole: "member",
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+
+    const res = await request(await createApp(db, company.id, owner.principalId))
+      .patch(`/api/companies/${company.id}/members/${agentMember.id}/permissions`)
+      .send({
+        grants: [
+          { permissionKey: "tasks:assign", scope: null },
+          { permissionKey: "agents:configure", scope: null },
+        ],
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const grants = await db
+      .select()
+      .from(principalPermissionGrants)
+      .where(
+        and(
+          eq(principalPermissionGrants.companyId, company.id),
+          eq(principalPermissionGrants.principalType, "agent"),
+          eq(principalPermissionGrants.principalId, agentMember.principalId),
+        ),
+      );
+    expect(grants.map((grant) => grant.permissionKey).sort()).toEqual([
+      "agents:configure",
+      "tasks:assign",
+    ]);
+  });
+
+  it("rejects board actors that do not belong to the target company", async () => {
+    const { company: actorCompany, owner: actorOwner } = await createCompanyWithOwner(db);
+    const { company: targetCompany } = await createCompanyWithOwner(db);
+    const targetAgent = await db
+      .insert(companyMemberships)
+      .values({
+        companyId: targetCompany.id,
+        principalType: "agent",
+        principalId: randomUUID(),
+        status: "active",
+        membershipRole: "member",
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+
+    const res = await request(await createApp(
+      db,
+      actorCompany.id,
+      actorOwner.principalId,
+      { restrictedSession: true },
+    ))
+      .patch(`/api/companies/${targetCompany.id}/members/${targetAgent.id}/permissions`)
+      .send({ grants: [{ permissionKey: "agents:configure", scope: null }] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    const grants = await db
+      .select()
+      .from(principalPermissionGrants)
+      .where(eq(principalPermissionGrants.principalId, targetAgent.principalId));
+    expect(grants).toHaveLength(0);
+  });
+
+  it("rejects a member id belonging to another company", async () => {
+    const { company: actorCompany, owner: actorOwner } = await createCompanyWithOwner(db);
+    const { company: otherCompany } = await createCompanyWithOwner(db);
+    const otherAgent = await db
+      .insert(companyMemberships)
+      .values({
+        companyId: otherCompany.id,
+        principalType: "agent",
+        principalId: randomUUID(),
+        status: "active",
+        membershipRole: "member",
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+
+    const res = await request(await createApp(db, actorCompany.id, actorOwner.principalId))
+      .patch(`/api/companies/${actorCompany.id}/members/${otherAgent.id}/permissions`)
+      .send({ grants: [{ permissionKey: "agents:configure", scope: null }] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(404);
+    const grants = await db
+      .select()
+      .from(principalPermissionGrants)
+      .where(eq(principalPermissionGrants.principalId, otherAgent.principalId));
+    expect(grants).toHaveLength(0);
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -29,6 +29,7 @@ const {
   loadConfigMock,
   resolveHeartbeatSchedulingSuppressionMock,
   routineServiceFactoryMock,
+  sweepConnectionHealthMock,
   routineServiceMock,
 } = vi.hoisted(() => {
   const createAppMock = vi.fn(async () => ((_: unknown, __: unknown) => {}) as never);
@@ -91,6 +92,12 @@ const {
     flushPendingFeedbackTraces: vi.fn(async () => ({ attempted: 0, sent: 0, failed: 0 })),
   };
   const feedbackServiceFactoryMock = vi.fn(() => feedbackExportServiceMock);
+  const sweepConnectionHealthMock = vi.fn(async () => ({
+    checked: 0,
+    healthy: 0,
+    needsAttention: 0,
+    failed: 0,
+  }));
   const fakeServer = {
     once: vi.fn().mockReturnThis(),
     off: vi.fn().mockReturnThis(),
@@ -123,6 +130,7 @@ const {
     resolveHeartbeatSchedulingSuppressionMock,
     routineServiceFactoryMock,
     routineServiceMock,
+    sweepConnectionHealthMock,
   };
 });
 
@@ -279,12 +287,7 @@ vi.mock("../services/index.js", () => ({
   routineService: routineServiceFactoryMock,
   statusCardService: vi.fn(() => ({})),
   toolAccessService: vi.fn(() => ({
-    sweepConnectionHealth: vi.fn(async () => ({
-      checked: 0,
-      healthy: 0,
-      needsAttention: 0,
-      failed: 0,
-    })),
+    sweepConnectionHealth: sweepConnectionHealthMock,
   })),
 }));
 
@@ -434,6 +437,32 @@ describe("startServer feedback export wiring", () => {
       storageService: { id: "storage-service" },
       serverPort: 3210,
     });
+  });
+
+  it("waits for bundled plugin startup before the initial tool health sweep", async () => {
+    loadConfigMock.mockReturnValue(buildTestConfig({
+      heartbeatSchedulerEnabled: true,
+      heartbeatSchedulerIntervalMs: 30000,
+    }));
+    let releasePlugins!: () => void;
+    const bundledPluginsStartup = new Promise<void>((resolve) => {
+      releasePlugins = resolve;
+    });
+    const app = Object.assign((_: unknown, __: unknown) => {}, {
+      locals: { bundledPluginsStartup },
+    });
+    createAppMock.mockResolvedValueOnce(app as never);
+
+    const started = startServer();
+    await vi.waitFor(() => expect(createAppMock).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sweepConnectionHealthMock).not.toHaveBeenCalled();
+
+    releasePlugins();
+    await started;
+    expect(sweepConnectionHealthMock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps routine ticks and setup cleanup active when heartbeat scheduling is suppressed", async () => {

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -1017,6 +1017,70 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(health.connection.healthStatus).toBe("ok");
   });
 
+  it("checks Paperclip plugin connections through the lifecycle registry without MCP HTTP", async () => {
+    const company = await createCompany(db);
+    const pluginKey = "paperclipai.plugin-llm-wiki";
+    const pluginToolDispatcher = {
+      listToolsForAgent: vi.fn(({ pluginId }: { pluginId?: string } = {}) => pluginId === pluginKey
+        ? [{
+            name: `${pluginKey}:search`,
+            displayName: "Search wiki",
+            description: "Search the wiki",
+            parametersSchema: {},
+            pluginId: pluginKey,
+          }]
+        : []),
+    };
+    const service = toolAccessService(db, { pluginToolDispatcher });
+    const connection = await service.createConnection(company.id, {
+      name: "Plugin: Wiki",
+      transport: "mcp_remote",
+      config: { url: "https://must-not-be-called.example/mcp" },
+      enabled: true,
+      status: "active",
+    });
+    await db.update(toolConnections).set({
+      config: { type: "paperclip_plugin", pluginKey },
+    }).where(eq(toolConnections.id, connection.id));
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const health = await service.checkHealth(connection.id);
+
+    expect(health.connection).toMatchObject({
+      healthStatus: "ok",
+      healthMessage: "Plugin worker is running with 1 registered tool.",
+    });
+    expect(pluginToolDispatcher.listToolsForAgent).toHaveBeenCalledWith({ pluginId: pluginKey });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("marks Paperclip plugin connections unhealthy when the worker is not registered", async () => {
+    const company = await createCompany(db);
+    const pluginKey = "paperclipai.plugin-llm-wiki";
+    const pluginToolDispatcher = { listToolsForAgent: vi.fn(() => []) };
+    const service = toolAccessService(db, { pluginToolDispatcher });
+    const connection = await service.createConnection(company.id, {
+      name: "Plugin: Wiki unavailable",
+      transport: "mcp_remote",
+      config: { url: "https://must-not-be-called.example/mcp" },
+      enabled: true,
+      status: "active",
+    });
+    await db.update(toolConnections).set({
+      config: { type: "paperclip_plugin", pluginKey },
+    }).where(eq(toolConnections.id, connection.id));
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(service.checkHealth(connection.id)).rejects.toMatchObject({ status: 502 });
+
+    const [persisted] = await db.select().from(toolConnections).where(eq(toolConnections.id, connection.id));
+    expect(persisted).toMatchObject({
+      healthStatus: "failed",
+      healthMessage: `Plugin worker ${pluginKey} is not running or has no registered tools.`,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("registers an approved local stdio template and exposes its runtime slot", async () => {
     const company = await createCompany(db);
     const service = toolAccessService(db);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -453,6 +453,7 @@ export async function createApp(
     deploymentExposure: opts.deploymentExposure,
     trustedLocalStdioRuntimeHost,
     toolGateway,
+    pluginToolDispatcher: toolDispatcher,
   }));
   api.use(smokeLabRoutes(db, {
     deploymentMode: opts.deploymentMode,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -759,6 +759,8 @@ export async function startServer(): Promise<StartedServer> {
     decisionServiceOptions,
     managedPluginAutoInstall,
   });
+  const bundledPluginsStartup = (app as { locals?: { bundledPluginsStartup?: Promise<unknown> } })
+    .locals?.bundledPluginsStartup;
   const server = createServer(app as unknown as Parameters<typeof createServer>[0]);
 
   // Increase keep-alive timeouts to safely outlive default idle timeouts
@@ -886,8 +888,6 @@ export async function startServer(): Promise<StartedServer> {
   // additionally gates each entry on a live plugin worker (and archives the
   // row of a provider that did not come up).
   try {
-    const bundledPluginsStartup = (app as { locals?: { bundledPluginsStartup?: Promise<unknown> } })
-      .locals?.bundledPluginsStartup;
     const managedEnvironmentsResult = await applyManagedEnvironments(db as any, managedConfig, {
       pluginsReady: bundledPluginsStartup,
       workerManager: pluginWorkerManager,
@@ -1074,6 +1074,7 @@ export async function startServer(): Promise<StartedServer> {
       logger.warn({ ...setupCleanup }, "startup environment customImage setup cleanup changed sessions");
     }
 
+    await bundledPluginsStartup;
     const toolHealthSweep = await tools.sweepConnectionHealth();
     if (toolHealthSweep.failed > 0) {
       logger.warn({ ...toolHealthSweep }, "startup tool connection health sweep found failing connections");

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1266,10 +1266,17 @@ async function getProtectedMemberReason(
   opts?: {
     actorRole?: HumanCompanyMembershipRole | null;
     instanceAdminUserIds?: ReadonlySet<string>;
-    operation?: "archive" | "update";
+    operation?: "archive" | "update" | "permissions";
   },
 ): Promise<string | null> {
-  if (member.principalType !== "user") return "Only human company members can be removed.";
+  if (member.principalType !== "user") {
+    if (opts?.operation !== "permissions") {
+      return "Only human company members can be removed.";
+    }
+    return req.actor.type === "board"
+      ? null
+      : "Board access is required to manage agent permissions.";
+  }
   if (req.actor.type !== "board") return "Board access is required to remove members.";
   if (member.principalId === req.actor.userId) return "You cannot remove yourself.";
   const isTargetInstanceAdmin = opts?.instanceAdminUserIds
@@ -1301,7 +1308,7 @@ async function assertCanManageCompanyMember(
   access: ReturnType<typeof accessService>,
   companyId: string,
   member: { principalId: string; principalType: string; membershipRole: string | null },
-  operation: "archive" | "update" = "update",
+  operation: "archive" | "update" | "permissions" = "update",
 ) {
   const reason = await getProtectedMemberReason(req, access, companyId, member, { operation });
   if (reason) throw forbidden(reason);
@@ -4725,7 +4732,7 @@ export function accessRoutes(
       await assertCompanyPermission(req, companyId, "users:manage_permissions");
       const memberToUpdate = await access.getMemberById(companyId, memberId);
       if (!memberToUpdate) throw notFound("Member not found");
-      await assertCanManageCompanyMember(req, access, companyId, memberToUpdate);
+      await assertCanManageCompanyMember(req, access, companyId, memberToUpdate, "permissions");
       const updated = await access.setMemberPermissions(
         companyId,
         memberId,
@@ -4744,9 +4751,20 @@ export function accessRoutes(
           grantCount: req.body.grants?.length ?? 0,
         },
       });
-      const member = (await loadCompanyMemberRecords(db, companyId)).find(
-        (entry) => entry.id === memberId,
-      );
+      const member = updated.principalType === "user"
+        ? (await loadCompanyMemberRecords(db, companyId)).find(
+            (entry) => entry.id === memberId,
+          )
+        : updated.principalType === "agent"
+          ? {
+              ...updated,
+              grants: await access.listPrincipalGrants(
+                companyId,
+                updated.principalType,
+                updated.principalId,
+              ),
+            }
+          : null;
       if (!member) throw notFound("Member not found");
       res.json(member);
     }

--- a/server/src/routes/tool-access.ts
+++ b/server/src/routes/tool-access.ts
@@ -45,6 +45,7 @@ import { getActorInfo, assertBoard, assertCompanyAccess, hasCompanyAccess } from
 import { badRequest, forbidden, notFound, unprocessable } from "../errors.js";
 import { accessService, googleSheetsRobotEmailFromEnv, logActivity, toolAccessPolicyService, toolAccessService } from "../services/index.js";
 import { ToolGatewayHttpError, type ToolGatewayService } from "../services/tool-gateway.js";
+import type { PluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
 
 /** Allowlist (e.g. Google Sheets allowed spreadsheet ids) lives in connection config. */
 function allowlistIds(config: Record<string, unknown> | null | undefined): string[] {
@@ -85,6 +86,7 @@ export function toolAccessRoutes(
     deploymentExposure?: DeploymentExposure;
     trustedLocalStdioRuntimeHost?: string | null;
     toolGateway?: ToolGatewayService;
+    pluginToolDispatcher?: Pick<PluginToolDispatcher, "listToolsForAgent">;
   } = {},
 ) {
   const router = Router();

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -118,6 +118,7 @@ import { readSignedToolArgumentsPayload } from "./tool-content-guards.js";
 import { narrowestScopeBindings, profileIdsInBindingOrder } from "./tool-profile-binding-precedence.js";
 import { recordToolRuntimeAuditWriteFailure, TOOL_RUNTIME_AUDIT_WRITE_FAILURE_METRIC } from "./tool-runtime-metrics.js";
 import { createToolRuntimeSupervisor, ToolRuntimeSupervisorError } from "./tool-runtime-supervisor.js";
+import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 
 type ActorInfo = {
   actorType?: "agent" | "user" | "system" | "plugin";
@@ -143,6 +144,7 @@ type ToolAccessServiceOptions = {
   deploymentExposure?: DeploymentExposure;
   trustedLocalStdioRuntimeHost?: string | null;
   now?: () => Date;
+  pluginToolDispatcher?: Pick<PluginToolDispatcher, "listToolsForAgent">;
 };
 
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
@@ -1245,6 +1247,13 @@ function sanitizeHttpFailure(error: unknown): { status: ToolConnectionHealthStat
         status: "failed",
         message: "OAuth credentials have expired and need to be reconnected.",
         code: "oauth_refresh_missing",
+      };
+    }
+    if (code === "plugin_unavailable") {
+      return {
+        status: "failed",
+        message: error.message,
+        code: "plugin_unavailable",
       };
     }
     if (code === "binding_missing" || code === "secret_deleted" || code === "secret_inactive" || code === "version_missing") {
@@ -2873,15 +2882,34 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
   async function checkConnectionHealth(connectionId: string, actor?: ActorInfo): Promise<ToolConnectionHealthCheckResult> {
     const connection = await getConnectionRow(connectionId);
     try {
-      if (connection.transport === "mcp_remote") {
+      const config = asRecord(connection.config);
+      const isPaperclipPlugin = config.type === "paperclip_plugin";
+      let successMessage: string;
+      if (isPaperclipPlugin) {
+        const pluginKey = typeof config.pluginKey === "string" ? config.pluginKey.trim() : "";
+        if (!pluginKey) {
+          throw badRequest("Paperclip plugin connection requires config.pluginKey", {
+            code: "plugin_config_invalid",
+          });
+        }
+        const tools = options.pluginToolDispatcher?.listToolsForAgent({ pluginId: pluginKey }) ?? [];
+        if (tools.length === 0) {
+          throw new HttpError(
+            503,
+            `Plugin worker ${pluginKey} is not running or has no registered tools.`,
+            { code: "plugin_unavailable" },
+          );
+        }
+        successMessage = `Plugin worker is running with ${tools.length} registered ${tools.length === 1 ? "tool" : "tools"}.`;
+      } else if (connection.transport === "mcp_remote") {
         await remoteTools(connection);
+        successMessage = "Remote MCP server responded to tools/list.";
       } else {
         await resolveCredentialHeaders(connection);
         await stdioTemplateId(connection.companyId, connection.config);
+        successMessage = "Approved stdio template is ready.";
       }
-      const updated = await updateConnectionHealth(connection, "ok", connection.transport === "local_stdio"
-        ? "Approved stdio template is ready."
-        : "Remote MCP server responded to tools/list.");
+      const updated = await updateConnectionHealth(connection, "ok", successMessage);
       const runtimeSlot = await ensureRuntimeSlot(updated);
       await audit({
         companyId: connection.companyId,


### PR DESCRIPTION
## Summary

- add company-scoped Notion sync and strategy polling to `plugin-llm-wiki`
- allow board owners to manage explicit grants for agent memberships while keeping other board-member memberships protected
- health-check `paperclip_plugin` connections through the existing plugin lifecycle dispatcher instead of treating them as MCP HTTP transports

The earlier lockfile synchronization commit is intentionally absent: current upstream already contains a refreshed lockfile with the required `@base-ui/react` entry.

## Why

These changes close three integration gaps:

1. Notion synchronization must be isolated per company rather than relying on global configuration.
2. Board owners need to administer agent grants without weakening the protection boundary around board-member memberships.
3. Built-in Paperclip plugin connections are lifecycle-managed workers, so their health must be derived from the plugin runtime registry/dispatcher rather than an MCP HTTP probe.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @paperclipai/plugin-llm-wiki test` — 14/14 passed
- `pnpm --filter @paperclipai/plugin-llm-wiki typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run src/__tests__/access-routes-permissions-upgrade.test.ts` — 5/5 passed (isolated; the same suite had one resource-contention timeout when run concurrently)
- `pnpm exec vitest run src/__tests__/tool-access-service.test.ts` — 114/114 passed
- `pnpm build`
- root `pnpm typecheck`

## Post-Deploy Monitoring & Validation

**Validation window:** startup plus the first scheduled Notion polling interval; owner: deploy operator.

**Healthy signals:**

- plugin startup reports the LLM Wiki worker running and tools/jobs registered
- `paperclip_plugin` connection health resolves through the lifecycle registry without MCP HTTP errors
- Notion sync logs identify the expected company/plugin scope and do not cross company boundaries
- board-owner agent grant updates succeed while attempts to alter another board-member membership remain denied

**Failure signals:**

- `Plugin worker ... is not running` persists after bundled plugin startup completes
- plugin connection health attempts an MCP URL/transport probe
- Notion jobs run with missing or incorrect company scope
- protected board-member membership updates become possible

**Rollback trigger / mitigation:** persistent plugin startup or health failure, cross-company sync evidence, or any authorization boundary regression. Revert the relevant commit(s) independently; the changes are split by concern to support targeted rollback.
