### PR TITLE
fix: release work assigned to terminated agents

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,6 +35,7 @@ export {
   ensureLinuxSharedLibraryAliases,
   prepareEmbeddedPostgresNativeRuntime,
 } from "./embedded-postgres-native.js";
+export { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 export { issueRelations } from "./schema/issue_relations.js";
 export { issueReferenceMentions } from "./schema/issue_reference_mentions.js";
 export * from "./schema/index.js";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -35,7 +35,7 @@ export {
   ensureLinuxSharedLibraryAliases,
   prepareEmbeddedPostgresNativeRuntime,
 } from "./embedded-postgres-native.js";
-export { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
+export { and, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 export { issueRelations } from "./schema/issue_relations.js";
 export { issueReferenceMentions } from "./schema/issue_reference_mentions.js";
 export * from "./schema/index.js";

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -1,5 +1,4 @@
-import { and, eq, inArray, isNotNull, isNull, or, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
-import { sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, or, sql, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
 import { isAgentAssignableToWork } from "../packages/shared/src/agent-eligibility.js";
 import { loadConfig } from "../server/src/config.js";
 

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -1,0 +1,92 @@
+import { and, eq, inArray, isNotNull, isNull, or, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
+import { isAgentStatusAssignableToWork } from "../packages/shared/src/agent-eligibility.js";
+import { loadConfig } from "../server/src/config.js";
+
+const OPEN_ISSUE_STATUSES = ["todo", "in_progress", "in_review", "blocked"] as const;
+
+function parseFlag(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  const value = index < 0 ? null : process.argv[index + 1];
+  return value && !value.startsWith("--") ? value : null;
+}
+
+async function main() {
+  const config = loadConfig();
+  const dbUrl = process.env.DATABASE_URL?.trim()
+    || config.databaseUrl
+    || `postgres://paperclip:paperclip@127.0.0.1:${config.embeddedPostgresPort}/paperclip`;
+  const companyId = parseFlag("--company");
+  const dryRun = process.argv.includes("--dry-run");
+  const db = createDb(dbUrl);
+  const companyRows = companyId ? [{ id: companyId }] : await db.select({ id: companies.id }).from(companies);
+
+  let beforeCount = 0;
+  let releasedToManager = 0;
+  let releasedToQueue = 0;
+
+  for (const company of companyRows) {
+    const candidates = await db.select({
+      issueId: issues.id,
+      assigneeAgentId: issues.assigneeAgentId,
+      assigneeStatus: agents.status,
+      managerId: agents.reportsTo,
+    }).from(issues).leftJoin(agents, eq(issues.assigneeAgentId, agents.id)).where(and(
+      eq(issues.companyId, company.id),
+      inArray(issues.status, OPEN_ISSUE_STATUSES),
+      isNotNull(issues.assigneeAgentId),
+      or(eq(agents.status, "terminated"), isNull(agents.id)),
+    ));
+
+    beforeCount += candidates.length;
+    for (const candidate of candidates) {
+      const manager = candidate.managerId
+        ? await db.select({ id: agents.id, status: agents.status }).from(agents)
+          .where(and(eq(agents.id, candidate.managerId), eq(agents.companyId, company.id)))
+          .then((rows) => rows[0] ?? null)
+        : null;
+      const assigneeAgentId = manager && isAgentStatusAssignableToWork(manager.status) ? manager.id : null;
+      if (assigneeAgentId) releasedToManager += 1;
+      else releasedToQueue += 1;
+      if (dryRun) continue;
+
+      await db.transaction(async (tx) => {
+        await tx.update(issues).set({ assigneeAgentId, updatedAt: new Date() })
+          .where(and(eq(issues.id, candidate.issueId), eq(issues.companyId, company.id)));
+        await tx.insert(issueComments).values({
+          companyId: company.id,
+          issueId: candidate.issueId,
+          authorType: "system",
+          body: assigneeAgentId
+            ? `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${candidate.assigneeStatus === "terminated" ? "agent was terminated" : "source agent is missing"}; reassigned to its manager.`
+            : `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${candidate.assigneeStatus === "terminated" ? "agent was terminated" : "source agent is missing"}; moved to the unassigned queue.`,
+        });
+      });
+    }
+  }
+
+  let afterCount = beforeCount;
+  if (!dryRun) {
+    afterCount = 0;
+    for (const company of companyRows) {
+      const remaining = await db.select({ issueId: issues.id }).from(issues)
+        .leftJoin(agents, eq(issues.assigneeAgentId, agents.id)).where(and(
+          eq(issues.companyId, company.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNotNull(issues.assigneeAgentId),
+          or(eq(agents.status, "terminated"), isNull(agents.id)),
+        ));
+      afterCount += remaining.length;
+    }
+  }
+  console.log(`${dryRun ? "Dry run: " : ""}terminated-assignee backfill counts`);
+  console.log(`before=${beforeCount}`);
+  console.log(`released_to_manager=${releasedToManager}`);
+  console.log(`released_to_unassigned_queue=${releasedToQueue}`);
+  console.log(`after=${afterCount}`);
+  await db.$client.end({ timeout: 1 });
+}
+
+void main().catch((error) => {
+  console.error(`Terminated-assignee backfill failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -35,7 +35,6 @@ async function main() {
     const candidates = await db.select({
       issueId: issues.id,
       assigneeAgentId: issues.assigneeAgentId,
-      assigneeStatus: agents.status,
       managerId: agents.reportsTo,
     }).from(issues).leftJoin(agents, eq(issues.assigneeAgentId, agents.id)).where(and(
       eq(issues.companyId, company.id),
@@ -57,7 +56,29 @@ async function main() {
       }
 
       await db.transaction(async (tx) => {
-        const released = await tx.update(issues).set({ assigneeAgentId, updatedAt: new Date() })
+        // Re-read the lifecycle graph inside the transaction. A long-running
+        // backfill must not assign work to a manager that was terminated or
+        // made ineligible after the initial candidate scan.
+        const currentAgents = await tx.select({
+          id: agents.id,
+          companyId: agents.companyId,
+          name: agents.name,
+          status: agents.status,
+          reportsTo: agents.reportsTo,
+        }).from(agents).where(eq(agents.companyId, company.id));
+        const source = currentAgents.find((agent) => agent.id === candidate.assigneeAgentId) ?? null;
+        if (source && source.status !== "terminated") return;
+        const releaseReason = source ? "agent was terminated" : "source agent is missing";
+        const currentManager = source?.reportsTo
+          ? currentAgents.find((agent) => agent.id === source.reportsTo) ?? null
+          : null;
+        const currentAssigneeAgentId = currentManager && isAgentAssignableToWork({
+          agent: currentManager,
+          agents: currentAgents,
+        })
+          ? currentManager.id
+          : null;
+        const released = await tx.update(issues).set({ assigneeAgentId: currentAssigneeAgentId, updatedAt: new Date() })
           .where(and(
             eq(issues.id, candidate.issueId),
             eq(issues.companyId, company.id),
@@ -70,11 +91,11 @@ async function main() {
           companyId: company.id,
           issueId: candidate.issueId,
           authorType: "system",
-          body: assigneeAgentId
-            ? `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${candidate.assigneeStatus === "terminated" ? "agent was terminated" : "source agent is missing"}; reassigned to its manager.`
-            : `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${candidate.assigneeStatus === "terminated" ? "agent was terminated" : "source agent is missing"}; moved to the unassigned queue.`,
+          body: currentAssigneeAgentId
+            ? `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${releaseReason}; reassigned to its manager.`
+            : `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${releaseReason}; moved to the unassigned queue.`,
         });
-        if (assigneeAgentId) releasedToManager += 1;
+        if (currentAssigneeAgentId) releasedToManager += 1;
         else releasedToQueue += 1;
       });
     }

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -1,5 +1,5 @@
 import { and, eq, inArray, isNotNull, isNull, or, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
-import { isAgentStatusAssignableToWork } from "../packages/shared/src/agent-eligibility.js";
+import { isAgentAssignableToWork } from "../packages/shared/src/agent-eligibility.js";
 import { loadConfig } from "../server/src/config.js";
 
 const OPEN_ISSUE_STATUSES = ["todo", "in_progress", "in_review", "blocked"] as const;
@@ -25,6 +25,13 @@ async function main() {
   let releasedToQueue = 0;
 
   for (const company of companyRows) {
+    const companyAgents = await db.select({
+      id: agents.id,
+      companyId: agents.companyId,
+      name: agents.name,
+      status: agents.status,
+      reportsTo: agents.reportsTo,
+    }).from(agents).where(eq(agents.companyId, company.id));
     const candidates = await db.select({
       issueId: issues.id,
       assigneeAgentId: issues.assigneeAgentId,
@@ -40,18 +47,25 @@ async function main() {
     beforeCount += candidates.length;
     for (const candidate of candidates) {
       const manager = candidate.managerId
-        ? await db.select({ id: agents.id, status: agents.status }).from(agents)
-          .where(and(eq(agents.id, candidate.managerId), eq(agents.companyId, company.id)))
-          .then((rows) => rows[0] ?? null)
+        ? companyAgents.find((agent) => agent.id === candidate.managerId) ?? null
         : null;
-      const assigneeAgentId = manager && isAgentStatusAssignableToWork(manager.status) ? manager.id : null;
-      if (assigneeAgentId) releasedToManager += 1;
-      else releasedToQueue += 1;
-      if (dryRun) continue;
+      const assigneeAgentId = manager && isAgentAssignableToWork({ agent: manager, agents: companyAgents }) ? manager.id : null;
+      if (dryRun) {
+        if (assigneeAgentId) releasedToManager += 1;
+        else releasedToQueue += 1;
+        continue;
+      }
 
       await db.transaction(async (tx) => {
-        await tx.update(issues).set({ assigneeAgentId, updatedAt: new Date() })
-          .where(and(eq(issues.id, candidate.issueId), eq(issues.companyId, company.id)));
+        const released = await tx.update(issues).set({ assigneeAgentId, updatedAt: new Date() })
+          .where(and(
+            eq(issues.id, candidate.issueId),
+            eq(issues.companyId, company.id),
+            eq(issues.assigneeAgentId, candidate.assigneeAgentId!),
+            inArray(issues.status, OPEN_ISSUE_STATUSES),
+          ))
+          .returning({ id: issues.id });
+        if (released.length === 0) return;
         await tx.insert(issueComments).values({
           companyId: company.id,
           issueId: candidate.issueId,
@@ -60,6 +74,8 @@ async function main() {
             ? `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${candidate.assigneeStatus === "terminated" ? "agent was terminated" : "source agent is missing"}; reassigned to its manager.`
             : `System backfill: released an assignment from source agent ${candidate.assigneeAgentId}; reason: ${candidate.assigneeStatus === "terminated" ? "agent was terminated" : "source agent is missing"}; moved to the unassigned queue.`,
         });
+        if (assigneeAgentId) releasedToManager += 1;
+        else releasedToQueue += 1;
       });
     }
   }

--- a/scripts/backfill-terminated-assignee-locks.ts
+++ b/scripts/backfill-terminated-assignee-locks.ts
@@ -1,4 +1,5 @@
 import { and, eq, inArray, isNotNull, isNull, or, agents, companies, createDb, issueComments, issues } from "../packages/db/src/index.js";
+import { sql } from "drizzle-orm";
 import { isAgentAssignableToWork } from "../packages/shared/src/agent-eligibility.js";
 import { loadConfig } from "../server/src/config.js";
 
@@ -56,9 +57,12 @@ async function main() {
       }
 
       await db.transaction(async (tx) => {
-        // Re-read the lifecycle graph inside the transaction. A long-running
-        // backfill must not assign work to a manager that was terminated or
-        // made ineligible after the initial candidate scan.
+        // Serialize against terminate() before reading the graph. Re-reading
+        // without locks still permits a manager termination to commit between
+        // this check and the issue assignment below.
+        await tx.execute(
+          sql`select ${agents.id} from ${agents} where ${agents.companyId} = ${company.id} order by ${agents.id} for update`,
+        );
         const currentAgents = await tx.select({
           id: agents.id,
           companyId: agents.companyId,

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -320,6 +320,7 @@ describeEmbeddedPostgres("agent service clearError", () => {
 
   it("revalidates a manager terminated concurrently before releasing work", async () => {
     const companyId = randomUUID();
+    const replacementManagerId = randomUUID();
     const managerId = randomUUID();
     const terminatedAgentId = randomUUID();
     const openIssueId = randomUUID();
@@ -327,6 +328,7 @@ describeEmbeddedPostgres("agent service clearError", () => {
     const allowManagerTermination = deferred<void>();
     await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, requireBoardApprovalForNewAgents: false });
     await db.insert(agents).values([
+      { id: replacementManagerId, companyId, name: "Replacement manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
       { id: managerId, companyId, name: "Manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
       { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: managerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
     ]);
@@ -337,6 +339,7 @@ describeEmbeddedPostgres("agent service clearError", () => {
       managerLocked.resolve();
       await allowManagerTermination.promise;
       await tx.update(agents).set({ status: "terminated", updatedAt: new Date() }).where(eq(agents.id, managerId));
+      await tx.update(agents).set({ reportsTo: replacementManagerId, updatedAt: new Date() }).where(eq(agents.reportsTo, managerId));
     });
     await managerLocked.promise;
     const terminateSource = agentService(db).terminate(terminatedAgentId);
@@ -344,7 +347,7 @@ describeEmbeddedPostgres("agent service clearError", () => {
     await Promise.all([concurrentManagerTermination, terminateSource]);
 
     const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
-    expect(openIssue?.assigneeAgentId).toBeNull();
+    expect(openIssue?.assigneeAgentId).toBe(replacementManagerId);
   });
 
   it("releases open work to the unassigned queue when no assignable manager exists", async () => {

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -325,4 +325,28 @@ describeEmbeddedPostgres("agent service clearError", () => {
     expect(openIssue?.assigneeAgentId).toBeNull();
     expect(comments[0]).toMatchObject({ authorType: "system", body: `System: assignment released from source agent ${terminatedAgentId}; reason: agent was terminated; moved to the unassigned queue.` });
   });
+
+  it("moves work to the unassigned queue when the manager has an invalid reporting chain", async () => {
+    const companyId = randomUUID();
+    const terminatedAncestorId = randomUUID();
+    const invalidManagerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const directReportId = randomUUID();
+    const openIssueId = randomUUID();
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, requireBoardApprovalForNewAgents: false });
+    await db.insert(agents).values([
+      { id: terminatedAncestorId, companyId, name: "Terminated ancestor", role: "manager", status: "terminated", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: invalidManagerId, companyId, name: "Invalid manager", role: "manager", reportsTo: terminatedAncestorId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: invalidManagerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: directReportId, companyId, name: "Report", role: "engineer", reportsTo: terminatedAgentId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values({ id: openIssueId, companyId, title: "Open work", status: "in_progress", priority: "high", assigneeAgentId: terminatedAgentId });
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    const [directReport] = await db.select().from(agents).where(eq(agents.id, directReportId));
+    expect(openIssue?.assigneeAgentId).toBeNull();
+    expect(directReport?.reportsTo).toBeNull();
+  });
 });

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -1,22 +1,43 @@
 import { randomUUID } from "node:crypto";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { eq } from "drizzle-orm";
+import request from "supertest";
 import {
   agents,
   agentRuntimeState,
+  activityLog,
   companies,
   createDb,
   heartbeatRunEvents,
   heartbeatRuns,
+  issueComments,
+  issues,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { agentService } from "../services/agents.ts";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+vi.mock("../services/issue-assignment-wakeup.js", () => ({ queueIssueAssignmentWakeup: vi.fn() }));
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function issuePatchApp(db: ReturnType<typeof createDb>, companyId: string, agentId: string, runId: string) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = { type: "agent", agentId, companyId, runId, source: "agent_jwt" };
+    next();
+  });
+  app.use("/api", issueRoutes(db, {} as any));
+  app.use(errorHandler);
+  return app;
+}
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -34,9 +55,12 @@ describeEmbeddedPostgres("agent service clearError", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueComments);
     await db.delete(heartbeatRunEvents);
     await db.delete(agentRuntimeState);
+    await db.delete(activityLog);
     await db.delete(heartbeatRuns);
+    await db.delete(issues);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -234,5 +258,71 @@ describeEmbeddedPostgres("agent service clearError", () => {
       status: 409,
       message: "Pending approval agents cannot have errors cleared",
     });
+  });
+
+  it("releases open work to an assignable manager and detaches direct reports", async () => {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const directReportId = randomUUID();
+    const openIssueId = randomUUID();
+    const terminalIssueId = randomUUID();
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, requireBoardApprovalForNewAgents: false });
+    await db.insert(agents).values([
+      { id: managerId, companyId, name: "Manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: managerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: directReportId, companyId, name: "Report", role: "engineer", reportsTo: terminatedAgentId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values([
+      { id: openIssueId, companyId, title: "Open work", status: "in_progress", priority: "high", assigneeAgentId: terminatedAgentId },
+      { id: terminalIssueId, companyId, title: "Done work", status: "done", priority: "high", assigneeAgentId: terminatedAgentId },
+    ]);
+
+    await agentService(db).terminate(terminatedAgentId);
+
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    const [terminalIssue] = await db.select().from(issues).where(eq(issues.id, terminalIssueId));
+    const [directReport] = await db.select().from(agents).where(eq(agents.id, directReportId));
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, openIssueId));
+    expect(openIssue?.assigneeAgentId).toBe(managerId);
+    expect(terminalIssue?.assigneeAgentId).toBe(terminatedAgentId);
+    expect(directReport?.reportsTo).toBe(managerId);
+    expect(comments[0]).toMatchObject({ authorType: "system", body: `System: assignment released from source agent ${terminatedAgentId}; reason: agent was terminated; reassigned to its manager.` });
+  });
+
+  it("lets the manager PATCH work released by termination", async () => {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const openIssueId = randomUUID();
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, requireBoardApprovalForNewAgents: false });
+    await db.insert(agents).values([
+      { id: managerId, companyId, name: "Manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: managerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values({ id: openIssueId, companyId, title: "Open work", status: "in_progress", priority: "high", assigneeAgentId: terminatedAgentId });
+    await agentService(db).terminate(terminatedAgentId);
+    const [managerRun] = await db.insert(heartbeatRuns).values({ companyId, agentId: managerId, status: "running", contextSnapshot: { issueId: openIssueId } }).returning();
+    const res = await request(issuePatchApp(db, companyId, managerId, managerRun!.id)).patch(`/api/issues/${openIssueId}`).send({ title: "Manager resumed released work" });
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({ id: openIssueId, assigneeAgentId: managerId, title: "Manager resumed released work" });
+  });
+
+  it("releases open work to the unassigned queue when no assignable manager exists", async () => {
+    const companyId = randomUUID();
+    const pendingManagerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const openIssueId = randomUUID();
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, requireBoardApprovalForNewAgents: false });
+    await db.insert(agents).values([
+      { id: pendingManagerId, companyId, name: "Pending manager", role: "manager", status: "pending_approval", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: pendingManagerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values({ id: openIssueId, companyId, title: "Open work", status: "blocked", priority: "high", assigneeAgentId: terminatedAgentId });
+    await agentService(db).terminate(terminatedAgentId);
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, openIssueId));
+    expect(openIssue?.assigneeAgentId).toBeNull();
+    expect(comments[0]).toMatchObject({ authorType: "system", body: `System: assignment released from source agent ${terminatedAgentId}; reason: agent was terminated; moved to the unassigned queue.` });
   });
 });

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import express from "express";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import request from "supertest";
 import {
   agents,
@@ -26,6 +26,16 @@ vi.mock("../services/issue-assignment-wakeup.js", () => ({ queueIssueAssignmentW
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 function issuePatchApp(db: ReturnType<typeof createDb>, companyId: string, agentId: string, runId: string) {
   const app = express();
@@ -306,6 +316,35 @@ describeEmbeddedPostgres("agent service clearError", () => {
     const res = await request(issuePatchApp(db, companyId, managerId, managerRun!.id)).patch(`/api/issues/${openIssueId}`).send({ title: "Manager resumed released work" });
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body).toMatchObject({ id: openIssueId, assigneeAgentId: managerId, title: "Manager resumed released work" });
+  });
+
+  it("revalidates a manager terminated concurrently before releasing work", async () => {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const terminatedAgentId = randomUUID();
+    const openIssueId = randomUUID();
+    const managerLocked = deferred<void>();
+    const allowManagerTermination = deferred<void>();
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, requireBoardApprovalForNewAgents: false });
+    await db.insert(agents).values([
+      { id: managerId, companyId, name: "Manager", role: "manager", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+      { id: terminatedAgentId, companyId, name: "Leaving", role: "engineer", reportsTo: managerId, adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} },
+    ]);
+    await db.insert(issues).values({ id: openIssueId, companyId, title: "Open work", status: "in_progress", priority: "high", assigneeAgentId: terminatedAgentId });
+
+    const concurrentManagerTermination = db.transaction(async (tx) => {
+      await tx.execute(sql`select ${agents.id} from ${agents} where ${agents.id} = ${managerId} for update`);
+      managerLocked.resolve();
+      await allowManagerTermination.promise;
+      await tx.update(agents).set({ status: "terminated", updatedAt: new Date() }).where(eq(agents.id, managerId));
+    });
+    await managerLocked.promise;
+    const terminateSource = agentService(db).terminate(terminatedAgentId);
+    allowManagerTermination.resolve();
+    await Promise.all([concurrentManagerTermination, terminateSource]);
+
+    const [openIssue] = await db.select().from(issues).where(eq(issues.id, openIssueId));
+    expect(openIssue?.assigneeAgentId).toBeNull();
   });
 
   it("releases open work to the unassigned queue when no assignable manager exists", async () => {

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -19,7 +19,7 @@ import {
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   getAgentWorkEligibility,
-  isAgentStatusAssignableToWork,
+  isAgentAssignableToWork,
   isUuidLike,
   normalizeAgentApiKeyScope,
   normalizeAgentUrlKey,
@@ -713,19 +713,23 @@ export function agentService(db: Db) {
 
       await db.transaction(async (tx) => {
         const now = new Date();
+        const companyAgents = await tx.select().from(agents).where(eq(agents.companyId, existing.companyId));
+        const eligibilityAgents = companyAgents.map(toEligibilityAgent);
         const manager = existing.reportsTo
-          ? await tx
-            .select({ id: agents.id, status: agents.status })
-            .from(agents)
-            .where(and(eq(agents.id, existing.reportsTo), eq(agents.companyId, existing.companyId)))
-            .then((rows) => rows[0] ?? null)
+          ? companyAgents.find((candidate) => candidate.id === existing.reportsTo) ?? null
           : null;
-        const replacementAssigneeId = manager && isAgentStatusAssignableToWork(manager.status) ? manager.id : null;
+        const replacementAssigneeId = manager && isAgentAssignableToWork({
+          agent: toEligibilityAgent(manager),
+          agents: eligibilityAgents,
+        })
+          ? manager.id
+          : null;
         const releasableIssues = await tx
           .select({ id: issues.id })
           .from(issues)
           .where(and(
             eq(issues.assigneeAgentId, id),
+            eq(issues.companyId, existing.companyId),
             inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
           ));
 
@@ -742,12 +746,13 @@ export function agentService(db: Db) {
         await tx
           .update(agents)
           .set({ reportsTo: replacementAssigneeId, updatedAt: now })
-          .where(eq(agents.reportsTo, id));
+          .where(and(eq(agents.reportsTo, id), eq(agents.companyId, existing.companyId)));
         await tx
           .update(issues)
           .set({ assigneeAgentId: replacementAssigneeId, updatedAt: now })
           .where(and(
             eq(issues.assigneeAgentId, id),
+            eq(issues.companyId, existing.companyId),
             inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
           ));
         if (releasableIssues.length > 0) {

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -722,8 +722,9 @@ export function agentService(db: Db) {
         );
         const companyAgents = await tx.select().from(agents).where(eq(agents.companyId, existing.companyId));
         const eligibilityAgents = companyAgents.map(toEligibilityAgent);
-        const manager = existing.reportsTo
-          ? companyAgents.find((candidate) => candidate.id === existing.reportsTo) ?? null
+        const sourceAgent = companyAgents.find((candidate) => candidate.id === id) ?? null;
+        const manager = sourceAgent?.reportsTo
+          ? companyAgents.find((candidate) => candidate.id === sourceAgent.reportsTo) ?? null
           : null;
         const replacementAssigneeId = manager && isAgentAssignableToWork({
           agent: toEligibilityAgent(manager),

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -713,6 +713,13 @@ export function agentService(db: Db) {
 
       await db.transaction(async (tx) => {
         const now = new Date();
+        // Agent lifecycle changes can race each other. Lock the complete
+        // company graph before deriving a replacement so a concurrent
+        // termination cannot make that replacement ineligible between the
+        // eligibility check and the issue/report reassignment writes.
+        await tx.execute(
+          sql`select ${agents.id} from ${agents} where ${agents.companyId} = ${existing.companyId} order by ${agents.id} for update`,
+        );
         const companyAgents = await tx.select().from(agents).where(eq(agents.companyId, existing.companyId));
         const eligibilityAgents = companyAgents.map(toEligibilityAgent);
         const manager = existing.reportsTo

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -19,6 +19,7 @@ import {
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
   getAgentWorkEligibility,
+  isAgentStatusAssignableToWork,
   isUuidLike,
   normalizeAgentApiKeyScope,
   normalizeAgentUrlKey,
@@ -710,21 +711,62 @@ export function agentService(db: Db) {
       const existing = await getById(id);
       if (!existing) return null;
 
-      await db
-        .update(agents)
-        .set({
-          status: "terminated",
-          pauseReason: null,
-          pausedAt: null,
-          errorReason: null,
-          updatedAt: new Date(),
-        })
-        .where(eq(agents.id, id));
+      await db.transaction(async (tx) => {
+        const now = new Date();
+        const manager = existing.reportsTo
+          ? await tx
+            .select({ id: agents.id, status: agents.status })
+            .from(agents)
+            .where(and(eq(agents.id, existing.reportsTo), eq(agents.companyId, existing.companyId)))
+            .then((rows) => rows[0] ?? null)
+          : null;
+        const replacementAssigneeId = manager && isAgentStatusAssignableToWork(manager.status) ? manager.id : null;
+        const releasableIssues = await tx
+          .select({ id: issues.id })
+          .from(issues)
+          .where(and(
+            eq(issues.assigneeAgentId, id),
+            inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+          ));
 
-      await db
-        .update(agentApiKeys)
-        .set({ revokedAt: new Date() })
-        .where(eq(agentApiKeys.agentId, id));
+        await tx
+          .update(agents)
+          .set({
+            status: "terminated",
+            pauseReason: null,
+            pausedAt: null,
+            errorReason: null,
+            updatedAt: now,
+          })
+          .where(eq(agents.id, id));
+        await tx
+          .update(agents)
+          .set({ reportsTo: replacementAssigneeId, updatedAt: now })
+          .where(eq(agents.reportsTo, id));
+        await tx
+          .update(issues)
+          .set({ assigneeAgentId: replacementAssigneeId, updatedAt: now })
+          .where(and(
+            eq(issues.assigneeAgentId, id),
+            inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+          ));
+        if (releasableIssues.length > 0) {
+          await tx.insert(issueComments).values(releasableIssues.map((issue) => ({
+            companyId: existing.companyId,
+            issueId: issue.id,
+            authorType: "system" as const,
+            body: replacementAssigneeId
+              ? `System: assignment released from source agent ${id}; reason: agent was terminated; reassigned to its manager.`
+              : `System: assignment released from source agent ${id}; reason: agent was terminated; moved to the unassigned queue.`,
+            createdAt: now,
+            updatedAt: now,
+          })));
+        }
+        await tx
+          .update(agentApiKeys)
+          .set({ revokedAt: now })
+          .where(eq(agentApiKeys.agentId, id));
+      });
 
       return getById(id);
     },


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their work.
> - Agent termination is an agent lifecycle operation.
> - Open issues owned by a terminated agent cannot accept agent mutations.
> - The termination path did not release these issue assignments.
> - This pull request releases open work in the same transaction as termination.
> - The result keeps work available to an assignable manager or the unassigned queue.

## Linked Issues or Issue Description

**What happened?**

Terminating an agent left its open issues assigned to the terminated agent. This made the issues unavailable for normal agent work.

**Steps to reproduce**

Create an open issue assigned to an agent. Terminate that agent. Attempt to update the issue as its manager.

**Expected behavior**

Termination moves open issues to an assignable manager, or clears the assignment. The manager can then update the released issue.

**Actual behavior**

The issue remained assigned to the terminated agent and the update path could return 403.

## What Changed

- Release non-terminal agent assignments during termination in one transaction.
- Re-parent direct reports to an assignable manager, or clear their manager.
- Add a system audit comment for each released issue.
- Add an idempotent terminated-or-missing-assignee backfill script that revalidates manager eligibility inside its transaction.
- Add service and PATCH-route regression coverage.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agents-service-clear-error.test.ts src/__tests__/authorization-service.test.ts --reporter=dot` — 62 passed.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- `pnpm --filter @paperclipai/db typecheck` — passed.
- Live company-scoped idempotent backfill: `node server/node_modules/tsx/dist/cli.mjs scripts/backfill-terminated-assignee-locks.ts --company <company-id>` — `before=0`, `released_to_manager=0`, `released_to_unassigned_queue=0`, `after=0`.

## Risks

Low risk. Termination now changes only non-terminal issue assignments and direct reports in the same transaction. Terminal issues retain their historical assignee. The backfill is idempotent, uses a compare-and-set issue update, and revalidates the source/manager lifecycle graph before each live release.

## Model Used

OpenAI Codex, GPT-5.6-terra. Tool-assisted code inspection, editing, testing, git, and command execution. Context window: platform-managed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR following the bug template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [ ] I have updated relevant documentation to reflect my changes (not needed; no user-facing behavior or command changed)
- [ ] All Paperclip CI gates are green (pending GitHub CI)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending review)
- [x] I will address all Greptile and reviewer comments before requesting merge