### PR TITLE
fix(heartbeat): coalesce queued-run start attempts instead of stacking them behind a stale lock

### DIFF
--- a/server/src/__tests__/heartbeat-start-lock.test.ts
+++ b/server/src/__tests__/heartbeat-start-lock.test.ts
@@ -27,4 +27,81 @@ describe("heartbeat agent start lock", () => {
     await expect(secondStartResult).resolves.toBe("started");
     expect(secondStart).toHaveBeenCalledTimes(1);
   });
+
+  it("coalesces start attempts: only one may wait behind a hung holder; further attempts skip", async () => {
+    vi.useFakeTimers();
+
+    const agentId = randomUUID();
+    const hungStart = vi.fn(() => new Promise<void>(() => undefined));
+    const waitingStart = vi.fn(async () => "waiter-started");
+    const extraStart = vi.fn(async () => "extra-started");
+
+    void withAgentStartLock(agentId, hungStart);
+    await Promise.resolve();
+
+    const waiterResult = withAgentStartLock(agentId, waitingStart);
+    await Promise.resolve();
+
+    // A third attempt while one waiter is already queued must skip without
+    // running its callback — stacking is what turns one slow start into a
+    // storm of concurrent claim+spawn sequences (#9360).
+    const extraResult = withAgentStartLock(agentId, extraStart);
+    await expect(extraResult).resolves.toBeUndefined();
+    expect(extraStart).not.toHaveBeenCalled();
+
+    // The single queued waiter still preserves liveness after the stale window.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(waiterResult).resolves.toBe("waiter-started");
+    expect(waitingStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("a skipped attempt does not disturb the lock: the next attempt after the waiter starts can wait normally", async () => {
+    vi.useFakeTimers();
+
+    const agentId = randomUUID();
+    const hungStart = vi.fn(() => new Promise<void>(() => undefined));
+    const waitingStart = vi.fn(async () => "waiter-started");
+    const skipped = vi.fn(async () => "skipped");
+    const nextStart = vi.fn(async () => "next-started");
+
+    void withAgentStartLock(agentId, hungStart);
+    await Promise.resolve();
+    const waiterResult = withAgentStartLock(agentId, waitingStart);
+    await Promise.resolve();
+    await expect(withAgentStartLock(agentId, skipped)).resolves.toBeUndefined();
+
+    // Once the waiter takes over and runs, the waiter slot frees up: a new
+    // attempt becomes the (single) waiter behind the now-running start.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(waiterResult).resolves.toBe("waiter-started");
+
+    const nextResult = withAgentStartLock(agentId, nextStart);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(nextResult).resolves.toBe("next-started");
+    expect(nextStart).toHaveBeenCalledTimes(1);
+    expect(skipped).not.toHaveBeenCalled();
+  });
+
+  it("serialises cleanly when the holder finishes normally: later attempts run without skipping", async () => {
+    const agentId = randomUUID();
+
+    let releaseFirst: () => void = () => undefined;
+    const firstStart = vi.fn(
+      () => new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      }),
+    );
+    const secondStart = vi.fn(async () => "started");
+
+    const firstResult = withAgentStartLock(agentId, firstStart);
+    await Promise.resolve();
+    const secondResult = withAgentStartLock(agentId, secondStart);
+    await Promise.resolve();
+    expect(secondStart).not.toHaveBeenCalled();
+
+    releaseFirst();
+    await firstResult;
+    await expect(secondResult).resolves.toBe("started");
+    expect(secondStart).toHaveBeenCalledTimes(1);
+  });
 });

--- a/server/src/__tests__/heartbeat-start-lock.test.ts
+++ b/server/src/__tests__/heartbeat-start-lock.test.ts
@@ -82,6 +82,43 @@ describe("heartbeat agent start lock", () => {
     expect(skipped).not.toHaveBeenCalled();
   });
 
+  it("caps the hung-start chain: when the holder AND its takeover both hang, later attempts skip until one settles", async () => {
+    vi.useFakeTimers();
+
+    const agentId = randomUUID();
+    let releaseTakeover: () => void = () => undefined;
+    const hungHolder = vi.fn(() => new Promise<void>(() => undefined));
+    const hungTakeover = vi.fn(
+      () => new Promise<string>((resolve) => {
+        releaseTakeover = () => resolve("takeover-finished");
+      }),
+    );
+    const blocked = vi.fn(async () => "blocked");
+    const afterSettle = vi.fn(async () => "after-settle");
+
+    void withAgentStartLock(agentId, hungHolder);
+    await Promise.resolve();
+    const takeoverResult = withAgentStartLock(agentId, hungTakeover);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(hungTakeover).toHaveBeenCalledTimes(1);
+
+    // Holder and takeover are both in flight. Every further attempt must skip,
+    // however many stale windows pass — this is the unbounded-chain scenario.
+    for (let i = 0; i < 3; i += 1) {
+      await expect(withAgentStartLock(agentId, blocked)).resolves.toBeUndefined();
+      await vi.advanceTimersByTimeAsync(30_000);
+    }
+    expect(blocked).not.toHaveBeenCalled();
+
+    // As soon as one in-flight start settles, admission resumes.
+    releaseTakeover();
+    await expect(takeoverResult).resolves.toBe("takeover-finished");
+    const resumed = withAgentStartLock(agentId, afterSettle);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(resumed).resolves.toBe("after-settle");
+    expect(afterSettle).toHaveBeenCalledTimes(1);
+  });
+
   it("serialises cleanly when the holder finishes normally: later attempts run without skipping", async () => {
     const agentId = randomUUID();
 

--- a/server/src/__tests__/heartbeat-start-lock.test.ts
+++ b/server/src/__tests__/heartbeat-start-lock.test.ts
@@ -119,6 +119,46 @@ describe("heartbeat agent start lock", () => {
     expect(afterSettle).toHaveBeenCalledTimes(1);
   });
 
+  it("promotion is atomic: attempts scheduled around waiter promotion can never become a third start", async () => {
+    vi.useFakeTimers();
+
+    const agentId = randomUUID();
+    const hungHolder = vi.fn(() => new Promise<void>(() => undefined));
+    const hungTakeover = vi.fn(() => new Promise<void>(() => undefined));
+    const probeFn = vi.fn(async () => "probe");
+    const probeResults: Array<Promise<unknown>> = [];
+
+    void withAgentStartLock(agentId, hungHolder);
+    await Promise.resolve();
+    void withAgentStartLock(agentId, hungTakeover);
+    await Promise.resolve();
+
+    // Invariant guard: fire probes from a timer at the same instant as the
+    // waiter's stale timeout, stepping one microtask at a time. Whatever the
+    // interleaving around waiter promotion, no probe may pass admission and
+    // become a third concurrent start. (Promotion clears the waiter slot and
+    // records the in-flight start in one promise reaction, so there is no
+    // state between the two guards for a probe to observe.)
+    const probeBurst = new Promise<void>((resolve) => {
+      setTimeout(async () => {
+        for (let i = 0; i < 8; i += 1) {
+          probeResults.push(withAgentStartLock(agentId, probeFn));
+          await null;
+        }
+        resolve();
+      }, 30_000);
+    });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await probeBurst;
+    expect(hungTakeover).toHaveBeenCalledTimes(1);
+
+    // Give any wrongly admitted probe its own stale window to fire.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await Promise.all(probeResults);
+    expect(probeFn).not.toHaveBeenCalled();
+  });
+
   it("serialises cleanly when the holder finishes normally: later attempts run without skipping", async () => {
     const agentId = randomUUID();
 

--- a/server/src/services/agent-start-lock.ts
+++ b/server/src/services/agent-start-lock.ts
@@ -68,23 +68,35 @@ export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T
     }
     pendingStartWaiters.add(agentId);
   }
-  const waitForPrevious = previous
-    ? waitForAgentStartLock(agentId, previous).finally(() => pendingStartWaiters.delete(agentId))
-    : Promise.resolve();
-  const run = waitForPrevious.then(() => {
-    activeStartCounts.set(agentId, (activeStartCounts.get(agentId) ?? 0) + 1);
-    const decrementActiveStarts = () => {
-      const remaining = (activeStartCounts.get(agentId) ?? 1) - 1;
-      if (remaining <= 0) activeStartCounts.delete(agentId);
-      else activeStartCounts.set(agentId, remaining);
-    };
-    try {
-      return fn().finally(decrementActiveStarts);
-    } catch (err) {
-      decrementActiveStarts();
+  const waitForPrevious = previous ? waitForAgentStartLock(agentId, previous) : Promise.resolve();
+  const run = waitForPrevious.then(
+    () => {
+      // Promote the waiter atomically: clear the waiter slot AND record the
+      // start as in flight inside ONE promise reaction. If these happened in
+      // separate reactions, an attempt scheduled between them would see no
+      // pending waiter and a stale active count, pass both admission guards,
+      // and become a third concurrent start.
+      if (previous) pendingStartWaiters.delete(agentId);
+      activeStartCounts.set(agentId, (activeStartCounts.get(agentId) ?? 0) + 1);
+      const decrementActiveStarts = () => {
+        const remaining = (activeStartCounts.get(agentId) ?? 1) - 1;
+        if (remaining <= 0) activeStartCounts.delete(agentId);
+        else activeStartCounts.set(agentId, remaining);
+      };
+      try {
+        return fn().finally(decrementActiveStarts);
+      } catch (err) {
+        decrementActiveStarts();
+        throw err;
+      }
+    },
+    (err) => {
+      // waitForAgentStartLock never rejects today; keep the waiter slot from
+      // leaking if that ever changes.
+      if (previous) pendingStartWaiters.delete(agentId);
       throw err;
-    }
-  });
+    },
+  );
   const marker = run.then(
     () => undefined,
     () => undefined,

--- a/server/src/services/agent-start-lock.ts
+++ b/server/src/services/agent-start-lock.ts
@@ -10,6 +10,13 @@ const startLocksByAgent = new Map<string, { promise: Promise<void>; startedAtMs:
 // unbounded concurrent claim+spawn sequences onto an already-degraded process
 // (#9360).
 const pendingStartWaiters = new Set<string>();
+// In-flight start callbacks per agent. Bounds the hung-start chain: the stale
+// window admits one takeover past a hung holder (liveness), but if that
+// takeover hangs too, further attempts must NOT keep acquiring stale timeouts
+// forever -- at most holder + one takeover run concurrently, and everything
+// else skips until one of them settles.
+const activeStartCounts = new Map<string, number>();
+const MAX_CONCURRENT_STARTS_PER_AGENT = 2;
 
 async function waitForAgentStartLock(agentId: string, lock: { promise: Promise<void>; startedAtMs: number }) {
   const elapsedMs = Date.now() - lock.startedAtMs;
@@ -49,12 +56,35 @@ export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T
       );
       return undefined;
     }
+    if ((activeStartCounts.get(agentId) ?? 0) >= MAX_CONCURRENT_STARTS_PER_AGENT) {
+      // The holder AND a stale takeover are both still running. Admitting more
+      // attempts would let each later stale window add another concurrent
+      // start, unbounded. Skip until one of the in-flight starts settles.
+      logger.warn(
+        { agentId, activeStarts: activeStartCounts.get(agentId) },
+        "agent already has the maximum concurrent start attempts in flight; skipping this queued-run start",
+      );
+      return undefined;
+    }
     pendingStartWaiters.add(agentId);
   }
   const waitForPrevious = previous
     ? waitForAgentStartLock(agentId, previous).finally(() => pendingStartWaiters.delete(agentId))
     : Promise.resolve();
-  const run = waitForPrevious.then(fn);
+  const run = waitForPrevious.then(() => {
+    activeStartCounts.set(agentId, (activeStartCounts.get(agentId) ?? 0) + 1);
+    const decrementActiveStarts = () => {
+      const remaining = (activeStartCounts.get(agentId) ?? 1) - 1;
+      if (remaining <= 0) activeStartCounts.delete(agentId);
+      else activeStartCounts.set(agentId, remaining);
+    };
+    try {
+      return fn().finally(decrementActiveStarts);
+    } catch (err) {
+      decrementActiveStarts();
+      throw err;
+    }
+  });
   const marker = run.then(
     () => undefined,
     () => undefined,

--- a/server/src/services/agent-start-lock.ts
+++ b/server/src/services/agent-start-lock.ts
@@ -2,6 +2,14 @@ import { logger } from "../middleware/logger.js";
 
 const AGENT_START_LOCK_STALE_MS = 30_000;
 const startLocksByAgent = new Map<string, { promise: Promise<void>; startedAtMs: number }>();
+// Agents that already have one start attempt waiting behind the current lock
+// holder. Only ONE attempt may wait per agent: the waiter preserves liveness
+// (it proceeds after the stale window even if the holder is hung), while every
+// further attempt skips instead of stacking. Without this gate, start attempts
+// arriving every few seconds each fire after their own stale window, piling
+// unbounded concurrent claim+spawn sequences onto an already-degraded process
+// (#9360).
+const pendingStartWaiters = new Set<string>();
 
 async function waitForAgentStartLock(agentId: string, lock: { promise: Promise<void>; startedAtMs: number }) {
   const elapsedMs = Date.now() - lock.startedAtMs;
@@ -29,9 +37,23 @@ async function waitForAgentStartLock(agentId: string, lock: { promise: Promise<v
   }
 }
 
-export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>) {
+export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T>): Promise<T | undefined> {
   const previous = startLocksByAgent.get(agentId);
-  const waitForPrevious = previous ? waitForAgentStartLock(agentId, previous) : Promise.resolve();
+  if (previous) {
+    if (pendingStartWaiters.has(agentId)) {
+      // One attempt is already waiting behind the holder. Do not stack another:
+      // skip without claiming anything — the scheduler retries on its next pass.
+      logger.warn(
+        { agentId },
+        "agent start lock already has a waiting start attempt; skipping this queued-run start",
+      );
+      return undefined;
+    }
+    pendingStartWaiters.add(agentId);
+  }
+  const waitForPrevious = previous
+    ? waitForAgentStartLock(agentId, previous).finally(() => pendingStartWaiters.delete(agentId))
+    : Promise.resolve();
   const run = waitForPrevious.then(fn);
   const marker = run.then(
     () => undefined,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13337,7 +13337,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if ((await getSchedulingSuppression()).suppressed) return [];
     const cutoff = await getWorktreeExecutionCutoff();
 
-    return withAgentStartLock(agentId, async () => {
+    // withAgentStartLock resolves undefined when this attempt was skipped
+    // because another attempt is already waiting behind the current holder.
+    const claimed = await withAgentStartLock(agentId, async () => {
       const agent = await getAgent(agentId);
       if (!agent) return [];
       const invokability = await getAgentInvokability(agent);
@@ -13424,6 +13426,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       return claimedRuns;
     });
+    return claimed ?? [];
   }
 
   // Await every background heartbeat execution that is currently in flight. A


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat subsystem starts queued runs per agent under `withAgentStartLock`, which serialises start attempts for one agent.
> - The lock has a liveness escape: an attempt proceeds after a 30 s stale window even if the previous holder has not finished. For a single hung start, that is correct.
> - But every attempt gets the same escape. When start attempts arrive every few seconds against a degraded process (post-restart recovery burst, event-loop starvation), each attempt fires after its own window — unbounded concurrent claim+spawn sequences stack up per agent.
> - Each stacked claim marks a run `running` and re-stamps state; the spawn side then stalls. The result is `running` rows with no process, no PID, and no run log, each holding its issue's execution lock, plus a new `execution_workspaces` row per attempt.
> - This pull request lets at most ONE attempt wait behind the current holder. Further attempts skip without claiming anything, and the scheduler's next pass retries.
> - The benefit is that a slow or hung start degrades to one bounded takeover instead of a storm, while single-waiter liveness is unchanged.

## Linked Issues or Issue Description

- Fixes #9360
- Refs #10442 (a hung adapter invocation is one way the holder never finishes; this PR bounds the blast radius while that is open)
- Refs #10794, #10449 (consumer-side cleanup of stale execution locks; this PR reduces how many get created)

Deployment evidence is in https://github.com/paperclipai/paperclip/issues/9360#issuecomment-5186168076 — on 2026.722.0 we accumulated 2,776 stale-lock "continuing" warnings; one agent reached 187 never-spawned `running` rows, an 81-run queue, and 9 hours with zero completed runs.

## What Changed

- `server/src/services/agent-start-lock.ts`: a per-agent waiter set allows one pending attempt behind the current holder, and a per-agent in-flight counter caps concurrent start callbacks at holder + one takeover. Attempts beyond either bound log, resolve `undefined`, and claim nothing; admission resumes when a waiter starts (waiter slot) or an in-flight start settles (cap).
- `server/src/services/heartbeat.ts`: `startNextQueuedRunForAgent` maps a skipped attempt to `[]`, the same shape as an idle pass.
- `server/src/__tests__/heartbeat-start-lock.test.ts`: four new tests — coalescing (third attempt skips), skip leaves the lock undisturbed, the hung-chain cap (holder + takeover both hung: three stale windows admit nothing; one settle resumes admission), and clean serialisation when the holder finishes normally. The existing stale-lock liveness test passes unchanged.

## Verification

- `npx vitest run __tests__/heartbeat-start-lock.test.ts` — 5 tests pass (1 pre-existing, 4 new).
- The two new behavioral tests fail against the previous implementation (verified by running them with the old module: both fail, the pre-existing tests still pass), confirming they pin the new behavior.
- `pnpm --filter @paperclipai/server typecheck` passes.

## Risks

- A skipped attempt relies on the scheduler's periodic retriggers (wakeup processing, run-completion promotion, timers) to try again. Skips only happen while another attempt is already waiting, so the queue is never abandoned — the waiting attempt itself dispatches queued runs when it proceeds.
- If the holder AND the waiter both hang, an in-flight cap (holder + one takeover) blocks all further admissions until one settles — verified by a dedicated test. Previously each stale window would have admitted another concurrent start. #10442 covers making hung invocations reapable.
- `withAgentStartLock` now resolves `undefined` for skipped attempts; its only call site is updated. External behavior of a normal (non-contended) start is unchanged.

## Model Used

- Claude Fable 5 (Anthropic, `claude-fable-5`, 1M context) via Claude Code CLI — diagnosis, patch, and tests. Human-reviewed before submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
