### PR TITLE
docs: company-creator: resolve the import command from the checkout

### DIFF
--- a/.agents/skills/company-creator/SKILL.md
+++ b/.agents/skills/company-creator/SKILL.md
@@ -173,7 +173,27 @@ Ask the user where to write the package. Common options:
 - Org chart as a markdown list or table showing agents, titles, reporting structure, and skills
 - Brief description of each agent's role
 - Citations and references: link to the source repo (if from-repo), link to the Agent Companies spec (https://agentcompanies.io/specification), and link to Paperclip (https://github.com/paperclipai/paperclip)
-- A "Getting Started" section explaining how to import: `paperclipai company import --from <path>`
+- A "Getting Started" section explaining how to import. **Verify the invocation
+  against this checkout before writing it** — never copy it from memory or from an
+  older README. Resolve it, in this order:
+  1. `grep -n 'command("import"' -A 12 cli/src/commands/client/company.ts` — the
+     source of truth for the arguments the CLI actually accepts;
+  2. if no such command exists, fall back to the HTTP route:
+     `grep -n 'companies/import' server/src/routes/openapi.ts`
+     (`POST /api/companies/import/preview`, then `POST /api/companies/import`).
+
+  As of this checkout the source is a POSITIONAL argument, **not** `--from`:
+
+  ```bash
+  paperclipai company import <pathOrUrl> \
+    --include company,agents,projects,issues,tasks,skills \
+    --target new --new-company-name "<Name>"
+  ```
+
+  Always pass `--include` explicitly, listing every part the package actually
+  contains. An under-specified include set imports a SUBSET and still reports
+  success — a package can land with zero projects, tasks and skills and look like
+  it worked.
 
 **LICENSE** — include a LICENSE file. The copyright holder is the user creating the company, not the upstream repo author (they made the skills, the user is making the company). Use the same license type as the source repo (if from-repo) or ask the user (if from-scratch). Default to MIT if unclear.
 

--- a/.agents/skills/company-creator/SKILL.md
+++ b/.agents/skills/company-creator/SKILL.md
@@ -195,6 +195,17 @@ Ask the user where to write the package. Common options:
   success — a package can land with zero projects, tasks and skills and look like
   it worked.
 
+  This applies to the HTTP fallback too. Omitting `include` there does not mean
+  "import everything". The server fills in `DEFAULT_INCLUDE`
+  (`server/src/services/company-portability.ts`), which is:
+
+  ```
+  company: true, agents: true, projects: false, issues: false, skills: false
+  ```
+
+  The request then succeeds while it drops every project, issue and skill in the
+  package. Send `include` with each part set explicitly.
+
 **LICENSE** — include a LICENSE file. The copyright holder is the user creating the company, not the upstream repo author (they made the skills, the user is making the company). Use the same license type as the source repo (if from-repo) or ask the user (if from-scratch). Default to MIT if unclear.
 
 ### Step 7: Write Files and Summarize


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The company-creator skill generates portable company packages that users import into Paperclip
> - Step 6 of the skill tells the author to document the import command in the package README
> - The documented command `paperclipai company import --from <path>` does not work, because the CLI takes the source as a positional argument
> - Every generated README therefore ships a getting-started command that fails on first use
> - This pull request makes the skill resolve the import entrypoint from the checkout before it writes the README
> - The benefit is that the instruction cannot drift again, because the skill reads the current interface instead of repeating a memorised one

## Linked Issues or Issue Description

No public issue exists for this. The problem is described below, following the bug report template.

**What happened.** The company-creator skill tells the author to document importing with `paperclipai company import --from <path>`. That command fails. `cli/src/commands/client/company.ts:1401` declares `.argument("<fromPathOrUrl>")`, and the import block declares no `--from` option. The source is positional.

**Expected behavior.** The command written into a generated README runs successfully.

**Steps to reproduce.**
1. Run `grep -n "company import" .agents/skills/company-creator/SKILL.md`. The result shows the `--from` form.
2. Run `grep -n 'command("import"' -A 12 cli/src/commands/client/company.ts`. The result shows a positional `<fromPathOrUrl>` argument and no `--from` option.
3. Generate a company package with the skill. The README contains a getting-started command that fails.

**Paperclip version or commit.** `master` @ `d5b9f6c`.

**Related pull requests.** These change import behaviour. None of them corrects the skill's documented invocation, so this pull request is not a duplicate.
Refs #10237, Refs #10245, Refs #10246, Refs #10248, Refs #7289, Refs #4137

## What Changed

- Step 6 now tells the author to resolve the import entrypoint from the checkout before writing the README. It greps the CLI command first, and falls back to the `openapi.ts` HTTP route if no CLI command exists.
- The step records the currently correct positional form as an example.
- The step documents that `--include` must be passed explicitly. An incomplete include set imports a subset and still returns success, so a package can land with zero projects, tasks and skills and look correct.

## Verification

- Run `grep -n 'command("import"' -A 12 cli/src/commands/client/company.ts`. The output shows the positional `<fromPathOrUrl>` argument and the supported `--include` values. This confirms the new example.
- Run `grep -c 'company import --from' .agents/skills/company-creator/SKILL.md`. The output is `0`. This confirms the broken form is gone.
- This pull request changes documentation only. It touches no runtime code path.

## Risks

Low risk. The change is Markdown only. There is no code change, no migration, and no behavioural shift. The worst case is that the example ages again. The new resolve-from-the-checkout instruction is designed to prevent exactly that, because it tells the author to read the current interface instead of copying a remembered one.

## Model Used

Claude Opus 5 (`claude-opus-5`), used through Claude Code with extended thinking and tool use (shell commands and file edits). The corrected invocation was derived by reading `cli/src/commands/client/company.ts` in this checkout, not from model memory.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass — not run. This pull request changes one Markdown file and no code path.
- [ ] I have added or updated tests where applicable — no test applies to a documentation string.
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not yet confirmed on this commit.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — currently 4/5, pending this description update.
- [x] I will address all Greptile and reviewer comments before requesting merge
