### PR TITLE
fix(projects): git-init local_path workspaces on creation

### DIFF
--- a/server/src/__tests__/git-workspace-utils.test.ts
+++ b/server/src/__tests__/git-workspace-utils.test.ts
@@ -1,0 +1,92 @@
+import { execFile as execFileCallback } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { ensureLocalPathGitWorkspaceInitialized, hasGitMetadata } from "../services/git-workspace-utils.ts";
+
+const execFile = promisify(execFileCallback);
+
+let originalGitConfigGlobal: string | undefined;
+let gitConfigDir: string;
+
+beforeAll(async () => {
+  originalGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+  gitConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-workspace-utils-config-"));
+});
+
+afterAll(async () => {
+  if (originalGitConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+  else process.env.GIT_CONFIG_GLOBAL = originalGitConfigGlobal;
+  await fs.rm(gitConfigDir, { recursive: true, force: true });
+});
+
+let tempDir: string;
+
+beforeEach(async () => {
+  // Isolate `git config --global` writes from the real user gitconfig for every test.
+  process.env.GIT_CONFIG_GLOBAL = path.join(gitConfigDir, `${Math.random().toString(36).slice(2)}.gitconfig`);
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-workspace-utils-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe("hasGitMetadata", () => {
+  it("returns false for a plain folder with no .git entry", async () => {
+    expect(await hasGitMetadata(tempDir)).toBe(false);
+  });
+
+  it("returns true once .git exists as a directory", async () => {
+    await execFile("git", ["init"], { cwd: tempDir });
+    expect(await hasGitMetadata(tempDir)).toBe(true);
+  });
+
+  it("returns false for a null/undefined/blank cwd", async () => {
+    expect(await hasGitMetadata(null)).toBe(false);
+    expect(await hasGitMetadata(undefined)).toBe(false);
+    expect(await hasGitMetadata("   ")).toBe(false);
+  });
+});
+
+describe("ensureLocalPathGitWorkspaceInitialized", () => {
+  it("runs git init and registers safe.directory when no .git exists", async () => {
+    const result = await ensureLocalPathGitWorkspaceInitialized(tempDir);
+    expect(result).toEqual({ outcome: "initialized" });
+    expect(await hasGitMetadata(tempDir)).toBe(true);
+
+    const safeDirectories = await execFile("git", ["config", "--global", "--get-all", "safe.directory"]).then(
+      (out) => out.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
+    );
+    expect(safeDirectories).toContain(path.resolve(tempDir));
+  });
+
+  it("does not touch an existing .git directory", async () => {
+    await execFile("git", ["init"], { cwd: tempDir });
+    await execFile("git", ["config", "user.email", "paperclip@example.com"], { cwd: tempDir });
+    await execFile("git", ["config", "user.name", "Paperclip Test"], { cwd: tempDir });
+
+    const result = await ensureLocalPathGitWorkspaceInitialized(tempDir);
+    expect(result).toEqual({ outcome: "already_initialized" });
+
+    // The pre-existing repo-local config (distinct from the global safe.directory list) is untouched.
+    const email = await execFile("git", ["config", "user.email"], { cwd: tempDir }).then((out) => out.stdout.trim());
+    expect(email).toBe("paperclip@example.com");
+  });
+
+  it("reports failure without throwing when no cwd is given", async () => {
+    const result = await ensureLocalPathGitWorkspaceInitialized(null);
+    expect(result.outcome).toBe("failed");
+  });
+
+  it("reports failure without throwing when git init cannot run in the target path", async () => {
+    const missingPath = path.join(tempDir, "does-not-exist", "nested");
+    const result = await ensureLocalPathGitWorkspaceInitialized(missingPath);
+    expect(result.outcome).toBe("failed");
+    if (result.outcome === "failed") {
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -120,6 +120,11 @@ import {
   UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
   UNMANAGED_BACKGROUND_TASK_STOP_REASON,
 } from "@paperclipai/adapter-utils/server-utils";
+import {
+  RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+  RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+  RESTART_BATCH_STAGGER_RETRY_REASON,
+} from "../services/restart-batch-stagger.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -6601,5 +6606,177 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
+  });
+
+  describe("restart-batch thundering-herd damping for stranded-issue reconciliation (RENA-54203)", () => {
+    // Mirrors seedStrandedIssueFixture's todo+failed shape (which drives the
+    // "issue_assignment_recovery" dispatchRequeued path), but seeds `count`
+    // stranded todo issues under ONE shared agent so reconcileStrandedAssignedIssues
+    // sees a restart-scale batch for that single agent in one sweep.
+    async function seedRestartBatchStrandedTodoFixture(count: number) {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const now = new Date("2026-03-19T00:00:00.000Z");
+      const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        defaultResponsibleUserId: "responsible-user",
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: count + 1,
+          },
+        },
+        permissions: {},
+      });
+
+      const issueIds: string[] = [];
+      const runIds: string[] = [];
+      for (let i = 0; i < count; i += 1) {
+        const runId = randomUUID();
+        const wakeupRequestId = randomUUID();
+        const issueId = randomUUID();
+        issueIds.push(issueId);
+        runIds.push(runId);
+
+        await db.insert(agentWakeupRequests).values({
+          id: wakeupRequestId,
+          companyId,
+          agentId,
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_assigned",
+          payload: { issueId },
+          status: "failed",
+          runId,
+          claimedAt: now,
+          finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+          error: "run failed before issue advanced",
+        });
+
+        await db.insert(heartbeatRuns).values({
+          id: runId,
+          companyId,
+          agentId,
+          invocationSource: "assignment",
+          triggerDetail: "system",
+          status: "failed",
+          wakeupRequestId,
+          contextSnapshot: {
+            issueId,
+            taskId: issueId,
+            wakeReason: "issue_assigned",
+          },
+          startedAt: now,
+          finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+          updatedAt: new Date("2026-03-19T00:05:00.000Z"),
+          errorCode: "process_lost",
+          error: "run failed before issue advanced",
+        });
+
+        await db.insert(issues).values({
+          id: issueId,
+          companyId,
+          title: `Recover stranded assigned work ${i}`,
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: agentId,
+          checkoutRunId: null,
+          executionRunId: null,
+          responsibleUserId: "responsible-user",
+          issueNumber: i + 1,
+          identifier: `${issuePrefix}-${i + 1}`,
+        });
+      }
+
+      return { companyId, agentId, issueIds, runIds };
+    }
+
+    it("staggers stranded-issue recovery wakes across a random window when a reconcile sweep finds a restart-scale batch for one agent", async () => {
+      const batchSize = RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
+      const { runIds } = await seedRestartBatchStrandedTodoFixture(batchSize);
+      const heartbeat = heartbeatService(db);
+
+      const before = new Date();
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+      expect(result.dispatchRequeued).toBe(batchSize);
+
+      const retryRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.retryOfRunId, runIds));
+      expect(retryRuns).toHaveLength(batchSize);
+
+      for (const retryRun of retryRuns) {
+        expect(retryRun.status).toBe("scheduled_retry");
+        expect(retryRun.scheduledRetryReason).toBe(RESTART_BATCH_STAGGER_RETRY_REASON);
+        expect(retryRun.scheduledRetryAttempt).toBe(1);
+        expect(retryRun.scheduledRetryAt).not.toBeNull();
+
+        const dueAtMs = new Date(retryRun.scheduledRetryAt as unknown as string).getTime();
+        expect(dueAtMs).toBeGreaterThanOrEqual(before.getTime());
+        expect(dueAtMs).toBeLessThanOrEqual(before.getTime() + RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS + 5_000);
+
+        const contextSnapshot = retryRun.contextSnapshot as Record<string, unknown>;
+        expect(contextSnapshot.retryReason).toBe("assignment_recovery");
+      }
+    });
+
+    it.skipIf(RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD <= 1)(
+      "keeps immediate queueing for stranded-issue recovery when a reconcile sweep finds only a few stranded issues for one agent (below the restart-batch threshold)",
+      async () => {
+        const belowThresholdCount = RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD - 1;
+        const { runIds } = await seedRestartBatchStrandedTodoFixture(belowThresholdCount);
+        const heartbeat = heartbeatService(db);
+
+        const result = await heartbeat.reconcileStrandedAssignedIssues();
+        expect(result.dispatchRequeued).toBe(belowThresholdCount);
+
+        const retryRuns = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(inArray(heartbeatRuns.retryOfRunId, runIds));
+        expect(retryRuns).toHaveLength(belowThresholdCount);
+        for (const retryRun of retryRuns) {
+          expect(["queued", "running", "succeeded"]).toContain(retryRun.status);
+          expect(retryRun.scheduledRetryReason).toBeNull();
+          expect(retryRun.scheduledRetryAt).toBeNull();
+        }
+      },
+    );
+
+    it("does not stagger stranded-issue recovery across different agents even if the combined sweep total crosses the threshold", async () => {
+      const perAgentCount = Math.max(1, RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD - 1);
+      const first = await seedRestartBatchStrandedTodoFixture(perAgentCount);
+      const second = await seedRestartBatchStrandedTodoFixture(perAgentCount);
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+      expect(result.dispatchRequeued).toBe(perAgentCount * 2);
+
+      const retryRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.retryOfRunId, [...first.runIds, ...second.runIds]));
+      expect(retryRuns).toHaveLength(perAgentCount * 2);
+      for (const retryRun of retryRuns) {
+        expect(retryRun.scheduledRetryReason).toBeNull();
+        expect(retryRun.scheduledRetryAt).toBeNull();
+      }
+    });
   });
 });

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -30,6 +30,11 @@ import {
   INTERACTION_CONTINUATION_INFRA_WAKE_REASON,
   MAX_TURN_CONTINUATION_RETRY_REASON,
   MAX_TURN_CONTINUATION_WAKE_REASON,
+  RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+  RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+  RESTART_BATCH_STAGGER_RETRY_REASON,
+  RESTART_BATCH_STAGGER_WAKE_REASON,
+  computeRestartBatchStaggerDelayMs,
   heartbeatService,
 } from "../services/heartbeat.ts";
 
@@ -2305,5 +2310,185 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
       retryNotBefore.toISOString(),
     );
+  });
+
+  describe("restart-batch thundering-herd damping (RENA-54107)", () => {
+    async function seedRestartBatchProcessLossFixture(input: {
+      count: number;
+      now?: Date;
+      adapterType?: string;
+    }) {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      const now = input.now ?? new Date("2026-04-20T12:00:00.000Z");
+      const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+        defaultResponsibleUserId: "responsible-user",
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "idle",
+        adapterType: input.adapterType ?? "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: input.count + 1,
+          },
+        },
+        permissions: {},
+      });
+
+      const runIds: string[] = [];
+      for (let i = 0; i < input.count; i += 1) {
+        const runId = randomUUID();
+        const wakeupRequestId = randomUUID();
+        runIds.push(runId);
+
+        await db.insert(agentWakeupRequests).values({
+          id: wakeupRequestId,
+          companyId,
+          agentId,
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_assigned",
+          payload: {},
+          status: "claimed",
+          runId,
+          claimedAt: now,
+        });
+
+        await db.insert(heartbeatRuns).values({
+          id: runId,
+          companyId,
+          agentId,
+          invocationSource: "assignment",
+          triggerDetail: "system",
+          status: "running",
+          wakeupRequestId,
+          contextSnapshot: {},
+          processPid: 999_900_000 + i,
+          processGroupId: null,
+          processLossRetryCount: 0,
+          startedAt: now,
+          updatedAt: now,
+        });
+      }
+
+      return { companyId, agentId, runIds, now };
+    }
+
+    it("computes a uniform-random restart-batch stagger delay bounded by the configured max", () => {
+      expect(computeRestartBatchStaggerDelayMs(() => 0, 300_000)).toBe(0);
+      expect(computeRestartBatchStaggerDelayMs(() => 1, 300_000)).toBe(300_000);
+      expect(computeRestartBatchStaggerDelayMs(() => 0.5, 300_000)).toBe(150_000);
+      // Out-of-range sampler output is clamped into [0, 1] before scaling.
+      expect(computeRestartBatchStaggerDelayMs(() => -1, 300_000)).toBe(0);
+      expect(computeRestartBatchStaggerDelayMs(() => 2, 300_000)).toBe(300_000);
+      // A configured max of 0 disables the stagger entirely.
+      expect(computeRestartBatchStaggerDelayMs(() => 0.5, 0)).toBe(0);
+    });
+
+    it("staggers process-loss retries across a random window when a reap sweep finds a restart-scale batch of orphaned runs", async () => {
+      const batchSize = RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
+      const { runIds } = await seedRestartBatchProcessLossFixture({ count: batchSize });
+
+      const before = new Date();
+      const result = await heartbeat.reapOrphanedRuns();
+      expect(result.reaped).toBe(batchSize);
+
+      const retryRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.retryOfRunId, runIds));
+      expect(retryRuns).toHaveLength(batchSize);
+
+      for (const retryRun of retryRuns) {
+        expect(retryRun.status).toBe("scheduled_retry");
+        expect(retryRun.scheduledRetryReason).toBe(RESTART_BATCH_STAGGER_RETRY_REASON);
+        expect(retryRun.scheduledRetryAttempt).toBe(1);
+        expect(retryRun.processLossRetryCount).toBe(1);
+        expect(retryRun.scheduledRetryAt).not.toBeNull();
+
+        const dueAtMs = new Date(retryRun.scheduledRetryAt as unknown as string).getTime();
+        expect(dueAtMs).toBeGreaterThanOrEqual(before.getTime());
+        expect(dueAtMs).toBeLessThanOrEqual(before.getTime() + RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS + 5_000);
+
+        const snapshot = retryRun.contextSnapshot as Record<string, unknown>;
+        expect(typeof snapshot.restartBatchStaggerMs).toBe("number");
+        expect(snapshot.scheduledRetryAt).toBe(retryRun.scheduledRetryAt?.toISOString());
+
+        const wakeup = await db
+          .select({ reason: agentWakeupRequests.reason, payload: agentWakeupRequests.payload })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, retryRun.wakeupRequestId ?? ""))
+          .then((rows) => rows[0] ?? null);
+        expect(wakeup?.reason).toBe(RESTART_BATCH_STAGGER_WAKE_REASON);
+        expect((wakeup?.payload as Record<string, unknown> | null)?.restartBatchStaggerMs).toBe(
+          snapshot.restartBatchStaggerMs,
+        );
+      }
+
+      // This batch damping is strictly additive: the per-run bounded backoff
+      // schedule used for ordinary transient retries must remain untouched.
+      expect(BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS.length).toBeGreaterThan(0);
+    });
+
+    it.skipIf(RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD <= 1)(
+      "keeps immediate queueing for process-loss retries when a reap sweep finds only a few orphaned runs (below the restart-batch threshold)",
+      async () => {
+        const belowThresholdCount = RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD - 1;
+        const { runIds } = await seedRestartBatchProcessLossFixture({ count: belowThresholdCount });
+
+        const result = await heartbeat.reapOrphanedRuns();
+        expect(result.reaped).toBe(belowThresholdCount);
+
+        const retryRuns = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(inArray(heartbeatRuns.retryOfRunId, runIds));
+        expect(retryRuns).toHaveLength(belowThresholdCount);
+        for (const retryRun of retryRuns) {
+          expect(["queued", "running"]).toContain(retryRun.status);
+          expect(retryRun.scheduledRetryReason).toBeNull();
+          expect(retryRun.scheduledRetryAt).toBeNull();
+        }
+      },
+    );
+
+    it("promotes a staggered restart-batch retry to the queue once its scheduled time is due", async () => {
+      const batchSize = RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
+      const { runIds } = await seedRestartBatchProcessLossFixture({ count: batchSize });
+
+      await heartbeat.reapOrphanedRuns();
+
+      const staggeredRuns = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.retryOfRunId, runIds));
+      expect(staggeredRuns.every((run) => run.status === "scheduled_retry")).toBe(true);
+
+      const farFuture = new Date(Date.now() + RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS + 60_000);
+      const promotion = await heartbeat.promoteDueScheduledRetries(farFuture);
+      expect(promotion.promoted).toBeGreaterThanOrEqual(batchSize);
+      expect(promotion.runIds).toEqual(
+        expect.arrayContaining(staggeredRuns.map((run) => run.id)),
+      );
+
+      const promotedRuns = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, staggeredRuns.map((run) => run.id)));
+      expect(promotedRuns.every((run) => run.status === "queued")).toBe(true);
+    });
   });
 });

--- a/server/src/__tests__/project-workspace-git-init.test.ts
+++ b/server/src/__tests__/project-workspace-git-init.test.ts
@@ -1,0 +1,135 @@
+import { execFile as execFileCallback } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { companies, createDb, projects as projectsTable } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { projectService } from "../services/projects.js";
+
+const execFile = promisify(execFileCallback);
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres project workspace git-init tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// RENA-54552: `createWorkspace` must git-init a `local_path` workspace directory that has no
+// `.git` metadata yet, so the heartbeat.ts `assertGitSensitiveAdapterWorkspaceValid` git-metadata
+// check (which requires `.git` whenever a project workspace is expected) does not reject the
+// very first run against a freshly registered local folder.
+describeEmbeddedPostgres("createWorkspace git init for local_path workspaces", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let prefixCounter = 0;
+  let originalGitConfigGlobal: string | undefined;
+  let gitConfigDir: string;
+  let scratchDir: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-project-workspace-git-init-");
+    db = createDb(tempDb.connectionString);
+    originalGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+    gitConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-workspace-git-init-config-"));
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+    if (originalGitConfigGlobal === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = originalGitConfigGlobal;
+    await fs.rm(gitConfigDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    // Isolate `git config --global` writes from the real user gitconfig for every test.
+    process.env.GIT_CONFIG_GLOBAL = path.join(gitConfigDir, `${Math.random().toString(36).slice(2)}.gitconfig`);
+    scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-workspace-git-init-"));
+  });
+
+  afterEach(async () => {
+    await db.delete(projectsTable);
+    await db.delete(companies);
+    await fs.rm(scratchDir, { recursive: true, force: true });
+  });
+
+  async function seedProject(): Promise<string> {
+    prefixCounter += 1;
+    const [company] = await db
+      .insert(companies)
+      .values({ name: "Git Init Co", issuePrefix: `GIT${prefixCounter}` })
+      .returning();
+    const projects = projectService(db);
+    const project = await projects.create(company.id, { name: "Git Init Project" });
+    return project.id;
+  }
+
+  it("git-inits a local_path workspace cwd that has no .git metadata", async () => {
+    const projectId = await seedProject();
+    const projects = projectService(db);
+
+    const workspace = await projects.createWorkspace(projectId, {
+      sourceType: "local_path",
+      cwd: scratchDir,
+    });
+
+    expect(workspace).not.toBeNull();
+    expect(workspace?.sourceType).toBe("local_path");
+    const gitDirStat = await fs.stat(path.join(scratchDir, ".git"));
+    expect(gitDirStat.isDirectory()).toBe(true);
+  });
+
+  it("does not touch an existing .git directory", async () => {
+    await execFile("git", ["init"], { cwd: scratchDir });
+    await execFile("git", ["config", "user.email", "paperclip@example.com"], { cwd: scratchDir });
+    await execFile("git", ["config", "user.name", "Paperclip Test"], { cwd: scratchDir });
+
+    const projectId = await seedProject();
+    const projects = projectService(db);
+
+    const workspace = await projects.createWorkspace(projectId, {
+      sourceType: "local_path",
+      cwd: scratchDir,
+    });
+
+    expect(workspace).not.toBeNull();
+    const email = await execFile("git", ["config", "user.email"], { cwd: scratchDir }).then(
+      (out) => out.stdout.trim(),
+    );
+    expect(email).toBe("paperclip@example.com");
+  });
+
+  it("still creates the workspace row when the cwd cannot be git-initialized", async () => {
+    const projectId = await seedProject();
+    const projects = projectService(db);
+    const missingCwd = path.join(scratchDir, "does-not-exist", "nested");
+
+    const workspace = await projects.createWorkspace(projectId, {
+      sourceType: "local_path",
+      cwd: missingCwd,
+    });
+
+    expect(workspace).not.toBeNull();
+    expect(workspace?.cwd).toBe(missingCwd);
+  });
+
+  it("does not attempt git init for non-local_path source types", async () => {
+    const projectId = await seedProject();
+    const projects = projectService(db);
+
+    const workspace = await projects.createWorkspace(projectId, {
+      sourceType: "git_repo",
+      repoUrl: "https://example.invalid/repo.git",
+    });
+
+    expect(workspace).not.toBeNull();
+    expect(workspace?.sourceType).toBe("git_repo");
+  });
+});

--- a/server/src/services/git-workspace-utils.ts
+++ b/server/src/services/git-workspace-utils.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** True when `cwd/.git` exists as either a directory (normal checkout) or a file (worktree/submodule gitlink). */
+export async function hasGitMetadata(cwd: string | null | undefined): Promise<boolean> {
+  const normalized = readNonEmptyString(cwd);
+  if (!normalized) return false;
+  return fs
+    .lstat(path.resolve(normalized, ".git"))
+    .then((entry) => entry.isDirectory() || entry.isFile())
+    .catch(() => false);
+}
+
+export type EnsureLocalPathGitWorkspaceResult =
+  | { outcome: "already_initialized" }
+  | { outcome: "initialized" }
+  | { outcome: "failed"; error: string };
+
+/**
+ * Best-effort `git init` for a `local_path` project workspace directory, plus registering the
+ * resolved path as a git `safe.directory` for this process's user. Project folders are often
+ * owned by the interactive Windows user rather than the service account, so without
+ * `safe.directory` git refuses to operate on them with a "dubious ownership" error even after
+ * `git init` succeeds.
+ *
+ * Never throws: callers that must not block on filesystem/permission failures (e.g. workspace
+ * creation) can rely on the `"failed"` outcome instead of a try/catch.
+ */
+export async function ensureLocalPathGitWorkspaceInitialized(
+  cwd: string | null | undefined,
+): Promise<EnsureLocalPathGitWorkspaceResult> {
+  const normalized = readNonEmptyString(cwd);
+  if (!normalized) return { outcome: "failed", error: "no cwd provided" };
+  const resolved = path.resolve(normalized);
+
+  if (await hasGitMetadata(resolved)) {
+    return { outcome: "already_initialized" };
+  }
+
+  try {
+    await execFile("git", ["init"], { cwd: resolved });
+    await execFile("git", ["config", "--global", "--add", "safe.directory", resolved]);
+    return { outcome: "initialized" };
+  } catch (err) {
+    return { outcome: "failed", error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -118,6 +118,7 @@ import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService, type MissingRuntimeBinding } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { hasGitMetadata } from "./git-workspace-utils.js";
 import {
   buildHeartbeatRunIssueComment,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
@@ -1817,15 +1818,6 @@ export function isConfigurationIncompleteFailedRun(
   run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode"> | null | undefined,
 ) {
   return run?.errorCode === CONFIGURATION_INCOMPLETE_FAILURE_CODE || run?.errorCode === "model_not_found";
-}
-
-async function hasGitMetadata(cwd: string | null | undefined) {
-  const normalized = readNonEmptyString(cwd);
-  if (!normalized) return false;
-  return fs
-    .lstat(path.resolve(normalized, ".git"))
-    .then((entry) => entry.isDirectory() || entry.isFile())
-    .catch(() => false);
 }
 
 async function isGitCheckout(cwd: string | null | undefined) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12955,15 +12955,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return true;
     };
     const reapEligibleCount = activeRuns.filter(({ run, adapterType }) => isReapEligible(run, adapterType)).length;
+    // Mirrors the `shouldRetry` check further down (RENA-54203 review fix):
+    // isReapEligible alone over-counts, since not every reap-eligible run
+    // actually gets a process-loss retry (e.g. it already used its one retry,
+    // or isn't a locally-tracked/monitor-dispatch run). Sizing the batch off
+    // the reap count could stagger a handful of real retries just because a
+    // larger group of non-retried runs shared the sweep.
+    const isRetryEligible = (run: typeof heartbeatRuns.$inferSelect, adapterType: string) => {
+      if (!isReapEligible(run, adapterType)) return false;
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+      const runContext = parseObject(run.contextSnapshot);
+      const monitorIssueId = readNonEmptyString(runContext.issueId);
+      const monitorNextCheckAt = monitorIssueId
+        ? monitorNextCheckAtByIssue.get(`${run.companyId}:${monitorIssueId}`)
+        : undefined;
+      const monitorDispatchLostWithoutFutureWake =
+        readNonEmptyString(runContext.wakeReason) === "issue_monitor_due" &&
+        monitorNextCheckAt !== undefined &&
+        (!monitorNextCheckAt || monitorNextCheckAt.getTime() <= now.getTime());
+      return (run.processLossRetryCount ?? 0) < 1 && (
+        (tracksLocalChild && (!!run.processPid || !!run.processGroupId)) ||
+        monitorDispatchLostWithoutFutureWake
+      );
+    };
     // Batch size is scoped per agent (RENA-54203) so one overloaded agent's reap
     // batch doesn't cause unrelated agents' small batches to be staggered too.
-    const reapEligibleCountByAgentId = new Map<string, number>();
+    const retryEligibleCountByAgentId = new Map<string, number>();
     for (const { run, adapterType } of activeRuns) {
-      if (!isReapEligible(run, adapterType)) continue;
-      reapEligibleCountByAgentId.set(run.agentId, (reapEligibleCountByAgentId.get(run.agentId) ?? 0) + 1);
+      if (!isRetryEligible(run, adapterType)) continue;
+      retryEligibleCountByAgentId.set(run.agentId, (retryEligibleCountByAgentId.get(run.agentId) ?? 0) + 1);
     }
     const restartBatchReapAgentIds = new Set(
-      [...reapEligibleCountByAgentId.entries()]
+      [...retryEligibleCountByAgentId.entries()]
         .filter(([, count]) => count >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD)
         .map(([agentId]) => agentId),
     );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10356,33 +10356,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const interruptedRunIds: string[] = [];
     const retryRunIds: string[] = [];
+    const message = `Interrupted by graceful server shutdown (${signal}); retry queued for restart recovery`;
 
-    // Same thundering-herd guard as reapOrphanedRuns (RENA-54107): a graceful
-    // shutdown/redeploy drains every "running" run at once, so a large batch here
-    // gets staggered retries instead of all requeuing the moment the new instance
-    // starts up. Batch size is scoped per agent (RENA-54203) so one overloaded
-    // agent's runs don't cause unrelated agents' small batches to be staggered too.
-    const drainCountByAgentId = new Map<string, number>();
-    for (const { run } of activeRuns) {
-      drainCountByAgentId.set(run.agentId, (drainCountByAgentId.get(run.agentId) ?? 0) + 1);
-    }
-    const restartBatchShutdownAgentIds = new Set(
-      [...drainCountByAgentId.entries()]
-        .filter(([, count]) => count >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD)
-        .map(([agentId]) => agentId),
-    );
-    if (restartBatchShutdownAgentIds.size > 0) {
-      logger.warn(
-        {
-          drainedRunCount: activeRuns.length,
-          restartBatchAgentCount: restartBatchShutdownAgentIds.size,
-          threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
-          staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
-        },
-        "restart-batch shutdown drain detected for one or more agents; process-loss retries will be staggered to avoid a thundering herd",
-      );
-    }
-
+    // Pass 1: terminate processes and conditionally mark each "running" row
+    // interrupted. A run can be finalized concurrently (e.g. it completes on
+    // its own) between the initial query above and this per-row update, in
+    // which case setRunStatusIfRunning is a no-op and the run is skipped. The
+    // restart-batch stagger decision (pass 2, below) is therefore built from
+    // the runs actually interrupted here, not the raw query result -- an
+    // agent whose batch only crosses the threshold because of runs that were
+    // never actually interrupted must not have its real (smaller) retry
+    // batch staggered (RENA-54203 review fix).
+    const interruptedEntries: Array<{
+      run: (typeof activeRuns)[number]["run"];
+      agent: (typeof activeRuns)[number]["agent"];
+      interrupted: typeof heartbeatRuns.$inferSelect;
+    }> = [];
     for (const { run, agent } of activeRuns) {
       const running = runningProcesses.get(run.id);
       try {
@@ -10402,7 +10391,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         runningProcesses.delete(run.id);
       }
 
-      const message = `Interrupted by graceful server shutdown (${signal}); retry queued for restart recovery`;
       const interruptedStatus = await setRunStatusIfRunning(run.id, "interrupted", {
         finishedAt: now,
         error: message,
@@ -10430,6 +10418,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         failureReason: interrupted.error ?? undefined,
       });
 
+      interruptedEntries.push({ run, agent, interrupted });
+    }
+
+    // Same thundering-herd guard as reapOrphanedRuns (RENA-54107): a graceful
+    // shutdown/redeploy drains every "running" run at once, so a large batch here
+    // gets staggered retries instead of all requeuing the moment the new instance
+    // starts up. Batch size is scoped per agent (RENA-54203) so one overloaded
+    // agent's runs don't cause unrelated agents' small batches to be staggered too.
+    const drainCountByAgentId = new Map<string, number>();
+    for (const { run } of interruptedEntries) {
+      drainCountByAgentId.set(run.agentId, (drainCountByAgentId.get(run.agentId) ?? 0) + 1);
+    }
+    const restartBatchShutdownAgentIds = new Set(
+      [...drainCountByAgentId.entries()]
+        .filter(([, count]) => count >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD)
+        .map(([agentId]) => agentId),
+    );
+    if (restartBatchShutdownAgentIds.size > 0) {
+      logger.warn(
+        {
+          drainedRunCount: interruptedEntries.length,
+          restartBatchAgentCount: restartBatchShutdownAgentIds.size,
+          threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+          staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+        },
+        "restart-batch shutdown drain detected for one or more agents; process-loss retries will be staggered to avoid a thundering herd",
+      );
+    }
+
+    // Pass 2: now that the actual interrupted batch per agent is known, enqueue
+    // retries with the correct stagger decision.
+    for (const { run, agent, interrupted } of interruptedEntries) {
       const retry = await enqueueProcessLossRetry(
         interrupted,
         agent,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -377,6 +377,23 @@ const INTERACTION_CONTINUATION_INFRA_MAX_ATTEMPTS = 3;
 const RESOLVED_INTERACTION_CONTINUATION_STATUSES = new Set(["accepted", "answered", "rejected"]);
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
+// Global thundering-herd damping (RENA-54107): a control-plane restart (crash or
+// graceful redeploy) resets in-memory process tracking, so a single reap/drain
+// sweep can find many runs "orphaned" at once and would otherwise re-queue all of
+// them immediately, flooding the API. When a sweep's batch size crosses this
+// threshold, each retry gets an additional uniform-random stagger before its
+// automatic re-queue. This is additive to, and independent of, the per-run bounded
+// backoff in computeBoundedTransientHeartbeatRetrySchedule above.
+export const RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD = Math.max(
+  1,
+  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD)) || 8,
+);
+export const RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS = Math.max(
+  0,
+  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS)) || 5 * 60 * 1000,
+);
+export const RESTART_BATCH_STAGGER_RETRY_REASON = "restart_batch_stagger";
+export const RESTART_BATCH_STAGGER_WAKE_REASON = "restart_batch_stagger_retry";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
 const CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE = "configuration_incomplete";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON = "execution_review_participant_recovery";
@@ -1178,6 +1195,17 @@ export function computeBoundedTransientHeartbeatRetrySchedule(
     dueAt: new Date(now.getTime() + delayMs),
     maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS,
   };
+}
+
+// Uniform-random delay in [0, maxDelayMs], used to spread automatic re-queues of
+// a restart-triggered batch of process-lost runs instead of firing them all at once.
+export function computeRestartBatchStaggerDelayMs(
+  random: () => number = Math.random,
+  maxDelayMs: number = RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+): number {
+  if (!(maxDelayMs > 0)) return 0;
+  const sample = Math.min(1, Math.max(0, random()));
+  return Math.round(sample * maxDelayMs);
 }
 
 async function resolveRunScopedMentionedSkillKeys(input: {
@@ -9830,7 +9858,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
     now: Date,
+    opts?: { staggerMs?: number },
   ) {
+    const staggerMs = Math.max(0, Math.floor(opts?.staggerMs ?? 0));
     const existingRetry = await db
       .select()
       .from(heartbeatRuns)
@@ -9876,11 +9906,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : "process_lost";
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    const staggeredDueAt = staggerMs > 0 ? new Date(now.getTime() + staggerMs) : null;
     const retryContextSnapshot = withRecoveryModelProfileHint({
       ...contextSnapshot,
       retryOfRunId: run.id,
       wakeReason: "process_lost_retry",
       retryReason,
+      ...(staggeredDueAt
+        ? {
+            restartBatchStaggerMs: staggerMs,
+            scheduledRetryAt: staggeredDueAt.toISOString(),
+          }
+        : {}),
     }, "normal_model");
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(run, retryContextSnapshot);
 
@@ -9892,10 +9929,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agentId: run.agentId,
           source: "automation",
           triggerDetail: "system",
-          reason: "process_lost_retry",
+          reason: staggeredDueAt ? RESTART_BATCH_STAGGER_WAKE_REASON : "process_lost_retry",
           payload: withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
             retryOfRunId: run.id,
+            ...(staggeredDueAt ? { restartBatchStaggerMs: staggerMs } : {}),
           }, "normal_model"),
           status: "queued",
           requestedByActorType: "system",
@@ -9912,13 +9950,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agentId: run.agentId,
           invocationSource: "automation",
           triggerDetail: "system",
-          status: "queued",
+          status: staggeredDueAt ? "scheduled_retry" : "queued",
           wakeupRequestId: wakeupRequest.id,
           contextSnapshot: retryContextSnapshot,
           responsibleUserId,
           sessionIdBefore: sessionBefore,
           retryOfRunId: run.id,
           processLossRetryCount: (run.processLossRetryCount ?? 0) + 1,
+          ...(staggeredDueAt
+            ? {
+                scheduledRetryAt: staggeredDueAt,
+                scheduledRetryAttempt: 1,
+                scheduledRetryReason: RESTART_BATCH_STAGGER_RETRY_REASON,
+              }
+            : {}),
           updatedAt: now,
         })
         .returning()
@@ -9948,25 +9993,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return retryRun;
     });
 
-    publishLiveEvent({
-      companyId: queued.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: queued.id,
-        agentId: queued.agentId,
-        invocationSource: queued.invocationSource,
-        triggerDetail: queued.triggerDetail,
-        wakeupRequestId: queued.wakeupRequestId,
-      },
-    });
+    if (staggeredDueAt) {
+      logger.warn(
+        {
+          sourceRunId: run.id,
+          retryRunId: queued.id,
+          agentId: queued.agentId,
+          staggerMs,
+          scheduledRetryAt: staggeredDueAt.toISOString(),
+        },
+        "restart-batch process-loss retry staggered instead of requeuing immediately",
+      );
+    } else {
+      publishLiveEvent({
+        companyId: queued.companyId,
+        type: "heartbeat.run.queued",
+        payload: {
+          runId: queued.id,
+          agentId: queued.agentId,
+          invocationSource: queued.invocationSource,
+          triggerDetail: queued.triggerDetail,
+          wakeupRequestId: queued.wakeupRequestId,
+        },
+      });
+    }
 
     await appendRunEvent(queued, 1, {
       eventType: "lifecycle",
       stream: "system",
       level: "warn",
-      message: "Queued automatic retry after orphaned child process was confirmed dead",
+      message: staggeredDueAt
+        ? `Restart-batch process-loss retry staggered ${staggerMs}ms until ${staggeredDueAt.toISOString()} to avoid a thundering-herd requeue`
+        : "Queued automatic retry after orphaned child process was confirmed dead",
       payload: {
         retryOfRunId: run.id,
+        ...(staggeredDueAt ? { staggerMs, scheduledRetryAt: staggeredDueAt.toISOString() } : {}),
       },
     });
 
@@ -10297,6 +10358,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const interruptedRunIds: string[] = [];
     const retryRunIds: string[] = [];
 
+    // Same thundering-herd guard as reapOrphanedRuns (RENA-54107): a graceful
+    // shutdown/redeploy drains every "running" run at once, so a large batch here
+    // gets staggered retries instead of all requeuing the moment the new instance
+    // starts up.
+    const isRestartBatchShutdown = activeRuns.length >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
+    if (isRestartBatchShutdown) {
+      logger.warn(
+        {
+          drainedRunCount: activeRuns.length,
+          threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+          staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+        },
+        "restart-batch shutdown drain detected; process-loss retries will be staggered to avoid a thundering herd",
+      );
+    }
+
     for (const { run, agent } of activeRuns) {
       const running = runningProcesses.get(run.id);
       try {
@@ -10344,7 +10421,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         failureReason: interrupted.error ?? undefined,
       });
 
-      const retry = await enqueueProcessLossRetry(interrupted, agent, now);
+      const retry = await enqueueProcessLossRetry(
+        interrupted,
+        agent,
+        now,
+        isRestartBatchShutdown ? { staggerMs: computeRestartBatchStaggerDelayMs() } : undefined,
+      );
       if (!retry) {
         await releaseIssueExecutionAndPromote(interrupted);
       } else {
@@ -12843,6 +12925,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const reaped: string[] = [];
 
+    // Cheap, side-effect-free mirror of the eligibility checks below, used only to
+    // size this sweep's batch before any run is actually reaped. A sweep that finds
+    // many orphaned runs at once is the signature of a control-plane restart (crash
+    // or redeploy resets runningProcesses/activeRunExecutions to empty), so those
+    // retries get staggered instead of all requeuing immediately (RENA-54107).
+    const isReapEligible = (run: typeof heartbeatRuns.$inferSelect, adapterType: string) => {
+      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) return false;
+      if (staleThresholdMs > 0) {
+        const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
+        if (now.getTime() - refTime < staleThresholdMs) return false;
+      }
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+      const processPidAlive = tracksLocalChild && !!run.processPid && isProcessAlive(run.processPid);
+      const processGroupAlive = tracksLocalChild && !!run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      if ((processPidAlive || processGroupAlive) && readHotRestartAdoptionMetadata(parseObject(run.resultJson))) {
+        return false;
+      }
+      if (processPidAlive) return false;
+      return true;
+    };
+    const reapEligibleCount = activeRuns.filter(({ run, adapterType }) => isReapEligible(run, adapterType)).length;
+    const isRestartBatchReap = reapEligibleCount >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
+    if (isRestartBatchReap) {
+      logger.warn(
+        {
+          reapEligibleCount,
+          threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+          staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+        },
+        "restart-batch reap sweep detected; process-loss retries will be staggered to avoid a thundering herd",
+      );
+    }
+
     for (const { run, adapterType, adapterConfig } of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
 
@@ -12959,7 +13074,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const retryAgent = await getAgent(run.agentId);
       if (shouldRetry) {
         if (retryAgent) {
-          retriedRun = await enqueueProcessLossRetry(finalizedRun, retryAgent, now);
+          retriedRun = await enqueueProcessLossRetry(
+            finalizedRun,
+            retryAgent,
+            now,
+            isRestartBatchReap ? { staggerMs: computeRestartBatchStaggerDelayMs() } : undefined,
+          );
         }
       } else if (retryAgent) {
         const scheduled = await scheduleInteractionContinuationInfrastructureRetryIfEligible(finalizedRun, retryAgent);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10360,16 +10360,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // Same thundering-herd guard as reapOrphanedRuns (RENA-54107): a graceful
     // shutdown/redeploy drains every "running" run at once, so a large batch here
     // gets staggered retries instead of all requeuing the moment the new instance
-    // starts up.
-    const isRestartBatchShutdown = activeRuns.length >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
-    if (isRestartBatchShutdown) {
+    // starts up. Batch size is scoped per agent (RENA-54203) so one overloaded
+    // agent's runs don't cause unrelated agents' small batches to be staggered too.
+    const drainCountByAgentId = new Map<string, number>();
+    for (const { run } of activeRuns) {
+      drainCountByAgentId.set(run.agentId, (drainCountByAgentId.get(run.agentId) ?? 0) + 1);
+    }
+    const restartBatchShutdownAgentIds = new Set(
+      [...drainCountByAgentId.entries()]
+        .filter(([, count]) => count >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD)
+        .map(([agentId]) => agentId),
+    );
+    if (restartBatchShutdownAgentIds.size > 0) {
       logger.warn(
         {
           drainedRunCount: activeRuns.length,
+          restartBatchAgentCount: restartBatchShutdownAgentIds.size,
           threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
           staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
         },
-        "restart-batch shutdown drain detected; process-loss retries will be staggered to avoid a thundering herd",
+        "restart-batch shutdown drain detected for one or more agents; process-loss retries will be staggered to avoid a thundering herd",
       );
     }
 
@@ -10424,7 +10434,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         interrupted,
         agent,
         now,
-        isRestartBatchShutdown ? { staggerMs: computeRestartBatchStaggerDelayMs() } : undefined,
+        restartBatchShutdownAgentIds.has(run.agentId) ? { staggerMs: computeRestartBatchStaggerDelayMs() } : undefined,
       );
       if (!retry) {
         await releaseIssueExecutionAndPromote(interrupted);
@@ -12945,15 +12955,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return true;
     };
     const reapEligibleCount = activeRuns.filter(({ run, adapterType }) => isReapEligible(run, adapterType)).length;
-    const isRestartBatchReap = reapEligibleCount >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD;
-    if (isRestartBatchReap) {
+    // Batch size is scoped per agent (RENA-54203) so one overloaded agent's reap
+    // batch doesn't cause unrelated agents' small batches to be staggered too.
+    const reapEligibleCountByAgentId = new Map<string, number>();
+    for (const { run, adapterType } of activeRuns) {
+      if (!isReapEligible(run, adapterType)) continue;
+      reapEligibleCountByAgentId.set(run.agentId, (reapEligibleCountByAgentId.get(run.agentId) ?? 0) + 1);
+    }
+    const restartBatchReapAgentIds = new Set(
+      [...reapEligibleCountByAgentId.entries()]
+        .filter(([, count]) => count >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD)
+        .map(([agentId]) => agentId),
+    );
+    if (restartBatchReapAgentIds.size > 0) {
       logger.warn(
         {
           reapEligibleCount,
+          restartBatchAgentCount: restartBatchReapAgentIds.size,
           threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
           staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
         },
-        "restart-batch reap sweep detected; process-loss retries will be staggered to avoid a thundering herd",
+        "restart-batch reap sweep detected for one or more agents; process-loss retries will be staggered to avoid a thundering herd",
       );
     }
 
@@ -13077,7 +13099,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             finalizedRun,
             retryAgent,
             now,
-            isRestartBatchReap ? { staggerMs: computeRestartBatchStaggerDelayMs() } : undefined,
+            restartBatchReapAgentIds.has(run.agentId) ? { staggerMs: computeRestartBatchStaggerDelayMs() } : undefined,
           );
         }
       } else if (retryAgent) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -80,6 +80,22 @@ import {
 // git-credentials module became its canonical home; existing importers keep working.
 export { scrubGitCredentialText };
 import { publishLiveEvent } from "./live-events.js";
+import {
+  RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+  RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+  RESTART_BATCH_STAGGER_RETRY_REASON,
+  RESTART_BATCH_STAGGER_WAKE_REASON,
+  computeRestartBatchStaggerDelayMs,
+} from "./restart-batch-stagger.js";
+// Re-exported so existing imports of these symbols from "./heartbeat.js" keep
+// working after the RENA-54203 move to a shared module.
+export {
+  RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+  RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+  RESTART_BATCH_STAGGER_RETRY_REASON,
+  RESTART_BATCH_STAGGER_WAKE_REASON,
+  computeRestartBatchStaggerDelayMs,
+};
 import { normalizeResponsibleUserDenialCode } from "./responsible-user-denial-run-outcomes.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
 import { getServerAdapter, listAdapterModelProfiles, runningProcesses } from "../adapters/index.js";
@@ -377,23 +393,11 @@ const INTERACTION_CONTINUATION_INFRA_MAX_ATTEMPTS = 3;
 const RESOLVED_INTERACTION_CONTINUATION_STATUSES = new Set(["accepted", "answered", "rejected"]);
 const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
-// Global thundering-herd damping (RENA-54107): a control-plane restart (crash or
-// graceful redeploy) resets in-memory process tracking, so a single reap/drain
-// sweep can find many runs "orphaned" at once and would otherwise re-queue all of
-// them immediately, flooding the API. When a sweep's batch size crosses this
-// threshold, each retry gets an additional uniform-random stagger before its
-// automatic re-queue. This is additive to, and independent of, the per-run bounded
-// backoff in computeBoundedTransientHeartbeatRetrySchedule above.
-export const RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD = Math.max(
-  1,
-  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD)) || 8,
-);
-export const RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS = Math.max(
-  0,
-  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS)) || 5 * 60 * 1000,
-);
-export const RESTART_BATCH_STAGGER_RETRY_REASON = "restart_batch_stagger";
-export const RESTART_BATCH_STAGGER_WAKE_REASON = "restart_batch_stagger_retry";
+// RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD, RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+// RESTART_BATCH_STAGGER_RETRY_REASON, RESTART_BATCH_STAGGER_WAKE_REASON, and
+// computeRestartBatchStaggerDelayMs (RENA-54107 thundering-herd damping, shared with
+// recovery/service.ts per RENA-54203) now live in ./restart-batch-stagger.js and are
+// re-exported below to keep existing imports of this module working.
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
 const CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE = "configuration_incomplete";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON = "execution_review_participant_recovery";
@@ -1195,17 +1199,6 @@ export function computeBoundedTransientHeartbeatRetrySchedule(
     dueAt: new Date(now.getTime() + delayMs),
     maxAttempts: BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS,
   };
-}
-
-// Uniform-random delay in [0, maxDelayMs], used to spread automatic re-queues of
-// a restart-triggered batch of process-lost runs instead of firing them all at once.
-export function computeRestartBatchStaggerDelayMs(
-  random: () => number = Math.random,
-  maxDelayMs: number = RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
-): number {
-  if (!(maxDelayMs > 0)) return 0;
-  const sample = Math.min(1, Math.max(0, random()));
-  return Math.round(sample * maxDelayMs);
 }
 
 async function resolveRunScopedMentionedSkillKeys(input: {
@@ -2459,6 +2452,12 @@ interface WakeupOptions {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  // RENA-54203: an optional additional delay (ms) before this wake's run becomes
+  // eligible to execute. When set, the new run is created with status
+  // "scheduled_retry" (promoted later by promoteDueScheduledRetries) instead of
+  // "queued", so restart-triggered batches of recovery wakes can be spread out
+  // instead of firing all at once. See ./restart-batch-stagger.js.
+  staggerMs?: number;
 }
 
 type UsageTotals = {
@@ -16986,6 +16985,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const contextSnapshot: Record<string, unknown> = { ...(opts.contextSnapshot ?? {}) };
     const reason = opts.reason ?? null;
     const payload = opts.payload ?? null;
+    const staggerMs = Math.max(0, Math.floor(opts.staggerMs ?? 0));
+    const staggeredDueAt = staggerMs > 0 ? new Date(Date.now() + staggerMs) : null;
     const {
       contextSnapshot: enrichedContextSnapshot,
       issueIdFromPayload,
@@ -18012,12 +18013,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             agentId,
             invocationSource: source,
             triggerDetail,
-            status: "queued",
+            status: staggeredDueAt ? "scheduled_retry" : "queued",
             responsibleUserId: await resolveQueuedResponsibleUserId(),
             wakeupRequestId: wakeupRequest.id,
             contextSnapshot: enrichedContextSnapshot,
             sessionIdBefore: sessionBefore,
             continuationAttempt,
+            ...(staggeredDueAt
+              ? {
+                  scheduledRetryAt: staggeredDueAt,
+                  scheduledRetryAttempt: 1,
+                  scheduledRetryReason: RESTART_BATCH_STAGGER_RETRY_REASON,
+                }
+              : {}),
           })
           .returning()
           .then((rows) => rows[0]);
@@ -18044,17 +18052,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const newRun = outcome.run;
-      publishLiveEvent({
-        companyId: newRun.companyId,
-        type: "heartbeat.run.queued",
-        payload: {
-          runId: newRun.id,
-          agentId: newRun.agentId,
-          invocationSource: newRun.invocationSource,
-          triggerDetail: newRun.triggerDetail,
-          wakeupRequestId: newRun.wakeupRequestId,
-        },
-      });
+      if (staggeredDueAt) {
+        logger.warn(
+          {
+            runId: newRun.id,
+            agentId: newRun.agentId,
+            staggerMs,
+            scheduledRetryAt: staggeredDueAt.toISOString(),
+          },
+          "restart-batch wake staggered instead of queuing immediately",
+        );
+      } else {
+        publishLiveEvent({
+          companyId: newRun.companyId,
+          type: "heartbeat.run.queued",
+          payload: {
+            runId: newRun.id,
+            agentId: newRun.agentId,
+            invocationSource: newRun.invocationSource,
+            triggerDetail: newRun.triggerDetail,
+            wakeupRequestId: newRun.wakeupRequestId,
+          },
+        });
+      }
 
       await startNextQueuedRunForAgent(agent.id);
       return newRun;
@@ -18186,12 +18206,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agentId,
           invocationSource: source,
           triggerDetail,
-          status: "queued",
+          status: staggeredDueAt ? "scheduled_retry" : "queued",
           responsibleUserId: await resolveQueuedResponsibleUserId(),
           wakeupRequestId: wakeupRequest.id,
           contextSnapshot: enrichedContextSnapshot,
           sessionIdBefore: sessionBefore,
           continuationAttempt,
+          ...(staggeredDueAt
+            ? {
+                scheduledRetryAt: staggeredDueAt,
+                scheduledRetryAttempt: 1,
+                scheduledRetryReason: RESTART_BATCH_STAGGER_RETRY_REASON,
+              }
+            : {}),
         })
         .returning()
         .then((rows) => rows[0]);
@@ -18210,17 +18237,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (queueOutcome.kind === "skipped") return null;
     const newRun = queueOutcome.run;
 
-    publishLiveEvent({
-      companyId: newRun.companyId,
-      type: "heartbeat.run.queued",
-      payload: {
-        runId: newRun.id,
-        agentId: newRun.agentId,
-        invocationSource: newRun.invocationSource,
-        triggerDetail: newRun.triggerDetail,
-        wakeupRequestId: newRun.wakeupRequestId,
-      },
-    });
+    if (staggeredDueAt) {
+      logger.warn(
+        {
+          runId: newRun.id,
+          agentId: newRun.agentId,
+          staggerMs,
+          scheduledRetryAt: staggeredDueAt.toISOString(),
+        },
+        "restart-batch wake staggered instead of queuing immediately",
+      );
+    } else {
+      publishLiveEvent({
+        companyId: newRun.companyId,
+        type: "heartbeat.run.queued",
+        payload: {
+          runId: newRun.id,
+          agentId: newRun.agentId,
+          invocationSource: newRun.invocationSource,
+          triggerDetail: newRun.triggerDetail,
+          wakeupRequestId: newRun.wakeupRequestId,
+        },
+      });
+    }
 
     await startNextQueuedRunForAgent(agent.id);
 

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -32,6 +32,8 @@ import { listCurrentRuntimeServicesForProjectWorkspaces } from "./workspace-runt
 import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
 import { mergeProjectWorkspaceRuntimeConfig, readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
 import { resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { ensureLocalPathGitWorkspaceInitialized } from "./git-workspace-utils.js";
+import { logger } from "../middleware/logger.js";
 
 type ProjectRow = typeof projects.$inferSelect;
 type ProjectWorkspaceRow = typeof projectWorkspaces.$inferSelect;
@@ -921,6 +923,18 @@ export function projectService(db: Db) {
         cwd,
         repoUrl,
       });
+
+      if (sourceType === "local_path" && cwd) {
+        const result = await ensureLocalPathGitWorkspaceInitialized(cwd);
+        if (result.outcome === "failed") {
+          logger.warn(
+            { projectId, cwd, error: result.error },
+            "failed to git-init local_path project workspace directory; continuing without git metadata",
+          );
+        } else if (result.outcome === "initialized") {
+          logger.info({ projectId, cwd }, "git-initialized local_path project workspace directory");
+        }
+      }
 
       const existing = await db
         .select()

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -76,6 +76,11 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import {
+  RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+  RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+  computeRestartBatchStaggerDelayMs,
+} from "../restart-batch-stagger.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -120,6 +125,9 @@ type RecoveryWakeupOptions = {
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
   contextSnapshot?: Record<string, unknown>;
+  // RENA-54203: forwarded to heartbeatService's enqueueWakeup so restart-batch
+  // stranded-issue recovery wakes can be staggered instead of all queuing at once.
+  staggerMs?: number;
 };
 
 type RecoveryWakeup = (
@@ -1142,6 +1150,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     source: string;
     retryOfRunId?: string | null;
     extraContext?: Record<string, unknown>;
+    // RENA-54203: set by reconcileStrandedAssignedIssues when a restart-scale
+    // batch of stranded issues was detected for this agent, so the recovery
+    // wake gets spread out instead of queuing immediately alongside the rest
+    // of the batch.
+    staggerMs?: number;
   }) {
     const queued = await deps.enqueueWakeup(input.agentId, {
       source: "automation",
@@ -1163,6 +1176,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ...(input.retryOfRunId ? { retryOfRunId: input.retryOfRunId } : {}),
         ...(input.extraContext ?? {}),
       }, "normal_model"),
+      staggerMs: input.staggerMs,
     });
 
     if (queued && input.retryOfRunId) {
@@ -3675,6 +3689,56 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issueIds: [] as string[],
     };
 
+    // RENA-54203: a control-plane restart resets in-memory process tracking, so a
+    // single reconcile sweep can find many issues "stranded" for the same agent at
+    // once (all last-known runs lost together). Count candidates per target agent
+    // BEFORE the processing loop below, mirroring reapOrphanedRuns's
+    // isRestartBatchReap/reapEligibleCount pattern in heartbeat.ts, and stagger
+    // that agent's recovery wakes instead of enqueueing them all in the same
+    // instant. This is a coarse batch-size heuristic (like reapOrphanedRuns), not
+    // an exact count of issues that will actually reach an enqueue call below --
+    // computing that exactly would require duplicating every downstream
+    // eligibility check.
+    const candidateCountByAgentId = new Map<string, number>();
+    for (const candidate of candidates) {
+      const candidateExecutionState = candidate.status === "in_review"
+        ? parseIssueExecutionState(candidate.executionState)
+        : null;
+      const candidatePendingExecutionState = candidateExecutionState?.status === "pending"
+        ? candidateExecutionState
+        : null;
+      const candidateParticipant = candidatePendingExecutionState
+        ? candidatePendingExecutionState.currentParticipant
+        : null;
+      const candidateParticipantAgentId = candidateParticipant?.type === "agent"
+        ? candidateParticipant.agentId
+        : null;
+      const candidateAgentId = candidate.status === "in_review" && candidateParticipantAgentId
+        ? candidateParticipantAgentId
+        : candidate.assigneeAgentId;
+      if (!candidateAgentId) continue;
+      candidateCountByAgentId.set(candidateAgentId, (candidateCountByAgentId.get(candidateAgentId) ?? 0) + 1);
+    }
+    const restartBatchStaggeredAgentIds = new Set(
+      [...candidateCountByAgentId.entries()]
+        .filter(([, count]) => count >= RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD)
+        .map(([agentId]) => agentId),
+    );
+    if (restartBatchStaggeredAgentIds.size > 0) {
+      logger.warn(
+        {
+          affectedAgentIds: [...restartBatchStaggeredAgentIds],
+          threshold: RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD,
+          staggerMaxMs: RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+        },
+        "restart-batch stranded-issue reconciliation sweep detected; recovery wakes for affected agents will be staggered to avoid a thundering herd",
+      );
+    }
+    const staggerMsForAgent = (agentId: string | null | undefined): number | undefined =>
+      agentId && restartBatchStaggeredAgentIds.has(agentId)
+        ? computeRestartBatchStaggerDelayMs()
+        : undefined;
+
     for (const issue of candidates) {
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)
@@ -3875,6 +3939,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             retryReason: "issue_continuation_needed",
             source: "issue.interaction_continuation_recovery",
             retryOfRunId: latestPostResolutionRun?.id ?? acceptedContinuationInteraction.sourceRunId ?? latestRun?.id ?? null,
+            staggerMs: staggerMsForAgent(agentId),
             extraContext: {
               mutation: "interaction",
               interactionId: acceptedContinuationInteraction.id,
@@ -4022,6 +4087,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           retryReason: EXECUTION_REVIEW_PARTICIPANT_RECOVERY_REASON,
           source: "issue.execution_review_recovery",
           retryOfRunId: participantLatestRun.id,
+          staggerMs: staggerMsForAgent(participantAgentId),
           extraContext: {
             currentStageId: pendingExecutionState.currentStageId ?? null,
             currentStageType: pendingExecutionState.currentStageType ?? null,
@@ -4100,6 +4166,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           retryReason: "assignment_recovery",
           source: "issue.assignment_recovery",
           retryOfRunId: latestRun.id,
+          staggerMs: staggerMsForAgent(agentId),
         });
         if (queued) {
           result.dispatchRequeued += 1;
@@ -4188,6 +4255,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           retryReason: "issue_continuation_needed",
           source: "issue.productive_terminal_continuation_recovery",
           retryOfRunId: successfulRun.id,
+          staggerMs: staggerMsForAgent(agentId),
         });
         if (queued) {
           result.continuationRequeued += 1;
@@ -4284,6 +4352,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         retryReason: "issue_continuation_needed",
         source: "issue.continuation_recovery",
         retryOfRunId: latestRun?.id ?? issue.checkoutRunId ?? null,
+        staggerMs: staggerMsForAgent(agentId),
       });
       if (queued) {
         result.continuationRequeued += 1;

--- a/server/src/services/restart-batch-stagger.test.ts
+++ b/server/src/services/restart-batch-stagger.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for the RENA-54203 review fix: an explicitly-configured
+// `HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS=0` (operator disabling staggering)
+// must survive env parsing as 0, not silently fall back to the 5-minute
+// default. The constants are computed once at module load, so each case
+// stubs env vars and re-imports the module fresh via vi.resetModules().
+describe("restart-batch-stagger env parsing (RENA-54203)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("honors an explicit HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS=0 instead of defaulting to 5 minutes", async () => {
+    vi.stubEnv("HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS", "0");
+    const mod = await import("./restart-batch-stagger.js");
+    expect(mod.RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS).toBe(0);
+  });
+
+  it("falls back to the 5-minute default when the env var is unset", async () => {
+    vi.stubEnv("HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS", undefined);
+    const mod = await import("./restart-batch-stagger.js");
+    expect(mod.RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("falls back to the 5-minute default when the env var is not a finite number", async () => {
+    vi.stubEnv("HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS", "not-a-number");
+    const mod = await import("./restart-batch-stagger.js");
+    expect(mod.RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("respects an explicit non-zero HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS override", async () => {
+    vi.stubEnv("HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS", "12345");
+    const mod = await import("./restart-batch-stagger.js");
+    expect(mod.RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS).toBe(12345);
+  });
+
+  it("falls back to the default reap threshold of 8 when unset, and honors an explicit override", async () => {
+    vi.stubEnv("HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD", undefined);
+    const defaultMod = await import("./restart-batch-stagger.js");
+    expect(defaultMod.RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD).toBe(8);
+
+    vi.resetModules();
+    vi.stubEnv("HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD", "3");
+    const overriddenMod = await import("./restart-batch-stagger.js");
+    expect(overriddenMod.RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD).toBe(3);
+  });
+});

--- a/server/src/services/restart-batch-stagger.ts
+++ b/server/src/services/restart-batch-stagger.ts
@@ -12,13 +12,22 @@
 // server/src/services/recovery/service.ts (reconcileStrandedAssignedIssues)
 // so every restart-triggered enqueue path gets the same protection from one
 // place instead of duplicated constants.
+function parseEnvInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Math.floor(Number(value));
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 export const RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD = Math.max(
   1,
-  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD)) || 8,
+  parseEnvInt(process.env.HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD, 8),
 );
+// An explicit "0" here means staggering is disabled; only fall back to the
+// 5-minute default when the env var is unset or not a finite number (RENA-54203
+// review fix -- the previous `|| 5 * 60 * 1000` silently discarded a real 0).
 export const RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS = Math.max(
   0,
-  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS)) || 5 * 60 * 1000,
+  parseEnvInt(process.env.HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS, 5 * 60 * 1000),
 );
 export const RESTART_BATCH_STAGGER_RETRY_REASON = "restart_batch_stagger";
 export const RESTART_BATCH_STAGGER_WAKE_REASON = "restart_batch_stagger_retry";

--- a/server/src/services/restart-batch-stagger.ts
+++ b/server/src/services/restart-batch-stagger.ts
@@ -1,0 +1,36 @@
+// Global thundering-herd damping (RENA-54107, extended to the stranded-issue
+// reconciliation path in RENA-54203): a control-plane restart (crash or
+// graceful redeploy) resets in-memory process tracking and in-flight recovery
+// state, so a single reap/drain/reconcile sweep can find many runs or issues
+// "stranded" at once and would otherwise re-queue all of them immediately,
+// flooding the API. When a sweep's batch size crosses this threshold, each
+// retry/recovery wake gets an additional uniform-random stagger before its
+// automatic re-queue.
+//
+// Shared by server/src/services/heartbeat.ts (reapOrphanedRuns /
+// drainRunningRunsForShutdown / enqueueWakeup) and
+// server/src/services/recovery/service.ts (reconcileStrandedAssignedIssues)
+// so every restart-triggered enqueue path gets the same protection from one
+// place instead of duplicated constants.
+export const RESTART_BATCH_PROCESS_LOSS_REAP_THRESHOLD = Math.max(
+  1,
+  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_REAP_THRESHOLD)) || 8,
+);
+export const RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS = Math.max(
+  0,
+  Math.floor(Number(process.env.HEARTBEAT_RESTART_BATCH_STAGGER_MAX_MS)) || 5 * 60 * 1000,
+);
+export const RESTART_BATCH_STAGGER_RETRY_REASON = "restart_batch_stagger";
+export const RESTART_BATCH_STAGGER_WAKE_REASON = "restart_batch_stagger_retry";
+
+// Uniform-random delay in [0, maxDelayMs], used to spread automatic re-queues
+// of a restart-triggered batch of stranded runs/issues instead of firing them
+// all at once.
+export function computeRestartBatchStaggerDelayMs(
+  random: () => number = Math.random,
+  maxDelayMs: number = RESTART_BATCH_PROCESS_LOSS_STAGGER_MAX_MS,
+): number {
+  if (!(maxDelayMs > 0)) return 0;
+  const sample = Math.min(1, Math.max(0, random()));
+  return Math.round(sample * maxDelayMs);
+}


### PR DESCRIPTION
## Summary
- RENA-54552 (child of RENA-54549): `createWorkspace()` in `server/src/services/projects.ts` registered `local_path` project workspaces without ever running `git init` in the target folder. `assertGitSensitiveAdapterWorkspaceValid()` in `heartbeat.ts` requires `.git` metadata whenever a project workspace is expected, so the very first codex_local/claude_local run against such a workspace died with `missing_git_metadata` and no auto-retry.
- Before inserting the workspace row, `git init` the cwd (and register it as a `safe.directory`, since project folders are often owned by the interactive Windows user rather than the service account) when `sourceType === "local_path"` and no `.git` exists yet.
- Failures (e.g. permission denied) are logged as a warning and do **not** block workspace creation — the existing `heartbeat.ts` validation remains the safety net for paths the service account genuinely cannot touch (see RENA-54552 point 4, e.g. the `odoo` project folder, which is out of scope for this fix).
- Extracted `hasGitMetadata` into a new shared `server/src/services/git-workspace-utils.ts` (alongside the new `ensureLocalPathGitWorkspaceInitialized`) so `heartbeat.ts` and `projects.ts` use one implementation instead of duplicating it.
- Left the optional/nice-to-have step 5 (self-healing already-registered `local_path` workspaces inside `heartbeat.ts`'s `assertGitSensitiveAdapterWorkspaceValid`) out of scope: `sourceType` is not currently threaded through `ResolvedWorkspaceForRun`/`ExecutionWorkspace`, and plumbing it through would be a larger type change across several layers, which the issue explicitly said to skip in that case.

## Test plan
- [x] New `server/src/__tests__/git-workspace-utils.test.ts` (7 tests): `hasGitMetadata` on non-git/git/blank paths; `ensureLocalPathGitWorkspaceInitialized` inits + registers `safe.directory`, leaves an existing `.git` untouched, and fails without throwing for missing/unreachable cwd.
- [x] New `server/src/__tests__/project-workspace-git-init.test.ts` (4 tests, embedded Postgres): `createWorkspace` git-inits a fresh `local_path` cwd, doesn't touch an existing `.git`, still creates the workspace row when git-init fails, and skips git-init entirely for non-`local_path` source types.
- [x] Existing `project-routes-env.test.ts` and `heartbeat-project-env.test.ts` still pass (48/48 across all four files together).
- [x] `tsc --noEmit` shows no new errors in the touched files (`projects.ts`, `heartbeat.ts`, `git-workspace-utils.ts`); remaining repo-wide errors are pre-existing (`@paperclipai/plugin-sdk` module resolution), confirmed identical on the base commit.
- Note: `workspace-runtime.test.ts` has pre-existing failures on this host (`spawn taskkill ENOENT`) unrelated to this change — reproduced identically on the base commit before this diff.