### PR TITLE
fix(ui): show the synced company logo on the Cloud org switcher trigger

### DIFF
--- a/ui/src/components/SidebarCompanyMenu.test.tsx
+++ b/ui/src/components/SidebarCompanyMenu.test.tsx
@@ -84,6 +84,7 @@ vi.mock("@/context/CompanyContext", () => ({
       issuePrefix: "PAP",
       name: "Acme Labs",
       brandColor: "#3366ff",
+      logoUrl: "/api/assets/logo-asset-1/content",
       status: "active",
     },
     setSelectedCompanyId: mockSetSelectedCompanyId,
@@ -97,8 +98,8 @@ vi.mock("@/context/DialogContext", () => ({
 }));
 
 vi.mock("./CompanyPatternIcon", () => ({
-  CompanyPatternIcon: ({ companyName }: { companyName: string }) => (
-    <span aria-hidden="true">{companyName.slice(0, 1)}</span>
+  CompanyPatternIcon: ({ companyName, logoUrl }: { companyName: string; logoUrl?: string | null }) => (
+    <span aria-hidden="true" data-logo-url={logoUrl ?? undefined}>{companyName.slice(0, 1)}</span>
   ),
 }));
 
@@ -491,6 +492,35 @@ describe("SidebarCompanyMenu", () => {
       // Drag-to-reorder is self-hosted only in v1.
       expect(Array.from(document.body.querySelectorAll("button"))
         .some((element) => element.textContent === "Edit")).toBe(false);
+
+      act(() => {
+        root.unmount();
+      });
+    });
+
+    it("shows the synced company logo on the trigger while stack rows keep monograms", async () => {
+      const { root } = renderMenu({ cloud: true });
+      await flushReact();
+      await flushReact();
+
+      // A Cloud tenant holds exactly one company, and the harness pushes the
+      // stack's uploaded workspace icon into that company's branding — so the
+      // trigger renders the company logo, not the monogram (PAP-16499).
+      const trigger = container.querySelector(
+        'button[aria-label="Open Acme Labs organization switcher"]',
+      );
+      expect(trigger).not.toBeNull();
+      expect(
+        trigger?.querySelector('[data-logo-url="/api/assets/logo-asset-1/content"]'),
+      ).not.toBeNull();
+
+      // Other stacks have no hot-linkable icon in the portfolio payload, so
+      // their rows keep the deterministic monogram treatment.
+      await openMenu("Open Acme Labs organization switcher");
+      const strataRow = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
+        .find((element) => element.textContent?.includes("Strata Systems"));
+      expect(strataRow).toBeTruthy();
+      expect(strataRow?.querySelector("[data-logo-url]")).toBeNull();
 
       act(() => {
         root.unmount();

--- a/ui/src/components/SidebarCompanyMenu.tsx
+++ b/ui/src/components/SidebarCompanyMenu.tsx
@@ -73,6 +73,29 @@ function StackIcon({ displayName }: { displayName: string }) {
   return <CompanyPatternIcon companyName={displayName} className={WORKSPACE_ICON_CLASS} />;
 }
 
+/**
+ * The switcher trigger on a Cloud instance. A Cloud tenant holds exactly one
+ * company and the harness pushes the stack's uploaded workspace icon into
+ * that company's branding, so the company logo is the stack logo here
+ * (PAP-16499). The stack rows keep the monogram treatment above.
+ */
+function CurrentStackIcon({
+  displayName,
+  company,
+}: {
+  displayName: string;
+  company: Company | null;
+}) {
+  return (
+    <CompanyPatternIcon
+      companyName={displayName}
+      logoUrl={company?.logoUrl}
+      brandColor={company?.brandColor}
+      className={WORKSPACE_ICON_CLASS}
+    />
+  );
+}
+
 function CloudStackItem({
   stack,
   isSelected,
@@ -336,7 +359,7 @@ export function SidebarCompanyMenu({ open: controlledOpen, onOpenChange }: Sideb
         >
           <span className="flex min-w-0 flex-1 items-center gap-2">
             {isCloud
-              ? currentName ? <StackIcon displayName={currentName} /> : null
+              ? currentName ? <CurrentStackIcon displayName={currentName} company={selectedCompany} /> : null
               : selectedCompany ? <WorkspaceIcon company={selectedCompany} /> : null}
             {/* The header has room for ~110px of name beside the collapse
                 control (~142px on mobile, which hides it) — search moved to


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - On Paperclip Cloud a tenant instance holds exactly one company, and the cloud harness pushes the stack's uploaded workspace icon into that company's branding.
> - The cloud-mode organization switcher trigger always rendered the deterministic monogram, so an uploaded organization logo never appeared in the app chrome.
> - This pull request renders the trigger through the tenant company's logo and brand color, with the monogram as the fallback.
> - The benefit is that the logo a customer uploads for their organization actually shows up inside their Paperclip app.

## Linked Issues or Issue Description

**Subsystem affected**

Board UI: the sidebar organization switcher in Paperclip Cloud mode.

**Problem or motivation**

PAP-16499: a customer created a stack with an uploaded logo; the cloud harness stores it and syncs it into the tenant company's branding, but the sidebar trigger still showed a letter monogram. `SidebarCompanyMenu`'s cloud branch rendered `StackIcon` (monogram-only, by design for stack rows) for the trigger too, ignoring `selectedCompany.logoUrl`.

**Proposed solution**

Add a `CurrentStackIcon` for the trigger that passes the selected company's `logoUrl`/`brandColor` into `CompanyPatternIcon`, seeded by the stack display name. Falls back to the exact previous monogram when no logo is set. Stack rows are unchanged: the portfolio payload deliberately carries no hot-linkable icon URL for other stacks.

**Alternatives considered**

Fetching per-stack icons for the rows was rejected: the tenant proxy payload carries no icon URLs (signed, expiring harness URLs would be wrong to embed), and the reported defect is the current organization's chrome, which the already-synced company logo covers.

## What Changed

- `ui/src/components/SidebarCompanyMenu.tsx`: cloud-mode trigger renders the tenant company logo (fallback: monogram); stack rows untouched.
- `ui/src/components/SidebarCompanyMenu.test.tsx`: new regression test that the trigger carries the company logo while stack rows keep monograms; `CompanyPatternIcon` mock now exposes `logoUrl`.

## Verification

- `pnpm --dir ui exec vitest run src/components/SidebarCompanyMenu.test.tsx`: 12/12 pass (11 existing + 1 new).
- `pnpm --dir ui exec tsc --noEmit`: clean.

## Risks

- Cloud-only rendering branch; self-hosted trigger path is untouched.
- If the branding sync has not run yet, the trigger shows the same monogram as before — no regression.

## Model Used

- Claude Fable 5 (`claude-fable-5`), Anthropic. The run used reasoning, repository tools, shell execution, and GitHub integration.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work

🤖 Generated with [Claude Code](https://claude.com/claude-code)