### PR TITLE
Fix Bubblewrap mount order on usr-merged hosts

### DIFF
--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -93,6 +93,11 @@ describe("local process sandbox", () => {
     expect(target.args).toContain("--tmpfs");
     expect(target.args).toContain(workspace);
     expect(target.args).toContain(managedHome);
+    const usrBindIndex = target.args.findIndex((arg, index) => arg === "/usr" && target.args[index - 1] === "--ro-bind");
+    const binBindIndex = target.args.findIndex((arg, index) => arg === "/bin" && target.args[index - 1] === "--ro-bind");
+    expect(usrBindIndex).toBeGreaterThan(-1);
+    expect(binBindIndex).toBeGreaterThan(-1);
+    expect(usrBindIndex).toBeLessThan(binBindIndex);
     expect(target.args.slice(-3)).toEqual([process.execPath, "-e", "console.log('ok')"]);
   });
 

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -49,9 +49,9 @@ interface NetworkAllowlistProxy {
 }
 
 const SYSTEM_READ_PATHS = [
+  "/usr",
   "/bin",
   "/sbin",
-  "/usr",
   "/lib",
   "/lib64",
   "/etc/ca-certificates",


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs local agents inside filesystem sandboxes.
> - The local-process sandbox uses Bubblewrap to build a fresh root.
> - On usr-merged Linux hosts, `/bin` and related paths resolve through `/usr`.
> - Bubblewrap cannot bind those compatibility paths before `/usr` exists in the fresh root.
> - The smallest safe fix mounts `/usr` before those dependent paths.
> - This pull request changes only that mount order and adds a regression assertion.
> - The benefit is that workspace-confined agents start on usr-merged hosts without broader filesystem access.

## Linked Issues or Issue Description

Fixes: #10684
Refs: #10753

Duplicate search completed on 2026-08-05. A repository-wide PR search for Bubblewrap usr-merged mount-order fixes found no matching pull request other than this one.

## What Changed

- Mount `/usr` before `/bin`, `/sbin`, `/lib`, and `/lib64` in fresh-root Bubblewrap sandboxes.
- Add a focused test that verifies the `/usr` read-only bind appears before the `/bin` bind.

## Verification

- `PAPERCLIP_TEST_BWRAP=/usr/bin/bwrap ./node_modules/.bin/vitest run packages/adapter-utils/src/local-process-sandbox.test.ts` — 13 passed and 1 separately gated build test skipped.
- `./node_modules/.bin/tsc --noEmit -p packages/adapter-utils/tsconfig.json` — passed.
- `git diff --check` — passed.
- GitHub CI reports all code, test, build, security, and Greptile checks successful. The PR-description `review` gate is being rerun after this metadata correction.

## Risks

Low risk. The change only reorders existing read-only mounts. It does not add mounts or permissions. Hosts with unusual filesystem layouts could expose another ordering dependency, but the focused regression test and existing sandbox suite cover the intended usr-merged behavior.

## Model Used

OpenAI Codex GPT-5.4 with reasoning, tool use, terminal access, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
