### PR TITLE
test(plugins): cover UI dev proxy guards

### DIFF
--- a/server/src/__tests__/plugin-ui-static.test.ts
+++ b/server/src/__tests__/plugin-ui-static.test.ts
@@ -161,4 +161,67 @@ describe("plugin UI static route", () => {
       expect.objectContaining({ signal: expect.any(Object) }),
     );
   });
+
+  it("ignores devUiUrl in production and serves the bundled UI", async () => {
+    process.env.NODE_ENV = "production";
+    readyPlugin(createPluginPackage("export const marker = 'production-static';\n"));
+    mockRegistry.getConfig.mockResolvedValue({
+      configJson: {
+        devUiUrl: "http://localhost:5173/",
+      },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const app = await createApp(boardActor([companyA]));
+
+    const res = await request(app)
+      .get(`/_plugins/${pluginId}/ui/index.js`)
+      .query({ companyId: companyA });
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain("production-static");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-loopback devUiUrl targets without proxying", async () => {
+    process.env.NODE_ENV = "development";
+    readyPlugin(createPluginPackage());
+    mockRegistry.getConfig.mockResolvedValue({
+      configJson: {
+        devUiUrl: "http://169.254.169.254/",
+      },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const app = await createApp(boardActor([companyA]));
+
+    const res = await request(app)
+      .get(`/_plugins/${pluginId}/ui/index.js`)
+      .query({ companyId: companyA });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/localhost/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects encoded absolute paths before they can override the devUiUrl base", async () => {
+    process.env.NODE_ENV = "development";
+    readyPlugin(createPluginPackage());
+    mockRegistry.getConfig.mockResolvedValue({
+      configJson: {
+        devUiUrl: "http://localhost:5173/",
+      },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const app = await createApp(boardActor([companyA]));
+
+    const res = await request(app)
+      .get(`/_plugins/${pluginId}/ui/https:%2F%2Fevil.example%2Fbundle.js`)
+      .query({ companyId: companyA });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invalid file path/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The plugin system lets self-hosted installs extend the control plane without hardcoding every integration into core.
> - Plugin UI bundles can optionally use `devUiUrl` during local development so authors get hot-reload while iterating on UI.
> - That dev proxy sits on a security-sensitive boundary because it constructs outbound server requests from plugin config plus a requested file path.
> - The route already has production and SSRF guard logic, but the tests only covered the successful localhost proxy path.
> - This pull request adds focused regression coverage for the guard behavior without changing production code.
> - The benefit is reviewer-friendly protection around plugin UI development semantics, especially production fallback and no-proxy guarantees for unsafe targets.

## Linked Issues or Issue Description

- No public issue found. Bug-style description:
- Summary: `plugin-ui-static` has security guard behavior for `devUiUrl`, but the test suite did not lock down production fallback, non-loopback rejection, or encoded absolute-path rejection.
- Expected behavior: production requests ignore `devUiUrl` and serve bundled assets, non-loopback dev proxy targets return an error without calling `fetch`, and encoded absolute paths cannot override the configured localhost base URL.
- Actual risk before this PR: future refactors could accidentally weaken those guards while the existing happy-path proxy test still passed.
- Scope: test-only regression coverage for the plugin UI static route.

## What Changed

- Added a production-mode test proving `devUiUrl` is ignored and bundled plugin UI assets are served without calling `fetch`.
- Added a non-loopback `devUiUrl` test proving unsafe dev proxy targets return `400` before any outbound request.
- Added an encoded absolute-path test proving a requested path cannot override the localhost dev proxy base URL.

## Verification

- `../node_modules/.bin/vitest run src/__tests__/plugin-ui-static.test.ts --config vitest.config.ts` from `server/` (7 tests passed)
- `git diff --check`

## Risks

- Low risk: test-only change, no production behavior changes.
- The tests intentionally assert no outbound `fetch` call on rejected dev proxy paths, so they should catch accidental SSRF guard regressions without coupling to unrelated route internals.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 coding agent, tool-enabled local repository inspection and command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
