### PR TITLE
feat(adapters): environment-aware quota — Phase 1 adapter contract

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -35,6 +35,7 @@ export type {
   ServerAdapterModule,
   QuotaWindow,
   ProviderQuotaResult,
+  AdapterQuotaContext,
   TranscriptEntry,
   StdoutLineParser,
   CLIAdapterModule,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -362,6 +362,20 @@ export interface ProviderQuotaResult {
   windows: QuotaWindow[];
 }
 
+/** Optional context for getQuotaWindows(). */
+export interface AdapterQuotaContext {
+  /**
+   * Optional execution target the adapter should probe for quota.
+   *
+   * If omitted (or `null`), the adapter probes the Paperclip host, the same as
+   * before this argument existed. A remote (SSH/sandbox) target tells the
+   * adapter to probe quota inside that environment so the result reflects what
+   * an agent run would see there. This context object mirrors the
+   * `AdapterEnvironmentTestContext` shape so later fields can extend it.
+   */
+  executionTarget?: AdapterExecutionTarget | null;
+}
+
 // ---------------------------------------------------------------------------
 // Adapter config schema — declarative UI config for external adapters
 // ---------------------------------------------------------------------------
@@ -450,8 +464,11 @@ export interface ServerAdapterModule {
    * Optional: fetch live provider quota/rate-limit windows for this adapter.
    * Returns a ProviderQuotaResult so the server can aggregate across adapters
    * without knowing provider-specific credential paths or API shapes.
+   *
+   * The optional context carries an execution target. An absent context (or a
+   * `null` executionTarget) probes the Paperclip host.
    */
-  getQuotaWindows?: () => Promise<ProviderQuotaResult>;
+  getQuotaWindows?: (ctx?: AdapterQuotaContext) => Promise<ProviderQuotaResult>;
   /**
    * Optional: detect the currently configured model from local config files.
    * Returns the detected model/provider and the config source, or null if

--- a/packages/adapters/claude-local/src/server/quota.execution-target.test.ts
+++ b/packages/adapters/claude-local/src/server/quota.execution-target.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AdapterQuotaContext } from "@paperclipai/adapter-utils";
+import { getQuotaWindows } from "./quota.js";
+
+describe("getQuotaWindows execution-target context", () => {
+  let previousBedrock: string | undefined;
+
+  beforeEach(() => {
+    // Force the Bedrock short-circuit so the host probe is deterministic. This
+    // path needs no network, no config files, and no Claude CLI. Both call
+    // shapes must return this same host result.
+    previousBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+  });
+
+  afterEach(() => {
+    if (previousBedrock === undefined) {
+      delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    } else {
+      process.env.CLAUDE_CODE_USE_BEDROCK = previousBedrock;
+    }
+  });
+
+  it("accepts an optional context and keeps the host result for a null target", async () => {
+    const hostResult = await getQuotaWindows();
+    const nullTargetResult = await getQuotaWindows({ executionTarget: null });
+
+    expect(nullTargetResult).toEqual(hostResult);
+    expect(hostResult).toEqual({
+      provider: "anthropic",
+      source: "bedrock",
+      ok: true,
+      windows: [],
+    });
+  });
+
+  it("accepts both the absent and the null-target call shapes", async () => {
+    // The type must accept a call with no argument and a call with an explicit
+    // context object.
+    const ctx: AdapterQuotaContext = { executionTarget: null };
+    await expect(getQuotaWindows()).resolves.toBeDefined();
+    await expect(getQuotaWindows(ctx)).resolves.toBeDefined();
+  });
+});

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { ProviderQuotaResult, QuotaWindow } from "@paperclipai/adapter-utils";
+import type { AdapterQuotaContext, ProviderQuotaResult, QuotaWindow } from "@paperclipai/adapter-utils";
 
 const execFileAsync = promisify(execFile);
 
@@ -478,7 +478,10 @@ function formatProviderError(source: string, error: unknown): string {
   return `${source}: ${message}`;
 }
 
-export async function getQuotaWindows(): Promise<ProviderQuotaResult> {
+// The `_ctx` execution target is accepted for the environment-aware quota
+// contract but not yet consumed. An absent context or a `null` executionTarget
+// keeps the host probe below. Remote-target probing lands in a later change.
+export async function getQuotaWindows(_ctx?: AdapterQuotaContext): Promise<ProviderQuotaResult> {
   if (
     process.env.CLAUDE_CODE_USE_BEDROCK === "1" ||
     process.env.CLAUDE_CODE_USE_BEDROCK === "true" ||

--- a/packages/adapters/codex-local/src/server/quota.execution-target.test.ts
+++ b/packages/adapters/codex-local/src/server/quota.execution-target.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSpawn } = vi.hoisted(() => ({ mockSpawn: vi.fn() }));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const cp = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...cp,
+    spawn: (...args: Parameters<typeof cp.spawn>) => mockSpawn(...args) as ReturnType<typeof cp.spawn>,
+  };
+});
+
+import type { AdapterQuotaContext } from "@paperclipai/adapter-utils";
+import { getQuotaWindows } from "./quota.js";
+
+function createChildThatErrorsOnMicrotask(err: Error): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  const stream = Object.assign(new EventEmitter(), { setEncoding: () => {} });
+  Object.assign(child, {
+    stdout: stream,
+    stderr: Object.assign(new EventEmitter(), { setEncoding: () => {} }),
+    stdin: { write: vi.fn(), end: vi.fn() },
+    kill: vi.fn(),
+  });
+  queueMicrotask(() => {
+    child.emit("error", err);
+  });
+  return child;
+}
+
+describe("getQuotaWindows execution-target context", () => {
+  let previousCodexHome: string | undefined;
+  let isolatedCodexHome: string | undefined;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    // Force a deterministic host probe with no network. The app-server spawn
+    // errors and CODEX_HOME points at an empty directory, so there is no auth
+    // token. Both call shapes must return this same host result.
+    mockSpawn.mockImplementation(() =>
+      createChildThatErrorsOnMicrotask(new Error("spawn codex ENOENT")),
+    );
+    previousCodexHome = process.env.CODEX_HOME;
+    isolatedCodexHome = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-codex-quota-target-test-"));
+    process.env.CODEX_HOME = isolatedCodexHome;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (isolatedCodexHome) {
+      try {
+        fs.rmSync(isolatedCodexHome, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+      isolatedCodexHome = undefined;
+    }
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
+  it("accepts an optional context and keeps the host result for a null target", async () => {
+    const hostResult = await getQuotaWindows();
+    const nullTargetResult = await getQuotaWindows({ executionTarget: null });
+
+    expect(nullTargetResult).toEqual(hostResult);
+    expect(hostResult.ok).toBe(false);
+    expect(hostResult.provider).toBe("openai");
+  });
+
+  it("accepts both the absent and the null-target call shapes", async () => {
+    // The type must accept a call with no argument and a call with an explicit
+    // context object.
+    const ctx: AdapterQuotaContext = { executionTarget: null };
+    await expect(getQuotaWindows()).resolves.toBeDefined();
+    await expect(getQuotaWindows(ctx)).resolves.toBeDefined();
+  });
+});

--- a/packages/adapters/codex-local/src/server/quota.ts
+++ b/packages/adapters/codex-local/src/server/quota.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { ProviderQuotaResult, QuotaWindow } from "@paperclipai/adapter-utils";
+import type { AdapterQuotaContext, ProviderQuotaResult, QuotaWindow } from "@paperclipai/adapter-utils";
 import {
   classifyCodexAuthRefreshFailure,
   type CodexAuthRefreshFailureClass,
@@ -597,7 +597,10 @@ export function readCodexQuotaErrorFamily(error: unknown): CodexAuthRefreshFailu
   return classifyCodexAuthRefreshFailure({ errorMessage: message });
 }
 
-export async function getQuotaWindows(): Promise<ProviderQuotaResult> {
+// The `_ctx` execution target is accepted for the environment-aware quota
+// contract but not yet consumed. An absent context or a `null` executionTarget
+// keeps the host probe below. Remote-target probing lands in a later change.
+export async function getQuotaWindows(_ctx?: AdapterQuotaContext): Promise<ProviderQuotaResult> {
   const errors: string[] = [];
   let rpcErrorFamily: CodexAuthRefreshFailureClass | null = null;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Adapter contracts define what every provider must accept
> - Quota lookups need an execution-target-aware context before later phases can route a target through the adapter layer
> - The current contract accepts no optional context argument
> - This pull request widens the contract in a backward-compatible way and keeps the host probe for an absent or null target
> - The benefit is a stable phase-1 contract for later environment-aware quota work without changing current runtime behavior

## Linked Issues or Issue Description

### Subsystem affected
packages/adapters — agent adapter implementations

### Problem or motivation
The adapter quota contract cannot yet accept execution-target context. Current callers do not pass a target, but later phases need a stable optional context shape first.

### Proposed solution
Add AdapterQuotaContext with an optional executionTarget field. Extend getQuotaWindows to accept one optional context argument. Keep the host probe path for an absent or null target.

### Alternatives considered
Change the call sites first. Rejected because the contract must exist before later phases can route execution-target data through it.

### Roadmap alignment
I reviewed ROADMAP.md and did not find a direct overlap that blocks this adapter-contract phase.

### Additional context
This PR is draft. Later phases will extend the same remote branch with follow-up commits for the remaining quota work.

## What Changed

- Added AdapterQuotaContext with an optional executionTarget field.
- Extended the getQuotaWindows contract to accept one optional context argument.
- Updated claude-local and codex-local to accept the context and keep the host probe for absent or null executionTarget values.
- Added regression tests for the absent and null-target call shapes.

## Verification

- `tsc --noEmit` passed for adapter-utils, claude-local, and codex-local.
- Adapter server unit tests passed: 296 tests.
- New focused tests passed for `getQuotaWindows()` and `getQuotaWindows({ executionTarget: null })`.
- `git log --oneline origin/master..HEAD` shows one expected commit.

## Risks

- Low risk. The change is backward compatible for current callers.
- The new context argument only widens the accepted contract. It does not change current host-probe behavior.

## Model Used

- OpenAI Codex, GPT-5, tool-use capable.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge