### PR TITLE
Fix manager-authorized blocked lane recovery

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1555,6 +1555,56 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalled();
   });
 
+  it("allows a manager to clear completed blockers and restore a direct report lane to todo", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts" ? "allow_manager_chain" : "deny_low_trust_boundary",
+      explanation:
+        input.action === "tasks:manage_active_checkouts"
+          ? "Allowed because the actor manages the issue assignee in the reporting chain."
+          : "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: [],
+      isDependencyReady: true,
+      unresolvedBlockerCount: 0,
+    });
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: "completed-blocker", status: "done" }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo", blockedByIssueIds: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "todo", blockedByIssueIds: [] }),
+    );
+  });
+
+  it("keeps direct-report lane recovery denied without manager authority", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: false,
+      action: input.action,
+      reason: "deny_low_trust_boundary",
+      explanation: "Issue is outside this low-trust boundary.",
+    }));
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo", blockedByIssueIds: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3803,6 +3803,11 @@ export function issueRoutes(
       }
       return assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue);
     }
+    const hasCheckoutManagementOverride =
+      issue.assigneeAgentId !== null &&
+      issue.assigneeAgentId !== actorAgentId &&
+      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId);
+    if (hasCheckoutManagementOverride) return true;
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
       res.status(403).json({ error: "Issue is outside this actor's authorization boundary" });
@@ -3812,9 +3817,6 @@ export function issueRoutes(
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
-      if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
-        return true;
-      }
       if (issue.status === "in_progress") {
         res.status(409).json({
           error: "Issue is checked out by another agent",
@@ -4498,7 +4500,15 @@ export function issueRoutes(
     issue: Parameters<typeof decideIssueAccess>[1],
     options: { resumeIntent?: boolean } = {},
   ) {
-    if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
+    const actorAgentId = req.actor.type === "agent" ? req.actor.agentId ?? null : null;
+    const hasCheckoutManagementOverride =
+      actorAgentId !== null &&
+      issue.assigneeAgentId !== null &&
+      issue.assigneeAgentId !== actorAgentId &&
+      await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId);
+    if (!hasCheckoutManagementOverride && await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) {
+      return false;
+    }
 
     // Structured resume intent is the sole comment surface that may revive a
     // cancelled issue. Bare status transitions and `reopen` keep using the
@@ -4552,7 +4562,6 @@ export function issueRoutes(
 
     if (req.actor.type !== "agent") return true;
 
-    const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
       res.status(403).json({ error: "Agent authentication required" });
       return false;
@@ -4565,9 +4574,7 @@ export function issueRoutes(
       return false;
     }
     if (issue.assigneeAgentId === actorAgentId) return true;
-    if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
-      return true;
-    }
+    if (hasCheckoutManagementOverride) return true;
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (isDefaultOpenIssueWriteDecision(boundaryDecision)) return true;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work through issue ownership and reporting-chain authority.
> - The issue route checks mutation and resume permissions before it updates an issue.
> - Paperclip already grants managers `tasks:manage_active_checkouts` for agents in their reporting chain.
> - The route checked the ordinary or low-trust boundary before it checked that manager grant.
> - This order denied an authorized manager who tried to clear completed blockers and restore a report's issue to `todo`.
> - This pull request makes the existing manager grant reachable at both gates.
> - The benefit is a working recovery path without access for unrelated agents.

## Linked Issues or Issue Description

Related: #9542

**What happened?**

An agent with manager-chain authority received HTTP 403 when it used `PATCH /api/issues/:id` to clear completed blocker links and move a direct report's blocked issue to `todo`. PR #9542 addresses the first mutation-boundary ordering problem. The resume-intent gate also had the same ordering problem.

**Expected behavior**

The existing `tasks:manage_active_checkouts` manager grant must authorize this recovery. An unrelated agent must still receive HTTP 403.

**Steps to reproduce**

1. Assign a blocked issue to an agent that reports to a manager.
2. Use the manager's agent key to send `{ "status": "todo", "blockedByIssueIds": [] }`.
3. Observe HTTP 403 before this change.

**Paperclip version or commit**

`678728f65`

## What Changed

- Check the existing checkout-management grant before the generic issue mutation boundary.
- Check the same grant before the low-trust resume boundary.
- Add a regression for completed-blocker removal and blocked-to-todo recovery.
- Add a negative regression for an unrelated agent.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 78 passed.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `pnpm test:run` — server phase passed 3,388 tests with 2 skipped. The command then found two unrelated timezone-sensitive UI failures in `IssueProperties.test.tsx` and `attention.test.ts` under Europe/Warsaw.
- `git diff --check` — passed.

## Risks

- Low risk. The change uses an existing same-company reporting-chain grant.
- Unrelated agents remain denied by the generic and low-trust boundaries.
- There are no schema or migration changes.
- This change overlaps with the mutation-order fix in #9542. It also fixes the separate resume-order gate. Maintainers can reconcile the shared hunk during review.

## Model Used

- OpenAI Codex with GPT-5. The model used repository tools, code execution, test authoring, and reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
