### PR TITLE
feat(ui): badge the review policy when it constrains approval

### DIFF
--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -172,6 +172,7 @@ describeEmbeddedPostgres("attention service", () => {
     unblockDescriptor?: { owner: { userId: string } | "board"; action: string } | null;
     blockedTransitionAt?: Date | null;
     harnessKind?: string | null;
+    reviewPolicy?: "anyone" | "not_creator" | "human_only" | null;
   }) {
     const id = input.id ?? randomUUID();
     await db.insert(issues).values({
@@ -181,6 +182,7 @@ describeEmbeddedPostgres("attention service", () => {
       title: input.title,
       status: input.status,
       priority: input.priority ?? "medium",
+      reviewPolicy: input.reviewPolicy ?? null,
       parentId: input.parentId ?? null,
       projectId: input.projectId ?? null,
       projectWorkspaceId: input.projectWorkspaceId ?? null,
@@ -314,6 +316,9 @@ describeEmbeddedPostgres("attention service", () => {
       title: "Stalled review blocker",
       status: "in_review",
       assigneeAgentId: reviewerId,
+      // PAP-16506: the /decisions review card states who may give the verdict,
+      // so the subject has to carry the issue's opt-in constraint.
+      reviewPolicy: "human_only",
       updatedAt: new Date("2026-07-09T12:05:00.000Z"),
     });
     await db.insert(issueRelations).values({
@@ -673,7 +678,10 @@ describeEmbeddedPostgres("attention service", () => {
       // A stalled review resolves in-row on the /decisions card (PAP-16080 §4.4).
       inlineResolvable: true,
       subject: expect.objectContaining({
-        metadata: expect.objectContaining({ reviewAttentionState: "stalled" }),
+        metadata: expect.objectContaining({
+          reviewAttentionState: "stalled",
+          reviewPolicy: "human_only",
+        }),
       }),
       decisionVerbs: expect.arrayContaining([
         expect.objectContaining({ id: "choose_review_path", label: "Choose review path" }),

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -43,6 +43,7 @@ import type {
   AttentionSubject,
   AttentionTriageAttribution,
   AttentionWorkspaceRef,
+  IssueReviewPolicy,
 } from "@paperclipai/shared";
 import { badRequest } from "../errors.js";
 import { PRODUCTIVITY_REVIEW_ORIGIN_KIND } from "./productivity-review.js";
@@ -123,6 +124,8 @@ type IssueSummaryRow = {
   title: string;
   status: string;
   priority: string;
+  /** Who may give the `in_review` verdict; `null`/absent ≡ "anyone" (PAP-16506). */
+  reviewPolicy?: IssueReviewPolicy | null;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
   createdAt: Date;
@@ -341,6 +344,9 @@ function issueSubject(prefix: string, issue: IssueSubjectRow): AttentionSubject 
       priority: issue.priority,
       assigneeAgentId: issue.assigneeAgentId,
       assigneeUserId: issue.assigneeUserId,
+      // Only present when the row was selected with the column, so subjects
+      // built from narrower selects do not claim a policy they never read.
+      ...(issue.reviewPolicy !== undefined ? { reviewPolicy: issue.reviewPolicy } : {}),
     },
   };
 }
@@ -776,6 +782,7 @@ async function issueSummaryMap(db: Db, companyId: string, issueIds: Array<string
       title: issues.title,
       status: issues.status,
       priority: issues.priority,
+      reviewPolicy: issues.reviewPolicy,
       assigneeAgentId: issues.assigneeAgentId,
       assigneeUserId: issues.assigneeUserId,
       createdAt: issues.createdAt,
@@ -801,6 +808,7 @@ async function issueSummaryMap(db: Db, companyId: string, issueIds: Array<string
     title: row.title,
     status: row.status,
     priority: row.priority,
+    reviewPolicy: row.reviewPolicy ?? null,
     assigneeAgentId: row.assigneeAgentId,
     assigneeUserId: row.assigneeUserId,
     createdAt: row.createdAt,

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -180,6 +180,92 @@ describe("AttentionQueueRow", () => {
     expect(el.textContent).toContain("Send back to work");
   });
 
+  // PAP-16506 P4: the card states who holds the verdict before offering the
+  // verbs, so nobody presses Approve on a review the server will 403.
+  it("states the default approver rule on a review with no policy set", () => {
+    const el = render(
+      <AttentionQueueRow
+        item={buildItem({
+          sourceKind: "review" as AttentionSourceKind,
+          inlineResolvable: true,
+          subject: {
+            kind: "issue",
+            id: "issue-1",
+            companyId: "c1",
+            title: "PR ready for review",
+            identifier: null,
+            status: "in_review",
+            href: "/PAP/issues/PAP-1",
+            metadata: { reviewAttentionState: "stalled" },
+          },
+        })}
+        companyId="c1"
+        expanded
+        onToggleExpand={noop}
+        onDismiss={noop}
+      />,
+    );
+    const copy = el.querySelector('[data-testid="review-policy-copy"]');
+    expect(copy?.getAttribute("data-review-policy")).toBe("anyone");
+    expect(copy?.textContent).toContain("Anyone with write access can approve");
+  });
+
+  it("states the opt-in constraint when the issue carries one", () => {
+    const el = render(
+      <AttentionQueueRow
+        item={buildItem({
+          sourceKind: "review" as AttentionSourceKind,
+          inlineResolvable: true,
+          subject: {
+            kind: "issue",
+            id: "issue-1",
+            companyId: "c1",
+            title: "PR ready for review",
+            identifier: null,
+            status: "in_review",
+            href: "/PAP/issues/PAP-1",
+            metadata: { reviewAttentionState: "stalled", reviewPolicy: "human_only" },
+          },
+        })}
+        companyId="c1"
+        expanded
+        onToggleExpand={noop}
+        onDismiss={noop}
+      />,
+    );
+    const copy = el.querySelector('[data-testid="review-policy-copy"]');
+    expect(copy?.getAttribute("data-review-policy")).toBe("human_only");
+    expect(copy?.textContent).toContain("Requires a human");
+  });
+
+  it("ignores a review policy the client does not recognise", () => {
+    const el = render(
+      <AttentionQueueRow
+        item={buildItem({
+          sourceKind: "review" as AttentionSourceKind,
+          inlineResolvable: true,
+          subject: {
+            kind: "issue",
+            id: "issue-1",
+            companyId: "c1",
+            title: "PR ready for review",
+            identifier: null,
+            status: "in_review",
+            href: "/PAP/issues/PAP-1",
+            metadata: { reviewAttentionState: "stalled", reviewPolicy: "board_only" },
+          },
+        })}
+        companyId="c1"
+        expanded
+        onToggleExpand={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(
+      el.querySelector('[data-testid="review-policy-copy"]')?.getAttribute("data-review-policy"),
+    ).toBe("anyone");
+  });
+
   it("deep-links a covered review instead of inlining", () => {
     const el = render(
       <AttentionQueueRow

--- a/ui/src/components/AttentionQueueRow.test.tsx
+++ b/ui/src/components/AttentionQueueRow.test.tsx
@@ -180,90 +180,88 @@ describe("AttentionQueueRow", () => {
     expect(el.textContent).toContain("Send back to work");
   });
 
-  // PAP-16506 P4: the card states who holds the verdict before offering the
-  // verbs, so nobody presses Approve on a review the server will 403.
-  it("states the default approver rule on a review with no policy set", () => {
+  // PAP-16506 P4: an opt-in policy warns before the card offers Approve, because
+  // the server refuses the verdict. The default earns no pixels.
+  const reviewItemWithPolicy = (reviewPolicy?: unknown) =>
+    buildItem({
+      sourceKind: "review" as AttentionSourceKind,
+      inlineResolvable: true,
+      subject: {
+        kind: "issue",
+        id: "issue-1",
+        companyId: "c1",
+        title: "PR ready for review",
+        identifier: null,
+        status: "in_review",
+        href: "/PAP/issues/PAP-1",
+        metadata: {
+          reviewAttentionState: "stalled",
+          ...(reviewPolicy === undefined ? {} : { reviewPolicy }),
+        },
+      },
+    });
+
+  it("says nothing about who can approve on a review with no policy set", () => {
     const el = render(
       <AttentionQueueRow
-        item={buildItem({
-          sourceKind: "review" as AttentionSourceKind,
-          inlineResolvable: true,
-          subject: {
-            kind: "issue",
-            id: "issue-1",
-            companyId: "c1",
-            title: "PR ready for review",
-            identifier: null,
-            status: "in_review",
-            href: "/PAP/issues/PAP-1",
-            metadata: { reviewAttentionState: "stalled" },
-          },
-        })}
+        item={reviewItemWithPolicy()}
         companyId="c1"
         expanded
         onToggleExpand={noop}
         onDismiss={noop}
       />,
     );
-    const copy = el.querySelector('[data-testid="review-policy-copy"]');
-    expect(copy?.getAttribute("data-review-policy")).toBe("anyone");
-    expect(copy?.textContent).toContain("Anyone with write access can approve");
+    expect(el.querySelector('[data-testid="review-policy-badge"]')).toBeNull();
+    expect(el.textContent).not.toContain("Anyone else");
+    expect(el.textContent).not.toContain("Human only");
+    // The verbs still render — suppressing the badge must not suppress the card.
+    expect(el.textContent).toContain("Send back to work");
   });
 
-  it("states the opt-in constraint when the issue carries one", () => {
+  it("badges the opt-in constraint when the issue carries one", () => {
     const el = render(
       <AttentionQueueRow
-        item={buildItem({
-          sourceKind: "review" as AttentionSourceKind,
-          inlineResolvable: true,
-          subject: {
-            kind: "issue",
-            id: "issue-1",
-            companyId: "c1",
-            title: "PR ready for review",
-            identifier: null,
-            status: "in_review",
-            href: "/PAP/issues/PAP-1",
-            metadata: { reviewAttentionState: "stalled", reviewPolicy: "human_only" },
-          },
-        })}
+        item={reviewItemWithPolicy("human_only")}
         companyId="c1"
         expanded
         onToggleExpand={noop}
         onDismiss={noop}
       />,
     );
-    const copy = el.querySelector('[data-testid="review-policy-copy"]');
-    expect(copy?.getAttribute("data-review-policy")).toBe("human_only");
-    expect(copy?.textContent).toContain("Requires a human");
+    const badge = el.querySelector('[data-testid="review-policy-badge"]');
+    expect(badge?.getAttribute("data-review-policy")).toBe("human_only");
+    expect(badge?.textContent).toContain("Human only");
+    expect(badge?.getAttribute("title")).toContain("Agents cannot");
   });
 
-  it("ignores a review policy the client does not recognise", () => {
+  it("badges a not_creator policy as 'Anyone else'", () => {
     const el = render(
       <AttentionQueueRow
-        item={buildItem({
-          sourceKind: "review" as AttentionSourceKind,
-          inlineResolvable: true,
-          subject: {
-            kind: "issue",
-            id: "issue-1",
-            companyId: "c1",
-            title: "PR ready for review",
-            identifier: null,
-            status: "in_review",
-            href: "/PAP/issues/PAP-1",
-            metadata: { reviewAttentionState: "stalled", reviewPolicy: "board_only" },
-          },
-        })}
+        item={reviewItemWithPolicy("not_creator")}
         companyId="c1"
         expanded
         onToggleExpand={noop}
         onDismiss={noop}
       />,
     );
-    expect(
-      el.querySelector('[data-testid="review-policy-copy"]')?.getAttribute("data-review-policy"),
-    ).toBe("anyone");
+    const badge = el.querySelector('[data-testid="review-policy-badge"]');
+    expect(badge?.getAttribute("data-review-policy")).toBe("not_creator");
+    expect(badge?.textContent).toContain("Anyone else");
+  });
+
+  it("shows no badge for an explicit default or an unrecognised policy", () => {
+    for (const policy of ["anyone", "board_only"]) {
+      const el = render(
+        <AttentionQueueRow
+          item={reviewItemWithPolicy(policy)}
+          companyId="c1"
+          expanded
+          onToggleExpand={noop}
+          onDismiss={noop}
+        />,
+      );
+      expect(el.querySelector('[data-testid="review-policy-badge"]')).toBeNull();
+    }
   });
 
   it("deep-links a covered review instead of inlining", () => {

--- a/ui/src/components/AttentionQueueRow.tsx
+++ b/ui/src/components/AttentionQueueRow.tsx
@@ -49,6 +49,7 @@ import {
 import { AttentionInteractionResolver } from "./AttentionInteractionResolver";
 import { DecisionResolver } from "./DecisionResolver";
 import { StalledReviewActions } from "./StalledReviewActions";
+import { readIssueReviewPolicyMetadata } from "../lib/review-policy";
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -843,6 +844,7 @@ function InlineResolver({
         issueId={item.subject.id}
         companyId={companyId}
         footerSlot={toggle}
+        reviewPolicy={readIssueReviewPolicyMetadata(item.subject.metadata)}
       />
     );
   }

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2692,4 +2692,85 @@ describe("IssueProperties", () => {
 
     act(() => root.unmount());
   });
+  // PAP-16506 P4: `in_review` means someone must give a verdict, and by default
+  // that is anyone with write access — including the agent that did the work.
+  // The row has to say so on a NULL column instead of reading "None".
+  it("shows the default review policy on an issue that has never set one", async () => {
+    const root = renderProperties(container, {
+      issue: createIssue({ reviewPolicy: null }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
+    });
+    await flush();
+
+    const trigger = findRowTrigger(container, "Review policy");
+    expect(trigger).toBeTruthy();
+    expect(trigger?.textContent).toContain("Anyone can approve");
+    expect(trigger?.textContent).not.toContain("None");
+
+    act(() => root.unmount());
+  });
+
+  it("shows the opt-in constraint when the issue sets one", async () => {
+    const root = renderProperties(container, {
+      issue: createIssue({ reviewPolicy: "human_only" }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
+    });
+    await flush();
+
+    expect(findRowTrigger(container, "Review policy")?.textContent).toContain("People only");
+
+    act(() => root.unmount());
+  });
+
+  it("PATCHes the chosen review policy and clears back to NULL for the default", async () => {
+    const onUpdate = vi.fn();
+    const root = renderProperties(container, {
+      issue: createIssue({ reviewPolicy: null }),
+      childIssues: [],
+      onUpdate,
+      inline: true,
+    });
+    await flush();
+
+    await act(async () => {
+      findRowTrigger(container, "Review policy")!.click();
+    });
+    await flush();
+
+    const option = container.querySelector<HTMLButtonElement>('[data-testid="review-policy-option-not_creator"]');
+    expect(option).toBeTruthy();
+    await act(async () => {
+      option!.click();
+    });
+    expect(onUpdate).toHaveBeenCalledWith({ reviewPolicy: "not_creator" });
+
+    act(() => root.unmount());
+  });
+
+  it("writes NULL rather than the literal default so the issue tracks the board default", async () => {
+    const onUpdate = vi.fn();
+    const root = renderProperties(container, {
+      issue: createIssue({ reviewPolicy: "human_only" }),
+      childIssues: [],
+      onUpdate,
+      inline: true,
+    });
+    await flush();
+
+    await act(async () => {
+      findRowTrigger(container, "Review policy")!.click();
+    });
+    await flush();
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="review-policy-option-anyone"]')!.click();
+    });
+    expect(onUpdate).toHaveBeenCalledWith({ reviewPolicy: null });
+
+    act(() => root.unmount());
+  });
 });

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2706,8 +2706,10 @@ describe("IssueProperties", () => {
 
     const trigger = findRowTrigger(container, "Review policy");
     expect(trigger).toBeTruthy();
-    expect(trigger?.textContent).toContain("Anyone can approve");
+    // The row shows the short noun fragment; the full label is in the picker.
+    expect(trigger?.textContent).toContain("Anyone");
     expect(trigger?.textContent).not.toContain("None");
+    expect(trigger?.querySelector("[title]")?.getAttribute("title")).toContain("Anyone can approve");
 
     act(() => root.unmount());
   });

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2692,10 +2692,14 @@ describe("IssueProperties", () => {
 
     act(() => root.unmount());
   });
-  // PAP-16506 P4: `in_review` means someone must give a verdict, and by default
-  // that is anyone with write access — including the agent that did the work.
-  // The row has to say so on a NULL column instead of reading "None".
-  it("shows the default review policy on an issue that has never set one", async () => {
+  // PAP-16506 P4: only an agent sets `reviewPolicy`, so the panel shows it and
+  // never offers a control. The default — a NULL column, meaning anyone with
+  // write access can approve — is what every issue already does, so it shows
+  // nothing at all rather than a row reading "Anyone" or "None".
+  const findApprovalsRow = () =>
+    container.querySelector('[data-property-label="Approvals"]')?.closest('[data-property-row="true"]') ?? null;
+
+  it("shows no approvals row on an issue that has never set a policy", async () => {
     const root = renderProperties(container, {
       issue: createIssue({ reviewPolicy: null }),
       childIssues: [],
@@ -2704,56 +2708,27 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const trigger = findRowTrigger(container, "Review policy");
-    expect(trigger).toBeTruthy();
-    // The row shows the short noun fragment; the full label is in the picker.
-    expect(trigger?.textContent).toContain("Anyone");
-    expect(trigger?.textContent).not.toContain("None");
-    expect(trigger?.querySelector("[title]")?.getAttribute("title")).toContain("Anyone can approve");
+    expect(findApprovalsRow()).toBeNull();
+    expect(container.textContent).not.toContain("Review policy");
 
     act(() => root.unmount());
   });
 
-  it("shows the opt-in constraint when the issue sets one", async () => {
+  it("shows no approvals row when the policy is the explicit default", async () => {
     const root = renderProperties(container, {
-      issue: createIssue({ reviewPolicy: "human_only" }),
+      issue: createIssue({ reviewPolicy: "anyone" }),
       childIssues: [],
       onUpdate: vi.fn(),
       inline: true,
     });
     await flush();
 
-    expect(findRowTrigger(container, "Review policy")?.textContent).toContain("People only");
+    expect(findApprovalsRow()).toBeNull();
 
     act(() => root.unmount());
   });
 
-  it("PATCHes the chosen review policy and clears back to NULL for the default", async () => {
-    const onUpdate = vi.fn();
-    const root = renderProperties(container, {
-      issue: createIssue({ reviewPolicy: null }),
-      childIssues: [],
-      onUpdate,
-      inline: true,
-    });
-    await flush();
-
-    await act(async () => {
-      findRowTrigger(container, "Review policy")!.click();
-    });
-    await flush();
-
-    const option = container.querySelector<HTMLButtonElement>('[data-testid="review-policy-option-not_creator"]');
-    expect(option).toBeTruthy();
-    await act(async () => {
-      option!.click();
-    });
-    expect(onUpdate).toHaveBeenCalledWith({ reviewPolicy: "not_creator" });
-
-    act(() => root.unmount());
-  });
-
-  it("writes NULL rather than the literal default so the issue tracks the board default", async () => {
+  it("badges an opt-in constraint read-only, with no control to change it", async () => {
     const onUpdate = vi.fn();
     const root = renderProperties(container, {
       issue: createIssue({ reviewPolicy: "human_only" }),
@@ -2763,15 +2738,25 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    await act(async () => {
-      findRowTrigger(container, "Review policy")!.click();
+    const row = findApprovalsRow();
+    expect(row?.textContent).toContain("Human only");
+    // Read-only: the row is a chip, not a picker — nothing here can PATCH.
+    expect(row?.querySelector("button")).toBeNull();
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+  });
+
+  it("badges a not_creator policy as 'Anyone else'", async () => {
+    const root = renderProperties(container, {
+      issue: createIssue({ reviewPolicy: "not_creator" }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
     });
     await flush();
 
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="review-policy-option-anyone"]')!.click();
-    });
-    expect(onUpdate).toHaveBeenCalledWith({ reviewPolicy: null });
+    expect(findApprovalsRow()?.textContent).toContain("Anyone else");
 
     act(() => root.unmount());
   });

--- a/ui/src/components/StalledReviewActions.tsx
+++ b/ui/src/components/StalledReviewActions.tsx
@@ -1,10 +1,11 @@
 import { useState, type ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, Loader2, RotateCcw, Undo2 } from "lucide-react";
-import type { StalledReviewDecisionAction } from "@paperclipai/shared";
+import type { IssueReviewPolicy, StalledReviewDecisionAction } from "@paperclipai/shared";
 import { issuesApi } from "../api/issues";
 import { useToastActions } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
+import { issueReviewPolicyCopy } from "../lib/review-policy";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
 import { Textarea } from "./ui/textarea";
@@ -16,6 +17,12 @@ interface StalledReviewActionsProps {
   footerSlot?: ReactNode;
   /** Fired after a decision lands so the surface can navigate / close / refetch extras. */
   onResolved?: (action: StalledReviewDecisionAction) => void;
+  /**
+   * The issue's `reviewPolicy` (PAP-16506). `null`/undefined ≡ "anyone", the
+   * default — the card then states that anyone with write access can approve
+   * rather than staying silent about who holds the verdict.
+   */
+  reviewPolicy?: IssueReviewPolicy | null;
   className?: string;
 }
 
@@ -40,6 +47,7 @@ export function StalledReviewActions({
   companyId,
   footerSlot,
   onResolved,
+  reviewPolicy,
   className,
 }: StalledReviewActionsProps) {
   const queryClient = useQueryClient();
@@ -73,9 +81,20 @@ export function StalledReviewActions({
   const noteEmpty = note.trim().length === 0;
   const runningFor = (action: StalledReviewDecisionAction) =>
     pending && decide.variables === action;
+  const policy = issueReviewPolicyCopy(reviewPolicy);
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
+      {/* Who holds the verdict, before the verbs — the server enforces the same
+          rule, so the card must not imply an approval the PATCH would 403. */}
+      <p
+        className="flex min-w-0 items-start gap-1.5 text-xs text-muted-foreground"
+        data-testid="review-policy-copy"
+        data-review-policy={policy.value}
+      >
+        <policy.Icon className="mt-0.5 size-3 shrink-0" aria-hidden />
+        <span className="min-w-0">{policy.approverCopy}</span>
+      </p>
       <Textarea
         value={note}
         onChange={(event) => setNote(event.target.value)}

--- a/ui/src/components/StalledReviewActions.tsx
+++ b/ui/src/components/StalledReviewActions.tsx
@@ -5,8 +5,9 @@ import type { IssueReviewPolicy, StalledReviewDecisionAction } from "@paperclipa
 import { issuesApi } from "../api/issues";
 import { useToastActions } from "../context/ToastContext";
 import { queryKeys } from "../lib/queryKeys";
-import { issueReviewPolicyCopy } from "../lib/review-policy";
+import { issueReviewPolicyBadge } from "../lib/review-policy";
 import { cn } from "../lib/utils";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Textarea } from "./ui/textarea";
 
@@ -18,9 +19,9 @@ interface StalledReviewActionsProps {
   /** Fired after a decision lands so the surface can navigate / close / refetch extras. */
   onResolved?: (action: StalledReviewDecisionAction) => void;
   /**
-   * The issue's `reviewPolicy` (PAP-16506). `null`/undefined ≡ "anyone", the
-   * default — the card then states that anyone with write access can approve
-   * rather than staying silent about who holds the verdict.
+   * The issue's `reviewPolicy` (PAP-16506). Only an opt-in constraint is shown;
+   * the default — `null`/`"anyone"` — renders nothing, because "anyone can
+   * approve" is what every issue already does.
    */
   reviewPolicy?: IssueReviewPolicy | null;
   className?: string;
@@ -81,20 +82,25 @@ export function StalledReviewActions({
   const noteEmpty = note.trim().length === 0;
   const runningFor = (action: StalledReviewDecisionAction) =>
     pending && decide.variables === action;
-  const policy = issueReviewPolicyCopy(reviewPolicy);
+  const policyBadge = issueReviewPolicyBadge(reviewPolicy);
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
-      {/* Who holds the verdict, before the verbs — the server enforces the same
-          rule, so the card must not imply an approval the PATCH would 403. */}
-      <p
-        className="flex min-w-0 items-start gap-1.5 text-xs text-muted-foreground"
-        data-testid="review-policy-copy"
-        data-review-policy={policy.value}
-      >
-        <policy.Icon className="mt-0.5 size-3 shrink-0" aria-hidden />
-        <span className="min-w-0">{policy.approverCopy}</span>
-      </p>
+      {/* Only a constrained policy gets a badge: the server refuses a verdict
+          from the wrong actor, so the card has to warn before offering Approve.
+          The default needs no line — anyone with write access can approve. */}
+      {policyBadge ? (
+        <Badge
+          variant="outline"
+          className="max-w-full min-w-0 self-start font-normal"
+          data-testid="review-policy-badge"
+          data-review-policy={policyBadge.value}
+          title={policyBadge.description}
+        >
+          <policyBadge.Icon aria-hidden />
+          <span className="min-w-0 truncate">{policyBadge.label}</span>
+        </Badge>
+      ) : null}
       <Textarea
         value={note}
         onChange={(event) => setNote(event.target.value)}

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -89,6 +89,11 @@ import {
 } from "./helpers";
 import { PropertyPicker } from "./property-picker";
 import { PropertyChip, PropertyRow, PropertySection } from "./primitives";
+import {
+  ISSUE_REVIEW_POLICY_OPTIONS,
+  issueReviewPolicyCopy,
+  resolveIssueReviewPolicy,
+} from "../../lib/review-policy";
 import { IssueCasesPanel } from "../IssueCasesPanel";
 import { ExpandRelationListButton, RemovableIssueReferencePill } from "./relation-controls";
 import { Badge } from "@/components/ui/badge";
@@ -229,6 +234,7 @@ export function IssueProperties({
   const [relatedTasksExpanded, setRelatedTasksExpanded] = useState(false);
   const [parentOpen, setParentOpen] = useState(false);
   const [parentSearch, setParentSearch] = useState("");
+  const [reviewPolicyOpen, setReviewPolicyOpen] = useState(false);
   const [reviewersOpen, setReviewersOpen] = useState(false);
   const [reviewerSearch, setReviewerSearch] = useState("");
   const [approversOpen, setApproversOpen] = useState(false);
@@ -801,6 +807,54 @@ export function IssueProperties({
   const approverTrigger = approverValues.length > 0
     ? <span className="text-sm truncate min-w-0" title={approverLabel}>{approverLabel}</span>
     : <span className="text-sm text-muted-foreground">None</span>;
+  // PAP-16506 P4: who may give the `in_review` verdict. `null` ≡ "anyone", the
+  // default for every issue — the trigger shows that baseline rather than "None"
+  // so the row never reads as "nobody can approve this".
+  const reviewPolicy = resolveIssueReviewPolicy(issue.reviewPolicy);
+  const reviewPolicyDetails = issueReviewPolicyCopy(reviewPolicy);
+  const reviewPolicyTrigger = (
+    <>
+      <reviewPolicyDetails.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <span
+        className={cn("text-sm truncate min-w-0", reviewPolicy === "anyone" && "text-muted-foreground")}
+        // The label truncates in a narrow panel, so the tooltip has to carry it
+        // as well as the rule — otherwise "Anyone can appro…" is unrecoverable.
+        title={`${reviewPolicyDetails.label} — ${reviewPolicyDetails.description}`}
+      >
+        {reviewPolicyDetails.label}
+      </span>
+    </>
+  );
+  const reviewPolicyContent = (
+    <div className="max-h-64 overflow-y-auto overscroll-contain">
+      {ISSUE_REVIEW_POLICY_OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          className={cn(
+            "flex w-full min-w-0 items-start gap-2 rounded px-2 py-1.5 text-left hover:bg-accent/50",
+            option.value === reviewPolicy && "bg-accent",
+          )}
+          data-testid={`review-policy-option-${option.value}`}
+          onClick={() => {
+            // Persist the default as NULL so an untouched issue keeps the
+            // board-wide default rather than pinning today's meaning of "anyone".
+            onUpdate({ reviewPolicy: option.value === "anyone" ? null : option.value });
+            setReviewPolicyOpen(false);
+          }}
+        >
+          <option.Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="min-w-0 flex-1">
+            <span className="block text-xs font-medium text-foreground">{option.label}</span>
+            <span className="block text-xs text-muted-foreground">{option.description}</span>
+          </span>
+          {option.value === reviewPolicy ? (
+            <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          ) : null}
+        </button>
+      ))}
+    </div>
+  );
   const nextRunnableExecutionStage = (() => {
     if (issue.executionState?.status === "changes_requested" && issue.executionState.currentStageType) {
       return issue.executionState.currentStageType;
@@ -2232,6 +2286,18 @@ export function IssueProperties({
       </PropertySection>
 
       <PropertySection title="Execution">
+        <PropertyPicker
+          inline={inline}
+          label="Review policy"
+          open={reviewPolicyOpen}
+          onOpenChange={setReviewPolicyOpen}
+          triggerContent={reviewPolicyTrigger}
+          triggerClassName="min-w-0 max-w-full"
+          popoverClassName={cn("max-w-full", inline ? "w-full" : "w-72")}
+        >
+          {reviewPolicyContent}
+        </PropertyPicker>
+
         <PropertyPicker
           inline={inline}
           label="Reviewers"

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -817,11 +817,11 @@ export function IssueProperties({
       <reviewPolicyDetails.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
       <span
         className={cn("text-sm truncate min-w-0", reviewPolicy === "anyone" && "text-muted-foreground")}
-        // The label truncates in a narrow panel, so the tooltip has to carry it
-        // as well as the rule — otherwise "Anyone can appro…" is unrecoverable.
+        // `title` never fires on touch, so the picker is the real recovery path.
+        // It still carries the full label and the rule for pointer users.
         title={`${reviewPolicyDetails.label} — ${reviewPolicyDetails.description}`}
       >
-        {reviewPolicyDetails.label}
+        {reviewPolicyDetails.triggerLabel}
       </span>
     </>
   );

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -89,11 +89,7 @@ import {
 } from "./helpers";
 import { PropertyPicker } from "./property-picker";
 import { PropertyChip, PropertyRow, PropertySection } from "./primitives";
-import {
-  ISSUE_REVIEW_POLICY_OPTIONS,
-  issueReviewPolicyCopy,
-  resolveIssueReviewPolicy,
-} from "../../lib/review-policy";
+import { issueReviewPolicyBadge } from "../../lib/review-policy";
 import { IssueCasesPanel } from "../IssueCasesPanel";
 import { ExpandRelationListButton, RemovableIssueReferencePill } from "./relation-controls";
 import { Badge } from "@/components/ui/badge";
@@ -234,7 +230,6 @@ export function IssueProperties({
   const [relatedTasksExpanded, setRelatedTasksExpanded] = useState(false);
   const [parentOpen, setParentOpen] = useState(false);
   const [parentSearch, setParentSearch] = useState("");
-  const [reviewPolicyOpen, setReviewPolicyOpen] = useState(false);
   const [reviewersOpen, setReviewersOpen] = useState(false);
   const [reviewerSearch, setReviewerSearch] = useState("");
   const [approversOpen, setApproversOpen] = useState(false);
@@ -807,54 +802,10 @@ export function IssueProperties({
   const approverTrigger = approverValues.length > 0
     ? <span className="text-sm truncate min-w-0" title={approverLabel}>{approverLabel}</span>
     : <span className="text-sm text-muted-foreground">None</span>;
-  // PAP-16506 P4: who may give the `in_review` verdict. `null` ≡ "anyone", the
-  // default for every issue — the trigger shows that baseline rather than "None"
-  // so the row never reads as "nobody can approve this".
-  const reviewPolicy = resolveIssueReviewPolicy(issue.reviewPolicy);
-  const reviewPolicyDetails = issueReviewPolicyCopy(reviewPolicy);
-  const reviewPolicyTrigger = (
-    <>
-      <reviewPolicyDetails.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-      <span
-        className={cn("text-sm truncate min-w-0", reviewPolicy === "anyone" && "text-muted-foreground")}
-        // `title` never fires on touch, so the picker is the real recovery path.
-        // It still carries the full label and the rule for pointer users.
-        title={`${reviewPolicyDetails.label} — ${reviewPolicyDetails.description}`}
-      >
-        {reviewPolicyDetails.triggerLabel}
-      </span>
-    </>
-  );
-  const reviewPolicyContent = (
-    <div className="max-h-64 overflow-y-auto overscroll-contain">
-      {ISSUE_REVIEW_POLICY_OPTIONS.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          className={cn(
-            "flex w-full min-w-0 items-start gap-2 rounded px-2 py-1.5 text-left hover:bg-accent/50",
-            option.value === reviewPolicy && "bg-accent",
-          )}
-          data-testid={`review-policy-option-${option.value}`}
-          onClick={() => {
-            // Persist the default as NULL so an untouched issue keeps the
-            // board-wide default rather than pinning today's meaning of "anyone".
-            onUpdate({ reviewPolicy: option.value === "anyone" ? null : option.value });
-            setReviewPolicyOpen(false);
-          }}
-        >
-          <option.Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-          <span className="min-w-0 flex-1">
-            <span className="block text-xs font-medium text-foreground">{option.label}</span>
-            <span className="block text-xs text-muted-foreground">{option.description}</span>
-          </span>
-          {option.value === reviewPolicy ? (
-            <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-          ) : null}
-        </button>
-      ))}
-    </div>
-  );
+  // PAP-16506 P4: who may give the `in_review` verdict. Only an agent sets this,
+  // and only the two opt-in constraints are worth a row — the default (`null` ≡
+  // "anyone can approve") is what every issue already does, so it shows nothing.
+  const reviewPolicyBadge = issueReviewPolicyBadge(issue.reviewPolicy);
   const nextRunnableExecutionStage = (() => {
     if (issue.executionState?.status === "changes_requested" && issue.executionState.currentStageType) {
       return issue.executionState.currentStageType;
@@ -2286,17 +2237,15 @@ export function IssueProperties({
       </PropertySection>
 
       <PropertySection title="Execution">
-        <PropertyPicker
-          inline={inline}
-          label="Review policy"
-          open={reviewPolicyOpen}
-          onOpenChange={setReviewPolicyOpen}
-          triggerContent={reviewPolicyTrigger}
-          triggerClassName="min-w-0 max-w-full"
-          popoverClassName={cn("max-w-full", inline ? "w-full" : "w-72")}
-        >
-          {reviewPolicyContent}
-        </PropertyPicker>
+        {/* Read-only: agents set the policy, the board does not. */}
+        {reviewPolicyBadge ? (
+          <PropertyRow label="Approvals">
+            <PropertyChip title={reviewPolicyBadge.description}>
+              <reviewPolicyBadge.Icon className="shrink-0 text-muted-foreground" aria-hidden />
+              <span className="min-w-0 truncate">{reviewPolicyBadge.label}</span>
+            </PropertyChip>
+          </PropertyRow>
+        ) : null}
 
         <PropertyPicker
           inline={inline}

--- a/ui/src/components/issue-properties/primitives.tsx
+++ b/ui/src/components/issue-properties/primitives.tsx
@@ -69,10 +69,13 @@ export function PropertyChip({
   children,
   className,
   style,
+  title,
 }: {
   children: ReactNode;
   className?: string;
   style?: CSSProperties;
+  /** Tooltip override for chips whose children are not a bare string. */
+  title?: string;
 }) {
   return (
     <Badge
@@ -80,7 +83,7 @@ export function PropertyChip({
       // Badge chassis; keep this chip's truncation + normal weight + start alignment.
       className={cn("max-w-full min-w-0 justify-start truncate font-normal", className)}
       style={style}
-      title={typeof children === "string" ? children : undefined}
+      title={title ?? (typeof children === "string" ? children : undefined)}
     >
       {children}
     </Badge>

--- a/ui/src/lib/activity-format.test.ts
+++ b/ui/src/lib/activity-format.test.ts
@@ -66,6 +66,43 @@ describe("activity formatting", () => {
     expect(formatIssueActivityAction("issue.monitor_recovery_issue_created")).toBe("created a monitor recovery issue");
   });
 
+  // PAP-16506 P4: agents can now approve or reject a review, so a verdict has to
+  // read as a verdict in the timeline instead of leaking the raw action id.
+  it("reads review verdicts as verdicts, whoever gave them", () => {
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted")).toBe("approved the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_rejected")).toBe("rejected the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_withdrawn")).toBe("withdrew the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_expired")).toBe("let the request expire");
+    expect(formatActivityVerb("issue.thread_interaction_accepted")).toBe("approved the request on");
+    expect(formatActivityVerb("issue.thread_interaction_rejected")).toBe("rejected the request on");
+  });
+
+  it("names the verb an actor chose on a stalled review", () => {
+    expect(formatIssueActivityAction("issue.stalled_review_decided", { action: "approve" }))
+      .toBe("approved the review");
+    expect(formatIssueActivityAction("issue.stalled_review_decided", { action: "request_changes" }))
+      .toBe("requested changes on the review");
+    expect(formatIssueActivityAction("issue.stalled_review_decided", { action: "send_back" }))
+      .toBe("sent the review back to work");
+    expect(formatActivityVerb("issue.stalled_review_decided", { action: "approve" }))
+      .toBe("approved the review on");
+  });
+
+  it("falls back to a generic verdict line when the decision verb is missing", () => {
+    expect(formatIssueActivityAction("issue.stalled_review_decided")).toBe("recorded a review verdict");
+    expect(formatIssueActivityAction("issue.stalled_review_decided", { action: "shrug" }))
+      .toBe("recorded a review verdict");
+  });
+
+  it("describes a review-policy change without calling the default 'none'", () => {
+    expect(formatIssueActivityAction("issue.updated", { reviewPolicy: null }))
+      .toBe("changed who can approve to anyone");
+    expect(formatIssueActivityAction("issue.updated", { reviewPolicy: "human_only" }))
+      .toBe("changed who can approve to people only");
+    expect(formatIssueActivityAction("issue.updated", { reviewPolicy: "not_creator" }))
+      .toBe("changed who can approve to not the requester");
+  });
+
   it("uses plain next-step copy for successful-run handoff activity", () => {
     expect(formatActivityVerb("issue.successful_run_handoff_required")).toBe("flagged missing next step on");
     expect(formatIssueActivityAction("issue.successful_run_handoff_required")).toBe("Run finished without a clear next step");

--- a/ui/src/lib/activity-format.test.ts
+++ b/ui/src/lib/activity-format.test.ts
@@ -66,15 +66,44 @@ describe("activity formatting", () => {
     expect(formatIssueActivityAction("issue.monitor_recovery_issue_created")).toBe("created a monitor recovery issue");
   });
 
-  // PAP-16506 P4: agents can now approve or reject a review, so a verdict has to
-  // read as a verdict in the timeline instead of leaking the raw action id.
-  it("reads review verdicts as verdicts, whoever gave them", () => {
-    expect(formatIssueActivityAction("issue.thread_interaction_accepted")).toBe("approved the request");
+  // PAP-16506 P4: agents can now resolve an interaction, including a review of
+  // their own work, so an outcome has to read as an outcome in the timeline
+  // instead of leaking the raw action id.
+  it("reads an interaction outcome as an outcome, whoever gave it", () => {
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted")).toBe("accepted the request");
     expect(formatIssueActivityAction("issue.thread_interaction_rejected")).toBe("rejected the request");
     expect(formatIssueActivityAction("issue.thread_interaction_withdrawn")).toBe("withdrew the request");
-    expect(formatIssueActivityAction("issue.thread_interaction_expired")).toBe("let the request expire");
-    expect(formatActivityVerb("issue.thread_interaction_accepted")).toBe("approved the request on");
+    expect(formatIssueActivityAction("issue.thread_interaction_expired")).toBe("expired the request");
+    expect(formatActivityVerb("issue.thread_interaction_accepted")).toBe("accepted the request on");
     expect(formatActivityVerb("issue.thread_interaction_rejected")).toBe("rejected the request on");
+  });
+
+  // The accepted/rejected actions fire for every interaction kind, so only a
+  // confirmation may read as an approval.
+  it("says 'approved' only for a confirmation, never for a suggestion or a question", () => {
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: "request_confirmation" }))
+      .toBe("approved the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: "request_checkbox_confirmation" }))
+      .toBe("approved the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: "suggest_tasks" }))
+      .toBe("accepted the task suggestions");
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: "ask_user_questions" }))
+      .toBe("accepted the answers");
+    expect(formatIssueActivityAction("issue.thread_interaction_rejected", { interactionKind: "request_confirmation" }))
+      .toBe("rejected the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_rejected", { interactionKind: "suggest_tasks" }))
+      .toBe("declined the task suggestions");
+    expect(formatActivityVerb("issue.thread_interaction_accepted", { interactionKind: "suggest_tasks" }))
+      .toBe("accepted the task suggestions on");
+  });
+
+  it("keeps the neutral wording for a kind it does not know", () => {
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: "request_item_verdicts" }))
+      .toBe("accepted the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: "future_kind" }))
+      .toBe("accepted the request");
+    expect(formatIssueActivityAction("issue.thread_interaction_accepted", { interactionKind: 7 }))
+      .toBe("accepted the request");
   });
 
   it("names the verb an actor chose on a stalled review", () => {

--- a/ui/src/lib/activity-format.test.ts
+++ b/ui/src/lib/activity-format.test.ts
@@ -127,9 +127,9 @@ describe("activity formatting", () => {
     expect(formatIssueActivityAction("issue.updated", { reviewPolicy: null }))
       .toBe("changed who can approve to anyone");
     expect(formatIssueActivityAction("issue.updated", { reviewPolicy: "human_only" }))
-      .toBe("changed who can approve to people only");
+      .toBe("changed who can approve to human only");
     expect(formatIssueActivityAction("issue.updated", { reviewPolicy: "not_creator" }))
-      .toBe("changed who can approve to not the requester");
+      .toBe("changed who can approve to anyone else");
   });
 
   it("uses plain next-step copy for successful-run handoff activity", () => {

--- a/ui/src/lib/activity-format.ts
+++ b/ui/src/lib/activity-format.ts
@@ -1,5 +1,6 @@
 import type { Agent } from "@paperclipai/shared";
 import type { CompanyUserProfile } from "./company-members";
+import { formatReviewPolicyValue } from "./review-policy";
 
 type ActivityDetails = Record<string, unknown> | null | undefined;
 
@@ -69,6 +70,18 @@ const ACTIVITY_ROW_VERBS: Record<string, string> = {
   "approval.created": "requested approval",
   "approval.approved": "approved",
   "approval.rejected": "rejected",
+  // Review verdicts (PAP-16506). An agent may now approve or reject a review —
+  // including its own work — so these must read as verdicts in the feed instead
+  // of falling through to the raw "issue thread interaction accepted" action id.
+  "issue.thread_interaction_created": "asked for a decision on",
+  "issue.thread_interaction_accepted": "approved the request on",
+  "issue.thread_interaction_rejected": "rejected the request on",
+  "issue.thread_interaction_answered": "answered the request on",
+  "issue.thread_interaction_withdrawn": "withdrew the request on",
+  "issue.thread_interaction_cancelled": "cancelled the request on",
+  "issue.thread_interaction_expired": "let the request expire on",
+  "issue.thread_interaction_item_verdicts_submitted": "submitted verdicts on",
+  "issue.stalled_review_decided": "recorded a review verdict on",
   "project.created": "created",
   "project.updated": "updated",
   "project.deleted": "deleted",
@@ -133,6 +146,26 @@ const ISSUE_ACTIVITY_LABELS: Record<string, string> = {
   "approval.created": "requested approval",
   "approval.approved": "approved",
   "approval.rejected": "rejected",
+  "issue.thread_interaction_created": "asked for a decision",
+  "issue.thread_interaction_accepted": "approved the request",
+  "issue.thread_interaction_rejected": "rejected the request",
+  "issue.thread_interaction_answered": "answered the request",
+  "issue.thread_interaction_withdrawn": "withdrew the request",
+  "issue.thread_interaction_cancelled": "cancelled the request",
+  "issue.thread_interaction_expired": "let the request expire",
+  "issue.thread_interaction_item_verdicts_submitted": "submitted verdicts on the request",
+  "issue.stalled_review_decided": "recorded a review verdict",
+};
+
+/**
+ * `issue.stalled_review_decided` carries the verb the actor chose, so the line
+ * names the verdict ("approved the review") rather than the generic action.
+ * Mirrors `StalledReviewDecisionAction` in shared.
+ */
+const STALLED_REVIEW_DECISION_LABELS: Record<string, string> = {
+  approve: "approved the review",
+  request_changes: "requested changes on the review",
+  send_back: "sent the review back to work",
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -284,6 +317,11 @@ function formatIssueUpdatedAction(details: ActivityDetails, options: ActivityFor
     const assigneeName = formatAssigneeName(details, options);
     parts.push(assigneeName ? `made ${assigneeName} responsible for the task` : "cleared the responsible");
   }
+  if (details.reviewPolicy !== undefined) {
+    // `null` is the default ("anyone can approve"), so it must not read as
+    // "changed the review policy to none" (PAP-16506).
+    parts.push(`changed who can approve to ${formatReviewPolicyValue(details.reviewPolicy)}`);
+  }
   if (details.title !== undefined) parts.push("updated the title");
   if (details.description !== undefined) parts.push("updated the description");
 
@@ -342,6 +380,12 @@ export function formatActivityVerb(
     if (issueUpdatedVerb) return issueUpdatedVerb;
   }
 
+  if (action === "issue.stalled_review_decided") {
+    const decision = typeof details?.action === "string" ? details.action : null;
+    const label = decision ? STALLED_REVIEW_DECISION_LABELS[decision] : null;
+    if (label) return `${label} on`;
+  }
+
   const structuredChange = formatStructuredIssueChange({
     action,
     details,
@@ -374,6 +418,12 @@ export function formatIssueActivityAction(
   if (action === "issue.accepted_plan_decomposition_updated") {
     const detail = formatAcceptedPlanDecompositionDetail(details);
     if (detail) return detail;
+  }
+
+  if (action === "issue.stalled_review_decided") {
+    const decision = typeof details?.action === "string" ? details.action : null;
+    const label = decision ? STALLED_REVIEW_DECISION_LABELS[decision] : null;
+    if (label) return label;
   }
 
   if (action.startsWith("issue.monitor_") && details) {

--- a/ui/src/lib/activity-format.ts
+++ b/ui/src/lib/activity-format.ts
@@ -70,16 +70,17 @@ const ACTIVITY_ROW_VERBS: Record<string, string> = {
   "approval.created": "requested approval",
   "approval.approved": "approved",
   "approval.rejected": "rejected",
-  // Review verdicts (PAP-16506). An agent may now approve or reject a review —
-  // including its own work — so these must read as verdicts in the feed instead
+  // Interaction outcomes (PAP-16506). An agent may now resolve one — including a
+  // review of its own work — so these must read as outcomes in the feed instead
   // of falling through to the raw "issue thread interaction accepted" action id.
+  // `details.interactionKind` sharpens the wording; see INTERACTION_OUTCOME_LABELS.
   "issue.thread_interaction_created": "asked for a decision on",
-  "issue.thread_interaction_accepted": "approved the request on",
+  "issue.thread_interaction_accepted": "accepted the request on",
   "issue.thread_interaction_rejected": "rejected the request on",
   "issue.thread_interaction_answered": "answered the request on",
   "issue.thread_interaction_withdrawn": "withdrew the request on",
   "issue.thread_interaction_cancelled": "cancelled the request on",
-  "issue.thread_interaction_expired": "let the request expire on",
+  "issue.thread_interaction_expired": "expired the request on",
   "issue.thread_interaction_item_verdicts_submitted": "submitted verdicts on",
   "issue.stalled_review_decided": "recorded a review verdict on",
   "project.created": "created",
@@ -147,12 +148,12 @@ const ISSUE_ACTIVITY_LABELS: Record<string, string> = {
   "approval.approved": "approved",
   "approval.rejected": "rejected",
   "issue.thread_interaction_created": "asked for a decision",
-  "issue.thread_interaction_accepted": "approved the request",
+  "issue.thread_interaction_accepted": "accepted the request",
   "issue.thread_interaction_rejected": "rejected the request",
   "issue.thread_interaction_answered": "answered the request",
   "issue.thread_interaction_withdrawn": "withdrew the request",
   "issue.thread_interaction_cancelled": "cancelled the request",
-  "issue.thread_interaction_expired": "let the request expire",
+  "issue.thread_interaction_expired": "expired the request",
   "issue.thread_interaction_item_verdicts_submitted": "submitted verdicts on the request",
   "issue.stalled_review_decided": "recorded a review verdict",
 };
@@ -167,6 +168,42 @@ const STALLED_REVIEW_DECISION_LABELS: Record<string, string> = {
   request_changes: "requested changes on the review",
   send_back: "sent the review back to work",
 };
+
+/**
+ * `issue.thread_interaction_accepted` / `_rejected` fire for *every* interaction
+ * kind, not only for a review. A task suggestion or a question is accepted, not
+ * approved, so the kind on the event picks the verb. Kinds absent from a map
+ * keep the neutral "accepted the request" wording from the tables above, which
+ * is also the fallback for an event that carries no kind.
+ */
+const INTERACTION_ACCEPTED_LABELS: Record<string, string> = {
+  request_confirmation: "approved the request",
+  request_checkbox_confirmation: "approved the request",
+  suggest_tasks: "accepted the task suggestions",
+  ask_user_questions: "accepted the answers",
+};
+
+const INTERACTION_REJECTED_LABELS: Record<string, string> = {
+  request_confirmation: "rejected the request",
+  request_checkbox_confirmation: "rejected the request",
+  suggest_tasks: "declined the task suggestions",
+  ask_user_questions: "declined the questions",
+};
+
+/**
+ * Kind-aware wording for an interaction outcome, or `null` when the tables
+ * above already say it well enough.
+ */
+function formatInteractionOutcomeLabel(action: string, details: ActivityDetails): string | null {
+  const table = action === "issue.thread_interaction_accepted"
+    ? INTERACTION_ACCEPTED_LABELS
+    : action === "issue.thread_interaction_rejected"
+      ? INTERACTION_REJECTED_LABELS
+      : null;
+  if (!table) return null;
+  const kind = typeof details?.interactionKind === "string" ? details.interactionKind : null;
+  return kind ? table[kind] ?? null : null;
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -386,6 +423,9 @@ export function formatActivityVerb(
     if (label) return `${label} on`;
   }
 
+  const outcomeLabel = formatInteractionOutcomeLabel(action, details);
+  if (outcomeLabel) return `${outcomeLabel} on`;
+
   const structuredChange = formatStructuredIssueChange({
     action,
     details,
@@ -425,6 +465,9 @@ export function formatIssueActivityAction(
     const label = decision ? STALLED_REVIEW_DECISION_LABELS[decision] : null;
     if (label) return label;
   }
+
+  const outcomeLabel = formatInteractionOutcomeLabel(action, details);
+  if (outcomeLabel) return outcomeLabel;
 
   if (action.startsWith("issue.monitor_") && details) {
     const serviceName = typeof details.serviceName === "string" && details.serviceName.trim()

--- a/ui/src/lib/issue-change-receipt.test.ts
+++ b/ui/src/lib/issue-change-receipt.test.ts
@@ -12,6 +12,7 @@ describe("issueChangeFieldLabel", () => {
     expect(issueChangeFieldLabel("assigneeAgentId")).toBe("Assignee");
     expect(issueChangeFieldLabel("blockedByIssueIds")).toBe("Blockers");
     expect(issueChangeFieldLabel("workMode")).toBe("Work mode");
+    expect(issueChangeFieldLabel("reviewPolicy")).toBe("Who can approve");
   });
 
   it("humanizes unknown camelCase and snake_case fields", () => {
@@ -33,6 +34,14 @@ describe("formatIssueChangeValue", () => {
   it("humanizes enum-ish values", () => {
     expect(formatIssueChangeValue("in_progress")).toBe("in progress");
     expect(formatIssueChangeValue("high")).toBe("high");
+  });
+
+  // A cleared `reviewPolicy` means "anyone can approve" (PAP-16506), so the
+  // receipt must not report the default as an absent value.
+  it("reads a cleared review policy as 'anyone', not 'none'", () => {
+    expect(formatIssueChangeValue(null, { field: "reviewPolicy" })).toBe("anyone");
+    expect(formatIssueChangeValue("human_only", { field: "reviewPolicy" })).toBe("people only");
+    expect(formatIssueChangeValue("not_creator", { field: "reviewPolicy" })).toBe("not the requester");
   });
 
   it("renders booleans and numbers plainly", () => {

--- a/ui/src/lib/issue-change-receipt.test.ts
+++ b/ui/src/lib/issue-change-receipt.test.ts
@@ -40,8 +40,8 @@ describe("formatIssueChangeValue", () => {
   // receipt must not report the default as an absent value.
   it("reads a cleared review policy as 'anyone', not 'none'", () => {
     expect(formatIssueChangeValue(null, { field: "reviewPolicy" })).toBe("anyone");
-    expect(formatIssueChangeValue("human_only", { field: "reviewPolicy" })).toBe("people only");
-    expect(formatIssueChangeValue("not_creator", { field: "reviewPolicy" })).toBe("not the requester");
+    expect(formatIssueChangeValue("human_only", { field: "reviewPolicy" })).toBe("human only");
+    expect(formatIssueChangeValue("not_creator", { field: "reviewPolicy" })).toBe("anyone else");
   });
 
   it("renders booleans and numbers plainly", () => {

--- a/ui/src/lib/issue-change-receipt.ts
+++ b/ui/src/lib/issue-change-receipt.ts
@@ -1,4 +1,5 @@
 import type { IssueChangeReceiptEntry } from "@paperclipai/shared";
+import { formatReviewPolicyValue } from "./review-policy";
 
 /**
  * Read + format the field-level change receipts carried on an `issue.updated`
@@ -25,6 +26,7 @@ const FIELD_LABELS: Record<string, string> = {
   projectId: "Project",
   goalId: "Goal",
   workMode: "Work mode",
+  reviewPolicy: "Who can approve",
   billingCode: "Billing code",
   checkoutRunId: "Checkout run",
   executionRunId: "Execution run",
@@ -64,6 +66,9 @@ export function formatIssueChangeValue(
     resolveUserLabel?: (id: string) => string | null | undefined;
     field?: string } = {},
 ): string {
+  // `reviewPolicy` is nullable-by-default: a cleared column means "anyone can
+  // approve", not "no value" (PAP-16506), so it resolves before the null branch.
+  if (options.field === "reviewPolicy") return formatReviewPolicyValue(value);
   if (value === null || value === undefined || value === "") return "none";
   if (typeof value === "boolean") return value ? "yes" : "no";
   if (typeof value === "number") return String(value);

--- a/ui/src/lib/review-policy.test.ts
+++ b/ui/src/lib/review-policy.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  DEFAULT_ISSUE_REVIEW_POLICY,
   ISSUE_REVIEW_POLICY_OPTIONS,
   formatReviewPolicyValue,
-  isConstrainedIssueReviewPolicy,
-  issueReviewPolicyApproverCopy,
-  issueReviewPolicyLabel,
+  issueReviewPolicyCopy,
   readIssueReviewPolicyMetadata,
   resolveIssueReviewPolicy,
 } from "./review-policy";
@@ -15,7 +12,6 @@ describe("resolveIssueReviewPolicy", () => {
   it("treats a cleared column as the board default, not as an absent setting", () => {
     expect(resolveIssueReviewPolicy(null)).toBe("anyone");
     expect(resolveIssueReviewPolicy(undefined)).toBe("anyone");
-    expect(DEFAULT_ISSUE_REVIEW_POLICY).toBe("anyone");
   });
 
   it("passes the two opt-in constraints through", () => {
@@ -30,15 +26,15 @@ describe("resolveIssueReviewPolicy", () => {
 
 describe("policy copy", () => {
   it("labels every policy without leaking the enum value", () => {
-    expect(issueReviewPolicyLabel(null)).toBe("Anyone can approve");
-    expect(issueReviewPolicyLabel("not_creator")).toBe("Not the requester");
-    expect(issueReviewPolicyLabel("human_only")).toBe("People only");
+    expect(issueReviewPolicyCopy(null).label).toBe("Anyone can approve");
+    expect(issueReviewPolicyCopy("not_creator").label).toBe("Not the requester");
+    expect(issueReviewPolicyCopy("human_only").label).toBe("People only");
   });
 
   it("states who may give the verdict on each policy", () => {
-    expect(issueReviewPolicyApproverCopy(null)).toContain("Anyone with write access");
-    expect(issueReviewPolicyApproverCopy("not_creator")).toContain("other than the requester");
-    expect(issueReviewPolicyApproverCopy("human_only")).toContain("Requires a human");
+    expect(issueReviewPolicyCopy(null).approverCopy).toContain("Anyone with write access");
+    expect(issueReviewPolicyCopy("not_creator").approverCopy).toContain("other than the requester");
+    expect(issueReviewPolicyCopy("human_only").approverCopy).toContain("Requires a human");
   });
 
   it("offers exactly the three states the board defined, default first", () => {
@@ -49,11 +45,9 @@ describe("policy copy", () => {
     ]);
   });
 
-  it("marks only the opt-in constraints as constrained", () => {
-    expect(isConstrainedIssueReviewPolicy(null)).toBe(false);
-    expect(isConstrainedIssueReviewPolicy("anyone")).toBe(false);
-    expect(isConstrainedIssueReviewPolicy("not_creator")).toBe(true);
-    expect(isConstrainedIssueReviewPolicy("human_only")).toBe(true);
+  it("gives every policy a distinct icon so the row is scannable", () => {
+    const icons = ISSUE_REVIEW_POLICY_OPTIONS.map((option) => option.Icon);
+    expect(new Set(icons).size).toBe(icons.length);
   });
 });
 

--- a/ui/src/lib/review-policy.test.ts
+++ b/ui/src/lib/review-policy.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ISSUE_REVIEW_POLICY,
+  ISSUE_REVIEW_POLICY_OPTIONS,
+  formatReviewPolicyValue,
+  isConstrainedIssueReviewPolicy,
+  issueReviewPolicyApproverCopy,
+  issueReviewPolicyLabel,
+  readIssueReviewPolicyMetadata,
+  resolveIssueReviewPolicy,
+} from "./review-policy";
+
+describe("resolveIssueReviewPolicy", () => {
+  it("treats a cleared column as the board default, not as an absent setting", () => {
+    expect(resolveIssueReviewPolicy(null)).toBe("anyone");
+    expect(resolveIssueReviewPolicy(undefined)).toBe("anyone");
+    expect(DEFAULT_ISSUE_REVIEW_POLICY).toBe("anyone");
+  });
+
+  it("passes the two opt-in constraints through", () => {
+    expect(resolveIssueReviewPolicy("not_creator")).toBe("not_creator");
+    expect(resolveIssueReviewPolicy("human_only")).toBe("human_only");
+  });
+
+  it("falls back to the default for a policy this build does not know", () => {
+    expect(resolveIssueReviewPolicy("board_only" as never)).toBe("anyone");
+  });
+});
+
+describe("policy copy", () => {
+  it("labels every policy without leaking the enum value", () => {
+    expect(issueReviewPolicyLabel(null)).toBe("Anyone can approve");
+    expect(issueReviewPolicyLabel("not_creator")).toBe("Not the requester");
+    expect(issueReviewPolicyLabel("human_only")).toBe("People only");
+  });
+
+  it("states who may give the verdict on each policy", () => {
+    expect(issueReviewPolicyApproverCopy(null)).toContain("Anyone with write access");
+    expect(issueReviewPolicyApproverCopy("not_creator")).toContain("other than the requester");
+    expect(issueReviewPolicyApproverCopy("human_only")).toContain("Requires a human");
+  });
+
+  it("offers exactly the three states the board defined, default first", () => {
+    expect(ISSUE_REVIEW_POLICY_OPTIONS.map((option) => option.value)).toEqual([
+      "anyone",
+      "not_creator",
+      "human_only",
+    ]);
+  });
+
+  it("marks only the opt-in constraints as constrained", () => {
+    expect(isConstrainedIssueReviewPolicy(null)).toBe(false);
+    expect(isConstrainedIssueReviewPolicy("anyone")).toBe(false);
+    expect(isConstrainedIssueReviewPolicy("not_creator")).toBe(true);
+    expect(isConstrainedIssueReviewPolicy("human_only")).toBe(true);
+  });
+});
+
+describe("formatReviewPolicyValue", () => {
+  it("reads a cleared policy as 'anyone', never as 'none'", () => {
+    expect(formatReviewPolicyValue(null)).toBe("anyone");
+    expect(formatReviewPolicyValue(undefined)).toBe("anyone");
+    expect(formatReviewPolicyValue("anyone")).toBe("anyone");
+  });
+
+  it("uses mid-sentence wording for the constraints", () => {
+    expect(formatReviewPolicyValue("not_creator")).toBe("not the requester");
+    expect(formatReviewPolicyValue("human_only")).toBe("people only");
+  });
+
+  it("humanizes an unknown policy rather than hiding it", () => {
+    expect(formatReviewPolicyValue("board_only")).toBe("board only");
+  });
+});
+
+describe("readIssueReviewPolicyMetadata", () => {
+  it("reads the policy off an attention subject's metadata bag", () => {
+    expect(readIssueReviewPolicyMetadata({ reviewPolicy: "human_only" })).toBe("human_only");
+  });
+
+  it("returns null when the subject carries no policy", () => {
+    expect(readIssueReviewPolicyMetadata(null)).toBeNull();
+    expect(readIssueReviewPolicyMetadata(undefined)).toBeNull();
+    expect(readIssueReviewPolicyMetadata({ priority: "high" })).toBeNull();
+  });
+
+  it("rejects a value outside the enum instead of trusting the wire", () => {
+    expect(readIssueReviewPolicyMetadata({ reviewPolicy: "board_only" })).toBeNull();
+    expect(readIssueReviewPolicyMetadata({ reviewPolicy: 3 })).toBeNull();
+  });
+});

--- a/ui/src/lib/review-policy.test.ts
+++ b/ui/src/lib/review-policy.test.ts
@@ -31,6 +31,15 @@ describe("policy copy", () => {
     expect(issueReviewPolicyCopy("human_only").label).toBe("People only");
   });
 
+  // The settings row is narrow, so its value is a noun fragment that leans on
+  // the row label. None of the three may truncate at phone width.
+  it("keeps every row value short enough for a narrow panel", () => {
+    expect(issueReviewPolicyCopy(null).triggerLabel).toBe("Anyone");
+    for (const option of ISSUE_REVIEW_POLICY_OPTIONS) {
+      expect(option.triggerLabel.length).toBeLessThanOrEqual("Not the requester".length);
+    }
+  });
+
   it("states who may give the verdict on each policy", () => {
     expect(issueReviewPolicyCopy(null).approverCopy).toContain("Anyone with write access");
     expect(issueReviewPolicyCopy("not_creator").approverCopy).toContain("other than the requester");

--- a/ui/src/lib/review-policy.test.ts
+++ b/ui/src/lib/review-policy.test.ts
@@ -1,62 +1,31 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  ISSUE_REVIEW_POLICY_OPTIONS,
   formatReviewPolicyValue,
-  issueReviewPolicyCopy,
+  issueReviewPolicyBadge,
   readIssueReviewPolicyMetadata,
-  resolveIssueReviewPolicy,
 } from "./review-policy";
 
-describe("resolveIssueReviewPolicy", () => {
-  it("treats a cleared column as the board default, not as an absent setting", () => {
-    expect(resolveIssueReviewPolicy(null)).toBe("anyone");
-    expect(resolveIssueReviewPolicy(undefined)).toBe("anyone");
+describe("issueReviewPolicyBadge", () => {
+  // The default is what every issue already does, so it earns no pixels.
+  it("shows nothing for the default, however the column spells it", () => {
+    expect(issueReviewPolicyBadge(null)).toBeNull();
+    expect(issueReviewPolicyBadge(undefined)).toBeNull();
+    expect(issueReviewPolicyBadge("anyone")).toBeNull();
   });
 
-  it("passes the two opt-in constraints through", () => {
-    expect(resolveIssueReviewPolicy("not_creator")).toBe("not_creator");
-    expect(resolveIssueReviewPolicy("human_only")).toBe("human_only");
+  it("badges each opt-in constraint in the board's words", () => {
+    expect(issueReviewPolicyBadge("not_creator")?.label).toBe("Anyone else");
+    expect(issueReviewPolicyBadge("human_only")?.label).toBe("Human only");
   });
 
-  it("falls back to the default for a policy this build does not know", () => {
-    expect(resolveIssueReviewPolicy("board_only" as never)).toBe("anyone");
-  });
-});
-
-describe("policy copy", () => {
-  it("labels every policy without leaking the enum value", () => {
-    expect(issueReviewPolicyCopy(null).label).toBe("Anyone can approve");
-    expect(issueReviewPolicyCopy("not_creator").label).toBe("Not the requester");
-    expect(issueReviewPolicyCopy("human_only").label).toBe("People only");
+  it("spells the rule out in the tooltip so the badge is recoverable", () => {
+    expect(issueReviewPolicyBadge("not_creator")?.description).toContain("asked for the review");
+    expect(issueReviewPolicyBadge("human_only")?.description).toContain("Agents cannot");
   });
 
-  // The settings row is narrow, so its value is a noun fragment that leans on
-  // the row label. None of the three may truncate at phone width.
-  it("keeps every row value short enough for a narrow panel", () => {
-    expect(issueReviewPolicyCopy(null).triggerLabel).toBe("Anyone");
-    for (const option of ISSUE_REVIEW_POLICY_OPTIONS) {
-      expect(option.triggerLabel.length).toBeLessThanOrEqual("Not the requester".length);
-    }
-  });
-
-  it("states who may give the verdict on each policy", () => {
-    expect(issueReviewPolicyCopy(null).approverCopy).toContain("Anyone with write access");
-    expect(issueReviewPolicyCopy("not_creator").approverCopy).toContain("other than the requester");
-    expect(issueReviewPolicyCopy("human_only").approverCopy).toContain("Requires a human");
-  });
-
-  it("offers exactly the three states the board defined, default first", () => {
-    expect(ISSUE_REVIEW_POLICY_OPTIONS.map((option) => option.value)).toEqual([
-      "anyone",
-      "not_creator",
-      "human_only",
-    ]);
-  });
-
-  it("gives every policy a distinct icon so the row is scannable", () => {
-    const icons = ISSUE_REVIEW_POLICY_OPTIONS.map((option) => option.Icon);
-    expect(new Set(icons).size).toBe(icons.length);
+  it("shows nothing for a policy this build does not know", () => {
+    expect(issueReviewPolicyBadge("board_only" as never)).toBeNull();
   });
 });
 
@@ -67,9 +36,9 @@ describe("formatReviewPolicyValue", () => {
     expect(formatReviewPolicyValue("anyone")).toBe("anyone");
   });
 
-  it("uses mid-sentence wording for the constraints", () => {
-    expect(formatReviewPolicyValue("not_creator")).toBe("not the requester");
-    expect(formatReviewPolicyValue("human_only")).toBe("people only");
+  it("uses the badge wording mid-sentence so a receipt matches the badge", () => {
+    expect(formatReviewPolicyValue("not_creator")).toBe("anyone else");
+    expect(formatReviewPolicyValue("human_only")).toBe("human only");
   });
 
   it("humanizes an unknown policy rather than hiding it", () => {

--- a/ui/src/lib/review-policy.ts
+++ b/ui/src/lib/review-policy.ts
@@ -1,0 +1,126 @@
+import { Users, UserMinus, UserRound, type LucideIcon } from "lucide-react";
+import { ISSUE_REVIEW_POLICIES, type IssueReviewPolicy } from "@paperclipai/shared";
+
+/**
+ * Copy + affordances for an issue's `reviewPolicy` (PAP-16506 P4).
+ *
+ * `in_review` means the work needs a review verdict before it is done — from
+ * anyone. By default each person *and each agent* with write access can
+ * approve, including the agent that did the work. `reviewPolicy` is the
+ * per-issue opt-in constraint on that default, and there are exactly two:
+ *
+ * - `not_creator` — the reviewer must not be the one who asked for the review.
+ * - `human_only` — only a person can approve.
+ *
+ * A `null` column means "anyone", which is the default for every new *and*
+ * existing issue — there is no backfill. Everything that renders the policy
+ * routes through here so the settings control, the review card, and the
+ * activity receipt never drift from each other or from the server's 403 copy
+ * in `server/src/services/issue-review-policy.ts`.
+ */
+
+export const DEFAULT_ISSUE_REVIEW_POLICY: IssueReviewPolicy = "anyone";
+
+export interface IssueReviewPolicyCopy {
+  value: IssueReviewPolicy;
+  /** Short label for the settings trigger. */
+  label: string;
+  /** Mid-sentence wording for activity lines and change receipts. */
+  valueLabel: string;
+  /** One line explaining the rule, shown under the label in the picker. */
+  description: string;
+  /** Who may give the verdict — the review card's line. */
+  approverCopy: string;
+  Icon: LucideIcon;
+}
+
+const COPY: Record<IssueReviewPolicy, IssueReviewPolicyCopy> = {
+  anyone: {
+    value: "anyone",
+    label: "Anyone can approve",
+    valueLabel: "anyone",
+    description: "Each person and each agent with write access can approve, including the agent that did the work.",
+    approverCopy: "Anyone with write access can approve — people and agents alike.",
+    Icon: Users,
+  },
+  not_creator: {
+    value: "not_creator",
+    label: "Not the requester",
+    valueLabel: "not the requester",
+    description: "The reviewer must not be the one who asked for the review.",
+    approverCopy: "Requires a reviewer other than the requester.",
+    Icon: UserMinus,
+  },
+  human_only: {
+    value: "human_only",
+    label: "People only",
+    valueLabel: "people only",
+    description: "Only a person can approve. Agents cannot give the verdict.",
+    approverCopy: "Requires a human. Agents cannot approve this review.",
+    Icon: UserRound,
+  },
+};
+
+/** `null`/unknown → the board's default, so callers never branch on absence. */
+export function resolveIssueReviewPolicy(
+  policy: IssueReviewPolicy | null | undefined,
+): IssueReviewPolicy {
+  if (policy && policy in COPY) return policy as IssueReviewPolicy;
+  return DEFAULT_ISSUE_REVIEW_POLICY;
+}
+
+export function issueReviewPolicyCopy(
+  policy: IssueReviewPolicy | null | undefined,
+): IssueReviewPolicyCopy {
+  return COPY[resolveIssueReviewPolicy(policy)];
+}
+
+export function issueReviewPolicyLabel(policy: IssueReviewPolicy | null | undefined): string {
+  return issueReviewPolicyCopy(policy).label;
+}
+
+export function issueReviewPolicyApproverCopy(
+  policy: IssueReviewPolicy | null | undefined,
+): string {
+  return issueReviewPolicyCopy(policy).approverCopy;
+}
+
+/**
+ * Mid-sentence wording for an activity line or a field-change receipt, where a
+ * cleared column must read "anyone" rather than "none".
+ */
+export function formatReviewPolicyValue(value: unknown): string {
+  if (typeof value === "string" && !(value in COPY)) {
+    // Forward-compatible: a policy this build does not know reads as itself.
+    return value.replace(/_/g, " ");
+  }
+  return issueReviewPolicyCopy(value as IssueReviewPolicy | null | undefined).valueLabel;
+}
+
+/**
+ * Read the policy off an untyped `AttentionSubject.metadata` bag. Absent or
+ * unrecognised → `null`, which every consumer resolves to the default.
+ */
+export function readIssueReviewPolicyMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): IssueReviewPolicy | null {
+  const raw = metadata?.reviewPolicy;
+  if (typeof raw !== "string") return null;
+  return (ISSUE_REVIEW_POLICIES as readonly string[]).includes(raw)
+    ? (raw as IssueReviewPolicy)
+    : null;
+}
+
+/** Picker options in "loosest first" order so the default reads as the baseline. */
+export const ISSUE_REVIEW_POLICY_OPTIONS: readonly IssueReviewPolicyCopy[] =
+  ISSUE_REVIEW_POLICIES.map((policy) => COPY[policy]);
+
+/**
+ * A constraint is worth calling out on the review card; the default is not.
+ * The card stays quiet on `anyone` so the common case adds no noise.
+ */
+export function isConstrainedIssueReviewPolicy(
+  policy: IssueReviewPolicy | null | undefined,
+): boolean {
+  return resolveIssueReviewPolicy(policy) !== DEFAULT_ISSUE_REVIEW_POLICY;
+}

--- a/ui/src/lib/review-policy.ts
+++ b/ui/src/lib/review-policy.ts
@@ -1,4 +1,4 @@
-import { Users, UserMinus, UserRound, type LucideIcon } from "lucide-react";
+import { Users, UserMinus, UserCheck, type LucideIcon } from "lucide-react";
 import { ISSUE_REVIEW_POLICIES, type IssueReviewPolicy } from "@paperclipai/shared";
 
 /**
@@ -23,8 +23,14 @@ const DEFAULT_ISSUE_REVIEW_POLICY: IssueReviewPolicy = "anyone";
 
 export interface IssueReviewPolicyCopy {
   value: IssueReviewPolicy;
-  /** Short label for the settings trigger. */
+  /** Full label for the picker option. */
   label: string;
+  /**
+   * Value shown on the settings row, which is narrow. A noun fragment that
+   * leans on the "Review policy" row label, so the three values read in
+   * parallel and none of them truncates at phone width (design review).
+   */
+  triggerLabel: string;
   /** Mid-sentence wording for activity lines and change receipts. */
   valueLabel: string;
   /** One line explaining the rule, shown under the label in the picker. */
@@ -38,6 +44,7 @@ const COPY: Record<IssueReviewPolicy, IssueReviewPolicyCopy> = {
   anyone: {
     value: "anyone",
     label: "Anyone can approve",
+    triggerLabel: "Anyone",
     valueLabel: "anyone",
     description: "Each person and each agent with write access can approve, including the agent that did the work.",
     approverCopy: "Anyone with write access can approve — people and agents alike.",
@@ -46,6 +53,7 @@ const COPY: Record<IssueReviewPolicy, IssueReviewPolicyCopy> = {
   not_creator: {
     value: "not_creator",
     label: "Not the requester",
+    triggerLabel: "Not the requester",
     valueLabel: "not the requester",
     description: "The reviewer must not be the one who asked for the review.",
     approverCopy: "Requires a reviewer other than the requester.",
@@ -54,10 +62,11 @@ const COPY: Record<IssueReviewPolicy, IssueReviewPolicyCopy> = {
   human_only: {
     value: "human_only",
     label: "People only",
+    triggerLabel: "People only",
     valueLabel: "people only",
     description: "Only a person can approve. Agents cannot give the verdict.",
     approverCopy: "Requires a human. Agents cannot approve this review.",
-    Icon: UserRound,
+    Icon: UserCheck,
   },
 };
 

--- a/ui/src/lib/review-policy.ts
+++ b/ui/src/lib/review-policy.ts
@@ -19,7 +19,7 @@ import { ISSUE_REVIEW_POLICIES, type IssueReviewPolicy } from "@paperclipai/shar
  * in `server/src/services/issue-review-policy.ts`.
  */
 
-export const DEFAULT_ISSUE_REVIEW_POLICY: IssueReviewPolicy = "anyone";
+const DEFAULT_ISSUE_REVIEW_POLICY: IssueReviewPolicy = "anyone";
 
 export interface IssueReviewPolicyCopy {
   value: IssueReviewPolicy;
@@ -75,16 +75,6 @@ export function issueReviewPolicyCopy(
   return COPY[resolveIssueReviewPolicy(policy)];
 }
 
-export function issueReviewPolicyLabel(policy: IssueReviewPolicy | null | undefined): string {
-  return issueReviewPolicyCopy(policy).label;
-}
-
-export function issueReviewPolicyApproverCopy(
-  policy: IssueReviewPolicy | null | undefined,
-): string {
-  return issueReviewPolicyCopy(policy).approverCopy;
-}
-
 /**
  * Mid-sentence wording for an activity line or a field-change receipt, where a
  * cleared column must read "anyone" rather than "none".
@@ -114,13 +104,3 @@ export function readIssueReviewPolicyMetadata(
 /** Picker options in "loosest first" order so the default reads as the baseline. */
 export const ISSUE_REVIEW_POLICY_OPTIONS: readonly IssueReviewPolicyCopy[] =
   ISSUE_REVIEW_POLICIES.map((policy) => COPY[policy]);
-
-/**
- * A constraint is worth calling out on the review card; the default is not.
- * The card stays quiet on `anyone` so the common case adds no noise.
- */
-export function isConstrainedIssueReviewPolicy(
-  policy: IssueReviewPolicy | null | undefined,
-): boolean {
-  return resolveIssueReviewPolicy(policy) !== DEFAULT_ISSUE_REVIEW_POLICY;
-}

--- a/ui/src/lib/review-policy.ts
+++ b/ui/src/lib/review-policy.ts
@@ -1,87 +1,65 @@
-import { Users, UserMinus, UserCheck, type LucideIcon } from "lucide-react";
+import { UserCheck, UserMinus, type LucideIcon } from "lucide-react";
 import { ISSUE_REVIEW_POLICIES, type IssueReviewPolicy } from "@paperclipai/shared";
 
 /**
- * Copy + affordances for an issue's `reviewPolicy` (PAP-16506 P4).
+ * Copy for an issue's `reviewPolicy` (PAP-16506 P4).
  *
- * `in_review` means the work needs a review verdict before it is done — from
- * anyone. By default each person *and each agent* with write access can
- * approve, including the agent that did the work. `reviewPolicy` is the
- * per-issue opt-in constraint on that default, and there are exactly two:
+ * `in_review` means the work needs a verdict, and by default anyone with write
+ * access can give it — people and agents alike, including the agent that did the
+ * work. That default needs no UI at all: it is what every issue already does,
+ * and there is no control for changing it. Only an agent sets the column, and
+ * only the two opt-in constraints are worth showing:
  *
- * - `not_creator` — the reviewer must not be the one who asked for the review.
- * - `human_only` — only a person can approve.
+ * - `not_creator` — "Anyone else": the reviewer must not be the requester.
+ * - `human_only` — "Human only": an agent cannot give the verdict.
  *
- * A `null` column means "anyone", which is the default for every new *and*
- * existing issue — there is no backfill. Everything that renders the policy
- * routes through here so the settings control, the review card, and the
- * activity receipt never drift from each other or from the server's 403 copy
- * in `server/src/services/issue-review-policy.ts`.
+ * A `null` or `"anyone"` column renders nothing. Every surface that shows the
+ * policy routes through {@link issueReviewPolicyBadge} so the review card, the
+ * issue properties row, and the activity receipt cannot drift from each other or
+ * from the server's refusal copy in `server/src/services/issue-review-policy.ts`.
  */
 
-const DEFAULT_ISSUE_REVIEW_POLICY: IssueReviewPolicy = "anyone";
-
-export interface IssueReviewPolicyCopy {
+export interface IssueReviewPolicyBadge {
   value: IssueReviewPolicy;
-  /** Full label for the picker option. */
+  /** Badge text. */
   label: string;
-  /**
-   * Value shown on the settings row, which is narrow. A noun fragment that
-   * leans on the "Review policy" row label, so the three values read in
-   * parallel and none of them truncates at phone width (design review).
-   */
-  triggerLabel: string;
-  /** Mid-sentence wording for activity lines and change receipts. */
-  valueLabel: string;
-  /** One line explaining the rule, shown under the label in the picker. */
+  /** Tooltip — the rule the server enforces, spelled out. */
   description: string;
-  /** Who may give the verdict — the review card's line. */
-  approverCopy: string;
   Icon: LucideIcon;
 }
 
-const COPY: Record<IssueReviewPolicy, IssueReviewPolicyCopy> = {
-  anyone: {
-    value: "anyone",
-    label: "Anyone can approve",
-    triggerLabel: "Anyone",
-    valueLabel: "anyone",
-    description: "Each person and each agent with write access can approve, including the agent that did the work.",
-    approverCopy: "Anyone with write access can approve — people and agents alike.",
-    Icon: Users,
-  },
+/** Only the constrained policies are shown; `anyone` is the silent default. */
+const BADGES: Partial<Record<IssueReviewPolicy, IssueReviewPolicyBadge>> = {
   not_creator: {
     value: "not_creator",
-    label: "Not the requester",
-    triggerLabel: "Not the requester",
-    valueLabel: "not the requester",
-    description: "The reviewer must not be the one who asked for the review.",
-    approverCopy: "Requires a reviewer other than the requester.",
+    label: "Anyone else",
+    description: "Anyone except whoever asked for the review can approve it.",
     Icon: UserMinus,
   },
   human_only: {
     value: "human_only",
-    label: "People only",
-    triggerLabel: "People only",
-    valueLabel: "people only",
-    description: "Only a person can approve. Agents cannot give the verdict.",
-    approverCopy: "Requires a human. Agents cannot approve this review.",
+    label: "Human only",
+    description: "Only a person can approve this review. Agents cannot give the verdict.",
     Icon: UserCheck,
   },
 };
 
-/** `null`/unknown → the board's default, so callers never branch on absence. */
-export function resolveIssueReviewPolicy(
-  policy: IssueReviewPolicy | null | undefined,
-): IssueReviewPolicy {
-  if (policy && policy in COPY) return policy as IssueReviewPolicy;
-  return DEFAULT_ISSUE_REVIEW_POLICY;
-}
+/** Mid-sentence wording for activity lines and field-change receipts. */
+const VALUE_LABELS: Record<IssueReviewPolicy, string> = {
+  anyone: "anyone",
+  not_creator: "anyone else",
+  human_only: "human only",
+};
 
-export function issueReviewPolicyCopy(
+/**
+ * The badge for a policy, or `null` when there is nothing to show — which is the
+ * common case, since an unset column means the default "anyone can approve".
+ */
+export function issueReviewPolicyBadge(
   policy: IssueReviewPolicy | null | undefined,
-): IssueReviewPolicyCopy {
-  return COPY[resolveIssueReviewPolicy(policy)];
+): IssueReviewPolicyBadge | null {
+  if (typeof policy !== "string") return null;
+  return BADGES[policy as IssueReviewPolicy] ?? null;
 }
 
 /**
@@ -89,16 +67,15 @@ export function issueReviewPolicyCopy(
  * cleared column must read "anyone" rather than "none".
  */
 export function formatReviewPolicyValue(value: unknown): string {
-  if (typeof value === "string" && !(value in COPY)) {
-    // Forward-compatible: a policy this build does not know reads as itself.
-    return value.replace(/_/g, " ");
-  }
-  return issueReviewPolicyCopy(value as IssueReviewPolicy | null | undefined).valueLabel;
+  if (value === null || value === undefined) return VALUE_LABELS.anyone;
+  if (typeof value !== "string") return VALUE_LABELS.anyone;
+  // Forward-compatible: a policy this build does not know reads as itself.
+  return VALUE_LABELS[value as IssueReviewPolicy] ?? value.replace(/_/g, " ");
 }
 
 /**
  * Read the policy off an untyped `AttentionSubject.metadata` bag. Absent or
- * unrecognised → `null`, which every consumer resolves to the default.
+ * unrecognised → `null`, which every consumer treats as the default.
  */
 export function readIssueReviewPolicyMetadata(
   metadata: Record<string, unknown> | null | undefined,
@@ -109,7 +86,3 @@ export function readIssueReviewPolicyMetadata(
     ? (raw as IssueReviewPolicy)
     : null;
 }
-
-/** Picker options in "loosest first" order so the default reads as the baseline. */
-export const ISSUE_REVIEW_POLICY_OPTIONS: readonly IssueReviewPolicyCopy[] =
-  ISSUE_REVIEW_POLICIES.map((policy) => COPY[policy]);


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents move their work into review, and a reviewer must then give a verdict on it
> - By default anyone with write access can give that verdict, including the agent that did the work
> - The server can constrain that default per issue with a `reviewPolicy` column, but no screen showed the value
> - A reviewer could therefore press Approve on a review that the server refuses, and get a 403
> - This pull request shows the policy as a badge on the two surfaces where a person gives a verdict
> - It also makes an agent verdict read as a verdict in the activity timeline
> - The benefit is that a reviewer sees who can approve before they try

## Linked Issues or Issue Description

No public GitHub issue exists for this change. The description below follows
`.github/ISSUE_TEMPLATE/enhancement.yml`.

**What existing behavior does this improve?**

The issue review flow. A reviewer cannot see the approval constraint on an issue
before they give a verdict.

**Subsystem affected**

Web UI (`ui/`), with one supporting change in the server attention service.

**Current behavior**

The server stores an optional approval constraint for each issue in a
`reviewPolicy` column. The column has three meaningful states: the default
(`NULL` or `anyone`), `not_creator`, and `human_only`. The server enforces the
constraint when it receives a verdict.

No screen shows the value. Two problems follow:

1. A reviewer presses Approve on a review that the server refuses. The server
   answers 403, and the reason is not visible on the card.
2. An agent that accepts or rejects a review renders in the activity timeline as
   the raw action id, for example "issue thread interaction accepted". A person
   who reads the timeline cannot tell that a verdict was given.

**Proposed behavior**

Show the constraint as a read-only badge on the two surfaces where a person
gives a verdict. Show no pixels for the default state, because the default is
what every issue already does. Make an agent verdict read as a verdict in the
timeline.

Only agents set the column today, so this change adds no control to set it.

**Reason and benefit**

A reviewer sees the constraint before they act. This prevents the 403, and it
removes the need to explain the 403 afterwards. The timeline also becomes
complete, because it now shows agent verdicts and human verdicts in the same way.

**Breaking changes**

None. The change adds a badge and changes copy. It adds no column, no endpoint,
and no request.

**Additional context**

The server-side column and the verdict enforcement landed earlier in #10931.
This pull request is the user interface for that column. The default state stays
unchanged on screen, so the badge appears on a small number of issues.

## What Changed

- **A read-only "Approvals" row** in the issue Execution properties. The row
  renders *only* for a constrained policy: "Anyone else" (`not_creator`) or
  "Human only" (`human_only`). A `NULL` or `anyone` column adds no row, so the
  panel is untouched on the overwhelming majority of issues.
- **The same badge on the stalled-review card** in `/decisions`, above the three
  review verbs. A reviewer now sees the constraint before they press Approve.
  The condition is the same, so the default card is unchanged.
- **Agent verdicts read as verdicts in the activity timeline.** An agent that
  accepted or rejected a review request previously rendered the raw action id
  ("issue thread interaction accepted"). It now reads "approved the request". A
  stalled-review decision names the verb that the actor chose.
- **A cleared policy reports as "anyone", not "none",** in the field-change
  receipt. The `reviewPolicy` column is nullable by default, so an absent value
  is a real setting rather than a missing one.
- **All copy comes from `ui/src/lib/review-policy.ts`.** Its badge lookup returns
  `null` for the default. This makes "no pixels for the default" one enforced
  decision instead of a condition repeated at each call site. It also keeps the
  badge, the activity line, and the receipt reading alike.
- **The server attention service carries the policy** on the review attention
  subject, so the stalled-review card can read it.

## Verification

Automated tests:

- `ui/src/lib/review-policy.test.ts` — the default returns no badge, however the
  column spells it (`null`, `undefined`, `"anyone"`). An unrecognised policy from
  the wire shows nothing rather than leaking an enum value.
- `ui/src/components/AttentionQueueRow.test.tsx` — no badge on the default card,
  and the verbs still render. Suppression of the badge must not suppress the card.
- `ui/src/components/IssueProperties.test.tsx` — no Approvals row on the default.
  The constrained row contains no `button`, so nothing there can PATCH.
- `server/src/__tests__/attention-service.test.ts` — the review attention subject
  carries the policy, and subjects built from narrower selects do not claim one.

Run them with:

```sh
pnpm vitest run ui/src/lib/review-policy.test.ts \
  ui/src/components/AttentionQueueRow.test.tsx \
  ui/src/components/IssueProperties.test.tsx \
  server/src/__tests__/attention-service.test.ts
```

Manual steps:

1. Open an issue that has no `reviewPolicy`. Confirm that the Execution
   properties panel shows no Approvals row.
2. Set the column to `not_creator`. Reload the issue. Confirm that the Approvals
   row reads "Anyone else", and that the row has no control.
3. Move that issue into review. Open `/decisions`. Confirm that the stalled
   review card shows the same badge above the review verbs.
4. Let an agent approve the review. Confirm that the activity timeline reads
   "approved the request" and not "issue thread interaction accepted".

Screenshots were captured at 1440x900 and 390x844, in light mode and dark mode,
with the three policy states side by side. The leftmost column in each capture is
the default. It carries no badge and no extra row.

## Risks

Low risk.

- The change is additive on screen. Every new surface is behind a constrained
  policy, so the default path renders exactly as before.
- The badge is read-only. It has no control and sends no request, and a test
  asserts that the row contains no `button`.
- An unknown policy value from the wire renders nothing. It does not render the
  raw enum.
- No migration, no schema change, and no endpoint change.

## Model Used

Claude Opus 5 (Anthropic), model id `claude-opus-5[1m]`, 1M context window,
with extended thinking and tool use enabled. Used through Claude Code for the
implementation, the tests, and this description.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
