### PR TITLE
fix(server): ignore req/res in the file log transport to stop unbounded thread-stream growth

### DIFF
--- a/server/src/__tests__/logger-file-transport-ignore.test.ts
+++ b/server/src/__tests__/logger-file-transport-ignore.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Regression test for https://github.com/paperclipai/paperclip/issues/1825
+ *
+ * The stdout pino-pretty target ignores `req,res,responseTime`; the file
+ * target historically did not. Prettifying the full req/res objects for
+ * every HTTP entry makes the file formatter worker slower than the log
+ * producers, so thread-stream's send buffer grows without bound and the
+ * server aborts at the V8 heap limit.
+ *
+ * We verify that EVERY pino-pretty transport target ignores the large HTTP
+ * fields, so the two targets cannot silently diverge again.
+ */
+
+const mockTransport = vi.hoisted(() => vi.fn(() => ({ write: vi.fn() })));
+const mockPino = vi.hoisted(() => {
+  const fn = vi.fn(() => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+  }));
+  (fn as any).transport = mockTransport;
+  return fn;
+});
+
+// Mock fs so the module-level mkdirSync call is a no-op in tests.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, mkdirSync: vi.fn() };
+});
+
+vi.mock("pino", () => ({
+  default: mockPino,
+}));
+vi.mock("pino-http", () => ({
+  pinoHttp: vi.fn(() => vi.fn()),
+}));
+vi.mock("../config-file.js", () => ({
+  readConfigFile: vi.fn(() => null),
+}));
+vi.mock("../home-paths.js", () => ({
+  resolveHomeAwarePath: vi.fn((p: string) => p),
+  resolveDefaultLogsDir: vi.fn(() => "/tmp/paperclip-test-logs"),
+}));
+
+describe("logger transports ignore large HTTP fields (issue #1825)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("every transport target ignores req, res, and responseTime", async () => {
+    await import("../middleware/logger.js");
+
+    expect(mockTransport).toHaveBeenCalledOnce();
+    const { targets } = mockTransport.mock.calls[0][0] as {
+      targets: Array<{ options: Record<string, unknown> }>;
+    };
+    expect(targets.length).toBeGreaterThanOrEqual(2);
+
+    for (const target of targets) {
+      const ignore = String(target.options.ignore ?? "");
+      const ignored = ignore.split(",").map((field) => field.trim());
+      for (const field of ["req", "res", "responseTime"]) {
+        expect(ignored, `target ignore list must include "${field}"`).toContain(field);
+      }
+    }
+  });
+});

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -41,7 +41,11 @@ export const logger = pino({
     },
     {
       target: "pino-pretty",
-      options: { ...sharedOpts, colorize: false, destination: logFile, mkdir: true },
+      // Must ignore req/res like the stdout target above: prettifying the full
+      // req/res objects for every HTTP entry makes this worker slower than the
+      // log producers, so thread-stream's send buffer grows without bound and
+      // the server OOMs at the V8 heap limit (#1825).
+      options: { ...sharedOpts, ignore: "pid,hostname,req,res,responseTime", colorize: false, destination: logFile, mkdir: true },
       level: "debug",
     },
   ],


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The server logs through pino with two pino-pretty transport targets: one to stdout, one to a file.
> - The stdout target ignores `pid,hostname,req,res,responseTime`. The file target does not.
> - The file target therefore prettifies the full `req`/`res` objects for every HTTP log entry. This makes the formatter worker slower than the log producers.
> - thread-stream's send buffer then grows without bound, and the server aborts at the V8 heap limit (`FATAL ERROR: Reached heap limit`). The crash cycle is roughly 60 minutes at default heap, and roughly 14 hours at `--max-old-space-size=4096`.
> - This pull request gives the file target the same ignore list the stdout target already has.
> - The benefit is that the server stops leaking heap under normal HTTP load and no longer crash-loops.

## Linked Issues or Issue Description

- Fixes #1825
- Refs #9313 (a different OOM path; the two compound on busy deployments)

Note: an earlier comment on #1825 says the bug was "fixed in commit eaf888c". That commit does not exist in this repository, and the missing ignore list is still present on `master` (`server/src/middleware/logger.ts`). The bug reproduces on 2026.707.0 (per a later comment on #1825) and on 2026.722.0 (our deployment).

## What Changed

- `server/src/middleware/logger.ts`: the file pino-pretty target now sets `ignore: "pid,hostname,req,res,responseTime"`, matching the stdout target. One line, plus a comment that explains why the ignore list must stay.

## Verification

- New regression test `server/src/__tests__/logger-file-transport-ignore.test.ts`: asserts every pino-pretty target ignores `req`, `res`, `responseTime`. Verified it fails against the pre-fix configuration and passes with this change.
- `npx vitest run __tests__/http-log-policy.test.ts __tests__/http-log-redaction.test.ts __tests__/log-redaction.test.ts __tests__/logger-tz.test.ts` — 13 tests pass.
- `pnpm typecheck` passes.
- Production observation (30-agent deployment, ~2,000 runs/day, paperclipai 2026.722.0): server RSS grows ~250 MB/hour and the process aborts at the heap ceiling. Hourly RSS samples: 685 MB fresh → 3,185 MB at 9.8 h → SIGABRT at ~4,081 MB with `--max-old-space-size=4096`. The stdout transport, which has this ignore list, shows no such growth. We have applied this exact change to the installed dist on that deployment and will report the post-patch RSS curve on #1825.

## Risks

- Low risk. The file log loses the prettified `req`/`res`/`responseTime` fields on debug-level HTTP entries — the same fields stdout already omits. Warn/error HTTP entries keep their structured request excerpts through the existing serializer paths. No API, schema, or behavior change beyond log file content.

## Model Used

- Claude Fable 5 (Anthropic, `claude-fable-5`, 1M context) via Claude Code CLI — diagnosis, patch, and tests. Human-reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
