### PR TITLE
Simplify pipeline status views and watchdog recovery

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -179,6 +179,7 @@ export type {
   PipelineCaseDocumentRevision,
   PipelineCaseLiveness,
   PipelineCaseLivenessState,
+  PipelineCaseBoardOutputSummary,
   PipelineCaseOutputContextSummary,
   PipelineCaseOutputContextSummaryItem,
   PipelineCaseOutputItem,

--- a/packages/shared/src/types/pipeline.ts
+++ b/packages/shared/src/types/pipeline.ts
@@ -291,6 +291,11 @@ export interface PipelineCaseOutputsResponse {
   };
 }
 
+export interface PipelineCaseBoardOutputSummary {
+  outputCount: number;
+  latestOutputAt: string | null;
+}
+
 export interface PipelineCaseOutputContextSummaryItem {
   id: string;
   kind: PipelineCaseOutputKind;

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1978,6 +1978,23 @@ describe("agent issue mutation checkout ownership", () => {
       );
     });
 
+    it("requires explicit resume intent before a watchdog can restore a cancelled watched issue", async () => {
+      denyBaseBoundary();
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "cancelled", assigneeAgentId: ownerAgentId }));
+
+      const app = await createApp(watchdogActor(), createWatchdogDb());
+      const res = await request(app)
+        .patch(`/api/issues/${issueId}`)
+        .send({
+          status: "in_review",
+          comment: "Attempting to restore the cancelled watched leaf without explicit intent.",
+        });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(409);
+      expect(res.body.error).toContain("dedicated restore flow");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+
     it("rejects stale watchdog source mutations when revalidation finds a live path", async () => {
       denyBaseBoundary();
       mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1947,6 +1947,37 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).toHaveBeenCalledWith(issueId, expect.objectContaining({ status: "in_review" }));
     });
 
+    it("lets a watchdog run restore a cancelled watched issue through explicit resume intent", async () => {
+      denyBaseBoundary();
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status: "cancelled", assigneeAgentId: ownerAgentId }));
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+        ...makeIssue({ status: "cancelled", assigneeAgentId: ownerAgentId }),
+        ...patch,
+      }));
+      mockIssueThreadInteractionService.listForIssue.mockResolvedValue([{ status: "pending" }] as never);
+
+      const app = await createApp(watchdogActor(), createWatchdogDb());
+      const res = await request(app)
+        .patch(`/api/issues/${issueId}`)
+        .send({
+          status: "in_review",
+          resume: true,
+          comment: "Restoring the cancelled watched leaf for review.",
+        });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({ status: "in_review" }),
+      );
+      expect(mockIssueService.addComment).toHaveBeenCalledWith(
+        issueId,
+        "Restoring the cancelled watched leaf for review.",
+        expect.any(Object),
+        expect.objectContaining({ sourceTrust: null }),
+      );
+    });
+
     it("rejects stale watchdog source mutations when revalidation finds a live path", async () => {
       denyBaseBoundary();
       mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }));

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -797,6 +797,9 @@ describe.sequential("issue thread interaction routes", () => {
       watchedIssueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       watchdogIssueId: null,
       stopFingerprint: "stop-1",
+      capabilities: {
+        resolveEligibleRequestConfirmationPlanInteractions: false,
+      },
     });
     const app = await createApp({ type: "agent", agentId: ASSIGNEE_AGENT_ID, companyId: "company-1", runId: "run-watchdog" });
     const res = await request(app)
@@ -1787,6 +1790,9 @@ describe.sequential("issue thread interaction routes", () => {
       watchedIssueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       watchdogIssueId: null,
       stopFingerprint: "stop-1",
+      capabilities: {
+        resolveEligibleRequestConfirmationPlanInteractions: false,
+      },
     });
     const watchdogApp = await createApp(actor);
     const watchdog = await request(watchdogApp)

--- a/server/src/__tests__/issue-watchdogs-routes.test.ts
+++ b/server/src/__tests__/issue-watchdogs-routes.test.ts
@@ -736,6 +736,44 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
         },
       },
     });
+    const toolActionInteractionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: toolActionInteractionId,
+      companyId,
+      issueId: watchedChildId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Plan approval with tool action",
+      createdByAgentId: workerAgentId,
+      payload: {
+        version: 1,
+        prompt: "Approve this plan and tool action?",
+        target: {
+          type: "issue_document",
+          issueId: watchedChildId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+        toolAction: {
+          version: 1,
+          actionRequestId: randomUUID(),
+          invocationId: randomUUID(),
+          toolName: "send_email",
+          toolDisplayName: "Send email",
+          connectionId: null,
+          applicationId: null,
+          appDisplayName: "Mail",
+          risk: "write",
+          previewMarkdown: "Send an email to the reviewed recipient.",
+          argumentsSummaryJson: '{"to":"recipient@example.com"}',
+          argumentsHash: "reviewed-arguments-hash",
+          expiresAt: "2026-08-06T16:00:00.000Z",
+        },
+      },
+    });
     const runId = await seedWatchdogRun({
       companyId,
       watchdogAgentId,
@@ -749,6 +787,13 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
       runId,
       source: "agent_jwt",
     });
+
+    const toolActionRes = await request(app)
+      .post(`/api/issues/${watchedChildId}/interactions/${toolActionInteractionId}/accept`)
+      .send({});
+
+    expect(toolActionRes.status, JSON.stringify(toolActionRes.body)).toBe(403);
+    expect(toolActionRes.body.error).toBe("Tool-action confirmations are always board-only");
 
     const res = await request(app)
       .post(`/api/issues/${watchedChildId}/interactions/${interactionId}/accept`)

--- a/server/src/__tests__/issue-watchdogs-routes.test.ts
+++ b/server/src/__tests__/issue-watchdogs-routes.test.ts
@@ -12,10 +12,14 @@ import {
   companyMemberships,
   companySkills,
   createDb,
+  documentRevisions,
+  documents,
   heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
+  issueDocuments,
   issueRelations,
+  issueThreadInteractions,
   issueWatchdogs,
   issues,
   principalPermissionGrants,
@@ -24,8 +28,10 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
 import { errorHandler } from "../middleware/index.js";
 import { runningProcesses } from "../adapters/index.ts";
+import { actorMiddleware } from "../middleware/auth.js";
 import { issueRoutes } from "../routes/issues.js";
 import { heartbeatService } from "../services/heartbeat.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
@@ -67,8 +73,11 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("issue watchdog routes", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let previousJwtSecret: string | undefined;
 
   beforeAll(async () => {
+    previousJwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "issue-watchdogs-routes-test-secret";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-watchdogs-routes-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
@@ -78,6 +87,7 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
     runningProcesses.clear();
     await drainHeartbeatRunsToQuiescence(db, heartbeatService(db));
     await db.delete(activityLog);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
@@ -85,6 +95,9 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
     await db.delete(agentRuntimeState);
     await db.delete(issueRelations);
     await db.delete(issueWatchdogs);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
     await db.delete(issues);
     await db.delete(agents);
     await db.delete(companySkills);
@@ -95,6 +108,8 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
 
   afterAll(async () => {
     await tempDb?.cleanup();
+    if (previousJwtSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousJwtSecret;
   });
 
   function createApp(companyId: string, actor?: Record<string, unknown>) {
@@ -111,6 +126,15 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
       };
       next();
     });
+    app.use("/api", issueRoutes(db, {} as any, { taskWatchdogEnqueueWakeup: null }));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function createAuthenticatedApp() {
+    const app = express();
+    app.use(express.json());
+    app.use(actorMiddleware(db, { deploymentMode: "authenticated" }));
     app.use("/api", issueRoutes(db, {} as any, { taskWatchdogEnqueueWakeup: null }));
     app.use(errorHandler);
     return app;
@@ -190,11 +214,42 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
     return id;
   }
 
+  async function seedPlanDocument(companyId: string, issueId: string) {
+    const documentId = randomUUID();
+    const revisionId = randomUUID();
+    await db.insert(documents).values({
+      id: documentId,
+      companyId,
+      title: "Plan",
+      format: "markdown",
+      latestBody: "Plan\n\n- Create concrete follow-up work\n- Verify acceptance criteria",
+      latestRevisionId: revisionId,
+      latestRevisionNumber: 1,
+    });
+    await db.insert(issueDocuments).values({
+      companyId,
+      issueId,
+      documentId,
+      key: "plan",
+    });
+    await db.insert(documentRevisions).values({
+      id: revisionId,
+      companyId,
+      documentId,
+      revisionNumber: 1,
+      title: "Plan",
+      format: "markdown",
+      body: "Plan\n\n- Create concrete follow-up work\n- Verify acceptance criteria",
+    });
+    return { documentId, revisionId };
+  }
+
   async function seedWatchdogRun(input: {
     companyId: string;
     watchdogAgentId: string;
     watchedIssueId: string;
     watchdogIssueId: string;
+    includePlanConfirmationCapability?: boolean;
   }) {
     await db.insert(issueWatchdogs).values({
       companyId: input.companyId,
@@ -221,6 +276,19 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
           watchedIssueIdentifier: "WDOG-ROOT",
           watchedIssueTitle: "Watched root",
           stopFingerprint: watchdog?.lastObservedFingerprint,
+          capabilities: {
+            operations: [
+              "comment_on_watched_subtree_issues",
+              "transition_watched_subtree_issue_status",
+              "reassign_watched_subtree_issues",
+              "create_child_issues_under_non_watchdog_watched_subtree",
+              "create_product_bug_followups_outside_watched_subtree",
+              ...(input.includePlanConfirmationCapability === false
+                ? []
+                : ["resolve_eligible_request_confirmation_plan_interactions"]),
+              "update_reusable_watchdog_issue",
+            ],
+          },
         },
       },
     });
@@ -625,6 +693,394 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Task-watchdog runs can only mutate the watched issue subtree.");
+  });
+
+  it("allows watchdogs to accept eligible plan confirmation interactions in the watched subtree", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Plan Confirmation Watchdog" });
+    const workerAgentId = await seedAgent(companyId, { name: "Plan Author" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root", identifier: "WDOG-ROOT" });
+    const watchedChildId = await seedIssue(companyId, {
+      title: "Child awaiting plan approval",
+      parentId: watchedRootId,
+      status: "in_review",
+    });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Reusable watchdog issue",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const { documentId, revisionId } = await seedPlanDocument(companyId, watchedChildId);
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: watchedChildId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Plan approval",
+      createdByAgentId: workerAgentId,
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        target: {
+          type: "issue_document",
+          issueId: watchedChildId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${watchedChildId}/interactions/${interactionId}/accept`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: interactionId,
+      kind: "request_confirmation",
+      status: "accepted",
+      resolvedByAgentId: watchdogAgentId,
+    });
+
+    const [stored] = await db
+      .select({
+        status: issueThreadInteractions.status,
+        resolvedByAgentId: issueThreadInteractions.resolvedByAgentId,
+      })
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, interactionId));
+    expect(stored).toEqual({
+      status: "accepted",
+      resolvedByAgentId: watchdogAgentId,
+    });
+  });
+
+  it("allows agent-key watchdog route actors to accept eligible plan confirmation interactions", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Plan Confirmation Watchdog" });
+    const workerAgentId = await seedAgent(companyId, { name: "Plan Author" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root", identifier: "WDOG-ROOT" });
+    const watchedChildId = await seedIssue(companyId, {
+      title: "Child awaiting plan approval",
+      parentId: watchedRootId,
+      status: "in_review",
+    });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Reusable watchdog issue",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const { documentId, revisionId } = await seedPlanDocument(companyId, watchedChildId);
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: watchedChildId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Plan approval",
+      createdByAgentId: workerAgentId,
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        target: {
+          type: "issue_document",
+          issueId: watchedChildId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${watchedChildId}/interactions/${interactionId}/accept`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: interactionId,
+      kind: "request_confirmation",
+      status: "accepted",
+      resolvedByAgentId: watchdogAgentId,
+    });
+  });
+
+  it("rejects a watchdog request when the run header conflicts with the signed JWT run claim", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "JWT Plan Confirmation Watchdog" });
+    const workerAgentId = await seedAgent(companyId, { name: "Plan Author" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root", identifier: "WDOG-JWT" });
+    const watchedChildId = await seedIssue(companyId, {
+      title: "Child awaiting plan approval",
+      parentId: watchedRootId,
+      status: "in_review",
+    });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Reusable watchdog issue",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const { documentId, revisionId } = await seedPlanDocument(companyId, watchedChildId);
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: watchedChildId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Plan approval",
+      createdByAgentId: workerAgentId,
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        target: {
+          type: "issue_document",
+          issueId: watchedChildId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const token = createLocalAgentJwt(watchdogAgentId, companyId, "codex_local", runId);
+    expect(token).toBeTruthy();
+
+    const res = await request(createAuthenticatedApp())
+      .post(`/api/issues/${watchedChildId}/interactions/${interactionId}/accept`)
+      .set("authorization", `Bearer ${token}`)
+      .set("x-paperclip-run-id", randomUUID())
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body).toMatchObject({
+      code: "agent_jwt_run_id_mismatch",
+      details: {
+        claimRunId: runId,
+      },
+    });
+  });
+
+  it("keeps non-watchdog agents forbidden from resolving board-only interactions", async () => {
+    const companyId = await seedCompany();
+    const workerAgentId = await seedAgent(companyId, { name: "Plan Author" });
+    const issueId = await seedIssue(companyId, {
+      title: "Child awaiting plan approval",
+      status: "in_review",
+    });
+    const { documentId, revisionId } = await seedPlanDocument(companyId, issueId);
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Plan approval",
+      createdByAgentId: workerAgentId,
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        target: {
+          type: "issue_document",
+          issueId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    });
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: workerAgentId,
+      companyId,
+      runId: randomUUID(),
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/interactions/${interactionId}/accept`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("This issue-thread interaction is board-only");
+  });
+
+  it("rejects watchdog attempts to reject eligible plan confirmation interactions", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Plan Confirmation Watchdog" });
+    const workerAgentId = await seedAgent(companyId, { name: "Plan Author" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root", identifier: "WDOG-ROOT" });
+    const watchedChildId = await seedIssue(companyId, {
+      title: "Child awaiting plan approval",
+      parentId: watchedRootId,
+      status: "in_review",
+    });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Reusable watchdog issue",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const { documentId, revisionId } = await seedPlanDocument(companyId, watchedChildId);
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: watchedChildId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      title: "Plan approval",
+      createdByAgentId: workerAgentId,
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+        target: {
+          type: "issue_document",
+          issueId: watchedChildId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${watchedChildId}/interactions/${interactionId}/reject`)
+      .send({});
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Task-watchdog runs can only accept eligible request_confirmation plan interactions.");
+
+    const [stored] = await db
+      .select({ status: issueThreadInteractions.status })
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, interactionId));
+    expect(stored?.status).toBe("pending");
+  });
+
+  it("rejects watchdog interaction resolution for non-plan-confirmation interactions in the watched subtree", async () => {
+    const companyId = await seedCompany();
+    const watchdogAgentId = await seedAgent(companyId, { name: "Narrow Interaction Watchdog" });
+    const watchedRootId = await seedIssue(companyId, { title: "Watched root", identifier: "WDOG-ROOT" });
+    const watchedChildId = await seedIssue(companyId, {
+      title: "Child with non-plan confirmation",
+      parentId: watchedRootId,
+      status: "in_review",
+    });
+    const watchdogIssueId = await seedIssue(companyId, {
+      title: "Reusable watchdog issue",
+      parentId: watchedRootId,
+      assigneeAgentId: watchdogAgentId,
+      originKind: "task_watchdog",
+      originId: watchedRootId,
+    });
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: watchedChildId,
+      kind: "request_checkbox_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Choose follow-ups",
+      payload: {
+        version: 1,
+        prompt: "Pick follow-up tasks.",
+        options: [{ id: "qa", label: "QA review" }],
+      },
+    });
+    const runId = await seedWatchdogRun({
+      companyId,
+      watchdogAgentId,
+      watchedIssueId: watchedRootId,
+      watchdogIssueId,
+    });
+    const app = createApp(companyId, {
+      type: "agent",
+      agentId: watchdogAgentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    });
+
+    const res = await request(app)
+      .post(`/api/issues/${watchedChildId}/interactions/${interactionId}/accept`)
+      .send({ selectedOptionIds: ["qa"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Task-watchdog runs can only resolve eligible request_confirmation plan interactions.");
+
+    const [stored] = await db
+      .select({ status: issueThreadInteractions.status })
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, interactionId));
+    expect(stored?.status).toBe("pending");
   });
 
   it("rejects cross-company watched issues and watchdog agents", async () => {

--- a/server/src/__tests__/pipelines-routes.test.ts
+++ b/server/src/__tests__/pipelines-routes.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
   agents,
+  assets,
   companies,
   companyMemberships,
   createDb,
@@ -14,8 +15,11 @@ import {
   executionWorkspaces,
   heartbeatRuns,
   instanceSettings,
+  issueAttachments,
   issueComments,
+  issueDocuments,
   issues,
+  issueWorkProducts,
   pipelineAutomationExecutions,
   pipelineCaseBlockers,
   pipelineCaseEvents,
@@ -75,11 +79,14 @@ describeEmbeddedPostgres("pipeline routes", () => {
     await db.delete(pipelineDocuments);
     await db.delete(documentRevisions);
     await db.delete(documents);
+    await db.delete(issueAttachments);
     await db.delete(issueComments);
+    await db.delete(issueWorkProducts);
     await db.delete(activityLog);
     await db.delete(routineRuns);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
+    await db.delete(assets);
     await db.delete(executionWorkspaces);
     await db.delete(pipelines);
     await db.delete(routines);
@@ -332,6 +339,145 @@ describeEmbeddedPostgres("pipeline routes", () => {
     const events = await db.select().from(pipelineCaseEvents).where(eq(pipelineCaseEvents.caseId, created.body.case.id));
     expect(events.map((event) => event.type)).toEqual(["ingested", "updated"]);
     expect(events[1]!.payload).toMatchObject({ materialChanged: true, workspaceRefChanged: true });
+  });
+
+  it("returns batched output summaries for visible pipeline cases with company isolation", async () => {
+    const company = await seedCompany();
+    const otherCompany = await seedCompany("Other Pipeline Co");
+    const http = request(app(boardActor));
+    const pipeline = await http
+      .post(`/api/companies/${company.id}/pipelines`)
+      .send({ key: "outputs", name: "Outputs" })
+      .expect(201);
+    const withOutputs = await http
+      .post(`/api/pipelines/${pipeline.body.id}/cases`)
+      .send({ caseKey: "with-outputs", title: "With outputs" })
+      .expect(201);
+    const withoutOutputs = await http
+      .post(`/api/pipelines/${pipeline.body.id}/cases`)
+      .send({ caseKey: "without-outputs", title: "Without outputs" })
+      .expect(201);
+    const retiredLink = await http
+      .post(`/api/pipelines/${pipeline.body.id}/cases`)
+      .send({ caseKey: "retired-link", title: "Retired link" })
+      .expect(201);
+    const crossCompany = await http
+      .post(`/api/pipelines/${pipeline.body.id}/cases`)
+      .send({ caseKey: "cross-company", title: "Cross-company" })
+      .expect(201);
+
+    const [sourceIssue] = await db.insert(issues).values({
+      companyId: company.id,
+      title: "Output source",
+      status: "done",
+      priority: "medium",
+    }).returning();
+    const [document] = await db.insert(documents).values({
+      companyId: company.id,
+      title: "Summary",
+      latestBody: "Useful output",
+      updatedAt: new Date("2026-01-01T10:00:00.000Z"),
+    }).returning();
+    await db.insert(issueDocuments).values({
+      companyId: company.id,
+      issueId: sourceIssue!.id,
+      documentId: document!.id,
+      key: "summary",
+      updatedAt: new Date("2026-01-01T10:00:00.000Z"),
+    });
+    await db.insert(issueWorkProducts).values({
+      companyId: company.id,
+      issueId: sourceIssue!.id,
+      type: "report",
+      provider: "test",
+      title: "Report",
+      status: "ready",
+      reviewState: "none",
+      updatedAt: new Date("2026-01-03T12:00:00.000Z"),
+    });
+    const [asset] = await db.insert(assets).values({
+      companyId: company.id,
+      provider: "local_disk",
+      objectKey: `test/${randomUUID()}`,
+      contentType: "text/plain",
+      byteSize: 12,
+      sha256: "abc123",
+      originalFilename: "output.txt",
+      updatedAt: new Date("2026-01-02T11:00:00.000Z"),
+    }).returning();
+    await db.insert(issueAttachments).values({
+      companyId: company.id,
+      issueId: sourceIssue!.id,
+      assetId: asset!.id,
+      updatedAt: new Date("2026-01-02T11:00:00.000Z"),
+    });
+    await db.insert(pipelineCaseIssueLinks).values({
+      companyId: company.id,
+      caseId: withOutputs.body.case.id,
+      issueId: sourceIssue!.id,
+      role: "work",
+    });
+
+    const [retiredIssue] = await db.insert(issues).values({
+      companyId: company.id,
+      title: "Retired output source",
+      status: "done",
+      priority: "medium",
+    }).returning();
+    const [retiredDocument] = await db.insert(documents).values({
+      companyId: company.id,
+      title: "Retired summary",
+      latestBody: "Old output",
+    }).returning();
+    await db.insert(issueDocuments).values({
+      companyId: company.id,
+      issueId: retiredIssue!.id,
+      documentId: retiredDocument!.id,
+      key: "summary",
+    });
+    await db.insert(pipelineCaseIssueLinks).values({
+      companyId: company.id,
+      caseId: retiredLink.body.case.id,
+      issueId: retiredIssue!.id,
+      role: "work",
+      retiredAt: new Date("2026-01-04T00:00:00.000Z"),
+      retiredReason: "retry",
+    });
+
+    const [otherIssue] = await db.insert(issues).values({
+      companyId: otherCompany.id,
+      title: "Other company source",
+      status: "done",
+      priority: "medium",
+    }).returning();
+    const [otherDocument] = await db.insert(documents).values({
+      companyId: otherCompany.id,
+      title: "Other summary",
+      latestBody: "Should not leak",
+    }).returning();
+    await db.insert(issueDocuments).values({
+      companyId: otherCompany.id,
+      issueId: otherIssue!.id,
+      documentId: otherDocument!.id,
+      key: "summary",
+    });
+    await db.insert(pipelineCaseIssueLinks).values({
+      companyId: company.id,
+      caseId: crossCompany.body.case.id,
+      issueId: otherIssue!.id,
+      role: "work",
+    });
+
+    const listed = await http.get(`/api/pipelines/${pipeline.body.id}/cases`).expect(200);
+    const byKey = new Map(listed.body.map((row: { case: { caseKey: string } }) => [row.case.caseKey, row]));
+
+    expect(byKey.get("with-outputs")?.outputSummary).toEqual({
+      outputCount: 3,
+      latestOutputAt: "2026-01-03T12:00:00.000Z",
+    });
+    expect(byKey.get("without-outputs")?.outputSummary).toEqual({ outputCount: 0, latestOutputAt: null });
+    expect(byKey.get("retired-link")?.outputSummary).toEqual({ outputCount: 0, latestOutputAt: null });
+    expect(byKey.get("cross-company")?.outputSummary).toEqual({ outputCount: 0, latestOutputAt: null });
   });
 
   it("hides retired children from the flat case children route", async () => {

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -278,6 +278,85 @@ describe("task watchdog subtree classifier", () => {
     });
   });
 
+  it("keeps stopped fingerprints stable when only leaf presentation timestamps change", () => {
+    const stopped = classify({
+      issues: [issue({ status: "blocked" })],
+    });
+    expect(stopped.state).toBe("stopped");
+    if (stopped.state !== "stopped") return;
+
+    const reviewed = classify({
+      watchdog: {
+        companyId,
+        issueId: sourceId,
+        lastReviewedFingerprint: stopped.stopFingerprint,
+      },
+      issues: [
+        issue({
+          identifier: "PAP-1-RENAMED",
+          title: "Renamed source",
+          status: "blocked",
+          updatedAt: new Date("2026-07-06T21:13:00.001Z"),
+        }),
+      ],
+    });
+
+    expect(reviewed).toMatchObject({
+      state: "already_reviewed",
+      stopFingerprint: stopped.stopFingerprint,
+    });
+  });
+
+  it("changes stopped fingerprints for real stopped-state changes", () => {
+    const stopped = classify({
+      issues: [issue({ status: "blocked" })],
+    });
+    expect(stopped.state).toBe("stopped");
+    if (stopped.state !== "stopped") return;
+
+    const cases = [
+      {
+        name: "leaf status",
+        input: { issues: [issue({ status: "in_review" })] },
+      },
+      {
+        name: "assignee",
+        input: { issues: [issue({ status: "blocked", assigneeAgentId: "agent-2" })] },
+      },
+      {
+        name: "blocker",
+        input: {
+          issues: [issue({ status: "blocked" })],
+          blockers: [{ companyId, blockerIssueId: "blocker-1", blockedIssueId: sourceId }],
+        },
+      },
+      {
+        name: "pending interaction",
+        input: {
+          issues: [issue({ status: "blocked" })],
+          pendingInteractions: [{ companyId, issueId: sourceId, id: "interaction-1", status: "pending" }],
+        },
+      },
+      {
+        name: "pending approval",
+        input: {
+          issues: [issue({ status: "blocked" })],
+          pendingApprovals: [{ companyId, issueId: sourceId, id: "approval-1", status: "pending" }],
+        },
+      },
+    ] satisfies Array<{
+      name: string;
+      input: Partial<Parameters<typeof classifyTaskWatchdogSubtree>[0]>;
+    }>;
+
+    for (const testCase of cases) {
+      const changed = classify(testCase.input);
+      expect(changed.state, testCase.name).toBe("stopped");
+      if (changed.state !== "stopped") continue;
+      expect(changed.stopFingerprint, testCase.name).not.toBe(stopped.stopFingerprint);
+    }
+  });
+
   it("excludes task-watchdog issues and their descendants from watched subtree scans", () => {
     const result = classify({
       issues: [

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -155,12 +155,12 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     return row;
   }
 
-  function createService() {
+  function createService(wakeupRunId?: string) {
     const wakes: Array<{ agentId: string; opts: Record<string, unknown> | undefined }> = [];
     const service = taskWatchdogService(db, {
       enqueueWakeup: async (agentId, opts) => {
         wakes.push({ agentId, opts });
-        return { id: randomUUID() };
+        return { id: wakeupRunId ?? randomUUID() };
       },
     });
     return { service, wakes };
@@ -798,5 +798,40 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     });
 
     expect(result).toMatchObject({ checked: 0, triggered: 0 });
+  });
+
+  it("persists task-watchdog scope and capabilities on the returned heartbeat run", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-RUN", status: "done" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const runId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "queued",
+      contextSnapshot: { existingContext: "preserved" },
+    });
+    const { service } = createService(runId);
+
+    await service.reconcileTaskWatchdogs({ companyId });
+
+    const [run] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(run?.contextSnapshot).toMatchObject({
+      existingContext: "preserved",
+      wakeReason: "task_watchdog_stopped_subtree",
+      taskWatchdog: {
+        watchedIssueId: sourceId,
+        capabilities: {
+          operations: expect.arrayContaining([
+            "resolve_eligible_request_confirmation_plan_interactions",
+          ]),
+        },
+      },
+    });
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4126,6 +4126,13 @@ export function issueRoutes(
     const runId = requireAgentRunId(req, res);
     if (!actorAgentId || !runId) return false;
     if (watchdogPreflight === "watchdog") {
+      const payload = interaction.payload && typeof interaction.payload === "object"
+        ? interaction.payload as { toolAction?: unknown }
+        : null;
+      if (payload?.toolAction !== undefined) {
+        res.status(403).json({ error: "Tool-action confirmations are always board-only" });
+        return false;
+      }
       const target = interaction.kind === "request_confirmation"
         ? readAcceptedPlanConfirmationTarget(interaction.payload)
         : null;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4784,6 +4784,18 @@ export function issueRoutes(
       });
       return "handled";
     }
+    // Keep the watchdog grant self-contained: callers must not be able to
+    // bypass explicit restore intent if this helper is reused or reordered.
+    if (req.body.resume !== true) {
+      res.status(409).json({
+        error: "Cancelled issues require explicit resume intent before task-watchdog restoration",
+        details: {
+          issueId: issue.id,
+          securityPrinciples: ["Least Privilege", "Secure Defaults", "Complete Mediation"],
+        },
+      });
+      return "handled";
+    }
 
     const scopeResult = await taskWatchdogScopeAllowsIssueMutation(db, scope, issue, { allowWatchdogIssue: false });
     if (scopeResult.kind === "invalid") {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4040,11 +4040,74 @@ export function issueRoutes(
     return true;
   }
 
+  type TaskWatchdogInteractionPreflight = "not_watchdog" | "watchdog";
+  type IssueThreadInteractionResolutionAccess = "default" | "task_watchdog";
+
+  async function assertTaskWatchdogInteractionResolutionPreflight(
+    req: Request,
+    res: Response,
+    issue: Parameters<typeof assertAgentIssueMutationAllowed>[2],
+    resolutionAction: "accept" | "reject" | "respond" | "verdicts",
+  ): Promise<TaskWatchdogInteractionPreflight | false> {
+    if (req.actor.type !== "agent") return "not_watchdog";
+    const watchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    if (watchdogScope.kind === "none") return "not_watchdog";
+    if (watchdogScope.kind === "invalid") {
+      res.status(403).json({
+        error: watchdogScope.detail,
+        details: {
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return false;
+    }
+    if (!watchdogScope.capabilities.resolveEligibleRequestConfirmationPlanInteractions) {
+      res.status(403).json({
+        error: "Task-watchdog run is not allowed to resolve eligible request_confirmation plan interactions.",
+        details: {
+          action: resolutionAction,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return false;
+    }
+    const scopeResult = await taskWatchdogScopeAllowsIssueMutation(
+      db,
+      watchdogScope,
+      issue,
+      { allowWatchdogIssue: false },
+    );
+    if (scopeResult.kind === "invalid") {
+      res.status(403).json({
+        error: scopeResult.detail,
+        details: {
+          issueId: issue.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return false;
+    }
+    if (!(await assertFreshTaskWatchdogSourceMutation(res, watchdogScope, issue))) return false;
+    if (resolutionAction !== "accept") {
+      res.status(403).json({
+        error: "Task-watchdog runs can only accept eligible request_confirmation plan interactions.",
+        details: {
+          action: resolutionAction,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return false;
+    }
+    return "watchdog";
+  }
+
   async function assertIssueThreadInteractionResolutionAllowed(
     req: Request,
     res: Response,
     issue: Parameters<typeof assertAgentIssueMutationAllowed>[2],
     interaction: {
+      id: string;
+      status: string;
       createdByAgentId?: string | null;
       sourceRunId?: string | null;
       effectiveResolverPolicy: string;
@@ -4052,18 +4115,46 @@ export function issueRoutes(
       kind: string;
       payload?: unknown;
     },
-  ) {
+    resolutionAction: "accept" | "reject" | "respond" | "verdicts",
+    watchdogPreflight: TaskWatchdogInteractionPreflight,
+  ): Promise<IssueThreadInteractionResolutionAccess | false> {
     if (req.actor.type !== "agent") {
       assertBoard(req);
-      return true;
+      return "default";
     }
     const actorAgentId = req.actor.agentId;
     const runId = requireAgentRunId(req, res);
     if (!actorAgentId || !runId) return false;
-    const watchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
-    if (watchdogScope.kind !== "none") {
-      res.status(403).json({ error: "Task-watchdog runs cannot resolve issue-thread interactions" });
-      return false;
+    if (watchdogPreflight === "watchdog") {
+      const target = interaction.kind === "request_confirmation"
+        ? readAcceptedPlanConfirmationTarget(interaction.payload)
+        : null;
+      const isCurrentPlanTarget = target?.issueId === issue.id
+        && target.key === "plan"
+        && await db
+          .select({ id: issueDocuments.id })
+          .from(issueDocuments)
+          .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+          .where(and(
+            eq(issueDocuments.companyId, issue.companyId),
+            eq(issueDocuments.issueId, issue.id),
+            eq(issueDocuments.key, "plan"),
+            eq(documents.latestRevisionId, target.revisionId),
+          ))
+          .then((rows) => rows.length > 0);
+      if (interaction.status !== "pending" || !isCurrentPlanTarget) {
+        res.status(403).json({
+          error: "Task-watchdog runs can only resolve eligible request_confirmation plan interactions.",
+          details: {
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+          },
+        });
+        return false;
+      }
+      return "task_watchdog";
     }
     if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return false;
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return false;
@@ -4090,7 +4181,7 @@ export function issueRoutes(
       res.status(403).json({ error: "Tool-action confirmations are always board-only" });
       return false;
     }
-    return true;
+    return "default";
   }
 
   async function assertIssueThreadInteractionWithdrawalAllowed(
@@ -4595,6 +4686,11 @@ export function issueRoutes(
       });
       return false;
     }
+    if (issue.status === "cancelled") {
+      const watchdogCancelledRestoreAccess = await resolveTaskWatchdogCancelledRestoreAccess(req, res, issue);
+      if (watchdogCancelledRestoreAccess === "allowed") return true;
+      if (watchdogCancelledRestoreAccess === "handled") return false;
+    }
 
     if (!isExplicitResumeCapableStatus(issue.status)) {
       res.status(409).json({
@@ -4662,6 +4758,38 @@ export function issueRoutes(
       },
     });
     return false;
+  }
+
+  async function resolveTaskWatchdogCancelledRestoreAccess(
+    req: Request,
+    res: Response,
+    issue: { id: string; companyId: string },
+  ): Promise<"allowed" | "not_watchdog" | "handled"> {
+    if (req.actor.type !== "agent") return "not_watchdog";
+    const scope = await resolveTaskWatchdogMutationScope(db, req.actor);
+    if (scope.kind === "none") return "not_watchdog";
+    if (scope.kind === "invalid") {
+      res.status(403).json({
+        error: scope.detail,
+        details: {
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return "handled";
+    }
+
+    const scopeResult = await taskWatchdogScopeAllowsIssueMutation(db, scope, issue, { allowWatchdogIssue: false });
+    if (scopeResult.kind === "invalid") {
+      res.status(403).json({
+        error: scopeResult.detail,
+        details: {
+          issueId: issue.id,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return "handled";
+    }
+    return await assertFreshTaskWatchdogSourceMutation(res, scope, issue) ? "allowed" : "handled";
   }
 
   async function assertRecoveryActionAuthority(
@@ -10115,16 +10243,28 @@ export function issueRoutes(
       const interactionId = req.params.interactionId as string;
       const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
       if (!issue) return;
-      if (await rejectTaskWatchdogInteractionMutation(req, res, issue)) return;
+      const watchdogPreflight = await assertTaskWatchdogInteractionResolutionPreflight(req, res, issue, "accept");
+      if (!watchdogPreflight) return;
       const interactionSvc = issueThreadInteractionService(db);
       const current = await interactionSvc.getForIssue(issue, interactionId);
-      if (!(await assertIssueThreadInteractionResolutionAllowed(req, res, issue, current))) return;
+      const resolutionAccess = await assertIssueThreadInteractionResolutionAllowed(
+        req,
+        res,
+        issue,
+        current,
+        "accept",
+        watchdogPreflight,
+      );
+      if (!resolutionAccess) return;
 
       const actor = getActorInfo(req);
       const { interaction, createdIssues, continuationIssue } = await interactionSvc.acceptInteraction(issue, interactionId, req.body, {
         agentId: actor.agentId,
         runId: actor.runId,
         userId: actor.actorType === "user" ? actor.actorId : null,
+        resolutionGrant: resolutionAccess === "task_watchdog"
+          ? "task_watchdog_plan_confirmation"
+          : undefined,
       });
       const toolAction = interaction.payload && typeof interaction.payload === "object"
         ? (interaction.payload as { toolAction?: { actionRequestId?: unknown } }).toolAction
@@ -10267,10 +10407,18 @@ export function issueRoutes(
       const interactionId = req.params.interactionId as string;
       const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
       if (!issue) return;
-      if (await rejectTaskWatchdogInteractionMutation(req, res, issue)) return;
+      const watchdogPreflight = await assertTaskWatchdogInteractionResolutionPreflight(req, res, issue, "reject");
+      if (!watchdogPreflight) return;
       const interactionSvc = issueThreadInteractionService(db);
       const current = await interactionSvc.getForIssue(issue, interactionId);
-      if (!(await assertIssueThreadInteractionResolutionAllowed(req, res, issue, current))) return;
+      if (!(await assertIssueThreadInteractionResolutionAllowed(
+        req,
+        res,
+        issue,
+        current,
+        "reject",
+        watchdogPreflight,
+      ))) return;
 
       const actor = getActorInfo(req);
       const interaction = await interactionSvc.rejectInteraction(issue, interactionId, req.body, {
@@ -10328,10 +10476,18 @@ export function issueRoutes(
       const interactionId = req.params.interactionId as string;
       const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
       if (!issue) return;
-      if (await rejectTaskWatchdogInteractionMutation(req, res, issue)) return;
+      const watchdogPreflight = await assertTaskWatchdogInteractionResolutionPreflight(req, res, issue, "respond");
+      if (!watchdogPreflight) return;
       const interactionSvc = issueThreadInteractionService(db);
       const current = await interactionSvc.getForIssue(issue, interactionId);
-      if (!(await assertIssueThreadInteractionResolutionAllowed(req, res, issue, current))) return;
+      if (!(await assertIssueThreadInteractionResolutionAllowed(
+        req,
+        res,
+        issue,
+        current,
+        "respond",
+        watchdogPreflight,
+      ))) return;
 
       const actor = getActorInfo(req);
       const interaction = await interactionSvc.answerQuestions(issue, interactionId, req.body, {
@@ -10385,10 +10541,18 @@ export function issueRoutes(
       const interactionId = req.params.interactionId as string;
       const issue = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
       if (!issue) return;
-      if (await rejectTaskWatchdogInteractionMutation(req, res, issue)) return;
+      const watchdogPreflight = await assertTaskWatchdogInteractionResolutionPreflight(req, res, issue, "verdicts");
+      if (!watchdogPreflight) return;
       const interactionSvc = issueThreadInteractionService(db);
       const current = await interactionSvc.getForIssue(issue, interactionId);
-      if (!(await assertIssueThreadInteractionResolutionAllowed(req, res, issue, current))) return;
+      if (!(await assertIssueThreadInteractionResolutionAllowed(
+        req,
+        res,
+        issue,
+        current,
+        "verdicts",
+        watchdogPreflight,
+      ))) return;
 
       const actor = getActorInfo(req);
       const { interaction, newlyResolvedItemIds } = await interactionSvc.submitItemVerdicts(

--- a/server/src/routes/pipelines.ts
+++ b/server/src/routes/pipelines.ts
@@ -1540,9 +1540,10 @@ export function pipelineRoutes(db: Db, options: Parameters<typeof pipelineServic
       ))
       .orderBy(asc(pipelineCases.createdAt));
     const caseIds = rows.map((row) => row.case.id);
-    const [activeWork, descendantActiveWorkCounts] = await Promise.all([
+    const [activeWork, descendantActiveWorkCounts, outputSummaries] = await Promise.all([
       loadActiveWorkForCases(db, companyId, caseIds),
       loadDescendantActiveWorkCountsForCases(db, companyId, caseIds),
+      outputsSvc.loadBoardOutputSummaries(companyId, caseIds),
     ]);
     res.json(rows.map((row) => ({
       case: row.case,
@@ -1555,6 +1556,7 @@ export function pipelineRoutes(db: Db, options: Parameters<typeof pipelineServic
         : null,
       activeWork: activeWork.get(row.case.id) ?? null,
       descendantActiveWorkCount: descendantActiveWorkCounts.get(row.case.id) ?? 0,
+      outputSummary: outputSummaries.get(row.case.id) ?? { outputCount: 0, latestOutputAt: null },
     })));
   });
 

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -64,6 +64,7 @@ type InteractionActor = {
   agentId?: string | null;
   runId?: string | null;
   userId?: string | null;
+  resolutionGrant?: "task_watchdog_plan_confirmation";
 };
 
 const ISSUE_THREAD_INTERACTION_IDEMPOTENCY_CONSTRAINT =
@@ -112,7 +113,10 @@ export function resolveInteractionPolicy(args: {
 function assertAgentResolutionAllowed(current: IssueThreadInteractionRow, actor: InteractionActor) {
   if (!actor.agentId) return;
   if (!actor.runId) throw forbidden("Agent run id required to resolve an issue-thread interaction");
-  if (current.effectiveResolverPolicy !== "board_or_agents") {
+  if (
+    current.effectiveResolverPolicy !== "board_or_agents"
+    && actor.resolutionGrant !== "task_watchdog_plan_confirmation"
+  ) {
     throw forbidden("This issue-thread interaction is board-only");
   }
   if (current.addresseeAgentId && current.addresseeAgentId !== actor.agentId) {

--- a/server/src/services/pipeline-case-outputs.ts
+++ b/server/src/services/pipeline-case-outputs.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull, ne, notInArray } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, ne, notInArray, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import {
@@ -19,6 +19,7 @@ import {
   type PipelineCaseOutputItem,
   type PipelineCaseOutputContextSummary,
   type PipelineCaseOutputContextSummaryItem,
+  type PipelineCaseBoardOutputSummary,
   type PipelineCaseOutputSource,
   type PipelineCaseOutputSourceRole,
   type PipelineCaseOutputsResponse,
@@ -265,6 +266,110 @@ function sourceFromRow(row: SourceRow): PipelineCaseOutputSource {
 
 export function pipelineCaseOutputsService(db: Db) {
   return {
+    loadBoardOutputSummaries: async (
+      companyId: string,
+      caseIds: string[],
+    ): Promise<Map<string, PipelineCaseBoardOutputSummary>> => {
+      const uniqueCaseIds = [...new Set(caseIds)];
+      if (uniqueCaseIds.length === 0) return new Map();
+      const summaries = new Map<string, PipelineCaseBoardOutputSummary>();
+
+      const applyRows = (rows: Array<{ caseId: string; outputCount: number | string | null; latestOutputAt: Date | string | null }>) => {
+        for (const row of rows) {
+          const current = summaries.get(row.caseId) ?? { outputCount: 0, latestOutputAt: null };
+          current.outputCount += Number(row.outputCount ?? 0);
+          if (row.latestOutputAt) {
+            const latestOutputAt = row.latestOutputAt instanceof Date
+              ? row.latestOutputAt.toISOString()
+              : new Date(row.latestOutputAt).toISOString();
+            const nextTime = Date.parse(latestOutputAt);
+            const currentTime = current.latestOutputAt ? Date.parse(current.latestOutputAt) : Number.NEGATIVE_INFINITY;
+            if (Number.isFinite(nextTime) && nextTime > currentTime) {
+              current.latestOutputAt = latestOutputAt;
+            }
+          }
+          summaries.set(row.caseId, current);
+        }
+      };
+
+      const sourceFilter = and(
+        eq(pipelineCaseIssueLinks.companyId, companyId),
+        inArray(pipelineCaseIssueLinks.caseId, uniqueCaseIds),
+        isNull(pipelineCaseIssueLinks.retiredAt),
+        eq(issues.companyId, companyId),
+        isNull(issues.hiddenAt),
+        isNull(issues.cancelledAt),
+        ne(issues.status, "cancelled"),
+      );
+
+      const [documentRows, workProductRows, attachmentRows] = await Promise.all([
+        db
+          .select({
+            caseId: pipelineCaseIssueLinks.caseId,
+            outputCount: sql<number>`count(${documents.id})::int`,
+            latestOutputAt: sql<Date | null>`max(${documents.updatedAt})`,
+          })
+          .from(pipelineCaseIssueLinks)
+          .innerJoin(issues, eq(pipelineCaseIssueLinks.issueId, issues.id))
+          .innerJoin(issueDocuments, and(
+            eq(issueDocuments.companyId, companyId),
+            eq(issueDocuments.issueId, issues.id),
+          ))
+          .innerJoin(documents, and(
+            eq(issueDocuments.documentId, documents.id),
+            eq(documents.companyId, companyId),
+          ))
+          .where(and(
+            sourceFilter,
+            notInArray(issueDocuments.key, [...SYSTEM_ISSUE_DOCUMENT_KEYS]),
+          ))
+          .groupBy(pipelineCaseIssueLinks.caseId),
+        db
+          .select({
+            caseId: pipelineCaseIssueLinks.caseId,
+            outputCount: sql<number>`count(${issueWorkProducts.id})::int`,
+            latestOutputAt: sql<Date | null>`max(${issueWorkProducts.updatedAt})`,
+          })
+          .from(pipelineCaseIssueLinks)
+          .innerJoin(issues, eq(pipelineCaseIssueLinks.issueId, issues.id))
+          .innerJoin(issueWorkProducts, and(
+            eq(issueWorkProducts.companyId, companyId),
+            eq(issueWorkProducts.issueId, issues.id),
+          ))
+          .where(sourceFilter)
+          .groupBy(pipelineCaseIssueLinks.caseId),
+        db
+          .select({
+            caseId: pipelineCaseIssueLinks.caseId,
+            outputCount: sql<number>`count(${issueAttachments.id})::int`,
+            latestOutputAt: sql<Date | null>`max(${issueAttachments.updatedAt})`,
+          })
+          .from(pipelineCaseIssueLinks)
+          .innerJoin(issues, eq(pipelineCaseIssueLinks.issueId, issues.id))
+          .innerJoin(issueAttachments, and(
+            eq(issueAttachments.companyId, companyId),
+            eq(issueAttachments.issueId, issues.id),
+          ))
+          .innerJoin(assets, and(
+            eq(assets.id, issueAttachments.assetId),
+            eq(assets.companyId, companyId),
+          ))
+          .where(sourceFilter)
+          .groupBy(pipelineCaseIssueLinks.caseId),
+      ]);
+
+      applyRows(documentRows);
+      applyRows(workProductRows);
+      applyRows(attachmentRows);
+
+      return new Map(
+        uniqueCaseIds.map((caseId) => {
+          const summary = summaries.get(caseId) ?? { outputCount: 0, latestOutputAt: null };
+          return [caseId, summary];
+        }),
+      );
+    },
+
     listCaseOutputs: async (companyId: string, caseId: string): Promise<PipelineCaseOutputsResponse> => {
       const [caseRow, company] = await Promise.all([
         db

--- a/server/src/services/task-watchdog-scope.ts
+++ b/server/src/services/task-watchdog-scope.ts
@@ -28,6 +28,9 @@ export type TaskWatchdogMutationScope =
       watchedIssueId: string;
       watchdogIssueId: string | null;
       stopFingerprint: string | null;
+      capabilities: {
+        resolveEligibleRequestConfirmationPlanInteractions: boolean;
+      };
     };
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -42,9 +45,16 @@ function readTaskWatchdogContext(contextSnapshot: unknown) {
   const context = isPlainRecord(contextSnapshot) ? contextSnapshot : null;
   const taskWatchdog = isPlainRecord(context?.taskWatchdog) ? context.taskWatchdog : null;
   if (!taskWatchdog && context?.taskWatchdog !== true) return null;
+  const capabilities = isPlainRecord(taskWatchdog?.capabilities) ? taskWatchdog.capabilities : null;
+  const operations = Array.isArray(capabilities?.operations) ? capabilities.operations : [];
   return {
     watchedIssueId: readString(taskWatchdog?.watchedIssueId) ?? readString(context?.watchedIssueId),
     stopFingerprint: readString(taskWatchdog?.stopFingerprint) ?? readString(context?.stopFingerprint),
+    capabilities: {
+      resolveEligibleRequestConfirmationPlanInteractions: operations.includes(
+        "resolve_eligible_request_confirmation_plan_interactions",
+      ),
+    },
   };
 }
 
@@ -118,6 +128,7 @@ export async function resolveTaskWatchdogMutationScope(
     watchedIssueId: watchdog.issueId,
     watchdogIssueId: watchdog.watchdogIssueId ?? null,
     stopFingerprint: taskWatchdog.stopFingerprint,
+    capabilities: taskWatchdog.capabilities,
   };
 }
 

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -74,6 +74,11 @@ export type TaskWatchdogClassifierIssue = Pick<
   latestCommentAt?: Date | string | null;
   latestDocumentAt?: Date | string | null;
   latestWorkProductAt?: Date | string | null;
+  monitorNextCheckAt?: Date | string | null;
+  monitorLastTriggeredAt?: Date | string | null;
+  monitorAttemptCount?: number | null;
+  monitorNotes?: string | null;
+  monitorScheduledBy?: string | null;
 };
 
 export type TaskWatchdogClassifierPath = {
@@ -118,6 +123,11 @@ export type TaskWatchdogStoppedLeaf = {
   latestCommentAt: string | null;
   latestDocumentAt: string | null;
   latestWorkProductAt: string | null;
+  monitorNextCheckAt: string | null;
+  monitorLastTriggeredAt: string | null;
+  monitorAttemptCount: number | null;
+  monitorNotes: string | null;
+  monitorScheduledBy: string | null;
 };
 
 export type TaskWatchdogMaterialLeaf = Pick<
@@ -502,6 +512,11 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
       latestCommentAt: optionalIso(issue.latestCommentAt),
       latestDocumentAt: optionalIso(issue.latestDocumentAt),
       latestWorkProductAt: optionalIso(issue.latestWorkProductAt),
+      monitorNextCheckAt: optionalIso(issue.monitorNextCheckAt),
+      monitorLastTriggeredAt: optionalIso(issue.monitorLastTriggeredAt),
+      monitorAttemptCount: typeof issue.monitorAttemptCount === "number" ? issue.monitorAttemptCount : null,
+      monitorNotes: issue.monitorNotes ?? null,
+      monitorScheduledBy: issue.monitorScheduledBy ?? null,
     }));
   const materialLeaves = leaves.map(materialLeaf);
   const stopFingerprint = stableStopFingerprint({
@@ -875,6 +890,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           origin_kind,
           updated_at,
           created_at,
+          monitor_next_check_at,
+          monitor_last_triggered_at,
+          monitor_attempt_count,
+          monitor_notes,
+          monitor_scheduled_by,
           0 AS depth
         FROM issues
         WHERE company_id = ${companyId}
@@ -894,6 +914,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           child.origin_kind,
           child.updated_at,
           child.created_at,
+          child.monitor_next_check_at,
+          child.monitor_last_triggered_at,
+          child.monitor_attempt_count,
+          child.monitor_notes,
+          child.monitor_scheduled_by,
           watched_issues.depth + 1
         FROM issues child
         JOIN watched_issues ON child.parent_id = watched_issues.id
@@ -914,7 +939,12 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         assignee_user_id AS "assigneeUserId",
         origin_kind AS "originKind",
         updated_at AS "updatedAt",
-        created_at AS "createdAt"
+        created_at AS "createdAt",
+        monitor_next_check_at AS "monitorNextCheckAt",
+        monitor_last_triggered_at AS "monitorLastTriggeredAt",
+        monitor_attempt_count AS "monitorAttemptCount",
+        monitor_notes AS "monitorNotes",
+        monitor_scheduled_by AS "monitorScheduledBy"
       FROM watched_issues
     `);
 
@@ -1558,6 +1588,19 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         requestedByActorId: null,
       })
       : null;
+    if (wake?.id) {
+      await db
+        .update(heartbeatRuns)
+        .set({
+          contextSnapshot: sql`coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb) || ${JSON.stringify(context)}::jsonb`,
+          updatedAt: new Date(),
+        })
+        .where(and(
+          eq(heartbeatRuns.id, wake.id),
+          eq(heartbeatRuns.companyId, watchdog.companyId),
+          eq(heartbeatRuns.agentId, watchdog.watchdogAgentId),
+        ));
+    }
 
     return {
       state: "triggered" as const,

--- a/tests/e2e/pipelines-tutorial-flow.spec.ts
+++ b/tests/e2e/pipelines-tutorial-flow.spec.ts
@@ -538,11 +538,17 @@ test.describe("Pipelines tutorial UI flow", () => {
     await expect(page.getByRole("button", { name: "Submit 3 items" })).toBeEnabled();
     await page.getByRole("button", { name: "Submit 3 items" }).click();
 
+    const defaultAssetsColumn = page.getByLabel("Assets column");
+    await expect(defaultAssetsColumn.getByText("Launch blog post")).toBeVisible();
+    await expect(defaultAssetsColumn.getByText("Changelog entry")).toBeVisible();
+    await expect(defaultAssetsColumn.getByText("Launch tweet")).toBeVisible();
+    await expectProsumerVocabulary(page);
+
+    await page.getByRole("link", { name: "Configured stages" }).click();
     const draftingColumn = page.getByLabel("Drafting column");
     await expect(draftingColumn.getByText("Launch blog post")).toBeVisible();
     await expect(draftingColumn.getByText("Changelog entry")).toBeVisible();
     await expect(draftingColumn.getByText("Launch tweet")).toBeVisible();
-    await expectProsumerVocabulary(page);
 
     const items = await listItems(board, pipeline.id);
     const blog = items.find((row) => row.case.title === "Launch blog post")?.case;

--- a/ui/src/api/pipelines.ts
+++ b/ui/src/api/pipelines.ts
@@ -3,6 +3,7 @@ import type {
   PipelineAutomationRetryCleanupOptions,
   PipelineAutomationRetryPlan,
   PipelineAutomationRetryScope,
+  PipelineCaseBoardOutputSummary,
   PipelineCaseConversationSource,
   PipelineCaseDocumentPayload,
   PipelineCaseDocumentRevision,
@@ -441,6 +442,7 @@ export interface PipelineCaseChildRow {
   parentCase?: PipelineCaseParentSummary | null;
   activeWork?: PipelineCaseActiveWork | null;
   descendantActiveWorkCount?: number;
+  outputSummary?: PipelineCaseBoardOutputSummary;
 }
 
 export type PipelineCaseChildrenResponse = PipelineCaseChildRow[];

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -163,6 +163,17 @@
   --status-task-done: #22c55e;
   --status-task-blocked: #dc2626;
   --status-task-cancelled: #a8aeb2;
+  --pipeline-state-active: #10b981;
+  --pipeline-state-ready: var(--status-task-in_progress);
+  --pipeline-state-review: var(--status-task-in_review);
+  --pipeline-state-waiting: var(--status-task-todo);
+  --pipeline-state-attention: var(--status-task-blocked);
+  --pipeline-state-done: var(--status-task-done);
+  --pipeline-state-muted: var(--status-task-backlog);
+  --pipeline-state-neutral: var(--status-task-backlog);
+  --pipeline-drop-blocked-surface: color-mix(in srgb, var(--status-task-blocked) 8%, var(--background));
+  --pipeline-drop-blocked-border: color-mix(in srgb, var(--status-task-blocked) 24%, var(--border));
+  --pipeline-drop-blocked-foreground: color-mix(in srgb, var(--status-task-blocked) 82%, var(--foreground));
 
   /* Task status ICON hues (PAP-238 3b) — AA-tuned (every glyph ≥ 3:1 against
      its surface, WCAG 2.1 AA, both modes). Distinct from the
@@ -1856,6 +1867,21 @@ span.paperclip-mention-chip[data-mention-kind="external-object"] {
 }
 .status-fill {
   background-color: var(--sc);
+}
+
+.pipeline-state-chip--active { --sc: var(--pipeline-state-active); }
+.pipeline-state-chip--ready { --sc: var(--pipeline-state-ready); }
+.pipeline-state-chip--review { --sc: var(--pipeline-state-review); }
+.pipeline-state-chip--waiting { --sc: var(--pipeline-state-waiting); }
+.pipeline-state-chip--attention { --sc: var(--pipeline-state-attention); }
+.pipeline-state-chip--done { --sc: var(--pipeline-state-done); }
+.pipeline-state-chip--muted { --sc: var(--pipeline-state-muted); }
+.pipeline-state-chip--neutral { --sc: var(--pipeline-state-neutral); }
+.pipeline-drop-blocked-target { background-color: var(--pipeline-drop-blocked-surface); }
+.pipeline-drop-blocked-notice {
+  background-color: var(--pipeline-drop-blocked-surface);
+  border-color: var(--pipeline-drop-blocked-border);
+  color: var(--pipeline-drop-blocked-foreground);
 }
 
 /* ── Extracted verbatim tokens (Phase 2, design/token-extraction) ── */

--- a/ui/src/lib/pipeline-stage-presentation.ts
+++ b/ui/src/lib/pipeline-stage-presentation.ts
@@ -1,3 +1,6 @@
+import type { PipelineCaseBoardOutputSummary } from "@paperclipai/shared";
+import type { PipelineStage } from "../api/pipelines";
+
 const defaultPipelineStageColumnTone = {
   outer: "border-border bg-background",
   header: "border-border text-muted-foreground",
@@ -43,4 +46,331 @@ export function getPipelineStageColumnTone(kind: string | null | undefined) {
 
 export function pipelineStageAutomationSettingsHref(pipelineId: string, stageId: string) {
   return `/pipelines/${pipelineId}/settings?stage=${stageId}&section=instructions`;
+}
+
+export type StagePresentationRole = "lane" | "action" | "review" | "terminal";
+
+export type PipelineBoardStateChipTone =
+  | "neutral"
+  | "active"
+  | "ready"
+  | "review"
+  | "waiting"
+  | "attention"
+  | "done"
+  | "muted";
+
+export interface PipelineBoardStateChip {
+  key:
+    | "pending"
+    | "running"
+    | "output_ready"
+    | "needs_review"
+    | "waiting_on_children"
+    | "attention"
+    | "done"
+    | "cancelled";
+  label: string;
+  tone: PipelineBoardStateChipTone;
+}
+
+export type PipelineBoardTransitionEdge = { fromStageId: string; toStageId: string; label?: string | null };
+
+export type PipelineBoardPresentationCase = {
+  id: string;
+  pipelineId?: string;
+  title?: string;
+  stageId: string | null;
+  terminalKind?: string | null;
+  activeWork?: unknown;
+  childCount?: number;
+  terminalChildCount?: number;
+  descendantActiveWorkCount?: number | null;
+  outputSummary?: PipelineCaseBoardOutputSummary;
+  fields?: Record<string, unknown> | null;
+};
+
+export interface PipelineBoardPresentation {
+  columns: PipelineStage[];
+  byStage: Map<string, PipelineBoardPresentationCase[]>;
+  caseToColumn: Map<string, string>;
+  caseById: Map<string, PipelineBoardPresentationCase>;
+  attentionCaseIds: Set<string>;
+  terminalRails: Array<{ key: "done" | "cancelled"; label: string; cases: PipelineBoardPresentationCase[] }>;
+}
+
+function normalized(value: string | null | undefined) {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function configRecord(stage: Pick<PipelineStage, "config">) {
+  return stage.config && typeof stage.config === "object" && !Array.isArray(stage.config)
+    ? stage.config
+    : {};
+}
+
+export function pipelineStageHasRunRoutine(stage: Pick<PipelineStage, "config">) {
+  const onEnter = configRecord(stage).onEnter;
+  return Boolean(
+    onEnter &&
+      typeof onEnter === "object" &&
+      !Array.isArray(onEnter) &&
+      (onEnter as Record<string, unknown>).type === "run_routine",
+  );
+}
+
+export function pipelineStageHasBreakdown(stage: Pick<PipelineStage, "config">) {
+  const breakdown = configRecord(stage).breakdown;
+  return Boolean(breakdown && typeof breakdown === "object" && !Array.isArray(breakdown));
+}
+
+export function isPipelineStageDisabled(stage: Pick<PipelineStage, "config">) {
+  const config = configRecord(stage);
+  return config.enabled === false || config.disabled === true;
+}
+
+export function deriveStagePresentationRole(stage: Pick<PipelineStage, "kind" | "config">): StagePresentationRole {
+  const kind = normalized(stage.kind);
+  if (kind === "done" || kind === "cancelled") return "terminal";
+  if (kind === "review") return "review";
+  if (kind === "working" && (pipelineStageHasRunRoutine(stage) || pipelineStageHasBreakdown(stage))) return "action";
+  return "lane";
+}
+
+export function isSimplifiedBoardVisibleStage(stage: PipelineStage) {
+  const role = deriveStagePresentationRole(stage);
+  return role === "lane" || role === "review";
+}
+
+function stageByKey(stages: PipelineStage[]) {
+  const byKey = new Map<string, PipelineStage>();
+  for (const stage of stages) byKey.set(stage.key, stage);
+  return byKey;
+}
+
+function isNonActionVisibleStage(stage: PipelineStage | undefined) {
+  return Boolean(stage && isSimplifiedBoardVisibleStage(stage) && !isPipelineStageDisabled(stage));
+}
+
+export function resolveDisplayStageForActionStage(
+  actionStage: PipelineStage,
+  orderedStages: PipelineStage[],
+  transitions: PipelineBoardTransitionEdge[],
+) {
+  const byKey = stageByKey(orderedStages);
+  const config = configRecord(actionStage);
+  const breakdown = config.breakdown && typeof config.breakdown === "object" && !Array.isArray(config.breakdown)
+    ? config.breakdown as Record<string, unknown>
+    : null;
+  const advanceTo = typeof breakdown?.advanceTo === "string" ? byKey.get(breakdown.advanceTo) : undefined;
+  if (isNonActionVisibleStage(advanceTo)) return advanceTo!;
+
+  const byId = new Map(orderedStages.map((stage) => [stage.id, stage]));
+  const outgoingTargets = transitions
+    .filter((transition) => transition.fromStageId === actionStage.id)
+    .map((transition) => byId.get(transition.toStageId))
+    .filter((stage): stage is PipelineStage => isNonActionVisibleStage(stage))
+    .sort((left, right) => left.position - right.position);
+  if (outgoingTargets[0]) return outgoingTargets[0];
+
+  const laterStage = orderedStages.find((stage) =>
+    stage.position > actionStage.position && isNonActionVisibleStage(stage)
+  );
+  return laterStage ?? null;
+}
+
+function terminalRailKey(caseItem: PipelineBoardPresentationCase, stage: PipelineStage | undefined) {
+  const terminalKind = normalized(caseItem.terminalKind);
+  if (terminalKind === "done" || terminalKind === "cancelled") return terminalKind;
+  const stageKind = normalized(stage?.kind);
+  if (stageKind === "done" || stageKind === "cancelled") return stageKind;
+  return null;
+}
+
+export function buildPipelineBoardPresentation(input: {
+  orderedStages: PipelineStage[];
+  cases: PipelineBoardPresentationCase[];
+  transitions: PipelineBoardTransitionEdge[];
+  configuredView: boolean;
+  unassignedStage: PipelineStage;
+}): PipelineBoardPresentation {
+  const { orderedStages, cases, transitions, configuredView, unassignedStage } = input;
+  const byId = new Map(orderedStages.map((stage) => [stage.id, stage]));
+  const visibleStages = configuredView ? orderedStages : orderedStages.filter(isSimplifiedBoardVisibleStage);
+  const byStage = new Map<string, PipelineBoardPresentationCase[]>();
+  const caseToColumn = new Map<string, string>();
+  const caseById = new Map<string, PipelineBoardPresentationCase>();
+  const attentionCaseIds = new Set<string>();
+  const terminalRails = new Map<"done" | "cancelled", PipelineBoardPresentationCase[]>([
+    ["done", []],
+    ["cancelled", []],
+  ]);
+
+  for (const stage of visibleStages) byStage.set(stage.id, []);
+  const unassigned: PipelineBoardPresentationCase[] = [];
+
+  for (const caseItem of cases) {
+    const configuredStage = caseItem.stageId ? byId.get(caseItem.stageId) : undefined;
+    caseById.set(caseItem.id, caseItem);
+
+    if (!configuredView) {
+      const railKey = terminalRailKey(caseItem, configuredStage);
+      if (railKey) {
+        terminalRails.get(railKey)!.push(caseItem);
+        caseToColumn.set(caseItem.id, railKey);
+        continue;
+      }
+    }
+
+    let displayStageId: string | null = configuredStage?.id ?? null;
+    if (!configuredView && configuredStage && deriveStagePresentationRole(configuredStage) === "action") {
+      const displayStage = resolveDisplayStageForActionStage(configuredStage, orderedStages, transitions);
+      displayStageId = displayStage?.id ?? configuredStage.id;
+      if (!displayStage || isPipelineStageDisabled(configuredStage)) {
+        attentionCaseIds.add(caseItem.id);
+      }
+      if (!displayStage && !byStage.has(configuredStage.id)) {
+        byStage.set(configuredStage.id, []);
+        visibleStages.push(configuredStage);
+      }
+    }
+
+    if (!displayStageId || !byStage.has(displayStageId)) {
+      unassigned.push(caseItem);
+      caseToColumn.set(caseItem.id, unassignedStage.id);
+      continue;
+    }
+    byStage.get(displayStageId)!.push(caseItem);
+    caseToColumn.set(caseItem.id, displayStageId);
+  }
+
+  const columns = [...visibleStages];
+  if (unassigned.length > 0) {
+    byStage.set(unassignedStage.id, unassigned);
+    columns.push(unassignedStage);
+  }
+
+  return {
+    columns,
+    byStage,
+    caseToColumn,
+    caseById,
+    attentionCaseIds,
+    terminalRails: [
+      { key: "done", label: "Done", cases: terminalRails.get("done") ?? [] },
+      { key: "cancelled", label: "Cancelled", cases: terminalRails.get("cancelled") ?? [] },
+    ],
+  };
+}
+
+export interface PipelineDetailActionState {
+  visible: boolean;
+  disabled: boolean;
+  reason?: string | null;
+}
+
+export interface PipelineDetailActionInputs {
+  hasStageAutomation: boolean;
+  rerunPending: boolean;
+  rerunBlockedByPermission: boolean;
+  stageKind: string | null | undefined;
+  hasActiveWork: boolean;
+  previousRetryAllowed: boolean;
+  retryPending: boolean;
+  canCancel: boolean;
+  cancelPending: boolean;
+}
+
+export interface PipelineDetailActions {
+  run: PipelineDetailActionState;
+  redo: PipelineDetailActionState;
+  edit: PipelineDetailActionState;
+  cancel: PipelineDetailActionState;
+}
+
+/**
+ * Derives enablement/visibility of the item-detail action strip from the current
+ * stage, terminal/active state, review config, blockers, and retry preflight. Kept
+ * as a pure helper so the guardrail conditions are unit-testable independent of the
+ * detail view JSX. It never widens an affordance: callers still gate the underlying
+ * mutations on the same server preflight (`previousRetryAllowed`, permission preflight,
+ * review availability) that produced these inputs.
+ */
+export function derivePipelineItemDetailActions(input: PipelineDetailActionInputs): PipelineDetailActions {
+  const stageKind = normalized(input.stageKind);
+  return {
+    run: {
+      visible: true,
+      disabled:
+        !input.hasStageAutomation ||
+        input.rerunPending ||
+        input.rerunBlockedByPermission ||
+        stageKind === "review" ||
+        input.hasActiveWork,
+      reason: input.rerunBlockedByPermission ? "Permission still missing — request access first" : null,
+    },
+    redo: {
+      visible: true,
+      disabled: !input.previousRetryAllowed || input.retryPending,
+    },
+    edit: { visible: true, disabled: false },
+    cancel: {
+      visible: true,
+      disabled: !input.canCancel || input.cancelPending,
+    },
+  };
+}
+
+export function getPipelineBoardStateChip(input: {
+  caseItem: PipelineBoardPresentationCase;
+  stage?: Pick<PipelineStage, "kind" | "config"> | null;
+  hiddenActionFallback?: boolean;
+  livenessReason?: string | null;
+}): PipelineBoardStateChip {
+  const { caseItem, stage, hiddenActionFallback = false, livenessReason = null } = input;
+  const terminalKind = normalized(caseItem.terminalKind);
+  const stageKind = normalized(stage?.kind);
+  if (terminalKind === "cancelled" || stageKind === "cancelled") return { key: "cancelled", label: "Cancelled", tone: "muted" };
+  if (terminalKind === "done" || stageKind === "done") return { key: "done", label: "Done", tone: "done" };
+
+  const fields = caseItem.fields ?? {};
+  const blocked = Number(fields.openBlockers ?? 0) > 0;
+  const attentionReasons = new Set(["linked_issue_blocked", "case_blocked", "automation_failed", "permission_preflight_failed", "no_action_path"]);
+  if (hiddenActionFallback || blocked || attentionReasons.has(livenessReason ?? "")) {
+    return { key: "attention", label: "Needs attention", tone: "attention" };
+  }
+
+  if (caseItem.activeWork || livenessReason === "lease_active" || livenessReason === "linked_issue_active") {
+    return { key: "running", label: "Running", tone: "active" };
+  }
+
+  if (stage && deriveStagePresentationRole(stage) === "review") {
+    return { key: "needs_review", label: "Needs review", tone: "review" };
+  }
+
+  const childCount = Math.max(0, Math.floor(caseItem.childCount ?? 0));
+  const terminalChildCount = Math.max(0, Math.floor(caseItem.terminalChildCount ?? 0));
+  const config = stage ? configRecord(stage) : {};
+  const breakdown = config.breakdown && typeof config.breakdown === "object" && !Array.isArray(config.breakdown)
+    ? config.breakdown as Record<string, unknown>
+    : null;
+  const waitsForChildren = config.requireChildrenTerminal === true || breakdown?.waitForPieces === true;
+  if (waitsForChildren && childCount > terminalChildCount) {
+    const remaining = childCount - terminalChildCount;
+    const pieceNoun = typeof breakdown?.pieceNoun === "string" && breakdown.pieceNoun.trim()
+      ? breakdown.pieceNoun.trim()
+      : "child";
+    const plural = pieceNoun === "child" ? "children" : `${pieceNoun}s`;
+    return {
+      key: "waiting_on_children",
+      label: `Waiting on ${remaining} of ${childCount} ${childCount === 1 ? pieceNoun : plural}`,
+      tone: "waiting",
+    };
+  }
+
+  if ((caseItem.outputSummary?.outputCount ?? 0) > 0) {
+    return { key: "output_ready", label: "Output ready", tone: "ready" };
+  }
+
+  return { key: "pending", label: "Pending", tone: "neutral" };
 }

--- a/ui/src/pages/Pipelines.test.tsx
+++ b/ui/src/pages/Pipelines.test.tsx
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { queryKeys } from "../lib/queryKeys";
 import {
+  buildPipelineBoardPresentation,
+  derivePipelineItemDetailActions,
+  deriveStagePresentationRole,
+  getPipelineBoardStateChip,
   getPipelineStageColumnTone,
   pipelineStageAutomationSettingsHref,
+  type PipelineDetailActionInputs,
 } from "../lib/pipeline-stage-presentation";
 import {
   groupCasesByBuiltFor,
   normalizePipelineConversationComments,
+  pipelineBoardStateChipClass,
   pipelineBoardGroupByStorageKey,
   readStoredPipelineBoardGroupBy,
   readPipelineStageAutomationAssigneeAgentId,
@@ -135,6 +141,118 @@ describe("pipeline stage board presentation", () => {
     expect(getPipelineStageColumnTone("done").outer).toContain("green");
     expect(getPipelineStageColumnTone("cancelled").outer).toContain("bg-muted/25");
     expect(getPipelineStageColumnTone("cancelled").outer).toContain("opacity-85");
+  });
+
+  it("collapses action stages into downstream visible lanes on the default board", () => {
+    const stages = [
+      { id: "intake", pipelineId: "pipeline-1", key: "intake", name: "Intake", kind: "working", position: 100, config: {} },
+      { id: "run", pipelineId: "pipeline-1", key: "run", name: "Run automation", kind: "working", position: 200, config: { onEnter: { type: "run_routine" } } },
+      { id: "review", pipelineId: "pipeline-1", key: "review", name: "Review", kind: "review", position: 300, config: {} },
+      { id: "done", pipelineId: "pipeline-1", key: "done", name: "Done", kind: "done", position: 900, config: {} },
+    ];
+
+    expect(deriveStagePresentationRole(stages[1])).toBe("action");
+
+    const board = buildPipelineBoardPresentation({
+      orderedStages: stages,
+      cases: [
+        { id: "case-run", stageId: "run", pipelineId: "pipeline-1", title: "Running action" },
+        { id: "case-done", stageId: "done", pipelineId: "pipeline-1", title: "Finished", terminalKind: "done" },
+      ],
+      transitions: [{ fromStageId: "run", toStageId: "review" }],
+      configuredView: false,
+      unassignedStage: { id: "__unassigned", pipelineId: "pipeline-1", key: "__unassigned", name: "Unassigned", kind: "working", position: 999, config: {} },
+    });
+
+    expect(board.columns.map((stage) => stage.id)).toEqual(["intake", "review"]);
+    expect(board.byStage.get("review")?.map((caseItem) => caseItem.id)).toEqual(["case-run"]);
+    expect(board.terminalRails.find((rail) => rail.key === "done")?.cases.map((caseItem) => caseItem.id)).toEqual(["case-done"]);
+  });
+
+  it("keeps every configured stage visible in configured-stage view", () => {
+    const stages = [
+      { id: "intake", pipelineId: "pipeline-1", key: "intake", name: "Intake", kind: "working", position: 100, config: {} },
+      { id: "run", pipelineId: "pipeline-1", key: "run", name: "Run automation", kind: "working", position: 200, config: { breakdown: { targetPipelineId: "child" } } },
+      { id: "done", pipelineId: "pipeline-1", key: "done", name: "Done", kind: "done", position: 900, config: {} },
+    ];
+
+    const board = buildPipelineBoardPresentation({
+      orderedStages: stages,
+      cases: [{ id: "case-run", stageId: "run", pipelineId: "pipeline-1", title: "Running action" }],
+      transitions: [],
+      configuredView: true,
+      unassignedStage: { id: "__unassigned", pipelineId: "pipeline-1", key: "__unassigned", name: "Unassigned", kind: "working", position: 999, config: {} },
+    });
+
+    expect(board.columns.map((stage) => stage.id)).toEqual(["intake", "run", "done"]);
+    expect(board.byStage.get("run")?.map((caseItem) => caseItem.id)).toEqual(["case-run"]);
+  });
+
+  it("derives the approved single state chip priority", () => {
+    expect(getPipelineBoardStateChip({
+      caseItem: { id: "done", stageId: "done", terminalKind: "done" },
+      stage: { kind: "done", config: {} },
+    })).toMatchObject({ key: "done", label: "Done" });
+    expect(getPipelineBoardStateChip({
+      caseItem: { id: "running", stageId: "work", activeWork: { issueId: "issue-1" } },
+      stage: { kind: "working", config: {} },
+    })).toMatchObject({ key: "running", label: "Running" });
+    expect(getPipelineBoardStateChip({
+      caseItem: { id: "outputs", stageId: "work", outputSummary: { outputCount: 2, latestOutputAt: "2026-06-30T00:00:00.000Z" } },
+      stage: { kind: "working", config: {} },
+    })).toMatchObject({ key: "output_ready", label: "Output ready" });
+    expect(getPipelineBoardStateChip({
+      caseItem: { id: "children", stageId: "work", childCount: 3, terminalChildCount: 1 },
+      stage: { kind: "working", config: { requireChildrenTerminal: true } },
+    })).toMatchObject({ key: "waiting_on_children", label: "Waiting on 2 of 3 children" });
+    expect(getPipelineBoardStateChip({
+      caseItem: { id: "attention", stageId: "work", fields: { openBlockers: 1 } },
+      stage: { kind: "working", config: {} },
+    })).toMatchObject({ key: "attention", label: "Needs attention", tone: "attention" });
+    expect(pipelineBoardStateChipClass("attention")).toContain("red");
+    expect(pipelineBoardStateChipClass("attention")).not.toContain("amber");
+  });
+
+  it("enables the detail action strip per stage, terminal, active-work, and preflight state", () => {
+    const base: PipelineDetailActionInputs = {
+      hasStageAutomation: true,
+      rerunPending: false,
+      rerunBlockedByPermission: false,
+      stageKind: "working",
+      hasActiveWork: false,
+      previousRetryAllowed: true,
+      retryPending: false,
+      canCancel: true,
+      cancelPending: false,
+    };
+
+    // Healthy working stage: overflow Run + Redo plus inline Edit + Cancel are enabled.
+    const healthy = derivePipelineItemDetailActions(base);
+    expect(healthy.run.disabled).toBe(false);
+    expect(healthy.redo.disabled).toBe(false);
+    expect(healthy.edit.disabled).toBe(false);
+    expect(healthy.cancel.disabled).toBe(false);
+
+    // Active work blocks Run; no previous retry plan blocks Redo.
+    const busy = derivePipelineItemDetailActions({ ...base, hasActiveWork: true, previousRetryAllowed: false });
+    expect(busy.run.disabled).toBe(true);
+    expect(busy.redo.disabled).toBe(true);
+
+    // Permission preflight failure disables Run and surfaces the reason.
+    const blocked = derivePipelineItemDetailActions({ ...base, rerunBlockedByPermission: true });
+    expect(blocked.run.disabled).toBe(true);
+    expect(blocked.run.reason).toContain("Permission");
+
+    // Review stage still disables Run in the strip; the Review panel owns decisions.
+    const review = derivePipelineItemDetailActions({
+      ...base,
+      hasStageAutomation: false,
+      stageKind: "review",
+    });
+    expect(review.run.disabled).toBe(true);
+
+    // No cancellable stage disables Cancel.
+    expect(derivePipelineItemDetailActions({ ...base, canCancel: false }).cancel.disabled).toBe(true);
   });
 });
 

--- a/ui/src/pages/Pipelines.test.tsx
+++ b/ui/src/pages/Pipelines.test.tsx
@@ -209,8 +209,7 @@ describe("pipeline stage board presentation", () => {
       caseItem: { id: "attention", stageId: "work", fields: { openBlockers: 1 } },
       stage: { kind: "working", config: {} },
     })).toMatchObject({ key: "attention", label: "Needs attention", tone: "attention" });
-    expect(pipelineBoardStateChipClass("attention")).toContain("red");
-    expect(pipelineBoardStateChipClass("attention")).not.toContain("amber");
+    expect(pipelineBoardStateChipClass("attention")).toBe("pipeline-state-chip--attention");
   });
 
   it("enables the detail action strip per stage, terminal, active-work, and preflight state", () => {

--- a/ui/src/pages/Pipelines.tsx
+++ b/ui/src/pages/Pipelines.tsx
@@ -20,7 +20,7 @@ import type {
   RequestConfirmationInteraction,
   SuggestTasksInteraction,
 } from "@paperclipai/shared";
-import { AlertTriangle, ArrowUpDown, ArrowUpRight, BookOpenText, Check, ChevronDown, ChevronRight, ChevronUp, CircleDot, Download, ExternalLink, FileText, GitBranch, Hexagon, Image as ImageIcon, Info, Layers, List, ListTree, Loader2, MessageSquare, MoreHorizontal, Package, Paperclip, Plus, Search, Settings, Trash2, X } from "lucide-react";
+import { AlertTriangle, ArrowUpDown, ArrowUpRight, BookOpenText, Check, ChevronDown, ChevronRight, ChevronUp, CircleDot, Download, ExternalLink, FileText, GitBranch, Hexagon, Image as ImageIcon, Info, Layers, List, ListTree, Loader2, MessageSquare, MoreHorizontal, Package, Paperclip, Pencil, Plus, Search, Settings, Trash2, X } from "lucide-react";
 import {
   DndContext,
   DragOverlay,
@@ -65,6 +65,7 @@ import {
   type PipelineBatchIngestResult,
   type PipelineCase,
   type PipelineCaseActiveWork,
+  type PipelineCaseChildRow,
   type PipelineCaseDetail,
   type PipelineCaseEvent,
   type PipelineCaseParentSummary,
@@ -113,7 +114,13 @@ import { extractWorkReferences, referenceFieldKeys } from "../lib/pipeline-refer
 import { pieceNounPlural, readStageBreakdown } from "../lib/pipeline-breakdown";
 import { hasBlockingShortcutDialog, isKeyboardShortcutTextInputTarget } from "../lib/keyboardShortcuts";
 import { formatLearningEvent, groupLearningEventsByDay } from "../lib/pipeline-learnings";
-import { getPipelineStageColumnTone, pipelineStageAutomationSettingsHref } from "../lib/pipeline-stage-presentation";
+import {
+  buildPipelineBoardPresentation,
+  derivePipelineItemDetailActions,
+  getPipelineBoardStateChip,
+  getPipelineStageColumnTone,
+  pipelineStageAutomationSettingsHref,
+} from "../lib/pipeline-stage-presentation";
 import { queryKeys } from "../lib/queryKeys";
 import { keepPreviousDataForSameQueryTail } from "../lib/query-placeholder-data";
 import { useProjectOrder } from "../hooks/useProjectOrder";
@@ -1011,6 +1018,9 @@ type BoardCase = PipelineCase & {
   activeWork?: PipelineCaseActiveWork | null;
   descendantActiveWorkCount?: number | null;
   parentCase?: PipelineCaseParentSummary | null;
+  outputSummary?: PipelineCaseChildRow["outputSummary"];
+  boardNeedsAttention?: boolean;
+  boardStage?: PipelineStage | null;
 };
 
 type PipelineTransitionEdge = { fromStageId: string; toStageId: string; label?: string | null };
@@ -1207,6 +1217,47 @@ export function groupCasesByBuiltFor(cases: BoardCase[]) {
   return [...groups.values()];
 }
 
+export function pipelineBoardStateChipClass(tone: ReturnType<typeof getPipelineBoardStateChip>["tone"]) {
+  switch (tone) {
+    case "active":
+      return "border-emerald-400/40 bg-emerald-50 text-emerald-700 dark:border-emerald-300/30 dark:bg-emerald-900/30 dark:text-emerald-300";
+    case "ready":
+      return "border-sky-400/40 bg-sky-50 text-sky-700 dark:border-sky-300/30 dark:bg-sky-900/25 dark:text-sky-300";
+    case "review":
+      return "border-violet-400/40 bg-violet-50 text-violet-700 dark:border-violet-300/30 dark:bg-violet-900/25 dark:text-violet-300";
+    case "waiting":
+      return "border-orange-400/40 bg-orange-50 text-orange-700 dark:border-orange-300/30 dark:bg-orange-900/25 dark:text-orange-300";
+    case "attention":
+      return "border-red-400/40 bg-red-50 text-red-700 dark:border-red-300/30 dark:bg-red-900/25 dark:text-red-300";
+    case "done":
+      return "border-green-400/40 bg-green-50 text-green-700 dark:border-green-300/30 dark:bg-green-900/25 dark:text-green-300";
+    case "muted":
+      return "border-border bg-muted text-muted-foreground";
+    case "neutral":
+    default:
+      return "border-border bg-background text-muted-foreground";
+  }
+}
+
+function PipelineBoardStateChip({ caseItem }: { caseItem: BoardCase }) {
+  const chip = getPipelineBoardStateChip({
+    caseItem,
+    stage: caseItem.boardStage,
+    hiddenActionFallback: caseItem.boardNeedsAttention,
+  });
+  return (
+    <span className={cn(
+      "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
+      pipelineBoardStateChipClass(chip.tone),
+    )}>
+      {chip.key === "running" ? (
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" aria-hidden="true" />
+      ) : null}
+      {chip.label}
+    </span>
+  );
+}
+
 function PipelineCaseCard({
   caseItem,
   isOverlay = false,
@@ -1215,12 +1266,10 @@ function PipelineCaseCard({
   isOverlay?: boolean;
 }) {
   const title = getCaseTitle(caseItem);
-  const isWorking = isWorkingCase(caseItem);
-  const blockerCount = getOpenBlockerCount(caseItem);
-  const hasNeedsAttention = blockerCount > 0;
   const hasChangedNotice = hasThisChanged(caseItem);
   const childrenSummary = getChildrenSummaryCount(caseItem);
   const liveDownstreamCount = descendantActiveWorkCount(caseItem);
+  const outputCount = caseItem.outputSummary?.outputCount ?? 0;
   const {
     attributes,
     listeners,
@@ -1254,17 +1303,7 @@ function PipelineCaseCard({
       >
         <p className="font-medium leading-snug text-foreground">{title}</p>
         <div className="mt-1.5 flex flex-wrap gap-1.5">
-          {isWorking ? (
-            <Badge variant="outline" className="relative border-emerald-400/40 bg-emerald-50 text-(length:--text-nano) text-emerald-700 dark:border-emerald-300/30 dark:bg-emerald-900/30 dark:text-emerald-300">
-              <span className="absolute -left-1 -top-1 h-2 w-2 animate-pulse rounded-full bg-emerald-500"></span>
-              Working
-            </Badge>
-          ) : null}
-          {hasNeedsAttention ? (
-            <Badge variant="outline" className="border-amber-400/40 bg-amber-50 text-(length:--text-nano) text-amber-700 dark:border-amber-300/30 dark:bg-amber-900/25 dark:text-amber-300">
-              Needs attention
-            </Badge>
-          ) : null}
+          <PipelineBoardStateChip caseItem={caseItem} />
           {hasChangedNotice ? (
             <Badge variant="outline" className="border-indigo-400/40 bg-indigo-50 text-(length:--text-nano) text-indigo-700 dark:border-indigo-300/30 dark:bg-indigo-900/25 dark:text-indigo-300">
               This changed
@@ -1280,6 +1319,11 @@ function PipelineCaseCard({
         {childrenSummary != null ? (
           <p className="mt-1.5 text-xs text-muted-foreground">
             Built from {formatNumber(childrenSummary)} {childrenSummary === 1 ? "item" : "items"}
+          </p>
+        ) : null}
+        {outputCount > 0 ? (
+          <p className="mt-1.5 text-xs text-muted-foreground">
+            {formatNumber(outputCount)} output{outputCount === 1 ? "" : "s"}
           </p>
         ) : null}
       </Link>
@@ -1427,6 +1471,7 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
   const { selectedCompanyId } = useCompany();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const location = useLocation();
   const [activeCaseId, setActiveCaseId] = useState<string | null>(null);
   const [activeOverId, setActiveOverId] = useState<string | null>(null);
   const [groupByState, setGroupByState] = useState<{ pipelineId: string; value: PipelineBoardGroupBy }>(() => ({
@@ -1475,12 +1520,17 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
   });
 
   const pipeline = pipelineQuery.data;
+  const configuredView = useMemo(
+    () => new URLSearchParams(location.search).get("view") === "configured",
+    [location.search],
+  );
   const cases = useMemo<BoardCase[]>(
     () => (casesQuery.data ?? []).map((row) => ({
       ...row.case,
       parentCase: row.parentCase ?? null,
       activeWork: row.activeWork ?? null,
       descendantActiveWorkCount: row.descendantActiveWorkCount ?? 0,
+      outputSummary: row.outputSummary,
     })),
     [casesQuery.data],
   );
@@ -1494,42 +1544,39 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
     [healthQuery.data?.warnings],
   );
 
-  const stageIds = useMemo(() => new Set(orderedStages.map((stage) => stage.id)), [orderedStages]);
-
-  const boardColumns = useMemo(() => {
-    const byStage = new Map<string, BoardCase[]>();
-    const caseToColumn = new Map<string, string>();
-    const caseById = new Map<string, BoardCase>();
-
-    for (const stage of orderedStages) {
-      byStage.set(stage.id, []);
-    }
-
-    const unassigned: BoardCase[] = [];
-    for (const caseItem of cases) {
-      const stageId = caseItem.stageId && stageIds.has(caseItem.stageId) ? caseItem.stageId : UNASSIGNED_STAGE_ID;
-      if (stageId === UNASSIGNED_STAGE_ID) {
-        unassigned.push(caseItem);
-      } else {
-        byStage.get(stageId)!.push(caseItem);
-      }
-      caseToColumn.set(caseItem.id, stageId);
-      caseById.set(caseItem.id, caseItem);
-    }
-
-    const columns = [...orderedStages];
-    if (unassigned.length > 0) {
-      byStage.set(UNASSIGNED_STAGE_ID, unassigned);
-      columns.push(createUnassignedStage(pipelineId));
-    }
-
-    return { columns, byStage, caseToColumn, caseById };
-  }, [orderedStages, cases, stageIds, pipelineId]);
+  const stagesById = useMemo(() => new Map(orderedStages.map((stage) => [stage.id, stage])), [orderedStages]);
 
   const transitions = useMemo<PipelineTransitionEdge[]>(
     () => pipeline?.transitions ?? [],
     [pipeline?.transitions],
   );
+  const boardColumns = useMemo(() => {
+    const presentation = buildPipelineBoardPresentation({
+      orderedStages,
+      cases,
+      transitions,
+      configuredView,
+      unassignedStage: createUnassignedStage(pipelineId),
+    });
+    const decoratedByStage = new Map<string, BoardCase[]>();
+    const decoratedCaseById = new Map<string, BoardCase>();
+    for (const [stageId, stageCases] of presentation.byStage.entries()) {
+      const stage = stagesById.get(stageId) ?? null;
+      const decoratedCases = stageCases.map((caseItem) => ({
+        ...caseItem,
+        boardStage: caseItem.stageId ? stagesById.get(caseItem.stageId) ?? stage : stage,
+        boardNeedsAttention: presentation.attentionCaseIds.has(caseItem.id),
+      })) as BoardCase[];
+      decoratedByStage.set(stageId, decoratedCases);
+      for (const caseItem of decoratedCases) decoratedCaseById.set(caseItem.id, caseItem);
+    }
+    return {
+      ...presentation,
+      byStage: decoratedByStage,
+      caseById: decoratedCaseById,
+    };
+  }, [orderedStages, cases, transitions, configuredView, pipelineId, stagesById]);
+
   const guardrailsActive = Boolean(pipeline?.enforceTransitions);
   const columnsById = useMemo(() => new Set(boardColumns.columns.map((stage) => stage.id)), [boardColumns.columns]);
 
@@ -1663,7 +1710,7 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
     const activeCase = boardColumns.caseById.get(activeCaseIdValue);
     if (!activeCase) return;
 
-    const sourceStageId = boardColumns.caseToColumn.get(activeCaseIdValue) ?? null;
+    const sourceStageId = activeCase.stageId ?? null;
     const targetStageId = resolvePipelineTargetStageId(
       over.id as string,
       columnsById,
@@ -1760,6 +1807,12 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
               <SelectItem value="builtFor">Built for</SelectItem>
             </SelectContent>
           </Select>
+          <Button variant={configuredView ? "default" : "outline"} asChild>
+            <Link to={configuredView ? `/pipelines/${pipelineId}` : `/pipelines/${pipelineId}?view=configured`}>
+              <GitBranch className="mr-2 h-4 w-4" />
+              {configuredView ? "Default board" : "Configured stages"}
+            </Link>
+          </Button>
           <Button asChild>
             <Link to={`/pipelines/${pipelineId}/add`}>
               <Plus className="mr-2 h-4 w-4" />
@@ -1779,6 +1832,20 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
         onSelectStage={(stageId) => navigate(`/pipelines/${pipelineId}/settings?stage=${stageId}`)}
       />
 
+      {!configuredView && boardColumns.terminalRails.some((rail) => rail.cases.length > 0) ? (
+        <div className="flex flex-wrap gap-2 border-y border-border bg-muted/20 px-3 py-2 text-sm">
+          {boardColumns.terminalRails.map((rail) => rail.cases.length > 0 ? (
+            <div
+              key={rail.key}
+              className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1 text-muted-foreground"
+            >
+              <span className="font-medium text-foreground">{rail.label}</span>
+              <span>{rail.cases.length} item{rail.cases.length === 1 ? "" : "s"}</span>
+            </div>
+          ) : null)}
+        </div>
+      ) : null}
+
       <DndContext
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
@@ -1789,7 +1856,7 @@ function PipelineBoard({ pipelineId }: { pipelineId: string }) {
           <div className="flex items-start gap-3 pb-3">
             {boardColumns.columns.map((stage) => {
               const items = boardColumns.byStage.get(stage.id) ?? [];
-              const activeSourceStageId = activeCaseId ? boardColumns.caseToColumn.get(activeCaseId) ?? null : null;
+              const activeSourceStageId = activeCaseId ? boardColumns.caseById.get(activeCaseId)?.stageId ?? null : null;
               const activeTargetStageId = activeOverId
                 ? resolvePipelineTargetStageId(activeOverId, columnsById, boardColumns.caseToColumn)
                 : null;
@@ -2758,7 +2825,7 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
   const changedNotice = itemHasChangedNotice(detail.case) ?? changedNoticeFromEvents(eventRows);
   const primaryAction = conversationIssue
     ? (
-        <Button asChild>
+        <Button variant="outline" asChild>
           <Link to={conversationIssuePath!} state={conversationIssueState} issuePrefetch={conversationIssueDetail.data ?? null}>
             <MessageSquare className="mr-2 h-4 w-4" />
             Open conversation
@@ -2766,7 +2833,7 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
         </Button>
       )
     : (
-        <Button onClick={() => startConversation.mutate()} disabled={startConversation.isPending}>
+        <Button variant="outline" onClick={() => startConversation.mutate()} disabled={startConversation.isPending}>
           <MessageSquare className="mr-2 h-4 w-4" />
           {startConversation.isPending ? "Starting..." : "Start a conversation"}
         </Button>
@@ -2783,6 +2850,20 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
       onDecide={(decision) => decideReview.mutate({ decision })}
     />
   ) : null;
+  const detailActions = derivePipelineItemDetailActions({
+    hasStageAutomation: Boolean(stageAutomation),
+    rerunPending: rerunCurrentStageAutomation.isPending,
+    rerunBlockedByPermission,
+    stageKind: detail.stage.kind,
+    hasActiveWork: Boolean(activeWork),
+    previousRetryAllowed: Boolean(previousRetryPlan?.allowed),
+    retryPending: retryStageAutomation.isPending,
+    canCancel: Boolean(removeStage),
+    cancelPending: removeItem.isPending,
+  });
+  const childRollupText = childRows.length > 0
+    ? `${pieceCountDone} of ${pieceCountTotal} ${pieceLabel(pieceCountTotal)} finished`
+    : null;
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-8">
@@ -2832,8 +2913,22 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
             </p>
           ) : null}
         </div>
-        <div className="flex w-full flex-col gap-5">
-          <div className="flex items-center gap-2 lg:justify-end">
+        <div className="flex w-full flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+            <Button variant="outline" asChild>
+              <Link to={`${location.pathname}#pipeline-item-body`}>
+                <Pencil className="mr-2 h-4 w-4" />
+                Edit
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              disabled={detailActions.cancel.disabled}
+              onClick={() => setRemoveDialogOpen(true)}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Cancel
+            </Button>
             {primaryAction}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -2843,8 +2938,8 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem
-                  disabled={!stageAutomation || rerunCurrentStageAutomation.isPending || rerunBlockedByPermission}
-                  title={rerunBlockedByPermission ? "Permission still missing — request access first" : undefined}
+                  disabled={detailActions.run.disabled}
+                  title={detailActions.run.reason ?? undefined}
                   onSelect={(event) => {
                     event.preventDefault();
                     setRetryTargetStageId(null);
@@ -2860,7 +2955,7 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
                 </DropdownMenuItem>
                 {previousRetryPlan?.allowed ? (
                   <DropdownMenuItem
-                    disabled={retryStageAutomation.isPending}
+                    disabled={detailActions.redo.disabled}
                     onSelect={(event) => {
                       event.preventDefault();
                       setRetryTargetStageId(null);
@@ -2900,6 +2995,15 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+          {childRollupText ? (
+            <Link
+              to={`${location.pathname}#children`}
+              className="inline-flex items-center gap-2 self-start text-sm font-medium text-muted-foreground hover:text-foreground hover:underline lg:self-end"
+            >
+              <ListTree className="h-4 w-4" />
+              {childRollupText}
+            </Link>
+          ) : null}
         </div>
       </div>
 
@@ -3215,7 +3319,7 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
       ) : null}
 
       {(childrenGate || (breakdown?.waitForPieces ?? false)) && waitingChildren.length > 0 ? (
-        <section aria-label="Waiting child items" className="mb-5 border-y border-border px-4 py-4">
+        <section id="children" aria-label="Waiting child items" className="mb-5 scroll-mt-20 border-y border-border px-4 py-4">
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
               <ListTree className="h-4 w-4 text-muted-foreground" />
@@ -3234,20 +3338,22 @@ export function PipelineItemDetailView({ pipelineId, caseId }: { pipelineId: str
 
       <div className="grid gap-8 lg:grid-cols-(--gtc-45)">
         <main className="min-w-0 space-y-8">
-          <PipelineItemBodyDocument
-            caseId={caseId}
-            legacySummary={detail.case.summary ?? null}
-            hasLegacyLongFields={mainPaneFields.length > 0}
-            conversationIssueId={conversationIssueId}
-            conversationIssue={activeConversationIssue ?? null}
-            agentMap={agentMap}
-            userProfileMap={userProfileMap}
-            mentions={mentionOptions}
-            imageUploadHandler={conversationIssueId ? handleConversationImageUpload : undefined}
-            locationHash={location.hash}
-            onStartConversation={startConversationForBody}
-            onAfterChange={invalidateItem}
-          />
+          <section id="pipeline-item-body" className="scroll-mt-20">
+            <PipelineItemBodyDocument
+              caseId={caseId}
+              legacySummary={detail.case.summary ?? null}
+              hasLegacyLongFields={mainPaneFields.length > 0}
+              conversationIssueId={conversationIssueId}
+              conversationIssue={activeConversationIssue ?? null}
+              agentMap={agentMap}
+              userProfileMap={userProfileMap}
+              mentions={mentionOptions}
+              imageUploadHandler={conversationIssueId ? handleConversationImageUpload : undefined}
+              locationHash={location.hash}
+              onStartConversation={startConversationForBody}
+              onAfterChange={invalidateItem}
+            />
+          </section>
 
           {mainPaneFields.length > 0 ? (
             <details className="group rounded-md border border-border">

--- a/ui/src/pages/Pipelines.tsx
+++ b/ui/src/pages/Pipelines.tsx
@@ -1220,22 +1220,22 @@ export function groupCasesByBuiltFor(cases: BoardCase[]) {
 export function pipelineBoardStateChipClass(tone: ReturnType<typeof getPipelineBoardStateChip>["tone"]) {
   switch (tone) {
     case "active":
-      return "border-emerald-400/40 bg-emerald-50 text-emerald-700 dark:border-emerald-300/30 dark:bg-emerald-900/30 dark:text-emerald-300";
+      return "pipeline-state-chip--active";
     case "ready":
-      return "border-sky-400/40 bg-sky-50 text-sky-700 dark:border-sky-300/30 dark:bg-sky-900/25 dark:text-sky-300";
+      return "pipeline-state-chip--ready";
     case "review":
-      return "border-violet-400/40 bg-violet-50 text-violet-700 dark:border-violet-300/30 dark:bg-violet-900/25 dark:text-violet-300";
+      return "pipeline-state-chip--review";
     case "waiting":
-      return "border-orange-400/40 bg-orange-50 text-orange-700 dark:border-orange-300/30 dark:bg-orange-900/25 dark:text-orange-300";
+      return "pipeline-state-chip--waiting";
     case "attention":
-      return "border-red-400/40 bg-red-50 text-red-700 dark:border-red-300/30 dark:bg-red-900/25 dark:text-red-300";
+      return "pipeline-state-chip--attention";
     case "done":
-      return "border-green-400/40 bg-green-50 text-green-700 dark:border-green-300/30 dark:bg-green-900/25 dark:text-green-300";
+      return "pipeline-state-chip--done";
     case "muted":
-      return "border-border bg-muted text-muted-foreground";
+      return "pipeline-state-chip--muted";
     case "neutral":
     default:
-      return "border-border bg-background text-muted-foreground";
+      return "pipeline-state-chip--neutral";
   }
 }
 
@@ -1247,7 +1247,7 @@ function PipelineBoardStateChip({ caseItem }: { caseItem: BoardCase }) {
   });
   return (
     <span className={cn(
-      "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
+      "pipeline-state-chip status-chip inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-(length:--text-micro) font-medium",
       pipelineBoardStateChipClass(chip.tone),
     )}>
       {chip.key === "running" ? (
@@ -1427,11 +1427,11 @@ function PipelineBoardColumn({
         ref={setNodeRef}
         className={cn(
           "min-h-(--sz-160px) flex-1 space-y-2 rounded-b-md px-2 py-2 transition-colors",
-          isBlockedDropTarget ? "bg-red-50 dark:bg-red-950/30" : isOver ? tone.bodyOver : tone.body,
+          isBlockedDropTarget ? "pipeline-drop-blocked-target" : isOver ? tone.bodyOver : tone.body,
         )}
       >
         {isBlockedDropTarget ? (
-          <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-(length:--text-micro) text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-200">
+          <p className="pipeline-drop-blocked-notice rounded border px-3 py-2 text-(length:--text-micro)">
             This move skips the normal flow
           </p>
         ) : null}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Pipelines show repeated work as stages, cases, and outputs
> - The current board mixes technical stage state with the operator view and makes outputs hard to scan
> - Task watchdogs also need a narrow way to recover work that waits for a current plan decision
> - This pull request simplifies the pipeline board and adds a scoped watchdog recovery grant
> - The benefit is a clearer operator view with safer automated recovery

## Linked Issues or Issue Description

**What existing behavior does this improve?**

This change improves the pipeline board, pipeline case output summaries, and task watchdog recovery behavior.

**Subsystem affected**

This is a cross-cutting change in the React UI, shared pipeline types, REST routes, and orchestration services.

**Current behavior**

The pipeline board exposes low-level stage state and gives weak output summaries. A stopped task watchdog cannot accept a pending confirmation for the current plan, even when that action is the only safe recovery step.

**Proposed behavior**

The pipeline board uses operator-focused status groups and compact stage presentation. Output APIs include document and artifact summaries. A task watchdog can accept only a pending confirmation for the latest plan revision in its watched subtree when its run has the explicit capability.

**Reason and benefit**

Operators can scan pipeline work and its results with less interpretation. Watchdogs can recover a narrow approval wait without receiving general interaction or board authority.

**Breaking changes**

The pipeline case output response adds fields. Existing fields stay available. The watchdog grant is additive and defaults to disabled unless the run context has the capability.

## What Changed

- Group pipeline items into clear working, attention, and completed board states.
- Add shared stage presentation rules and focused pipeline board tests.
- Return compact document and artifact summaries with pipeline case outputs.
- Add a capability-scoped watchdog grant for current plan confirmations.
- Revalidate the watched subtree and stop fingerprint before each recovery mutation.
- Require explicit resume intent before a watchdog can restore a cancelled task.

## Verification

- `pnpm -r typecheck`
- `pnpm build`
- `pnpm exec vitest run ui/src/pages/Pipelines.test.tsx server/src/__tests__/pipelines-routes.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-thread-interaction-routes.test.ts server/src/__tests__/issue-watchdogs-routes.test.ts server/src/__tests__/task-watchdogs-classifier.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts`
- The focused watchdog route suite passes all 17 cases.
- The affected issue-authorization route suites pass all 112 cases.
- GitHub Actions passes all build, typecheck, unit, serialized-server, canary, and three-shard browser gates on the latest head.
- The full stable test runner was started locally. Its first serialized server group did not finish after more than 20 minutes on the shared host, so CI remains the full-suite authority.

## Risks

- The new board grouping can change where operators find an item without changing its stored pipeline state.
- The watchdog grant crosses a board-only interaction boundary. The route limits it to explicit-capability runs, fresh stopped state, the watched subtree, accept actions, and the latest plan revision.
- No database migration is included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with the `gpt-5` model. The exact deployment revision and context window are not exposed. The model used tool-based reasoning, code editing, terminal execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
