### PR TITLE
feat(nix): add native NixOS packaging

### DIFF
--- a/docs/deploy/nixos.md
+++ b/docs/deploy/nixos.md
@@ -1,0 +1,139 @@
+---
+title: NixOS
+summary: Native package and systemd service deployment
+---
+
+Paperclip provides a flake package, development shell, overlay, and NixOS
+module. Docker is not required.
+
+## Run or build the package
+
+From a Paperclip checkout:
+
+```sh
+nix build
+nix run -- --help
+nix develop
+```
+
+The package builds the same UI and server entrypoints as the production Docker
+image. It also installs the `paperclip` CLI and `paperclip-server` executable.
+
+## Add the NixOS module
+
+Add Paperclip as an updateable flake input and import its module:
+
+```nix
+{
+  inputs.paperclip.url = "github:paperclipai/paperclip";
+
+  outputs = { nixpkgs, paperclip, ... }: {
+    nixosConfigurations.example = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        paperclip.nixosModules.paperclip
+        {
+          services.paperclip = {
+            enable = true;
+            host = "127.0.0.1";
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+This default uses `local_trusted` mode on loopback and embedded PostgreSQL. It
+stores mutable data under `/var/lib/paperclip`.
+
+The package already provides Node.js to its bundled local adapters. Use
+`services.paperclip.extraPackages` for additional adapter CLIs or other runtime
+tools.
+
+## Authenticated deployments and secrets
+
+Authenticated mode requires `BETTER_AUTH_SECRET`. External PostgreSQL requires
+`DATABASE_URL`. Supply these and all other credentials through a runtime-only
+systemd environment file:
+
+```nix
+services.paperclip = {
+  enable = true;
+  host = "0.0.0.0";
+  openFirewall = true;
+  publicExposure = true;
+
+  auth = {
+    enable = true;
+    publicBaseUrl = "https://paperclip.example.com";
+  };
+
+  database.external.enable = true;
+  environmentFiles = [ "/run/secrets/paperclip.env" ];
+};
+```
+
+`publicExposure = true` is required for an internet-facing endpoint. It makes
+Paperclip apply its stricter public exposure policy. Keep it `false` only when
+the authenticated service is reachable exclusively over a private LAN, VPN,
+or tailnet. Public exposure also requires external PostgreSQL, so `DATABASE_URL`
+must be present in the runtime environment file.
+
+Provision that file at runtime with a secret manager such as sops-nix or
+agenix. Its format is:
+
+```sh
+BETTER_AUTH_SECRET=...
+PAPERCLIP_TOOL_ACTION_SIGNING_SECRET=...
+DATABASE_URL=postgresql://...
+```
+
+Never use `pkgs.writeText`, inline Nix strings, or another store-backed value
+for this file. The module rejects environment file paths under `/nix/store`.
+The generated Paperclip JSON configuration contains only non-secret settings.
+
+## External PostgreSQL and S3
+
+Enable external PostgreSQL after adding `DATABASE_URL` to the runtime
+environment file:
+
+```nix
+services.paperclip.database.external.enable = true;
+```
+
+S3 access keys also belong in the environment file. Bucket and endpoint
+metadata are non-secret Nix options:
+
+```nix
+services.paperclip.storage.s3 = {
+  enable = true;
+  bucket = "paperclip";
+  region = "us-east-1";
+};
+```
+
+## Additional writable workspaces
+
+The service can write its state directory by default. Explicitly allow any
+host workspaces used by local agents:
+
+```nix
+services.paperclip.readWritePaths = [ "/srv/paperclip-workspaces" ];
+```
+
+The module supports state directories outside `/var/lib`; systemd-tmpfiles
+creates the selected path with service-user ownership.
+
+## Verify the flake
+
+Run all flake checks, the package build, or the NixOS VM test directly:
+
+```sh
+nix flake check
+nix build .#paperclip
+nix build .#checks.x86_64-linux.nixos-module
+```
+
+The VM test boots NixOS, creates representative secrets after boot, starts
+Paperclip with embedded PostgreSQL, and verifies the health endpoint.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -83,6 +83,7 @@
               "deploy/local-development",
               "deploy/tailscale-private-access",
               "deploy/docker",
+              "deploy/nixos",
               "deploy/deployment-modes",
               "deploy/database",
               "deploy/secrets",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,355 @@
+{
+  description = "Paperclip — AI agent orchestration platform";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    let
+      paperclipModule = import ./nix/modules/nixos/paperclip.nix;
+
+      paperclipOverlay = final: _prev: {
+        paperclip = self.packages.${final.stdenv.hostPlatform.system}.paperclip;
+      };
+
+      nixosModule =
+        { lib, pkgs, ... }:
+        {
+          imports = [ paperclipModule ];
+
+          services.paperclip.package =
+            lib.mkDefault
+              self.packages.${pkgs.stdenv.hostPlatform.system}.paperclip;
+        };
+    in
+    {
+      nixosModules = {
+        default = nixosModule;
+        paperclip = nixosModule;
+      };
+
+      overlays = {
+        default = paperclipOverlay;
+        paperclip = paperclipOverlay;
+      };
+    }
+    //
+      flake-utils.lib.eachSystem
+        [
+          "x86_64-linux"
+          "aarch64-linux"
+          "aarch64-darwin"
+        ]
+        (
+          system:
+          let
+            pkgs = import nixpkgs { inherit system; };
+            inherit (pkgs) lib;
+            nodejs = pkgs.nodejs;
+            pnpm = pkgs.pnpm_10;
+            version = (builtins.fromJSON (builtins.readFile ./server/package.json)).version;
+
+            # Keep packaging inputs independent from Nix modules, tests, and
+            # documentation. Otherwise editing a VM assertion needlessly
+            # rebuilds the entire JavaScript application.
+            packageSource = lib.fileset.toSource {
+              root = ./.;
+              fileset = lib.fileset.unions [
+                ./.npmrc
+                ./LICENSE
+                ./README.md
+                ./package.json
+                ./pnpm-lock.yaml
+                ./pnpm-workspace.yaml
+                ./tsconfig.base.json
+                ./tsconfig.json
+                ./cli
+                ./packages
+                ./patches
+                ./scripts
+                ./server
+                ./skills
+                ./skills-releases
+                ./ui
+              ];
+            };
+
+            runtimePath = lib.makeBinPath [
+              pkgs.curl
+              pkgs.gh
+              pkgs.git
+              pkgs.jq
+              pkgs.openssh
+              pkgs.postgresql
+              pkgs.ripgrep
+              pkgs.wget
+            ];
+
+            # pnpm-generated launchers for bundled local adapters execute
+            # `node` via PATH rather than using Paperclip's absolute Node path.
+            # Add it in the lightweight public wrapper layer so every adapter
+            # child inherits Node without rebuilding the large JS runtime.
+            adapterRuntimePath = lib.makeBinPath [ nodejs ];
+
+            paperclipUnwrapped = pkgs.stdenv.mkDerivation (finalAttrs: {
+              pname = "paperclip";
+              inherit version;
+              src = packageSource;
+
+              strictDeps = true;
+
+              nativeBuildInputs = [
+                nodejs
+                pnpm
+                pkgs.pnpmConfigHook
+                pkgs.makeWrapper
+                pkgs.python3
+                pkgs.pkg-config
+              ];
+
+              buildInputs = [
+                pkgs.postgresql
+                pkgs.vips
+              ];
+
+              # The workspace packages export TypeScript sources during monorepo
+              # development. Hoisting keeps those exports and their dependencies
+              # resolvable from the installed application tree.
+              pnpmInstallFlags = [ "--shamefully-hoist" ];
+              pnpmWorkspaces = [
+                "paperclipai..."
+                "@paperclipai/ui..."
+              ];
+
+              # pnpm 10 is the supported, non-vulnerable pnpm in nixpkgs. The
+              # repository lockfile is maintained by GitHub Actions with pnpm 9,
+              # whose patch hashes use the older short form. Normalize only the
+              # sandbox copy until the upstream lockfile moves to pnpm 10.
+              prePnpmInstall = ''
+                # Large optional agent SDK binaries can otherwise saturate this
+                # host's connection and make pnpm discard the entire fixed-output
+                # fetch after a transient registry timeout.
+                pnpm config set network-concurrency 4
+                pnpm config set fetch-retries 5
+                pnpm config set fetch-retry-mintimeout 20000
+                pnpm config set fetch-retry-maxtimeout 120000
+                pnpm config set fetch-timeout 600000
+
+                substituteInPlace pnpm-lock.yaml \
+                  --replace-fail x3fethhotv43zektyl5prdwf54 a93c6b5344b036508a5a86ba7e8589b11302119d46bdc51318e297b74fa5666e \
+                  --replace-fail 55uhvnotpqyiy37rn3pqpukhei d8b1e087e95f559a6342fc15954f11af22d9dca43a7fcca5762b6459913b5800
+              '';
+
+              pnpmDeps = pkgs.fetchPnpmDeps {
+                inherit (finalAttrs)
+                  pname
+                  version
+                  src
+                  pnpmWorkspaces
+                  prePnpmInstall
+                  ;
+                inherit pnpm;
+                fetcherVersion = 4;
+                hash = "sha256-xcAji32woqLG93dclH/hDaWyNUeLHWdXfW+AKeIPF7o=";
+              };
+
+              buildPhase = ''
+                runHook preBuild
+
+                # Keep this aligned with the production Docker build. The CLI is
+                # built as well because it is the flake's default executable.
+                pnpm --filter @paperclipai/ui build
+                pnpm --filter @paperclipai/plugin-sdk build
+                # TypeScript's server program exceeds V8's default ~2 GiB heap
+                # on memory-constrained Nix builders.
+                NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @paperclipai/server build
+                pnpm --filter paperclipai build
+
+                test -f server/dist/index.js
+                test -f cli/dist/index.js
+
+                runHook postBuild
+              '';
+
+              installPhase = ''
+                runHook preInstall
+
+                mkdir -p "$out/lib/paperclip"
+                cp -R . "$out/lib/paperclip"
+
+                mkdir -p "$out/bin"
+                makeWrapper ${nodejs}/bin/node "$out/bin/paperclip" \
+                  --add-flags "$out/lib/paperclip/cli/dist/index.js" \
+                  --set-default NODE_ENV production \
+                  --set-default PAPERCLIP_BUILD_VERSION ${lib.escapeShellArg version} \
+                  --prefix PATH : ${lib.escapeShellArg runtimePath}
+
+                # server/dist is JavaScript, but it imports workspace packages
+                # whose development manifests intentionally export src/*.ts.
+                # Keep the tsx loader until the production build rewrites those
+                # workspace exports to dist/*.js.
+                makeWrapper ${nodejs}/bin/node "$out/bin/paperclip-server" \
+                  --add-flags "--import $out/lib/paperclip/server/node_modules/tsx/dist/loader.mjs" \
+                  --add-flags "$out/lib/paperclip/server/dist/index.js" \
+                  --set-default NODE_ENV production \
+                  --set-default PAPERCLIP_BUILD_VERSION ${lib.escapeShellArg version} \
+                  --set-default SERVE_UI true \
+                  --set-default HOST 127.0.0.1 \
+                  --set-default PORT 3100 \
+                  --prefix PATH : ${lib.escapeShellArg runtimePath}
+
+                runHook postInstall
+              '';
+
+              meta = {
+                description = "Control plane for autonomous AI companies";
+                homepage = "https://github.com/paperclipai/paperclip";
+                license = lib.licenses.mit;
+                mainProgram = "paperclip";
+                platforms = lib.platforms.unix;
+              };
+            });
+
+            # Paperclip prepares soname aliases for its embedded PostgreSQL at
+            # runtime. Nix store paths are immutable, so create those aliases
+            # in a lightweight post-processing derivation instead of letting
+            # the service attempt to mutate its installed package.
+            paperclipRuntime =
+              pkgs.runCommand "paperclip-${version}"
+                {
+                  inherit (paperclipUnwrapped) meta;
+                  passthru.unwrapped = paperclipUnwrapped;
+                  dontFixup = true;
+                }
+                ''
+                  cp -a --reflink=auto ${paperclipUnwrapped} "$out"
+
+                  chmod u+w "$out/bin/paperclip" "$out/bin/paperclip-server"
+                  substituteInPlace "$out/bin/paperclip" "$out/bin/paperclip-server" \
+                    --replace-fail ${paperclipUnwrapped} "$out"
+
+                  # The upstream embedded PostgreSQL binaries use the generic
+                  # FHS loader path (/lib64/ld-linux-x86-64.so.2 on x86_64),
+                  # which does not exist on a normal NixOS system. Point every
+                  # bundled ELF executable at this platform's store loader;
+                  # Paperclip itself supplies the matching native library path
+                  # before spawning them.
+                  while IFS= read -r -d "" executable; do
+                    if ${pkgs.patchelf}/bin/patchelf --print-interpreter "$executable" >/dev/null 2>&1; then
+                      chmod u+w "$executable"
+                      ${pkgs.patchelf}/bin/patchelf \
+                        --set-interpreter ${lib.escapeShellArg pkgs.stdenv.cc.bintools.dynamicLinker} \
+                        "$executable"
+                    fi
+                  done < <(
+                    find "$out/lib/paperclip/node_modules/.pnpm" \
+                      -path '*/@embedded-postgres/*/native/bin/*' \
+                      -type f -print0
+                  )
+
+                  while IFS= read -r -d "" library; do
+                    libDir="$(dirname "$library")"
+                    libraryName="$(basename "$library")"
+                    aliasName="$(printf '%s\n' "$libraryName" | sed -E 's/^(lib.+\.so\.[0-9]+)\.[0-9]+(\.[0-9]+)?$/\1/')"
+                    if [ "$aliasName" = "$libraryName" ] || [ -e "$libDir/$aliasName" ]; then
+                      continue
+                    fi
+
+                    chmod u+w "$libDir"
+                    ln -s "$libraryName" "$libDir/$aliasName"
+                    chmod u-w "$libDir"
+                  done < <(
+                    find "$out/lib/paperclip/node_modules/.pnpm" \
+                      -path '*/@embedded-postgres/*/native/lib/lib*.so.*.*' \
+                      -type f -print0
+                  )
+                '';
+
+            # Keep the large, immutable runtime as its own cached layer. The
+            # public package only adds wrappers, including the C++ runtime
+            # needed by the bundled initdb/postgres binaries.
+            paperclip =
+              pkgs.runCommand "paperclip-${version}"
+                {
+                  inherit (paperclipRuntime) meta;
+                  nativeBuildInputs = [ pkgs.makeWrapper ];
+                  passthru = {
+                    inherit paperclipRuntime paperclipUnwrapped;
+                    runtime = paperclipRuntime;
+                    unwrapped = paperclipUnwrapped;
+                  };
+                }
+                ''
+                  mkdir -p "$out/bin"
+                  ln -s ${paperclipRuntime}/lib "$out/lib"
+                  makeWrapper \
+                    ${paperclipRuntime}/bin/paperclip \
+                    "$out/bin/paperclip" \
+                    --prefix PATH : ${lib.escapeShellArg adapterRuntimePath}
+                  makeWrapper \
+                    ${paperclipRuntime}/bin/paperclip-server \
+                    "$out/bin/paperclip-server" \
+                    --prefix PATH : ${lib.escapeShellArg adapterRuntimePath} \
+                    --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]}
+                '';
+          in
+          {
+            packages = {
+              default = paperclip;
+              inherit paperclip;
+            };
+
+            apps = {
+              default = {
+                type = "app";
+                program = "${paperclip}/bin/paperclip";
+              };
+              paperclip-server = {
+                type = "app";
+                program = "${paperclip}/bin/paperclip-server";
+              };
+            };
+
+            checks = {
+              package = paperclip;
+            }
+            // lib.optionalAttrs pkgs.stdenv.isLinux {
+              nixos-module = import ./nix/tests/nixos-module.nix {
+                inherit pkgs self;
+              };
+            };
+
+            devShells.default = pkgs.mkShell {
+              packages = [
+                nodejs
+                pnpm
+                pkgs.curl
+                pkgs.gh
+                pkgs.git
+                pkgs.jq
+                pkgs.openssh
+                pkgs.pkg-config
+                pkgs.playwright-driver.browsers
+                pkgs.python3
+                pkgs.ripgrep
+                pkgs.vips
+                pkgs.wget
+              ];
+
+              shellHook = ''
+                export PLAYWRIGHT_BROWSERS_PATH="${pkgs.playwright-driver.browsers}"
+                export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+              '';
+            };
+
+            formatter = pkgs.nixfmt;
+          }
+        );
+}

--- a/nix/modules/nixos/paperclip.nix
+++ b/nix/modules/nixos/paperclip.nix
@@ -1,0 +1,437 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.paperclip;
+  instanceDir = "${cfg.stateDir}/instances/${cfg.instanceId}";
+  storeDir = builtins.storeDir;
+
+  isAbsolutePath = path: lib.hasPrefix "/" path;
+  isStorePath = path: path == storeDir || lib.hasPrefix "${storeDir}/" path;
+  isNormalizedAbsolutePath =
+    path:
+    isAbsolutePath path
+    && path != "/"
+    && !lib.hasSuffix "/" path
+    && !lib.hasInfix "//" path
+    && lib.all (segment: segment != "." && segment != "..") (lib.splitString "/" path);
+  isMutablePath = path: isNormalizedAbsolutePath path && !isStorePath path;
+
+  configJson = pkgs.writeText "paperclip-config.json" (
+    builtins.toJSON {
+      "$meta" = {
+        version = 1;
+        updatedAt = "1970-01-01T00:00:00.000Z";
+        source = "nixos-module";
+      };
+      server = {
+        deploymentMode = if cfg.auth.enable then "authenticated" else "local_trusted";
+        exposure = if cfg.publicExposure then "public" else "private";
+        host = cfg.host;
+        port = cfg.port;
+        allowedHostnames = cfg.allowedHostnames;
+        serveUi = cfg.serveUi;
+      };
+      auth = {
+        baseUrlMode = if cfg.auth.publicBaseUrl == null then "auto" else "explicit";
+        disableSignUp = cfg.auth.disableSignUp;
+      }
+      // lib.optionalAttrs (cfg.auth.publicBaseUrl != null) {
+        inherit (cfg.auth) publicBaseUrl;
+      };
+      database = {
+        mode = if cfg.database.external.enable then "postgres" else "embedded-postgres";
+        embeddedPostgresDataDir = "${instanceDir}/db";
+        embeddedPostgresPort = cfg.database.embeddedPort;
+        backup = {
+          enabled = cfg.database.backup.enable;
+          intervalMinutes = cfg.database.backup.intervalMinutes;
+          retentionDays = cfg.database.backup.retentionDays;
+          dir = "${instanceDir}/data/backups";
+        };
+      };
+      storage = {
+        provider = if cfg.storage.s3.enable then "s3" else "local_disk";
+        localDisk.baseDir = "${instanceDir}/data/storage";
+        s3 = {
+          inherit (cfg.storage.s3)
+            bucket
+            region
+            prefix
+            forcePathStyle
+            ;
+        }
+        // lib.optionalAttrs (cfg.storage.s3.endpoint != null) {
+          inherit (cfg.storage.s3) endpoint;
+        };
+      };
+      logging = {
+        mode = "file";
+        logDir = "${instanceDir}/logs";
+      };
+      secrets = {
+        provider = "local_encrypted";
+        strictMode = cfg.secrets.strictMode;
+        localEncrypted.keyFilePath = "${instanceDir}/secrets/master.key";
+      };
+      telemetry.enabled = cfg.telemetry.enable;
+    }
+  );
+in
+{
+  options.services.paperclip = {
+    enable = lib.mkEnableOption "Paperclip AI agent orchestration platform";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.paperclip;
+      defaultText = lib.literalExpression "pkgs.paperclip";
+      description = "The Paperclip package to use.";
+    };
+
+    autoStart = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Start Paperclip automatically during boot.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3100;
+      description = "Port on which the server listens.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address to which the server binds.";
+    };
+
+    allowedHostnames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional hostnames accepted by Paperclip's host validation.";
+    };
+
+    serveUi = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to serve the bundled web UI.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the server port in the NixOS firewall.";
+    };
+
+    auth = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Use authenticated deployment mode instead of local_trusted mode.";
+      };
+
+      publicBaseUrl = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "https://paperclip.example.com";
+        description = "Canonical browser-facing URL used by authenticated deployments.";
+      };
+
+      disableSignUp = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Disable new user sign-up after the instance has been claimed.";
+      };
+    };
+
+    publicExposure = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Declare an authenticated deployment as internet-facing. Enable this
+        for public endpoints so Paperclip applies its stricter public exposure
+        policy; leave it disabled only for private LAN, VPN, or tailnet access.
+        Public exposure requires an external PostgreSQL database.
+      '';
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.strMatching "^/[^[:space:]]*$";
+      default = "/var/lib/paperclip";
+      description = "Base directory for Paperclip database, logs, storage, and runtime secrets.";
+    };
+
+    instanceId = lib.mkOption {
+      type = lib.types.strMatching "^[A-Za-z0-9][A-Za-z0-9_-]*$";
+      default = "default";
+      description = "Identifier for this isolated Paperclip instance.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "paperclip";
+      description = "User account under which Paperclip runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "paperclip";
+      description = "Group under which Paperclip runs.";
+    };
+
+    createUser = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Create the configured service user and group.";
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "/run/secrets/paperclip.env" ];
+      description = ''
+        Runtime-only systemd EnvironmentFile paths. Put DATABASE_URL,
+        BETTER_AUTH_SECRET, API keys, and other secret values here. Store paths
+        are rejected so secret material cannot be copied into /nix/store.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Additional executables made available to Paperclip and its local agents.";
+    };
+
+    readWritePaths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "/srv/paperclip-workspaces" ];
+      description = "Additional absolute paths that Paperclip and local agents may modify.";
+    };
+
+    database = {
+      external.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Use external PostgreSQL. Supply DATABASE_URL, and optionally
+          DATABASE_MIGRATION_URL, through environmentFiles.
+        '';
+      };
+
+      embeddedPort = lib.mkOption {
+        type = lib.types.port;
+        default = 54329;
+        description = "Port used by the embedded PostgreSQL server.";
+      };
+
+      backup = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Enable automatic logical database backups.";
+        };
+
+        intervalMinutes = lib.mkOption {
+          type = lib.types.ints.between 1 10080;
+          default = 60;
+          description = "Minutes between automatic database backups.";
+        };
+
+        retentionDays = lib.mkOption {
+          type = lib.types.ints.between 1 3650;
+          default = 7;
+          description = "Days for which automatic backups are retained.";
+        };
+      };
+    };
+
+    storage.s3 = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Use S3-compatible object storage instead of local disk.";
+      };
+
+      bucket = lib.mkOption {
+        type = lib.types.str;
+        default = "paperclip";
+        description = "S3 bucket name.";
+      };
+
+      region = lib.mkOption {
+        type = lib.types.str;
+        default = "us-east-1";
+        description = "S3 region.";
+      };
+
+      endpoint = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Custom endpoint for an S3-compatible service.";
+      };
+
+      prefix = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Key prefix for objects stored by Paperclip.";
+      };
+
+      forcePathStyle = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Use path-style S3 URLs.";
+      };
+    };
+
+    secrets.strictMode = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Require Paperclip-managed secret references for sensitive agent environment values.";
+    };
+
+    telemetry.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable Paperclip telemetry.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !cfg.publicExposure || cfg.auth.enable;
+        message = "services.paperclip: publicExposure requires auth.enable = true.";
+      }
+      {
+        assertion = !cfg.publicExposure || cfg.auth.publicBaseUrl != null;
+        message = "services.paperclip: publicExposure requires auth.publicBaseUrl.";
+      }
+      {
+        assertion = !cfg.publicExposure || cfg.database.external.enable;
+        message = "services.paperclip: publicExposure requires database.external.enable = true and DATABASE_URL.";
+      }
+      {
+        assertion =
+          cfg.auth.enable
+          || lib.elem (lib.toLower cfg.host) [
+            "127.0.0.1"
+            "::1"
+            "localhost"
+          ];
+        message = "services.paperclip: local_trusted mode requires a loopback host.";
+      }
+      {
+        assertion = !cfg.auth.enable || cfg.environmentFiles != [ ];
+        message = "services.paperclip: authenticated mode requires a runtime environmentFiles entry for BETTER_AUTH_SECRET.";
+      }
+      {
+        assertion = !cfg.database.external.enable || cfg.environmentFiles != [ ];
+        message = "services.paperclip: external PostgreSQL requires DATABASE_URL in a runtime environmentFiles entry.";
+      }
+      {
+        assertion = lib.all isNormalizedAbsolutePath cfg.environmentFiles;
+        message = "services.paperclip: every environmentFiles entry must be a normalized absolute runtime file path.";
+      }
+      {
+        assertion = lib.all (path: !isStorePath path) cfg.environmentFiles;
+        message = "services.paperclip: environmentFiles must not refer to /nix/store; provision secrets at runtime instead.";
+      }
+      {
+        assertion = isMutablePath cfg.stateDir;
+        message = "services.paperclip: stateDir must be a normalized mutable path outside /nix/store and must not be /.";
+      }
+      {
+        assertion = lib.all isMutablePath cfg.readWritePaths;
+        message = "services.paperclip: every readWritePaths entry must be a normalized mutable path outside /nix/store and must not be /.";
+      }
+    ];
+
+    users.users = lib.mkIf cfg.createUser {
+      ${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.stateDir;
+        createHome = false;
+        description = "Paperclip service user";
+      };
+    };
+
+    users.groups = lib.mkIf cfg.createUser {
+      ${cfg.group} = { };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.stateDir} 0750 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.stateDir}/instances 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir} 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/db 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/data 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/data/storage 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/data/backups 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/logs 0750 ${cfg.user} ${cfg.group} -"
+      "d ${instanceDir}/secrets 0700 ${cfg.user} ${cfg.group} -"
+    ];
+
+    environment.etc."paperclip/config.json" = {
+      source = configJson;
+      mode = "0444";
+    };
+
+    systemd.services.paperclip = {
+      description = "Paperclip AI agent orchestration platform";
+      wantedBy = lib.optionals cfg.autoStart [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = cfg.extraPackages;
+
+      environment = {
+        # The package wrapper provides safe loopback defaults for direct use,
+        # while Paperclip gives environment variables precedence over its JSON
+        # config. Export the module options explicitly so non-default bind
+        # addresses and ports cannot be shadowed by those wrapper defaults.
+        HOST = cfg.host;
+        PORT = toString cfg.port;
+        SERVE_UI = if cfg.serveUi then "true" else "false";
+        PAPERCLIP_HOME = cfg.stateDir;
+        PAPERCLIP_INSTANCE_ID = cfg.instanceId;
+        PAPERCLIP_CONFIG = "/etc/paperclip/config.json";
+        PAPERCLIP_MIGRATION_AUTO_APPLY = "true";
+        PAPERCLIP_MIGRATION_PROMPT = "never";
+        NODE_ENV = "production";
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${cfg.package}/bin/paperclip-server";
+        Restart = "on-failure";
+        RestartSec = 5;
+        UMask = "0077";
+
+        WorkingDirectory = "${cfg.package}/lib/paperclip";
+        EnvironmentFile = cfg.environmentFiles;
+
+        ProtectHome = "read-only";
+        ProtectSystem = "strict";
+        ReadWritePaths = [ cfg.stateDir ] ++ cfg.readWritePaths;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        LockPersonality = true;
+        RestrictSUIDSGID = true;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+}

--- a/nix/tests/nixos-module.nix
+++ b/nix/tests/nixos-module.nix
@@ -1,0 +1,111 @@
+{ pkgs, self }:
+
+let
+  paperclip = self.packages.${pkgs.stdenv.hostPlatform.system}.paperclip;
+in
+
+pkgs.testers.nixosTest {
+  name = "paperclip-nixos-module";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ self.nixosModules.paperclip ];
+
+      services.paperclip = {
+        enable = true;
+        autoStart = false;
+        stateDir = "/srv/paperclip";
+        host = "0.0.0.0";
+        allowedHostnames = [ "127.0.0.1" ];
+        auth = {
+          enable = true;
+          publicBaseUrl = "http://127.0.0.1:3100";
+        };
+        database.backup.enable = false;
+        telemetry.enable = false;
+        environmentFiles = [ "/run/paperclip/runtime.env" ];
+      };
+
+      # Generate representative secrets only after the VM boots. The values
+      # therefore never become Nix expressions or store objects.
+      systemd.services.paperclip-runtime-env = {
+        description = "Create Paperclip's runtime-only test environment";
+        requiredBy = [ "paperclip.service" ];
+        before = [ "paperclip.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          install -d -m 0700 /run/paperclip
+          umask 0077
+          auth_secret="$(${pkgs.openssl}/bin/openssl rand -hex 32)"
+          action_secret="$(${pkgs.openssl}/bin/openssl rand -hex 32)"
+          printf 'BETTER_AUTH_SECRET=%s\nPAPERCLIP_TOOL_ACTION_SIGNING_SECRET=%s\n' \
+            "$auth_secret" "$action_secret" > /run/paperclip/runtime.env
+          chown root:paperclip /run/paperclip/runtime.env
+          chmod 0600 /run/paperclip/runtime.env
+        '';
+      };
+
+      # Keep a startup failure observable instead of hiding it behind the
+      # production restart policy until the test driver's global timeout.
+      systemd.services.paperclip.serviceConfig.Restart = pkgs.lib.mkForce "no";
+
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+  nodes.public = {
+    imports = [ self.nixosModules.paperclip ];
+
+    services.paperclip = {
+      enable = true;
+      autoStart = false;
+      host = "0.0.0.0";
+      openFirewall = true;
+      publicExposure = true;
+      auth = {
+        enable = true;
+        publicBaseUrl = "https://paperclip.example.com";
+      };
+      database.external.enable = true;
+      environmentFiles = [ "/run/paperclip/runtime.env" ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.succeed("test \"$(stat -c %U:%G /srv/paperclip/instances)\" = paperclip:paperclip")
+    machine.succeed("test \"$(stat -c %U:%G /srv/paperclip/instances/default)\" = paperclip:paperclip")
+    machine.succeed("systemctl start paperclip.service")
+    machine.wait_for_unit("paperclip.service")
+    machine.wait_until_succeeds(
+      "ss -H -ltn 'sport = :3100' | grep -q '0.0.0.0:3100' || systemctl is-failed --quiet paperclip.service",
+      timeout=600,
+    )
+    machine.succeed("systemctl is-active --quiet paperclip.service")
+    machine.wait_for_open_port(3100, timeout=30)
+    machine.succeed("systemctl show paperclip.service -p Environment --value | grep -q 'HOST=0.0.0.0'")
+    machine.succeed("systemctl show paperclip.service -p Environment --value | grep -q 'PORT=3100'")
+    machine.succeed("systemctl show paperclip.service -p Environment --value | grep -q 'SERVE_UI=true'")
+    machine.succeed(
+      "main_pid=$(systemctl show paperclip.service -p MainPID --value); "
+      "service_path=$(tr '\\0' '\\n' < /proc/$main_pid/environ | sed -n 's/^PATH=//p'); "
+      "printf '%s\\n' \"$service_path\" | grep -Fq '${pkgs.nodejs}/bin'; "
+      "PATH=\"$service_path\" ${paperclip}/lib/paperclip/packages/adapters/codex-local/node_modules/.bin/codex-acp --version "
+      "| grep -q '^@agentclientprotocol/codex-acp '"
+    )
+
+    machine.succeed(
+      "curl --fail --silent http://127.0.0.1:3100/api/health | grep -q '\"status\":\"ok\"'"
+    )
+    machine.succeed("test \"$(stat -c %a /run/paperclip/runtime.env)\" = 600")
+    machine.succeed("test \"$(stat -c %U /run/paperclip/runtime.env)\" = root")
+    machine.succeed("systemctl cat paperclip.service | grep -q 'EnvironmentFile=/run/paperclip/runtime.env'")
+    machine.succeed("grep -q '\"source\":\"nixos-module\"' /etc/paperclip/config.json")
+    machine.succeed("! grep -Eq 'BETTER_AUTH_SECRET|PAPERCLIP_TOOL_ACTION_SIGNING_SECRET|DATABASE_URL' /etc/paperclip/config.json")
+    public.succeed("grep -q '\"exposure\":\"public\"' /etc/paperclip/config.json")
+    public.succeed("grep -q '\"mode\":\"postgres\"' /etc/paperclip/config.json")
+  '';
+}

--- a/packages/shared/src/config-schema.test.ts
+++ b/packages/shared/src/config-schema.test.ts
@@ -6,6 +6,25 @@ import {
 } from "./config-schema.js";
 
 describe("paperclip config schema", () => {
+  it("accepts declarative NixOS module configuration", () => {
+    const parsed = paperclipConfigSchema.parse({
+      $meta: {
+        version: 1,
+        updatedAt: "1970-01-01T00:00:00.000Z",
+        source: "nixos-module",
+      },
+      database: {
+        mode: "embedded-postgres",
+      },
+      logging: {
+        mode: "file",
+      },
+      server: {},
+    });
+
+    expect(parsed.$meta.source).toBe("nixos-module");
+  });
+
   it("defaults omitted runtime paths to legacy instance-root locations", () => {
     const parsed = paperclipConfigSchema.parse({
       $meta: {

--- a/packages/shared/src/config-schema.ts
+++ b/packages/shared/src/config-schema.ts
@@ -12,7 +12,7 @@ import { validateConfiguredBindMode } from "./network-bind.js";
 export const configMetaSchema = z.object({
   version: z.literal(1),
   updatedAt: z.string(),
-  source: z.enum(["onboard", "configure", "doctor"]),
+  source: z.enum(["onboard", "configure", "doctor", "nixos-module"]),
 }).passthrough();
 
 export const llmConfigSchema = z.object({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source app that manages AI agents for work
> - Paperclip supports local and shared deployments
> - NixOS users do not have a native package or declarative service module
> - A native package must include the UI, server, CLI, adapters, and embedded database runtime
> - A safe service module must keep secrets out of the Nix store and restrict unauthenticated access
> - This pull request adds a flake package and a NixOS module with integration tests
> - The benefit is a reproducible NixOS deployment without Docker

## Linked Issues or Issue Description

**Problem or motivation**

NixOS users cannot install and operate Paperclip as a native declarative service. They must use another deployment method and maintain the service integration themselves.

**Proposed solution**

Provide a Nix flake package, apps, an overlay, a development shell, and a NixOS module. Keep credentials in runtime environment files. Validate unsafe service settings before activation. Test the complete service in a NixOS VM.

**Alternatives considered**

The Docker deployment remains available, but it does not provide native NixOS service configuration. A package without a module would still leave user management, secret handling, firewall settings, and systemd hardening to each operator.

**Roadmap alignment**

The change supports the local-first and shared deployment direction in `ROADMAP.md`. It does not replace or duplicate a listed roadmap item.

This pull request supersedes https://github.com/paperclipai/paperclip/pull/4270. It credits @jamesdury and addresses the review findings from that pull request.

## What Changed

- Add a reproducible Paperclip package, flake apps, an overlay, and a development shell.
- Add an opt-in NixOS module for the service, authentication, database, storage, backup, firewall, and runtime path settings.
- Keep credentials in systemd environment files and reject Nix store secret paths.
- Add hardened systemd settings and support custom mutable state and workspace paths.
- Prepare the bundled PostgreSQL runtime for NixOS and provide Node.js to bundled local adapters.
- Add a NixOS VM test that checks startup, health, network binding, embedded PostgreSQL, runtime secrets, a custom state directory, and the Codex ACP adapter.
- Accept the NixOS module as a configuration source and document native deployment.

## Verification

- `nix fmt flake.nix nix/modules/nixos/paperclip.nix nix/tests/nixos-module.nix` passed.
- `nix build .#paperclip --no-link -L` passed.
- `nix build .#checks.x86_64-linux.nixos-module --no-link -L` passed.
- `nix flake check -L` passed.
- `nix flake check --all-systems --no-build` passed.
- `pnpm -r typecheck` passed.
- `pnpm exec vitest run packages/shared/src/config-schema.test.ts --maxWorkers=1` passed.
- `pnpm build` passed.
- `pnpm test:run` passed 3,369 tests and skipped 4 tests. It reported 41 failures in three existing FHS-dependent test files on NixOS. The same 41 failures reproduce on the clean upstream commit `8142e541`.

## Risks

- The feature is opt-in. Existing installation methods and default application behavior do not change.
- Nix dependency updates can require a new fixed-output dependency hash.
- Changes to the embedded PostgreSQL package layout can require updates to the runtime fixup.
- The module defaults to loopback-only `local_trusted` mode. It requires authentication settings and runtime secrets before public exposure.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex (GPT-5; the exact serving snapshot and context-window size are not exposed to the agent), with high reasoning, repository tools, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
