### PR TITLE
chore(plugin-llm-wiki): publish SDK-compatible package

### DIFF
--- a/packages/plugins/plugin-llm-wiki/README.md
+++ b/packages/plugins/plugin-llm-wiki/README.md
@@ -84,6 +84,14 @@ Remaining alpha gaps:
 
 ## Install Into Paperclip
 
+Install the published plugin from the Paperclip release channel:
+
+```bash
+paperclipai plugin install @paperclipai/plugin-llm-wiki
+```
+
+For local development, install the package from the repository instead:
+
 ```bash
 curl -X POST http://127.0.0.1:3100/api/plugins/install \
   -H "Content-Type: application/json" \

--- a/packages/plugins/plugin-llm-wiki/package.json
+++ b/packages/plugins/plugin-llm-wiki/package.json
@@ -2,8 +2,19 @@
   "name": "@paperclipai/plugin-llm-wiki",
   "version": "0.1.0",
   "type": "module",
-  "private": true,
   "description": "Local-file LLM Wiki plugin for source ingestion, wiki browsing, query, lint, and maintenance workflows.",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/plugins/plugin-llm-wiki"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "agents",
     "dist",
@@ -19,7 +30,9 @@
     "dev": "node ./esbuild.config.mjs --watch",
     "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
     "test": "vitest run --config ./vitest.config.ts",
-    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../scripts/generate-plugin-package-json.mjs",
+    "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
   },
   "paperclipPlugin": {
     "manifest": "./dist/manifest.js",

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -90,6 +90,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/plugins/plugin-llm-wiki",
+    "name": "@paperclipai/plugin-llm-wiki",
+    "publishFromCi": true
+  },
+  {
     "dir": "server",
     "name": "@paperclipai/server",
     "publishFromCi": true


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Plugins extend Paperclip with optional capabilities such as LLM Wiki.
> - The published LLM Wiki worker was built with an older plugin SDK and did not send the invocation scope identifier on host callbacks.
> - The current repository already contains the SDK support, but LLM Wiki was private and absent from the release package manifest.
> - This pull request enrolls LLM Wiki in the public release flow and adds the standard plugin packaging step.
> - The benefit is that future Paperclip releases publish a fresh worker bundle that can complete scoped host calls.

## Linked Issues or Issue Description

Fixes: #8036

## What Changed

- Make `@paperclipai/plugin-llm-wiki` a public first-party package.
- Add the package to the release package manifest with CI publishing enabled.
- Add the standard `prepack` and `postpack` scripts so the published manifest contains the released SDK dependency instead of `workspace:*`.
- Document the published package install command while keeping the local development install path.

## Verification

- `pnpm --filter @paperclipai/plugin-llm-wiki typecheck`
- `pnpm --filter @paperclipai/plugin-llm-wiki test` — 101 tests passed.
- `pnpm --filter @paperclipai/plugin-llm-wiki build`
- `node --test scripts/release-package-map.test.mjs` — 12 tests passed.
- `node scripts/release-package-map.mjs check`
- `npm pack --dry-run` — confirmed the package contains `dist/worker.js`, migrations, skills, templates, and a generated runtime package manifest.
- `git diff --check`

## Risks

Low risk. This change affects package publication and release metadata. It does not change LLM Wiki runtime behavior or local-path installation. The next release will publish the package as part of the existing first-party release set.

## Model Used

OpenAI Codex, GPT-5-based coding agent. Exact deployed model ID and context window were not surfaced. Tool-enabled local shell execution and GitHub access were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have linked the existing public issue with `Fixes: #8036`
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
