### PR TITLE
fix(ui): restore iPadOS hover and expose keyboard shortcuts

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -12,6 +12,7 @@ import { authApi } from "../api/auth";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { queryKeys } from "../lib/queryKeys";
 import { useIssueExternalObjectSummaries } from "../hooks/useIssueExternalObjects";
+import { usePointerMovedSinceKeyNav } from "../hooks/usePointerMovedSinceKeyNav";
 import {
   shouldBlurPageSearchOnEnter,
   shouldBlurPageSearchOnEscape,
@@ -716,14 +717,7 @@ export function IssuesList({
   // selection only after real pointer movement, so keyboard-driven scrolling
   // doesn't hand the selection to whatever row lands under the cursor.
   const [selectedNavKey, setSelectedNavKey] = useState<string | null>(null);
-  const pointerMovedSinceKeyNavRef = useRef(true);
-  useEffect(() => {
-    const handlePointerMove = () => {
-      pointerMovedSinceKeyNavRef.current = true;
-    };
-    window.addEventListener("mousemove", handlePointerMove, { passive: true });
-    return () => window.removeEventListener("mousemove", handlePointerMove);
-  }, []);
+  const pointerMovedSinceKeyNavRef = usePointerMovedSinceKeyNav();
   // Which entry the cursor is over, tracked WITHOUT React state so scrubbing the
   // list costs zero re-renders (hover paints via CSS `:hover`). Keyboard nav
   // reads this to continue from the hovered row. Key-based, so it self-heals if

--- a/ui/src/components/KeyboardShortcutsCheatsheet.test.tsx
+++ b/ui/src/components/KeyboardShortcutsCheatsheet.test.tsx
@@ -2,8 +2,24 @@
 
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { KeyboardShortcutsCheatsheetContent } from "./KeyboardShortcutsCheatsheet";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The settings link is the only routing dependency; stub it so this stays a unit
+// test of the sheet's content instead of dragging in Router + CompanyProvider.
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const generalSettingsMock = { keyboardShortcutsEnabled: true };
+vi.mock("../context/GeneralSettingsContext", () => ({
+  useGeneralSettings: () => generalSettingsMock,
+}));
+
+const { KeyboardShortcutsCheatsheetContent } = await import("./KeyboardShortcutsCheatsheet");
 
 describe("KeyboardShortcutsCheatsheet", () => {
   let container: HTMLDivElement;
@@ -11,6 +27,7 @@ describe("KeyboardShortcutsCheatsheet", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
+    generalSettingsMock.keyboardShortcutsEnabled = true;
   });
 
   afterEach(() => {
@@ -36,6 +53,39 @@ describe("KeyboardShortcutsCheatsheet", () => {
     expect(caps.some((cap) => cap === "⌘" || cap === "Ctrl")).toBe(true);
     expect(row?.textContent).toContain("+");
     expect(row?.textContent).not.toContain("then");
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  // `?` is the only way into this sheet, and it used to be gated on the same
+  // setting it documents — so when shortcuts were off there was no trace in the
+  // app that they existed or where to turn them on.
+  it("points at the setting when shortcuts are turned off", () => {
+    generalSettingsMock.keyboardShortcutsEnabled = false;
+    const root = createRoot(container);
+    flushSync(() => {
+      root.render(<KeyboardShortcutsCheatsheetContent />);
+    });
+
+    expect(container.textContent).toContain("Keyboard shortcuts are currently");
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("/company/settings/instance/general");
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  it("shows no setting callout while shortcuts are enabled", () => {
+    const root = createRoot(container);
+    flushSync(() => {
+      root.render(<KeyboardShortcutsCheatsheetContent />);
+    });
+
+    expect(container.textContent).not.toContain("Keyboard shortcuts are currently");
+    expect(container.querySelector("a")).toBeNull();
 
     flushSync(() => {
       root.unmount();

--- a/ui/src/components/KeyboardShortcutsCheatsheet.tsx
+++ b/ui/src/components/KeyboardShortcutsCheatsheet.tsx
@@ -1,4 +1,8 @@
+import { Link } from "@/lib/router";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useGeneralSettings } from "../context/GeneralSettingsContext";
+
+const KEYBOARD_SHORTCUTS_SETTING_PATH = "/company/settings/instance/general";
 
 interface ShortcutEntry {
   keys: string[];
@@ -81,9 +85,30 @@ function KeyCap({ children }: { children: string }) {
   );
 }
 
-export function KeyboardShortcutsCheatsheetContent() {
+export function KeyboardShortcutsCheatsheetContent({
+  onNavigateToSetting,
+}: {
+  /** Lets the dialog close itself when the settings link navigates away. */
+  onNavigateToSetting?: () => void;
+} = {}) {
+  const { keyboardShortcutsEnabled } = useGeneralSettings();
   return (
     <>
+      {!keyboardShortcutsEnabled && (
+        <div className="border-t border-border bg-accent/30 px-5 py-3">
+          <p className="text-sm text-foreground/90">
+            Keyboard shortcuts are currently <span className="font-medium">off</span>, so the keys
+            below do nothing yet.
+          </p>
+          <Link
+            to={KEYBOARD_SHORTCUTS_SETTING_PATH}
+            onClick={onNavigateToSetting}
+            className="mt-1 inline-flex text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+          >
+            Turn them on in Settings → Instance settings → General
+          </Link>
+        </div>
+      )}
       <div className="divide-y divide-border border-t border-border">
         {sections.map((section) => (
           <div key={section.title} className="px-5 py-3">
@@ -137,7 +162,7 @@ export function KeyboardShortcutsCheatsheet({
         <DialogHeader className="px-5 pt-5 pb-3">
           <DialogTitle className="text-base">Keyboard shortcuts</DialogTitle>
         </DialogHeader>
-        <KeyboardShortcutsCheatsheetContent />
+        <KeyboardShortcutsCheatsheetContent onNavigateToSetting={() => onOpenChange(false)} />
       </DialogContent>
     </Dialog>
   );

--- a/ui/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/ui/src/hooks/useKeyboardShortcuts.test.tsx
@@ -13,18 +13,23 @@ function TestHarness({
   onSearch,
   onToggleCollapse,
   onGoToInbox,
+  onShowShortcuts,
+  enabled = true,
 }: {
   onNewIssue: () => void;
   onSearch?: () => void;
   onToggleCollapse?: () => void;
   onGoToInbox?: () => void;
+  onShowShortcuts?: () => void;
+  enabled?: boolean;
 }) {
   useKeyboardShortcuts({
-    enabled: true,
+    enabled,
     onNewIssue,
     onSearch,
     onToggleCollapse,
     onGoToInbox,
+    onShowShortcuts,
   });
 
   return <div>keyboard shortcuts test</div>;
@@ -215,6 +220,60 @@ describe("useKeyboardShortcuts", () => {
       cancelable: true,
     }));
     expect(onToggleCollapse).not.toHaveBeenCalled();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  // The cheatsheet is only reachable via `?`, and `?` used to be gated on the
+  // same setting the cheatsheet documents — so a disabled instance had no way to
+  // discover that shortcuts exist or where the toggle lives.
+  it("still opens the cheatsheet on '?' while shortcuts are disabled", () => {
+    const root = createRoot(container);
+    const onShowShortcuts = vi.fn();
+    const onNewIssue = vi.fn();
+
+    act(() => {
+      root.render(
+        <TestHarness enabled={false} onNewIssue={onNewIssue} onShowShortcuts={onShowShortcuts} />,
+      );
+    });
+
+    document.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "?",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(onShowShortcuts).toHaveBeenCalledTimes(1);
+
+    // ...but only `?`. Every other shortcut stays off.
+    document.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "c",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(onNewIssue).not.toHaveBeenCalled();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("does not double-fire '?' when shortcuts are enabled", () => {
+    const root = createRoot(container);
+    const onShowShortcuts = vi.fn();
+
+    act(() => {
+      root.render(<TestHarness onNewIssue={vi.fn()} onShowShortcuts={onShowShortcuts} />);
+    });
+
+    document.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "?",
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(onShowShortcuts).toHaveBeenCalledTimes(1);
 
     act(() => {
       root.unmount();

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -27,6 +27,31 @@ export function useKeyboardShortcuts({
   onShowShortcuts,
   onGoToInbox,
 }: ShortcutHandlers) {
+  // With shortcuts disabled, `?` is the one key that still works. Everything
+  // else about the feature is invisible when the flag is off — the cheatsheet
+  // was reachable only through `?`, which the flag also gated, so there was no
+  // trace in the UI of shortcuts existing or of the setting that turns them on
+  // at all. The cheatsheet itself explains how to enable them.
+  useEffect(() => {
+    if (enabled) return;
+    // Bound to a const, and an arrow rather than a hoisted declaration, so the
+    // null check above still narrows at the call site.
+    const showShortcuts = onShowShortcuts;
+    if (!showShortcuts) return;
+
+    const handleHelpKeyDown = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.key !== "?" || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isKeyboardShortcutTextInputTarget(e.target)) return;
+      if (hasBlockingShortcutDialog()) return;
+      e.preventDefault();
+      showShortcuts();
+    };
+
+    document.addEventListener("keydown", handleHelpKeyDown);
+    return () => document.removeEventListener("keydown", handleHelpKeyDown);
+  }, [enabled, onShowShortcuts]);
+
   useEffect(() => {
     if (!enabled) return;
 

--- a/ui/src/hooks/usePointerMovedSinceKeyNav.ts
+++ b/ui/src/hooks/usePointerMovedSinceKeyNav.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+/**
+ * Tracks whether the pointer has physically moved since the last keyboard nav,
+ * so hover can hand the selection back to the mouse without a keyboard-driven
+ * scroll stealing it (keyboard nav scrolls the list, which fires mouseenter on
+ * whatever row lands under the stationary cursor).
+ *
+ * Callers set the ref to `false` when they handle a nav key; it flips back to
+ * `true` on the next real pointer movement.
+ *
+ * Prefers pointer events so a trackpad on iPadOS keeps hover and `hjkl` in sync
+ * on touch-first devices: touch is ignored because a finger never hovers a row, so a scroll
+ * gesture must not take the selection away from the keyboard. `mousemove` is only
+ * a fallback for browsers without PointerEvent — on iOS it also fires as a
+ * synthetic compatibility event on tap, which would defeat that filter.
+ */
+export function usePointerMovedSinceKeyNav(): RefObject<boolean> {
+  const pointerMovedRef = useRef(true);
+
+  useEffect(() => {
+    const markMoved = () => {
+      pointerMovedRef.current = true;
+    };
+
+    if (typeof window.PointerEvent !== "function") {
+      window.addEventListener("mousemove", markMoved, { passive: true });
+      return () => window.removeEventListener("mousemove", markMoved);
+    }
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (e.pointerType === "touch") return;
+      markMoved();
+    };
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    return () => window.removeEventListener("pointermove", handlePointerMove);
+  }, []);
+
+  return pointerMovedRef;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -19,6 +19,26 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Tailwind v4 compiles every `hover:*` utility inside `@media (hover: hover)`,
+   and iPadOS Safari never flips that query when a trackpad/mouse attaches (the
+   same WebKit defect that previously broke sidebar hover-peek). So once row
+   hover moved from React selection state to CSS `:hover`, every hover highlight
+   went dead on iPad while staying fine on desktop.
+
+   Swapping in `any-hover` would not have helped — iPadOS misreports that too.
+   Instead the media query is replaced with a class the app removes at runtime:
+   `startPointerCapabilityDetection` marks `<html>` `no-hover` only while the
+   platform looks touch-only, and drops it the instant a real `pointerType:
+   "mouse"` event proves otherwise. Fail-open by design — with no JS (Storybook,
+   unit tests) or on desktop the class is never added, so hover behaves exactly
+   as before; touch-only phones keep the class and so keep skipping hover, which
+   is what prevents sticky-hover-after-tap.
+
+   `:not(:where(...))` keeps specificity identical to a bare `:hover`, so this
+   reorders nothing. Overriding `hover` also covers `group-hover:`/`peer-hover:`,
+   which Tailwind composes from this variant. */
+@custom-variant hover (&:hover:not(:where(.no-hover *)));
+
 @theme inline {
   --font-sans: "InterVariable", "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;

--- a/ui/src/lib/pointerCapability.test.ts
+++ b/ui/src/lib/pointerCapability.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  NO_HOVER_CLASS,
+  looksTouchOnly,
+  resetPointerCapabilityDetectionForTests,
+  startPointerCapabilityDetection,
+} from "./pointerCapability";
+
+// Mutable media state driving the matchMedia mock, mirroring SidebarContext.test.
+const mediaState = { anyHover: true, anyCoarse: false };
+const changeListeners = new Set<(e: MediaQueryListEvent) => void>();
+
+function installMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => {
+      const matches = query.includes("any-hover")
+        ? mediaState.anyHover
+        : query.includes("any-pointer: coarse")
+          ? mediaState.anyCoarse
+          : false;
+      return {
+        matches,
+        media: query,
+        addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+          changeListeners.add(cb);
+        },
+        removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+          changeListeners.delete(cb);
+        },
+      } as unknown as MediaQueryList;
+    },
+  });
+}
+
+/** Simulate iPadOS finally reporting hover capability. */
+function fireHoverMediaChange(matches: boolean) {
+  mediaState.anyHover = matches;
+  for (const cb of [...changeListeners]) cb({ matches } as MediaQueryListEvent);
+}
+
+function pointerEvent(type: string, pointerType: string) {
+  // jsdom lacks PointerEvent, so synthesize one carrying `pointerType`.
+  const event = new Event(type, { bubbles: true }) as Event & { pointerType?: string };
+  event.pointerType = pointerType;
+  return event;
+}
+
+/** Touch-only tablet/phone: nothing can hover, and a coarse pointer exists. */
+function setTouchOnly() {
+  mediaState.anyHover = false;
+  mediaState.anyCoarse = true;
+}
+
+let teardown: (() => void) | null = null;
+
+beforeEach(() => {
+  mediaState.anyHover = true;
+  mediaState.anyCoarse = false;
+  changeListeners.clear();
+  installMatchMedia();
+  // jsdom has no PointerEvent; the module feature-detects it, so stub it in.
+  (window as unknown as { PointerEvent: unknown }).PointerEvent = function () {} as unknown;
+  document.documentElement.classList.remove(NO_HOVER_CLASS);
+  resetPointerCapabilityDetectionForTests();
+});
+
+afterEach(() => {
+  teardown?.();
+  teardown = null;
+  document.documentElement.classList.remove(NO_HOVER_CLASS);
+  resetPointerCapabilityDetectionForTests();
+});
+
+describe("looksTouchOnly", () => {
+  it("is false on a hover-capable desktop", () => {
+    expect(looksTouchOnly()).toBe(false);
+  });
+
+  it("is true when nothing can hover and a coarse pointer exists", () => {
+    setTouchOnly();
+    expect(looksTouchOnly()).toBe(true);
+  });
+
+  it("fails open when the platform reports no hover but no coarse pointer either", () => {
+    mediaState.anyHover = false;
+    mediaState.anyCoarse = false;
+    expect(looksTouchOnly()).toBe(false);
+  });
+});
+
+describe("startPointerCapabilityDetection", () => {
+  it("leaves hover enabled on a desktop", () => {
+    teardown = startPointerCapabilityDetection();
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(false);
+  });
+
+  it("suppresses hover on a touch-only device", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(true);
+  });
+
+  it("re-enables hover when a real cursor appears (iPadOS trackpad)", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(true);
+
+    window.dispatchEvent(pointerEvent("pointermove", "mouse"));
+
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(false);
+  });
+
+  it("re-enables hover on pointerover, before any movement is reported", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+
+    window.dispatchEvent(pointerEvent("pointerover", "mouse"));
+
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(false);
+  });
+
+  it("ignores touch and pen input, so a tap never leaves a stuck highlight", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+
+    window.dispatchEvent(pointerEvent("pointermove", "touch"));
+    window.dispatchEvent(pointerEvent("pointerover", "touch"));
+    window.dispatchEvent(pointerEvent("pointerover", "pen"));
+
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(true);
+  });
+
+  it("latches: hover stays enabled after the cursor goes away", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+    window.dispatchEvent(pointerEvent("pointermove", "mouse"));
+    // Later touch input must not re-suppress hover for the session.
+    window.dispatchEvent(pointerEvent("pointermove", "touch"));
+
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(false);
+  });
+
+  it("re-enables hover if the hover media query starts matching", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+
+    fireHoverMediaChange(true);
+
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(false);
+  });
+
+  it("stops listening once hover is enabled", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+    window.dispatchEvent(pointerEvent("pointermove", "mouse"));
+
+    expect(changeListeners.size).toBe(0);
+  });
+
+  it("is idempotent", () => {
+    setTouchOnly();
+    teardown = startPointerCapabilityDetection();
+    const second = startPointerCapabilityDetection();
+    second();
+
+    // The second call must not have torn down the first one's listeners.
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(true);
+    window.dispatchEvent(pointerEvent("pointermove", "mouse"));
+    expect(document.documentElement.classList.contains(NO_HOVER_CLASS)).toBe(false);
+  });
+});

--- a/ui/src/lib/pointerCapability.ts
+++ b/ui/src/lib/pointerCapability.ts
@@ -1,0 +1,127 @@
+/**
+ * Runtime hover-capability detection.
+ *
+ * iPadOS Safari never flips `(hover: hover)` / `(any-hover: hover)` when a Magic
+ * Keyboard trackpad or Bluetooth mouse is attached — it reports a touch-only
+ * device for the life of the page. That broke sidebar hover-peek and then every
+ * CSS hover highlight in the app, because Tailwind wraps
+ * all `hover:*` utilities in that media query.
+ *
+ * A real cursor is still observable: mouse/trackpad input emits pointer events
+ * with `pointerType: "mouse"`, whereas touch reports `"touch"` and the Pencil
+ * reports `"pen"`. So we drive the `no-hover` class off events rather than media
+ * queries, and treat hover capability as a **one-way latch** — once a cursor has
+ * been seen, hover stays enabled for the session.
+ *
+ * The class is subtractive (fail-open) on purpose: it is only ever added when the
+ * platform claims no hovering input at all. Anything that renders without calling
+ * `startPointerCapabilityDetection` (Storybook, unit tests, SSR-less harnesses)
+ * therefore keeps normal hover behaviour instead of silently losing it.
+ */
+
+/** Set on `<html>` while the device looks touch-only. See `index.css`. */
+export const NO_HOVER_CLASS = "no-hover";
+
+const HOVER_QUERY = "(any-hover: hover)";
+const COARSE_QUERY = "(any-pointer: coarse)";
+
+function mediaMatches(query: string): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+
+  try {
+    return window.matchMedia(query).matches;
+  } catch {
+    // Some embedded webviews throw on unknown media features.
+    return false;
+  }
+}
+
+/**
+ * Whether the platform currently claims it has no hovering pointer at all.
+ *
+ * Deliberately conservative: it takes BOTH "nothing can hover" and "a coarse
+ * pointer exists" to suppress hover, so a browser that simply does not report
+ * hover capability keeps hover rather than losing it.
+ */
+export function looksTouchOnly(): boolean {
+  return !mediaMatches(HOVER_QUERY) && mediaMatches(COARSE_QUERY);
+}
+
+let started = false;
+
+/**
+ * Marks `<html>` as touch-only until a real cursor shows up. Idempotent, safe to
+ * call before React renders, and a no-op on hover-capable platforms.
+ *
+ * Returns a teardown for tests; production calls it once from `main.tsx`.
+ */
+export function startPointerCapabilityDetection(): () => void {
+  if (typeof window === "undefined" || typeof document === "undefined") return () => {};
+  if (started) return () => {};
+  started = true;
+
+  const root = document.documentElement;
+  if (!looksTouchOnly()) {
+    // Desktop and anything honest about its pointer: nothing to suppress, and no
+    // listeners to keep around.
+    started = false;
+    return () => {};
+  }
+
+  root.classList.add(NO_HOVER_CLASS);
+
+  let disposed = false;
+  const enableHover = () => {
+    if (disposed) return;
+    root.classList.remove(NO_HOVER_CLASS);
+    teardown();
+  };
+
+  const onPointer = (e: PointerEvent) => {
+    // Touch never hovers, and counting it would leave a stuck highlight after a
+    // tap. A Pencil does hover, but it also fires `pointerover` on tap, so only
+    // an actual cursor unlocks hover.
+    if (e.pointerType === "mouse") enableHover();
+  };
+
+  const onMediaChange = (e: MediaQueryListEvent) => {
+    if (e.matches) enableHover();
+  };
+
+  let mql: MediaQueryList | null = null;
+  const hasPointerEvents = typeof window.PointerEvent === "function";
+
+  function teardown() {
+    if (disposed) return;
+    disposed = true;
+    started = false;
+    if (hasPointerEvents) {
+      window.removeEventListener("pointerover", onPointer);
+      window.removeEventListener("pointermove", onPointer);
+    }
+    mql?.removeEventListener("change", onMediaChange);
+  }
+
+  if (hasPointerEvents) {
+    // `pointerover` fires as soon as the cursor crosses into an element, so hover
+    // lights up on the first movement rather than after a click.
+    window.addEventListener("pointerover", onPointer, { passive: true });
+    window.addEventListener("pointermove", onPointer, { passive: true });
+  }
+
+  if (typeof window.matchMedia === "function") {
+    try {
+      mql = window.matchMedia(HOVER_QUERY);
+      mql.addEventListener("change", onMediaChange);
+    } catch {
+      mql = null;
+    }
+  }
+
+  return teardown;
+}
+
+/** Test-only: forget that detection already ran. */
+export function resetPointerCapabilityDetectionForTests(): void {
+  started = false;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -19,6 +19,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { initPluginBridge } from "./plugins/bridge-init";
 import { PluginLauncherProvider } from "./plugins/launchers";
 import { startPerfMeasureReaper } from "./lib/perf-measure-reaper";
+import { startPointerCapabilityDetection } from "./lib/pointerCapability";
 import "@mdxeditor/editor/style.css";
 import "./index.css";
 
@@ -28,6 +29,11 @@ initPluginBridge(React, ReactDOM);
 // DevTools performance tracks and never clears them; on a long-lived tab they
 // accumulate into millions of native objects (GBs). Reap them periodically.
 startPerfMeasureReaper();
+
+// iPadOS lies about hover capability, so CSS `hover:*` is gated on a class this
+// maintains instead of a media query. Run it before the first render
+// so touch-only devices never paint a hover state.
+startPointerCapabilityDetection();
 
 if ("serviceWorker" in navigator) {
   window.addEventListener("load", () => {

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -176,6 +176,7 @@ import {
 } from "../lib/inbox";
 import { useDismissedInboxAlerts, useInboxDismissals, useReadInboxItems } from "../hooks/useInboxBadge";
 import { useInboxSortAttention } from "../hooks/useInboxSortAttention";
+import { usePointerMovedSinceKeyNav } from "../hooks/usePointerMovedSinceKeyNav";
 import {
   captureInboxOrderPin,
   reconcileInboxOrderPin,
@@ -1713,14 +1714,7 @@ export function Inbox() {
   // Keyboard nav scrolls the list, which fires mouseenter on whatever row lands
   // under the stationary cursor — that must not steal the selection. Hover only
   // selects after the pointer has physically moved since the last key nav.
-  const pointerMovedSinceKeyNavRef = useRef(true);
-  useEffect(() => {
-    const handlePointerMove = () => {
-      pointerMovedSinceKeyNavRef.current = true;
-    };
-    window.addEventListener("mousemove", handlePointerMove, { passive: true });
-    return () => window.removeEventListener("mousemove", handlePointerMove);
-  }, []);
+  const pointerMovedSinceKeyNavRef = usePointerMovedSinceKeyNav();
   // Which row the cursor is over, tracked WITHOUT React state so scrubbing the
   // list costs zero re-renders (hover paints via CSS `:hover`, see IssueRow).
   // Keyboard nav reads this to continue from the hovered row.


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Operators use task lists and the inbox to scan work and move through rows quickly.
> - iPadOS reports that hover is unavailable even after a mouse or trackpad connects.
> - This report prevents Tailwind hover styles from painting, although pointer events still move the selection.
> - The keyboard shortcut setting also hides the help key when shortcuts are off, so users cannot discover the feature or its setting.
> - This pull request uses real pointer events to enable hover and keeps the help key available while other shortcuts remain off.
> - The benefit is consistent pointer and keyboard navigation on iPadOS, plus a clear path to enable shortcuts.

## Linked Issues or Issue Description

No public GitHub issue exists for these bugs.

Related: #8228 includes an earlier sidebar pointer-detection change. It does not restore global Tailwind hover styles or change shortcut discovery.

**What happened?**

On iPadOS, a connected mouse or trackpad moved the row selection but did not paint hover highlights. Tailwind gated hover styles on a media query that iPadOS continued to report as false. Separately, disabling keyboard shortcuts also disabled `?`, which was the only way to open the shortcut help dialog.

**Expected behavior**

A real mouse or trackpad must enable hover highlights on iPadOS. Touch input must not create sticky hover. The `?` key must open the shortcut help dialog even when shortcuts are off. The dialog must show where to enable the setting.

**Steps to reproduce**

1. Open the inbox or task list on an iPad with a connected mouse or trackpad.
2. Move the pointer across rows.
3. Observe that selection follows the pointer but the row has no hover paint.
4. Turn keyboard shortcuts off in instance settings.
5. Press `?` outside a text input.
6. Observe that the shortcut help dialog does not open on the unmodified build.

**Paperclip version or commit**

`536d5880c5` (`public-gh/master` at preparation time).

**Deployment mode**

Local source build of the board UI.

**Installation method**

Built from source with pnpm.

## What Changed

- Replace Tailwind's hover media-query gate with a fail-open class gate.
- Detect real mouse pointer events and remove the touch-only hover gate for the rest of the session.
- Ignore touch pointer movement when keyboard navigation owns row selection.
- Keep `?` active when shortcuts are off, while every other shortcut remains disabled.
- Add a disabled-state message and a company-aware settings link to the shortcut help dialog.
- Add focused regression tests for pointer capability, shortcut handling, and shortcut help content.

## Verification

- `NODE_ENV=test pnpm exec vitest run ui/src/lib/pointerCapability.test.ts ui/src/hooks/useKeyboardShortcuts.test.tsx ui/src/components/KeyboardShortcutsCheatsheet.test.tsx` — 3 files and 24 tests passed.
- `pnpm check:token-gates` — all four token gates are clean.
- `pnpm -r typecheck` — passed.
- `pnpm test:run` — passed.
- `pnpm build` — passed with existing CSS, font, and bundle-size warnings.
- `git diff --check public-gh/master...HEAD` — passed.

## Risks

- A touch-first device keeps hover disabled until it emits a real mouse pointer event or changes its hover media query.
- Pen input does not unlock hover because a pen can emit pointer-over events during a tap.
- No API, database, migration, dependency, or workflow behavior changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, GPT-5-based coding agent through the `codex_local` adapter. The runtime did not expose a more specific model snapshot or context-window size. The agent used reasoning, repository tools, shell execution, GitHub CLI, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (not applicable; no documented contract changed)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

