### PR TITLE
feat(SAG-6327): pricing staleness detection — full stack Phases 0-5 (alerts table + feeds + runner + nightly hook + freeze arming)

### DIFF
--- a/infra/runtime-eval/nightly_eval.sh
+++ b/infra/runtime-eval/nightly_eval.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# SAG-4193: Nightly eval runner — single-runner (flock), then digest + alert.
+#
+# Run by a Paperclip routine or on-box cron. Designed to be launched from a
+# heartbeat as a detached background process so the heartbeat can exit while
+# the ~2h GPU-bound eval continues.
+#
+# Usage (detached from heartbeat):
+#   setsid nohup bash infra/runtime-eval/nightly_eval.sh >> infra/runtime-eval/results/nightly.log 2>&1 &
+#
+# Usage (foreground, for manual runs):
+#   bash infra/runtime-eval/nightly_eval.sh
+#
+# Environment:
+#   PAPERCLIP_API_URL  PAPERCLIP_API_KEY  PAPERCLIP_COMPANY_ID  PAPERCLIP_RUN_ID
+#   EVAL_MODEL          (optional override, default gemma4:26b-a4b-it-q4_K_M)
+#   EVAL_TIMEOUT_S      (optional, default 300)
+#   NIGHTLY_EVAL_NOTIFY_ISSUE  (issue ID to post completion comment to, default SAG-4193)
+#   TMP_HOUSEKEEPING_APPLY              (SAG-6346: default 0/dry-run; set 1 to actually delete)
+#   TMP_HOUSEKEEPING_ROOT               (optional, default /tmp)
+#   TMP_HOUSEKEEPING_PCVT_AGE_HOURS     (optional, default 12)
+#   TMP_HOUSEKEEPING_WORKTREE_AGE_HOURS (optional, default 24)
+#   LOCAL_AI_EVAL_SKIP_ON_PRESSURE      (optional, default 1)
+#   LOCAL_AI_EVAL_MAX_QWEN_PROCS        (optional, default 0)
+#   LOCAL_AI_EVAL_MAX_OPENCODE_PROCS    (optional, default 0)
+#   LOCAL_AI_EVAL_MAX_LOADED_MODELS     (optional, default 0)
+#   LOCAL_AI_EVAL_PREFLIGHT_ONLY        (optional test mode: run preflight then exit)
+#   PRICING_STALENESS_DB_DSN            (optional; SAG-6327/SAG-6344 pricing staleness
+#                                        detection runner. Unset = loud-fail skip, logged
+#                                        but non-fatal to this pipeline.)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results"
+LOCK_FILE="/tmp/sag4193-nightly-eval.lock"
+LOG_FILE="$RESULTS_DIR/nightly.log"
+NOTIFY_ISSUE="${NIGHTLY_EVAL_NOTIFY_ISSUE:-c8304ce0-3116-40b2-a718-4e7d0fb2c6d8}"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+mkdir -p "$RESULTS_DIR"
+echo "$(ts) [nightly_eval] Starting — PID $$" >> "$LOG_FILE"
+
+# ---------------------------------------------------------------------------
+# Single-runner lock (SAG-3514 lesson: ONE runner, no daemon respawning)
+# ---------------------------------------------------------------------------
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "$(ts) [nightly_eval] Already running (lock held). Exiting." >> "$LOG_FILE"
+  exit 0
+fi
+echo "$(ts) [nightly_eval] Lock acquired." >> "$LOG_FILE"
+
+# Ensure lock is released on exit (even on error)
+trap 'flock -u 9; echo "$(ts) [nightly_eval] Lock released." >> "$LOG_FILE"' EXIT
+
+# ---------------------------------------------------------------------------
+# Non-destructive local-AI pressure guard (SAG-5279)
+# ---------------------------------------------------------------------------
+echo "$(ts) [nightly_eval] Running local-AI pressure preflight ..." >> "$LOG_FILE"
+PREFLIGHT_EXIT=0
+python3 "$SCRIPT_DIR/local_ai_pressure_preflight.py" >> "$LOG_FILE" 2>&1 || PREFLIGHT_EXIT=$?
+if [ "$PREFLIGHT_EXIT" -eq 2 ]; then
+  echo "$(ts) [nightly_eval] EVAL SKIPPED: local model pressure. run_eval.py was not started." >> "$LOG_FILE"
+  if [ -n "${PAPERCLIP_API_URL:-}" ] && [ -n "${PAPERCLIP_API_KEY:-}" ]; then
+    SKIP_BODY=$(printf '%s' '## Nightly Eval SKIPPED
+
+EVAL SKIPPED: local model pressure. `run_eval.py` was not started; check `infra/runtime-eval/results/nightly.log` and the timestamped `local_ai_pressure_preflight_*.json` diagnostics artifact.' | python3 -c 'import json, sys; print(json.dumps({"body": sys.stdin.read()}))')
+    curl -s -X POST "$PAPERCLIP_API_URL/api/issues/$NOTIFY_ISSUE/comments" \
+      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+      -H "Content-Type: application/json" \
+      ${PAPERCLIP_RUN_ID:+-H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"} \
+      -d "$SKIP_BODY" >> "$LOG_FILE" 2>&1 || true
+  fi
+  exit 0
+elif [ "$PREFLIGHT_EXIT" -ne 0 ]; then
+  echo "$(ts) [nightly_eval] Pressure preflight failed with code $PREFLIGHT_EXIT" >> "$LOG_FILE"
+  exit "$PREFLIGHT_EXIT"
+fi
+
+if [ "${LOCAL_AI_EVAL_PREFLIGHT_ONLY:-0}" = "1" ]; then
+  echo "$(ts) [nightly_eval] LOCAL_AI_EVAL_PREFLIGHT_ONLY=1; exiting before run_eval.py." >> "$LOG_FILE"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Run eval
+# ---------------------------------------------------------------------------
+echo "$(ts) [nightly_eval] Running run_eval.py ..." >> "$LOG_FILE"
+EVAL_EXIT=0
+python3 "$SCRIPT_DIR/run_eval.py" >> "$LOG_FILE" 2>&1 || EVAL_EXIT=$?
+
+if [ $EVAL_EXIT -ne 0 ]; then
+  echo "$(ts) [nightly_eval] run_eval.py exited with code $EVAL_EXIT" >> "$LOG_FILE"
+  # Post failure notice if API is available
+  if [ -n "${PAPERCLIP_API_URL:-}" ] && [ -n "${PAPERCLIP_API_KEY:-}" ]; then
+    FAIL_BODY=$(python3 -c "import json; print(json.dumps({'body': '## Nightly Eval FAILED\n\nrun_eval.py exited with code $EVAL_EXIT. Check \`infra/runtime-eval/results/nightly.log\` for details.\n\n[@CTO](agent://f3c48afc-c339-4e43-b47b-a42a0891229d)'}))")
+    curl -s -X POST "$PAPERCLIP_API_URL/api/issues/$NOTIFY_ISSUE/comments" \
+      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+      -H "Content-Type: application/json" \
+      ${PAPERCLIP_RUN_ID:+-H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"} \
+      -d "$FAIL_BODY" >> "$LOG_FILE" 2>&1 || true
+  fi
+  exit $EVAL_EXIT
+fi
+
+echo "$(ts) [nightly_eval] run_eval.py complete. Running digest_and_alert.py ..." >> "$LOG_FILE"
+
+# ---------------------------------------------------------------------------
+# Digest + alert
+# ---------------------------------------------------------------------------
+DIGEST_EXIT=0
+python3 "$SCRIPT_DIR/digest_and_alert.py" >> "$LOG_FILE" 2>&1 || DIGEST_EXIT=$?
+
+echo "$(ts) [nightly_eval] digest_and_alert.py exited with code $DIGEST_EXIT" >> "$LOG_FILE"
+
+if [ $DIGEST_EXIT -ne 0 ]; then
+  echo "$(ts) [nightly_eval] Digest/alert step failed (see log). Eval results are still in $RESULTS_DIR." >> "$LOG_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# /tmp housekeeping (SAG-6346) — dry-run by default; never blocks nightly exit.
+# Set TMP_HOUSEKEEPING_APPLY=1 to enable real deletion once dry-run logs look right.
+# ---------------------------------------------------------------------------
+echo "$(ts) [nightly_eval] Running tmp_housekeeping.py (apply=${TMP_HOUSEKEEPING_APPLY:-0}) ..." >> "$LOG_FILE"
+HOUSEKEEPING_EXIT=0
+python3 "$SCRIPT_DIR/tmp_housekeeping.py" >> "$LOG_FILE" 2>&1 || HOUSEKEEPING_EXIT=$?
+echo "$(ts) [nightly_eval] tmp_housekeeping.py exited with code $HOUSEKEEPING_EXIT" >> "$LOG_FILE"
+
+# ---------------------------------------------------------------------------
+# Pricing staleness detection (SAG-6327 Phase 3+4 / SAG-6344)
+#
+# Independent of the local-AI eval above. Exits 0 both on a clean detection
+# run and on the expected pending-dependency state (real rate feeds still
+# pending, SAG-6341/SAG-6343 — Phase 1's alerts table already landed in
+# migration 003, commit b35be578) — it never fails nightly_eval.sh. A
+# non-zero exit here means an unexpected error, which is logged but still
+# does not abort the unrelated eval/digest steps above.
+# ---------------------------------------------------------------------------
+echo "$(ts) [nightly_eval] Running pricing_staleness_runner.py ..." >> "$LOG_FILE"
+STALENESS_EXIT=0
+python3 "$SCRIPT_DIR/pricing_staleness_runner.py" >> "$LOG_FILE" 2>&1 || STALENESS_EXIT=$?
+echo "$(ts) [nightly_eval] pricing_staleness_runner.py exited with code $STALENESS_EXIT" >> "$LOG_FILE"
+
+# Post completion notice to the routine issue
+if [ -n "${PAPERCLIP_API_URL:-}" ] && [ -n "${PAPERCLIP_API_KEY:-}" ]; then
+  LATEST=$(ls -t "$RESULTS_DIR"/*.json 2>/dev/null | head -1 || echo "(none)")
+  STATUS_MSG="✅ Nightly eval complete. Latest results: \`$(basename "$LATEST")\`. Digest posted to [SAG-3196](/SAG/issues/SAG-3196)."
+  if [ $DIGEST_EXIT -ne 0 ]; then
+    STATUS_MSG="⚠️ Eval complete but digest/alert step failed (exit $DIGEST_EXIT). Latest results: \`$(basename "$LATEST")\`. Check \`nightly.log\`."
+  fi
+  DONE_BODY=$(python3 -c "import json; print(json.dumps({'body': '$STATUS_MSG'}))")
+  curl -s -X POST "$PAPERCLIP_API_URL/api/issues/$NOTIFY_ISSUE/comments" \
+    -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+    -H "Content-Type: application/json" \
+    ${PAPERCLIP_RUN_ID:+-H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"} \
+    -d "$DONE_BODY" >> "$LOG_FILE" 2>&1 || true
+fi
+
+echo "$(ts) [nightly_eval] Done." >> "$LOG_FILE"
+exit 0

--- a/infra/runtime-eval/pricing_feeds.py
+++ b/infra/runtime-eval/pricing_feeds.py
@@ -1,0 +1,142 @@
+"""Typed read-adapter contract for the pricing staleness-detection feeds (SAG-6327 Phase 0).
+
+Three upstream feeds back the staleness runner (SAG-6302 plan):
+  1. Rate-record store   - active rate records w/ rate_card_version, imported_at, content_hash.
+  2. Negotiated-rate change log - append-only manual rate changes (drives the SLA signal).
+  3. Margin/SUT policy-change log - append-only policy changes (suppresses anomaly alerts).
+
+None of the three physical feeds exist yet. Per SAG-6337 (Director of Pricing, resolved):
+Pricing owns the data-semantics spec (filed as SAG-6341); Engineering owns the physical
+store + these read entrypoints (SAG-6343, blocked on SAG-6341). Until SAG-6341 lands, the
+Not-Implemented adapters below raise FeedUnavailableError rather than silently returning
+empty/fake data, so the detection runner (SAG-6344) fails loudly instead of reporting a
+false "no staleness detected."
+
+The Fake* adapters exist so the runner and its tests can be built today against this
+contract, ahead of the real feeds.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+
+class FeedUnavailableError(RuntimeError):
+    """Raised when a real feed is queried before its physical store exists.
+
+    Callers must handle this by escalating, not by treating it as "zero results."
+    """
+
+
+@dataclass(frozen=True)
+class RateRecord:
+    """One active rate record. Grain = product estimate group x fee/cost bucket x territory.
+
+    `rate_bearing_fields` holds the columns the content-hash covers (the $/sqft fee +
+    cost-basis fields) as key/value pairs; the exact field names are a Pricing decision
+    pending SAG-6341 and are intentionally not hard-coded as dataclass fields here.
+    """
+
+    product_estimate_group: str
+    bucket_code: str
+    territory: str
+    rate_card_version: str
+    imported_at: datetime
+    rate_bearing_fields: dict[str, Decimal]
+    content_hash: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NegotiatedRateChange:
+    """One append-only entry in the negotiated-rate change log."""
+
+    record_key: str
+    old_value: Decimal
+    new_value: Decimal
+    source: str
+    reason: str
+    entered_at: datetime
+    committed_at: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class PolicyChange:
+    """One append-only entry in the margin/SUT policy-change log."""
+
+    policy_key: str
+    old: str
+    new: str
+    effective_at: datetime
+    reason: str
+
+
+class RateRecordFeed(ABC):
+    @abstractmethod
+    def get_active_rate_records(self, as_of: datetime) -> list[RateRecord]:
+        """Return all rate records active as of the given timestamp."""
+
+
+class NegotiatedRateChangeFeed(ABC):
+    @abstractmethod
+    def get_changes_since(self, since: datetime) -> list[NegotiatedRateChange]:
+        """Return negotiated-rate changes entered since the given timestamp."""
+
+
+class MarginPolicyChangeFeed(ABC):
+    @abstractmethod
+    def get_changes_since(self, since: datetime) -> list[PolicyChange]:
+        """Return margin/SUT policy changes effective since the given timestamp."""
+
+
+class NotImplementedRateRecordFeed(RateRecordFeed):
+    def get_active_rate_records(self, as_of: datetime) -> list[RateRecord]:
+        raise FeedUnavailableError(
+            "Rate-record store does not exist yet. Column spec pending SAG-6341 "
+            "(Pricing feed-spec); physical store build tracked as SAG-6343."
+        )
+
+
+class NotImplementedNegotiatedRateChangeFeed(NegotiatedRateChangeFeed):
+    def get_changes_since(self, since: datetime) -> list[NegotiatedRateChange]:
+        raise FeedUnavailableError(
+            "Negotiated-rate change log does not exist yet. Format spec pending SAG-6341; "
+            "physical store build tracked as SAG-6343."
+        )
+
+
+class NotImplementedMarginPolicyChangeFeed(MarginPolicyChangeFeed):
+    def get_changes_since(self, since: datetime) -> list[PolicyChange]:
+        raise FeedUnavailableError(
+            "Margin/SUT policy-change log does not exist yet. Format spec pending SAG-6341; "
+            "physical store build tracked as SAG-6343."
+        )
+
+
+@dataclass
+class FakeRateRecordFeed(RateRecordFeed):
+    """In-memory feed for detection-runner development/tests (SAG-6344), ahead of the real store."""
+
+    records: list[RateRecord] = field(default_factory=list)
+
+    def get_active_rate_records(self, as_of: datetime) -> list[RateRecord]:
+        return [r for r in self.records if r.imported_at <= as_of]
+
+
+@dataclass
+class FakeNegotiatedRateChangeFeed(NegotiatedRateChangeFeed):
+    changes: list[NegotiatedRateChange] = field(default_factory=list)
+
+    def get_changes_since(self, since: datetime) -> list[NegotiatedRateChange]:
+        return [c for c in self.changes if c.entered_at >= since]
+
+
+@dataclass
+class FakeMarginPolicyChangeFeed(MarginPolicyChangeFeed):
+    changes: list[PolicyChange] = field(default_factory=list)
+
+    def get_changes_since(self, since: datetime) -> list[PolicyChange]:
+        return [c for c in self.changes if c.effective_at >= since]

--- a/infra/runtime-eval/pricing_freeze_arming.py
+++ b/infra/runtime-eval/pricing_freeze_arming.py
@@ -1,0 +1,347 @@
+"""Quote-freeze arming mechanism — SAG-6327 Phase 5 (SAG-6345).
+
+BUILD-ONLY. This module MUST NOT autonomously arm a client-facing quote freeze.
+Per SAG-6302's binding CEO operating condition, the freeze has direct revenue
+impact, so *arming* is not an autonomous action: it requires explicit
+human/board sign-off. This module therefore does two separable things:
+
+  1. `evaluate_arming_readiness()` — a pure, side-effect-free evaluation of
+     whether the arming preconditions are met, and (if so) which record_keys
+     are in the proposed freeze scope. This is safe to call on every nightly
+     run for reporting; it takes no action.
+
+  2. `arm_freeze()` — the only function that produces an armed-freeze record,
+     and it structurally cannot be triggered autonomously: it *requires* a
+     valid `ArmingAuthorization` carrying an explicit human/board sign-off. No
+     caller in this codebase (the nightly runner included) constructs an
+     `ArmingAuthorization`; only a human/board sign-off flow does. Absent that
+     token, `arm_freeze()` raises rather than arming.
+
+Binding preconditions (SAG-6302 "quote-freeze arming"):
+
+  * No arming during the 30-day observe-only warm-up (Phase 4). Warm-up is
+    evaluated with the runner's own `is_warm_up()` so the two phases can never
+    disagree on the window.
+  * Arms only AFTER warm-up completes AND at least one clean baseline median
+    exists per (SKU, bucket) — here, per `record_key`
+    (`product_estimate_group|bucket_code|territory`, the runner's grain).
+
+When armed (behavior the sign-off flow authorizes — enforcement wiring into the
+quoting system is a downstream phase, out of scope here):
+
+  * freeze is scoped to affected client-facing lines only — CRITICAL alerts
+    only, and only where a clean baseline median exists to fall back to;
+  * existing quotes are honored (the freeze gates new quotes, not booked ones);
+  * unfreeze requires a refreshed record + paired-write log + Auditor/Director
+    sign-off, a 2-business-day remediation SLA, then CEO escalation.
+
+The baseline-median source is injected via the `BaselineMedianProvider`
+contract, following the epic's established loud-fail dependency-injection
+pattern (see pricing_feeds.py Phase 0): the `NotImplemented*` provider raises
+rather than silently reporting "no baselines," so a mis-wired caller cannot
+accidentally look un-armable (or, worse, mint a spurious clean baseline).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from pricing_staleness_runner import (
+    WARM_UP_DURATION_DAYS,
+    WARM_UP_START_DATE,
+    is_warm_up,
+)
+
+# Sign-off authorities that may authorize arming. Deliberately excludes every
+# agent/automation identity: only a human or the board can arm.
+VALID_ARMING_AUTHORITIES = frozenset({"human", "board"})
+
+# Documented unfreeze contract (SAG-6302). Carried on the armed record so the
+# sign-off/unfreeze flow reads it from one place rather than re-deriving it.
+UNFREEZE_REQUIREMENTS = (
+    "refreshed rate record",
+    "paired-write log entry",
+    "Auditor/Director sign-off",
+    "2-business-day remediation SLA, then CEO escalation",
+)
+
+
+class ArmingError(RuntimeError):
+    """Base class for all freeze-arming refusals."""
+
+
+class ArmingBlockedError(ArmingError):
+    """Raised when arming is attempted while a hard precondition is unmet
+    (still in warm-up, no clean baseline, or empty freeze scope)."""
+
+
+class ArmingNotAuthorizedError(ArmingError):
+    """Raised when arming is attempted without a valid explicit human/board
+    sign-off. This is the guard that makes auto-arming structurally impossible."""
+
+
+class BaselineMedianUnavailableError(RuntimeError):
+    """Raised when the baseline-median source is queried before it is wired.
+
+    Callers must handle this by reporting "not yet evaluable," never by
+    treating it as "no clean baselines exist."
+    """
+
+
+@dataclass(frozen=True)
+class BaselineMedian:
+    """One materialized trailing-3-month baseline median for a record_key.
+
+    `is_clean` is True when the median is usable as a freeze reference: it was
+    computed from a sufficient sample and is not itself contaminated by an
+    unresolved CRITICAL anomaly on the same record. The provider owns that
+    determination (it has the history); this module only consumes the flag.
+    """
+
+    record_key: str
+    field_name: str
+    median_value: Decimal
+    sample_size: int
+    computed_at: datetime
+    is_clean: bool = True
+
+
+class BaselineMedianProvider:
+    """Contract for the clean-baseline-median source (materialized during the
+    Phase 4 warm-up). Abstract; implementations below."""
+
+    def get_clean_baseline_medians(self, as_of: datetime) -> list[BaselineMedian]:
+        raise NotImplementedError
+
+
+class NotImplementedBaselineMedianProvider(BaselineMedianProvider):
+    """Loud-fail default: raises rather than silently reporting no baselines."""
+
+    def get_clean_baseline_medians(self, as_of: datetime) -> list[BaselineMedian]:
+        raise BaselineMedianUnavailableError(
+            "No baseline-median source wired (Phase 4 warm-up materialization "
+            "not yet connected); refusing to report freeze-arming readiness "
+            "against an empty baseline set."
+        )
+
+
+@dataclass
+class InMemoryBaselineMedianProvider(BaselineMedianProvider):
+    """In-memory provider for development/tests."""
+
+    medians: list[BaselineMedian] = field(default_factory=list)
+
+    def get_clean_baseline_medians(self, as_of: datetime) -> list[BaselineMedian]:
+        return [m for m in self.medians if m.is_clean and m.computed_at <= as_of]
+
+
+@dataclass(frozen=True)
+class ArmingReadiness:
+    """Pure evaluation of whether the freeze may be armed, and over what scope.
+
+    This is a *report*, not an action. `eligible_to_arm` being True does NOT
+    mean the freeze is or will be armed — it means a human/board sign-off is
+    now permitted to arm it via `arm_freeze()`.
+    """
+
+    as_of: datetime
+    warm_up_complete: bool
+    warm_up_ends_on: date
+    clean_baseline_keys: frozenset[str]
+    outstanding_critical_keys: frozenset[str]
+    armable_scope: tuple[str, ...]
+    blocked_critical_keys: tuple[str, ...]
+    eligible_to_arm: bool
+    blocking_reasons: tuple[str, ...]
+    requires_signoff: bool = True
+
+
+def warm_up_end_date(warm_up_start: date = WARM_UP_START_DATE) -> date:
+    """First calendar date on which warm-up is over (arming may be considered)."""
+    from datetime import timedelta
+
+    return warm_up_start + timedelta(days=WARM_UP_DURATION_DAYS)
+
+
+def evaluate_arming_readiness(
+    *,
+    as_of: datetime,
+    baseline_provider: BaselineMedianProvider,
+    outstanding_critical_keys: set[str] | frozenset[str],
+    warm_up_start: date = WARM_UP_START_DATE,
+) -> ArmingReadiness:
+    """Evaluate arming preconditions. Pure/read-only — takes no action.
+
+    `outstanding_critical_keys` are the record_keys currently carrying a
+    CRITICAL staleness alert (the client-facing lines a freeze would scope to).
+    The freeze scope is those keys intersected with keys that have a clean
+    baseline median to fall back to; a CRITICAL key without a clean baseline is
+    reported as blocked (unsafe to freeze) rather than silently dropped.
+    """
+    warm_up_complete = not is_warm_up(as_of, warm_up_start)
+
+    clean_keys = frozenset(
+        m.record_key for m in baseline_provider.get_clean_baseline_medians(as_of)
+    )
+    critical_keys = frozenset(outstanding_critical_keys)
+
+    armable = tuple(sorted(critical_keys & clean_keys))
+    blocked = tuple(sorted(critical_keys - clean_keys))
+
+    reasons: list[str] = []
+    if not warm_up_complete:
+        reasons.append(
+            f"in 30-day observe-only warm-up (ends {warm_up_end_date(warm_up_start).isoformat()})"
+        )
+    if not clean_keys:
+        reasons.append("no clean baseline median exists for any (SKU, bucket) yet")
+
+    eligible = warm_up_complete and len(clean_keys) >= 1
+
+    return ArmingReadiness(
+        as_of=as_of,
+        warm_up_complete=warm_up_complete,
+        warm_up_ends_on=warm_up_end_date(warm_up_start),
+        clean_baseline_keys=clean_keys,
+        outstanding_critical_keys=critical_keys,
+        armable_scope=armable,
+        blocked_critical_keys=blocked,
+        eligible_to_arm=eligible,
+        blocking_reasons=tuple(reasons),
+    )
+
+
+@dataclass(frozen=True)
+class FreezeArmingProposal:
+    """A freeze that *could* be armed, pending explicit human/board sign-off.
+
+    Produced by `build_freeze_proposal()` only when preconditions are met and
+    there is a non-empty scope. It is the artifact a human/board reviews before
+    authorizing `arm_freeze()`. Constructing a proposal arms nothing.
+    """
+
+    as_of: datetime
+    scope: tuple[str, ...]
+    baseline_refs: tuple[str, ...]
+    rationale: str
+    requires_signoff: bool = True
+
+
+def build_freeze_proposal(readiness: ArmingReadiness) -> Optional[FreezeArmingProposal]:
+    """Turn a readiness evaluation into a sign-off-ready proposal, or None.
+
+    Returns None when arming is not eligible or there is nothing CRITICAL to
+    freeze (an empty scope) — i.e. when there is no proposal to put in front of
+    a human/board.
+    """
+    if not readiness.eligible_to_arm or not readiness.armable_scope:
+        return None
+    return FreezeArmingProposal(
+        as_of=readiness.as_of,
+        scope=readiness.armable_scope,
+        baseline_refs=tuple(sorted(readiness.clean_baseline_keys & set(readiness.armable_scope))),
+        rationale=(
+            f"{len(readiness.armable_scope)} client-facing line(s) carry a CRITICAL "
+            "staleness alert and have a clean baseline median to fall back to; "
+            "warm-up is complete. Arming requires explicit human/board sign-off."
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class ArmingAuthorization:
+    """Explicit human/board sign-off authorizing a specific arm action.
+
+    The presence of a validated instance of this class is the ONLY thing that
+    lets `arm_freeze()` proceed. Nothing in the automated pipeline constructs
+    one; it is minted by a human/board sign-off flow.
+    """
+
+    authorized_by: str
+    authority: str  # must be one of VALID_ARMING_AUTHORITIES
+    reference: str  # audit pointer: sign-off comment / issue / board minute id
+    authorized_at: datetime
+
+    def validate(self) -> None:
+        if self.authority not in VALID_ARMING_AUTHORITIES:
+            raise ArmingNotAuthorizedError(
+                f"arming authority {self.authority!r} is not a human/board sign-off "
+                f"(must be one of {sorted(VALID_ARMING_AUTHORITIES)}); refusing to arm."
+            )
+        if not self.authorized_by.strip():
+            raise ArmingNotAuthorizedError("arming sign-off is missing an authorizer identity.")
+        if not self.reference.strip():
+            raise ArmingNotAuthorizedError(
+                "arming sign-off is missing an audit reference (comment/issue/minute id)."
+            )
+
+
+@dataclass(frozen=True)
+class ArmedFreeze:
+    """Record of an armed freeze. Reachable only via a signed `arm_freeze()`."""
+
+    scope: tuple[str, ...]
+    armed_at: datetime
+    authorization: ArmingAuthorization
+    existing_quotes_honored: bool = True
+    unfreeze_requirements: tuple[str, ...] = UNFREEZE_REQUIREMENTS
+
+
+def arm_freeze(
+    proposal: Optional[FreezeArmingProposal],
+    authorization: Optional[ArmingAuthorization],
+    *,
+    as_of: datetime,
+    warm_up_start: date = WARM_UP_START_DATE,
+) -> ArmedFreeze:
+    """Arm the freeze for `proposal.scope`. NEVER auto-arms.
+
+    Refuses unless BOTH hold:
+      * a valid, non-empty proposal whose preconditions still hold at `as_of`
+        (defense-in-depth re-check that warm-up is over), and
+      * an explicit, valid human/board `ArmingAuthorization`.
+
+    Raises `ArmingBlockedError` (preconditions) or `ArmingNotAuthorizedError`
+    (no/invalid sign-off) otherwise. There is no code path that arms without a
+    caller-supplied `ArmingAuthorization`.
+    """
+    # Defense in depth: re-assert the warm-up gate at the moment of arming,
+    # independent of whatever readiness evaluation produced the proposal.
+    if is_warm_up(as_of, warm_up_start):
+        raise ArmingBlockedError(
+            "refusing to arm during the 30-day observe-only warm-up "
+            f"(ends {warm_up_end_date(warm_up_start).isoformat()})."
+        )
+    if proposal is None or not proposal.scope:
+        raise ArmingBlockedError(
+            "no armable freeze proposal (preconditions unmet or empty scope); nothing to arm."
+        )
+    if authorization is None:
+        raise ArmingNotAuthorizedError(
+            "quote-freeze arming requires explicit human/board sign-off; "
+            "refusing to arm autonomously (SAG-6302 binding operating condition)."
+        )
+    authorization.validate()
+
+    return ArmedFreeze(
+        scope=proposal.scope,
+        armed_at=as_of,
+        authorization=authorization,
+    )
+
+
+def format_arming_readiness(readiness: ArmingReadiness) -> str:
+    """One-line-ish, report-only rendering for the nightly digest. No action."""
+    if readiness.eligible_to_arm and readiness.armable_scope:
+        head = (
+            f"ELIGIBLE — {len(readiness.armable_scope)} line(s) proposable for freeze, "
+            "AWAITING explicit human/board sign-off (not armed)"
+        )
+    elif readiness.eligible_to_arm:
+        head = "eligible, but no CRITICAL client-facing line to freeze right now (not armed)"
+    else:
+        head = "NOT eligible to arm: " + "; ".join(readiness.blocking_reasons)
+    return f"Quote-freeze arming — {readiness.as_of.date().isoformat()}: {head}"

--- a/infra/runtime-eval/pricing_staleness_alerts.py
+++ b/infra/runtime-eval/pricing_staleness_alerts.py
@@ -1,0 +1,133 @@
+"""Alert-sink contract for the pricing staleness-detection runner (SAG-6344).
+
+The `enrichment_staging.pricing_staleness_alerts` append-only table (SAG-6327
+Phase 1) landed in migration `003_pricing_staleness_alerts_up.sql` and was
+reconciled in SAG-6353 to the runner's own `StalenessAlert` shape: the table's
+`signal_type`/`severity` CHECK constraints use exactly the strings the runner
+emits (`anomaly`/`version_hash_drift`/`sla_breach`/`bulk_escalation`,
+`warn`/`critical`), and its columns are `record_key`, `detected_at`,
+`warm_up`, and a `details_json` JSONB blob for signal-specific evidence. The
+table and the runner now share the same grain, so `alert_to_row()` is a
+direct field-for-field mapping onto the table's columns -- no splitting or
+translation required.
+
+Per the epic's established loud-fail pattern (see pricing_feeds.py Phase 0),
+`NotImplementedAlertSink` raises rather than silently dropping alerts on the
+floor -- used only if a caller constructs the runner without a DSN and
+without opting into the in-memory fakes.
+"""
+
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Optional
+
+import psycopg2
+import psycopg2.extras
+
+
+class AlertSinkUnavailableError(RuntimeError):
+    """Raised when the real alert sink is queried before its physical table exists.
+
+    Callers must handle this by escalating, not by treating it as "alert written."
+    """
+
+
+@dataclass(frozen=True)
+class StalenessAlert:
+    """One detection event, in the detection runner's own working shape.
+
+    `record_key` identifies the affected rate record or negotiated-rate change
+    (e.g. "product_estimate_group|bucket_code|territory" for `RateRecord`-derived
+    signals, or an opaque feed-supplied key for change-feed-derived signals).
+    `details` carries signal-specific evidence (pct_delta, versions, due/committed
+    timestamps, etc.) and is persisted verbatim in the `details_json` column.
+    """
+
+    signal_type: str
+    severity: str
+    record_key: str
+    detected_at: datetime
+    warm_up: bool
+    details: dict[str, Any]
+    id: Optional[str] = None
+
+
+def alert_to_row(alert: StalenessAlert) -> dict[str, Any]:
+    """Map a `StalenessAlert` onto the exact column set of
+    `enrichment_staging.pricing_staleness_alerts` (migration 003, SAG-6353)."""
+    return {
+        "signal_type": alert.signal_type,
+        "severity": alert.severity,
+        "record_key": alert.record_key,
+        "detected_at": alert.detected_at,
+        "warm_up": alert.warm_up,
+        "details_json": psycopg2.extras.Json(alert.details),
+    }
+
+
+class AlertSink(ABC):
+    @abstractmethod
+    def write_alert(self, alert: StalenessAlert) -> None:
+        """Persist one alert. Must raise rather than silently drop on failure."""
+
+
+class NotImplementedAlertSink(AlertSink):
+    def write_alert(self, alert: StalenessAlert) -> None:
+        raise AlertSinkUnavailableError(
+            "No pricing-staleness DB DSN configured (PRICING_STALENESS_DB_DSN unset) "
+            "and --use-fakes not passed; refusing to silently drop this alert."
+        )
+
+
+@dataclass
+class InMemoryAlertSink(AlertSink):
+    """In-memory sink for detection-runner development/tests (SAG-6344)."""
+
+    alerts: list[StalenessAlert] = field(default_factory=list)
+
+    def write_alert(self, alert: StalenessAlert) -> None:
+        if alert.id is None:
+            alert = StalenessAlert(
+                signal_type=alert.signal_type,
+                severity=alert.severity,
+                record_key=alert.record_key,
+                detected_at=alert.detected_at,
+                warm_up=alert.warm_up,
+                details=alert.details,
+                id=str(uuid.uuid4()),
+            )
+        self.alerts.append(alert)
+
+
+class PostgresAlertSink(AlertSink):
+    """Writes alerts into `enrichment_staging.pricing_staleness_alerts` (migration 003).
+
+    Expects a DSN authenticating as the `pricing_staleness_writer` role
+    (SELECT+INSERT only; append-only, no UPDATE/DELETE granted -- see
+    migrations/README.md). One connection is opened at construction and
+    reused for the life of the sink (one nightly run = one connection).
+    """
+
+    def __init__(self, dsn: str):
+        self._conn = psycopg2.connect(dsn)
+        self._conn.autocommit = True
+
+    def write_alert(self, alert: StalenessAlert) -> None:
+        row = alert_to_row(alert)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO enrichment_staging.pricing_staleness_alerts
+                    (signal_type, severity, record_key, detected_at, warm_up, details_json)
+                VALUES
+                    (%(signal_type)s, %(severity)s, %(record_key)s, %(detected_at)s, %(warm_up)s, %(details_json)s)
+                """,
+                row,
+            )
+
+    def close(self) -> None:
+        self._conn.close()

--- a/infra/runtime-eval/pricing_staleness_runner.py
+++ b/infra/runtime-eval/pricing_staleness_runner.py
@@ -1,0 +1,406 @@
+"""Pricing staleness detection runner — SAG-6327 Phase 3+4 (SAG-6344).
+
+Four signals, each producing zero or more `StalenessAlert` rows:
+  1. anomaly       — latest rate-bearing field value vs trailing 3-mo median,
+                      +-5% (warn) / +-10% (critical), suppressed by a recent
+                      margin/SUT policy change.
+  2. version/hash  — same `rate_card_version` but a different `content_hash`
+                      between consecutive imports of the same record (silent
+                      drift without a version bump).
+  3. sla_breach    — a negotiated-rate change not committed by 18:00
+                      America/Chicago on the next business day after it was
+                      entered.
+  4. bulk_escalation — a meta-signal: when signals 1-3 fire >= threshold times
+                      in a single run, one additional escalation row is
+                      written summarizing the batch.
+
+Phase 4 (30-day warm-up): every alert is stamped `warm_up=True` while inside
+the warm-up window. This module takes **zero enforcement action** in either
+mode — it only detects and records. Quote-freeze arming is Phase 5 (SAG-6345,
+separately blocked, build-only, never auto-armed) and is intentionally not
+referenced here.
+
+SAG-6327 Phase 1 (the `pricing_staleness_alerts` table, migration 003,
+commit b35be578) has landed. Real writes go through the `AlertSink` contract
+in pricing_staleness_alerts.py: `PostgresAlertSink` writes to the real table
+when `PRICING_STALENESS_DB_DSN` is set; otherwise `NotImplementedAlertSink`
+raises loudly instead of pretending to persist alerts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import statistics
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from pricing_feeds import (
+    FeedUnavailableError,
+    MarginPolicyChangeFeed,
+    NegotiatedRateChange,
+    NegotiatedRateChangeFeed,
+    NotImplementedMarginPolicyChangeFeed,
+    NotImplementedNegotiatedRateChangeFeed,
+    NotImplementedRateRecordFeed,
+    RateRecordFeed,
+)
+from pricing_staleness_alerts import (
+    AlertSink,
+    AlertSinkUnavailableError,
+    NotImplementedAlertSink,
+    StalenessAlert,
+)
+
+log = logging.getLogger(__name__)
+
+CHICAGO = ZoneInfo("America/Chicago")
+
+TRAILING_WINDOW = timedelta(days=90)
+WARN_THRESHOLD = Decimal("0.05")
+CRITICAL_THRESHOLD = Decimal("0.10")
+ANOMALY_SUPPRESSION_WINDOW = timedelta(days=3)
+SLA_LOOKBACK_DAYS = 30
+BULK_ESCALATION_THRESHOLD = 5
+
+WARM_UP_START_DATE = date(2026, 7, 7)  # runner go-live; SAG-6327 Phase 4
+WARM_UP_DURATION_DAYS = 30
+
+PRICING_LANE_ISSUE_ID = "61fe7650-d932-47cf-ac3c-8989e3b72f57"  # SAG-6327
+
+
+def _ensure_aware(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def commit_due_at(entered_at: datetime) -> datetime:
+    """Next business day, 18:00 America/Chicago, after `entered_at`.
+
+    Naive input is treated as UTC before converting to Chicago local time.
+    Weekends are skipped; US holidays are not modeled (known simplification).
+    """
+    local = _ensure_aware(entered_at).astimezone(CHICAGO)
+    next_day = local.date() + timedelta(days=1)
+    while next_day.weekday() >= 5:  # Saturday=5, Sunday=6
+        next_day += timedelta(days=1)
+    return datetime(next_day.year, next_day.month, next_day.day, 18, 0, tzinfo=CHICAGO)
+
+
+def is_sla_breached(change: NegotiatedRateChange, as_of: datetime) -> bool:
+    due = commit_due_at(change.entered_at)
+    if change.committed_at is not None:
+        return _ensure_aware(change.committed_at) > due
+    return _ensure_aware(as_of) > due
+
+
+def _record_key(record) -> str:
+    return f"{record.product_estimate_group}|{record.bucket_code}|{record.territory}"
+
+
+def _is_anomaly_suppressed(policy_feed: MarginPolicyChangeFeed, latest_imported_at: datetime) -> bool:
+    since = latest_imported_at - ANOMALY_SUPPRESSION_WINDOW
+    changes = policy_feed.get_changes_since(since)
+    return any(c.effective_at <= latest_imported_at for c in changes)
+
+
+def detect_anomalies(
+    rate_feed: RateRecordFeed,
+    policy_feed: MarginPolicyChangeFeed,
+    as_of: datetime,
+    warm_up: bool,
+) -> list[StalenessAlert]:
+    records = rate_feed.get_active_rate_records(as_of=as_of)
+    by_key: dict[tuple, list] = defaultdict(list)
+    for record in records:
+        by_key[(record.product_estimate_group, record.bucket_code, record.territory)].append(record)
+
+    alerts: list[StalenessAlert] = []
+    window_start = as_of - TRAILING_WINDOW
+    for key, recs in by_key.items():
+        recs_sorted = sorted(recs, key=lambda r: r.imported_at)
+        latest = recs_sorted[-1]
+        history = [r for r in recs_sorted[:-1] if r.imported_at >= window_start]
+        if not history:
+            continue
+        if _is_anomaly_suppressed(policy_feed, latest.imported_at):
+            continue
+
+        for field_name, latest_val in latest.rate_bearing_fields.items():
+            hist_vals = [
+                r.rate_bearing_fields[field_name]
+                for r in history
+                if field_name in r.rate_bearing_fields
+            ]
+            if not hist_vals:
+                continue
+            median_val = statistics.median(hist_vals)
+            if median_val == 0:
+                continue
+            pct_delta = abs(latest_val - median_val) / median_val
+            if pct_delta >= CRITICAL_THRESHOLD:
+                severity = "critical"
+            elif pct_delta >= WARN_THRESHOLD:
+                severity = "warn"
+            else:
+                continue
+
+            alerts.append(
+                StalenessAlert(
+                    signal_type="anomaly",
+                    severity=severity,
+                    record_key=_record_key(latest),
+                    detected_at=as_of,
+                    warm_up=warm_up,
+                    details={
+                        "field": field_name,
+                        "pct_delta": float(pct_delta),
+                        "latest_value": str(latest_val),
+                        "median_value": str(median_val),
+                        "rate_card_version": latest.rate_card_version,
+                    },
+                )
+            )
+    return alerts
+
+
+def detect_version_hash_drift(
+    rate_feed: RateRecordFeed, as_of: datetime, warm_up: bool
+) -> list[StalenessAlert]:
+    records = rate_feed.get_active_rate_records(as_of=as_of)
+    by_key: dict[tuple, list] = defaultdict(list)
+    for record in records:
+        by_key[(record.product_estimate_group, record.bucket_code, record.territory)].append(record)
+
+    alerts: list[StalenessAlert] = []
+    for key, recs in by_key.items():
+        recs_sorted = sorted(recs, key=lambda r: r.imported_at)
+        for prev, curr in zip(recs_sorted, recs_sorted[1:]):
+            if prev.rate_card_version == curr.rate_card_version and prev.content_hash != curr.content_hash:
+                alerts.append(
+                    StalenessAlert(
+                        signal_type="version_hash_drift",
+                        severity="critical",
+                        record_key=_record_key(curr),
+                        detected_at=as_of,
+                        warm_up=warm_up,
+                        details={
+                            "rate_card_version": curr.rate_card_version,
+                            "prev_content_hash": prev.content_hash,
+                            "curr_content_hash": curr.content_hash,
+                            "prev_imported_at": prev.imported_at.isoformat(),
+                            "curr_imported_at": curr.imported_at.isoformat(),
+                        },
+                    )
+                )
+    return alerts
+
+
+def detect_sla_breaches(
+    change_feed: NegotiatedRateChangeFeed,
+    as_of: datetime,
+    lookback_days: int,
+    warm_up: bool,
+) -> list[StalenessAlert]:
+    since = as_of - timedelta(days=lookback_days)
+    alerts: list[StalenessAlert] = []
+    for change in change_feed.get_changes_since(since):
+        if not is_sla_breached(change, as_of):
+            continue
+        alerts.append(
+            StalenessAlert(
+                signal_type="sla_breach",
+                severity="warn",
+                record_key=change.record_key,
+                detected_at=as_of,
+                warm_up=warm_up,
+                details={
+                    "entered_at": change.entered_at.isoformat(),
+                    "committed_at": change.committed_at.isoformat() if change.committed_at else None,
+                    "due_at": commit_due_at(change.entered_at).isoformat(),
+                    "source": change.source,
+                    "reason": change.reason,
+                },
+            )
+        )
+    return alerts
+
+
+def detect_bulk_escalation(
+    prior_alerts: list[StalenessAlert], as_of: datetime, warm_up: bool
+) -> list[StalenessAlert]:
+    if len(prior_alerts) < BULK_ESCALATION_THRESHOLD:
+        return []
+    return [
+        StalenessAlert(
+            signal_type="bulk_escalation",
+            severity="critical",
+            record_key="MULTIPLE",
+            detected_at=as_of,
+            warm_up=warm_up,
+            details={
+                "count": len(prior_alerts),
+                "affected_keys": sorted({a.record_key for a in prior_alerts}),
+                "signal_types": sorted({a.signal_type for a in prior_alerts}),
+            },
+        )
+    ]
+
+
+def is_warm_up(as_of: datetime, warm_up_start: date = WARM_UP_START_DATE) -> bool:
+    return (as_of.date() - warm_up_start).days < WARM_UP_DURATION_DAYS
+
+
+def run_detection(
+    *,
+    as_of: datetime,
+    rate_feed: RateRecordFeed,
+    change_feed: NegotiatedRateChangeFeed,
+    policy_feed: MarginPolicyChangeFeed,
+    alert_sink: AlertSink,
+    warm_up: bool,
+) -> list[StalenessAlert]:
+    """Run all four signals and write one alert row per detection. Detect-only:
+    no enforcement action of any kind is taken here, warm-up or not."""
+    alerts: list[StalenessAlert] = []
+    alerts += detect_anomalies(rate_feed, policy_feed, as_of, warm_up)
+    alerts += detect_version_hash_drift(rate_feed, as_of, warm_up)
+    alerts += detect_sla_breaches(change_feed, as_of, SLA_LOOKBACK_DAYS, warm_up)
+    alerts += detect_bulk_escalation(alerts, as_of, warm_up)
+
+    for alert in alerts:
+        alert_sink.write_alert(alert)
+
+    return alerts
+
+
+# ---------------------------------------------------------------------------
+# Digest posting (nightly digest comment to the pricing lane)
+# ---------------------------------------------------------------------------
+
+
+def format_digest(alerts: list[StalenessAlert], as_of: datetime, warm_up: bool) -> str:
+    if not alerts:
+        mode = "warm-up (observe-only)" if warm_up else "enforced"
+        return f"## Pricing Staleness Detection — {as_of.date().isoformat()} ({mode})\n\nNo alerts."
+
+    by_signal: dict[str, int] = defaultdict(int)
+    for a in alerts:
+        by_signal[a.signal_type] += 1
+    mode = "warm-up (observe-only, zero enforcement)" if warm_up else "enforced"
+    lines = [
+        f"## Pricing Staleness Detection — {as_of.date().isoformat()} ({mode})",
+        "",
+        f"**{len(alerts)}** alert(s) this run:",
+    ]
+    for signal_type, count in sorted(by_signal.items()):
+        lines.append(f"- `{signal_type}`: {count}")
+    return "\n".join(lines)
+
+
+def post_digest_comment(body: str, issue_id: str = PRICING_LANE_ISSUE_ID) -> None:
+    api_url = os.environ.get("PAPERCLIP_API_URL", "http://127.0.0.1:3100")
+    api_key = os.environ.get("PAPERCLIP_API_KEY", "")
+    if not api_key:
+        log.warning("PAPERCLIP_API_KEY not set; skipping digest post.")
+        return
+    run_id = os.environ.get("PAPERCLIP_RUN_ID", "")
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    if run_id:
+        headers["X-Paperclip-Run-Id"] = run_id
+    req = urllib.request.Request(
+        f"{api_url}/api/issues/{issue_id}/comments",
+        data=json.dumps({"body": body}).encode(),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            resp.read()
+    except urllib.error.URLError as e:
+        log.warning("Failed to post digest comment: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [pricing-staleness] %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--use-fakes",
+        action="store_true",
+        help="Run against empty in-memory fakes (local dev/demo only).",
+    )
+    parser.add_argument("--no-post", action="store_true", help="Do not post the digest comment.")
+    args = parser.parse_args(argv)
+
+    as_of = datetime.now(timezone.utc)
+    warm_up = is_warm_up(as_of)
+    dsn = os.environ.get("PRICING_STALENESS_DB_DSN", "")
+
+    if args.use_fakes:
+        from pricing_feeds import FakeMarginPolicyChangeFeed, FakeNegotiatedRateChangeFeed, FakeRateRecordFeed
+        from pricing_staleness_alerts import InMemoryAlertSink
+
+        rate_feed = FakeRateRecordFeed()
+        change_feed = FakeNegotiatedRateChangeFeed()
+        policy_feed = FakeMarginPolicyChangeFeed()
+        alert_sink = InMemoryAlertSink()
+    else:
+        # Rate-record/change/policy feeds still have no physical store (SAG-6341
+        # pending, blocks SAG-6343's Phase 2 real adapters) -- always
+        # NotImplemented outside --use-fakes. The alert sink, however, is real
+        # once a DSN is configured, since Phase 1 (the table) has landed.
+        rate_feed = NotImplementedRateRecordFeed()
+        change_feed = NotImplementedNegotiatedRateChangeFeed()
+        policy_feed = NotImplementedMarginPolicyChangeFeed()
+        if dsn:
+            from pricing_staleness_alerts import PostgresAlertSink
+
+            alert_sink = PostgresAlertSink(dsn=dsn)
+        else:
+            alert_sink = NotImplementedAlertSink()
+
+    try:
+        alerts = run_detection(
+            as_of=as_of,
+            rate_feed=rate_feed,
+            change_feed=change_feed,
+            policy_feed=policy_feed,
+            alert_sink=alert_sink,
+            warm_up=warm_up,
+        )
+    except (FeedUnavailableError, AlertSinkUnavailableError) as e:
+        log.info(
+            "Pricing staleness runner not yet wired to production (%s). "
+            "This is an expected pending-dependency state (SAG-6341/SAG-6343 rate "
+            "feeds still pending) -- skipping this run without failing nightly_eval.",
+            e,
+        )
+        return 0
+    finally:
+        if hasattr(alert_sink, "close"):
+            alert_sink.close()
+
+    log.info("Detection complete: %d alert(s), warm_up=%s", len(alerts), warm_up)
+
+    if not args.no_post:
+        post_digest_comment(format_digest(alerts, as_of, warm_up))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/runtime-eval/test_pricing_feeds.py
+++ b/infra/runtime-eval/test_pricing_feeds.py
@@ -1,0 +1,109 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from pricing_feeds import (
+    FakeMarginPolicyChangeFeed,
+    FakeNegotiatedRateChangeFeed,
+    FakeRateRecordFeed,
+    FeedUnavailableError,
+    NegotiatedRateChange,
+    NotImplementedMarginPolicyChangeFeed,
+    NotImplementedNegotiatedRateChangeFeed,
+    NotImplementedRateRecordFeed,
+    PolicyChange,
+    RateRecord,
+)
+
+NOW = datetime(2026, 7, 7, 12, 0, 0)
+
+
+class TestNotImplementedAdapters:
+    def test_rate_record_feed_raises_feed_unavailable(self):
+        with pytest.raises(FeedUnavailableError, match="SAG-6341"):
+            NotImplementedRateRecordFeed().get_active_rate_records(as_of=NOW)
+
+    def test_negotiated_rate_change_feed_raises_feed_unavailable(self):
+        with pytest.raises(FeedUnavailableError, match="SAG-6341"):
+            NotImplementedNegotiatedRateChangeFeed().get_changes_since(since=NOW)
+
+    def test_margin_policy_change_feed_raises_feed_unavailable(self):
+        with pytest.raises(FeedUnavailableError, match="SAG-6341"):
+            NotImplementedMarginPolicyChangeFeed().get_changes_since(since=NOW)
+
+
+class TestFakeRateRecordFeed:
+    def test_returns_only_records_imported_at_or_before_as_of(self):
+        older = RateRecord(
+            product_estimate_group="FG3",
+            bucket_code="FQ3-A",
+            territory="TX",
+            rate_card_version="v1",
+            imported_at=NOW - timedelta(days=1),
+            rate_bearing_fields={"fee_per_sqft": Decimal("12.50")},
+        )
+        newer = RateRecord(
+            product_estimate_group="FG3",
+            bucket_code="FQ3-A",
+            territory="TX",
+            rate_card_version="v2",
+            imported_at=NOW + timedelta(days=1),
+            rate_bearing_fields={"fee_per_sqft": Decimal("13.00")},
+        )
+        feed = FakeRateRecordFeed(records=[older, newer])
+
+        result = feed.get_active_rate_records(as_of=NOW)
+
+        assert result == [older]
+
+    def test_empty_feed_returns_empty_list(self):
+        assert FakeRateRecordFeed().get_active_rate_records(as_of=NOW) == []
+
+
+class TestFakeNegotiatedRateChangeFeed:
+    def test_returns_only_changes_entered_since_cutoff(self):
+        before = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=NOW - timedelta(days=2),
+        )
+        after = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.50"),
+            new_value=Decimal("13.00"),
+            source="manual",
+            reason="renegotiation",
+            entered_at=NOW + timedelta(hours=1),
+        )
+        feed = FakeNegotiatedRateChangeFeed(changes=[before, after])
+
+        result = feed.get_changes_since(since=NOW)
+
+        assert result == [after]
+
+
+class TestFakeMarginPolicyChangeFeed:
+    def test_returns_only_changes_effective_since_cutoff(self):
+        before = PolicyChange(
+            policy_key="margin_floor",
+            old="0.10",
+            new="0.12",
+            effective_at=NOW - timedelta(days=5),
+            reason="quarterly review",
+        )
+        after = PolicyChange(
+            policy_key="sut_dimension",
+            old="width",
+            new="width+depth",
+            effective_at=NOW + timedelta(days=1),
+            reason="new SKU class",
+        )
+        feed = FakeMarginPolicyChangeFeed(changes=[before, after])
+
+        result = feed.get_changes_since(since=NOW)
+
+        assert result == [after]

--- a/infra/runtime-eval/test_pricing_freeze_arming.py
+++ b/infra/runtime-eval/test_pricing_freeze_arming.py
@@ -1,0 +1,239 @@
+"""Tests for the SAG-6345 Phase 5 quote-freeze arming mechanism.
+
+These lock the binding constraints: no arming during warm-up, arming needs a
+clean baseline median, freeze scope is CRITICAL-and-clean-baseline only, and —
+the core of the ticket — arming is impossible without an explicit human/board
+sign-off. The mechanism is built and fully exercised, but never auto-arms.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from pricing_staleness_runner import WARM_UP_DURATION_DAYS, WARM_UP_START_DATE
+from pricing_freeze_arming import (
+    ArmingAuthorization,
+    ArmingBlockedError,
+    ArmingNotAuthorizedError,
+    BaselineMedian,
+    BaselineMedianUnavailableError,
+    InMemoryBaselineMedianProvider,
+    NotImplementedBaselineMedianProvider,
+    UNFREEZE_REQUIREMENTS,
+    arm_freeze,
+    build_freeze_proposal,
+    evaluate_arming_readiness,
+    format_arming_readiness,
+    warm_up_end_date,
+)
+
+UTC = timezone.utc
+
+# A datetime safely inside the warm-up window and one safely after it.
+DURING_WARM_UP = datetime.combine(WARM_UP_START_DATE, datetime.min.time(), tzinfo=UTC) + timedelta(days=5)
+POST_WARM_UP = datetime.combine(WARM_UP_START_DATE, datetime.min.time(), tzinfo=UTC) + timedelta(
+    days=WARM_UP_DURATION_DAYS + 1
+)
+
+
+def _clean_median(record_key, computed_at=None, is_clean=True):
+    return BaselineMedian(
+        record_key=record_key,
+        field_name="fee_per_sqft",
+        median_value=Decimal("12.50"),
+        sample_size=6,
+        computed_at=computed_at or (POST_WARM_UP - timedelta(days=1)),
+        is_clean=is_clean,
+    )
+
+
+def _signoff(as_of=POST_WARM_UP, authority="human", by="pricing-director", ref="SAG-6345#signoff"):
+    return ArmingAuthorization(
+        authorized_by=by, authority=authority, reference=ref, authorized_at=as_of
+    )
+
+
+# ---------------------------------------------------------------------------
+# Warm-up gate
+# ---------------------------------------------------------------------------
+
+
+class TestWarmUpGate:
+    def test_not_eligible_during_warm_up_even_with_clean_baselines(self):
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX", DURING_WARM_UP - timedelta(days=1))])
+        readiness = evaluate_arming_readiness(
+            as_of=DURING_WARM_UP,
+            baseline_provider=provider,
+            outstanding_critical_keys={"FG3|FQ3-A|TX"},
+        )
+        assert readiness.warm_up_complete is False
+        assert readiness.eligible_to_arm is False
+        assert any("warm-up" in r for r in readiness.blocking_reasons)
+
+    def test_warm_up_end_date_is_start_plus_duration(self):
+        assert warm_up_end_date() == WARM_UP_START_DATE + timedelta(days=WARM_UP_DURATION_DAYS)
+
+    def test_arm_freeze_refuses_during_warm_up_defense_in_depth(self):
+        # Even if handed a non-empty proposal + valid sign-off, arming during
+        # warm-up is refused by the arm_freeze re-check.
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX", POST_WARM_UP - timedelta(days=1))])
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        proposal = build_freeze_proposal(readiness)
+        assert proposal is not None
+        with pytest.raises(ArmingBlockedError, match="warm-up"):
+            arm_freeze(proposal, _signoff(DURING_WARM_UP), as_of=DURING_WARM_UP)
+
+
+# ---------------------------------------------------------------------------
+# Clean-baseline precondition + scope
+# ---------------------------------------------------------------------------
+
+
+class TestBaselinePrecondition:
+    def test_not_eligible_post_warm_up_without_any_clean_baseline(self):
+        provider = InMemoryBaselineMedianProvider([])  # no baselines materialized
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        assert readiness.warm_up_complete is True
+        assert readiness.eligible_to_arm is False
+        assert any("clean baseline" in r for r in readiness.blocking_reasons)
+
+    def test_contaminated_baseline_does_not_count_as_clean(self):
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX", is_clean=False)])
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        assert readiness.clean_baseline_keys == frozenset()
+        assert readiness.eligible_to_arm is False
+
+    def test_scope_is_critical_intersect_clean_baseline(self):
+        provider = InMemoryBaselineMedianProvider(
+            [_clean_median("FG3|FQ3-A|TX"), _clean_median("FG3|FQ3-B|TX"), _clean_median("FG3|FQ3-C|TX")]
+        )
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP,
+            baseline_provider=provider,
+            # FQ3-A has a clean baseline (armable); FQ3-Z is critical but has no
+            # baseline (blocked); FQ3-B has a baseline but isn't critical (out of scope).
+            outstanding_critical_keys={"FG3|FQ3-A|TX", "FG3|FQ3-Z|TX"},
+        )
+        assert readiness.eligible_to_arm is True
+        assert readiness.armable_scope == ("FG3|FQ3-A|TX",)
+        assert readiness.blocked_critical_keys == ("FG3|FQ3-Z|TX",)
+
+    def test_no_proposal_during_warm_up_even_with_critical_and_baseline(self):
+        # Directly pin the `not eligible_to_arm` branch of build_freeze_proposal.
+        provider = InMemoryBaselineMedianProvider(
+            [_clean_median("FG3|FQ3-A|TX", DURING_WARM_UP - timedelta(days=1))]
+        )
+        readiness = evaluate_arming_readiness(
+            as_of=DURING_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        assert readiness.eligible_to_arm is False
+        assert build_freeze_proposal(readiness) is None
+
+    def test_eligible_with_no_critical_lines_yields_no_proposal(self):
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX")])
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP, baseline_provider=provider, outstanding_critical_keys=set()
+        )
+        assert readiness.eligible_to_arm is True
+        assert readiness.armable_scope == ()
+        assert build_freeze_proposal(readiness) is None
+
+
+# ---------------------------------------------------------------------------
+# Loud-fail provider
+# ---------------------------------------------------------------------------
+
+
+class TestLoudFailProvider:
+    def test_notimplemented_provider_raises_rather_than_reporting_empty(self):
+        with pytest.raises(BaselineMedianUnavailableError):
+            evaluate_arming_readiness(
+                as_of=POST_WARM_UP,
+                baseline_provider=NotImplementedBaselineMedianProvider(),
+                outstanding_critical_keys={"FG3|FQ3-A|TX"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# The core guard: no autonomous arming
+# ---------------------------------------------------------------------------
+
+
+class TestArmingRequiresSignoff:
+    def _eligible_proposal(self):
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX")])
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        return build_freeze_proposal(readiness)
+
+    def test_arm_without_authorization_is_refused(self):
+        proposal = self._eligible_proposal()
+        with pytest.raises(ArmingNotAuthorizedError, match="human/board sign-off"):
+            arm_freeze(proposal, None, as_of=POST_WARM_UP)
+
+    def test_arm_with_agent_authority_is_rejected(self):
+        proposal = self._eligible_proposal()
+        bad = ArmingAuthorization(
+            authorized_by="cloud-eng-director", authority="agent", reference="run-123", authorized_at=POST_WARM_UP
+        )
+        with pytest.raises(ArmingNotAuthorizedError, match="not a human/board"):
+            arm_freeze(proposal, bad, as_of=POST_WARM_UP)
+
+    def test_arm_with_blank_authorizer_is_rejected(self):
+        proposal = self._eligible_proposal()
+        bad = ArmingAuthorization(authorized_by="   ", authority="board", reference="minute-9", authorized_at=POST_WARM_UP)
+        with pytest.raises(ArmingNotAuthorizedError, match="authorizer identity"):
+            arm_freeze(proposal, bad, as_of=POST_WARM_UP)
+
+    def test_arm_with_missing_reference_is_rejected(self):
+        proposal = self._eligible_proposal()
+        bad = ArmingAuthorization(authorized_by="pricing-director", authority="human", reference="", authorized_at=POST_WARM_UP)
+        with pytest.raises(ArmingNotAuthorizedError, match="audit reference"):
+            arm_freeze(proposal, bad, as_of=POST_WARM_UP)
+
+    def test_arm_with_no_proposal_is_blocked(self):
+        with pytest.raises(ArmingBlockedError, match="nothing to arm"):
+            arm_freeze(None, _signoff(), as_of=POST_WARM_UP)
+
+    def test_happy_path_arms_only_with_valid_human_signoff(self):
+        proposal = self._eligible_proposal()
+        armed = arm_freeze(proposal, _signoff(authority="human"), as_of=POST_WARM_UP)
+        assert armed.scope == ("FG3|FQ3-A|TX",)
+        assert armed.existing_quotes_honored is True
+        assert armed.unfreeze_requirements == UNFREEZE_REQUIREMENTS
+        assert armed.authorization.authority == "human"
+
+    def test_board_authority_also_arms(self):
+        proposal = self._eligible_proposal()
+        armed = arm_freeze(proposal, _signoff(authority="board", by="local-board", ref="board-minute-42"), as_of=POST_WARM_UP)
+        assert armed.authorization.authority == "board"
+
+
+# ---------------------------------------------------------------------------
+# Report rendering (report-only; proves no action is implied)
+# ---------------------------------------------------------------------------
+
+
+class TestReporting:
+    def test_report_says_awaiting_signoff_when_eligible(self):
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX")])
+        readiness = evaluate_arming_readiness(
+            as_of=POST_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        text = format_arming_readiness(readiness)
+        assert "AWAITING" in text and "not armed" in text
+
+    def test_report_states_warm_up_block(self):
+        provider = InMemoryBaselineMedianProvider([_clean_median("FG3|FQ3-A|TX", DURING_WARM_UP - timedelta(days=1))])
+        readiness = evaluate_arming_readiness(
+            as_of=DURING_WARM_UP, baseline_provider=provider, outstanding_critical_keys={"FG3|FQ3-A|TX"}
+        )
+        assert "NOT eligible" in format_arming_readiness(readiness)

--- a/infra/runtime-eval/test_pricing_staleness_alerts.py
+++ b/infra/runtime-eval/test_pricing_staleness_alerts.py
@@ -1,0 +1,138 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+import pricing_staleness_alerts
+from pricing_staleness_alerts import (
+    AlertSinkUnavailableError,
+    InMemoryAlertSink,
+    NotImplementedAlertSink,
+    PostgresAlertSink,
+    StalenessAlert,
+    alert_to_row,
+)
+
+NOW = datetime(2026, 7, 7, 12, 0, 0)
+
+ALL_SIGNAL_TYPES = ["anomaly", "version_hash_drift", "sla_breach", "bulk_escalation"]
+ALL_SEVERITIES = ["warn", "critical"]
+
+
+def _alert(**overrides) -> StalenessAlert:
+    defaults = dict(
+        signal_type="anomaly",
+        severity="warn",
+        record_key="FG3|FQ3-A|TX",
+        detected_at=NOW,
+        warm_up=True,
+        details={"pct_delta": 0.06},
+    )
+    defaults.update(overrides)
+    return StalenessAlert(**defaults)
+
+
+class TestNotImplementedAlertSink:
+    def test_write_alert_raises_sink_unavailable(self):
+        with pytest.raises(AlertSinkUnavailableError, match="PRICING_STALENESS_DB_DSN"):
+            NotImplementedAlertSink().write_alert(_alert())
+
+
+class TestInMemoryAlertSink:
+    def test_write_alert_appends_and_assigns_id(self):
+        sink = InMemoryAlertSink()
+
+        sink.write_alert(_alert())
+        sink.write_alert(_alert(signal_type="sla_breach"))
+
+        assert len(sink.alerts) == 2
+        assert sink.alerts[0].signal_type == "anomaly"
+        assert sink.alerts[1].signal_type == "sla_breach"
+        assert sink.alerts[0].id is not None
+        assert sink.alerts[0].id != sink.alerts[1].id
+
+
+# ---------------------------------------------------------------------------
+# alert_to_row: the table's grain matches the runner's StalenessAlert shape
+# 1:1 (SAG-6353), so this is a direct field-for-field mapping onto the
+# `pricing_staleness_alerts` columns -- no splitting or enum translation.
+# ---------------------------------------------------------------------------
+
+
+class TestAlertToRow:
+    @pytest.mark.parametrize("signal_type", ALL_SIGNAL_TYPES)
+    @pytest.mark.parametrize("severity", ALL_SEVERITIES)
+    def test_maps_fields_directly_onto_table_columns(self, signal_type, severity):
+        alert = _alert(
+            signal_type=signal_type,
+            severity=severity,
+            record_key="FG3|FQ3-A|TX",
+            warm_up=False,
+            details={"pct_delta": 0.06},
+        )
+
+        row = alert_to_row(alert)
+
+        assert row["signal_type"] == signal_type
+        assert row["severity"] == severity
+        assert row["record_key"] == "FG3|FQ3-A|TX"
+        assert row["detected_at"] == NOW
+        assert row["warm_up"] is False
+        assert row["details_json"].adapted == {"pct_delta": 0.06}
+
+    def test_details_json_wraps_arbitrary_evidence_dict(self):
+        alert = _alert(details={"count": 5, "affected_keys": ["MULTIPLE"], "signal_types": ["anomaly"]})
+
+        row = alert_to_row(alert)
+
+        assert row["details_json"].adapted == {
+            "count": 5,
+            "affected_keys": ["MULTIPLE"],
+            "signal_types": ["anomaly"],
+        }
+
+
+# ---------------------------------------------------------------------------
+# PostgresAlertSink: verified against a mocked psycopg2 connection (no live
+# DB in this environment -- see migrations/README.md "Which Postgres
+# instance: TBD").
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresAlertSink:
+    @pytest.mark.parametrize("signal_type", ALL_SIGNAL_TYPES)
+    @pytest.mark.parametrize("severity", ALL_SEVERITIES)
+    def test_write_alert_inserts_new_grain_for_every_signal_type_and_severity(
+        self, monkeypatch, signal_type, severity
+    ):
+        fake_cursor = MagicMock()
+        fake_cursor.__enter__.return_value = fake_cursor
+        fake_conn = MagicMock()
+        fake_conn.cursor.return_value = fake_cursor
+        monkeypatch.setattr(pricing_staleness_alerts.psycopg2, "connect", lambda dsn: fake_conn)
+
+        sink = PostgresAlertSink(dsn="postgresql://pricing_staleness_writer@localhost/db")
+        sink.write_alert(_alert(signal_type=signal_type, severity=severity))
+
+        assert fake_conn.autocommit is True
+        assert fake_cursor.execute.called
+        sql, params = fake_cursor.execute.call_args.args
+        assert "enrichment_staging.pricing_staleness_alerts" in sql
+        assert "record_key" in sql
+        assert "warm_up" in sql
+        assert "details_json" in sql
+        assert params["signal_type"] == signal_type
+        assert params["severity"] == severity
+        assert params["record_key"] == "FG3|FQ3-A|TX"
+        assert params["detected_at"] == NOW
+        assert params["warm_up"] is True
+        assert params["details_json"].adapted == {"pct_delta": 0.06}
+
+    def test_close_closes_connection(self, monkeypatch):
+        fake_conn = MagicMock()
+        monkeypatch.setattr(pricing_staleness_alerts.psycopg2, "connect", lambda dsn: fake_conn)
+
+        sink = PostgresAlertSink(dsn="postgresql://pricing_staleness_writer@localhost/db")
+        sink.close()
+
+        fake_conn.close.assert_called_once()

--- a/infra/runtime-eval/test_pricing_staleness_runner.py
+++ b/infra/runtime-eval/test_pricing_staleness_runner.py
@@ -1,0 +1,394 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from pricing_feeds import (
+    FakeMarginPolicyChangeFeed,
+    FakeNegotiatedRateChangeFeed,
+    FakeRateRecordFeed,
+    NegotiatedRateChange,
+    PolicyChange,
+    RateRecord,
+)
+from pricing_staleness_alerts import InMemoryAlertSink
+from pricing_staleness_runner import (
+    BULK_ESCALATION_THRESHOLD,
+    commit_due_at,
+    detect_anomalies,
+    detect_bulk_escalation,
+    detect_sla_breaches,
+    detect_version_hash_drift,
+    is_sla_breached,
+    run_detection,
+)
+
+CHICAGO = ZoneInfo("America/Chicago")
+UTC = timezone.utc
+
+
+def _record(imported_at, value, version="v1", content_hash="h1", **overrides):
+    defaults = dict(
+        product_estimate_group="FG3",
+        bucket_code="FQ3-A",
+        territory="TX",
+        rate_card_version=version,
+        imported_at=imported_at,
+        rate_bearing_fields={"fee_per_sqft": Decimal(str(value))},
+        content_hash=content_hash,
+    )
+    defaults.update(overrides)
+    return RateRecord(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Signal 3 helper: business-day + timezone math
+# ---------------------------------------------------------------------------
+
+
+class TestCommitDueAt:
+    def test_friday_entry_due_monday_18_00_chicago(self):
+        # Friday 2026-07-10 (America/Chicago) -> next business day is Monday 2026-07-13
+        entered_at = datetime(2026, 7, 10, 9, 0, tzinfo=CHICAGO)
+
+        due = commit_due_at(entered_at)
+
+        assert due == datetime(2026, 7, 13, 18, 0, tzinfo=CHICAGO)
+
+    def test_monday_entry_due_tuesday_18_00_chicago(self):
+        entered_at = datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO)  # Monday
+
+        due = commit_due_at(entered_at)
+
+        assert due == datetime(2026, 7, 7, 18, 0, tzinfo=CHICAGO)
+
+    def test_saturday_entry_due_monday(self):
+        entered_at = datetime(2026, 7, 11, 10, 0, tzinfo=CHICAGO)  # Saturday
+
+        due = commit_due_at(entered_at)
+
+        assert due == datetime(2026, 7, 13, 18, 0, tzinfo=CHICAGO)
+
+    def test_naive_entered_at_is_treated_as_utc_then_converted(self):
+        # 2026-07-10 23:30 UTC == 2026-07-10 18:30 America/Chicago (CDT, UTC-5) -> still Friday
+        entered_at = datetime(2026, 7, 10, 23, 30)
+
+        due = commit_due_at(entered_at)
+
+        assert due == datetime(2026, 7, 13, 18, 0, tzinfo=CHICAGO)
+
+
+class TestIsSlaBreached:
+    def test_not_breached_when_committed_before_due(self):
+        change = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO),
+            committed_at=datetime(2026, 7, 7, 10, 0, tzinfo=CHICAGO),
+        )
+
+        assert is_sla_breached(change, as_of=datetime(2026, 7, 8, tzinfo=CHICAGO)) is False
+
+    def test_breached_when_committed_after_due(self):
+        change = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO),
+            committed_at=datetime(2026, 7, 7, 19, 0, tzinfo=CHICAGO),
+        )
+
+        assert is_sla_breached(change, as_of=datetime(2026, 7, 8, tzinfo=CHICAGO)) is True
+
+    def test_breached_when_still_uncommitted_past_due(self):
+        change = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO),
+            committed_at=None,
+        )
+
+        assert is_sla_breached(change, as_of=datetime(2026, 7, 8, tzinfo=CHICAGO)) is True
+
+    def test_not_breached_when_uncommitted_before_due(self):
+        change = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO),
+            committed_at=None,
+        )
+
+        assert is_sla_breached(change, as_of=datetime(2026, 7, 7, 12, 0, tzinfo=CHICAGO)) is False
+
+
+# ---------------------------------------------------------------------------
+# Signal 1: anomaly vs trailing 3-mo median, with policy-change suppression
+# ---------------------------------------------------------------------------
+
+
+class TestDetectAnomalies:
+    def test_flags_warn_at_5pct_and_critical_at_10pct(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        history = [
+            _record(as_of - timedelta(days=80), 10.00),
+            _record(as_of - timedelta(days=60), 10.00),
+            _record(as_of - timedelta(days=40), 10.00),
+        ]
+        warn_latest = _record(as_of, 10.51)  # +5.1%
+        feed = FakeRateRecordFeed(records=history + [warn_latest])
+        policy_feed = FakeMarginPolicyChangeFeed(changes=[])
+
+        alerts = detect_anomalies(feed, policy_feed, as_of=as_of, warm_up=True)
+
+        assert len(alerts) == 1
+        assert alerts[0].signal_type == "anomaly"
+        assert alerts[0].severity == "warn"
+
+    def test_flags_critical_at_10pct(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        history = [_record(as_of - timedelta(days=80), 10.00)]
+        critical_latest = _record(as_of, 11.20)  # +12%
+        feed = FakeRateRecordFeed(records=history + [critical_latest])
+        policy_feed = FakeMarginPolicyChangeFeed(changes=[])
+
+        alerts = detect_anomalies(feed, policy_feed, as_of=as_of, warm_up=True)
+
+        assert len(alerts) == 1
+        assert alerts[0].severity == "critical"
+
+    def test_no_alert_below_5pct(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        history = [_record(as_of - timedelta(days=80), 10.00)]
+        latest = _record(as_of, 10.20)  # +2%
+        feed = FakeRateRecordFeed(records=history + [latest])
+        policy_feed = FakeMarginPolicyChangeFeed(changes=[])
+
+        alerts = detect_anomalies(feed, policy_feed, as_of=as_of, warm_up=True)
+
+        assert alerts == []
+
+    def test_suppressed_by_recent_policy_change(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        history = [_record(as_of - timedelta(days=80), 10.00)]
+        latest = _record(as_of, 11.20)  # would be critical
+        feed = FakeRateRecordFeed(records=history + [latest])
+        policy_feed = FakeMarginPolicyChangeFeed(
+            changes=[
+                PolicyChange(
+                    policy_key="margin_floor",
+                    old="0.10",
+                    new="0.12",
+                    effective_at=as_of - timedelta(days=1),
+                    reason="quarterly review",
+                )
+            ]
+        )
+
+        alerts = detect_anomalies(feed, policy_feed, as_of=as_of, warm_up=True)
+
+        assert alerts == []
+
+    def test_no_alert_with_insufficient_history(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        feed = FakeRateRecordFeed(records=[_record(as_of, 50.00)])
+        policy_feed = FakeMarginPolicyChangeFeed(changes=[])
+
+        alerts = detect_anomalies(feed, policy_feed, as_of=as_of, warm_up=True)
+
+        assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Signal 2: rate_card_version / content-hash drift
+# ---------------------------------------------------------------------------
+
+
+class TestDetectVersionHashDrift:
+    def test_flags_same_version_different_hash(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        older = _record(as_of - timedelta(days=5), 10.00, version="v3", content_hash="hash-a")
+        newer = _record(as_of, 10.00, version="v3", content_hash="hash-b")
+        feed = FakeRateRecordFeed(records=[older, newer])
+
+        alerts = detect_version_hash_drift(feed, as_of=as_of, warm_up=True)
+
+        assert len(alerts) == 1
+        assert alerts[0].signal_type == "version_hash_drift"
+        assert alerts[0].severity == "critical"
+
+    def test_no_alert_when_version_bumped_with_hash(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        older = _record(as_of - timedelta(days=5), 10.00, version="v3", content_hash="hash-a")
+        newer = _record(as_of, 10.50, version="v4", content_hash="hash-b")
+        feed = FakeRateRecordFeed(records=[older, newer])
+
+        alerts = detect_version_hash_drift(feed, as_of=as_of, warm_up=True)
+
+        assert alerts == []
+
+    def test_no_alert_when_version_and_hash_both_unchanged(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        older = _record(as_of - timedelta(days=5), 10.00, version="v3", content_hash="hash-a")
+        newer = _record(as_of, 10.00, version="v3", content_hash="hash-a")
+        feed = FakeRateRecordFeed(records=[older, newer])
+
+        alerts = detect_version_hash_drift(feed, as_of=as_of, warm_up=True)
+
+        assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Signal 3 (feed-level wiring): SLA breach detection over a change feed
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSlaBreaches:
+    def test_flags_uncommitted_change_past_due(self):
+        as_of = datetime(2026, 7, 8, tzinfo=CHICAGO)
+        change = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO),
+            committed_at=None,
+        )
+        feed = FakeNegotiatedRateChangeFeed(changes=[change])
+
+        alerts = detect_sla_breaches(feed, as_of=as_of, lookback_days=30, warm_up=True)
+
+        assert len(alerts) == 1
+        assert alerts[0].signal_type == "sla_breach"
+        assert alerts[0].record_key == "FG3-FQ3-A-TX"
+
+    def test_no_alert_when_committed_on_time(self):
+        as_of = datetime(2026, 7, 8, tzinfo=CHICAGO)
+        change = NegotiatedRateChange(
+            record_key="FG3-FQ3-A-TX",
+            old_value=Decimal("12.00"),
+            new_value=Decimal("12.50"),
+            source="manual",
+            reason="cost increase",
+            entered_at=datetime(2026, 7, 6, 8, 0, tzinfo=CHICAGO),
+            committed_at=datetime(2026, 7, 7, 10, 0, tzinfo=CHICAGO),
+        )
+        feed = FakeNegotiatedRateChangeFeed(changes=[change])
+
+        alerts = detect_sla_breaches(feed, as_of=as_of, lookback_days=30, warm_up=True)
+
+        assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Signal 4: bulk escalator
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBulkEscalation:
+    def test_no_escalation_below_threshold(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        prior_alerts = [
+            _anomaly_alert(f"key-{i}", as_of) for i in range(BULK_ESCALATION_THRESHOLD - 1)
+        ]
+
+        result = detect_bulk_escalation(prior_alerts, as_of=as_of, warm_up=True)
+
+        assert result == []
+
+    def test_escalates_at_threshold(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        prior_alerts = [
+            _anomaly_alert(f"key-{i}", as_of) for i in range(BULK_ESCALATION_THRESHOLD)
+        ]
+
+        result = detect_bulk_escalation(prior_alerts, as_of=as_of, warm_up=True)
+
+        assert len(result) == 1
+        assert result[0].signal_type == "bulk_escalation"
+        assert result[0].severity == "critical"
+        assert result[0].details["count"] == BULK_ESCALATION_THRESHOLD
+
+
+def _anomaly_alert(key, as_of):
+    from pricing_staleness_alerts import StalenessAlert
+
+    return StalenessAlert(
+        signal_type="anomaly",
+        severity="warn",
+        record_key=key,
+        detected_at=as_of,
+        warm_up=True,
+        details={"pct_delta": 0.06},
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_detection: end-to-end wiring + warm-up stamping + zero enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestRunDetection:
+    def test_writes_one_alert_per_detection_and_stamps_warm_up(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        history = [_record(as_of - timedelta(days=80), 10.00)]
+        latest = _record(as_of, 11.20)  # critical anomaly
+        rate_feed = FakeRateRecordFeed(records=history + [latest])
+        change_feed = FakeNegotiatedRateChangeFeed(changes=[])
+        policy_feed = FakeMarginPolicyChangeFeed(changes=[])
+        sink = InMemoryAlertSink()
+
+        run_detection(
+            as_of=as_of,
+            rate_feed=rate_feed,
+            change_feed=change_feed,
+            policy_feed=policy_feed,
+            alert_sink=sink,
+            warm_up=True,
+        )
+
+        assert len(sink.alerts) == 1
+        assert all(a.warm_up is True for a in sink.alerts)
+
+    def test_warm_up_false_is_stamped_through(self):
+        as_of = datetime(2026, 7, 7, tzinfo=UTC)
+        history = [_record(as_of - timedelta(days=80), 10.00)]
+        latest = _record(as_of, 11.20)
+        rate_feed = FakeRateRecordFeed(records=history + [latest])
+        change_feed = FakeNegotiatedRateChangeFeed(changes=[])
+        policy_feed = FakeMarginPolicyChangeFeed(changes=[])
+        sink = InMemoryAlertSink()
+
+        run_detection(
+            as_of=as_of,
+            rate_feed=rate_feed,
+            change_feed=change_feed,
+            policy_feed=policy_feed,
+            alert_sink=sink,
+            warm_up=False,
+        )
+
+        assert len(sink.alerts) == 1
+        assert sink.alerts[0].warm_up is False
+
+    def test_never_imports_or_calls_freeze_arming(self):
+        # Phase 5 (quote-freeze arming) is separately blocked/build-only and out of
+        # scope here. Guard against scope creep: this module must not reference it.
+        import pricing_staleness_runner as runner_module
+
+        source = open(runner_module.__file__).read()
+
+        assert "arm_freeze" not in source
+        assert "freeze_arm" not in source

--- a/migrations/003_pricing_staleness_alerts_down.sql
+++ b/migrations/003_pricing_staleness_alerts_down.sql
@@ -1,0 +1,43 @@
+-- Migration 003 (DOWN): drop pricing_staleness_alerts table, roles
+-- SAG-6327 Phase 1 | Parent: SAG-6302
+--
+-- Drops everything created by 003_pricing_staleness_alerts_up.sql in reverse
+-- order. DESTRUCTIVE -- deletes all pricing staleness alert history.
+-- Does NOT drop the enrichment_staging schema itself (owned by migration 001).
+
+BEGIN;
+
+-- ─── Revoke all grants before dropping objects ────────────────────────────────
+
+REVOKE ALL ON TABLE enrichment_staging.pricing_staleness_alerts
+    FROM pricing_staleness_writer;
+REVOKE ALL ON TABLE enrichment_staging.pricing_staleness_alerts
+    FROM pricing_staleness_reader;
+REVOKE USAGE ON SCHEMA enrichment_staging
+    FROM pricing_staleness_writer, pricing_staleness_reader;
+
+-- ─── Drop table (CASCADE drops indexes automatically) ─────────────────────────
+
+DROP TABLE IF EXISTS enrichment_staging.pricing_staleness_alerts CASCADE;
+
+-- ─── Drop roles (skip if other objects still reference them) ──────────────────
+
+DO $$
+BEGIN
+    DROP ROLE IF EXISTS pricing_staleness_writer;
+EXCEPTION
+    WHEN dependent_objects_still_exist THEN
+        RAISE NOTICE 'Role pricing_staleness_writer has dependents outside this migration; skipping drop.';
+END
+$$;
+
+DO $$
+BEGIN
+    DROP ROLE IF EXISTS pricing_staleness_reader;
+EXCEPTION
+    WHEN dependent_objects_still_exist THEN
+        RAISE NOTICE 'Role pricing_staleness_reader has dependents outside this migration; skipping drop.';
+END
+$$;
+
+COMMIT;

--- a/migrations/003_pricing_staleness_alerts_up.sql
+++ b/migrations/003_pricing_staleness_alerts_up.sql
@@ -1,0 +1,89 @@
+-- Migration 003 (UP): pricing_staleness_alerts table, roles, permissions
+-- SAG-6327 Phase 1 | Parent: SAG-6302
+-- Reconciled to the tested runner contract in SAG-6353.
+--
+-- Append-only detection-alert log for the pricing staleness runner. Lives in
+-- the existing 'enrichment_staging' schema, fully isolated from the
+-- production catalog (public schema) and decoupled from Pricing's own
+-- feed-spec grain (SAG-6341) -- record_key is a plain text identifier, not a
+-- FK. Role permissions enforce INSERT/SELECT-only (no UPDATE / DELETE
+-- granted to any role) -- append-only, matching the enrichment_promotion_log
+-- precedent from migration 001.
+
+BEGIN;
+
+-- ─── pricing_staleness_alerts ──────────────────────────────────────────────
+-- One row per detection event, written by the nightly detection runner
+-- (SAG-6327 Phase 3+4, SAG-6344). Column grain matches the runner's own
+-- `StalenessAlert` shape 1:1 (infra/runtime-eval/pricing_staleness_alerts.py)
+-- so no reconciliation/mapping layer is needed between the two: signal_type
+-- and severity CHECK values are exactly the strings the runner emits.
+-- warm_up is stamped by the runner (true for the 30-day warm-up window,
+-- SAG-6327 Phase 4); details_json carries signal-specific evidence
+-- (pct_delta, versions, due/committed timestamps, etc.).
+
+CREATE TABLE enrichment_staging.pricing_staleness_alerts (
+    id           UUID        NOT NULL DEFAULT gen_random_uuid(),
+    signal_type  TEXT        NOT NULL
+        CHECK (signal_type IN ('anomaly','version_hash_drift','sla_breach','bulk_escalation')),
+    severity     TEXT        NOT NULL
+        CHECK (severity IN ('warn','critical')),
+    record_key   TEXT        NOT NULL,
+    detected_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    warm_up      BOOLEAN     NOT NULL DEFAULT FALSE,
+    details_json JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    CONSTRAINT pricing_staleness_alerts_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX pricing_staleness_alerts_detected_at_idx
+    ON enrichment_staging.pricing_staleness_alerts (detected_at);
+
+-- Serves the Phase 5 freeze-arming check ("≥1 clean baseline median per
+-- record") now that sku/bucket_code are folded into record_key.
+CREATE INDEX pricing_staleness_alerts_record_key_idx
+    ON enrichment_staging.pricing_staleness_alerts (record_key);
+
+-- ─── Roles ───────────────────────────────────────────────────────────────────
+-- Create roles only if they don't already exist (idempotent via DO block).
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pricing_staleness_writer') THEN
+        CREATE ROLE pricing_staleness_writer NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pricing_staleness_reader') THEN
+        CREATE ROLE pricing_staleness_reader NOLOGIN;
+    END IF;
+END
+$$;
+
+-- ─── Permissions: enrichment_staging schema ──────────────────────────────────
+
+GRANT USAGE ON SCHEMA enrichment_staging
+    TO pricing_staleness_writer, pricing_staleness_reader;
+
+-- pricing_staleness_writer: the nightly detection runner. INSERT + SELECT
+--   only (append-only; no UPDATE/DELETE granted to any role).
+GRANT SELECT, INSERT
+    ON TABLE enrichment_staging.pricing_staleness_alerts
+    TO pricing_staleness_writer;
+
+-- pricing_staleness_reader: digest/QA/freeze-arming consumers. SELECT-only.
+GRANT SELECT
+    ON TABLE enrichment_staging.pricing_staleness_alerts
+    TO pricing_staleness_reader;
+
+-- ─── Negative isolation: no write access to public (production) schema ────────
+-- Belt-and-suspenders: revoke CREATE on public so these roles cannot create
+-- objects there, and they carry no DML grants on public tables.
+REVOKE CREATE ON SCHEMA public FROM pricing_staleness_writer;
+REVOKE CREATE ON SCHEMA public FROM pricing_staleness_reader;
+
+REVOKE INSERT, UPDATE, DELETE
+    ON ALL TABLES IN SCHEMA public
+    FROM pricing_staleness_writer;
+REVOKE INSERT, UPDATE, DELETE
+    ON ALL TABLES IN SCHEMA public
+    FROM pricing_staleness_reader;
+
+COMMIT;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,153 @@
+# Enrichment Staging — Database Migrations
+
+[SAG-2147](/SAG/issues/SAG-2147) + [SAG-2149](/SAG/issues/SAG-2149) | Parent: [SAG-2136](/SAG/issues/SAG-2136)
+
+Plain SQL migrations for the enrichment pipeline's isolated Postgres schema.
+No migration runner required — apply with `psql` directly.
+
+---
+
+## Schema design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Schema name | `enrichment_staging` | Matches pilot terminology; clearly separate from `public` (production catalog) |
+| Migration tool | Plain SQL + `psql` | No framework dependency; easy to audit; wraps each migration in a transaction |
+| Status type | Postgres `ENUM` (typed) | Prevents invalid status strings at the DB level |
+| Append-only enforcement | Role-level `GRANT INSERT` (no UPDATE/DELETE granted) | Strongest guarantee; survives application-layer bugs |
+| FK to production | None | Hard constraint from issue spec; promotion is explicit `INSERT ... SELECT` |
+| `anomaly_score` | `NUMERIC(5,4)` | 4 decimal places (0.0000–1.0000); matches validator.py output range |
+
+**Which Postgres instance:** TBD — SSI Director sign-off required (acceptance criterion).
+The migration is instance-agnostic and runs on any Postgres ≥ 13.
+
+---
+
+## Applying the migration
+
+```bash
+# Migration 001: schema + tables + roles (SAG-2147)
+psql -U postgres -d <your_db> -f migrations/001_enrichment_staging_up.sql
+
+# Migration 002: review view + enrichment_ui_reader role (SAG-2149)
+psql -U postgres -d <your_db> -f migrations/002_review_view_up.sql
+
+# Migration 003: pricing_staleness_alerts table + roles (SAG-6327 Phase 1)
+psql -U postgres -d <your_db> -f migrations/003_pricing_staleness_alerts_up.sql
+
+# Rollback 003, then 002, then 001
+psql -U postgres -d <your_db> -f migrations/003_pricing_staleness_alerts_down.sql
+psql -U postgres -d <your_db> -f migrations/002_review_view_down.sql
+psql -U postgres -d <your_db> -f migrations/001_enrichment_staging_down.sql
+```
+
+Run as a superuser (`postgres`) or a role with `CREATEROLE` + `CREATE ON DATABASE`.
+
+---
+
+## Verifying permissions
+
+After applying the forward migration, run the negative-test suite:
+
+```bash
+psql -U postgres -d <your_db> -f migrations/tests/test_permissions.sql
+
+# Migration 003: pricing_staleness_alerts negative-test suite
+psql -U postgres -d <your_db> -f migrations/tests/test_pricing_staleness_permissions.sql
+```
+
+Scan the output for any `UNEXPECTED` lines. Zero such lines = all checks passed.
+
+`test_permissions.sql` verifies:
+1. `enrichment_dispatcher` cannot INSERT/UPDATE/DELETE into `public` schema tables.
+2. `enrichment_reviewer` cannot INSERT into `public` schema tables.
+3. `enrichment_promotion_log` is append-only: INSERT allowed, UPDATE/DELETE denied for both roles.
+
+`test_pricing_staleness_permissions.sql` verifies:
+1. `pricing_staleness_writer` cannot INSERT into `public` schema tables.
+2. `pricing_staleness_reader` cannot INSERT into `public` schema tables.
+3. `pricing_staleness_alerts` is append-only: INSERT allowed for the writer role, UPDATE/DELETE denied for both roles.
+
+---
+
+## Tables
+
+### `enrichment_staging.enrichment_queue`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | `gen_random_uuid()` |
+| `source_row_id` | TEXT | Catalog SKU or equivalent identifier |
+| `payload_json` | JSONB | Raw source row sent to the enrichment model |
+| `status` | ENUM | `pending` → `in_flight` → `done` \| `failed` |
+| `created_at` | TIMESTAMPTZ | Auto-set |
+| `started_at` | TIMESTAMPTZ | Set when dispatcher picks up the row |
+| `finished_at` | TIMESTAMPTZ | Set on terminal status |
+
+### `enrichment_staging.enrichment_staging`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `batch_id` | UUID | Groups rows processed in the same dispatcher run |
+| `source_row_id` | TEXT | Matches `enrichment_queue.source_row_id` (no FK) |
+| `primary_output_json` | JSONB | Model's primary enrichment output |
+| `fallback_output_json` | JSONB | Fallback/secondary enrichment (if used) |
+| `validator_result` | JSONB | Output from `validator.py` |
+| `anomaly_score` | NUMERIC(5,4) | 0.0–1.0 from anomaly detector |
+| `reviewer_verdict` | TEXT | Free-text verdict from reviewer agent or human |
+| `human_approved_at` | TIMESTAMPTZ | |
+| `human_approved_by` | TEXT | User or agent ID |
+| `promoted_at` | TIMESTAMPTZ | Set when row is promoted to production |
+
+### `enrichment_staging.enrichment_promotion_log`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | |
+| `batch_id` | UUID | Batch that was promoted |
+| `row_count` | INTEGER | Number of rows in this promotion event |
+| `approver_agent_id` | TEXT | Paperclip agent ID of approver |
+| `approver_user_id` | TEXT | Human user ID of approver |
+| `promoted_at` | TIMESTAMPTZ | Auto-set; promotion timestamp |
+| `payload_json` | JSONB | Snapshot of promoted rows or promotion metadata |
+
+### `enrichment_staging.pricing_staleness_alerts`
+
+[SAG-6327](/SAG/issues/SAG-6327) Phase 1 | Parent: [SAG-6302](/SAG/issues/SAG-6302)
+Reconciled to the tested runner contract in [SAG-6353](/SAG/issues/SAG-6353).
+
+Append-only detection-alert log written by the nightly pricing staleness runner
+(SAG-6327 Phase 3+4, SAG-6344). One row per detection event across the four
+signals (anomaly, version/hash drift, SLA breach, bulk escalation). Column
+grain matches the runner's own `StalenessAlert` shape 1:1 — no reconciliation
+layer needed between the two.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | `gen_random_uuid()` |
+| `signal_type` | TEXT | CHECK-constrained: `anomaly` \| `version_hash_drift` \| `sla_breach` \| `bulk_escalation` |
+| `severity` | TEXT | CHECK-constrained: `warn` \| `critical` |
+| `record_key` | TEXT | Plain text identifier; no FK; decoupled from Pricing's feed-spec grain (SAG-6341) |
+| `detected_at` | TIMESTAMPTZ | Auto-set; indexed |
+| `warm_up` | BOOLEAN | True while inside the Phase 4 30-day warm-up window |
+| `details_json` | JSONB | Signal-specific evidence (pct_delta, versions, due/committed timestamps, etc.) |
+
+Indexed on `(detected_at)` and `(record_key)` — the latter serves the Phase 5
+freeze-arming check ("≥1 clean baseline median per record").
+
+---
+
+## Roles
+
+| Role | Table | Privileges |
+|---|---|---|
+| `enrichment_dispatcher` | `enrichment_queue` | SELECT, INSERT, UPDATE |
+| `enrichment_dispatcher` | `enrichment_staging` | SELECT, INSERT, UPDATE |
+| `enrichment_dispatcher` | `enrichment_promotion_log` | INSERT only |
+| `enrichment_reviewer` | `enrichment_queue` | SELECT only |
+| `enrichment_reviewer` | `enrichment_staging` | SELECT, INSERT, UPDATE |
+| `enrichment_reviewer` | `enrichment_promotion_log` | INSERT only |
+| `pricing_staleness_writer` | `pricing_staleness_alerts` | SELECT, INSERT (append-only; nightly runner) |
+| `pricing_staleness_reader` | `pricing_staleness_alerts` | SELECT only (digest / QA / freeze-arming consumers) |
+| All roles | `public` schema | **No write access** (explicitly revoked) |

--- a/migrations/tests/test_pricing_staleness_permissions.sql
+++ b/migrations/tests/test_pricing_staleness_permissions.sql
@@ -1,0 +1,138 @@
+-- Permission negative-test for SAG-6327 Phase 1
+--
+-- Purpose: verify that pricing_staleness_writer and pricing_staleness_reader
+-- cannot write to production catalog tables in the public schema, and that
+-- pricing_staleness_alerts is truly append-only (no UPDATE/DELETE granted to
+-- any role, matching the enrichment_promotion_log precedent).
+--
+-- Run as a superuser (e.g. postgres) AFTER applying
+-- 003_pricing_staleness_alerts_up.sql.
+-- Expected result: every SET ROLE + DML block below raises an ERROR, proving
+-- the roles have no write access to public and no UPDATE/DELETE on the alerts
+-- table.
+--
+-- Usage:
+--   psql -U postgres -d <your_db> -f migrations/tests/test_pricing_staleness_permissions.sql
+--
+-- The script uses DO blocks so failures print NOTICE instead of aborting the
+-- entire run. Exit code 0 means all negative checks passed. Any "UNEXPECTED:
+-- write SUCCEEDED" line indicates a permission leak and must be treated as a
+-- test failure.
+
+\set ON_ERROR_STOP off
+
+-- ── Test 1: pricing_staleness_writer cannot INSERT into public schema ─────────
+SET ROLE pricing_staleness_writer;
+
+DO $$
+BEGIN
+    BEGIN
+        EXECUTE 'INSERT INTO public.products DEFAULT VALUES';
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_writer write to public.products SUCCEEDED — permission leak!';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_writer INSERT on public.products correctly denied.';
+        WHEN undefined_table THEN
+            RAISE NOTICE 'SKIP: public.products does not exist yet; role has no grants (structural pass).';
+        WHEN OTHERS THEN
+            RAISE NOTICE 'PASS (other error, not permission): %', SQLERRM;
+    END;
+END
+$$;
+
+RESET ROLE;
+
+-- ── Test 2: pricing_staleness_reader cannot INSERT into public schema ─────────
+SET ROLE pricing_staleness_reader;
+
+DO $$
+BEGIN
+    BEGIN
+        EXECUTE 'INSERT INTO public.products DEFAULT VALUES';
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_reader write to public.products SUCCEEDED — permission leak!';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_reader INSERT on public.products correctly denied.';
+        WHEN undefined_table THEN
+            RAISE NOTICE 'SKIP: public.products does not exist yet; structural pass.';
+        WHEN OTHERS THEN
+            RAISE NOTICE 'PASS (other error): %', SQLERRM;
+    END;
+END
+$$;
+
+RESET ROLE;
+
+-- ── Test 3: pricing_staleness_alerts is truly append-only (no UPDATE/DELETE) ──
+SET ROLE pricing_staleness_writer;
+
+DO $$
+DECLARE
+    v_id UUID := gen_random_uuid();
+BEGIN
+    -- First, insert a test row (INSERT is allowed).
+    INSERT INTO enrichment_staging.pricing_staleness_alerts
+        (id, detected_at, signal_type, severity, record_key, warm_up, details_json)
+    VALUES
+        (v_id, NOW(), 'anomaly', 'warn', 'TEST-SKU|FQ3-A', FALSE, '{}'::jsonb);
+    RAISE NOTICE 'PASS: pricing_staleness_writer INSERT on pricing_staleness_alerts succeeded (expected).';
+
+    -- Now attempt UPDATE — must be denied.
+    BEGIN
+        EXECUTE format('UPDATE enrichment_staging.pricing_staleness_alerts SET severity = %L WHERE id = %L', 'critical', v_id);
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_writer UPDATE on pricing_staleness_alerts SUCCEEDED — not append-only!';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_writer UPDATE on pricing_staleness_alerts correctly denied (append-only).';
+    END;
+
+    -- Attempt DELETE — must be denied.
+    BEGIN
+        EXECUTE format('DELETE FROM enrichment_staging.pricing_staleness_alerts WHERE id = %L', v_id);
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_writer DELETE on pricing_staleness_alerts SUCCEEDED — not append-only!';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_writer DELETE on pricing_staleness_alerts correctly denied (append-only).';
+    END;
+END
+$$;
+
+RESET ROLE;
+
+-- ── Test 4: pricing_staleness_reader cannot INSERT/UPDATE/DELETE the alerts table ──
+SET ROLE pricing_staleness_reader;
+
+DO $$
+BEGIN
+    BEGIN
+        EXECUTE $q$INSERT INTO enrichment_staging.pricing_staleness_alerts
+            (detected_at, signal_type, severity, record_key, warm_up, details_json)
+            VALUES (NOW(), 'anomaly', 'warn', 'TEST-SKU|FQ3-A', FALSE, '{}'::jsonb)$q$;
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_reader INSERT on pricing_staleness_alerts SUCCEEDED.';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_reader INSERT on pricing_staleness_alerts correctly denied.';
+    END;
+
+    BEGIN
+        EXECUTE 'UPDATE enrichment_staging.pricing_staleness_alerts SET severity = ''critical'' WHERE false';
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_reader UPDATE on pricing_staleness_alerts SUCCEEDED.';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_reader UPDATE on pricing_staleness_alerts correctly denied.';
+    END;
+
+    BEGIN
+        EXECUTE 'DELETE FROM enrichment_staging.pricing_staleness_alerts WHERE false';
+        RAISE NOTICE 'UNEXPECTED: pricing_staleness_reader DELETE on pricing_staleness_alerts SUCCEEDED.';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'PASS: pricing_staleness_reader DELETE on pricing_staleness_alerts correctly denied.';
+    END;
+END
+$$;
+
+RESET ROLE;
+
+-- ─── Summary ─────────────────────────────────────────────────────────────────
+-- Scan output for "UNEXPECTED" lines. Zero such lines = all checks passed.


### PR DESCRIPTION
## SAG-6345 Phase 5 — Quote-Freeze Arming Mechanism

### Summary

Adds the gated quote-freeze arming mechanism per SAG-6302 Phase 5 policy.
**Build-only: no automated path arms a freeze. Actual freeze arming remains
gated on explicit human/board sign-off and is NOT part of this commit.**

### Artifacts

- `infra/runtime-eval/pricing_freeze_arming.py` (347 lines) — evaluate
  readiness (pure/read-only), build proposal, and gated `arm_freeze()`.
- `infra/runtime-eval/test_pricing_freeze_arming.py` (239 lines) — 18 tests.

### Phase 5 Policy Audit — PASS (QA Auditor SAG-8399)

| Policy | Implementation | Test coverage |
|--------|---------------|---------------|
| Non-autonomy guard — no code path arms without human/board sign-off | `arm_freeze()` requires `ArmingAuthorization` with `authority ∈ {human, board}`; `authorization is None → ArmingNotAuthorizedError` | `test_arm_without_authorization_is_refused`, `test_arm_with_agent_authority_is_rejected` |
| Warm-up gate at evaluation time | `evaluate_arming_readiness()` calls `is_warm_up()` imported from runner | `test_not_eligible_during_warm_up_even_with_clean_baselines` |
| Warm-up re-check at arm time (defense-in-depth) | `arm_freeze()` independently calls `is_warm_up()` before accepting proposal+auth | `test_arm_freeze_refuses_during_warm_up_defense_in_depth` |
| Scope = CRITICAL ∩ clean-baseline | `armable = critical_keys & clean_keys`; CRITICAL w/o baseline → `blocked_critical_keys` (not silently dropped) | `test_scope_is_critical_intersect_clean_baseline` |
| Loud-fail baseline provider | `NotImplementedBaselineMedianProvider` raises `BaselineMedianUnavailableError` | `test_notimplemented_provider_raises_rather_than_reporting_empty` |
| Existing quotes honored | `ArmedFreeze.existing_quotes_honored = True` (field default) | `test_happy_path_arms_only_with_valid_human_signoff` |
| Unfreeze contract attributes | `UNFREEZE_REQUIREMENTS` 4-step tuple carried on `ArmedFreeze` | `test_happy_path_arms_only_with_valid_human_signoff` |
| Nightly runner isolation | `pricing_freeze_arming` not imported by nightly runner or `run_eval.py` | Verified by grep + `test_pricing_staleness_runner` |

### Test Results

- 18/18 module tests PASS (`test_pricing_freeze_arming.py`)
- 143/143 regression tests PASS (`test_digest_and_alert.py` + `test_run_eval.py`)

### Downstream note (out of scope, no action needed)

`ArmingAuthorization` is a plain in-process dataclass — the real control is
that no automated path constructs one and the nightly runner does not import
the module (both verified). Stronger binding of `reference` to a verifiable
external sign-off record is a downstream hardening item.

Closes SAG-6345. QA sign-off: SAG-8399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)