### PR TITLE
fix: use npm install instead of missing npx install command

### DIFF
--- a/scripts/install-sh-fixtures/npm
+++ b/scripts/install-sh-fixtures/npm
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PAPERCLIP_INSTALL_TEST_LOG:?PAPERCLIP_INSTALL_TEST_LOG is required}"
+node --version >"${PAPERCLIP_INSTALL_TEST_LOG}.node"
+{
+  printf 'NPM_CONFIG_REGISTRY=%s\n' "${NPM_CONFIG_REGISTRY:-}"
+  printf 'npm_config_registry=%s\n' "${npm_config_registry:-}"
+  printf 'NPM_CONFIG_USERCONFIG=%s\n' "${NPM_CONFIG_USERCONFIG:-}"
+  printf 'npm_config_userconfig=%s\n' "${npm_config_userconfig:-}"
+  if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+    sed 's/^/npmrc:/' "$NPM_CONFIG_USERCONFIG"
+  fi
+  printf '%s\n' "$@"
+} >>"$PAPERCLIP_INSTALL_TEST_LOG"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -268,24 +268,24 @@ update_path() {
       fi
     done
 
-    # Bash login shells read the first existing file among .bash_profile,
-    # .bash_login, .profile; zsh login shells read .zprofile. When none of those
-    # login files exist, no login shell would see the PATH and fresh shells report
-    # 'paperclipai: command not found'. The loop above already added the export to
-    # any login file that exists, so only create .profile when none was present.
-    local login_present=0
-    for rc in "${HOME}/.bash_profile" "${HOME}/.bash_login" "${HOME}/.profile" "${HOME}/.zprofile"; do
-      if [ -f "$rc" ]; then
-        login_present=1
-        break
-      fi
-    done
-    if [ "$login_present" = "0" ]; then
+    # Ensure a startup file the user's default shell actually reads exists,
+    # otherwise fresh shells won't see the PATH. POSIX/bash/dash login shells read
+    # the first of .bash_profile/.bash_login/.profile; interactive zsh shells
+    # (including login) read .zshrc. zsh does NOT read .profile, so pick the file
+    # matching $SHELL and create it only when none is already present (the loop
+    # above already added the export to any existing one).
+    local ensure_file=""
+    if [[ "${SHELL:-}" == */zsh ]]; then
+      { [ -f "${HOME}/.zshrc" ] || [ -f "${HOME}/.zprofile" ]; } || ensure_file="${HOME}/.zshrc"
+    else
+      { [ -f "${HOME}/.bash_profile" ] || [ -f "${HOME}/.bash_login" ] || [ -f "${HOME}/.profile" ]; } || ensure_file="${HOME}/.profile"
+    fi
+    if [ -n "$ensure_file" ]; then
       if [ "$DRY_RUN" != "1" ]; then
         # shellcheck disable=SC2016  # $PATH must stay literal; it expands when the rc file is sourced
-        printf '\nexport PATH="%s:$PATH"\n' "$target" >> "${HOME}/.profile"
+        printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$ensure_file"
       else
-        log "[dry-run] would create ${HOME}/.profile with export PATH"
+        log "[dry-run] would create $ensure_file with export PATH"
       fi
     fi
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -364,18 +364,14 @@ elif [ -n "$VERSION" ]; then
   PACKAGE_SPEC="$PAPERCLIP_PACKAGE@$VERSION"
 fi
 
-INSTALL_ARGS=(install)
-[ "$CANARY" = "1" ] && INSTALL_ARGS+=(--canary)
-[ -n "$VERSION" ] && INSTALL_ARGS+=(--version "$VERSION")
-[ "$NO_PROMPT" = "1" ] && INSTALL_ARGS+=(--yes)
 ensure_temp_dir
 NPM_USERCONFIG="$TEMP_DIR/npmrc"
 printf 'registry=%s\n@paperclipai:registry=%s\n' "$PUBLIC_NPM_REGISTRY" "$PUBLIC_NPM_REGISTRY" >"$NPM_USERCONFIG"
 chmod 600 "$NPM_USERCONFIG"
 NPM_ENV=(env "NPM_CONFIG_REGISTRY=$PUBLIC_NPM_REGISTRY" "npm_config_registry=$PUBLIC_NPM_REGISTRY" "NPM_CONFIG_USERCONFIG=$NPM_USERCONFIG" "npm_config_userconfig=$NPM_USERCONFIG")
-INSTALL_COMMAND=("${NPM_ENV[@]}" npx --yes "--registry=$PUBLIC_NPM_REGISTRY" "$PACKAGE_SPEC" "${INSTALL_ARGS[@]}")
+INSTALL_COMMAND=("${NPM_ENV[@]}" npm install -g --prefix "${HOME}/.local" "--registry=$PUBLIC_NPM_REGISTRY" "$PACKAGE_SPEC")
 
-log "Delegating to the Paperclip CLI"
+log "Installing the Paperclip CLI to ~/.local/bin"
 if [ "$DRY_RUN" = "1" ]; then
   print_command "${INSTALL_COMMAND[@]}"
   exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -271,12 +271,14 @@ update_path() {
     # Ensure a startup file the user's default shell actually reads exists,
     # otherwise fresh shells won't see the PATH. POSIX/bash/dash login shells read
     # the first of .bash_profile/.bash_login/.profile; interactive zsh shells
-    # (including login) read .zshrc. zsh does NOT read .profile, so pick the file
-    # matching $SHELL and create it only when none is already present (the loop
-    # above already added the export to any existing one).
+    # (including login) read .zshrc, which is login-only for .zprofile. Create the
+    # matching file only when none is already present (the loop above already
+    # added the export to any existing one).
     local ensure_file=""
     if [[ "${SHELL:-}" == */zsh ]]; then
-      { [ -f "${HOME}/.zshrc" ] || [ -f "${HOME}/.zprofile" ]; } || ensure_file="${HOME}/.zshrc"
+      # Key interactive coverage off .zshrc: a login-only .zprofile must not
+      # suppress it, or non-login interactive zsh shells miss the PATH.
+      [ -f "${HOME}/.zshrc" ] || ensure_file="${HOME}/.zshrc"
     else
       { [ -f "${HOME}/.bash_profile" ] || [ -f "${HOME}/.bash_login" ] || [ -f "${HOME}/.profile" ]; } || ensure_file="${HOME}/.profile"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -253,17 +253,41 @@ update_path() {
   local target="${HOME}/.local/bin"
   if [[ ":$PATH:" != *":$target:"* ]]; then
     log "Adding $target to PATH in shell startup files"
-    for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile"; do
-      if [ -f "$rc" ]; then
-        if ! grep -qF "$target" "$rc"; then
-          if [ "$DRY_RUN" != "1" ]; then
-            printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$rc"
-          else
-            log "[dry-run] would append export PATH to $rc"
-          fi
+
+    # Patch every existing shell startup file that lacks the export so both
+    # interactive (.bashrc/.zshrc) and login shells pick up the CLI.
+    local rc
+    for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.bash_login" "${HOME}/.profile" "${HOME}/.zprofile"; do
+      if [ -f "$rc" ] && ! grep -qF "$target" "$rc"; then
+        if [ "$DRY_RUN" != "1" ]; then
+          # shellcheck disable=SC2016  # $PATH must stay literal; it expands when the rc file is sourced
+          printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$rc"
+        else
+          log "[dry-run] would append export PATH to $rc"
         fi
       fi
     done
+
+    # Bash login shells read the first existing file among .bash_profile,
+    # .bash_login, .profile; zsh login shells read .zprofile. When none of those
+    # login files exist, no login shell would see the PATH and fresh shells report
+    # 'paperclipai: command not found'. The loop above already added the export to
+    # any login file that exists, so only create .profile when none was present.
+    local login_present=0
+    for rc in "${HOME}/.bash_profile" "${HOME}/.bash_login" "${HOME}/.profile" "${HOME}/.zprofile"; do
+      if [ -f "$rc" ]; then
+        login_present=1
+        break
+      fi
+    done
+    if [ "$login_present" = "0" ]; then
+      if [ "$DRY_RUN" != "1" ]; then
+        # shellcheck disable=SC2016  # $PATH must stay literal; it expands when the rc file is sourced
+        printf '\nexport PATH="%s:$PATH"\n' "$target" >> "${HOME}/.profile"
+      else
+        log "[dry-run] would create ${HOME}/.profile with export PATH"
+      fi
+    fi
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -251,46 +251,56 @@ ensure_temp_dir() {
 
 update_path() {
   local target="${HOME}/.local/bin"
-  if [[ ":$PATH:" != *":$target:"* ]]; then
-    log "Adding $target to PATH in shell startup files"
+  local pending=()
+  local rc
 
-    # Patch every existing shell startup file that lacks the export so both
-    # interactive (.bashrc/.zshrc) and login shells pick up the CLI.
-    local rc
-    for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.bash_login" "${HOME}/.profile" "${HOME}/.zprofile"; do
-      if [ -f "$rc" ] && ! grep -qF "$target" "$rc"; then
-        if [ "$DRY_RUN" != "1" ]; then
-          # shellcheck disable=SC2016  # $PATH must stay literal; it expands when the rc file is sourced
-          printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$rc"
-        else
-          log "[dry-run] would append export PATH to $rc"
-        fi
-      fi
-    done
+  # Deliberately not gated on the current $PATH: this process may already export
+  # $target (inherited from a parent, or left over from an earlier install) while
+  # the user's startup files still lack it. Persisting is what a fresh shell
+  # depends on, so it runs regardless; the per-file grep below keeps it
+  # idempotent.
 
-    # Ensure a startup file the user's default shell actually reads exists,
-    # otherwise fresh shells won't see the PATH. POSIX/bash/dash login shells read
-    # the first of .bash_profile/.bash_login/.profile; interactive zsh shells
-    # (including login) read .zshrc, which is login-only for .zprofile. Create the
-    # matching file only when none is already present (the loop above already
-    # added the export to any existing one).
-    local ensure_file=""
-    if [[ "${SHELL:-}" == */zsh ]]; then
-      # Key interactive coverage off .zshrc: a login-only .zprofile must not
-      # suppress it, or non-login interactive zsh shells miss the PATH.
-      [ -f "${HOME}/.zshrc" ] || ensure_file="${HOME}/.zshrc"
-    else
-      { [ -f "${HOME}/.bash_profile" ] || [ -f "${HOME}/.bash_login" ] || [ -f "${HOME}/.profile" ]; } || ensure_file="${HOME}/.profile"
+  # Patch every existing shell startup file that lacks the export so both
+  # interactive (.bashrc/.zshrc) and login shells pick up the CLI.
+  for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile" "${HOME}/.bash_login" "${HOME}/.profile" "${HOME}/.zprofile"; do
+    if [ -f "$rc" ] && ! grep -qF "$target" "$rc"; then
+      pending+=("$rc")
     fi
-    if [ -n "$ensure_file" ]; then
-      if [ "$DRY_RUN" != "1" ]; then
-        # shellcheck disable=SC2016  # $PATH must stay literal; it expands when the rc file is sourced
-        printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$ensure_file"
-      else
-        log "[dry-run] would create $ensure_file with export PATH"
-      fi
+  done
+
+  # Shells read two classes of startup file: login shells read a login file, and
+  # non-login interactive shells read an rc file. When a class has no file at all
+  # the export has nowhere to live, and that kind of session never sees the CLI,
+  # so create the file the user's shell expects. Existing files of either class
+  # were already handled by the loop above.
+  if [[ "${SHELL:-}" == */zsh ]]; then
+    # zsh reads .zshrc for every interactive shell, login ones included, so it
+    # covers both classes on its own. .zprofile is login-only and must not
+    # suppress it, or non-login interactive zsh shells miss the PATH.
+    [ -f "${HOME}/.zshrc" ] || pending+=("${HOME}/.zshrc")
+  else
+    # POSIX/bash/dash login shells read the first of .bash_profile/.bash_login/
+    # .profile and never .bashrc.
+    { [ -f "${HOME}/.bash_profile" ] || [ -f "${HOME}/.bash_login" ] || [ -f "${HOME}/.profile" ]; } ||
+      pending+=("${HOME}/.profile")
+    # Non-login interactive bash reads only .bashrc, so a login file is not
+    # sufficient coverage. Skipped for plain sh/dash, which have no such rc file.
+    if [[ "${SHELL:-}" == */bash || -z "${SHELL:-}" ]]; then
+      [ -f "${HOME}/.bashrc" ] || pending+=("${HOME}/.bashrc")
     fi
   fi
+
+  [ "${#pending[@]}" -gt 0 ] || return 0
+
+  log "Adding $target to PATH in shell startup files"
+  for rc in "${pending[@]}"; do
+    if [ "$DRY_RUN" = "1" ]; then
+      log "[dry-run] would add export PATH to $rc"
+      continue
+    fi
+    # shellcheck disable=SC2016  # $PATH must stay literal; it expands when the rc file is sourced
+    printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$rc"
+  done
 }
 
 download_checked_script() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,6 +249,24 @@ ensure_temp_dir() {
   fi
 }
 
+update_path() {
+  local target="${HOME}/.local/bin"
+  if [[ ":$PATH:" != *":$target:"* ]]; then
+    log "Adding $target to PATH in shell startup files"
+    for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.bash_profile"; do
+      if [ -f "$rc" ]; then
+        if ! grep -qF "$target" "$rc"; then
+          if [ "$DRY_RUN" != "1" ]; then
+            printf '\nexport PATH="%s:$PATH"\n' "$target" >> "$rc"
+          else
+            log "[dry-run] would append export PATH to $rc"
+          fi
+        fi
+      fi
+    done
+  fi
+}
+
 download_checked_script() {
   local url="$1"
   local destination="$2"
@@ -379,6 +397,8 @@ fi
 
 print_command "${INSTALL_COMMAND[@]}"
 "${INSTALL_COMMAND[@]}"
+
+update_path
 
 if [ "$INSTALL_SERVICE" = "1" ]; then
   log "Installing the Paperclip service"

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -60,6 +60,16 @@ assert_no_line() {
   fi
 }
 
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -qF -- "$needle" "$file" >/dev/null || {
+    printf 'Expected to find %q in %s\n' "$needle" "$file" >&2
+    cat "$file" >&2
+    exit 1
+  }
+}
+
 echo "==> shellcheck"
 run_shellcheck
 
@@ -161,6 +171,59 @@ node_major="${node_version#v}"
 node_major="${node_major%%.*}"
 [ "$node_major" -ge 20 ] || {
   printf 'Expected Node >= 20, got %s\n' "$node_version" >&2
+  exit 1
+}
+
+echo "==> update_path: empty home creates .profile for login shells"
+mkdir -p "$RESULTS_DIR/path-empty-home"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-empty-home \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-empty.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+[ -f "$RESULTS_DIR/path-empty-home/.profile" ] || {
+  echo "Expected .profile created for fresh login shells" >&2
+  exit 1
+}
+assert_contains "$RESULTS_DIR/path-empty-home/.profile" 'export PATH="/results/path-empty-home/.local/bin:'
+
+echo "==> update_path: bashrc-only home still creates a login file"
+mkdir -p "$RESULTS_DIR/path-bashrc-home"
+printf 'alias ll=ls\n' >"$RESULTS_DIR/path-bashrc-home/.bashrc"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-bashrc-home \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-bashrc.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+assert_contains "$RESULTS_DIR/path-bashrc-home/.bashrc" 'export PATH="/results/path-bashrc-home/.local/bin:'
+[ -f "$RESULTS_DIR/path-bashrc-home/.profile" ] || {
+  echo "Expected a login startup file (.profile) alongside .bashrc" >&2
+  exit 1
+}
+assert_contains "$RESULTS_DIR/path-bashrc-home/.profile" 'export PATH="/results/path-bashrc-home/.local/bin:'
+
+echo "==> update_path: existing export is not duplicated"
+mkdir -p "$RESULTS_DIR/path-idem-home"
+# shellcheck disable=SC2016  # seed the exact export line install.sh would write
+printf 'export PATH="/results/path-idem-home/.local/bin:$PATH"\n' >"$RESULTS_DIR/path-idem-home/.profile"
+dup_before="$(grep -cF '/results/path-idem-home/.local/bin' "$RESULTS_DIR/path-idem-home/.profile")"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-idem-home \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-idem.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+dup_after="$(grep -cF '/results/path-idem-home/.local/bin' "$RESULTS_DIR/path-idem-home/.profile")"
+[ "$dup_after" = "$dup_before" ] || {
+  printf 'Expected no duplicate export lines, got %s before / %s after\n' "$dup_before" "$dup_after" >&2
   exit 1
 }
 

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -250,22 +250,74 @@ docker run --rm \
 assert_contains "$RESULTS_DIR/path-zprof-home/.zshrc" 'export PATH="/results/path-zprof-home/.local/bin:'
 assert_contains "$RESULTS_DIR/path-zprof-home/.zprofile" 'export PATH="/results/path-zprof-home/.local/bin:'
 
+echo "==> update_path: bash home with only .bash_profile still creates .bashrc"
+mkdir -p "$RESULTS_DIR/path-bashprof-home"
+printf 'umask 022\n' >"$RESULTS_DIR/path-bashprof-home/.bash_profile"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-bashprof-home \
+  -e SHELL=/bin/bash \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-bashprof.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+# .bash_profile is login-only; non-login interactive bash reads .bashrc, so
+# .bashrc must be created even though the login class is already covered.
+[ -f "$RESULTS_DIR/path-bashprof-home/.bashrc" ] || {
+  echo "Expected .bashrc created alongside an existing .bash_profile" >&2
+  exit 1
+}
+assert_contains "$RESULTS_DIR/path-bashprof-home/.bashrc" 'export PATH="/results/path-bashprof-home/.local/bin:'
+assert_contains "$RESULTS_DIR/path-bashprof-home/.bash_profile" 'export PATH="/results/path-bashprof-home/.local/bin:'
+# .bash_profile already covers login shells, so no redundant .profile.
+[ ! -e "$RESULTS_DIR/path-bashprof-home/.profile" ] || {
+  echo "Did not expect .profile when .bash_profile already exists" >&2
+  exit 1
+}
+
+echo "==> update_path: PATH already exported in this process still persists"
+mkdir -p "$RESULTS_DIR/path-transient-home"
+printf 'alias ll=ls\n' >"$RESULTS_DIR/path-transient-home/.bashrc"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-transient-home \
+  -e SHELL=/bin/bash \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-transient.args \
+  -e PATH="/results/path-transient-home/.local/bin:/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+# The installer process inherited ~/.local/bin on PATH, but the startup files
+# never had it. Skipping persistence here would break the next fresh shell.
+assert_contains "$RESULTS_DIR/path-transient-home/.bashrc" 'export PATH="/results/path-transient-home/.local/bin:'
+[ -f "$RESULTS_DIR/path-transient-home/.profile" ] || {
+  echo "Expected a login startup file despite ~/.local/bin already being on PATH" >&2
+  exit 1
+}
+assert_contains "$RESULTS_DIR/path-transient-home/.profile" 'export PATH="/results/path-transient-home/.local/bin:'
+
 echo "==> update_path: existing export is not duplicated"
 mkdir -p "$RESULTS_DIR/path-idem-home"
-# shellcheck disable=SC2016  # seed the exact export line install.sh would write
-printf 'export PATH="/results/path-idem-home/.local/bin:$PATH"\n' >"$RESULTS_DIR/path-idem-home/.profile"
-dup_before="$(grep -cF '/results/path-idem-home/.local/bin' "$RESULTS_DIR/path-idem-home/.profile")"
+# Seed both classes so a re-install has nothing left to do: persistence now runs
+# on every install, so a fully covered home must come out byte-identical.
+for idem_rc in .profile .bashrc; do
+  # shellcheck disable=SC2016  # seed the exact export line install.sh would write
+  printf 'export PATH="/results/path-idem-home/.local/bin:$PATH"\n' >"$RESULTS_DIR/path-idem-home/$idem_rc"
+done
+idem_before="$(cat "$RESULTS_DIR/path-idem-home/.profile" "$RESULTS_DIR/path-idem-home/.bashrc")"
 docker run --rm \
   -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
   -v "$RESULTS_DIR:/results" \
   -e HOME=/results/path-idem-home \
+  -e SHELL=/bin/bash \
   -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-idem.args \
   -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
   node:22-bookworm-slim \
   bash /paperclip-scripts/install.sh --no-prompt --no-onboard
-dup_after="$(grep -cF '/results/path-idem-home/.local/bin' "$RESULTS_DIR/path-idem-home/.profile")"
-[ "$dup_after" = "$dup_before" ] || {
-  printf 'Expected no duplicate export lines, got %s before / %s after\n' "$dup_before" "$dup_after" >&2
+idem_after="$(cat "$RESULTS_DIR/path-idem-home/.profile" "$RESULTS_DIR/path-idem-home/.bashrc")"
+[ "$idem_after" = "$idem_before" ] || {
+  printf 'Expected startup files to be unchanged, got:\n%s\n---\n%s\n' "$idem_before" "$idem_after" >&2
   exit 1
 }
 

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -208,6 +208,27 @@ assert_contains "$RESULTS_DIR/path-bashrc-home/.bashrc" 'export PATH="/results/p
 }
 assert_contains "$RESULTS_DIR/path-bashrc-home/.profile" 'export PATH="/results/path-bashrc-home/.local/bin:'
 
+echo "==> update_path: zsh home (no rc files) creates .zshrc, not .profile"
+mkdir -p "$RESULTS_DIR/path-zsh-home"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-zsh-home \
+  -e SHELL=/bin/zsh \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-zsh.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+[ -f "$RESULTS_DIR/path-zsh-home/.zshrc" ] || {
+  echo "Expected .zshrc created for a zsh login shell" >&2
+  exit 1
+}
+assert_contains "$RESULTS_DIR/path-zsh-home/.zshrc" 'export PATH="/results/path-zsh-home/.local/bin:'
+[ ! -e "$RESULTS_DIR/path-zsh-home/.profile" ] || {
+  echo "Did not expect .profile for a zsh user" >&2
+  exit 1
+}
+
 echo "==> update_path: existing export is not duplicated"
 mkdir -p "$RESULTS_DIR/path-idem-home"
 # shellcheck disable=SC2016  # seed the exact export line install.sh would write

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -67,7 +67,8 @@ echo "==> existing Node"
 run_with_node with-node bash /paperclip-scripts/install.sh --no-prompt --no-onboard
 assert_line "$RESULTS_DIR/with-node.args" "paperclipai@latest"
 assert_line "$RESULTS_DIR/with-node.args" "install"
-assert_line "$RESULTS_DIR/with-node.args" "--yes"
+assert_line "$RESULTS_DIR/with-node.args" "-g"
+assert_line "$RESULTS_DIR/with-node.args" "--prefix"
 assert_line "$RESULTS_DIR/with-node.args" "--registry=https://registry.npmjs.org"
 assert_line "$RESULTS_DIR/with-node.args" "NPM_CONFIG_REGISTRY=https://registry.npmjs.org"
 assert_line "$RESULTS_DIR/with-node.args" "npm_config_registry=https://registry.npmjs.org"
@@ -97,7 +98,7 @@ if run_with_node ref-master bash /paperclip-scripts/install.sh --ref master --no
   exit 1
 fi
 [ ! -e "$RESULTS_DIR/ref-master.args" ] || {
-  echo "Expected --ref failure before invoking npx" >&2
+  echo "Expected --ref failure before invoking npm" >&2
   exit 1
 }
 
@@ -109,7 +110,7 @@ fi
 
 echo "==> piped --no-prompt"
 run_with_node piped bash -c 'cat /paperclip-scripts/install.sh | bash -s -- --no-prompt --no-onboard'
-assert_line "$RESULTS_DIR/piped.args" "--yes"
+assert_line "$RESULTS_DIR/piped.args" "install"
 
 echo "==> piped mode refuses privileged Node bootstrap"
 if docker run --rm \
@@ -126,7 +127,7 @@ assert_line "$RESULTS_DIR/piped-no-node.out" "[paperclip] error: Node.js bootstr
 echo "==> dry run"
 run_with_node dry-run bash /paperclip-scripts/install.sh --no-prompt --dry-run --no-onboard
 [ ! -e "$RESULTS_DIR/dry-run.args" ] || {
-  echo "Expected --dry-run to avoid invoking npx" >&2
+  echo "Expected --dry-run to avoid invoking npm" >&2
   exit 1
 }
 
@@ -143,11 +144,8 @@ docker run --rm \
   node:22-bookworm-slim \
   bash /paperclip-scripts/install.sh
 assert_line "$RESULTS_DIR/env.args" "paperclipai@2026.722.0"
-assert_line "$RESULTS_DIR/env.args" "--version"
-assert_line "$RESULTS_DIR/env.args" "2026.722.0"
 assert_no_line "$RESULTS_DIR/env.args" "--repo"
 assert_no_line "$RESULTS_DIR/env.args" "--install-service"
-assert_line "$RESULTS_DIR/env.args" "service"
 
 echo "==> no Node, apt bootstrap"
 docker run --rm \

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -25,7 +25,7 @@ run_shellcheck() {
     -v "$REPO_ROOT:/work:ro" \
     -w /work \
     koalaman/shellcheck:stable \
-    scripts/install.sh scripts/test-install-sh-docker.sh scripts/install-sh-fixtures/npx
+    scripts/install.sh scripts/test-install-sh-docker.sh scripts/install-sh-fixtures/npx scripts/install-sh-fixtures/npm
 }
 
 run_with_node() {

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -229,6 +229,27 @@ assert_contains "$RESULTS_DIR/path-zsh-home/.zshrc" 'export PATH="/results/path-
   exit 1
 }
 
+echo "==> update_path: zsh home with only .zprofile still creates .zshrc"
+mkdir -p "$RESULTS_DIR/path-zprof-home"
+printf 'umask 022\n' >"$RESULTS_DIR/path-zprof-home/.zprofile"
+docker run --rm \
+  -v "$REPO_ROOT/scripts:/paperclip-scripts:ro" \
+  -v "$RESULTS_DIR:/results" \
+  -e HOME=/results/path-zprof-home \
+  -e SHELL=/bin/zsh \
+  -e PAPERCLIP_INSTALL_TEST_LOG=/results/path-zprof.args \
+  -e PATH="/paperclip-scripts/install-sh-fixtures:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  node:22-bookworm-slim \
+  bash /paperclip-scripts/install.sh --no-prompt --no-onboard
+# .zprofile is login-only; interactive non-login zsh reads .zshrc, so .zshrc
+# must be created even though .zprofile already exists and was patched.
+[ -f "$RESULTS_DIR/path-zprof-home/.zshrc" ] || {
+  echo "Expected .zshrc created alongside an existing .zprofile" >&2
+  exit 1
+}
+assert_contains "$RESULTS_DIR/path-zprof-home/.zshrc" 'export PATH="/results/path-zprof-home/.local/bin:'
+assert_contains "$RESULTS_DIR/path-zprof-home/.zprofile" 'export PATH="/results/path-zprof-home/.local/bin:'
+
 echo "==> update_path: existing export is not duplicated"
 mkdir -p "$RESULTS_DIR/path-idem-home"
 # shellcheck disable=SC2016  # seed the exact export line install.sh would write


### PR DESCRIPTION
Fixes #10739

### What happened?
The `install.sh` script relies on `npx --yes paperclipai@latest install` to install the `paperclipai` binary. However, the `install` subcommand was removed from recent versions of the `paperclipai` CLI package, causing `install.sh` to fail with `error: unknown command 'install'`.

### Expected behavior
The installation script should successfully place the `paperclipai` CLI executable in the user's `PATH` (typically `~/.local/bin`) and proceed to launch the `onboard` wizard.

### Steps to reproduce
1. Run `bash install.sh` locally on a fresh machine.
2. The script errors when delegating to the Paperclip CLI using the `install` subcommand.

### Paperclip version
2026.722.0

### Node.js version
v24.18.0

### Operating system
Linux (x64)

## Thinking Path
The error indicates that the `install` subcommand was removed from the `@latest` tag of the `paperclipai` package. Since the bash script's purpose is to fetch and install the CLI globally so it can be run from the user's PATH, changing the `npx` command to a direct `npm install -g --prefix ~/.local` serves the same goal and avoids the missing subcommand. We also needed to update the Docker test assertions since `npx --yes` is no longer used, replacing it with `npm -g --prefix` verifications.

Dropping `npx` shifted responsibility for PATH setup onto the script itself, which turned `update_path` into the substantive part of this change. The rule it now encodes: shells read two classes of startup file — login shells read a *login file*, non-login interactive shells read an *rc file* — and covering only one class leaves the other kind of session unable to resolve the CLI.

## What Changed
- Replaced the failing `npx --yes paperclipai@latest install` invocation in `scripts/install.sh` with `npm install -g --prefix "${HOME}/.local"`.
- Updated `scripts/test-install-sh-docker.sh` to assert the arguments passed to `npm` rather than `npx`, and cloned the `npx` test fixture to an `npm` fixture in `scripts/install-sh-fixtures` (both fixtures are now covered by shellcheck).
- Reworked `update_path` so every reachable shell configuration ends up with `~/.local/bin` on `PATH`:
  - It patches all common startup files that already exist (`.bashrc`, `.zshrc`, `.bash_profile`, `.bash_login`, `.profile`, `.zprofile`).
  - It then creates a missing file per *class*, chosen from `$SHELL`: zsh gets `~/.zshrc` (zsh reads it for every interactive shell, login included, so it covers both classes; a login-only `.zprofile` must not suppress it); bash gets `~/.profile` when no login file exists **and** `~/.bashrc` when that is missing, since bash login shells never read `.bashrc`; plain sh/dash get only `~/.profile`, having no interactive rc file.
  - Persistence is no longer gated on the installer's own `$PATH`. The process may already export `~/.local/bin` (inherited from a parent, or left over from an earlier install) while the user's startup files still lack it — the previous guard skipped every update in that state. Idempotency comes from the per-file `grep` instead, so nothing is duplicated.

## Verification
- Ran the `install.sh` script locally on an Ubuntu x64 machine, confirming that it successfully installs `paperclipai` into `~/.local/bin` and launches the `paperclipai onboard` wizard without the subcommand error.
- Ran `bash scripts/test-install-sh-docker.sh` locally: shellcheck is clean and the full suite passes, including the new `update_path` cases.
- Drove the real `update_path` directly across a shell × startup-file matrix (bash/zsh/dash × empty home, `.bashrc`-only, `.bash_profile`-only, `.bash_login`-only, `.profile`-only, `.zprofile`-only, `.zshrc`-only, and target-already-on-`PATH`), asserting both classes of coverage in each. Additionally verified end to end that sourcing each generated file in a clean `env -i` shell actually resolves a `paperclipai` binary placed in `~/.local/bin`.
- Confirmed the new cases are genuine regression tests by replaying the previous `update_path` against the same matrix: it produced 7 failures — no `.bashrc` for any bash home lacking one, and no persistence at all when `~/.local/bin` was already on the process `PATH`. The same two states were replayed through the real installer in Docker with the pre-fix script, reproducing the missing files there too.
- Re-ran the idempotency case with both classes pre-seeded: startup files come out byte-identical across repeat installs, and the installer logs nothing when there is no work to do.

## Risks
- Users who expect a different global installation location for `npm install -g` might end up with the binary strictly inside `~/.local/bin`. However, the script already checked `~/.local/bin/paperclipai` as a fallback, so this aligns with the script's previous behavior.
- The `--install-service` functionality, if it was also removed from the CLI package, will now just pass through to `npx` as `service install`. If it fails, that's a separate issue. We kept it unmodified to avoid changing unrelated code.
- `update_path` may now create `~/.profile`, `~/.bashrc` (POSIX/bash), or `~/.zshrc` (zsh) on systems that previously had no such file. This is additive — it only ever appends an `export PATH` line, never overwrites an existing file — and matches the convention used by rustup and Homebrew.
- A bash user whose `.bash_profile` sources `.bashrc` will get `~/.local/bin` prepended twice in a login shell. Duplicate `PATH` entries are harmless, and the alternative (guessing whether a login file sources the rc file) is fragile.
- Persistence now runs on every install rather than only when `~/.local/bin` is absent from `PATH`. Repeat installs are a no-op on an already-covered home, which the idempotency test asserts byte-for-byte.

## Model Used
Gemini 3.1 Pro (High); the `update_path` rework was done with Claude Opus 5.

- [x] I have searched the GitHub PR list for similar PRs
