### PR TITLE
chore(plugin-daytona): pin @daytonaio/sdk to 0.203.0

### DIFF
--- a/packages/plugins/sandbox-providers/daytona/package.json
+++ b/packages/plugins/sandbox-providers/daytona/package.json
@@ -50,7 +50,7 @@
     "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
   },
   "dependencies": {
-    "@daytonaio/sdk": "^0.171.0"
+    "@daytonaio/sdk": "0.203.0"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Daytona sandbox provider lives in `packages/plugins/sandbox-providers/daytona`
> - That plugin depends on `@daytonaio/sdk` for session control and command execution
> - The stable SDK version moved forward, but the plugin still used an older pin
> - This pull request pins the SDK to the current stable release and keeps the package build and tests green
> - The benefit is the plugin uses the current client surface with a very small change set

## Linked Issues or Issue Description

**What existing behavior does this improve?**
The Daytona plugin keeps an older `@daytonaio/sdk` pin than the current stable release.

**Current behavior**
The plugin depends on `^0.171.0`.

**Proposed behavior**
The plugin pins `@daytonaio/sdk` to `0.203.0`.

**Reason and benefit**
The plugin uses the current stable client. The build and the existing tests still pass with the real 0.203.0 types. The change keeps the tracked diff small.

**Breaking changes**
None. The package manifest changes only the SDK pin. The workspace package is excluded from the root lockfile.

**Additional context**
Refs #7333, which updated the same package to `0.183.0`.

## What Changed

- Updated `packages/plugins/sandbox-providers/daytona/package.json` to pin `@daytonaio/sdk` at `0.203.0`.
- Kept the change limited to the plugin package manifest.

## Verification

- `pnpm run build` in the plugin directory passed.
- `pnpm exec vitest run --config packages/plugins/sandbox-providers/daytona/vitest.config.ts` passed.
- `git status` showed only the one-line manifest change before the PR open step.
- `git fetch origin chore/daytona-sdk-0-203-0` returned `d2592644e80dfac2cfae6d9ccc2188267fe75758`.
- `git diff --stat origin/master...HEAD` showed only the one manifest file change.

## Risks

- Low risk. The change only updates a package pin.
- The plugin build and tests already passed against the new SDK surface.
- A future SDK release could need a follow-up pin update.

## Model Used

OpenAI Codex, GPT-5, tool-use enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
