### PR TITLE
fix: allow recovery owners to resolve assigned sources

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -8,6 +8,7 @@ const issueId = "11111111-1111-4111-8111-111111111111";
 const companyId = "22222222-2222-4222-8222-222222222222";
 const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
+const unrelatedAgentId = "88888888-8888-4888-8888-888888888888";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 
@@ -1724,6 +1725,102 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(mockIssueService.update).toHaveBeenCalled();
+    expect(mockIssueRecoveryActionService.resolveActiveForIssue).toHaveBeenCalled();
+  });
+
+  it("allows the active recovery owner to resolve and hand back a source issue assigned to another agent", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId: peerAgentId,
+      returnOwnerAgentId: ownerAgentId,
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/recovery-actions/resolve`)
+      .send({
+        actionId: recoveryActionId,
+        outcome: "restored",
+        sourceIssueStatus: "todo",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "todo",
+        assigneeAgentId: ownerAgentId,
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(mockIssueRecoveryActionService.resolveActiveForIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: recoveryActionId,
+        outcome: "handed_back",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects an unrelated agent resolving a source issue assigned to another agent", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId: peerAgentId,
+      returnOwnerAgentId: ownerAgentId,
+    });
+
+    const res = await request(await createApp(peerActor({ agentId: unrelatedAgentId })))
+      .post(`/api/issues/${issueId}/recovery-actions/resolve`)
+      .send({
+        actionId: recoveryActionId,
+        outcome: "restored",
+        sourceIssueStatus: "todo",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueRecoveryActionService.resolveActiveForIssue).not.toHaveBeenCalled();
+  });
+
+  it("allows a checkout-management override to resolve the active recovery owner's action", async () => {
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:mutate" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: "allow_explicit_grant",
+      explanation: "Allowed by test grant.",
+    }));
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+    );
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+    mockIssueRecoveryActionService.getActiveForIssue.mockResolvedValue({
+      id: recoveryActionId,
+      ownerAgentId: peerAgentId,
+      returnOwnerAgentId: ownerAgentId,
+    });
+
+    const res = await request(await createApp(peerActor({ agentId: unrelatedAgentId })))
+      .post(`/api/issues/${issueId}/recovery-actions/resolve`)
+      .send({
+        actionId: recoveryActionId,
+        outcome: "restored",
+        sourceIssueStatus: "todo",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(mockIssueRecoveryActionService.resolveActiveForIssue).toHaveBeenCalled();
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6064,8 +6064,20 @@ export function issueRoutes(
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id);
+    const actorAgentId = req.actor.type === "agent" ? req.actor.agentId : null;
+    const recoveryOwnerAgentId = activeRecoveryAction?.ownerAgentId ?? null;
+    const actorHasRecoveryOwnerGrant = Boolean(
+      actorAgentId &&
+      recoveryOwnerAgentId &&
+      (
+        recoveryOwnerAgentId === actorAgentId ||
+        await hasActiveCheckoutManagementOverride(actorAgentId, existing.companyId, recoveryOwnerAgentId)
+      ),
+    );
+    // Recovery ownership is a grant for this resolution endpoint only. Keep
+    // every other caller behind the ordinary source-issue mutation boundary.
+    if (!actorHasRecoveryOwnerGrant && !(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     if (
       !(await assertRecoveryActionAuthority(
         req,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages controlled work by AI agents.
> - Recovery actions give one actor responsibility for restoring a stopped issue.
> - The recovery resolution endpoint checked general issue mutation rights before it checked recovery ownership.
> - This order denied a recorded recovery owner when another agent owned the source issue.
> - The recovery owner grant must apply only to the active recovery action and its resolution endpoint.
> - This pull request makes that narrow grant reachable and keeps normal issue mutation checks for other callers.
> - The benefit is a safe recovery hand-back path without general source issue write access.

## Linked Issues or Issue Description

**What happened?**

An agent that owned an active recovery action received HTTP 403 from `POST /api/issues/:id/recovery-actions/resolve` when another agent was assigned to the source issue. The route applied the general source issue mutation boundary before the recovery action ownership check.

**Expected behavior**

The active recovery action owner, or an actor with a valid active-checkout management override for that owner, can resolve that action. An unrelated agent remains denied. Other source issue mutation routes keep their existing boundaries.

**Steps to reproduce**

1. Assign a blocked source issue to agent A.
2. Create an active recovery action for that source issue and record agent B as its owner.
3. Authenticate as agent B and request a restored resolution with hand-back to agent A.
4. Observe HTTP 403 before this change.

**Paperclip version or commit**

`c54936e2e`

**Deployment mode**

Self-hosted server.

**Access context**

Agent bearer API key.

## What Changed

- Resolve the active recovery action before the general source issue mutation check.
- Bypass the general source issue mutation check only for the recorded recovery owner or its active-checkout management override.
- Keep the recovery action authority check as complete mediation for the endpoint.
- Add regression tests for owner hand-back, unrelated-agent denial, and checkout-management override access.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` passed: 79 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm -r typecheck` passed.
- The general server suite passed: 313 files and 3,410 tests, with 4 skipped tests.
- `pnpm test:run` reached the UI workspace and found two existing timezone-sensitive failures under `Europe/Warsaw`.
- `TZ=UTC pnpm --filter @paperclipai/ui exec vitest run src/components/IssueProperties.test.tsx src/lib/attention.test.ts` passed: 100 tests.
- `pnpm build` passed.
- This repository has no `bin/ci`.

## Risks

- Low risk. The bypass is limited to one endpoint and the current active recovery action owner.
- The endpoint still applies company access and recovery authority checks.
- Ordinary issue mutation routes are unchanged and their existing test suite remains green.

> This fix supports the enforced recovery outcomes in `ROADMAP.md`. It does not add a new core feature.

## Model Used

- OpenAI Codex with GPT-5, reasoning, tool use, and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
