### PR TITLE
fix(worktree): quarantine cloned execution state

### DIFF
--- a/cli/src/__tests__/worktree.test.ts
+++ b/cli/src/__tests__/worktree.test.ts
@@ -4,13 +4,15 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:net";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agents,
+  agentWakeupRequests,
   authUsers,
   companies,
   createDb,
+  heartbeatRuns,
   issueComments,
   issues,
   projects,
@@ -385,6 +387,8 @@ describe("worktree helpers", () => {
         backupSummary: "snapshot.sql",
         pausedScheduledRoutines: 2,
         executionQuarantine: {
+          cancelledHeartbeatRuns: 1,
+          cancelledWakeupRequests: 1,
           disabledTimerHeartbeats: 1,
           resetRunningAgents: 1,
           quarantinedInProgressIssues: 1,
@@ -491,6 +495,8 @@ describe("worktree helpers", () => {
           backupSummary: "snapshot.sql",
           pausedScheduledRoutines: 0,
           executionQuarantine: {
+            cancelledHeartbeatRuns: 0,
+            cancelledWakeupRequests: 0,
             disabledTimerHeartbeats: 0,
             resetRunningAgents: 0,
             quarantinedInProgressIssues: 0,
@@ -555,6 +561,14 @@ describe("worktree helpers", () => {
     const todoIssueId = randomUUID();
     const reviewIssueId = randomUUID();
     const userIssueId = randomUUID();
+    const queuedRunId = randomUUID();
+    const runningRunId = randomUUID();
+    const scheduledRetryRunId = randomUUID();
+    const succeededRunId = randomUUID();
+    const queuedWakeupId = randomUUID();
+    const deferredWakeupId = randomUUID();
+    const claimedWakeupId = randomUUID();
+    const completedWakeupId = randomUUID();
 
     try {
       await db.insert(companies).values({
@@ -590,6 +604,75 @@ describe("worktree helpers", () => {
           permissions: {},
         },
       ]);
+      await db.insert(agentWakeupRequests).values([
+        {
+          id: queuedWakeupId,
+          companyId,
+          agentId,
+          source: "copied-queued-wakeup",
+          status: "queued",
+        },
+        {
+          id: deferredWakeupId,
+          companyId,
+          agentId,
+          source: "copied-deferred-wakeup",
+          status: "deferred_issue_execution",
+        },
+        {
+          id: claimedWakeupId,
+          companyId,
+          agentId,
+          source: "copied-claimed-wakeup",
+          status: "claimed",
+        },
+        {
+          id: completedWakeupId,
+          companyId,
+          agentId,
+          source: "completed-wakeup-history",
+          status: "completed",
+          finishedAt: new Date("2026-04-17T23:00:00.000Z"),
+        },
+      ]);
+      await db.insert(heartbeatRuns).values([
+        {
+          id: queuedRunId,
+          companyId,
+          agentId,
+          status: "queued",
+          wakeupRequestId: queuedWakeupId,
+        },
+        {
+          id: runningRunId,
+          companyId,
+          agentId,
+          status: "running",
+          wakeupRequestId: claimedWakeupId,
+          startedAt: new Date("2026-04-18T00:00:00.000Z"),
+          processPid: 12345,
+          processGroupId: 12345,
+          processStartedAt: new Date("2026-04-18T00:00:00.000Z"),
+          livenessState: "advanced",
+          livenessReason: "Copied source-instance state",
+          nextAction: "Continue source work",
+        },
+        {
+          id: scheduledRetryRunId,
+          companyId,
+          agentId,
+          status: "scheduled_retry",
+          wakeupRequestId: deferredWakeupId,
+          scheduledRetryAt: new Date("2026-04-18T01:00:00.000Z"),
+        },
+        {
+          id: succeededRunId,
+          companyId,
+          agentId,
+          status: "succeeded",
+          finishedAt: new Date("2026-04-17T23:00:00.000Z"),
+        },
+      ]);
       await db.insert(issues).values([
         {
           id: inProgressIssueId,
@@ -600,6 +683,8 @@ describe("worktree helpers", () => {
           assigneeAgentId: agentId,
           issueNumber: 1,
           identifier: "WTQ-1",
+          checkoutRunId: queuedRunId,
+          executionRunId: runningRunId,
           executionAgentNameKey: "codexcoder",
           executionLockedAt: new Date("2026-04-18T00:00:00.000Z"),
         },
@@ -636,6 +721,8 @@ describe("worktree helpers", () => {
       ]);
 
       await expect(quarantineSeededWorktreeExecutionState(tempDb.connectionString)).resolves.toEqual({
+        cancelledHeartbeatRuns: 3,
+        cancelledWakeupRequests: 3,
         disabledTimerHeartbeats: 1,
         resetRunningAgents: 1,
         quarantinedInProgressIssues: 1,
@@ -653,8 +740,54 @@ describe("worktree helpers", () => {
       const [inProgressIssue] = await db.select().from(issues).where(eq(issues.id, inProgressIssueId));
       expect(inProgressIssue?.status).toBe("blocked");
       expect(inProgressIssue?.assigneeAgentId).toBeNull();
+      expect(inProgressIssue?.checkoutRunId).toBeNull();
+      expect(inProgressIssue?.executionRunId).toBeNull();
       expect(inProgressIssue?.executionAgentNameKey).toBeNull();
       expect(inProgressIssue?.executionLockedAt).toBeNull();
+
+      const cancelledRuns = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, [queuedRunId, runningRunId, scheduledRetryRunId]));
+      expect(cancelledRuns).toHaveLength(3);
+      for (const run of cancelledRuns) {
+        expect(run.status).toBe("cancelled");
+        expect(run.errorCode).toBe("worktree_seed_quarantine");
+        expect(run.error).toContain("Cancelled during worktree seed");
+        expect(run.finishedAt).toBeInstanceOf(Date);
+        expect(run.processPid).toBeNull();
+        expect(run.processGroupId).toBeNull();
+        expect(run.processStartedAt).toBeNull();
+        expect(run.scheduledRetryAt).toBeNull();
+        expect(run.livenessState).toBeNull();
+        expect(run.livenessReason).toBeNull();
+        expect(run.nextAction).toBeNull();
+      }
+
+      const [succeededRun] = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, succeededRunId));
+      expect(succeededRun?.status).toBe("succeeded");
+      expect(succeededRun?.errorCode).toBeNull();
+
+      const cancelledWakeups = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(inArray(agentWakeupRequests.id, [queuedWakeupId, deferredWakeupId, claimedWakeupId]));
+      expect(cancelledWakeups).toHaveLength(3);
+      for (const wakeup of cancelledWakeups) {
+        expect(wakeup.status).toBe("cancelled");
+        expect(wakeup.error).toContain("Cancelled during worktree seed");
+        expect(wakeup.finishedAt).toBeInstanceOf(Date);
+      }
+
+      const [completedWakeup] = await db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, completedWakeupId));
+      expect(completedWakeup?.status).toBe("completed");
+      expect(completedWakeup?.error).toBeNull();
 
       const [todoIssue] = await db.select().from(issues).where(eq(issues.id, todoIssueId));
       expect(todoIssue?.status).toBe("todo");

--- a/cli/src/commands/worktree.ts
+++ b/cli/src/commands/worktree.ts
@@ -23,6 +23,7 @@ import pc from "picocolors";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import {
   applyPendingMigrations,
+  agentWakeupRequests,
   agents,
   assets,
   companies,
@@ -228,6 +229,8 @@ export type EnsureWorktreeSeededResult = {
 };
 
 export type SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: number;
+  cancelledWakeupRequests: number;
   disabledTimerHeartbeats: number;
   resetRunningAgents: number;
   quarantinedInProgressIssues: number;
@@ -251,6 +254,8 @@ function formatSeededWorktreeExecutionQuarantineSummary(
   summary: SeededWorktreeExecutionQuarantineSummary,
 ): string {
   return [
+    `cancelled heartbeat runs: ${summary.cancelledHeartbeatRuns}`,
+    `cancelled wake requests: ${summary.cancelledWakeupRequests}`,
     `disabled timer heartbeats: ${summary.disabledTimerHeartbeats}`,
     `reset running agents: ${summary.resetRunningAgents}`,
     `quarantined in-progress issues: ${summary.quarantinedInProgressIssues}`,
@@ -1182,6 +1187,8 @@ export async function pauseSeededScheduledRoutines(connectionString: string): Pr
 }
 
 const EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY: SeededWorktreeExecutionQuarantineSummary = {
+  cancelledHeartbeatRuns: 0,
+  cancelledWakeupRequests: 0,
   disabledTimerHeartbeats: 0,
   resetRunningAgents: 0,
   quarantinedInProgressIssues: 0,
@@ -1225,6 +1232,43 @@ export async function quarantineSeededWorktreeExecutionState(
   const summary = { ...EMPTY_SEEDED_WORKTREE_EXECUTION_QUARANTINE_SUMMARY };
   try {
     await db.transaction(async (tx) => {
+      const now = new Date();
+      const quarantineReason =
+        "Cancelled during worktree seed because copied execution state cannot be resumed in an isolated instance.";
+      const cancelledRuns = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: quarantineReason,
+          errorCode: "worktree_seed_quarantine",
+          processPid: null,
+          processGroupId: null,
+          processStartedAt: null,
+          scheduledRetryAt: null,
+          livenessState: null,
+          livenessReason: null,
+          nextAction: null,
+          updatedAt: now,
+        })
+        .where(inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"]))
+        .returning({ id: heartbeatRuns.id });
+      summary.cancelledHeartbeatRuns = cancelledRuns.length;
+
+      const cancelledWakeups = await tx
+        .update(agentWakeupRequests)
+        .set({
+          status: "cancelled",
+          finishedAt: now,
+          error: quarantineReason,
+          updatedAt: now,
+        })
+        .where(
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution", "claimed"]),
+        )
+        .returning({ id: agentWakeupRequests.id });
+      summary.cancelledWakeupRequests = cancelledWakeups.length;
+
       const seededAgents = await tx
         .select({
           id: agents.id,
@@ -1248,7 +1292,7 @@ export async function quarantineSeededWorktreeExecutionState(
             .set({
               runtimeConfig: normalized.runtimeConfig,
               status: nextStatus,
-              updatedAt: new Date(),
+              updatedAt: now,
             })
             .where(eq(agents.id, agent.id));
         }
@@ -1281,7 +1325,7 @@ export async function quarantineSeededWorktreeExecutionState(
             executionAgentNameKey: null,
             executionLockedAt: null,
             executionWorkspaceId: null,
-            updatedAt: new Date(),
+            updatedAt: now,
           })
           .where(eq(issues.id, issue.id));
 

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -444,7 +444,7 @@ Seed modes:
 - `full` makes a full logical clone of the source instance
 - `--no-seed` creates an empty isolated instance
 
-Seeded worktree instances quarantine copied live execution by default for both `minimal` and `full` seeds. During restore, Paperclip disables copied agent timer heartbeats, resets copied `running` agents to `idle`, blocks and unassigns copied agent-owned `in_progress` issues, and unassigns copied agent-owned `todo`/`in_review` issues. This keeps a freshly booted worktree from starting agents for work already owned by the source instance. Pass `--preserve-live-work` only when you intentionally want the isolated worktree to resume copied assignments.
+Seeded worktree instances quarantine copied live execution by default for both `minimal` and `full` seeds. During restore, Paperclip cancels copied `queued`/`running`/`scheduled_retry` heartbeat runs and live wake requests, disables copied agent timer heartbeats, resets copied `running` agents to `idle`, blocks and unassigns copied agent-owned `in_progress` issues, and unassigns copied agent-owned `todo`/`in_review` issues. Completed execution history is preserved. This keeps a freshly booted worktree from starting agents for work already owned by the source instance or presenting copied work as still live. Pass `--preserve-live-work` only when you intentionally want the isolated worktree to resume copied assignments.
 
 After `worktree init`, both the server and the CLI auto-load the repo-local `.paperclip/.env` when run inside that worktree, so normal commands like `pnpm dev`, `paperclipai doctor`, and `paperclipai db:backup` stay scoped to the worktree instance.
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Isolated worktrees clone control-plane data so maintainers can review changes safely.
> - A full worktree seed copied active heartbeat runs and wake requests from the source instance.
> - Worktree scheduling suppression stopped real execution, but the cloned app still showed the copied work as live.
> - A safe clone must keep completed history and make copied live execution inert by default.
> - This pull request quarantines copied run and wake state during the existing seed transaction.
> - The benefit is a truthful review workspace that cannot appear to resume source-instance work.

## Linked Issues or Issue Description

**What happened?**

`paperclipai worktree reseed --seed-mode full` restored queued, running, and retrying heartbeat runs. It also restored live wake requests. The worktree scheduler stayed suppressed, but the cloned app displayed old work as active.

**Expected behavior**

A seeded worktree must be inert by default. It must cancel copied live execution state and preserve completed history. Operators can still use `--preserve-live-work` when they explicitly want live state.

**Steps to reproduce**

1. Create source-instance heartbeat runs in queued, running, and scheduled-retry states.
2. Create wake requests in queued, deferred, and claimed states.
3. Run a full worktree seed or reseed.
4. Start the isolated worktree and inspect the copied execution state.

**Paperclip version or commit**

Current `master` before this pull request.

**Deployment mode**

Local development worktree with embedded PostgreSQL.

## What Changed

- Cancel copied queued, running, and scheduled-retry heartbeat runs during seed quarantine.
- Clear copied process, retry, and liveness metadata from those runs.
- Cancel copied queued, deferred, and claimed wake requests.
- Preserve succeeded runs and completed wake-request history.
- Extend the quarantine summary, focused tests, and development documentation.

## Verification

- `pnpm exec vitest run cli/src/__tests__/worktree.test.ts` — 41 tests passed.
- `pnpm --filter @paperclipai/plugin-sdk build` — passed as the typecheck prerequisite.
- `pnpm --filter paperclipai typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.
- A full seeded worktree cancelled nonzero copied runs and wake requests, then started healthy with worktree scheduling suppressed.

## Risks

- The default seed path now converts copied live rows to cancelled rows. This is intentional for isolated worktrees.
- The quarantine transaction updates only the cloned target database. It does not mutate the source instance.
- `--preserve-live-work` keeps the explicit opt-in path for operators who need live-state fidelity.
- No schema migration is required.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex using model ID `gpt-5`. The context-window size was not exposed to this run. Reasoning, shell tools, code editing, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
