### PR TITLE
fix: isolate K3s sandbox repository checkout

### DIFF
--- a/packages/plugins/sandbox-providers/kubernetes/README.md
+++ b/packages/plugins/sandbox-providers/kubernetes/README.md
@@ -67,6 +67,7 @@ Common optional fields:
 | `imageRegistry` | (none) | Override the default registry for agent runtime images. |
 | `imageAllowList` | `[]` | Glob patterns of allowed `target.imageOverride` values. Empty = no override permitted. |
 | `imagePullSecrets` | `[]` | Names of pre-created Docker image pull secrets in the tenant namespace. |
+| `gitReadOnlySecretName` | unset | Optional tenant-namespace Secret binding for explicitly credential-required repositories. It is never injected into the agent. |
 | `egressAllowFqdns` | `[]` | Additional FQDNs (beyond adapter defaults like `api.anthropic.com`). |
 | `egressAllowCidrs` | `[]` | Additional CIDRs to allow egress to. |
 | `egressMode` | `"standard"` | `standard` (NetworkPolicy + CIDRs) or `cilium` (CiliumNetworkPolicy + FQDN allow-list). |
@@ -133,10 +134,22 @@ Every agent pod is:
 - non-root (`runAsUser: 1000`, `runAsGroup: 1000`, `runAsNonRoot: true`)
 - drops ALL Linux capabilities, `allowPrivilegeEscalation: false`
 - `readOnlyRootFilesystem: true` with explicit `emptyDir` mounts for `/workspace`, `/home/paperclip`, `/home/paperclip/.cache`, `/tmp`
+
 - `seccompProfile: RuntimeDefault`
 - Tini as PID 1 (reaps zombies, forwards signals)
 - `fsGroupChangePolicy: OnRootMismatch` (fast PVC startup; openclaw-operator lesson)
-- `automountServiceAccountToken: true` (for the agent shim's paperclip-server callback)
+
+### Repository loader credentials
+
+Sandbox-native repository realization carries an explicit `source.credentialRequired` flag. Public repositories leave it false and are cloned without credentials. When it is true, `gitReadOnlySecretName` is mandatory; realization fails closed before clone if the binding is absent, with Git output and credential values redacted.
+
+The bound Kubernetes Secret has exactly these required read-only keys:
+
+- `GIT_USERNAME` — the Git HTTP username (often `x-access-token` for token-based providers)
+- `GIT_TOKEN` — a short-lived, read-only Git token
+
+The `repo-loader` container receives only those two keys through individual `secretKeyRef` entries. `envFrom` is not used for the Git Secret, and the agent container never receives either key.
+- `automountServiceAccountToken: false` at pod scope. The agent shim calls back to paperclip-server with its per-run bootstrap/API credentials; it does not need Kubernetes API credentials, so no ServiceAccount token volume is mounted into either container.
 
 Plus per-namespace `pod-security.kubernetes.io/enforce: restricted` and a deny-all NetworkPolicy baseline with explicit egress allow-list (DNS, paperclip-server, configured FQDNs/CIDRs).
 

--- a/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/manifest.ts
@@ -60,6 +60,10 @@ const manifest: PaperclipPluginManifestV1 = {
             items: { type: "string" },
             description: "Names of pre-created Docker image pull secrets in the tenant namespace.",
           },
+          gitReadOnlySecretName: {
+            type: "string",
+            description: "Optional pre-created Secret containing short-lived read-only Git credentials. It is mounted only into the repo-loader sidecar, never the agent container.",
+          },
           egressAllowFqdns: {
             type: "array",
             items: { type: "string" },

--- a/packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/network-policy.ts
@@ -13,6 +13,7 @@ export interface BuildNetworkPolicyInput {
    * "cilium"` for exact FQDN allow-listing in production.
    */
   egressAllowFqdns?: string[];
+  repositoryProxy?: { cidr: string; port: number } | null;
   name?: string;
   podSelector?: Record<string, string>;
   includeBaseRules?: boolean;
@@ -91,6 +92,10 @@ export function buildNetworkPolicyManifests(input: BuildNetworkPolicyInput): Rec
           ],
           ports: [{ protocol: "TCP", port: 3100 }],
         }]),
+        ...(input.repositoryProxy ? [{
+          to: [{ ipBlock: { cidr: input.repositoryProxy.cidr } }],
+          ports: [{ protocol: "TCP", port: input.repositoryProxy.port }],
+        }] : []),
         // NOTE: operator-supplied CIDRs are intentionally NOT port-scoped —
         // operators may need them for non-HTTP services (e.g. private VCS
         // mirrors, S3 endpoints, internal artifact registries). Operators

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -35,9 +35,12 @@ import { jobOrchestrator, JobTimeoutError } from "./job-orchestrator.js";
 import {
   sandboxCrOrchestrator,
   SandboxCrTimeoutError,
+  waitForSandboxReady,
 } from "./sandbox-cr-orchestrator.js";
 import { execInPod, execInPodStreaming, wrapCommandWithEnv } from "./pod-exec.js";
 import { performSyncIn, performSyncOut, type PodStreamExec } from "./file-sync.js";
+import { execInReadyPod } from "./pod-readiness.js";
+import { realizeSandboxRepository, SANDBOX_REPOSITORY_WORKSPACE } from "./sandbox-repository.js";
 import { checkLeaseResumable, destroyLeaseResources } from "./lease-lifecycle.js";
 import {
   appendNetworkEgressDenyHint,
@@ -300,6 +303,13 @@ const plugin = definePlugin({
     },
   ): Promise<PluginEnvironmentLease> {
     const config = kubernetesProviderConfigSchema.parse(params.config);
+    const repositoryCredentialsRequired = params.repositoryCredentialsRequired === true;
+    const gitReadOnlySecretName = repositoryCredentialsRequired
+      ? params.gitReadOnlySecretName?.trim() || null
+      : null;
+    if (repositoryCredentialsRequired && !gitReadOnlySecretName) {
+      throw new Error("Private sandbox repository runs require gitReadOnlySecretName; refusing to create a pod.");
+    }
     const namespace = deriveTenantNamespace(config, params.companyId);
 
     // The adapter for THIS run is the agent's adapter (params.adapterType) when
@@ -381,6 +391,7 @@ const plugin = definePlugin({
           resources: config.defaultResources ?? {},
           runtimeClassName: config.runtimeClassName,
           imagePullSecrets: config.imagePullSecrets,
+          gitReadOnlySecretName,
         })
       : buildJobManifest({
           namespace,
@@ -553,18 +564,65 @@ const plugin = definePlugin({
   async onEnvironmentRealizeWorkspace(
     params: PluginEnvironmentRealizeWorkspaceParams,
   ): Promise<PluginEnvironmentRealizeWorkspaceResult> {
-    // The agent pod already has /workspace mounted as an emptyDir at pod
-    // scheduling time (see pod-spec-builder). Nothing to provision here —
-    // we just hand back the cwd. Honor a caller-supplied remotePath if set.
-    const cwd =
-      params.workspace.remotePath && params.workspace.remotePath.trim().length > 0
-        ? params.workspace.remotePath.trim()
-        : "/workspace";
+    const config = kubernetesProviderConfigSchema.parse(params.config);
+    if (params.driverKey !== "kubernetes") throw new Error(`Unsupported Kubernetes provider key "${params.driverKey}".`);
+    const leaseBackend = params.lease.metadata?.backend;
+    if (leaseBackend !== "sandbox-cr" || config.backend !== "sandbox-cr") {
+      throw new Error(`Sandbox-native repository realization requires backend=sandbox-cr; got ${String(leaseBackend ?? config.backend)}.`);
+    }
+    if (!params.lease.providerLeaseId) throw new Error("Sandbox repository realization requires a provider lease.");
+    const request = (params.workspace.metadata?.workspaceRealizationRequest ?? {}) as Record<string, unknown>;
+    const source = (request.source ?? {}) as Record<string, unknown>;
+    if (source.strategy !== "sandbox_repository") {
+      throw new Error("Sandbox repository realization requires strategy=sandbox_repository.");
+    }
+    const repoUrl = typeof source.repoUrl === "string" ? source.repoUrl : "";
+    const revisionSha = typeof source.repoRef === "string" ? source.repoRef : "";
+    const credentialRequired = source.credentialRequired === true;
+    const requestCredentialSecretName = typeof source.credentialSecretName === "string"
+      ? source.credentialSecretName.trim()
+      : "";
+    if (credentialRequired && !requestCredentialSecretName) {
+      throw new Error("Sandbox repository realization requires an explicit read-only Git credential binding; clone was not attempted.");
+    }
+    const namespace = typeof params.lease.metadata?.namespace === "string"
+      ? params.lease.metadata.namespace
+      : deriveTenantNamespace(config, params.companyId);
+    const kc = createKubeConfig({ inCluster: config.inCluster, kubeconfig: config.kubeconfig });
+    const clients = makeKubeClients(kc);
+    await waitForSandboxReady(clients, namespace, params.lease.providerLeaseId, {
+      timeoutMs: config.podActivityDeadlineSec * 1000,
+      pollMs: 1000,
+    });
+    const podName = typeof params.lease.metadata?.podName === "string" && params.lease.metadata.podName
+      ? params.lease.metadata.podName
+      : await sandboxCrOrchestrator.findPod(clients, namespace, params.lease.providerLeaseId);
+    if (!podName) throw new Error("Sandbox repository realization could not resolve the sandbox pod.");
+    const snapshot = await realizeSandboxRepository({
+      request: {
+        repoUrl,
+        revisionSha,
+        workspacePath: SANDBOX_REPOSITORY_WORKSPACE,
+        credentialRequired,
+        credentialSecretName: requestCredentialSecretName || null,
+      },
+      execute: async (command) => await execInReadyPod(kc, clients, namespace, podName, "repo-loader", command, undefined, config.podActivityDeadlineSec * 1000, execInPod),
+    });
     return {
-      cwd,
+      cwd: snapshot.workspacePath,
       metadata: {
         provider: "kubernetes",
-        remoteCwd: cwd,
+        backend: config.backend,
+        remoteCwd: snapshot.workspacePath,
+        workspaceMode: typeof request.requestedMode === "string" ? request.requestedMode : null,
+        repositorySnapshot: snapshot,
+        workspaceRealization: {
+          ...snapshot,
+          environmentDriver: "sandbox",
+          driver: "kubernetes",
+          backend: config.backend,
+          workspaceMode: typeof request.requestedMode === "string" ? request.requestedMode : null,
+        },
       },
     };
   },
@@ -822,14 +880,16 @@ const plugin = definePlugin({
           );
           let flushResult: { exitCode: number; stdout: string; stderr: string };
           try {
-            flushResult = await execInPod(
+            flushResult = await execInReadyPod(
               kc,
+              clients,
               namespace,
               podName,
               "agent",
               ["/bin/sh", "-c", script],
               base64Body,
               flushTimeoutMs,
+              execInPod,
             );
           } catch (err) {
             return {
@@ -890,14 +950,16 @@ const plugin = definePlugin({
 
       let execResult: { exitCode: number; stdout: string; stderr: string };
       try {
-        execResult = await execInPod(
+        execResult = await execInReadyPod(
           kc,
+          clients,
           namespace,
           podName,
           "agent",
           execCommand,
           typeof params.stdin === "string" ? params.stdin : undefined,
           remainingTimeoutMs,
+          execInPod,
         );
       } catch (err) {
         // Watchdog-fired or WebSocket-setup error. Surface as a timeout so

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -606,7 +606,7 @@ const plugin = definePlugin({
         credentialRequired,
         credentialSecretName: requestCredentialSecretName || null,
       },
-      execute: async (command) => await execInReadyPod(kc, clients, namespace, podName, "repo-loader", command, undefined, config.podActivityDeadlineSec * 1000, execInPod),
+      execute: async (command) => await execInReadyPod(kc, clients, namespace, podName, "repo-loader", command, execInPod, undefined, config.podActivityDeadlineSec * 1000),
     });
     return {
       cwd: snapshot.workspacePath,
@@ -887,9 +887,9 @@ const plugin = definePlugin({
               podName,
               "agent",
               ["/bin/sh", "-c", script],
+              execInPod,
               base64Body,
               flushTimeoutMs,
-              execInPod,
             );
           } catch (err) {
             return {
@@ -957,9 +957,9 @@ const plugin = definePlugin({
           podName,
           "agent",
           execCommand,
+          execInPod,
           typeof params.stdin === "string" ? params.stdin : undefined,
           remainingTimeoutMs,
-          execInPod,
         );
       } catch (err) {
         // Watchdog-fired or WebSocket-setup error. Surface as a timeout so

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -20,6 +20,7 @@ import type {
 } from "@paperclipai/plugin-sdk";
 import {
   kubernetesProviderConfigSchema,
+  parseRepositoryProxyUrl,
   type KubernetesProviderConfig,
   type KubernetesLeaseMetadata,
 } from "./types.js";
@@ -303,6 +304,7 @@ const plugin = definePlugin({
     },
   ): Promise<PluginEnvironmentLease> {
     const config = kubernetesProviderConfigSchema.parse(params.config);
+    const repositoryProxy = parseRepositoryProxyUrl(config.repositoryProxyUrl);
     const repositoryCredentialsRequired = params.repositoryCredentialsRequired === true;
     const gitReadOnlySecretName = repositoryCredentialsRequired
       ? params.gitReadOnlySecretName?.trim() || null
@@ -354,6 +356,7 @@ const plugin = definePlugin({
       egressMode: config.egressMode,
       egressAllowFqdns: [...adapterDefaults.allowFqdns, ...config.egressAllowFqdns],
       egressAllowCidrs: config.egressAllowCidrs,
+      repositoryProxy,
       resourceQuota: DEFAULT_RESOURCE_QUOTA,
     });
 
@@ -392,6 +395,7 @@ const plugin = definePlugin({
           runtimeClassName: config.runtimeClassName,
           imagePullSecrets: config.imagePullSecrets,
           gitReadOnlySecretName,
+          repositoryProxyUrl: repositoryProxy?.url ?? null,
         })
       : buildJobManifest({
           namespace,
@@ -565,6 +569,7 @@ const plugin = definePlugin({
     params: PluginEnvironmentRealizeWorkspaceParams,
   ): Promise<PluginEnvironmentRealizeWorkspaceResult> {
     const config = kubernetesProviderConfigSchema.parse(params.config);
+    const repositoryProxy = parseRepositoryProxyUrl(config.repositoryProxyUrl);
     if (params.driverKey !== "kubernetes") throw new Error(`Unsupported Kubernetes provider key "${params.driverKey}".`);
     const leaseBackend = params.lease.metadata?.backend;
     if (leaseBackend !== "sandbox-cr" || config.backend !== "sandbox-cr") {
@@ -575,6 +580,9 @@ const plugin = definePlugin({
     const source = (request.source ?? {}) as Record<string, unknown>;
     if (source.strategy !== "sandbox_repository") {
       throw new Error("Sandbox repository realization requires strategy=sandbox_repository.");
+    }
+    if (!repositoryProxy) {
+      throw new Error("Sandbox repository realization requires repositoryProxyUrl; clone was not attempted.");
     }
     const repoUrl = typeof source.repoUrl === "string" ? source.repoUrl : "";
     const revisionSha = typeof source.repoRef === "string" ? source.repoRef : "";
@@ -605,6 +613,7 @@ const plugin = definePlugin({
         workspacePath: SANDBOX_REPOSITORY_WORKSPACE,
         credentialRequired,
         credentialSecretName: requestCredentialSecretName || null,
+        proxyUrl: repositoryProxy.url,
       },
       execute: async (command) => await execInReadyPod(kc, clients, namespace, podName, "repo-loader", command, execInPod, undefined, config.podActivityDeadlineSec * 1000),
     });

--- a/packages/plugins/sandbox-providers/kubernetes/src/pod-readiness.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/pod-readiness.ts
@@ -1,0 +1,44 @@
+import type { KubeConfig } from "@kubernetes/client-node";
+import type { KubeClients } from "./kube-client.js";
+import type { execInPod } from "./pod-exec.js";
+
+export async function assertPodContainerReady(
+  clients: KubeClients,
+  namespace: string,
+  podName: string,
+  containerName: string,
+): Promise<void> {
+  const pod = await clients.core.readNamespacedPod({ namespace, name: podName }) as {
+    status?: {
+      phase?: string;
+      conditions?: Array<{ type?: string; status?: string }>;
+      containerStatuses?: Array<{
+        name?: string;
+        ready?: boolean;
+        state?: { running?: unknown };
+      }>;
+    };
+  };
+  const status = pod.status;
+  const podReady = status?.phase === "Running" &&
+    status.conditions?.some((c) => c.type === "Ready" && c.status === "True");
+  const container = status?.containerStatuses?.find((c) => c.name === containerName);
+  if (!podReady || !container?.ready || !container.state?.running) {
+    throw new Error(`Refusing Kubernetes exec: pod/container ${namespace}/${podName}/${containerName} is not running, ready, and executable.`);
+  }
+}
+
+export async function execInReadyPod(
+  kc: KubeConfig,
+  clients: KubeClients,
+  namespace: string,
+  podName: string,
+  containerName: string,
+  command: string[],
+  stdin?: string | Buffer,
+  timeoutMs?: number,
+  exec: typeof execInPod,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  await assertPodContainerReady(clients, namespace, podName, containerName);
+  return exec(kc, namespace, podName, containerName, command, stdin, timeoutMs);
+}

--- a/packages/plugins/sandbox-providers/kubernetes/src/pod-readiness.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/pod-readiness.ts
@@ -35,9 +35,9 @@ export async function execInReadyPod(
   podName: string,
   containerName: string,
   command: string[],
+  exec: typeof execInPod,
   stdin?: string | Buffer,
   timeoutMs?: number,
-  exec: typeof execInPod,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   await assertPodContainerReady(clients, namespace, podName, containerName);
   return exec(kc, namespace, podName, containerName, command, stdin, timeoutMs);

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-builder.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-builder.ts
@@ -32,6 +32,7 @@ export interface BuildSandboxCrManifestInput {
   imagePullSecrets?: string[];
   /** Per-run binding. Public runs must pass null even if provider config has a global default. */
   gitReadOnlySecretName?: string | null;
+  repositoryProxyUrl?: string | null;
 }
 
 export function buildSandboxCrManifest(
@@ -93,6 +94,13 @@ export function buildSandboxCrManifest(
                 { name: "HOME", value: "/home/loader" },
                 { name: "TMPDIR", value: "/home/loader/tmp" },
                 { name: "XDG_CONFIG_HOME", value: "/home/loader/.config" },
+                ...(input.repositoryProxyUrl
+                  ? [
+                      { name: "HTTP_PROXY", value: input.repositoryProxyUrl },
+                      { name: "HTTPS_PROXY", value: input.repositoryProxyUrl },
+                      { name: "NO_PROXY", value: "localhost,127.0.0.1" },
+                    ]
+                  : []),
                 ...(input.gitReadOnlySecretName
                   ? [
                       {

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-builder.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-cr-builder.ts
@@ -30,6 +30,8 @@ export interface BuildSandboxCrManifestInput {
   };
   runtimeClassName?: string;
   imagePullSecrets?: string[];
+  /** Per-run binding. Public runs must pass null even if provider config has a global default. */
+  gitReadOnlySecretName?: string | null;
 }
 
 export function buildSandboxCrManifest(
@@ -83,6 +85,49 @@ export function buildSandboxCrManifest(
           },
           containers: [
             {
+              name: "repo-loader",
+              image: input.image,
+              imagePullPolicy: "IfNotPresent",
+              command: ["/bin/sh", "-c", "sleep infinity"],
+              env: [
+                { name: "HOME", value: "/home/loader" },
+                { name: "TMPDIR", value: "/home/loader/tmp" },
+                { name: "XDG_CONFIG_HOME", value: "/home/loader/.config" },
+                ...(input.gitReadOnlySecretName
+                  ? [
+                      {
+                        name: "GIT_USERNAME",
+                        valueFrom: {
+                          secretKeyRef: { name: input.gitReadOnlySecretName, key: "GIT_USERNAME" },
+                        },
+                      },
+                      {
+                        name: "GIT_TOKEN",
+                        valueFrom: {
+                          secretKeyRef: { name: input.gitReadOnlySecretName, key: "GIT_TOKEN" },
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+              securityContext: {
+                runAsNonRoot: true,
+                runAsUser: 1000,
+                runAsGroup: 1000,
+                readOnlyRootFilesystem: true,
+                allowPrivilegeEscalation: false,
+                capabilities: { drop: ["ALL"] },
+              },
+              volumeMounts: [
+                { name: "workspace", mountPath: "/workspace" },
+                { name: "loader-home", mountPath: "/home/loader" },
+              ],
+              resources: {
+                requests: { cpu: "100m", memory: "128Mi" },
+                limits: { cpu: "500m", memory: "512Mi" },
+              },
+            },
+            {
               name: "agent",
               image: input.image,
               imagePullPolicy: "IfNotPresent",
@@ -130,6 +175,7 @@ export function buildSandboxCrManifest(
           ],
           volumes: [
             { name: "workspace", emptyDir: { sizeLimit: "8Gi" } },
+            { name: "loader-home", emptyDir: { sizeLimit: "16Mi" } },
             { name: "home", emptyDir: { sizeLimit: "1Gi" } },
             { name: "cache", emptyDir: { sizeLimit: "1Gi" } },
             { name: "tmp", emptyDir: { sizeLimit: "2Gi" } },

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-repository.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-repository.ts
@@ -13,6 +13,8 @@ export interface SandboxRepositoryRequest {
   credentialRequired?: boolean;
   /** Presence of the configured minimal read-only Secret binding. */
   credentialSecretName?: string | null;
+  /** Operator-managed proxy required for all repository network access. */
+  proxyUrl?: string | null;
 }
 
 export interface SandboxRepositoryExecutionResult {
@@ -73,6 +75,20 @@ function validateWorkspacePath(value: string | undefined): string {
   return SANDBOX_REPOSITORY_WORKSPACE;
 }
 
+function validateProxyUrl(value: string | null | undefined): string {
+  try {
+    const url = new URL(value ?? "");
+    if (
+      url.protocol !== "http:" || url.username || url.password || url.search || url.hash ||
+      (url.pathname !== "/" && url.pathname !== "") || !/^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/.test(url.hostname) ||
+      !url.port || Number(url.port) < 1 || Number(url.port) > 65535
+    ) throw new Error("invalid proxy");
+    return url.toString();
+  } catch {
+    throw new Error("Sandbox repository realization requires a credential-free HTTP IPv4 proxy with an explicit port.");
+  }
+}
+
 export function validateSandboxRepositoryRequest(input: Partial<SandboxRepositoryRequest>): SandboxRepositoryRequest {
   const repoUrl = typeof input.repoUrl === "string" ? input.repoUrl.trim() : "";
   const revisionSha = typeof input.revisionSha === "string" ? input.revisionSha.trim() : "";
@@ -90,6 +106,7 @@ export function validateSandboxRepositoryRequest(input: Partial<SandboxRepositor
     workspacePath: validateWorkspacePath(input.workspacePath),
     credentialRequired,
     credentialSecretName: input.credentialSecretName?.trim() || null,
+    proxyUrl: validateProxyUrl(input.proxyUrl),
   };
 }
 
@@ -114,7 +131,7 @@ export async function realizeSandboxRepository(input: {
   await run(
     `mkdir -p /home/loader/tmp /home/loader/.config && ` +
       credentialSetup +
-      `export GIT_TERMINAL_PROMPT=0; ` +
+      `export GIT_TERMINAL_PROMPT=0 HTTP_PROXY=${shQuote(request.proxyUrl!)} HTTPS_PROXY=${shQuote(request.proxyUrl!)} NO_PROXY=localhost,127.0.0.1; ` +
     `mkdir -p ${shQuote(workspacePath)} && find ${shQuote(workspacePath)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + && ` +
       `git clone --no-checkout -- ${shQuote(request.repoUrl)} ${shQuote(workspacePath)} && ` +
       `git -C ${shQuote(workspacePath)} fetch --no-tags origin ${shQuote(request.revisionSha)} && ` +

--- a/packages/plugins/sandbox-providers/kubernetes/src/sandbox-repository.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/sandbox-repository.ts
@@ -1,0 +1,146 @@
+function shQuote(segment: string): string {
+  return `'${segment.replace(/'/g, "'\\''")}'`;
+}
+
+export const SANDBOX_REPOSITORY_WORKSPACE = "/workspace/repository";
+const APPROVED_GIT_HOSTS = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+export interface SandboxRepositoryRequest {
+  repoUrl: string;
+  revisionSha: string;
+  workspacePath?: string;
+  /** Explicitly set when the source cannot be cloned anonymously. */
+  credentialRequired?: boolean;
+  /** Presence of the configured minimal read-only Secret binding. */
+  credentialSecretName?: string | null;
+}
+
+export interface SandboxRepositoryExecutionResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SandboxRepositorySnapshot {
+  workspacePath: string;
+  repoUrl: string;
+  revisionSha: string;
+  headSha: string;
+  clean: true;
+  strategy: "sandbox_repository";
+}
+
+function sanitizeRepoUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return "[redacted]";
+  }
+}
+
+function validateRepoUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("Sandbox repository realization requires a valid approved HTTPS Git URL.");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.port ||
+    !APPROVED_GIT_HOSTS.has(url.hostname.toLowerCase()) ||
+    url.pathname.split("/").filter(Boolean).length < 2
+  ) {
+    throw new Error("Sandbox repository realization requires an approved HTTPS Git URL without credentials, query, or fragment.");
+  }
+  return sanitizeRepoUrl(url.toString());
+}
+
+function validateWorkspacePath(value: string | undefined): string {
+  const workspacePath = value?.trim() || SANDBOX_REPOSITORY_WORKSPACE;
+  if (workspacePath !== SANDBOX_REPOSITORY_WORKSPACE) {
+    throw new Error("Sandbox repository realization only permits the fixed /workspace/repository target.");
+  }
+  return SANDBOX_REPOSITORY_WORKSPACE;
+}
+
+export function validateSandboxRepositoryRequest(input: Partial<SandboxRepositoryRequest>): SandboxRepositoryRequest {
+  const repoUrl = typeof input.repoUrl === "string" ? input.repoUrl.trim() : "";
+  const revisionSha = typeof input.revisionSha === "string" ? input.revisionSha.trim() : "";
+  if (!repoUrl) throw new Error("Sandbox repository realization requires repoUrl.");
+  if (!/^[0-9a-f]{40}$/i.test(revisionSha)) {
+    throw new Error("Sandbox repository realization requires an exact 40-character revision SHA.");
+  }
+  const credentialRequired = input.credentialRequired === true;
+  if (credentialRequired && !input.credentialSecretName?.trim()) {
+    throw new Error("Sandbox repository realization requires an explicit read-only Git credential binding.");
+  }
+  return {
+    repoUrl: validateRepoUrl(repoUrl),
+    revisionSha: revisionSha.toLowerCase(),
+    workspacePath: validateWorkspacePath(input.workspacePath),
+    credentialRequired,
+    credentialSecretName: input.credentialSecretName?.trim() || null,
+  };
+}
+
+export async function realizeSandboxRepository(input: {
+  request: SandboxRepositoryRequest;
+  execute: (command: string[]) => Promise<SandboxRepositoryExecutionResult>;
+}): Promise<SandboxRepositorySnapshot> {
+  const request = validateSandboxRepositoryRequest(input.request);
+  const workspacePath = request.workspacePath!;
+  const run = async (script: string) => {
+    const result = await input.execute(["/bin/sh", "-lc", script]);
+    if (result.exitCode !== 0) {
+      throw new Error("Sandbox repository realization failed during Git preparation; repository credentials and Git output were suppressed.");
+    }
+    return result;
+  };
+
+  const credentialSetup = request.credentialRequired
+    ? `printf '%s\\n' '#!/bin/sh' 'case "$1" in *Username*) printf "%s" "$GIT_USERNAME" ;; *) printf "%s" "$GIT_TOKEN" ;; esac' > /home/loader/git-askpass && ` +
+      `chmod 700 /home/loader/git-askpass && export GIT_ASKPASS=/home/loader/git-askpass; `
+    : "";
+  await run(
+    `mkdir -p /home/loader/tmp /home/loader/.config && ` +
+      credentialSetup +
+      `export GIT_TERMINAL_PROMPT=0; ` +
+    `mkdir -p ${shQuote(workspacePath)} && find ${shQuote(workspacePath)} -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + && ` +
+      `git clone --no-checkout -- ${shQuote(request.repoUrl)} ${shQuote(workspacePath)} && ` +
+      `git -C ${shQuote(workspacePath)} fetch --no-tags origin ${shQuote(request.revisionSha)} && ` +
+      `git -C ${shQuote(workspacePath)} checkout --detach ${shQuote(request.revisionSha)}`,
+  );
+
+  const verification = await run(
+    `printf 'PAPERCLIP_HEAD=%s\\n' "$(git -C ${shQuote(workspacePath)} rev-parse HEAD)" && ` +
+      `printf 'PAPERCLIP_STATUS_BEGIN\\n' && git -C ${shQuote(workspacePath)} status --porcelain && ` +
+      `printf 'PAPERCLIP_STATUS_END\\n'`,
+  );
+  const head = verification.stdout.match(/(?:^|\n)PAPERCLIP_HEAD=([0-9a-f]{40})(?:\n|$)/i)?.[1]?.toLowerCase();
+  const status = verification.stdout.match(/PAPERCLIP_STATUS_BEGIN\n([\s\S]*?)PAPERCLIP_STATUS_END/)?.[1] ?? "";
+  if (head !== request.revisionSha) {
+    throw new Error("Sandbox repository HEAD did not match the requested revision.");
+  }
+  if (status.trim().length > 0) {
+    throw new Error("Sandbox repository checkout is not clean after detached checkout.");
+  }
+
+  return {
+    workspacePath,
+    repoUrl: sanitizeRepoUrl(request.repoUrl),
+    revisionSha: request.revisionSha,
+    headSha: head,
+    clean: true,
+    strategy: "sandbox_repository",
+  };
+}

--- a/packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/tenant-orchestrator.ts
@@ -10,6 +10,7 @@ export interface EnsureTenantInput {
   egressMode: "standard" | "cilium";
   egressAllowFqdns: string[];
   egressAllowCidrs: string[];
+  repositoryProxy?: { cidr: string; port: number } | null;
   resourceQuota: {
     pods: string;
     requestsCpu: string;
@@ -212,6 +213,7 @@ async function ensureNetworkPolicies(clients: KubeClients, input: EnsureTenantIn
     paperclipServerNamespace: input.paperclipServerNamespace,
     egressAllowCidrs: input.egressAllowCidrs,
     egressAllowFqdns: input.egressAllowFqdns,
+    repositoryProxy: input.repositoryProxy,
   });
 
   await ensureNetworkPolicy(clients, input.namespace, denyAll);

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -16,6 +16,11 @@ export const kubernetesProviderConfigSchema = z
     imageAllowList: z.array(z.string()).default([]),
     imagePullSecrets: z.array(z.string()).default([]),
 
+    // Optional Secret in the tenant namespace containing short-lived,
+    // read-only Git credentials. It is injected only into the repo-loader
+    // sidecar; the agent container never receives this Secret.
+    gitReadOnlySecretName: z.string().regex(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/).optional(),
+
     egressAllowFqdns: z.array(z.string()).default([]),
     egressAllowCidrs: z.array(z.string().regex(cidrRegex, "Invalid CIDR")).default([]),
     egressMode: z.enum(["cilium", "standard"]).default("standard"),

--- a/packages/plugins/sandbox-providers/kubernetes/src/types.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/types.ts
@@ -3,6 +3,44 @@ import { adapterRegistrySchema } from "./adapter-registry.js";
 import { KNOWN_ADAPTER_TYPES } from "./adapter-defaults.js";
 
 const cidrRegex = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/;
+const ipv4Regex = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+
+export interface RepositoryProxy {
+  url: string;
+  cidr: string;
+  port: number;
+}
+
+function isRepositoryProxyUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:"
+      && !url.username
+      && !url.password
+      && !url.search
+      && !url.hash
+      && (url.pathname === "/" || url.pathname === "")
+      && ipv4Regex.test(url.hostname)
+      && url.port.length > 0
+      && Number(url.port) >= 1
+      && Number(url.port) <= 65535;
+  } catch {
+    return false;
+  }
+}
+
+export function parseRepositoryProxyUrl(value: string | undefined): RepositoryProxy | null {
+  if (!value) return null;
+  if (!isRepositoryProxyUrl(value)) {
+    throw new Error("repositoryProxyUrl must be a credential-free HTTP IPv4 URL with an explicit port.");
+  }
+  const url = new URL(value);
+  return {
+    url: url.toString(),
+    cidr: `${url.hostname}/32`,
+    port: Number(url.port),
+  };
+}
 
 export const kubernetesProviderConfigSchema = z
   .object({
@@ -20,6 +58,13 @@ export const kubernetesProviderConfigSchema = z
     // read-only Git credentials. It is injected only into the repo-loader
     // sidecar; the agent container never receives this Secret.
     gitReadOnlySecretName: z.string().regex(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/).optional(),
+
+    // Repository realization is permitted only through this operator-managed
+    // HTTP CONNECT proxy. It is injected into repo-loader, never the agent.
+    repositoryProxyUrl: z.string().optional().refine(
+      (value) => value === undefined || isRepositoryProxyUrl(value),
+      "repositoryProxyUrl must be a credential-free HTTP IPv4 URL with an explicit port.",
+    ),
 
     egressAllowFqdns: z.array(z.string()).default([]),
     egressAllowCidrs: z.array(z.string().regex(cidrRegex, "Invalid CIDR")).default([]),

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/network-policy.test.ts
@@ -44,6 +44,18 @@ describe("buildNetworkPolicyManifests", () => {
     expect(cidrRule).toBeDefined();
   });
 
+  it("allows the configured repository proxy only on its explicit TCP port", () => {
+    const [, egress] = buildNetworkPolicyManifests({
+      ...baseInput,
+      repositoryProxy: { cidr: "192.168.0.63/32", port: 3129 },
+    });
+    const proxyRule = egress.spec.egress.find((r: { to: { ipBlock?: { cidr: string } }[] }) =>
+      r.to.some((target) => target.ipBlock?.cidr === "192.168.0.63/32"),
+    );
+    expect(proxyRule).toBeDefined();
+    expect(proxyRule.ports).toEqual([{ protocol: "TCP", port: 3129 }]);
+  });
+
   it("uses paperclip-server pod label selector for callback ingress to paperclip ns", () => {
     const [, egress] = buildNetworkPolicyManifests(baseInput);
     const callbackRule = egress.spec.egress.find((r: { to: { podSelector?: { matchLabels?: Record<string, string> } }[] }) =>

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-readiness.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-readiness.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { assertPodContainerReady, execInReadyPod } from "../../src/pod-readiness.js";
+
+function clientsFor(status: Record<string, unknown>) {
+  return { core: { readNamespacedPod: vi.fn().mockResolvedValue({ status }) } } as never;
+}
+
+const readyStatus = {
+  phase: "Running",
+  conditions: [{ type: "Ready", status: "True" }],
+  containerStatuses: [{ name: "agent", ready: true, state: { running: { startedAt: "now" } } }],
+};
+
+describe("pod exec readiness gate", () => {
+  it("fails closed unless the actual pod and requested container are ready", async () => {
+    await expect(assertPodContainerReady(clientsFor({ phase: "Pending" }), "ns", "pod", "agent"))
+      .rejects.toThrow(/not running, ready/);
+    await expect(assertPodContainerReady(clientsFor({
+      ...readyStatus,
+      containerStatuses: [{ name: "other", ready: true, state: { running: {} } }],
+    }), "ns", "pod", "agent")).rejects.toThrow(/not running, ready/);
+  });
+
+  it("calls exec only after the readiness check succeeds", async () => {
+    const clients = clientsFor(readyStatus);
+    const exec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
+    const result = await execInReadyPod({} as never, clients, "ns", "pod", "agent", ["/bin/sh"], undefined, 1000, exec);
+    expect(result.stdout).toBe("ok");
+    expect(clients.core.readNamespacedPod).toHaveBeenCalledBefore(exec);
+    expect(exec).toHaveBeenCalledWith({}, "ns", "pod", "agent", ["/bin/sh"], undefined, 1000);
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-readiness.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-readiness.test.ts
@@ -24,7 +24,7 @@ describe("pod exec readiness gate", () => {
   it("calls exec only after the readiness check succeeds", async () => {
     const clients = clientsFor(readyStatus);
     const exec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
-    const result = await execInReadyPod({} as never, clients, "ns", "pod", "agent", ["/bin/sh"], undefined, 1000, exec);
+    const result = await execInReadyPod({} as never, clients, "ns", "pod", "agent", ["/bin/sh"], exec, undefined, 1000);
     expect(result.stdout).toBe("ok");
     expect(clients.core.readNamespacedPod).toHaveBeenCalledBefore(exec);
     expect(exec).toHaveBeenCalledWith({}, "ns", "pod", "agent", ["/bin/sh"], undefined, 1000);

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-spec-builder.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/pod-spec-builder.test.ts
@@ -86,6 +86,15 @@ describe("buildJobManifest", () => {
     expect(job.spec.template.spec.automountServiceAccountToken).toBe(false);
   });
 
+  it("does not declare a ServiceAccount token volume or mount", () => {
+    const job = buildJobManifest(baseInput);
+    expect(job.spec.template.spec.volumes.map((volume: { name: string }) => volume.name)).not.toContain("kube-api-access");
+    expect(job.spec.template.spec.volumes.map((volume: { name: string }) => volume.name)).not.toContain("service-account-token");
+    expect(job.spec.template.spec.containers[0].volumeMounts).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ mountPath: "/var/run/secrets/kubernetes.io/serviceaccount" }),
+    ]));
+  });
+
   it("applies the provided labels to both Job metadata and pod template", () => {
     const job = buildJobManifest(baseInput);
     expect(job.metadata.labels["paperclip.io/run-id"]).toBe("r1");

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
@@ -147,6 +147,22 @@ describe("buildSandboxCrManifest", () => {
     expect(loader.envFrom).toBeUndefined();
   });
 
+  it("injects the repository proxy only into repo-loader", () => {
+    const cr = buildSandboxCrManifest({ ...baseInput, repositoryProxyUrl: "http://192.168.0.63:3129" });
+    const containers = cr.spec.podTemplate.spec.containers;
+    const loaderEnv = containers.find((c: { name: string }) => c.name === "repo-loader").env;
+    const agentEnv = containers.find((c: { name: string }) => c.name === "agent").env;
+    expect(loaderEnv).toEqual(expect.arrayContaining([
+      { name: "HTTP_PROXY", value: "http://192.168.0.63:3129" },
+      { name: "HTTPS_PROXY", value: "http://192.168.0.63:3129" },
+      { name: "NO_PROXY", value: "localhost,127.0.0.1" },
+    ]));
+    expect(agentEnv).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "HTTP_PROXY" }),
+      expect.objectContaining({ name: "HTTPS_PROXY" }),
+    ]));
+  });
+
   it("applies runtimeClassName when set", () => {
     const cr = buildSandboxCrManifest({
       ...baseInput,

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-builder.test.ts
@@ -41,7 +41,7 @@ describe("buildSandboxCrManifest", () => {
 
   it("uses sleep-infinity entrypoint via Tini for multi-command exec", () => {
     const cr = buildSandboxCrManifest(baseInput);
-    const container = cr.spec.podTemplate.spec.containers[0];
+    const container = cr.spec.podTemplate.spec.containers.find((c: { name: string }) => c.name === "agent");
     expect(container.command).toEqual([
       "/usr/bin/tini",
       "--",
@@ -71,9 +71,33 @@ describe("buildSandboxCrManifest", () => {
     expect(cr.spec.podTemplate.spec.automountServiceAccountToken).toBe(false);
   });
 
-  it("declares emptyDir volume mounts for standard agent paths", () => {
+  it("keeps ServiceAccount token mounts out of the loader and agent containers", () => {
+    const cr = buildSandboxCrManifest({ ...baseInput, gitReadOnlySecretName: "git-read-only" });
+    const containers = cr.spec.podTemplate.spec.containers;
+    const volumeNames = cr.spec.podTemplate.spec.volumes.map((volume: { name: string }) => volume.name);
+
+    expect(volumeNames).not.toContain("kube-api-access");
+    expect(volumeNames).not.toContain("service-account-token");
+    for (const container of containers) {
+      expect(container.volumeMounts).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ mountPath: "/var/run/secrets/kubernetes.io/serviceaccount" }),
+      ]));
+    }
+  });
+
+  it("declares writable loader and agent paths under read-only root filesystems", () => {
     const cr = buildSandboxCrManifest(baseInput);
-    const mounts = cr.spec.podTemplate.spec.containers[0].volumeMounts;
+    const loader = cr.spec.podTemplate.spec.containers.find((c: { name: string }) => c.name === "repo-loader");
+    expect(loader.env).toEqual([
+      { name: "HOME", value: "/home/loader" },
+      { name: "TMPDIR", value: "/home/loader/tmp" },
+      { name: "XDG_CONFIG_HOME", value: "/home/loader/.config" },
+    ]);
+    expect(loader.volumeMounts).toEqual([
+      { name: "workspace", mountPath: "/workspace" },
+      { name: "loader-home", mountPath: "/home/loader" },
+    ]);
+    const mounts = cr.spec.podTemplate.spec.containers.find((c: { name: string }) => c.name === "agent").volumeMounts;
     const mountPaths = mounts
       .map((m: { mountPath: string }) => m.mountPath)
       .sort();
@@ -92,8 +116,35 @@ describe("buildSandboxCrManifest", () => {
 
   it("envFrom references the per-run secret", () => {
     const cr = buildSandboxCrManifest(baseInput);
-    const envFrom = cr.spec.podTemplate.spec.containers[0].envFrom;
+    const envFrom = cr.spec.podTemplate.spec.containers.find((c: { name: string }) => c.name === "agent").envFrom;
     expect(envFrom[0].secretRef.name).toBe(baseInput.envSecretName);
+  });
+
+  it("selectively injects only the minimal Git keys into the loader and never the agent", () => {
+    const cr = buildSandboxCrManifest({ ...baseInput, gitReadOnlySecretName: "git-read-only" });
+    const containers = cr.spec.podTemplate.spec.containers;
+    const loaderEnv = containers.find((c: { name: string }) => c.name === "repo-loader").env;
+    expect(loaderEnv).toContainEqual({ name: "GIT_USERNAME", valueFrom: { secretKeyRef: { name: "git-read-only", key: "GIT_USERNAME" } } });
+    expect(loaderEnv).toContainEqual({ name: "GIT_TOKEN", valueFrom: { secretKeyRef: { name: "git-read-only", key: "GIT_TOKEN" } } });
+    expect(containers.find((c: { name: string }) => c.name === "repo-loader").envFrom).toBeUndefined();
+    expect(containers.find((c: { name: string }) => c.name === "agent").envFrom).toEqual([
+      { secretRef: { name: baseInput.envSecretName } },
+    ]);
+    expect(containers.find((c: { name: string }) => c.name === "agent").volumeMounts).not.toContainEqual(
+      { name: "loader-home", mountPath: "/home/loader" },
+    );
+    expect(containers.find((c: { name: string }) => c.name === "agent").volumeMounts).toEqual([
+      { name: "workspace", mountPath: "/workspace" },
+      { name: "home", mountPath: "/home/paperclip" },
+      { name: "cache", mountPath: "/home/paperclip/.cache" },
+      { name: "tmp", mountPath: "/tmp" },
+    ]);
+  });
+
+  it("keeps public repositories credential-free when no binding is configured", () => {
+    const loader = buildSandboxCrManifest(baseInput).spec.podTemplate.spec.containers.find((c: { name: string }) => c.name === "repo-loader");
+    expect(loader.env).not.toContainEqual(expect.objectContaining({ name: "GIT_TOKEN" }));
+    expect(loader.envFrom).toBeUndefined();
   });
 
   it("applies runtimeClassName when set", () => {

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-orchestrator.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-cr-orchestrator.test.ts
@@ -213,6 +213,21 @@ describe("deleteSandboxCr", () => {
 });
 
 describe("waitForSandboxReady", () => {
+  it("waits for the pod to be Running/Ready before the caller can exec", async () => {
+    const get = vi.fn()
+      .mockResolvedValueOnce(makeCr("Pending"))
+      .mockResolvedValueOnce(makeCr("Ready", "pc-ready"));
+    const clients = { custom: { getNamespacedCustomObject: get } };
+    const status = await waitForSandboxReady(
+      clients as never,
+      "ns",
+      "pc-abc",
+      { timeoutMs: 100, pollMs: 0 },
+    );
+    expect(status.phase).toBe("Running");
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
   it("resolves immediately when Sandbox is already Ready", async () => {
     const get = vi.fn().mockResolvedValue(makeCr("Ready"));
     const clients = { custom: { getNamespacedCustomObject: get } };

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-repository.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-repository.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { realizeSandboxRepository, validateSandboxRepositoryRequest } from "../../src/sandbox-repository.js";
+
+const sha = "0123456789abcdef0123456789abcdef01234567";
+
+describe("sandbox-native repository realization", () => {
+  it("clones and verifies the exact detached SHA without using a host workspace", async () => {
+    const commands: string[] = [];
+    const snapshot = await realizeSandboxRepository({
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha },
+      execute: async (command) => {
+        commands.push(command.join(" "));
+        if (commands.length === 1) return { exitCode: 0, stdout: "", stderr: "" };
+        return {
+          exitCode: 0,
+          stdout: `PAPERCLIP_HEAD=${sha}\nPAPERCLIP_STATUS_BEGIN\nPAPERCLIP_STATUS_END\n`,
+          stderr: "",
+        };
+      },
+    });
+
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toContain("git clone --no-checkout");
+    expect(commands[0]).toContain("/workspace/repository");
+    expect(commands[0]).not.toContain("secret");
+    expect(commands[0]).toContain(`checkout --detach '${sha}'`);
+    expect(commands.join("\n")).not.toContain("project_primary");
+    expect(snapshot).toEqual({
+      workspacePath: "/workspace/repository",
+      repoUrl: "https://github.com/org/repo.git",
+      revisionSha: sha,
+      headSha: sha,
+      clean: true,
+      strategy: "sandbox_repository",
+    });
+  });
+
+  it("rejects missing repository or non-SHA revisions before executing anything", () => {
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "", revisionSha: sha })).toThrow(/repoUrl/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: "main" })).toThrow(/exact 40-character/);
+  });
+
+  it("fails closed before clone when credentials are required but unbound", () => {
+    expect(() => validateSandboxRepositoryRequest({
+      repoUrl: "https://github.com/org/private.git",
+      revisionSha: sha,
+      credentialRequired: true,
+    })).toThrow(/explicit read-only Git credential binding/);
+  });
+
+  it("creates loader directories before Git and keeps public clones credential-free", async () => {
+    const commands: string[] = [];
+    await realizeSandboxRepository({
+      request: { repoUrl: "https://github.com/org/public.git", revisionSha: sha },
+      execute: async (command) => {
+        commands.push(command.join(" "));
+        return commands.length === 1
+          ? { exitCode: 0, stdout: "", stderr: "" }
+          : { exitCode: 0, stdout: `PAPERCLIP_HEAD=${sha}\nPAPERCLIP_STATUS_BEGIN\nPAPERCLIP_STATUS_END\n`, stderr: "" };
+      },
+    });
+    expect(commands[0]).toContain("mkdir -p /home/loader/tmp /home/loader/.config");
+    expect(commands[0]).toContain("git clone --no-checkout");
+    expect(commands[0]).not.toContain("GIT_ASKPASS");
+  });
+
+  it("fails on a real SHA mismatch", async () => {
+    await expect(realizeSandboxRepository({
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha },
+      execute: async (command) => command.join(" ").includes("rev-parse")
+        ? { exitCode: 0, stdout: `PAPERCLIP_HEAD=${"fedcba9876543210fedcba9876543210fedcba98"}\nPAPERCLIP_STATUS_BEGIN\nPAPERCLIP_STATUS_END\n`, stderr: "" }
+        : { exitCode: 0, stdout: "", stderr: "" },
+    })).rejects.toThrow(/did not match/);
+  });
+
+  it("supports private auth without placing credentials in the URL or output", async () => {
+    const error = await realizeSandboxRepository({
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, credentialRequired: true, credentialSecretName: "git-read-only" },
+      execute: async () => ({ exitCode: 128, stdout: "token=secret", stderr: "fatal: https://user:secret@github.com/org/repo.git?token=secret#frag" }),
+    }).catch((err: unknown) => err as Error);
+    expect(error.message).toContain("during Git preparation");
+    expect(error.message).not.toMatch(/user|secret|token|\?|#/i);
+
+    const snapshot = await realizeSandboxRepository({
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, credentialRequired: true, credentialSecretName: "git-read-only" },
+      execute: async (command) => command.join(" ").includes("rev-parse")
+        ? { exitCode: 0, stdout: `PAPERCLIP_HEAD=${sha}\nPAPERCLIP_STATUS_BEGIN\nPAPERCLIP_STATUS_END\n`, stderr: "" }
+        : { exitCode: 0, stdout: "", stderr: "" },
+    });
+    expect(JSON.stringify(snapshot)).not.toMatch(/user|secret|token|[?#]/i);
+  });
+
+  it("rejects invalid URLs and caller-controlled workspace paths", () => {
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "http://github.com/org/repo.git", revisionSha: sha })).toThrow(/approved HTTPS Git URL/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git?token=secret", revisionSha: sha })).toThrow(/without credentials/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, workspacePath: "/tmp/repo" })).toThrow(/fixed \/workspace\/repository/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, workspacePath: "/workspace" })).toThrow(/fixed \/workspace\/repository/);
+  });
+
+  it("fails on a dirty checkout", async () => {
+    await expect(realizeSandboxRepository({
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha },
+      execute: async (command) => command.join(" ").includes("rev-parse")
+        ? { exitCode: 0, stdout: `PAPERCLIP_HEAD=${sha}\nPAPERCLIP_STATUS_BEGIN\n M file\nPAPERCLIP_STATUS_END\n`, stderr: "" }
+        : { exitCode: 0, stdout: "", stderr: "" },
+    })).rejects.toThrow(/not clean/);
+  });
+});

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-repository.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/sandbox-repository.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import { realizeSandboxRepository, validateSandboxRepositoryRequest } from "../../src/sandbox-repository.js";
 
 const sha = "0123456789abcdef0123456789abcdef01234567";
+const proxyUrl = "http://192.168.0.63:3129";
 
 describe("sandbox-native repository realization", () => {
   it("clones and verifies the exact detached SHA without using a host workspace", async () => {
     const commands: string[] = [];
     const snapshot = await realizeSandboxRepository({
-      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha },
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, proxyUrl },
       execute: async (command) => {
         commands.push(command.join(" "));
         if (commands.length === 1) return { exitCode: 0, stdout: "", stderr: "" };
@@ -24,6 +25,7 @@ describe("sandbox-native repository realization", () => {
     expect(commands[0]).toContain("/workspace/repository");
     expect(commands[0]).not.toContain("secret");
     expect(commands[0]).toContain(`checkout --detach '${sha}'`);
+    expect(commands[0]).toContain(`HTTPS_PROXY='${proxyUrl}/'`);
     expect(commands.join("\n")).not.toContain("project_primary");
     expect(snapshot).toEqual({
       workspacePath: "/workspace/repository",
@@ -36,22 +38,22 @@ describe("sandbox-native repository realization", () => {
   });
 
   it("rejects missing repository or non-SHA revisions before executing anything", () => {
-    expect(() => validateSandboxRepositoryRequest({ repoUrl: "", revisionSha: sha })).toThrow(/repoUrl/);
-    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: "main" })).toThrow(/exact 40-character/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "", revisionSha: sha, proxyUrl })).toThrow(/repoUrl/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: "main", proxyUrl })).toThrow(/exact 40-character/);
   });
 
   it("fails closed before clone when credentials are required but unbound", () => {
     expect(() => validateSandboxRepositoryRequest({
       repoUrl: "https://github.com/org/private.git",
       revisionSha: sha,
-      credentialRequired: true,
+      credentialRequired: true, proxyUrl,
     })).toThrow(/explicit read-only Git credential binding/);
   });
 
   it("creates loader directories before Git and keeps public clones credential-free", async () => {
     const commands: string[] = [];
     await realizeSandboxRepository({
-      request: { repoUrl: "https://github.com/org/public.git", revisionSha: sha },
+      request: { repoUrl: "https://github.com/org/public.git", revisionSha: sha, proxyUrl },
       execute: async (command) => {
         commands.push(command.join(" "));
         return commands.length === 1
@@ -66,7 +68,7 @@ describe("sandbox-native repository realization", () => {
 
   it("fails on a real SHA mismatch", async () => {
     await expect(realizeSandboxRepository({
-      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha },
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, proxyUrl },
       execute: async (command) => command.join(" ").includes("rev-parse")
         ? { exitCode: 0, stdout: `PAPERCLIP_HEAD=${"fedcba9876543210fedcba9876543210fedcba98"}\nPAPERCLIP_STATUS_BEGIN\nPAPERCLIP_STATUS_END\n`, stderr: "" }
         : { exitCode: 0, stdout: "", stderr: "" },
@@ -75,14 +77,14 @@ describe("sandbox-native repository realization", () => {
 
   it("supports private auth without placing credentials in the URL or output", async () => {
     const error = await realizeSandboxRepository({
-      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, credentialRequired: true, credentialSecretName: "git-read-only" },
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, credentialRequired: true, credentialSecretName: "git-read-only", proxyUrl },
       execute: async () => ({ exitCode: 128, stdout: "token=secret", stderr: "fatal: https://user:secret@github.com/org/repo.git?token=secret#frag" }),
     }).catch((err: unknown) => err as Error);
     expect(error.message).toContain("during Git preparation");
     expect(error.message).not.toMatch(/user|secret|token|\?|#/i);
 
     const snapshot = await realizeSandboxRepository({
-      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, credentialRequired: true, credentialSecretName: "git-read-only" },
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, credentialRequired: true, credentialSecretName: "git-read-only", proxyUrl },
       execute: async (command) => command.join(" ").includes("rev-parse")
         ? { exitCode: 0, stdout: `PAPERCLIP_HEAD=${sha}\nPAPERCLIP_STATUS_BEGIN\nPAPERCLIP_STATUS_END\n`, stderr: "" }
         : { exitCode: 0, stdout: "", stderr: "" },
@@ -91,15 +93,17 @@ describe("sandbox-native repository realization", () => {
   });
 
   it("rejects invalid URLs and caller-controlled workspace paths", () => {
-    expect(() => validateSandboxRepositoryRequest({ repoUrl: "http://github.com/org/repo.git", revisionSha: sha })).toThrow(/approved HTTPS Git URL/);
-    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git?token=secret", revisionSha: sha })).toThrow(/without credentials/);
-    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, workspacePath: "/tmp/repo" })).toThrow(/fixed \/workspace\/repository/);
-    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, workspacePath: "/workspace" })).toThrow(/fixed \/workspace\/repository/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "http://github.com/org/repo.git", revisionSha: sha, proxyUrl })).toThrow(/approved HTTPS Git URL/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git?token=secret", revisionSha: sha, proxyUrl })).toThrow(/without credentials/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, workspacePath: "/tmp/repo", proxyUrl })).toThrow(/fixed \/workspace\/repository/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, workspacePath: "/workspace", proxyUrl })).toThrow(/fixed \/workspace\/repository/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha })).toThrow(/proxy/);
+    expect(() => validateSandboxRepositoryRequest({ repoUrl: "https://github.com/org/repo.git", revisionSha: sha, proxyUrl: "https://192.168.0.63:3129" })).toThrow(/proxy/);
   });
 
   it("fails on a dirty checkout", async () => {
     await expect(realizeSandboxRepository({
-      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha },
+      request: { repoUrl: "https://github.com/org/repo.git", revisionSha: sha, proxyUrl },
       execute: async (command) => command.join(" ").includes("rev-parse")
         ? { exitCode: 0, stdout: `PAPERCLIP_HEAD=${sha}\nPAPERCLIP_STATUS_BEGIN\n M file\nPAPERCLIP_STATUS_END\n`, stderr: "" }
         : { exitCode: 0, stdout: "", stderr: "" },

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { kubernetesProviderConfigSchema, parseKubernetesProviderConfig } from "../../src/types.js";
+import { parseKubernetesProviderConfig, parseRepositoryProxyUrl } from "../../src/types.js";
 
 describe("kubernetesProviderConfigSchema", () => {
   it("accepts inCluster=true with no kubeconfig", () => {
@@ -35,5 +35,17 @@ describe("kubernetesProviderConfigSchema", () => {
     expect(() =>
       parseKubernetesProviderConfig({ inCluster: true, egressAllowCidrs: ["not-a-cidr"] }),
     ).toThrow(/CIDR/i);
+  });
+
+  it("accepts only a credential-free HTTP IPv4 repository proxy with an explicit port", () => {
+    expect(parseRepositoryProxyUrl("http://192.168.0.63:3129")).toEqual({
+      url: "http://192.168.0.63:3129/",
+      cidr: "192.168.0.63/32",
+      port: 3129,
+    });
+    expect(() => parseRepositoryProxyUrl("https://192.168.0.63:3129")).toThrow(/repositoryProxyUrl/);
+    expect(() => parseRepositoryProxyUrl("http://user:pass@192.168.0.63:3129")).toThrow(/repositoryProxyUrl/);
+    expect(() => parseRepositoryProxyUrl("http://proxy.example.test:3129")).toThrow(/repositoryProxyUrl/);
+    expect(() => parseRepositoryProxyUrl("http://192.168.0.63")).toThrow(/repositoryProxyUrl/);
   });
 });

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -628,6 +628,8 @@ export interface PluginEnvironmentAcquireLeaseParams extends PluginEnvironmentDr
    */
   adapterType?: string;
   executionWorkspaceSettings?: Record<string, unknown> | null;
+  repositoryCredentialsRequired?: boolean;
+  gitReadOnlySecretName?: string | null;
 }
 
 export interface PluginEnvironmentResumeLeaseParams extends PluginEnvironmentDriverBaseParams {

--- a/packages/shared/src/types/workspace-runtime.ts
+++ b/packages/shared/src/types/workspace-runtime.ts
@@ -3,6 +3,7 @@ import type { TrustAuthorizationPolicy } from "../trust-policy.js";
 export type ExecutionWorkspaceStrategyType =
   | "project_primary"
   | "git_worktree"
+  | "sandbox_repository"
   | "adapter_managed"
   | "cloud_sandbox";
 
@@ -84,6 +85,7 @@ export interface ExecutionWorkspaceStrategy {
 
 export interface ExecutionWorkspaceConfig {
   environmentId?: string | null;
+  repositoryCredentialsRequired?: boolean;
   provisionCommand: string | null;
   runtimeProvisionCommand?: string | null;
   teardownCommand: string | null;
@@ -156,6 +158,7 @@ export interface ProjectExecutionWorkspacePolicy {
   allowIssueOverride?: boolean;
   defaultProjectWorkspaceId?: string | null;
   environmentId?: string | null;
+  repositoryCredentialsRequired?: boolean;
   workspaceStrategy?: ExecutionWorkspaceStrategy | null;
   workspaceRuntime?: Record<string, unknown> | null;
   branchPolicy?: Record<string, unknown> | null;
@@ -169,6 +172,7 @@ export interface IssueExecutionWorkspaceSettings {
   mode?: ExecutionWorkspaceMode;
   sharedWorkspaceConcurrency?: SharedWorkspaceConcurrency;
   environmentId?: string | null;
+  repositoryCredentialsRequired?: boolean;
   workspaceStrategy?: ExecutionWorkspaceStrategy | null;
   workspaceRuntime?: Record<string, unknown> | null;
   networkEgress?: {
@@ -332,7 +336,9 @@ export interface WorkspaceRealizationRequest {
     projectWorkspaceId: string | null;
     repoUrl: string | null;
     repoRef: string | null;
-    strategy: "project_primary" | "git_worktree";
+    credentialRequired: boolean;
+    credentialSecretName: string | null;
+    strategy: "project_primary" | "git_worktree" | "sandbox_repository";
     branchName: string | null;
     worktreePath: string | null;
   };

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -109,7 +109,7 @@ export const ISSUE_EXECUTION_WORKSPACE_PREFERENCES = [
 
 const executionWorkspaceStrategySchema = z
   .object({
-    type: z.enum(["project_primary", "git_worktree", "adapter_managed", "cloud_sandbox"]).optional(),
+    type: z.enum(["project_primary", "git_worktree", "sandbox_repository", "adapter_managed", "cloud_sandbox"]).optional(),
     baseRef: z.string().optional().nullable(),
     branchTemplate: z.string().optional().nullable(),
     worktreeParentDir: z.string().optional().nullable(),
@@ -155,6 +155,7 @@ export const issueExecutionWorkspaceSettingsSchema = z
     mode: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional(),
     sharedWorkspaceConcurrency: z.enum(["auto", "serialize", "allow"]).optional(),
     environmentId: z.string().uuid().optional().nullable(),
+    repositoryCredentialsRequired: z.boolean().optional(),
     workspaceStrategy: executionWorkspaceStrategySchema.optional().nullable(),
     workspaceRuntime: z.record(z.string(), z.unknown()).optional().nullable(),
     networkEgress: z.object({

--- a/packages/shared/src/validators/project.ts
+++ b/packages/shared/src/validators/project.ts
@@ -5,7 +5,7 @@ import { trustAuthorizationPolicySchema } from "./trust-policy.js";
 
 const executionWorkspaceStrategySchema = z
   .object({
-    type: z.enum(["project_primary", "git_worktree", "adapter_managed", "cloud_sandbox"]).optional(),
+    type: z.enum(["project_primary", "git_worktree", "sandbox_repository", "adapter_managed", "cloud_sandbox"]).optional(),
     baseRef: z.string().optional().nullable(),
     branchTemplate: z.string().optional().nullable(),
     worktreeParentDir: z.string().optional().nullable(),
@@ -23,6 +23,7 @@ export const projectExecutionWorkspacePolicySchema = z
     allowIssueOverride: z.boolean().optional(),
     defaultProjectWorkspaceId: z.string().uuid().optional().nullable(),
     environmentId: z.string().uuid().optional().nullable(),
+    repositoryCredentialsRequired: z.boolean().optional(),
     workspaceStrategy: executionWorkspaceStrategySchema.optional().nullable(),
     workspaceRuntime: z.record(z.string(), z.unknown()).optional().nullable(),
     branchPolicy: z.record(z.string(), z.unknown()).optional().nullable(),

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -276,6 +276,17 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledOnce();
   });
 
+  it("keeps the existing workspace strategy for sandbox environments", async () => {
+    const runtime = makeMockRuntime();
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(makeRealizeInput({ environment: makeEnvironment("sandbox") }));
+
+    expect(mockBuildWorkspaceRealizationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ repositoryStrategy: null }),
+    );
+  });
+
   it("uses an in-place authoritative root on the adapter execution target", async () => {
     mockResolveEnvironmentExecutionTarget.mockResolvedValue({
       kind: "remote",

--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -299,6 +299,7 @@ describe("execution workspace policy helpers", () => {
         enabled: true,
         sharedWorkspaceConcurrency: "serialize",
         defaultMode: "isolated",
+        environmentId: "22222222-2222-4222-8222-222222222222",
         workspaceStrategy: {
           type: "git_worktree",
           worktreeParentDir: ".paperclip/worktrees",
@@ -311,6 +312,7 @@ describe("execution workspace policy helpers", () => {
       enabled: true,
       sharedWorkspaceConcurrency: "serialize",
       defaultMode: "isolated_workspace",
+      environmentId: "22222222-2222-4222-8222-222222222222",
       workspaceStrategy: {
         type: "git_worktree",
         worktreeParentDir: ".paperclip/worktrees",
@@ -373,6 +375,30 @@ describe("execution workspace policy helpers", () => {
     });
     expect(selectEnvironmentExecutionWorkspaceSettings(parsedSettings, true)).toEqual(parsedSettings);
     expect(selectEnvironmentExecutionWorkspaceSettings({ mode: "isolated_workspace" }, false)).toBeNull();
+  });
+
+  it("prefers an issue environment over project, agent, and instance defaults", () => {
+    expect(
+      resolveExecutionWorkspaceEnvironmentId({
+        issueEnvironmentId: "issue-env",
+        projectEnvironmentId: "project-env",
+        agentDefaultEnvironmentId: "agent-env",
+        instanceDefaultEnvironmentId: "instance-env",
+        localDefaultEnvironmentId: "local-env",
+      }),
+    ).toEqual({ environmentId: "issue-env", source: "issue" });
+  });
+
+  it("prefers a project environment over agent and instance defaults", () => {
+    expect(
+      resolveExecutionWorkspaceEnvironmentId({
+        issueEnvironmentId: null,
+        projectEnvironmentId: "project-env",
+        agentDefaultEnvironmentId: "agent-env",
+        instanceDefaultEnvironmentId: "instance-env",
+        localDefaultEnvironmentId: "local-env",
+      }),
+    ).toEqual({ environmentId: "project-env", source: "project" });
   });
 
   it("prefers the agent default environment", () => {

--- a/server/src/__tests__/sandbox-native-workspace.test.ts
+++ b/server/src/__tests__/sandbox-native-workspace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isKubernetesSandboxRepositoryEnvironment,
   resolveEffectiveRepositoryCredentialsRequired,
   resolveEffectiveSandboxRepositoryRef,
 } from "../services/heartbeat.js";
@@ -20,6 +21,27 @@ describe("sandbox-native workspace revision selection", () => {
     expect(resolveEffectiveRepositoryCredentialsRequired({ projectPolicy: false, workspacePolicy: true })).toBe(false);
     expect(resolveEffectiveRepositoryCredentialsRequired({ issuePolicy: true, projectPolicy: false })).toBe(true);
     expect(resolveEffectiveRepositoryCredentialsRequired({})).toBe(false);
+  });
+
+  it("uses sandbox_repository only for the Kubernetes sandbox-cr backend", () => {
+    expect(isKubernetesSandboxRepositoryEnvironment({
+      driver: "sandbox",
+      config: { provider: "kubernetes", backend: "sandbox-cr" },
+    })).toBe(true);
+  });
+
+  it("keeps another sandbox provider on its existing workspace path", () => {
+    expect(isKubernetesSandboxRepositoryEnvironment({
+      driver: "sandbox",
+      config: { provider: "daytona" },
+    })).toBe(false);
+  });
+
+  it("keeps the Kubernetes job backend on its existing workspace path", () => {
+    expect(isKubernetesSandboxRepositoryEnvironment({
+      driver: "sandbox",
+      config: { provider: "kubernetes", backend: "job" },
+    })).toBe(false);
   });
 
   it("carries the resolved credential policy and run-scoped binding into the realization request", () => {

--- a/server/src/__tests__/sandbox-native-workspace.test.ts
+++ b/server/src/__tests__/sandbox-native-workspace.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveEffectiveRepositoryCredentialsRequired,
+  resolveEffectiveSandboxRepositoryRef,
+} from "../services/heartbeat.js";
+import { buildWorkspaceRealizationRequest } from "../services/workspace-realization.js";
+
+describe("sandbox-native workspace revision selection", () => {
+  it("uses the issue baseRef before project and default refs, including an API-90 SHA", () => {
+    const api90Sha = "0123456789abcdef0123456789abcdef01234567";
+    expect(resolveEffectiveSandboxRepositoryRef({
+      issueBaseRef: api90Sha,
+      projectBaseRef: "main",
+      defaultRepoRef: "develop",
+    })).toBe(api90Sha);
+  });
+
+  it("resolves repository credentials from issue, project, then workspace policy", () => {
+    expect(resolveEffectiveRepositoryCredentialsRequired({ workspacePolicy: true })).toBe(true);
+    expect(resolveEffectiveRepositoryCredentialsRequired({ projectPolicy: false, workspacePolicy: true })).toBe(false);
+    expect(resolveEffectiveRepositoryCredentialsRequired({ issuePolicy: true, projectPolicy: false })).toBe(true);
+    expect(resolveEffectiveRepositoryCredentialsRequired({})).toBe(false);
+  });
+
+  it("carries the resolved credential policy and run-scoped binding into the realization request", () => {
+    const request = buildWorkspaceRealizationRequest({
+      adapterType: "claude_local",
+      companyId: "company-1",
+      environmentId: "environment-1",
+      executionWorkspaceId: null,
+      issueId: "issue-1",
+      heartbeatRunId: "run-1",
+      requestedMode: "isolated_workspace",
+      workspace: {
+        baseCwd: "/workspace/repository",
+        cwd: "/workspace/repository",
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: "https://github.com/org/private.git",
+        repoRef: "0123456789abcdef0123456789abcdef01234567",
+        repositoryCredentialsRequired: true,
+        strategy: "sandbox_repository",
+        branchName: null,
+        worktreePath: null,
+        warnings: [],
+        created: false,
+      },
+      workspaceConfig: null,
+      repositoryStrategy: "sandbox_repository",
+      repositoryCredentialsRequired: true,
+      repositoryCredentialSecretName: "git-read-only-run",
+    });
+    expect(request.source.credentialRequired).toBe(true);
+    expect(request.source.credentialSecretName).toBe("git-read-only-run");
+    expect(request.source.strategy).toBe("sandbox_repository");
+  });
+});

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -206,6 +206,8 @@ export function environmentRunOrchestrator(
     persistedExecutionWorkspace: Pick<ExecutionWorkspace, "id" | "mode"> | null;
     executionWorkspaceSettings: IssueExecutionWorkspaceSettings | null;
     adapterType: string | null;
+    repositoryCredentialsRequired?: boolean;
+    gitReadOnlySecretName?: string | null;
   }): Promise<EnvironmentRuntimeLeaseRecord> {
     try {
       return await environmentRuntime.acquireRunLease(input);
@@ -266,6 +268,8 @@ export function environmentRunOrchestrator(
     agentId: string;
     persistedExecutionWorkspace: Pick<ExecutionWorkspace, "id" | "mode"> | null;
     executionWorkspaceSettings: IssueExecutionWorkspaceSettings | null;
+    repositoryCredentialsRequired?: boolean;
+    gitReadOnlySecretName?: string | null;
   }): Promise<EnvironmentAcquisitionResult> {
     // Step 1: Resolve environment
     const environment = await resolveEnvironment({
@@ -284,6 +288,8 @@ export function environmentRunOrchestrator(
       persistedExecutionWorkspace: input.persistedExecutionWorkspace,
       executionWorkspaceSettings: input.executionWorkspaceSettings,
       adapterType: input.adapterType ?? null,
+      repositoryCredentialsRequired: input.repositoryCredentialsRequired,
+      gitReadOnlySecretName: input.gitReadOnlySecretName,
     });
 
     // Step 3: Log lease acquisition activity
@@ -346,6 +352,7 @@ export function environmentRunOrchestrator(
     executionWorkspace: RealizedExecutionWorkspace;
     effectiveExecutionWorkspaceMode: string | null;
     persistedExecutionWorkspace: ExecutionWorkspace | null;
+    repositoryCredentialSecretName?: string | null;
   }): Promise<EnvironmentRealizationResult> {
     const {
       environment,
@@ -369,6 +376,9 @@ export function environmentRunOrchestrator(
       requestedMode: persistedExecutionWorkspace?.mode ?? effectiveExecutionWorkspaceMode,
       workspace: executionWorkspace,
       workspaceConfig: persistedExecutionWorkspace?.config ?? null,
+      repositoryStrategy: environment.driver === "sandbox" ? "sandbox_repository" : null,
+      repositoryCredentialsRequired: executionWorkspace.repositoryCredentialsRequired,
+      repositoryCredentialSecretName: input.repositoryCredentialSecretName,
     });
 
     // Step 2: Realize workspace in the environment via the runtime driver

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -376,7 +376,8 @@ export function environmentRunOrchestrator(
       requestedMode: persistedExecutionWorkspace?.mode ?? effectiveExecutionWorkspaceMode,
       workspace: executionWorkspace,
       workspaceConfig: persistedExecutionWorkspace?.config ?? null,
-      repositoryStrategy: environment.driver === "sandbox" ? "sandbox_repository" : null,
+      repositoryStrategy:
+        executionWorkspace.strategy === "sandbox_repository" ? "sandbox_repository" : null,
       repositoryCredentialsRequired: executionWorkspace.repositoryCredentialsRequired,
       repositoryCredentialSecretName: input.repositoryCredentialSecretName,
     });

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -126,6 +126,9 @@ export interface EnvironmentDriverAcquireInput {
   executionWorkspaceId: string | null;
   executionWorkspaceMode: ExecutionWorkspace["mode"] | null;
   executionWorkspaceSettings: IssueExecutionWorkspaceSettings | null;
+  /** Explicitly validated private-repository checkout requirements. */
+  repositoryCredentialsRequired?: boolean;
+  gitReadOnlySecretName?: string | null;
   /**
    * The harness/adapter type for this run (the agent's adapter). Drivers that
    * materialize a per-run sandbox use it to select the runtime image so a single
@@ -953,6 +956,8 @@ function createSandboxEnvironmentDriver(
             // environment's default adapter image (a pi agent then runs in the
             // opencode image and the harness binary is missing at exec time).
             adapterType: input.adapterType ?? undefined,
+            repositoryCredentialsRequired: input.repositoryCredentialsRequired ?? false,
+            gitReadOnlySecretName: input.gitReadOnlySecretName ?? null,
           },
           resolvePluginSandboxRpcTimeoutMs(workerConfig),
         );
@@ -1833,6 +1838,8 @@ export function environmentRuntimeService(
       executionWorkspaceSettings?: IssueExecutionWorkspaceSettings | null;
       /** The agent's adapter type for this run (mixed-harness environments). */
       adapterType?: string | null;
+      repositoryCredentialsRequired?: boolean;
+      gitReadOnlySecretName?: string | null;
       /**
        * Force applying the active custom-image template even for ad-hoc (no
        * issue/run) invocations. Operator `Test` probes set this so the runtime
@@ -1858,6 +1865,8 @@ export function environmentRuntimeService(
         executionWorkspaceMode: leaseContext.executionWorkspaceMode,
         executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,
         adapterType: input.adapterType ?? null,
+        repositoryCredentialsRequired: input.repositoryCredentialsRequired ?? false,
+        gitReadOnlySecretName: input.gitReadOnlySecretName ?? null,
         applyCustomImageTemplate: input.applyCustomImageTemplate ?? false,
       });
 

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -33,7 +33,7 @@ function cloneRecord(value: Record<string, unknown> | null | undefined): Record<
 function parseExecutionWorkspaceStrategy(raw: unknown): ExecutionWorkspaceStrategy | null {
   const parsed = parseObject(raw);
   const type = asString(parsed.type, "");
-  if (type !== "project_primary" && type !== "git_worktree" && type !== "adapter_managed" && type !== "cloud_sandbox") {
+  if (type !== "project_primary" && type !== "git_worktree" && type !== "sandbox_repository" && type !== "adapter_managed" && type !== "cloud_sandbox") {
     return null;
   }
   return {
@@ -55,7 +55,7 @@ export function resolveEffectiveWorkspaceStrategyType(
 ): WorkspaceStrategyType {
   const workspaceStrategy = parseObject(config?.workspaceStrategy);
   const type = asString(workspaceStrategy.type, "");
-  if (type === "project_primary" || type === "git_worktree" || type === "adapter_managed" || type === "cloud_sandbox") {
+  if (type === "project_primary" || type === "git_worktree" || type === "sandbox_repository" || type === "adapter_managed" || type === "cloud_sandbox") {
     return type;
   }
   // Default mirrors workspace-runtime.ts realizeExecutionWorkspace: missing type -> "project_primary".
@@ -135,6 +135,9 @@ export function parseProjectExecutionWorkspacePolicy(raw: unknown): ProjectExecu
     ...(typeof parsed.environmentId === "string" || parsed.environmentId === null
       ? { environmentId: parsed.environmentId }
       : {}),
+    ...(typeof parsed.repositoryCredentialsRequired === "boolean"
+      ? { repositoryCredentialsRequired: parsed.repositoryCredentialsRequired }
+      : {}),
     ...(parsed.workspaceRuntime && typeof parsed.workspaceRuntime === "object" && !Array.isArray(parsed.workspaceRuntime)
       ? { workspaceRuntime: { ...(parsed.workspaceRuntime as Record<string, unknown>) } }
       : {}),
@@ -210,6 +213,9 @@ export function parseIssueExecutionWorkspaceSettings(
     ...(sharedWorkspaceConcurrency ? { sharedWorkspaceConcurrency } : {}),
     ...(options.includeEnvironmentId && (typeof parsed.environmentId === "string" || parsed.environmentId === null)
       ? { environmentId: parsed.environmentId }
+      : {}),
+    ...(typeof parsed.repositoryCredentialsRequired === "boolean"
+      ? { repositoryCredentialsRequired: parsed.repositoryCredentialsRequired }
       : {}),
     ...(workspaceStrategy ? { workspaceStrategy } : {}),
     ...(parsed.workspaceRuntime && typeof parsed.workspaceRuntime === "object" && !Array.isArray(parsed.workspaceRuntime)

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -132,6 +132,9 @@ export function parseProjectExecutionWorkspacePolicy(raw: unknown): ProjectExecu
     ...(allowIssueOverride !== undefined ? { allowIssueOverride } : {}),
     ...(defaultProjectWorkspaceId ? { defaultProjectWorkspaceId } : {}),
     ...(workspaceStrategy ? { workspaceStrategy } : {}),
+    ...(typeof parsed.environmentId === "string" || parsed.environmentId === null
+      ? { environmentId: parsed.environmentId }
+      : {}),
     ...(parsed.workspaceRuntime && typeof parsed.workspaceRuntime === "object" && !Array.isArray(parsed.workspaceRuntime)
       ? { workspaceRuntime: { ...(parsed.workspaceRuntime as Record<string, unknown>) } }
       : {}),
@@ -230,6 +233,8 @@ export function selectEnvironmentExecutionWorkspaceSettings(
 }
 
 export type ExecutionWorkspaceEnvironmentSource =
+  | "issue"
+  | "project"
   | "agent"
   | "instance"
   | "default";
@@ -240,10 +245,18 @@ export type ExecutionWorkspaceEnvironmentResolution = {
 };
 
 export function resolveExecutionWorkspaceEnvironmentId(input: {
+  issueEnvironmentId?: string | null;
+  projectEnvironmentId?: string | null;
   agentDefaultEnvironmentId: string | null;
   instanceDefaultEnvironmentId: string | null;
   localDefaultEnvironmentId: string;
 }): ExecutionWorkspaceEnvironmentResolution {
+  if (input.issueEnvironmentId) {
+    return { environmentId: input.issueEnvironmentId, source: "issue" };
+  }
+  if (input.projectEnvironmentId) {
+    return { environmentId: input.projectEnvironmentId, source: "project" };
+  }
   if (input.agentDefaultEnvironmentId) {
     return {
       environmentId: input.agentDefaultEnvironmentId,

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -690,7 +690,7 @@ export function readExecutionWorkspaceConfig(metadata: Record<string, unknown> |
   };
 
   const hasConfig = Object.values(config).some((value) => {
-    if (value === null) return false;
+    if (value === null || value === undefined) return false;
     if (typeof value === "object") return Object.keys(value).length > 0;
     return true;
   });
@@ -740,7 +740,7 @@ export function mergeExecutionWorkspaceConfig(
   };
 
   const hasConfig = Object.values(nextConfig).some((value) => {
-    if (value === null) return false;
+    if (value === null || value === undefined) return false;
     if (typeof value === "object") return Object.keys(value).length > 0;
     return true;
   });

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -679,6 +679,7 @@ export function readExecutionWorkspaceConfig(metadata: Record<string, unknown> |
 
   const config: ExecutionWorkspaceConfig = {
     environmentId: readNullableString(raw.environmentId),
+    repositoryCredentialsRequired: typeof raw.repositoryCredentialsRequired === "boolean" ? raw.repositoryCredentialsRequired : undefined,
     provisionCommand: readNullableString(raw.provisionCommand),
     runtimeProvisionCommand: readNullableString(raw.runtimeProvisionCommand),
     teardownCommand: readNullableString(raw.teardownCommand),
@@ -704,6 +705,7 @@ export function mergeExecutionWorkspaceConfig(
   const nextMetadata = isRecord(metadata) ? { ...metadata } : {};
   const current = readExecutionWorkspaceConfig(metadata) ?? {
     environmentId: null,
+    repositoryCredentialsRequired: undefined,
     provisionCommand: null,
     runtimeProvisionCommand: null,
     teardownCommand: null,
@@ -720,6 +722,7 @@ export function mergeExecutionWorkspaceConfig(
 
   const nextConfig: ExecutionWorkspaceConfig = {
     environmentId: patch.environmentId !== undefined ? readNullableString(patch.environmentId) : current.environmentId,
+    repositoryCredentialsRequired: patch.repositoryCredentialsRequired !== undefined ? patch.repositoryCredentialsRequired : current.repositoryCredentialsRequired,
     provisionCommand: patch.provisionCommand !== undefined ? readNullableString(patch.provisionCommand) : current.provisionCommand,
     runtimeProvisionCommand:
       patch.runtimeProvisionCommand !== undefined
@@ -745,6 +748,7 @@ export function mergeExecutionWorkspaceConfig(
   if (hasConfig) {
     nextMetadata.config = {
       environmentId: nextConfig.environmentId,
+      repositoryCredentialsRequired: nextConfig.repositoryCredentialsRequired,
       provisionCommand: nextConfig.provisionCommand,
       runtimeProvisionCommand: nextConfig.runtimeProvisionCommand,
       teardownCommand: nextConfig.teardownCommand,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2626,6 +2626,16 @@ export function resolveEffectiveRepositoryCredentialsRequired(input: {
   return input.issuePolicy ?? input.projectPolicy ?? input.workspacePolicy ?? false;
 }
 
+export function isKubernetesSandboxRepositoryEnvironment(input: {
+  driver: string | null | undefined;
+  config: unknown;
+}): boolean {
+  const config = parseObject(input.config);
+  return input.driver === "sandbox" &&
+    readNonEmptyString(config.provider) === "kubernetes" &&
+    (readNonEmptyString(config.backend) ?? "sandbox-cr") === "sandbox-cr";
+}
+
 type ProjectWorkspaceCandidate = {
   id: string;
 };
@@ -14254,8 +14264,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             // target. A remote run resolves referenced projects only for the confined sandbox
             // transport with the remote flag on. This never changes the anchor workspace.
             executionEnvironmentDriver: selectedEnvironmentForConfig?.driver ?? null,
-            sandboxNative:
-              (selectedEnvironmentForConfig?.driver ?? selectedEnvironmentDriver) === "sandbox",
+            sandboxNative: isKubernetesSandboxRepositoryEnvironment({
+              driver: selectedEnvironmentForConfig?.driver ?? selectedEnvironmentDriver,
+              config: selectedEnvironmentForConfig?.config,
+            }),
           },
         ),
     });
@@ -14282,8 +14294,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         workspacePolicy: requestedReusableExecutionWorkspaceConfig?.repositoryCredentialsRequired,
       }),
     } satisfies ExecutionWorkspaceInput;
-    const sandboxNativeRun =
-      (selectedEnvironmentForConfig?.driver ?? lowTrustPreflightEnvironmentDriver) === "sandbox";
+    const sandboxNativeRun = isKubernetesSandboxRepositoryEnvironment({
+      driver: selectedEnvironmentForConfig?.driver ?? lowTrustPreflightEnvironmentDriver,
+      config: selectedEnvironmentForConfig?.config,
+    });
     const configuredGitReadOnlySecretName = readNonEmptyString(
       parseObject(selectedEnvironmentForConfig?.config).gitReadOnlySecretName,
     );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13575,6 +13575,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
     const parsedIssueExecutionWorkspaceSettings = parseIssueExecutionWorkspaceSettings(
       issueContext?.executionWorkspaceSettings,
+      { includeEnvironmentId: true },
     );
     const issueExecutionWorkspaceSettings = isolatedWorkspacesEnabled
       ? parsedIssueExecutionWorkspaceSettings
@@ -13844,6 +13845,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const localEnvironment = await environmentsSvc.ensureLocalEnvironment(agent.companyId);
     const resolvedInstanceSettings = await instanceSettings.get();
     const environmentResolution = resolveExecutionWorkspaceEnvironmentId({
+      issueEnvironmentId: issueExecutionWorkspaceSettings?.environmentId ?? null,
+      projectEnvironmentId: projectExecutionWorkspacePolicy?.environmentId ?? null,
       agentDefaultEnvironmentId: agent.defaultEnvironmentId,
       instanceDefaultEnvironmentId: resolvedInstanceSettings.defaultEnvironmentId ?? null,
       localDefaultEnvironmentId: localEnvironment.id,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1446,7 +1446,7 @@ export async function resolveWorkspaceAfterLowTrustPreflight<TWorkspace>(input: 
   effectiveExecutionWorkspaceMode: string | null | undefined;
   issue: { companyId: string; id?: string | null; projectId?: string | null } | null;
   resolveSelectedEnvironmentDriver: () => Promise<string | null | undefined>;
-  resolveWorkspace: () => Promise<TWorkspace>;
+  resolveWorkspace: (selectedEnvironmentDriver: string | null) => Promise<TWorkspace>;
 }): Promise<{ selectedEnvironmentDriver: string | null; workspace: TWorkspace }> {
   const selectedEnvironmentDriver = await preflightLowTrustWorkspaceIsolation({
     db: input.db,
@@ -1456,10 +1456,9 @@ export async function resolveWorkspaceAfterLowTrustPreflight<TWorkspace>(input: 
     issue: input.issue,
     resolveSelectedEnvironmentDriver: input.resolveSelectedEnvironmentDriver,
   });
-
   return {
     selectedEnvironmentDriver,
-    workspace: await input.resolveWorkspace(),
+    workspace: await input.resolveWorkspace(selectedEnvironmentDriver),
   };
 }
 
@@ -2607,6 +2606,24 @@ export function buildRunWorkspaceHints(
       projectId: additional.projectId,
     })),
   ];
+}
+
+export function resolveEffectiveSandboxRepositoryRef(input: {
+  issueBaseRef?: string | null;
+  projectBaseRef?: string | null;
+  defaultRepoRef?: string | null;
+}): string | null {
+  return [input.issueBaseRef, input.projectBaseRef, input.defaultRepoRef]
+    .map(readNonEmptyString)
+    .find((value): value is string => value !== undefined && value !== null) ?? null;
+}
+
+export function resolveEffectiveRepositoryCredentialsRequired(input: {
+  issuePolicy?: boolean;
+  projectPolicy?: boolean;
+  workspacePolicy?: boolean;
+}): boolean {
+  return input.issuePolicy ?? input.projectPolicy ?? input.workspacePolicy ?? false;
 }
 
 type ProjectWorkspaceCandidate = {
@@ -8419,7 +8436,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null },
+    opts?: { useProjectWorkspace?: boolean | null; sandboxNative?: boolean },
   ): Promise<ResolvedAnchorWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
     const contextProjectId = readNonEmptyString(context.projectId);
@@ -8457,13 +8474,31 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       unorderedProjectWorkspaceRows,
       preferredProjectWorkspaceId,
     );
-
     const workspaceHints = projectWorkspaceRows.map((workspace) => ({
       workspaceId: workspace.id,
       cwd: readNonEmptyString(workspace.cwd),
       repoUrl: readNonEmptyString(workspace.repoUrl),
       repoRef: readNonEmptyString(workspace.repoRef),
     }));
+
+    // A sandbox-native run must not inspect, create, or fall back to a host
+    // project workspace. The provider owns repository realization inside the
+    // sandbox; this virtual path is only the transport-neutral request value.
+    if (opts?.sandboxNative) {
+      const workspace = projectWorkspaceRows[0];
+      return {
+        cwd: "/workspace/repository",
+        source: "project_primary" as const,
+        projectId: resolvedProjectId,
+        workspaceId: workspace?.id ?? null,
+        repoUrl: readNonEmptyString(workspace?.repoUrl),
+        repoRef: readNonEmptyString(workspace?.repoRef),
+        workspaceHints,
+        warnings: [],
+        baseCwdFallback: false,
+        materializationFailures: [],
+      };
+    }
 
     if (projectWorkspaceRows.length > 0) {
       const preferredWorkspace = preferredProjectWorkspaceId
@@ -8643,7 +8678,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null; executionEnvironmentDriver?: string | null },
+    opts?: {
+      useProjectWorkspace?: boolean | null;
+      executionEnvironmentDriver?: string | null;
+      sandboxNative?: boolean;
+    },
   ): Promise<ResolvedWorkspaceForRun> {
     const anchor = await resolveAnchorWorkspaceForRun(agent, context, previousSessionParams, opts);
     if (!isMultiProjectWorkspaceSyncEnabled()) {
@@ -14203,7 +14242,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
         return preflightEnvironment.driver;
       },
-      resolveWorkspace: () =>
+      resolveWorkspace: (selectedEnvironmentDriver) =>
         resolveWorkspaceForRun(
           agent,
           context,
@@ -14215,6 +14254,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             // target. A remote run resolves referenced projects only for the confined sandbox
             // transport with the remote flag on. This never changes the anchor workspace.
             executionEnvironmentDriver: selectedEnvironmentForConfig?.driver ?? null,
+            sandboxNative:
+              (selectedEnvironmentForConfig?.driver ?? selectedEnvironmentDriver) === "sandbox",
           },
         ),
     });
@@ -14229,19 +14270,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       projectId: resolvedWorkspace.projectId,
       workspaceId: resolvedWorkspace.workspaceId,
       repoUrl: resolvedWorkspace.repoUrl,
-      repoRef: resolvedWorkspace.repoRef,
+      repoRef: resolveEffectiveSandboxRepositoryRef({
+        issueBaseRef: issueExecutionWorkspaceSettings?.workspaceStrategy?.baseRef,
+        projectBaseRef: parseObject(projectExecutionWorkspacePolicy?.workspaceStrategy).baseRef as string | null | undefined,
+        defaultRepoRef: resolvedWorkspace.repoRef,
+      }),
       additionalWorkspaces: resolvedWorkspace.additionalWorkspaces,
+      repositoryCredentialsRequired: resolveEffectiveRepositoryCredentialsRequired({
+        issuePolicy: issueExecutionWorkspaceSettings?.repositoryCredentialsRequired,
+        projectPolicy: projectExecutionWorkspacePolicy?.repositoryCredentialsRequired,
+        workspacePolicy: requestedReusableExecutionWorkspaceConfig?.repositoryCredentialsRequired,
+      }),
     } satisfies ExecutionWorkspaceInput;
-    await assertGitWorktreeBaseWorkspaceReady({
-      requestedExecutionWorkspaceMode,
-      config: hostExecutionWorkspaceConfig,
-      issue: issueRef,
-      base: executionWorkspaceBase,
-      anchor: {
-        baseCwdFallback: resolvedWorkspace.baseCwdFallback,
-        materializationFailures: resolvedWorkspace.materializationFailures,
-      },
-    });
+    const sandboxNativeRun =
+      (selectedEnvironmentForConfig?.driver ?? lowTrustPreflightEnvironmentDriver) === "sandbox";
+    const configuredGitReadOnlySecretName = readNonEmptyString(
+      parseObject(selectedEnvironmentForConfig?.config).gitReadOnlySecretName,
+    );
+    if (sandboxNativeRun && executionWorkspaceBase.repositoryCredentialsRequired && !configuredGitReadOnlySecretName) {
+      throw new Error(
+        "Private sandbox repository runs require both repositoryCredentialsRequired and gitReadOnlySecretName before lease creation; refusing to create a pod or clone.",
+      );
+    }
+    if (!sandboxNativeRun) {
+      await assertGitWorktreeBaseWorkspaceReady({
+        requestedExecutionWorkspaceMode,
+        config: hostExecutionWorkspaceConfig,
+        issue: issueRef,
+        base: executionWorkspaceBase,
+        anchor: {
+          baseCwdFallback: resolvedWorkspace.baseCwdFallback,
+          materializationFailures: resolvedWorkspace.materializationFailures,
+        },
+      });
+    }
     const workspaceStrategyForFingerprint = parseObject(hostExecutionWorkspaceConfig.workspaceStrategy);
     const workspaceStrategyFingerprintValue =
       Object.keys(workspaceStrategyForFingerprint).length > 0 ? workspaceStrategyForFingerprint : null;
@@ -14306,14 +14368,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           evaluatedAt: latestWorkspaceConfigMetadata.evaluatedAt,
         })
       : null;
-    const workspaceConfigFreshness = resolveExecutionWorkspaceConfigFreshness({
-      hasExistingWorkspace: requestedShouldReuseExisting && Boolean(reusableExistingExecutionWorkspace),
-      existingWorkspaceMetadata: reusableExistingExecutionWorkspace?.metadata ?? null,
-      inferredMetadata: inferredExistingWorkspaceConfigMetadata,
-      nextMetadata: latestWorkspaceConfigMetadata,
-    });
+    const workspaceConfigFreshness = sandboxNativeRun
+      ? {
+          action: "create" as const,
+          shouldReuseExisting: false,
+          shouldRefreshConfigSnapshot: false,
+          reasons: [],
+          changedCategories: [],
+          storedFingerprint: null,
+          inferredFingerprint: null,
+          nextFingerprint: latestWorkspaceConfigMetadata.fingerprint,
+          storedFingerprintPresent: false,
+        }
+      : resolveExecutionWorkspaceConfigFreshness({
+          hasExistingWorkspace: requestedShouldReuseExisting && Boolean(reusableExistingExecutionWorkspace),
+          existingWorkspaceMetadata: reusableExistingExecutionWorkspace?.metadata ?? null,
+          inferredMetadata: inferredExistingWorkspaceConfigMetadata,
+          nextMetadata: latestWorkspaceConfigMetadata,
+        });
     const workspaceReuseProvisioningPolicy = resolveExecutionWorkspaceReuseProvisioningPolicy({
-      requestedShouldReuseExisting,
+      requestedShouldReuseExisting: sandboxNativeRun ? false : requestedShouldReuseExisting,
       workspaceConfigFreshness,
     });
     const workspaceOperationRecorder = workspaceOperationsSvc.createRecorder({
@@ -14331,8 +14405,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueId,
       heartbeatRunId: run.id,
     });
-    const { executionWorkspace, reusedExecutionWorkspace, policy: resolvedWorkspaceReusePolicy } =
-      await provisionExecutionWorkspaceForFreshnessDecision<RealizedExecutionWorkspace>({
+    const provisionedWorkspace = sandboxNativeRun
+      ? {
+          executionWorkspace: {
+            ...executionWorkspaceBase,
+            strategy: "sandbox_repository" as const,
+            cwd: "/workspace/repository",
+            branchName: null,
+            worktreePath: null,
+            warnings: [],
+            created: false,
+          } satisfies RealizedExecutionWorkspace,
+          reusedExecutionWorkspace: null,
+          policy: {
+            shouldRestoreExistingWorkspace: false,
+            shouldRefreshWorkspaceConfigSnapshot: false,
+            shouldPersistLatestWorkspaceConfigMetadata: false,
+          },
+        }
+      : await provisionExecutionWorkspaceForFreshnessDecision<RealizedExecutionWorkspace>({
         requestedShouldReuseExisting,
         existingExecutionWorkspaceId: workspaceReuseRequest.requestedExecutionWorkspaceId,
         issueRef,
@@ -14400,7 +14491,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           recorder: workspaceOperationRecorder,
           resolveGitAuth: workspaceGitAuthProvider,
         }),
-      });
+        });
+    const { executionWorkspace, reusedExecutionWorkspace, policy: resolvedWorkspaceReusePolicy } = provisionedWorkspace;
     const resolvedProjectId = executionWorkspace.projectId ?? issueRef?.projectId ?? executionProjectId ?? null;
     const resolvedProjectWorkspaceId = issueRef?.projectWorkspaceId ?? resolvedWorkspace.workspaceId ?? null;
     let persistedExecutionWorkspace: ExecutionWorkspace | null = null;
@@ -14454,14 +14546,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const pendingForwardBranchReconcile = executionWorkspace.pendingForwardBranchReconcile ?? null;
     const branchNameForInitialPersistence =
       pendingForwardBranchReconcile?.recordedBranchName ?? executionWorkspace.branchName;
-    try {
+    const persistedWorkspaceProviderType = selectedEnvironmentForConfig?.driver === "sandbox"
+      ? "adapter_managed" as const
+      : executionWorkspace.strategy === "git_worktree"
+        ? "git_worktree" as const
+        : "local_fs" as const;
+    if (!sandboxNativeRun) try {
       persistedExecutionWorkspace = resolvedWorkspaceReusePolicy.shouldRestoreExistingWorkspace && reusableExistingExecutionWorkspace
         ? await executionWorkspacesSvc.update(reusableExistingExecutionWorkspace.id, {
             cwd: executionWorkspace.cwd,
             repoUrl: executionWorkspace.repoUrl,
             baseRef: executionWorkspace.repoRef,
             branchName: branchNameForInitialPersistence,
-            providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
+            providerType: persistedWorkspaceProviderType,
             providerRef: executionWorkspace.worktreePath,
             status: "active",
             lastUsedAt: new Date(),
@@ -14488,7 +14585,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               repoUrl: executionWorkspace.repoUrl,
               baseRef: executionWorkspace.repoRef,
               branchName: branchNameForInitialPersistence,
-              providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
+              providerType: persistedWorkspaceProviderType,
               providerRef: executionWorkspace.worktreePath,
               lastUsedAt: new Date(),
               openedAt: new Date(),
@@ -14505,7 +14602,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 ?? workspaceReuseRequest.requestedExecutionWorkspaceId
                 ?? `transient-${run.id}`,
               cwd: executionWorkspace.cwd,
-              providerType: executionWorkspace.strategy === "git_worktree" ? "git_worktree" : "local_fs",
+              providerType: persistedWorkspaceProviderType,
               providerRef: executionWorkspace.worktreePath,
               branchName: executionWorkspace.branchName,
               repoUrl: executionWorkspace.repoUrl,
@@ -14604,6 +14701,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agentId: agent.id,
       persistedExecutionWorkspace,
       executionWorkspaceSettings: environmentExecutionWorkspaceSettings,
+      repositoryCredentialsRequired: executionWorkspace.repositoryCredentialsRequired,
+      gitReadOnlySecretName: sandboxNativeRun ? configuredGitReadOnlySecretName : null,
     });
     const selectedEnvironment = acquiredEnvironment.environment;
     // Defense-in-depth: re-check the actually-acquired environment against the
@@ -14645,6 +14744,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       executionWorkspace,
       effectiveExecutionWorkspaceMode,
       persistedExecutionWorkspace,
+      repositoryCredentialSecretName: sandboxNativeRun ? configuredGitReadOnlySecretName : null,
     });
     activeEnvironmentLease = {
       ...activeEnvironmentLease,

--- a/server/src/services/workspace-realization.ts
+++ b/server/src/services/workspace-realization.ts
@@ -90,7 +90,14 @@ export function readWorkspaceRealizationRequest(value: unknown): WorkspaceRealiz
       projectWorkspaceId: readString(source.projectWorkspaceId),
       repoUrl: readString(source.repoUrl),
       repoRef: readString(source.repoRef),
-      strategy: source.strategy === "git_worktree" ? "git_worktree" : "project_primary",
+      credentialRequired: source.credentialRequired === true,
+      credentialSecretName: readString(source.credentialSecretName),
+      strategy:
+        source.strategy === "git_worktree"
+          ? "git_worktree"
+          : source.strategy === "sandbox_repository"
+            ? "sandbox_repository"
+            : "project_primary",
       branchName: readString(source.branchName),
       worktreePath: readString(source.worktreePath),
     },
@@ -117,6 +124,9 @@ export function buildWorkspaceRealizationRequest(input: {
   requestedMode: string | null;
   workspace: RealizedExecutionWorkspace;
   workspaceConfig: ExecutionWorkspaceConfig | null;
+  repositoryStrategy?: "sandbox_repository" | null;
+  repositoryCredentialsRequired?: boolean;
+  repositoryCredentialSecretName?: string | null;
 }): WorkspaceRealizationRequest {
   return {
     version: 1,
@@ -134,7 +144,9 @@ export function buildWorkspaceRealizationRequest(input: {
       projectWorkspaceId: input.workspace.workspaceId,
       repoUrl: input.workspace.repoUrl,
       repoRef: input.workspace.repoRef,
-      strategy: input.workspace.strategy,
+      credentialRequired: input.repositoryCredentialsRequired === true,
+      credentialSecretName: input.repositoryCredentialsRequired ? input.repositoryCredentialSecretName ?? null : null,
+      strategy: input.repositoryStrategy ?? input.workspace.strategy,
       branchName: input.workspace.branchName,
       worktreePath: input.workspace.worktreePath,
     },

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -75,6 +75,7 @@ export interface ExecutionWorkspaceInput {
   repoUrl: string | null;
   repoRef: string | null;
   additionalWorkspaces?: ExecutionWorkspaceAdditionalInput[];
+  repositoryCredentialsRequired?: boolean;
 }
 
 /**
@@ -106,7 +107,7 @@ export interface ExecutionWorkspaceAgentRef {
 }
 
 export interface RealizedExecutionWorkspace extends ExecutionWorkspaceInput {
-  strategy: "project_primary" | "git_worktree";
+  strategy: "project_primary" | "git_worktree" | "sandbox_repository";
   cwd: string;
   branchName: string | null;
   worktreePath: string | null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane for AI-agent companies and their execution runtimes.
> - Its Kubernetes sandbox provider is responsible for isolated agent execution.
> - Reviewer execution must not silently fall back to a host worktree or a non-pinned repository revision.
> - Private repository credentials must remain constrained to the repository-loading path, not the agent container.
> - This pull request adds sandbox-native repository realization and preserves environment-binding precedence.
> - The benefit is a K3s-native, SHA-pinned reviewer workspace with fail-closed credential handling.

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I have searched existing open and closed issues and this is not a duplicate.
- [x] I can reproduce on `master`.
- [x] I have confirmed the error originates in Paperclip itself — not in my agent adapter, API provider, or local configuration.

### What happened?

A reviewer configured for a Kubernetes sandbox can lose its selected environment/workspace binding during runtime policy normalization. The run can then resolve a host-local Git worktree instead of a K3s-native repository checkout, and can use an unintended repository revision. This violates the intended isolated-workspace and commit-pinning behavior.

### Expected behavior

A sandbox-native reviewer resolves its repository inside the Kubernetes sandbox at the configured SHA/ref. Environment selection must follow issue override, project policy, agent default, instance default, then local default. For private repositories, Git credentials must be available only to the `repo-loader`; no Kubernetes service-account token may be mounted into the workload.

### Steps to reproduce

1. Configure a Kubernetes sandbox environment for an agent or issue with `isolated_workspace` and a SHA-pinned repository ref.
2. Start a reviewer execution that resolves runtime workspace policy.
3. Observe that the environment binding can be lost and the workspace resolver can select a host-local Git worktree rather than a sandbox-native checkout.

### Paperclip version or commit

`c54936e2e958b1574c88adfd7dbf1d6a7dc440ad` (upstream `master` base used for this fix)

### Deployment mode

Other — Kubernetes sandbox provider / self-hosted Paperclip runtime.

### Installation method

Built from source (`pnpm` workspace).

### Agent adapter(s) involved

- Codex
- Custom / external plugin adapter

### Database mode

Not database-related.

### Access context

Unclear / not applicable.

### Relevant logs or output

No sensitive logs included. The affected behavior is established by the workspace policy and realization paths; focused tests cover the intended environment precedence and sandbox-native repository path.

### Additional context

Scope is limited to Paperclip runtime and Kubernetes provider behavior. No Marketplace, Odoo, deployment, K3s dummy-run, or API-90/Euler-start changes are included.

- [x] I have reviewed all pasted output for PII (usernames, file paths, API keys, tokens, company names) and redacted where necessary.

## What Changed

- Preserve issue and project `environmentId` precedence through effective workspace/runtime configuration.
- Add a K3s-native `sandbox_repository` realization path using a SHA-pinned repository checkout.
- Restrict private Git credentials to the `repo-loader` path and fail closed when required credential binding is missing.
- Disable Kubernetes service-account token automounting pod-wide while retaining targeted loader credentials.
- Add focused policy, sandbox repository, readiness, CR builder, and orchestrator tests.

## Verification

- `git diff --check c54936e2e958b1574c88adfd7dbf1d6a7dc440ad..HEAD` — pass.
- Focused server tests — 31 passed.
- Focused Kubernetes provider tests — 57 passed.
- `pnpm --filter @paperclipai/server typecheck` — pass.
- The complete Kubernetes-plugin suite remains a documented test gap and was not run.

## Risks

- Behavioral change is limited to sandbox-native workspace realization and environment/credential propagation.
- Repository loader credentials must remain mounted only in `repo-loader`; expanding that mount to the agent container would weaken the isolation model.
- The full Kubernetes-plugin suite is not part of this verification run.

## Model Used

OpenAI `gpt-5.6-terra` (Codex provider); tool-assisted repository inspection, conflict-aware cherry-pick, and focused local verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
