### PR TITLE
fix(ui): show the synced company logo on the Cloud org switcher trigger

### DIFF
--- a/ui/src/components/SidebarCompanyMenu.test.tsx
+++ b/ui/src/components/SidebarCompanyMenu.test.tsx
@@ -84,6 +84,7 @@ vi.mock("@/context/CompanyContext", () => ({
       issuePrefix: "PAP",
       name: "Acme Labs",
       brandColor: "#3366ff",
+      logoUrl: "/api/assets/logo-asset-1/content",
       status: "active",
     },
     setSelectedCompanyId: mockSetSelectedCompanyId,
@@ -97,8 +98,8 @@ vi.mock("@/context/DialogContext", () => ({
 }));
 
 vi.mock("./CompanyPatternIcon", () => ({
-  CompanyPatternIcon: ({ companyName }: { companyName: string }) => (
-    <span aria-hidden="true">{companyName.slice(0, 1)}</span>
+  CompanyPatternIcon: ({ companyName, logoUrl }: { companyName: string; logoUrl?: string | null }) => (
+    <span aria-hidden="true" data-logo-url={logoUrl ?? undefined}>{companyName.slice(0, 1)}</span>
   ),
 }));
 
@@ -491,6 +492,35 @@ describe("SidebarCompanyMenu", () => {
       // Drag-to-reorder is self-hosted only in v1.
       expect(Array.from(document.body.querySelectorAll("button"))
         .some((element) => element.textContent === "Edit")).toBe(false);
+
+      act(() => {
+        root.unmount();
+      });
+    });
+
+    it("shows the synced company logo on the trigger while stack rows keep monograms", async () => {
+      const { root } = renderMenu({ cloud: true });
+      await flushReact();
+      await flushReact();
+
+      // A Cloud tenant holds exactly one company, and the harness pushes the
+      // stack's uploaded workspace icon into that company's branding — so the
+      // trigger renders the company logo, not the monogram.
+      const trigger = container.querySelector(
+        'button[aria-label="Open Acme Labs organization switcher"]',
+      );
+      expect(trigger).not.toBeNull();
+      expect(
+        trigger?.querySelector('[data-logo-url="/api/assets/logo-asset-1/content"]'),
+      ).not.toBeNull();
+
+      // Other stacks have no hot-linkable icon in the portfolio payload, so
+      // their rows keep the deterministic monogram treatment.
+      await openMenu("Open Acme Labs organization switcher");
+      const strataRow = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
+        .find((element) => element.textContent?.includes("Strata Systems"));
+      expect(strataRow).toBeTruthy();
+      expect(strataRow?.querySelector("[data-logo-url]")).toBeNull();
 
       act(() => {
         root.unmount();

--- a/ui/src/components/SidebarCompanyMenu.tsx
+++ b/ui/src/components/SidebarCompanyMenu.tsx
@@ -76,8 +76,8 @@ function StackIcon({ displayName }: { displayName: string }) {
 /**
  * The switcher trigger on a Cloud instance. A Cloud tenant holds exactly one
  * company and the harness pushes the stack's uploaded workspace icon into
- * that company's branding, so the company logo is the stack logo here
- * here. The stack rows keep the monogram treatment above.
+ * that company's branding, so the company logo is the stack logo here.
+ * The stack rows keep the monogram treatment above.
  */
 function CurrentStackIcon({
   displayName,

--- a/ui/src/components/SidebarCompanyMenu.tsx
+++ b/ui/src/components/SidebarCompanyMenu.tsx
@@ -73,6 +73,29 @@ function StackIcon({ displayName }: { displayName: string }) {
   return <CompanyPatternIcon companyName={displayName} className={WORKSPACE_ICON_CLASS} />;
 }
 
+/**
+ * The switcher trigger on a Cloud instance. A Cloud tenant holds exactly one
+ * company and the harness pushes the stack's uploaded workspace icon into
+ * that company's branding, so the company logo is the stack logo here
+ * here. The stack rows keep the monogram treatment above.
+ */
+function CurrentStackIcon({
+  displayName,
+  company,
+}: {
+  displayName: string;
+  company: Company | null;
+}) {
+  return (
+    <CompanyPatternIcon
+      companyName={displayName}
+      logoUrl={company?.logoUrl}
+      brandColor={company?.brandColor}
+      className={WORKSPACE_ICON_CLASS}
+    />
+  );
+}
+
 function CloudStackItem({
   stack,
   isSelected,
@@ -336,7 +359,7 @@ export function SidebarCompanyMenu({ open: controlledOpen, onOpenChange }: Sideb
         >
           <span className="flex min-w-0 flex-1 items-center gap-2">
             {isCloud
-              ? currentName ? <StackIcon displayName={currentName} /> : null
+              ? currentName ? <CurrentStackIcon displayName={currentName} company={selectedCompany} /> : null
               : selectedCompany ? <WorkspaceIcon company={selectedCompany} /> : null}
             {/* The header has room for ~110px of name beside the collapse
                 control (~142px on mobile, which hides it) — search moved to


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - On Paperclip Cloud a tenant instance holds exactly one company, and the cloud control plane pushes the stack's uploaded workspace icon into that company's branding.
> - The cloud-mode organization switcher trigger always rendered the deterministic monogram, so an uploaded organization logo never appeared in the app chrome.
> - This pull request renders the trigger through the tenant company's logo and brand color, with the monogram as the fallback.
> - The benefit is that the logo a customer uploads for their organization actually shows up inside their Paperclip app.

## Linked Issues or Issue Description

No existing public issue found (searched open/closed PRs and issues for "organization logo", "switcher logo", "company logo cloud" — closest related PR is #10850, which introduced the cloud-mode switcher). Describing in-PR:

**Subsystem affected**

Board UI: the sidebar organization switcher in Paperclip Cloud mode (`SidebarCompanyMenu`).

**Problem or motivation**

A Cloud customer uploads an organization logo when creating their workspace; the control plane syncs it into the tenant company's branding (`company.logoUrl`). But the cloud branch of the switcher trigger rendered `StackIcon` — monogram-only by design for stack rows — for the trigger too, ignoring `selectedCompany.logoUrl`. Result: the uploaded logo never appears in the app chrome; users see a letter tile instead.

**Proposed solution**

Add a `CurrentStackIcon` for the trigger that passes the selected company's `logoUrl`/`brandColor` into `CompanyPatternIcon`, seeded by the stack display name. Falls back to the exact previous monogram when no logo is set. Stack rows are unchanged: the portfolio payload deliberately carries no hot-linkable icon URL for other stacks.

**Alternatives considered**

Fetching per-stack icons for the rows was rejected: the cloud portfolio payload carries no icon URLs (embedding signed, expiring control-plane URLs would be wrong), and the defect is the current organization's chrome, which the already-synced company logo covers.

## What Changed

- `ui/src/components/SidebarCompanyMenu.tsx`: cloud-mode trigger renders the tenant company logo (fallback: monogram); stack rows untouched; self-hosted path untouched.
- `ui/src/components/SidebarCompanyMenu.test.tsx`: new regression test that the trigger carries the company logo while stack rows keep monograms; the `CompanyPatternIcon` mock now exposes `logoUrl`.

## Verification

- `pnpm --dir ui exec vitest run src/components/SidebarCompanyMenu.test.tsx`: 12/12 pass (11 existing + 1 new).
- `pnpm --dir ui exec tsc --noEmit`: clean.

## Risks

- Cloud-only rendering branch; self-hosted trigger rendering is untouched.
- If the branding sync has not run yet, the trigger shows the same monogram as before — no regression, and it upgrades in place once `logoUrl` arrives.

## Model Used

- Claude Fable 5 (`claude-fable-5`), Anthropic. The run used extended reasoning, repository tools, shell execution, and GitHub integration.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)