### PR TITLE
fix: trust isolated Codex runtime workspace

### DIFF
--- a/docker/agent-runtime/Dockerfile.codex
+++ b/docker/agent-runtime/Dockerfile.codex
@@ -3,7 +3,8 @@ ARG BASE_TAG=dev
 FROM paperclipai/agent-runtime-base:${BASE_TAG}
 
 USER root
-RUN npm install -g @openai/codex@latest \
+RUN git config --system --add safe.directory /tmp \
+    && npm install -g @openai/codex@latest \
     && { chown -R 1000:1000 /usr/lib/node_modules || true; }
 
 USER 1000:1000


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open-source control plane for AI-agent companies and their execution runtimes.
> - The Codex agent runtime image installs the Codex CLI for use in isolated workspaces.
> - Isolated runtime workspaces may be checked out under `/tmp` with ownership that differs from the process invoking Git.
> - Git protects against that ownership mismatch by rejecting the repository unless its directory is marked safe.
> - This pull request configures `/tmp` as a system-level safe Git directory while building the Codex runtime image.
> - The benefit is that Codex can use Git inside the intended isolated runtime workspace without a dubious-ownership failure.

## Linked Issues or Issue Description

**What happened:** In an isolated Codex runtime workspace located under `/tmp`, Git can reject repository operations with a dubious-ownership/safe-directory error when the checkout owner differs from the invoking user.

**Expected behavior:** The Codex runtime should be able to perform Git operations in its intended isolated workspace.

**Steps to reproduce:**
1. Build and run the Codex agent runtime image.
2. Provide an isolated repository checkout below `/tmp` whose ownership differs from the Codex process user.
3. Run a Git operation through Codex in that checkout.
4. Observe Git reject the repository as unsafe.

**Paperclip commit:** `8e435eb5370ac717d00f3578d46a6135ab32ae35`

**Deployment mode:** Docker

**Agent adapter:** Codex

**Database mode / access context:** Not database-related / not applicable.

## What Changed

- Add `git config --system --add safe.directory /tmp` before installing the Codex CLI in `docker/agent-runtime/Dockerfile.codex`.
- Preserve the existing global Codex installation and ownership normalization steps.

## Verification

- Inspected the committed Dockerfile diff and confirmed the safe-directory configuration is chained into the existing root-level build step.
- Automated build/runtime tests were not run in this hand-off; the change is limited to the Dockerfile build configuration.

## Risks

- `/tmp` is intentionally trusted inside this dedicated agent-runtime image. This broadens Git's safe-directory allowance within that container, but is scoped to the isolated runtime image rather than the host.
- Low code-change risk: the modification adds one Git configuration command before the existing install command.

## Model Used

OpenAI `gpt-5.6-terra` (Codex provider); tool-assisted repository inspection and GitHub workflow execution. Context window and internal reasoning details are platform-managed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
