### PR TITLE
fix(server): preserve source SHA in packaged builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+server/src/build-commit.ts export-subst

--- a/scripts/write-build-commit.mjs
+++ b/scripts/write-build-commit.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FULL_SHA_RE = /^[0-9a-f]{40}$/i;
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..");
+
+export function parseBuildCommit(value) {
+  const commit = value?.trim() ?? "";
+  return FULL_SHA_RE.test(commit) ? commit.toLowerCase() : null;
+}
+
+export function resolveBuildCommit({
+  environmentCommit = process.env.PAPERCLIP_BUILD_COMMIT,
+  gitCommand = () =>
+    execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1500,
+    }),
+} = {}) {
+  const environmentBuildCommit = parseBuildCommit(environmentCommit);
+  if (environmentBuildCommit) return environmentBuildCommit;
+
+  try {
+    return parseBuildCommit(gitCommand());
+  } catch {
+    return null;
+  }
+}
+
+export function writeBuildCommitMarker(outputPath, opts = {}) {
+  const buildCommit = resolveBuildCommit(opts);
+  if (!buildCommit) {
+    rmSync(outputPath, { force: true });
+    return null;
+  }
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${buildCommit}\n`, "utf8");
+  return buildCommit;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  const outputPath = process.argv[2];
+  if (!outputPath) {
+    console.error("Usage: write-build-commit.mjs <output-path>");
+    process.exitCode = 1;
+  } else {
+    writeBuildCommitMarker(resolve(process.cwd(), outputPath));
+  }
+}

--- a/scripts/write-build-commit.test.mjs
+++ b/scripts/write-build-commit.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  resolveBuildCommit,
+  writeBuildCommitMarker,
+} from "./write-build-commit.mjs";
+
+test("resolveBuildCommit prefers explicit deployment metadata", () => {
+  let gitCalled = false;
+
+  assert.equal(
+    resolveBuildCommit({
+      environmentCommit: "0123456789ABCDEF0123456789ABCDEF01234567",
+      gitCommand: () => {
+        gitCalled = true;
+        return "ffffffffffffffffffffffffffffffffffffffff";
+      },
+    }),
+    "0123456789abcdef0123456789abcdef01234567",
+  );
+  assert.equal(gitCalled, false);
+});
+
+test("writeBuildCommitMarker writes a package-local marker", () => {
+  const directory = mkdtempSync(join(tmpdir(), "paperclip-build-commit-"));
+  const outputPath = join(directory, "dist", ".paperclip-build-commit");
+
+  assert.equal(
+    writeBuildCommitMarker(outputPath, {
+      environmentCommit: null,
+      gitCommand: () => "89abcdef0123456789abcdef0123456789abcdef\n",
+    }),
+    "89abcdef0123456789abcdef0123456789abcdef",
+  );
+  assert.equal(
+    readFileSync(outputPath, "utf8"),
+    "89abcdef0123456789abcdef0123456789abcdef\n",
+  );
+});
+
+test("writeBuildCommitMarker removes a stale marker when metadata is unavailable", () => {
+  const directory = mkdtempSync(join(tmpdir(), "paperclip-build-commit-"));
+  const outputPath = join(directory, ".paperclip-build-commit");
+  writeFileSync(outputPath, "ffffffffffffffffffffffffffffffffffffffff\n", "utf8");
+
+  assert.equal(
+    writeBuildCommitMarker(outputPath, {
+      environmentCommit: null,
+      gitCommand: () => {
+        throw new Error("git unavailable");
+      },
+    }),
+    null,
+  );
+  assert.throws(() => readFileSync(outputPath, "utf8"), { code: "ENOENT" });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "dev": "tsx src/index.ts",
     "dev:watch": "cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
-    "build": "tsc && mkdir -p dist/onboarding-assets dist/built-ins && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/",
+    "build": "tsc && node ../scripts/write-build-commit.mjs dist/.paperclip-build-commit && mkdir -p dist/onboarding-assets dist/built-ins && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/",
     "prepack": "pnpm run prepare:ui-dist",
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",

--- a/server/src/__tests__/build-commit.test.ts
+++ b/server/src/__tests__/build-commit.test.ts
@@ -39,4 +39,28 @@ describe("readBuildCommit", () => {
       }),
     ).toBe("0123456789abcdef0123456789abcdef01234567");
   });
+
+  it("uses the commit embedded in a git archive when no marker exists", () => {
+    expect(
+      readBuildCommit({
+        environmentCommit: null,
+        archiveCommit: "89abcdef0123456789abcdef0123456789abcdef",
+        readTextFile: () => {
+          throw new Error("missing deployment marker");
+        },
+      }),
+    ).toBe("89abcdef0123456789abcdef0123456789abcdef");
+  });
+
+  it("ignores the unsubstituted git archive placeholder", () => {
+    expect(
+      readBuildCommit({
+        environmentCommit: null,
+        archiveCommit: "$Format:%H$",
+        readTextFile: () => {
+          throw new Error("missing deployment marker");
+        },
+      }),
+    ).toBeNull();
+  });
 });

--- a/server/src/__tests__/version.test.ts
+++ b/server/src/__tests__/version.test.ts
@@ -190,6 +190,24 @@ describe("resolveServerVersion", () => {
     );
   });
 
+  it("uses embedded commit metadata for packaged source builds", () => {
+    const debugLog = vi.fn();
+    const gitDescribeCommand = vi.fn(() => "v2026.626.0-58-g518fc71ce\n");
+
+    expect(
+      resolveServerVersion({
+        buildCommit: "0123456789abcdef0123456789abcdef01234567",
+        packageVersion: "0.3.1",
+        debugLog,
+        gitDescribeCommand,
+        packageRoot: "/tmp/npm/_npx/example/node_modules/@paperclipai/server",
+      }),
+    ).toBe("0.3.1+0.git.0123456");
+
+    expect(gitDescribeCommand).not.toHaveBeenCalled();
+    expect(debugLog).not.toHaveBeenCalled();
+  });
+
   it("uses git metadata for source checkouts whose path contains node_modules", () => {
     const debugLog = vi.fn();
     const gitDescribeCommand = vi.fn(() => "v2026.626.0-58-g518fc71ce\n");

--- a/server/src/build-commit.ts
+++ b/server/src/build-commit.ts
@@ -6,7 +6,7 @@ type ReadTextFile = (path: string) => string;
 const FULL_SHA_RE = /^[0-9a-f]{40}$/i;
 const ARCHIVE_BUILD_COMMIT = "$Format:%H$";
 const DEFAULT_BUILD_COMMIT_PATH = fileURLToPath(
-  new URL("../../.paperclip-build-commit", import.meta.url),
+  new URL("./.paperclip-build-commit", import.meta.url),
 );
 
 export function parseBuildCommit(value: string | null | undefined): string | null {

--- a/server/src/build-commit.ts
+++ b/server/src/build-commit.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 type ReadTextFile = (path: string) => string;
 
 const FULL_SHA_RE = /^[0-9a-f]{40}$/i;
+const ARCHIVE_BUILD_COMMIT = "$Format:%H$";
 const DEFAULT_BUILD_COMMIT_PATH = fileURLToPath(
   new URL("../../.paperclip-build-commit", import.meta.url),
 );
@@ -16,6 +17,7 @@ export function parseBuildCommit(value: string | null | undefined): string | nul
 export function readBuildCommit(
   opts: {
     environmentCommit?: string | null;
+    archiveCommit?: string | null;
     buildCommitPath?: string;
     readTextFile?: ReadTextFile;
   } = {},
@@ -29,8 +31,13 @@ export function readBuildCommit(
 
   try {
     const readTextFile = opts.readTextFile ?? ((path: string) => readFileSync(path, "utf8"));
-    return parseBuildCommit(readTextFile(opts.buildCommitPath ?? DEFAULT_BUILD_COMMIT_PATH));
-  } catch {
-    return null;
-  }
+    const markerCommit = parseBuildCommit(
+      readTextFile(opts.buildCommitPath ?? DEFAULT_BUILD_COMMIT_PATH),
+    );
+    if (markerCommit) return markerCommit;
+  } catch {}
+
+  return parseBuildCommit(
+    opts.archiveCommit === undefined ? ARCHIVE_BUILD_COMMIT : opts.archiveCommit,
+  );
 }

--- a/server/src/version.ts
+++ b/server/src/version.ts
@@ -20,6 +20,7 @@ const pkg = requirePackage("../package.json") as PackageJson;
 
 const GIT_DESCRIBE_RE =
   /^v(?<publicVersion>\d+\.\d+\.\d+)-(?<commitsSinceTag>\d+)-g(?<sha>[0-9a-f]{7,40})(?<dirty>-dirty)?$/i;
+const FORMAL_PACKAGE_VERSION_RE = /^\d{4}\.\d{3,4}\.\d+(?:-canary\.\d+)?$/;
 
 function defaultDebugLog(fields: Record<string, unknown>, message: string): void {
   if (process.env.PAPERCLIP_DEBUG_VERSION_RESOLUTION !== "1") return;
@@ -163,6 +164,10 @@ export function resolveServerVersion(
   const gitDescribeCommand = opts.gitDescribeCommand ?? defaultGitDescribeCommand;
   const debugLog = opts.debugLog ?? defaultDebugLog;
   const resolvedPackageRoot = opts.packageRoot ?? packageRoot;
+  const buildCommit =
+    opts.buildCommit === undefined
+      ? readBuildCommit()
+      : parseBuildCommit(opts.buildCommit);
 
   if (
     isPackagedInstall(resolvedPackageRoot, {
@@ -170,6 +175,10 @@ export function resolveServerVersion(
       realpath: opts.realpath,
     })
   ) {
+    if (buildCommit && !FORMAL_PACKAGE_VERSION_RE.test(packageVersion)) {
+      return `${packageVersion}+0.git.${buildCommit.slice(0, 7)}`;
+    }
+
     debugLog(
       { reason: "packaged_install" },
       "falling back to package version for server version",
@@ -210,10 +219,6 @@ export function resolveServerVersion(
     return parseGitDescribeVersion(buildVersion) ?? buildVersion;
   }
 
-  const buildCommit =
-    opts.buildCommit === undefined
-      ? readBuildCommit()
-      : parseBuildCommit(opts.buildCommit);
   if (buildCommit) {
     return `${packageVersion}+0.git.${buildCommit.slice(0, 7)}`;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Operators need the running server to identify its source revision.
> - Formal releases already use the package version as the public identifier.
> - Source archives and packaged source builds can run without Git metadata.
> - These builds lost the source SHA and showed only the non-release package version.
> - This pull request records the source SHA during archive export or package build.
> - The server uses that SHA only when no formal release identifier is available.
> - The benefit is an accurate version identifier for every supported build path.

## Linked Issues or Issue Description

**What happened?**

The server could not find its source SHA when it ran from a Git archive or a packaged source build without a `.git` directory. It then reported only the non-release package version.

**Expected behavior**

The server should report the source SHA for non-release builds even when runtime Git metadata is not available. Formal release and canary versions must keep their existing identifiers.

**Steps to reproduce**

1. Create a source archive or a packaged source build from `master`.
2. Run the compiled server outside the source repository.
3. Read the server version.
4. Observe that the version does not contain the source SHA.

Related work: Refs #9508, #9637, #9638, #10563, and #10566.

## What Changed

- Marked the build-commit source file for Git archive substitution.
- Added a build helper that records the source SHA in the server package output.
- Made the server read the package-local marker before the archive fallback.
- Added non-release version formatting for packaged builds with a known SHA.
- Added tests for archive substitution, marker creation, source precedence, and version behavior.

## Verification

- `TMPDIR="$PAPERCLIP_RUN_SCRATCH_DIR" node --test scripts/write-build-commit.test.mjs`
- `pnpm exec vitest run server/src/__tests__/build-commit.test.ts server/src/__tests__/version.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server build`
- `pnpm -r typecheck`
- `pnpm test:run` (the credential-sensitive CLI project was rerun with inherited AWS credentials removed)
- `env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN pnpm exec vitest run --project paperclipai`
- `pnpm build`
- Confirmed that `server/dist/.paperclip-build-commit` matches `HEAD`.
- Confirmed that `git archive` substitutes the full `HEAD` SHA in `server/src/build-commit.ts`.

## Risks

- Low risk. The new fallbacks only run when a higher-priority environment value or formal release identifier is not available.
- A stale marker could identify the wrong revision if a custom packaging flow reuses an old output directory. The server build always rewrites the marker.
- This change has no database migration, API contract change, or UI change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5. The runtime did not expose a more specific model ID or context-window size. The model used repository tools, shell commands, code execution, and extended reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
