### PR TITLE
fix(server): recover missing hot-restart snapshots

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -141,15 +141,21 @@ Use `--drain-required` only when the deploy intentionally requires the old termi
 When Paperclip manages embedded PostgreSQL, it suppresses that dependency's eager
 `SIGINT`/`SIGTERM` cleanup hooks. Paperclip owns signal ordering so the heartbeat
 snapshot and any required drain complete while the database is still available;
-the coordinated shutdown path stops embedded PostgreSQL afterward.
+the coordinated shutdown path stops embedded PostgreSQL afterward. If the
+shutdown database query still fails, Paperclip logs the error and writes a
+filesystem-only snapshot of the preflight run set instead of leaving the marker
+without a shutdown snapshot.
 
 The request command records the preflight set of running heartbeat IDs and writes
 an instance-scoped marker plus a PID-targeted legacy home-root handoff marker.
 This lets a previous server version capture its snapshot at the old path while
 the new server correlates that snapshot back to the authoritative instance
 request. If any preflight run ID is absent from the shutdown snapshot, the
-startup report includes it in `lostRunIds`; a missing snapshot therefore cannot
-look like a zero-loss restart.
+replacement server reconstructs that candidate from its fresh database
+connection. A live detached process remains eligible for adoption. A dead or
+server-stdio process is recorded as `server_shutdown_interrupted` and queued for
+retry. Only a failed adoption or failed interruption appears in `lostRunIds`, so
+a missing shutdown-time database connection cannot silently lose every run.
 
 A healthy guarded deploy must compare the report against `/api/health` (`version` or `serverVersion`) and treat any `lostRunIds` entry as a continuity failure that needs recovery before marking deployment complete.
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1947,6 +1947,91 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("reports a reconstructed run that finalizes during targeted drain as finalized", async () => {
+    const { runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 987_654,
+      processGroupId: null,
+      contextSnapshot: {
+        executionEngine: "acp",
+        processTopology: "server_stdio",
+      },
+    });
+
+    await withTempPaperclipHome(async (home) => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "targeted-drain-race-version",
+        requestedAt: new Date("2026-08-06T01:24:35.000Z"),
+        preflightActiveRunIds: [runId],
+      });
+
+      const originalSelect = db.select.bind(db);
+      let selectCall = 0;
+      const selectSpy = vi.spyOn(db, "select").mockImplementation(((...args: unknown[]) => {
+        const builder = (originalSelect as (...input: unknown[]) => any)(...args);
+        selectCall += 1;
+        if (selectCall !== 2) return builder;
+
+        const originalFrom = builder.from.bind(builder);
+        builder.from = (table: unknown) => {
+          const fromBuilder = originalFrom(table);
+          const originalInnerJoin = fromBuilder.innerJoin.bind(fromBuilder);
+          fromBuilder.innerJoin = (...joinArgs: unknown[]) => {
+            const joinedBuilder = originalInnerJoin(...joinArgs);
+            const originalWhere = joinedBuilder.where.bind(joinedBuilder);
+            joinedBuilder.where = (condition: unknown) => {
+              const query = originalWhere(condition);
+              return (async () => {
+                await db
+                  .update(heartbeatRuns)
+                  .set({
+                    status: "succeeded",
+                    finishedAt: new Date("2026-08-06T01:24:36.000Z"),
+                    updatedAt: new Date("2026-08-06T01:24:36.000Z"),
+                  })
+                  .where(eq(heartbeatRuns.id, runId));
+                return query;
+              })();
+            };
+            return joinedBuilder;
+          };
+          return fromBuilder;
+        };
+        return builder;
+      }) as typeof db.select);
+
+      try {
+        const heartbeat = heartbeatService(db);
+        const adoption = await heartbeat.reconcileHotRestartAdoption(
+          new Date("2026-08-06T01:24:39.862Z"),
+        );
+        expect(adoption).toMatchObject({
+          mode: "reported",
+          adoptedRunIds: [],
+          finalizedWhileDownRunIds: [runId],
+          lostRunIds: [],
+        });
+
+        const report = JSON.parse(
+          await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
+        ) as { runs?: Array<Record<string, unknown>> };
+        expect(report.runs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              runId,
+              classification: "finalized_while_down",
+              reason: "run_status_succeeded",
+              status: "succeeded",
+            }),
+          ]),
+        );
+      } finally {
+        selectSpy.mockRestore();
+      }
+    });
+  });
+
   it("reports a preflight run that finished before snapshot capture as finalized", async () => {
     const { runId } = await seedRunFixture({
       agentStatus: "running",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1504,6 +1504,52 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("writes a preflight fallback snapshot when the shutdown database query fails", async () => {
+    const { runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 987_654,
+      processGroupId: null,
+    });
+
+    await withTempPaperclipHome(async () => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "dead-shutdown-socket-version",
+        requestedAt: new Date("2026-08-06T01:23:00.000Z"),
+        preflightActiveRunIds: [runId],
+      });
+      const queryError = new Error("read ECONNRESET");
+      const failingDb = new Proxy(db, {
+        get(target, property, receiver) {
+          if (property === "select") {
+            return () => {
+              throw queryError;
+            };
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const heartbeat = heartbeatService(failingDb);
+
+      await expect(heartbeat.prepareHotRestartShutdown(
+        "SIGTERM",
+        new Date("2026-08-06T01:24:35.000Z"),
+      )).resolves.toEqual({
+        mode: "preflight_snapshot_fallback",
+        skipDrain: true,
+        activeRunIds: [runId],
+      });
+      await expect(readHotRestartIntent()).resolves.toMatchObject({
+        preflightActiveRunIds: [runId],
+        shutdownSnapshot: {
+          capturedAt: "2026-08-06T01:24:35.000Z",
+          signal: "SIGTERM",
+          activeRuns: [],
+        },
+      });
+    });
+  });
+
   it("snapshots and drains a server-stdio ACP run before embedded database shutdown", async () => {
     const child = spawnAliveProcess();
     childProcesses.add(child);
@@ -1805,11 +1851,18 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
-  it("reports preflight live runs as lost when the shutdown snapshot is missing", async () => {
+  it("adopts a live preflight run reconstructed when the shutdown snapshot is missing", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeGreaterThan(0);
     const { runId } = await seedRunFixture({
       agentStatus: "running",
-      processPid: process.pid,
+      processPid: child.pid,
       processGroupId: null,
+      contextSnapshot: {
+        executionEngine: "cli",
+        processTopology: "detached",
+      },
     });
 
     await withTempPaperclipHome(async (home) => {
@@ -1826,18 +1879,70 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       );
       expect(adoption).toMatchObject({
         mode: "reported",
-        adoptedRunIds: [],
+        adoptedRunIds: [runId],
         finalizedWhileDownRunIds: [],
-        lostRunIds: [runId],
+        lostRunIds: [],
       });
 
       const report = JSON.parse(
         await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
       ) as Record<string, unknown>;
       expect(report).toMatchObject({
-        adoptedRunIds: [],
+        adoptedRunIds: [runId],
         finalizedWhileDownRunIds: [],
-        lostRunIds: [runId],
+        lostRunIds: [],
+      });
+    });
+  });
+
+  it("interrupts and retries a dead server-stdio run reconstructed from preflight", async () => {
+    const { agentId, runId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 987_654,
+      processGroupId: null,
+      contextSnapshot: {
+        executionEngine: "acp",
+        processTopology: "server_stdio",
+      },
+    });
+
+    await withTempPaperclipHome(async (home) => {
+      await writeHotRestartIntent({
+        previousServerPid: process.pid,
+        previousServerVersion: "missing-snapshot-acp-version",
+        requestedAt: new Date("2026-08-06T01:24:35.000Z"),
+        preflightActiveRunIds: [runId],
+      });
+
+      const heartbeat = heartbeatService(db);
+      const adoption = await heartbeat.reconcileHotRestartAdoption(
+        new Date("2026-08-06T01:24:39.862Z"),
+      );
+      expect(adoption).toMatchObject({
+        mode: "reported",
+        adoptedRunIds: [],
+        finalizedWhileDownRunIds: [runId],
+        lostRunIds: [],
+      });
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+      expect(runs.find((run) => run.id === runId)).toMatchObject({
+        status: "interrupted",
+        errorCode: "server_shutdown_interrupted",
+      });
+      expect(runs.find((run) => run.retryOfRunId === runId)).toMatchObject({
+        status: "queued",
+      });
+      const report = JSON.parse(
+        await fs.readFile(resolveHotRestartReportPath(home), "utf8"),
+      ) as Record<string, unknown>;
+      expect(report).toMatchObject({
+        adoptedRunIds: [],
+        finalizedWhileDownRunIds: [runId],
+        lostRunIds: [],
       });
     });
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1435,6 +1435,12 @@ export async function startServer(): Promise<StartedServer> {
         signal,
         prepareHotRestartShutdown,
         waitForHeartbeatSchedulerIdle,
+        reportPreparationError: (err, context) => {
+          logger.error(
+            { err, ...context },
+            "hot-restart shutdown preparation failed; falling back to graceful heartbeat run drain",
+          );
+        },
       });
       const skipHeartbeatDrain = heartbeatShutdown.hotRestart?.skipDrain === true;
       const selectiveDrainRunIds = heartbeatShutdown.hotRestart?.drainRunIds ?? null;
@@ -1442,11 +1448,6 @@ export async function startServer(): Promise<StartedServer> {
         logger.info(
           { signal, hotRestart: heartbeatShutdown.hotRestart },
           "hot-restart shutdown prepared after scheduler quiescence; skipping graceful run drain",
-        );
-      } else if (heartbeatShutdown.preparationError) {
-        logger.error(
-          { err: heartbeatShutdown.preparationError, signal },
-          "hot-restart shutdown preparation failed; falling back to graceful heartbeat run drain",
         );
       }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10135,15 +10135,51 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return { mode: "pid_mismatch" as const, skipDrain: false as const, activeRunIds: [] as string[] };
     }
 
-    const activeRuns = await db
-      .select({
-        run: heartbeatRuns,
-        adapterType: agents.adapterType,
-        adapterConfig: agents.adapterConfig,
-      })
-      .from(heartbeatRuns)
-      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
-      .where(eq(heartbeatRuns.status, "running"));
+    let activeRuns: Array<{
+      run: typeof heartbeatRuns.$inferSelect;
+      adapterType: string;
+      adapterConfig: unknown;
+    }>;
+    try {
+      activeRuns = await db
+        .select({
+          run: heartbeatRuns,
+          adapterType: agents.adapterType,
+          adapterConfig: agents.adapterConfig,
+        })
+        .from(heartbeatRuns)
+        .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+        .where(eq(heartbeatRuns.status, "running"));
+    } catch (err) {
+      // The restart request captures running ids before SIGTERM. Preserve that
+      // durable preflight set in a filesystem-only snapshot when the shutdown
+      // database socket is already gone. The replacement server can hydrate
+      // those rows from its fresh connection and adopt or interrupt them.
+      await writeHotRestartShutdownSnapshot({
+        intent: {
+          ...intent,
+          previousServerVersion: intent.previousServerVersion ?? serverVersion,
+        },
+        signal,
+        activeRuns: [],
+        capturedAt: now,
+      });
+      logger.error(
+        {
+          err,
+          signal,
+          previousServerPid: intent.previousServerPid,
+          preflightActiveRunIds: intent.preflightActiveRunIds,
+          resolvedMode: "preflight_snapshot_fallback",
+        },
+        "hot-restart active-run query failed; wrote preflight fallback snapshot",
+      );
+      return {
+        mode: "preflight_snapshot_fallback" as const,
+        skipDrain: true as const,
+        activeRunIds: intent.preflightActiveRunIds,
+      };
+    }
     const snapshotRuns = activeRuns.map(toHotRestartIntentRun);
     const intentWithVersion = {
       ...intent,
@@ -10252,25 +10288,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
         intent.drainRequired
           ? "drain-required restart intent has no adoption snapshot"
-          : "hot-restart intent present but shutdown snapshot is missing; no runs can be adopted",
+          : "hot-restart intent present but shutdown snapshot is missing; reconstructing from preflight runs",
       );
     }
-    const candidates = intent.shutdownSnapshot?.activeRuns ?? [];
+    const snapshotCandidates = intent.shutdownSnapshot?.activeRuns ?? [];
     const missingSnapshotRunIds = findMissingHotRestartSnapshotRunIds(intent);
     const reconciliationRunIds = [
-      ...new Set([...candidates.map((run) => run.runId), ...missingSnapshotRunIds]),
+      ...new Set([...snapshotCandidates.map((run) => run.runId), ...missingSnapshotRunIds]),
     ];
     const currentRows = reconciliationRunIds.length > 0
       ? await db
         .select({
           run: heartbeatRuns,
           adapterType: agents.adapterType,
+          adapterConfig: agents.adapterConfig,
         })
         .from(heartbeatRuns)
         .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
         .where(inArray(heartbeatRuns.id, reconciliationRunIds))
       : [];
     const currentByRunId = new Map(currentRows.map((row) => [row.run.id, row]));
+    const reconstructedCandidateRunIds = new Set(missingSnapshotRunIds);
+    const reconstructedCandidates = missingSnapshotRunIds.flatMap((runId) => {
+      const current = currentByRunId.get(runId);
+      return current ? [toHotRestartIntentRun(current)] : [];
+    });
+    const candidates = [...snapshotCandidates, ...reconstructedCandidates];
 
     const reportRuns: HotRestartReportRun[] = [];
     const adoptedRunIds: string[] = [];
@@ -10293,24 +10336,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
 
     for (const runId of missingSnapshotRunIds) {
-      const current = currentByRunId.get(runId);
-      if (!current) {
-        finalizedWhileDownRunIds.push(runId);
-        continue;
-      }
-
-      const candidate = toHotRestartIntentRun(current);
-      if (current.run.status !== "running") {
-        classify(candidate, "finalized_while_down", `run_status_${current.run.status}`);
-      } else {
-        classify(candidate, "lost", "missing_shutdown_snapshot");
-      }
+      if (!currentByRunId.has(runId)) finalizedWhileDownRunIds.push(runId);
     }
 
-    if (lostRunIds.length > 0) {
-      logger.error(
-        { previousServerPid: intent.previousServerPid, lostRunIds },
-        "hot-restart shutdown snapshot omitted live preflight runs; reporting them as lost",
+    if (reconstructedCandidates.length > 0) {
+      logger.warn(
+        {
+          previousServerPid: intent.previousServerPid,
+          reconstructedRunIds: reconstructedCandidates.map((run) => run.runId),
+        },
+        "reconstructing hot-restart candidates from the preflight active-run set",
       );
     }
 
@@ -10321,7 +10356,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         continue;
       }
 
-      const { run, adapterType } = current;
+      const { run, adapterType, adapterConfig } = current;
       const patch = {
         adapterType,
         status: run.status,
@@ -10332,6 +10367,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (run.status !== "running") {
         classify(candidate, "finalized_while_down", `run_status_${run.status}`, patch);
         continue;
+      }
+
+      if (reconstructedCandidateRunIds.has(run.id)) {
+        const processPid = run.processPid ?? candidate.processPid;
+        const processGroupId = run.processGroupId ?? candidate.processGroupId;
+        const processAlive = isProcessAlive(processPid) || isProcessGroupAlive(processGroupId);
+        const requiresInterrupt = !processAlive || isServerStdioBoundHotRestartRun({
+          run,
+          adapterType,
+          adapterConfig,
+        });
+        if (requiresInterrupt) {
+          const signal = intent.shutdownSnapshot?.signal ?? "SIGTERM";
+          const drain = await drainRunningRunsForShutdown(signal, now, [run.id]);
+          if (drain.interruptedRunIds.includes(run.id)) {
+            classify(candidate, "finalized_while_down", "server_shutdown_interrupted", patch);
+          } else {
+            classify(candidate, "lost", "preflight_interrupt_not_applied", patch);
+          }
+          continue;
+        }
       }
 
       const hasSelectiveAcpDrain = intent.drainReason === "active_acp_run"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10384,7 +10384,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (drain.interruptedRunIds.includes(run.id)) {
             classify(candidate, "finalized_while_down", "server_shutdown_interrupted", patch);
           } else {
-            classify(candidate, "lost", "preflight_interrupt_not_applied", patch);
+            const latest = await db
+              .select({ status: heartbeatRuns.status })
+              .from(heartbeatRuns)
+              .where(eq(heartbeatRuns.id, run.id))
+              .then((rows) => rows[0] ?? null);
+            if (latest && latest.status !== "running") {
+              classify(candidate, "finalized_while_down", `run_status_${latest.status}`, {
+                ...patch,
+                status: latest.status,
+              });
+            } else {
+              classify(candidate, "lost", "preflight_interrupt_not_applied", patch);
+            }
           }
           continue;
         }

--- a/server/src/shutdown.test.ts
+++ b/server/src/shutdown.test.ts
@@ -169,6 +169,7 @@ describe("coordinateHeartbeatSchedulerShutdown", () => {
   it("falls back to the scheduler idle wait when hot-restart preparation fails", async () => {
     const preparationError = new Error("snapshot failed");
     const waitForHeartbeatSchedulerIdle = vi.fn(async () => undefined);
+    const reportPreparationError = vi.fn();
 
     const result = await coordinateHeartbeatSchedulerShutdown({
       signal: "SIGTERM",
@@ -176,9 +177,15 @@ describe("coordinateHeartbeatSchedulerShutdown", () => {
         throw preparationError;
       }),
       waitForHeartbeatSchedulerIdle,
+      reportPreparationError,
     });
 
     expect(waitForHeartbeatSchedulerIdle).toHaveBeenCalledOnce();
+    expect(reportPreparationError).toHaveBeenCalledOnce();
+    expect(reportPreparationError).toHaveBeenCalledWith(preparationError, {
+      signal: "SIGTERM",
+      resolvedMode: "graceful_drain",
+    });
     expect(result).toEqual({
       hotRestart: null,
       preparationError,

--- a/server/src/shutdown.ts
+++ b/server/src/shutdown.ts
@@ -53,6 +53,10 @@ export async function coordinateHeartbeatSchedulerShutdown<
   signal: "SIGINT" | "SIGTERM";
   prepareHotRestartShutdown: ((signal: "SIGINT" | "SIGTERM") => Promise<TPreparation>) | null;
   waitForHeartbeatSchedulerIdle: () => Promise<void>;
+  reportPreparationError?: (error: unknown, context: {
+    signal: "SIGINT" | "SIGTERM";
+    resolvedMode: "graceful_drain";
+  }) => void;
 }): Promise<{
   hotRestart: TPreparation | null;
   preparationError: unknown;
@@ -72,6 +76,10 @@ export async function coordinateHeartbeatSchedulerShutdown<
       hotRestart = await input.prepareHotRestartShutdown(input.signal);
     } catch (err) {
       preparationError = err;
+      input.reportPreparationError?.(err, {
+        signal: input.signal,
+        resolvedMode: "graceful_drain",
+      });
     }
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - A hot restart must preserve or finalize every active agent run.
> - The restart request stores the active run IDs before it sends the shutdown signal.
> - The old server then queries PostgreSQL to build the full shutdown snapshot.
> - That query can fail when the shutdown database socket is already closed.
> - The coordinator caught this error, but the production path did not guarantee an immediate error report.
> - The replacement server already loads the preflight rows, but it marked all omitted rows as lost.
> - This pull request uses the durable preflight IDs to adopt safe runs or interrupt and retry unsafe runs.

## Linked Issues or Issue Description

**What happened?**

A hot restart can lose its shutdown snapshot even when the PID check passes. The old server queries active heartbeat runs after it receives `SIGTERM`. If that query fails with a closed PostgreSQL socket, no complete snapshot is available. The replacement server then reports every preflight run as lost.

**Expected behavior**

The old server must write a shutdown snapshot without a live database connection. The replacement server must reconstruct each omitted preflight run. It must adopt a live detached process. It must record `server_shutdown_interrupted` and queue a retry for a dead or server-stdio process.

**Steps to reproduce**

1. Start Paperclip from source with embedded PostgreSQL.
2. Start a local agent run.
3. Write a valid hot-restart request with the active run ID.
4. Make the shutdown active-run query reject with `ECONNRESET` after `SIGTERM`.
5. Start the replacement server.
6. Observe a missing snapshot and a `lost` run on the current code.

**Paperclip version or commit**

The defect reproduces on `f5e9ca3e89f806b404fa075cd00785967a3f29be`.

**Deployment mode**

Self-hosted server built from source, with embedded PostgreSQL.

Related work: Refs #10815. That pull request fixed the known embedded PostgreSQL signal-hook race. This change covers the remaining closed-socket path.

## What Changed

- Report a shutdown preparation rejection inside the coordinator with the signal and resolved drain mode.
- Write a filesystem-only shutdown snapshot from the preflight run set when the shutdown database query fails.
- Skip the old-server drain after this fallback because it uses the same failed database connection.
- Reconstruct omitted candidates from the replacement server's fresh database connection.
- Adopt live detached runs after reconstruction.
- Record dead or server-stdio runs as `server_shutdown_interrupted` and queue retries.
- Update the hot-restart operator documentation.

## Verification

- `PAPERCLIP_TEST_DATABASE_MODE=native pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts --testTimeout=15000` passed: 102 tests.
- `pnpm exec vitest run server/src/shutdown.test.ts` passed: 7 tests.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `git diff --check` passed.
- The database test forces `ECONNRESET`, verifies the fallback snapshot, adopts a live detached run, and interrupts and retries a dead server-stdio run.

## Risks

- Moderate risk. This changes restart recovery for rows omitted from the shutdown snapshot.
- A stale preflight PID can still be unsafe if the operating system reuses it during the short restart window. This pull request does not change the existing process identity checks.
- The fallback depends on the preflight run IDs that the restart request already persists.
- There is no schema migration or API change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The runtime did not expose a more specific model revision or context-window size. Reasoning, repository editing, shell execution, and test execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
