### PR TITLE
feat(heartbeat): block process adapters from auto-claiming locked issues awaiting human action

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -225,6 +225,11 @@ import {
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import {
+  checkProcessAdapterAutoAssignmentConstraint,
+  PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON,
+  resolveHumanActionLockRestrictedAdapterTypes,
+} from "./process-adapter-assignment-constraints.js";
+import {
   recoveryAssigneeAdapterOverrides,
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
@@ -12367,6 +12372,71 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         );
         return null;
       }
+
+      const restrictedAdapterTypes = resolveHumanActionLockRestrictedAdapterTypes();
+      if (restrictedAdapterTypes.has(agent.adapterType)) {
+        const lockState = await db
+          .select({
+            executionLockedAt: issues.executionLockedAt,
+            executionRunId: issues.executionRunId,
+          })
+          .from(issues)
+          .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+          .then((rows) => rows[0] ?? null);
+
+        if (lockState?.executionLockedAt) {
+          const [pendingInteraction, pendingApproval] = await Promise.all([
+            db
+              .select({ id: issueThreadInteractions.id })
+              .from(issueThreadInteractions)
+              .where(
+                and(
+                  eq(issueThreadInteractions.companyId, run.companyId),
+                  eq(issueThreadInteractions.issueId, issueId),
+                  eq(issueThreadInteractions.status, "pending"),
+                ),
+              )
+              .limit(1)
+              .then((rows) => rows[0] ?? null),
+            db
+              .select({ id: issueApprovals.approvalId })
+              .from(issueApprovals)
+              .innerJoin(approvals, eq(issueApprovals.approvalId, approvals.id))
+              .where(
+                and(
+                  eq(issueApprovals.companyId, run.companyId),
+                  eq(issueApprovals.issueId, issueId),
+                  inArray(approvals.status, ["pending", "revision_requested"]),
+                ),
+              )
+              .limit(1)
+              .then((rows) => rows[0] ?? null),
+          ]);
+
+          const constraintResult = checkProcessAdapterAutoAssignmentConstraint({
+            adapterType: agent.adapterType,
+            currentRunId: run.id,
+            executionLockedAt: lockState.executionLockedAt,
+            executionLockRunId: lockState.executionRunId,
+            hasPendingHumanAction: Boolean(pendingInteraction || pendingApproval),
+            restrictedAdapterTypes,
+          });
+
+          if (!constraintResult.allowed) {
+            await cancelQueuedRunForProcessAdapterHumanActionLock(run, issueId, {
+              adapterType: agent.adapterType,
+              executionLockedAt: lockState.executionLockedAt,
+              pendingInteractionId: pendingInteraction?.id ?? null,
+              pendingApprovalId: pendingApproval?.id ?? null,
+            });
+            logger.info(
+              { runId: run.id, issueId, agentId: run.agentId, adapterType: agent.adapterType },
+              "claimQueuedRun: rejected process adapter auto-assignment to issue locked and awaiting human action",
+            );
+            return null;
+          }
+        }
+      }
     }
 
     const claimedAt = new Date();
@@ -12490,6 +12560,59 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       payload: {
         issueId,
         unresolvedBlockerIssueIds,
+      },
+    });
+
+    return cancelled;
+  }
+
+  async function cancelQueuedRunForProcessAdapterHumanActionLock(
+    run: typeof heartbeatRuns.$inferSelect,
+    issueId: string,
+    details: {
+      adapterType: string;
+      executionLockedAt: Date | string;
+      pendingInteractionId: string | null;
+      pendingApprovalId: string | null;
+    },
+  ) {
+    const now = new Date();
+    const reason =
+      `Cancelled because ${details.adapterType} adapters are restricted from auto-claiming an issue ` +
+      "that is execution-locked by another run and awaiting human action";
+    const cancelled = await setRunStatus(run.id, "cancelled", {
+      finishedAt: now,
+      error: reason,
+      errorCode: PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON,
+      resultJson: {
+        ...parseObject(run.resultJson),
+        stopReason: PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON,
+        effectiveTimeoutSec: 0,
+        timeoutConfigured: false,
+        timeoutSource: "human_action_lock_gate",
+        timeoutFired: false,
+      },
+    });
+    if (!cancelled) return null;
+
+    // This run never owned the issue's execution lock (it belongs to a different, still-running
+    // run), so unlike cancelQueuedRunForBlockedDependencies above, the lock must not be cleared here.
+    await setWakeupStatus(run.wakeupRequestId, "skipped", {
+      finishedAt: now,
+      error: reason,
+    });
+
+    await appendRunEvent(cancelled, await nextRunEventSeq(cancelled.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message: reason,
+      payload: {
+        issueId,
+        adapterType: details.adapterType,
+        executionLockedAt: new Date(details.executionLockedAt).toISOString(),
+        pendingInteractionId: details.pendingInteractionId,
+        pendingApprovalId: details.pendingApprovalId,
       },
     });
 

--- a/server/src/services/process-adapter-assignment-constraints.test.ts
+++ b/server/src/services/process-adapter-assignment-constraints.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HUMAN_ACTION_LOCK_RESTRICTED_ADAPTER_TYPES,
+  PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON,
+  checkProcessAdapterAutoAssignmentConstraint,
+  resolveHumanActionLockRestrictedAdapterTypes,
+} from "./process-adapter-assignment-constraints.js";
+
+const baseInput = {
+  adapterType: "process",
+  currentRunId: "run-current",
+  executionLockedAt: new Date("2026-08-05T00:00:00Z"),
+  executionLockRunId: "run-other",
+  hasPendingHumanAction: true,
+};
+
+describe("checkProcessAdapterAutoAssignmentConstraint", () => {
+  it("blocks a process adapter from claiming an issue locked by another run and awaiting human action", () => {
+    const result = checkProcessAdapterAutoAssignmentConstraint(baseInput);
+    expect(result).toEqual({
+      allowed: false,
+      reason: PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON,
+      adapterType: "process",
+    });
+  });
+
+  it("allows an adapter type that is not in the restricted set", () => {
+    const result = checkProcessAdapterAutoAssignmentConstraint({
+      ...baseInput,
+      adapterType: "claude_local",
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("allows claiming when the issue is not execution-locked", () => {
+    const result = checkProcessAdapterAutoAssignmentConstraint({
+      ...baseInput,
+      executionLockedAt: null,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("allows a run to reclaim the execution lock it already owns", () => {
+    const result = checkProcessAdapterAutoAssignmentConstraint({
+      ...baseInput,
+      executionLockRunId: "run-current",
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("allows claiming a locked issue when there is no pending human action", () => {
+    const result = checkProcessAdapterAutoAssignmentConstraint({
+      ...baseInput,
+      hasPendingHumanAction: false,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("respects an explicitly passed restrictedAdapterTypes set", () => {
+    const blocked = checkProcessAdapterAutoAssignmentConstraint({
+      ...baseInput,
+      adapterType: "codex_local",
+      restrictedAdapterTypes: new Set(["codex_local"]),
+    });
+    expect(blocked.allowed).toBe(false);
+
+    const allowed = checkProcessAdapterAutoAssignmentConstraint({
+      ...baseInput,
+      adapterType: "process",
+      restrictedAdapterTypes: new Set(["codex_local"]),
+    });
+    expect(allowed).toEqual({ allowed: true });
+  });
+});
+
+describe("resolveHumanActionLockRestrictedAdapterTypes", () => {
+  it("defaults to the process adapter type when unconfigured", () => {
+    expect(resolveHumanActionLockRestrictedAdapterTypes({})).toEqual(
+      new Set(DEFAULT_HUMAN_ACTION_LOCK_RESTRICTED_ADAPTER_TYPES),
+    );
+  });
+
+  it("parses a comma-separated env override", () => {
+    expect(
+      resolveHumanActionLockRestrictedAdapterTypes({
+        PROCESS_ADAPTER_AUTO_ASSIGNMENT_RESTRICTED_TYPES: "process, codex_local ,claude_local",
+      }),
+    ).toEqual(new Set(["process", "codex_local", "claude_local"]));
+  });
+
+  it("falls back to the default when the env override is blank", () => {
+    expect(
+      resolveHumanActionLockRestrictedAdapterTypes({
+        PROCESS_ADAPTER_AUTO_ASSIGNMENT_RESTRICTED_TYPES: "  , ,",
+      }),
+    ).toEqual(new Set(DEFAULT_HUMAN_ACTION_LOCK_RESTRICTED_ADAPTER_TYPES));
+  });
+});

--- a/server/src/services/process-adapter-assignment-constraints.ts
+++ b/server/src/services/process-adapter-assignment-constraints.ts
@@ -1,0 +1,76 @@
+// RENA-1628: prevent process adapters from auto-claiming a queued run for an issue that is
+// currently execution-locked by a different run and is waiting on a human (a pending thread
+// interaction or a pending/revision-requested approval). Without this gate, a process adapter
+// (the default local adapter that shells out to an agent-configured command) can pile onto an
+// issue mid human-in-the-loop review instead of leaving it for the human to unblock.
+
+export const PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON =
+  "process_adapter_human_action_lock_blocked";
+
+export const DEFAULT_HUMAN_ACTION_LOCK_RESTRICTED_ADAPTER_TYPES = ["process"] as const;
+
+const RESTRICTED_ADAPTER_TYPES_ENV_KEY = "PROCESS_ADAPTER_AUTO_ASSIGNMENT_RESTRICTED_TYPES";
+
+/**
+ * Adapter types subject to the locked+human-action auto-assignment constraint. Defaults to just
+ * "process", but is overridable via PROCESS_ADAPTER_AUTO_ASSIGNMENT_RESTRICTED_TYPES (a
+ * comma-separated list) so the restriction can be widened/narrowed without a deploy.
+ */
+export function resolveHumanActionLockRestrictedAdapterTypes(
+  env: Record<string, string | undefined> = process.env,
+): Set<string> {
+  const configured = env[RESTRICTED_ADAPTER_TYPES_ENV_KEY];
+  if (!configured) return new Set(DEFAULT_HUMAN_ACTION_LOCK_RESTRICTED_ADAPTER_TYPES);
+  const types = configured
+    .split(",")
+    .map((type) => type.trim())
+    .filter((type) => type.length > 0);
+  return types.length > 0 ? new Set(types) : new Set(DEFAULT_HUMAN_ACTION_LOCK_RESTRICTED_ADAPTER_TYPES);
+}
+
+export type ProcessAdapterAutoAssignmentConstraintInput = {
+  adapterType: string;
+  /** The run attempting to claim the queued work. */
+  currentRunId: string;
+  /** The issue's current execution lock timestamp, if any. */
+  executionLockedAt: Date | string | null;
+  /** The run id that currently owns the issue's execution lock, if any. */
+  executionLockRunId: string | null;
+  /** Whether the issue has a pending thread interaction or a pending/revision-requested approval. */
+  hasPendingHumanAction: boolean;
+  restrictedAdapterTypes?: Set<string>;
+};
+
+export type ProcessAdapterAutoAssignmentConstraintResult =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: typeof PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON;
+      adapterType: string;
+    };
+
+/**
+ * Pure decision function: given the facts about a queued run's target issue, decide whether a
+ * process (or otherwise restricted) adapter may claim it. Kept free of DB access so it can be
+ * unit tested directly; callers are responsible for fetching executionLockedAt/executionRunId
+ * and pending-interaction/approval state before calling this.
+ */
+export function checkProcessAdapterAutoAssignmentConstraint(
+  input: ProcessAdapterAutoAssignmentConstraintInput,
+): ProcessAdapterAutoAssignmentConstraintResult {
+  const restrictedAdapterTypes =
+    input.restrictedAdapterTypes ?? resolveHumanActionLockRestrictedAdapterTypes();
+  if (!restrictedAdapterTypes.has(input.adapterType)) return { allowed: true };
+  if (!input.executionLockedAt) return { allowed: true };
+  // A run reclaiming the lock it already holds (retry/resume) isn't a foreign lock — allow it.
+  if (input.executionLockRunId && input.executionLockRunId === input.currentRunId) {
+    return { allowed: true };
+  }
+  if (!input.hasPendingHumanAction) return { allowed: true };
+
+  return {
+    allowed: false,
+    reason: PROCESS_ADAPTER_HUMAN_ACTION_LOCK_BLOCKED_REASON,
+    adapterType: input.adapterType,
+  };
+}


### PR DESCRIPTION
## Summary
- RENA-1628 (Phase 2, child of RENA-1626): add constraint validation so process adapters cannot auto-claim a queued run for an issue that another run is currently execution-locking while it is awaiting human action (a pending thread interaction or a pending/revision-requested approval).
- New standalone, DB-free module `server/src/services/process-adapter-assignment-constraints.ts` exports `checkProcessAdapterAutoAssignmentConstraint` (pure decision function) and `resolveHumanActionLockRestrictedAdapterTypes` (config, defaults to `["process"]`, overridable via `PROCESS_ADAPTER_AUTO_ASSIGNMENT_RESTRICTED_TYPES`, comma-separated).
- Wired into `claimQueuedRun` in `server/src/services/heartbeat.ts`: when the target agent's adapter type is restricted, it fetches the issue's `executionLockedAt`/`executionRunId` plus pending-interaction/pending-approval state and runs the constraint check before claiming. Rejections cancel the run via a new `cancelQueuedRunForProcessAdapterHumanActionLock` helper (mirroring the existing `cancelQueuedRunForBlockedDependencies` pattern) which logs a structured `lifecycle` run event (issueId, adapterType, executionLockedAt, pendingInteractionId, pendingApprovalId) plus a `logger.info` line for observability.
- A run reclaiming a lock it already owns (retry/resume) is explicitly allowed — only a *foreign* lock plus pending human action blocks the claim.

## Test plan
- [x] `npx vitest run src/services/process-adapter-assignment-constraints.test.ts` — 9/9 passed (new unit tests: restricted/unrestricted adapter types, no lock, same-run reclaim, no pending human action, explicit restricted-set override, env-var parsing incl. blank/whitespace fallback).
- [x] `npx vitest run src/__tests__/heartbeat-workspace-session.test.ts` — 134/134 passed (regression check on heartbeat.ts).
- [x] `npx vitest run src/__tests__/adapter-routes.test.ts` — 13/13 passed (regression check on adapter routing).
- [x] `npx tsc --noEmit` (server package) — no new errors in either changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
