### PR TITLE
Preserve company display names in cloud tenants

### DIFF
--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -1,8 +1,12 @@
 import express from "express";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { companyMemberships, instanceUserRoles } from "@paperclipai/db";
-import { actorMiddleware } from "../middleware/auth.js";
+import { companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import {
+  actorMiddleware,
+  humanizeCloudStackSlug,
+  isKnownBadCloudCompanyName,
+} from "../middleware/auth.js";
 import { errorHandler } from "../middleware/error-handler.js";
 import { assertCompanyAccess } from "../routes/authz.js";
 
@@ -96,7 +100,7 @@ describe("actorMiddleware authenticated session profile", () => {
         return chain;
       }),
       delete: vi.fn(() => ({ where: () => Promise.resolve(undefined) })),
-      select: vi.fn(),
+      select: vi.fn(() => createSelectChain([])),
     } as any;
     const app = express();
     app.use(
@@ -117,6 +121,7 @@ describe("actorMiddleware authenticated session profile", () => {
       .set("x-paperclip-cloud-user-name", "Stack Owner")
       .set("x-paperclip-cloud-stack-id", "stack-alpha")
       .set("x-paperclip-cloud-paperclip-company-id", "paperclip-stack-alpha")
+      .set("x-paperclip-cloud-paperclip-company-name", "Purple Rain")
       .set("x-paperclip-cloud-stack-role", "owner");
 
     expect(res.status).toBe(200);
@@ -130,13 +135,16 @@ describe("actorMiddleware authenticated session profile", () => {
       memberships: [expect.objectContaining({ membershipRole: "owner", status: "active" })],
     });
     expect(res.body.companyIds[0]).toMatch(/^[0-9a-f-]{36}$/);
-    // authUsers, companies, companyMemberships, and the role-default
-    // principalPermissionGrants seeded in place of instance-admin elevation.
-    expect(inserts).toHaveLength(4);
+    // authUsers, companies, companyMemberships, the role-default
+    // principalPermissionGrants, and the lazily initialized instance setting.
+    expect(inserts).toHaveLength(5);
     expect(inserts[0]?.values).toMatchObject({
       id: "global-user-1",
       email: "owner@example.com",
       emailVerified: true,
+    });
+    expect(inserts[1]?.values).toMatchObject({
+      name: "Purple Rain",
     });
   });
 
@@ -217,6 +225,75 @@ describe("actorMiddleware authenticated session profile", () => {
     expect(denied.status).toBe(403);
   });
 
+  it("repairs a legacy machine company name from the trusted human-name header", async () => {
+    process.env.PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN = "tenant-token";
+    const updates: Array<Record<string, unknown>> = [];
+    const insertChain = {
+      values() {
+        return insertChain;
+      },
+      onConflictDoUpdate() {
+        return insertChain;
+      },
+      onConflictDoNothing() {
+        return insertChain;
+      },
+      returning() {
+        return Promise.resolve([
+          { companyId: "company-1", membershipRole: "owner", status: "active" },
+        ]);
+      },
+      then(resolve: (value: unknown) => unknown) {
+        return Promise.resolve(undefined).then(resolve);
+      },
+    };
+    const db = {
+      select: vi.fn(() => ({
+        from: (table: unknown) => ({
+          where: () =>
+            Promise.resolve(
+              table === companies
+                ? [{ name: "paperclip-stack-purple-rain" }]
+                : [],
+            ),
+        }),
+      })),
+      insert: vi.fn(() => insertChain),
+      update: vi.fn(() => ({
+        set(values: Record<string, unknown>) {
+          updates.push(values);
+          return { where: () => Promise.resolve(undefined) };
+        },
+      })),
+      delete: vi.fn(() => ({ where: () => Promise.resolve(undefined) })),
+    } as any;
+    const app = express();
+    app.use(
+      actorMiddleware(db, {
+        deploymentMode: "authenticated",
+        resolveSession: async () => null,
+      }),
+    );
+    app.get("/actor", (req, res) => res.json(req.actor));
+
+    const res = await request(app)
+      .get("/actor")
+      .set("x-paperclip-cloud-tenant-token", "tenant-token")
+      .set("x-paperclip-cloud-user-id", "global-user-1")
+      .set("x-paperclip-cloud-user-email", "owner@example.com")
+      .set("x-paperclip-cloud-stack-id", "stack-purple-rain")
+      .set(
+        "x-paperclip-cloud-paperclip-company-id",
+        "paperclip-stack-purple-rain",
+      )
+      .set("x-paperclip-cloud-paperclip-company-name", "Purple Rain")
+      .set("x-paperclip-cloud-stack-role", "owner");
+
+    expect(res.status).toBe(200);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ name: "Purple Rain" });
+  });
+
   it("purges a stale instance_admin row so the session path stops elevating the cloud-tenant user", async () => {
     process.env.PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN = "tenant-token";
     // Simulates a deployment that previously ran the pre-hardening cloud_tenant
@@ -293,5 +370,35 @@ describe("actorMiddleware authenticated session profile", () => {
       userId: "global-user-1",
       isInstanceAdmin: false,
     });
+  });
+});
+
+describe("Cloud tenant company naming", () => {
+  const ids = {
+    companyId: "11111111-1111-4111-8111-111111111111",
+    paperclipCompanyId: "paperclip-stack-purple-rain",
+  };
+
+  it.each([
+    "paperclip-stack-purple-rain",
+    "stack-purple-rain Paperclip",
+    ids.companyId,
+  ])("repairs the known-bad machine name %s", (name) => {
+    expect(isKnownBadCloudCompanyName(name, ids)).toBe(true);
+  });
+
+  it.each([
+    "Purple Rain",
+    "Paperclip Stack Purple Rain",
+    "The Purple Rain Paperclip",
+  ])("preserves the genuine company name %s", (name) => {
+    expect(isKnownBadCloudCompanyName(name, ids)).toBe(false);
+  });
+
+  it("humanizes the stack slug for old harnesses without a name header", () => {
+    expect(humanizeCloudStackSlug("stack-purple-rain")).toBe("Purple Rain");
+    expect(humanizeCloudStackSlug("paperclip-stack-purple-rain")).toBe(
+      "Purple Rain",
+    );
   });
 });

--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import { activityLog, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import {
   actorMiddleware,
   humanizeCloudStackSlug,
@@ -228,6 +228,7 @@ describe("actorMiddleware authenticated session profile", () => {
   it("repairs a legacy machine company name from the trusted human-name header", async () => {
     process.env.PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN = "tenant-token";
     const updates: Array<Record<string, unknown>> = [];
+    const activities: Array<Record<string, unknown>> = [];
     const insertChain = {
       values() {
         return insertChain;
@@ -258,15 +259,28 @@ describe("actorMiddleware authenticated session profile", () => {
             ),
         }),
       })),
-      insert: vi.fn(() => insertChain),
+      insert: vi.fn((table: unknown) => {
+        if (table !== activityLog) return insertChain;
+        return {
+          values(values: Record<string, unknown>) {
+            activities.push(values);
+            return Promise.resolve(undefined);
+          },
+        };
+      }),
       update: vi.fn(() => ({
         set(values: Record<string, unknown>) {
           updates.push(values);
-          return { where: () => Promise.resolve(undefined) };
+          return {
+            where: () => ({
+              returning: () => Promise.resolve([{ id: "company-1" }]),
+            }),
+          };
         },
       })),
       delete: vi.fn(() => ({ where: () => Promise.resolve(undefined) })),
     } as any;
+    db.transaction = vi.fn(async (run: (tx: typeof db) => Promise<void>) => run(db));
     const app = express();
     app.use(
       actorMiddleware(db, {
@@ -292,6 +306,20 @@ describe("actorMiddleware authenticated session profile", () => {
     expect(res.status).toBe(200);
     expect(updates).toHaveLength(1);
     expect(updates[0]).toMatchObject({ name: "Purple Rain" });
+    expect(activities).toEqual([
+      expect.objectContaining({
+        companyId: expect.any(String),
+        actorType: "system",
+        actorId: "cloud-tenant-auth",
+        action: "company.updated",
+        entityType: "company",
+        details: expect.objectContaining({
+          reason: "legacy_machine_name_repair",
+          previousName: "paperclip-stack-purple-rain",
+          name: "Purple Rain",
+        }),
+      }),
+    ]);
   });
 
   it("purges a stale instance_admin row so the session path stops elevating the cloud-tenant user", async () => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -439,8 +439,11 @@ export async function resolveCloudTenantActor(db: Db, req: Request): Promise<Exp
   const stackRole = stackMembershipRole(req.header("x-paperclip-cloud-stack-role"));
   const userName = req.header("x-paperclip-cloud-user-name")?.trim() || userEmail;
   const paperclipCompanyId = req.header("x-paperclip-cloud-paperclip-company-id")?.trim();
+  const paperclipCompanyName = req
+    .header("x-paperclip-cloud-paperclip-company-name")
+    ?.trim();
   const companyId = cloudTenantCompanyId(stackId);
-  const companyName = paperclipCompanyId || `${stackId} Paperclip`;
+  const companyName = paperclipCompanyName || humanizeCloudStackSlug(stackId);
   const now = new Date();
 
   await db
@@ -486,6 +489,15 @@ export async function resolveCloudTenantActor(db: Db, req: Request): Promise<Exp
     .onConflictDoNothing({
       target: companies.id,
     });
+
+  if (paperclipCompanyName) {
+    await repairCloudTenantCompanyName(db, {
+      companyId,
+      paperclipCompanyId,
+      paperclipCompanyName,
+      now,
+    });
+  }
 
   const membershipRole = stackRole === "owner" || stackRole === "admin" ? "owner" : stackRole;
   const membership = await db
@@ -600,6 +612,77 @@ function cloudTenantCompanyId(stackId: string): string {
   bytes[8] = (bytes[8] & 0x3f) | 0x80;
   const hex = bytes.subarray(0, 16).toString("hex");
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+export function humanizeCloudStackSlug(stackId: string): string {
+  const slug = stackId
+    .trim()
+    .replace(/^paperclip-stack-/i, "")
+    .replace(/^stack-/i, "");
+  const displayName = slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+  return displayName || "Workspace";
+}
+
+export function isKnownBadCloudCompanyName(
+  name: string,
+  ids: { companyId: string; paperclipCompanyId?: string },
+): boolean {
+  const normalized = name.trim();
+  return (
+    /^paperclip-stack-.+/i.test(normalized) ||
+    /^stack-.+\s+paperclip$/i.test(normalized) ||
+    normalized === ids.companyId ||
+    (ids.paperclipCompanyId !== undefined &&
+      normalized === ids.paperclipCompanyId)
+  );
+}
+
+async function repairCloudTenantCompanyName(
+  db: Db,
+  input: {
+    companyId: string;
+    paperclipCompanyId?: string;
+    paperclipCompanyName: string;
+    now: Date;
+  },
+): Promise<void> {
+  try {
+    const existing = await db
+      .select({ name: companies.name })
+      .from(companies)
+      .where(eq(companies.id, input.companyId))
+      .then((rows) => rows[0]);
+    if (
+      !existing ||
+      !isKnownBadCloudCompanyName(existing.name, {
+        companyId: input.companyId,
+        paperclipCompanyId: input.paperclipCompanyId,
+      })
+    ) {
+      return;
+    }
+    await db
+      .update(companies)
+      .set({ name: input.paperclipCompanyName, updatedAt: input.now })
+      .where(
+        and(
+          eq(companies.id, input.companyId),
+          // A user may rename the company between the read above and this
+          // repair. Match the exact observed machine name so that concurrent
+          // genuine renames always win.
+          eq(companies.name, existing.name),
+        ),
+      );
+  } catch (err) {
+    logger.warn(
+      { err, companyId: input.companyId },
+      "Failed to repair legacy Cloud tenant company name",
+    );
+  }
 }
 
 function issuePrefixForCloudStack(stackId: string): string {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -665,18 +665,37 @@ async function repairCloudTenantCompanyName(
     ) {
       return;
     }
-    await db
-      .update(companies)
-      .set({ name: input.paperclipCompanyName, updatedAt: input.now })
-      .where(
-        and(
-          eq(companies.id, input.companyId),
-          // A user may rename the company between the read above and this
-          // repair. Match the exact observed machine name so that concurrent
-          // genuine renames always win.
-          eq(companies.name, existing.name),
-        ),
-      );
+    await db.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(companies)
+        .set({ name: input.paperclipCompanyName, updatedAt: input.now })
+        .where(
+          and(
+            eq(companies.id, input.companyId),
+            // A user may rename the company between the read above and this
+            // repair. Match the exact observed machine name so that concurrent
+            // genuine renames always win.
+            eq(companies.name, existing.name),
+          ),
+        )
+        .returning({ id: companies.id });
+      if (!updated) return;
+
+      await tx.insert(activityLog).values({
+        companyId: input.companyId,
+        actorType: "system",
+        actorId: "cloud-tenant-auth",
+        action: "company.updated",
+        entityType: "company",
+        entityId: input.companyId,
+        details: {
+          source: "cloud_tenant_auth",
+          reason: "legacy_machine_name_repair",
+          previousName: existing.name,
+          name: input.paperclipCompanyName,
+        },
+      });
+    });
   } catch (err) {
     logger.warn(
       { err, companyId: input.companyId },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Cloud tenants use trusted proxy headers to create the local actor and company records.
> - The proxy previously sent only a machine company identifier.
> - The tenant stored that identifier as the company name and never repaired it.
> - This pull request accepts a trusted human name and repairs only known machine-generated names.
> - The benefit is a correct company name without overwriting names that users changed in the app.

## Linked Issues or Issue Description

**Pre-submission checklist**

- [x] I searched open and closed issues and pull requests. I found no duplicate.
- [x] I reproduced the behavior on `master`.
- [x] The error originates in the Paperclip cloud-tenant authentication path.

**What happened?**

A trusted cloud-tenant request created the local company with a machine identifier such as `paperclip-stack-purple-rain`. The conflict-safe insert kept that value on all later requests.

**Expected behavior**

The tenant must use the trusted human display-name header. An older proxy without that header must produce a humanized name from the stack slug.

**Steps to reproduce**

1. Send a trusted cloud-tenant request with a stack id and a machine company id.
2. Create the local tenant company through the authentication middleware.
3. Observe that the stored company name uses the machine id instead of a human display name.

**Paperclip version or commit**

`master` at `678728f650`.

**Deployment mode**

Self-hosted server behind a trusted Paperclip Cloud proxy.

**Privacy checklist**

- [x] I reviewed this description and the test fixtures for secrets and personal data.

## What Changed

- Prefer the trusted company-name header when the tenant creates its company row.
- Humanize the stack slug when an older proxy does not send the new header.
- Repair names that match the old machine patterns or the exact company identifier.
- Preserve all other names so an in-app user rename always wins.
- Match the observed old name during the update to protect a concurrent user rename.
- Record each successful automatic repair in the company activity history.
- Add middleware, audit, and pattern-matching regression tests.

## Verification

- `pnpm exec vitest run server/src/__tests__/auth-session-route.test.ts` (12 passed)
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm build`
- `pnpm test:run`

## Risks

- Low risk. The repair runs only for authenticated trusted-header requests that include the new name.
- The update accepts only known legacy patterns and matches the exact observed old value.
- The name repair and activity entry share one transaction.
- Old proxies remain compatible because the fallback humanizes the existing stack id.
- No schema change or migration is required.

## Model Used

- OpenAI Codex (GPT-5), reasoning mode with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
