### PR TITLE
fix(heartbeat): stop propagating stale workspaceId for projectless runs

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -287,6 +287,48 @@ describe("assertGitSensitiveAdapterWorkspaceValid", () => {
     );
   });
 
+  it("does not require a persisted execution workspace for a projectless issue carrying a stale resolvedWorkspace.workspaceId", async () => {
+    // RENA-54683: resolveAnchorWorkspaceForRun's task_session branch used to propagate
+    // workspaceId from an earlier, project-bound session even when no project resolves for the
+    // current run. executionWorkspacesSvc.create() is unconditionally skipped without a project,
+    // so requiring persistence here was unsatisfiable by construction and killed every such run
+    // with missing_persisted_execution_workspace. A stale workspaceId with no backing project
+    // must not raise the workspace expectation.
+    await expect(
+      assertGitSensitiveAdapterWorkspaceValid(
+        buildWorkspaceValidationInput({
+          issue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            projectId: null,
+            projectWorkspaceId: null,
+          },
+          resolvedWorkspace: buildResolvedWorkspace({
+            source: "task_session",
+            projectId: null,
+            workspaceId: "workspace-from-stale-session",
+          }),
+          executionWorkspace: {
+            baseCwd: "/tmp/task-session-cwd",
+            source: "task_session",
+            projectId: null,
+            workspaceId: "workspace-from-stale-session",
+            repoUrl: null,
+            repoRef: null,
+            strategy: "project_primary",
+            cwd: "/tmp/task-session-cwd",
+            branchName: null,
+            worktreePath: null,
+            warnings: [],
+            created: false,
+            baseRefSha: null,
+          },
+          persistedExecutionWorkspace: null,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it("rejects a workspace-linked issue when no effective adapter cwd was resolved", async () => {
     const input = buildWorkspaceValidationInput();
 
@@ -439,6 +481,49 @@ describe("assertGitSensitiveAdapterWorkspaceValid", () => {
       "missing_git_metadata",
       "has no .git metadata",
     );
+  });
+
+  it("does not require a persisted execution workspace for a stale workspaceId inherited from an earlier, project-bound session when no project backs the current run", async () => {
+    // Regression for RENA-54683: resolveAnchorWorkspaceForRun's task_session branch used to
+    // propagate previousSessionParams.workspaceId verbatim even when the current run resolved no
+    // project. That stale id made workspaceExpectation true here even though
+    // executionWorkspacesSvc.create() is skipped whenever no project backs the run, so
+    // persistedExecutionWorkspace could never be non-null — an unconditional false positive.
+    await expect(
+      assertGitSensitiveAdapterWorkspaceValid(
+        buildWorkspaceValidationInput({
+          issue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            projectId: null,
+            projectWorkspaceId: null,
+          },
+          resolvedWorkspace: buildResolvedWorkspace({
+            source: "task_session",
+            projectId: null,
+            // Stale id from an earlier, project-bound session of the same issue.
+            workspaceId: "workspace-1",
+            cwd: "/tmp/task-session-cwd",
+          }),
+          executionWorkspace: {
+            baseCwd: "/tmp/task-session-cwd",
+            source: "task_session",
+            projectId: null,
+            workspaceId: "workspace-1",
+            repoUrl: null,
+            repoRef: null,
+            strategy: "project_primary",
+            cwd: "/tmp/task-session-cwd",
+            branchName: null,
+            worktreePath: null,
+            warnings: [],
+            created: false,
+            baseRefSha: null,
+          },
+          persistedExecutionWorkspace: null,
+        }),
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("does not apply the git-sensitive workspace guard to non-local execution targets", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2014,7 +2014,11 @@ export async function assertGitSensitiveAdapterWorkspaceValid(input: {
   const agentFallbackCwd = resolveDefaultAgentWorkspaceDir(input.agentId);
   const workspaceExpectation =
     Boolean(issue.projectWorkspaceId) ||
-    Boolean(input.resolvedWorkspace.workspaceId) ||
+    // A resolvedWorkspace.workspaceId only implies a persistable execution workspace when a
+    // project actually backs the run. Without one, executionWorkspacesSvc.create() is skipped
+    // unconditionally (resolvedProjectId is null), so requiring persistence here would be
+    // unsatisfiable by construction — see resolveAnchorWorkspaceForRun's task_session branch.
+    (Boolean(input.resolvedWorkspace.workspaceId) && Boolean(input.resolvedWorkspace.projectId)) ||
     input.executionWorkspace.strategy === "git_worktree";
 
   const fail = (reason: string, message: string, extra: Record<string, unknown> = {}) => {
@@ -8585,13 +8589,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .then((stats) => stats.isDirectory())
         .catch(() => false);
       if (sessionCwdExists) {
+        // No project resolved for this run means no execution_workspace can ever be
+        // persisted for it (see the resolvedProjectId gate around executionWorkspacesSvc.create
+        // below in the caller). A workspaceId/repoUrl/repoRef inherited here from an earlier,
+        // project-bound session of the same task is therefore orphaned and would make
+        // assertGitSensitiveAdapterWorkspaceValid's workspaceExpectation fire without anything
+        // ever being persisted to satisfy it. Only propagate these when a project still backs
+        // the current run.
         return {
           cwd: sessionCwd,
           source: "task_session" as const,
           projectId: resolvedProjectId,
-          workspaceId: readNonEmptyString(previousSessionParams?.workspaceId),
-          repoUrl: readNonEmptyString(previousSessionParams?.repoUrl),
-          repoRef: readNonEmptyString(previousSessionParams?.repoRef),
+          workspaceId: resolvedProjectId ? readNonEmptyString(previousSessionParams?.workspaceId) : null,
+          repoUrl: resolvedProjectId ? readNonEmptyString(previousSessionParams?.repoUrl) : null,
+          repoRef: resolvedProjectId ? readNonEmptyString(previousSessionParams?.repoRef) : null,
           workspaceHints,
           warnings: [],
           baseCwdFallback: false,


### PR DESCRIPTION
## Summary
- `resolveAnchorWorkspaceForRun`'s `task_session` branch (server/src/services/heartbeat.ts) inherited `workspaceId`/`repoUrl`/`repoRef` from `previousSessionParams` of an earlier, project-bound session even when the current run resolves no project. Since `executionWorkspacesSvc.create()` is unconditionally skipped when no project backs the run, that stale `workspaceId` made `assertGitSensitiveAdapterWorkspaceValid`'s `workspaceExpectation` trip without anything ever being persisted to satisfy it — killing runs ~6s before adapter start with `missing_persisted_execution_workspace`, no auto-retry.
- Root fix: only propagate `workspaceId`/`repoUrl`/`repoRef` from `previousSessionParams` in the `task_session` branch when a project (`resolvedProjectId`) still backs the current run.
- Safety net: `workspaceExpectation` in `assertGitSensitiveAdapterWorkspaceValid` now only trusts `resolvedWorkspace.workspaceId` when a `resolvedWorkspace.projectId` backs it too, closing the same trap for other entry points (e.g. `explicitResumeSessionParams`).

Fixes RENA-54683 (separate code path from RENA-54552, which only touches `projects.ts` `createWorkspace()` / git-init for `project_workspaces`).

## Test plan
- [x] Added regression test in `server/src/__tests__/heartbeat-workspace-session.test.ts`: issue with no `projectId`, `resolvedWorkspace` sourced from `task_session` with a stale `workspaceId` and no `projectId` → `assertGitSensitiveAdapterWorkspaceValid` resolves instead of throwing `missing_persisted_execution_workspace`.
- [x] `vitest run src/__tests__/heartbeat-workspace-session.test.ts` — 136 passed
- [x] `vitest run src/__tests__/execution-workspace-policy.test.ts src/__tests__/environment-run-orchestrator.test.ts` — 26 passed
- [x] `pnpm run typecheck` (server package) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)