### PR TITLE
fix(ui): center scroll control above task composer

### DIFF
--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -2939,6 +2939,10 @@ describe("IssueChatThread", () => {
   });
 
   it("keeps the composer floating with a capped editor height", () => {
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 2000,
+    });
     const root = createRoot(container);
 
     act(() => {
@@ -2962,6 +2966,13 @@ describe("IssueChatThread", () => {
     expect(dock?.className).toContain("bottom-(--sz-calc-8)");
     expect(dock?.className).toContain("z-20");
 
+    const scrollToBottom = dock?.querySelector('button[aria-label="Scroll to bottom"]');
+    expect(scrollToBottom).not.toBeNull();
+    expect(scrollToBottom?.className).toContain("absolute");
+    expect(scrollToBottom?.className).toContain("bottom-full");
+    expect(scrollToBottom?.className).toContain("left-1/2");
+    expect(scrollToBottom?.className).toContain("-translate-x-1/2");
+
     const composer = container.querySelector('[data-testid="issue-chat-composer"]') as HTMLDivElement | null;
     expect(composer).not.toBeNull();
     expect(composer?.className).toContain("rounded-md");
@@ -2977,6 +2988,7 @@ describe("IssueChatThread", () => {
     act(() => {
       root.unmount();
     });
+    Reflect.deleteProperty(document.documentElement, "scrollHeight");
   });
 
   it("shows full-composer drop instructions while dragging files over the issue composer", () => {

--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -2948,6 +2948,10 @@ describe("IssueChatThread", () => {
   });
 
   it("keeps the composer floating with a capped editor height", () => {
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 2000,
+    });
     const root = createRoot(container);
 
     act(() => {
@@ -2971,6 +2975,13 @@ describe("IssueChatThread", () => {
     expect(dock?.className).toContain("bottom-(--sz-calc-8)");
     expect(dock?.className).toContain("z-20");
 
+    const scrollToBottom = dock?.querySelector('button[aria-label="Scroll to bottom"]');
+    expect(scrollToBottom).not.toBeNull();
+    expect(scrollToBottom?.className).toContain("absolute");
+    expect(scrollToBottom?.className).toContain("bottom-full");
+    expect(scrollToBottom?.className).toContain("left-1/2");
+    expect(scrollToBottom?.className).toContain("-translate-x-1/2");
+
     const composer = container.querySelector('[data-testid="issue-chat-composer"]') as HTMLDivElement | null;
     expect(composer).not.toBeNull();
     expect(composer?.className).toContain("rounded-md");
@@ -2986,6 +2997,7 @@ describe("IssueChatThread", () => {
     act(() => {
       root.unmount();
     });
+    Reflect.deleteProperty(document.documentElement, "scrollHeight");
   });
 
   it("shows full-composer drop instructions while dragging files over the issue composer", () => {

--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -2975,6 +2975,7 @@ describe("IssueChatThread", () => {
 
     const composer = container.querySelector('[data-testid="issue-chat-composer"]') as HTMLDivElement | null;
     expect(composer).not.toBeNull();
+    expect(composer?.nextElementSibling).toBe(scrollToBottom);
     expect(composer?.className).toContain("rounded-md");
     expect(composer?.className).not.toContain("rounded-lg");
     expect(composer?.className).toContain("p-(--sz-15px)");

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -109,6 +109,7 @@ import {
 import { MarkdownBody, type MarkdownExternalReferenceMap } from "./MarkdownBody";
 import { WorkspaceFileMarkdownBody } from "./WorkspaceFileMarkdownBody";
 import { MarkdownEditor, type MentionOption, type MarkdownEditorRef } from "./MarkdownEditor";
+import { ScrollToBottom } from "./ScrollToBottom";
 import { Identity } from "./Identity";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
 import { IssueThreadInteractionCard } from "./IssueThreadInteractionCard";
@@ -5018,6 +5019,7 @@ export function IssueChatThread({
             data-testid="issue-chat-composer-dock"
             className="sticky bottom-(--sz-calc-8) z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
           >
+            <ScrollToBottom placement="composer" />
             <IssueChatComposer
               ref={composerRef}
               onImageUpload={imageUploadHandler}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -111,6 +111,7 @@ import { MarkdownBody, type MarkdownExternalReferenceMap } from "./MarkdownBody"
 import type { TaskChatIssueBrief } from "./task-chat/TaskChatDescriptionBubble";
 import { WorkspaceFileMarkdownBody } from "./WorkspaceFileMarkdownBody";
 import { MarkdownEditor, type MentionOption, type MarkdownEditorRef } from "./MarkdownEditor";
+import { ScrollToBottom } from "./ScrollToBottom";
 import { Identity } from "./Identity";
 import { InlineEntitySelector, type InlineEntityOption } from "./InlineEntitySelector";
 import { IssueThreadInteractionCard } from "./IssueThreadInteractionCard";
@@ -5176,6 +5177,7 @@ export function IssueChatThread({
             data-testid="issue-chat-composer-dock"
             className="sticky bottom-(--sz-calc-8) z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
           >
+            <ScrollToBottom placement="composer" />
             <IssueChatComposer
               ref={composerRef}
               onImageUpload={imageUploadHandler}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -5019,7 +5019,6 @@ export function IssueChatThread({
             data-testid="issue-chat-composer-dock"
             className="sticky bottom-(--sz-calc-8) z-20 space-y-2 bg-gradient-to-t from-background via-background/95 to-background/0 pt-6"
           >
-            <ScrollToBottom placement="composer" />
             <IssueChatComposer
               ref={composerRef}
               onImageUpload={imageUploadHandler}
@@ -5040,6 +5039,7 @@ export function IssueChatThread({
               issueWorkMode={issueWorkMode}
               onWorkModeChange={onWorkModeChange}
             />
+            <ScrollToBottom placement="composer" />
           </div>
         ) : null}
       </div>

--- a/ui/src/components/ScrollToBottom.tsx
+++ b/ui/src/components/ScrollToBottom.tsx
@@ -33,9 +33,8 @@ function distanceFromBottom(target: ReturnType<typeof resolveScrollTarget>) {
  * Floating scroll-to-bottom button that follows the active page scroller.
  * On desktop that is `#main-content`; on mobile it falls back to window/page scroll.
  */
-export function ScrollToBottom() {
+export function ScrollToBottom({ placement = "viewport" }: { placement?: "composer" | "viewport" }) {
   const [visible, setVisible] = useState(false);
-  const { panelVisible, panelContent } = usePanel();
 
   useEffect(() => {
     const check = () => {
@@ -70,12 +69,39 @@ export function ScrollToBottom() {
 
   if (!visible) return null;
 
+  if (placement === "composer") {
+    return (
+      <ScrollToBottomButton
+        onClick={scroll}
+        className="absolute bottom-full left-1/2 -translate-x-1/2 transition-colors"
+      />
+    );
+  }
+
+  return <ViewportScrollToBottomButton onClick={scroll} />;
+}
+
+function ViewportScrollToBottomButton({ onClick }: { onClick: () => void }) {
+  const { panelVisible, panelContent } = usePanel();
+
+  return (
+    <ScrollToBottomButton
+      onClick={onClick}
+      className={cn(
+        "fixed bottom-(--sz-calc-21) right-6 transition-(--tp-background-color-right) md:bottom-6",
+        panelVisible && panelContent && "md:right-(--sz-calc-22)",
+      )}
+    />
+  );
+}
+
+function ScrollToBottomButton({ onClick, className }: { onClick: () => void; className: string }) {
   return (
     <button
-      onClick={scroll}
+      onClick={onClick}
       className={cn(
-        "fixed bottom-(--sz-calc-21) right-6 z-40 flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background shadow-md hover:bg-accent transition-(--tp-background-color-right) duration-200 md:bottom-6",
-        panelVisible && panelContent && "md:right-(--sz-calc-22)",
+        "z-40 flex h-9 w-9 items-center justify-center rounded-full border border-border bg-background shadow-md hover:bg-accent duration-200",
+        className,
       )}
       aria-label="Scroll to bottom"
     >

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -326,10 +326,6 @@ vi.mock("../components/ImageGalleryModal", () => ({
   },
 }));
 
-vi.mock("../components/ScrollToBottom", () => ({
-  ScrollToBottom: () => null,
-}));
-
 vi.mock("../components/StatusIcon", () => ({
   StatusIcon: ({ status, blockerAttention }: { status: string; blockerAttention?: Issue["blockerAttention"] }) => (
     <span data-status-icon-state={blockerAttention?.state}>{status}</span>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -124,7 +124,6 @@ import { ImageGalleryModal, type GalleryMediaItem } from "../components/ImageGal
 import { FileViewerProvider, useRequiredFileViewer } from "../context/FileViewerContext";
 import { FileViewerSheet } from "../components/FileViewerSheet";
 import { ArtifactFileChip } from "../components/ArtifactFileChip";
-import { ScrollToBottom } from "../components/ScrollToBottom";
 import { StatusIcon } from "../components/StatusIcon";
 import { PriorityIcon } from "../components/PriorityIcon";
 import { ProductivityReviewBadge } from "../components/ProductivityReviewBadge";
@@ -5080,7 +5079,6 @@ export function IssueDetail() {
           onPromptOpenChange={setFileViewerPromptOpen}
         />
       ) : null}
-      <ScrollToBottom />
     </div>
     </FileViewerProvider>
   );

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -132,7 +132,6 @@ import { ImageGalleryModal, type GalleryMediaItem } from "../components/ImageGal
 import { FileViewerProvider, useRequiredFileViewer } from "../context/FileViewerContext";
 import { FileViewerSheet } from "../components/FileViewerSheet";
 import { ArtifactFileChip } from "../components/ArtifactFileChip";
-import { ScrollToBottom } from "../components/ScrollToBottom";
 import { StatusIcon } from "../components/StatusIcon";
 import { PriorityIcon } from "../components/PriorityIcon";
 import { ProductivityReviewBadge } from "../components/ProductivityReviewBadge";
@@ -5284,7 +5283,6 @@ export function IssueDetail() {
           onPromptOpenChange={setFileViewerPromptOpen}
         />
       ) : null}
-      <ScrollToBottom />
     </div>
     </FileViewerProvider>
   );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Operators review long task threads and reply through a sticky composer.
> - The scroll-to-bottom control was fixed to the viewport edge.
> - That position moved the control away from the narrower composer.
> - The control must follow the composer while transcript controls keep their viewport position.
> - This pull request adds a composer placement and mounts it after the composer in the dock.
> - The benefit is a centered control that does not move the composer.

## Linked Issues or Issue Description

Supersedes #9606. That PR used an old base snapshot. This PR refreshes the same reviewed change on current `master`.

**What happened?**

On long task threads, the scroll-to-bottom button appeared near the viewport edge instead of above the reply input. Its position changed with the viewport and properties panel.

**Expected behavior**

The task-thread control stays centered directly above the sticky reply composer. Agent-run transcript controls keep their existing viewport-fixed placement.

**Steps to reproduce**

1. Open a task with enough thread content to make the page scroll.
2. Scroll away from the bottom until the scroll-to-bottom control appears.
3. Open and close the properties panel.
4. Observe that the control follows the viewport edge instead of the composer.

**Paperclip version or commit**

Reproduced on `master` before this change.

**Deployment mode**

Local development from source with `pnpm dev`.

## What Changed

- Added `composer` and `viewport` placement modes to the shared scroll-to-bottom control.
- Mounted the task-thread control after the sticky composer so it centers above the input without moving it.
- Preserved viewport-fixed placement and properties-panel offsets for agent-run transcripts.
- Removed the stale page-level control and test mock.
- Added regression coverage for nesting, centered positioning, and composer order.

## Verification

- `NODE_ENV=test pnpm exec vitest run --project @paperclipai/ui ui/src/components/IssueChatThread.test.tsx ui/src/pages/IssueDetail.test.tsx` — 118 tests passed.
- `pnpm --filter @paperclipai/ui typecheck` — passed.
- `pnpm check:token-gates` — passed; all gates are clean.
- Prior browser QA on the same final UI change passed on desktop and mobile, with the properties panel open and closed, including click-to-bottom behavior.

## Risks

- Low risk. The change affects only task-thread placement.
- Run transcript placement remains the default.
- The visibility and scroll logic do not change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5.4 produced the original implementation and review fixes. It used medium reasoning, repository tools, terminal execution, and code editing. The runtime did not expose its context-window size.
- OpenAI Codex with GPT-5 refreshed the branch and PR. It used reasoning, repository tools, terminal execution, code editing, and GitHub CLI access. The runtime did not expose a more specific model ID or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
