### PR TITLE
fix(server): allow scoped issue-graph cleanup reconciliation

### DIFF
--- a/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
+++ b/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
@@ -90,6 +90,31 @@ describeEmbeddedPostgres("execution lock orphan cleanup", () => {
   }
 
   describe("heartbeat run finalization", () => {
+    it("rolls back a prepared cancellation with the caller transaction", async () => {
+      const companyId = await seedCompany();
+      const agentId = await seedAgent(companyId, "Cleanup owner");
+      const runId = randomUUID();
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "running",
+        contextSnapshot: {},
+      });
+
+      const heartbeat = heartbeatService(db);
+      await expect(db.transaction(async (tx) => {
+        await heartbeat.prepareRunCancellationInTransaction(tx as any, runId);
+        const [inside] = await tx.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+        expect(inside?.status).toBe("cancelled");
+        throw new Error("force caller rollback");
+      })).rejects.toThrow("force caller rollback");
+
+      const [afterRollback] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+      expect(afterRollback?.status).toBe("running");
+    });
+
     it("clears execution_run_id on every issue that references the finalized run, not just the run's contextSnapshot issue", async () => {
       // Regression test for the "stale execution lock" bug:
       //

--- a/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
+++ b/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
@@ -113,6 +113,53 @@ describeEmbeddedPostgres("execution lock orphan cleanup", () => {
 
       const [afterRollback] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
       expect(afterRollback?.status).toBe("running");
+      expect(afterRollback?.resultJson).toBeNull();
+    });
+
+    it("durably records prepared cancellation finalization until reconciliation completes", async () => {
+      const companyId = await seedCompany();
+      const agentId = await seedAgent(companyId, "Cleanup owner");
+      const runId = randomUUID();
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "running",
+        contextSnapshot: {},
+      });
+
+      const heartbeat = heartbeatService(db);
+      const prepared = await db.transaction(async (tx) => {
+        const cancellation = await heartbeat.prepareRunCancellationInTransaction(tx as any, runId);
+        const marker = (cancellation.run.resultJson as Record<string, unknown> | null)
+          ?.pendingCancellationFinalization;
+        expect(marker).toMatchObject({ id: cancellation.finalizationId });
+        return cancellation;
+      });
+
+      const [committed] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+      expect(committed?.status).toBe("cancelled");
+      expect((committed?.resultJson as Record<string, unknown> | null)?.pendingCancellationFinalization)
+        .toMatchObject({ id: prepared.finalizationId });
+
+      await db
+        .update(heartbeatRuns)
+        .set({ updatedAt: new Date(Date.now() - 60_000) })
+        .where(eq(heartbeatRuns.id, runId));
+      const sweep = await heartbeatService(db).reconcilePendingRunCancellations();
+
+      const [finalized] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+      const lifecycleEvents = await db
+        .select()
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, runId));
+      const [finalizedAgent] = await db.select().from(agents).where(eq(agents.id, agentId));
+      expect((finalized?.resultJson as Record<string, unknown> | null)?.pendingCancellationFinalization)
+        .toBeUndefined();
+      expect(sweep).toEqual({ checked: 1, reconciled: 1, failed: 0 });
+      expect(lifecycleEvents).toHaveLength(1);
+      expect(finalizedAgent?.status).toBe("idle");
     });
 
     it("clears execution_run_id on every issue that references the finalized run, not just the run's contextSnapshot issue", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -279,6 +279,7 @@ function createRunContextDb(
   contextSnapshot: Record<string, unknown> = {},
   runAgentOrRows: string | Record<string, unknown>[] = ownerAgentId,
   runId: string = ownerRunId,
+  lockedRunRows?: Record<string, unknown>[],
 ) {
   const runRows = Array.isArray(runAgentOrRows)
     ? runAgentOrRows
@@ -297,6 +298,7 @@ function createRunContextDb(
     const keys = Object.keys(selection);
     if (keys.includes("entityId")) return [];
     if (keys.includes("contextSnapshot")) return runRows;
+    if (keys.includes("status")) return lockedRunRows ?? runRows;
     if (keys.includes("agentCompanyId")) return runRows;
     return [{ id: runAgentId, companyId: runAgentCompanyId, permissions: {}, role: "engineer", reportsTo: null }];
   };
@@ -307,6 +309,7 @@ function createRunContextDb(
       limit: vi.fn(() => ({
         then: async (resolve: (limitedRows: unknown[]) => unknown) => resolve(rows),
       })),
+      for: vi.fn(async () => rows),
       then: async (resolve: (selectedRows: unknown[]) => unknown) => resolve(rows),
     };
     const query = {
@@ -315,12 +318,13 @@ function createRunContextDb(
     };
     return query;
   };
-  return {
-    transaction: async (callback: (tx: Record<string, never>) => Promise<unknown>) => callback({}),
+  const routeDb: any = {
+    transaction: async (callback: (tx: any) => Promise<unknown>) => callback(routeDb),
     select: vi.fn((selection: Record<string, unknown> = {}) => ({
       from: vi.fn(() => buildQuery(selection)),
     })),
   };
+  return routeDb;
 }
 
 async function createApp(actor: Record<string, unknown>, db?: unknown) {
@@ -1638,6 +1642,7 @@ describe("agent issue mutation checkout ownership", () => {
         status: "cancelled",
         actorAgentId: peerAgentId,
       }),
+      expect.any(Object),
     );
     expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith(targetRunId);
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
@@ -1645,7 +1650,94 @@ describe("agent issue mutation checkout ownership", () => {
       "Duplicate sibling closed by cleanup reconciliation.",
       expect.objectContaining({ agentId: peerAgentId, runId: managerRunId }),
       expect.any(Object),
+      expect.any(Object),
     );
+  });
+
+  it("rejects cleanup when the manager run terminates between authorization and mutation", async () => {
+    const cleanupIssueId = "eeeeeeee-1111-4111-8111-eeeeeeee1111";
+    const cleanupParentIssueId = "eeeeeeee-2222-4222-8222-eeeeeeee2222";
+    const targetParentIssueId = "eeeeeeee-3333-4333-8333-eeeeeeee3333";
+    const treeRootIssueId = "eeeeeeee-4444-4444-8444-eeeeeeee4444";
+    const targetRunId = "eeeeeeee-5555-4555-8555-eeeeeeee5555";
+    const managerRunId = peerActor().runId as string;
+    const issueById = new Map<string, Record<string, unknown>>([
+      [issueId, makeIssue({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: ownerAgentId,
+        parentId: targetParentIssueId,
+        executionRunId: targetRunId,
+      })],
+      [cleanupIssueId, makeIssue({
+        id: cleanupIssueId,
+        status: "in_progress",
+        assigneeAgentId: peerAgentId,
+        parentId: cleanupParentIssueId,
+        originKind: "harness_liveness_escalation",
+        checkoutRunId: managerRunId,
+        executionRunId: managerRunId,
+      })],
+      [cleanupParentIssueId, makeIssue({
+        id: cleanupParentIssueId,
+        status: "blocked",
+        assigneeAgentId: peerAgentId,
+        parentId: treeRootIssueId,
+      })],
+      [targetParentIssueId, makeIssue({
+        id: targetParentIssueId,
+        status: "blocked",
+        assigneeAgentId: ownerAgentId,
+        parentId: treeRootIssueId,
+      })],
+      [treeRootIssueId, makeIssue({
+        id: treeRootIssueId,
+        status: "blocked",
+        assigneeAgentId: peerAgentId,
+        parentId: null,
+      })],
+    ]);
+    mockIssueService.getById.mockImplementation(async (id: string) => issueById.get(id) ?? null);
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts"
+        ? "allow_manager_chain"
+        : input.action === "issue:read"
+          ? "allow_explicit_grant"
+          : "deny_missing_grant",
+      explanation: input.action === "tasks:manage_active_checkouts"
+        ? "Allowed because the actor manages the issue assignee."
+        : input.action === "issue:read"
+          ? "Allowed to read the target issue."
+          : "No agent permission mapping exists for issue:mutate.",
+    }));
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: targetRunId,
+      companyId,
+      agentId: ownerAgentId,
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+
+    const app = await createApp(
+      peerActor(),
+      createRunContextDb(
+        { issueId: cleanupIssueId },
+        peerAgentId,
+        managerRunId,
+        [],
+      ),
+    );
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "Cleanup must lose authority atomically." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("issue_graph_cleanup_run_not_running");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects terminal manager cleanup runs with stale issue lock references", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -287,6 +287,7 @@ function createRunContextDb(
         companyId,
         agentId: runAgentOrRows,
         agentCompanyId: companyId,
+        status: "running",
         contextSnapshot,
       }];
   const firstRun = runRows[0] ?? {};
@@ -1645,6 +1646,77 @@ describe("agent issue mutation checkout ownership", () => {
       expect.objectContaining({ agentId: peerAgentId, runId: managerRunId }),
       expect.any(Object),
     );
+  });
+
+  it("rejects terminal manager cleanup runs with stale issue lock references", async () => {
+    const cleanupIssueId = "dddddddd-1111-4111-8111-dddddddd1111";
+    const targetParentIssueId = "dddddddd-2222-4222-8222-dddddddd2222";
+    const treeRootIssueId = "dddddddd-3333-4333-8333-dddddddd3333";
+    const managerRunId = peerActor().runId as string;
+    const issueById = new Map<string, Record<string, unknown>>([
+      [issueId, makeIssue({
+        id: issueId,
+        status: "in_progress",
+        assigneeAgentId: ownerAgentId,
+        parentId: targetParentIssueId,
+      })],
+      [cleanupIssueId, makeIssue({
+        id: cleanupIssueId,
+        status: "in_progress",
+        assigneeAgentId: peerAgentId,
+        parentId: treeRootIssueId,
+        originKind: "harness_liveness_escalation",
+        checkoutRunId: managerRunId,
+        executionRunId: managerRunId,
+      })],
+      [targetParentIssueId, makeIssue({
+        id: targetParentIssueId,
+        status: "blocked",
+        assigneeAgentId: ownerAgentId,
+        parentId: treeRootIssueId,
+      })],
+      [treeRootIssueId, makeIssue({
+        id: treeRootIssueId,
+        status: "blocked",
+        assigneeAgentId: peerAgentId,
+        parentId: null,
+      })],
+    ]);
+    mockIssueService.getById.mockImplementation(async (id: string) => issueById.get(id) ?? null);
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts"
+        ? "allow_manager_chain"
+        : input.action === "issue:read"
+          ? "allow_explicit_grant"
+          : "deny_missing_grant",
+      explanation: input.action === "tasks:manage_active_checkouts"
+        ? "Allowed because the actor manages the issue assignee."
+        : input.action === "issue:read"
+          ? "Allowed to read the target issue."
+          : "No agent permission mapping exists for issue:mutate.",
+    }));
+
+    const app = await createApp(
+      peerActor(),
+      createRunContextDb({}, [{
+        id: managerRunId,
+        companyId,
+        agentId: peerAgentId,
+        agentCompanyId: companyId,
+        status: "failed",
+        contextSnapshot: { issueId: cleanupIssueId },
+      }]),
+    );
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "Stale terminal run attempted cleanup." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("issue_write_not_visible");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
 
   it("rejects ordinary manager runs from mutating same-tree sibling issues", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1559,6 +1559,194 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalled();
   });
 
+  it("allows manager cleanup runs to reconcile in-tree sibling issue status and cancel the active run", async () => {
+    const cleanupIssueId = "aaaaaaaa-1111-4111-8111-aaaaaaaa1111";
+    const cleanupParentIssueId = "aaaaaaaa-2222-4222-8222-aaaaaaaa2222";
+    const targetParentIssueId = "aaaaaaaa-3333-4333-8333-aaaaaaaa3333";
+    const treeRootIssueId = "aaaaaaaa-4444-4444-8444-aaaaaaaa4444";
+    const targetRunId = "aaaaaaaa-5555-4555-8555-aaaaaaaa5555";
+    const managerRunId = peerActor().runId as string;
+    const targetIssue = makeIssue({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId: ownerAgentId,
+      parentId: targetParentIssueId,
+      executionRunId: targetRunId,
+    });
+    const cleanupIssue = makeIssue({
+      id: cleanupIssueId,
+      status: "in_progress",
+      assigneeAgentId: peerAgentId,
+      parentId: cleanupParentIssueId,
+      checkoutRunId: managerRunId,
+      executionRunId: managerRunId,
+    });
+    const issueById = new Map<string, Record<string, unknown>>([
+      [issueId, targetIssue],
+      [cleanupIssueId, cleanupIssue],
+      [cleanupParentIssueId, makeIssue({ id: cleanupParentIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: treeRootIssueId })],
+      [targetParentIssueId, makeIssue({ id: targetParentIssueId, status: "blocked", assigneeAgentId: ownerAgentId, parentId: treeRootIssueId })],
+      [treeRootIssueId, makeIssue({ id: treeRootIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: null })],
+    ]);
+    mockIssueService.getById.mockImplementation(async (id: string) => issueById.get(id) ?? null);
+    mockIssueService.update.mockImplementation(async (id: string, patch: Record<string, unknown>) => ({
+      ...issueById.get(id),
+      ...patch,
+    }));
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts"
+        ? "allow_manager_chain"
+        : input.action === "issue:read"
+          ? "allow_explicit_grant"
+          : "deny_missing_grant",
+      explanation: input.action === "tasks:manage_active_checkouts"
+        ? "Allowed because the actor manages the issue assignee."
+        : input.action === "issue:read"
+          ? "Allowed to read the target issue."
+          : "No agent permission mapping exists for issue:mutate.",
+    }));
+    mockHeartbeatService.getRun.mockResolvedValue({
+      id: targetRunId,
+      companyId,
+      agentId: ownerAgentId,
+      status: "running",
+      contextSnapshot: { issueId },
+    });
+    mockHeartbeatService.cancelRun.mockResolvedValue({
+      id: targetRunId,
+      companyId,
+      agentId: ownerAgentId,
+      status: "cancelled",
+    });
+
+    const app = await createApp(
+      peerActor(),
+      createRunContextDb({ issueId: cleanupIssueId }, peerAgentId, managerRunId),
+    );
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "Duplicate sibling closed by cleanup reconciliation." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "cancelled",
+        actorAgentId: peerAgentId,
+      }),
+    );
+    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith(targetRunId);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Duplicate sibling closed by cleanup reconciliation.",
+      expect.objectContaining({ agentId: peerAgentId, runId: managerRunId }),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects manager cleanup reconciliation for out-of-tree sibling issues", async () => {
+    const cleanupIssueId = "bbbbbbbb-1111-4111-8111-bbbbbbbb1111";
+    const cleanupParentIssueId = "bbbbbbbb-2222-4222-8222-bbbbbbbb2222";
+    const cleanupRootIssueId = "bbbbbbbb-3333-4333-8333-bbbbbbbb3333";
+    const outOfTreeRootIssueId = "bbbbbbbb-4444-4444-8444-bbbbbbbb4444";
+    const managerRunId = peerActor().runId as string;
+    const issueById = new Map<string, Record<string, unknown>>([
+      [issueId, makeIssue({ id: issueId, status: "in_progress", assigneeAgentId: ownerAgentId, parentId: outOfTreeRootIssueId })],
+      [cleanupIssueId, makeIssue({
+        id: cleanupIssueId,
+        status: "in_progress",
+        assigneeAgentId: peerAgentId,
+        parentId: cleanupParentIssueId,
+        checkoutRunId: managerRunId,
+        executionRunId: managerRunId,
+      })],
+      [cleanupParentIssueId, makeIssue({ id: cleanupParentIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: cleanupRootIssueId })],
+      [cleanupRootIssueId, makeIssue({ id: cleanupRootIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: null })],
+      [outOfTreeRootIssueId, makeIssue({ id: outOfTreeRootIssueId, status: "todo", assigneeAgentId: ownerAgentId, parentId: null })],
+    ]);
+    mockIssueService.getById.mockImplementation(async (id: string) => issueById.get(id) ?? null);
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts"
+        ? "allow_manager_chain"
+        : input.action === "issue:read"
+          ? "allow_explicit_grant"
+          : "deny_missing_grant",
+      explanation: input.action === "tasks:manage_active_checkouts"
+        ? "Allowed because the actor manages the issue assignee."
+        : input.action === "issue:read"
+          ? "Allowed to read the target issue."
+          : "No agent permission mapping exists for issue:mutate.",
+    }));
+
+    const app = await createApp(
+      peerActor(),
+      createRunContextDb({ issueId: cleanupIssueId }, peerAgentId, managerRunId),
+    );
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it("keeps low-trust issue-boundary denials ahead of manager cleanup overrides", async () => {
+    const cleanupIssueId = "cccccccc-1111-4111-8111-cccccccc1111";
+    const cleanupParentIssueId = "cccccccc-2222-4222-8222-cccccccc2222";
+    const treeRootIssueId = "cccccccc-3333-4333-8333-cccccccc3333";
+    const managerRunId = peerActor().runId as string;
+    const issueById = new Map<string, Record<string, unknown>>([
+      [issueId, makeIssue({ id: issueId, status: "in_progress", assigneeAgentId: ownerAgentId, parentId: treeRootIssueId })],
+      [cleanupIssueId, makeIssue({
+        id: cleanupIssueId,
+        status: "in_progress",
+        assigneeAgentId: peerAgentId,
+        parentId: cleanupParentIssueId,
+        checkoutRunId: managerRunId,
+        executionRunId: managerRunId,
+      })],
+      [cleanupParentIssueId, makeIssue({ id: cleanupParentIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: treeRootIssueId })],
+      [treeRootIssueId, makeIssue({ id: treeRootIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: null })],
+    ]);
+    mockIssueService.getById.mockImplementation(async (id: string) => issueById.get(id) ?? null);
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts"
+        ? "allow_manager_chain"
+        : input.action === "issue:read"
+          ? "allow_explicit_grant"
+          : "deny_low_trust_boundary",
+      explanation: input.action === "tasks:manage_active_checkouts"
+        ? "Allowed because the actor manages the issue assignee."
+        : input.action === "issue:read"
+          ? "Allowed to read the target issue."
+          : "Issue is outside this low-trust boundary.",
+    }));
+
+    const app = await createApp(
+      peerActor(),
+      createRunContextDb({ issueId: cleanupIssueId }, peerAgentId, managerRunId),
+    );
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockAccessService.decide).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "tasks:manage_active_checkouts" }),
+    );
+  });
+
+
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1578,6 +1578,7 @@ describe("agent issue mutation checkout ownership", () => {
       status: "in_progress",
       assigneeAgentId: peerAgentId,
       parentId: cleanupParentIssueId,
+      originKind: "harness_liveness_escalation",
       checkoutRunId: managerRunId,
       executionRunId: managerRunId,
     });
@@ -1646,6 +1647,56 @@ describe("agent issue mutation checkout ownership", () => {
     );
   });
 
+  it("rejects ordinary manager runs from mutating same-tree sibling issues", async () => {
+    const managerIssueId = "aaaaaaaa-6666-4666-8666-aaaaaaaa6666";
+    const managerParentIssueId = "aaaaaaaa-7777-4777-8777-aaaaaaaa7777";
+    const targetParentIssueId = "aaaaaaaa-8888-4888-8888-aaaaaaaa8888";
+    const treeRootIssueId = "aaaaaaaa-9999-4999-8999-aaaaaaaa9999";
+    const managerRunId = peerActor().runId as string;
+    const issueById = new Map<string, Record<string, unknown>>([
+      [issueId, makeIssue({ id: issueId, status: "in_progress", assigneeAgentId: ownerAgentId, parentId: targetParentIssueId })],
+      [managerIssueId, makeIssue({
+        id: managerIssueId,
+        status: "in_progress",
+        assigneeAgentId: peerAgentId,
+        parentId: managerParentIssueId,
+        checkoutRunId: managerRunId,
+        executionRunId: managerRunId,
+      })],
+      [managerParentIssueId, makeIssue({ id: managerParentIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: treeRootIssueId })],
+      [targetParentIssueId, makeIssue({ id: targetParentIssueId, status: "blocked", assigneeAgentId: ownerAgentId, parentId: treeRootIssueId })],
+      [treeRootIssueId, makeIssue({ id: treeRootIssueId, status: "blocked", assigneeAgentId: peerAgentId, parentId: null })],
+    ]);
+    mockIssueService.getById.mockImplementation(async (id: string) => issueById.get(id) ?? null);
+    mockAccessService.decide.mockImplementation(async (input: { action: string }) => ({
+      allowed: input.action === "issue:read" || input.action === "tasks:manage_active_checkouts",
+      action: input.action,
+      reason: input.action === "tasks:manage_active_checkouts"
+        ? "allow_manager_chain"
+        : input.action === "issue:read"
+          ? "allow_explicit_grant"
+          : "deny_missing_grant",
+      explanation: input.action === "tasks:manage_active_checkouts"
+        ? "Allowed because the actor manages the issue assignee."
+        : input.action === "issue:read"
+          ? "Allowed to read the target issue."
+          : "No agent permission mapping exists for issue:mutate.",
+    }));
+
+    const app = await createApp(
+      peerActor(),
+      createRunContextDb({ issueId: managerIssueId }, peerAgentId, managerRunId),
+    );
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "Ordinary manager task attempted cleanup." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+  });
+
   it("rejects manager cleanup reconciliation for out-of-tree sibling issues", async () => {
     const cleanupIssueId = "bbbbbbbb-1111-4111-8111-bbbbbbbb1111";
     const cleanupParentIssueId = "bbbbbbbb-2222-4222-8222-bbbbbbbb2222";
@@ -1659,6 +1710,7 @@ describe("agent issue mutation checkout ownership", () => {
         status: "in_progress",
         assigneeAgentId: peerAgentId,
         parentId: cleanupParentIssueId,
+        originKind: "harness_liveness_escalation",
         checkoutRunId: managerRunId,
         executionRunId: managerRunId,
       })],
@@ -1708,6 +1760,7 @@ describe("agent issue mutation checkout ownership", () => {
         status: "in_progress",
         assigneeAgentId: peerAgentId,
         parentId: cleanupParentIssueId,
+        originKind: "harness_liveness_escalation",
         checkoutRunId: managerRunId,
         executionRunId: managerRunId,
       })],

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1652,6 +1652,21 @@ describe("agent issue mutation checkout ownership", () => {
       expect.any(Object),
       expect.any(Object),
     );
+    expect(mockIssueService.update.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockHeartbeatService.cancelRun.mock.invocationCallOrder[0]!,
+    );
+
+    mockIssueService.update.mockClear();
+    mockIssueService.update.mockRejectedValueOnce(new Error("cleanup write failed"));
+    mockHeartbeatService.cancelRun.mockClear();
+    mockIssueService.addComment.mockClear();
+    const failedRes = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "This cleanup transaction must roll back." });
+
+    expect(failedRes.status, JSON.stringify(failedRes.body)).toBe(500);
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
   it("rejects cleanup when the manager run terminates between authorization and mutation", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1692,7 +1692,7 @@ describe("agent issue mutation checkout ownership", () => {
       .send({ status: "cancelled", comment: "Ordinary manager task attempted cleanup." });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.details.code).toBe("issue_write_not_visible");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
@@ -1743,7 +1743,7 @@ describe("agent issue mutation checkout ownership", () => {
       .send({ status: "cancelled" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.details.code).toBe("issue_write_not_visible");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
@@ -1792,7 +1792,7 @@ describe("agent issue mutation checkout ownership", () => {
       .send({ status: "cancelled" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
-    expect(res.body.error).toBe("Issue is outside this actor's authorization boundary");
+    expect(res.body.details.code).toBe("issue_write_actor_class_excluded");
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockAccessService.decide).not.toHaveBeenCalledWith(
       expect.objectContaining({ action: "tasks:manage_active_checkouts" }),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1696,6 +1696,23 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockHeartbeatService.finalizePreparedRunCancellation).not.toHaveBeenCalled();
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+
+    mockIssueService.update.mockClear();
+    mockHeartbeatService.prepareRunCancellationInTransaction.mockClear();
+    mockHeartbeatService.finalizePreparedRunCancellation.mockClear();
+    mockHeartbeatService.finalizePreparedRunCancellation.mockRejectedValueOnce(
+      new Error("cleanup cancellation finalization failed"),
+    );
+    mockIssueService.addComment.mockClear();
+    const finalizationFailedRes = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled", comment: "This cleanup must report finalization failure." });
+
+    expect(finalizationFailedRes.status, JSON.stringify(finalizationFailedRes.body)).toBe(500);
+    expect(mockHeartbeatService.prepareRunCancellationInTransaction).toHaveBeenCalled();
+    expect(mockHeartbeatService.finalizePreparedRunCancellation).toHaveBeenCalledWith(preparedCancellation);
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalled();
   });
 
   it("rejects cleanup when the manager run terminates between authorization and mutation", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -106,6 +106,8 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getRun: vi.fn(async () => null),
   getActiveRunForAgent: vi.fn(async () => null),
   cancelRun: vi.fn(async () => null),
+  prepareRunCancellationInTransaction: vi.fn(async () => null),
+  finalizePreparedRunCancellation: vi.fn(async () => null),
 }));
 const mockExternalObjectService = vi.hoisted(() => ({
   getIssueSummaries: vi.fn(async () => new Map()),
@@ -519,6 +521,10 @@ describe("agent issue mutation checkout ownership", () => {
     mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
     mockHeartbeatService.cancelRun.mockReset();
     mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockHeartbeatService.prepareRunCancellationInTransaction.mockReset();
+    mockHeartbeatService.prepareRunCancellationInTransaction.mockResolvedValue(null);
+    mockHeartbeatService.finalizePreparedRunCancellation.mockReset();
+    mockHeartbeatService.finalizePreparedRunCancellation.mockResolvedValue(null);
     mockIssueApprovalService.link.mockReset();
     mockIssueApprovalService.unlink.mockReset();
     mockIssueApprovalService.listApprovalsForIssue.mockReset();
@@ -1620,7 +1626,19 @@ describe("agent issue mutation checkout ownership", () => {
       status: "running",
       contextSnapshot: { issueId },
     });
-    mockHeartbeatService.cancelRun.mockResolvedValue({
+    const preparedCancellation = {
+      run: {
+        id: targetRunId,
+        companyId,
+        agentId: ownerAgentId,
+        status: "cancelled",
+      },
+      cancelled: true,
+      wasFirstHeartbeat: false,
+      eventMessage: "run cancelled",
+    };
+    mockHeartbeatService.prepareRunCancellationInTransaction.mockResolvedValue(preparedCancellation);
+    mockHeartbeatService.finalizePreparedRunCancellation.mockResolvedValue({
       id: targetRunId,
       companyId,
       agentId: ownerAgentId,
@@ -1644,7 +1662,12 @@ describe("agent issue mutation checkout ownership", () => {
       }),
       expect.any(Object),
     );
-    expect(mockHeartbeatService.cancelRun).toHaveBeenCalledWith(targetRunId);
+    expect(mockHeartbeatService.prepareRunCancellationInTransaction).toHaveBeenCalledWith(
+      expect.any(Object),
+      targetRunId,
+    );
+    expect(mockHeartbeatService.finalizePreparedRunCancellation).toHaveBeenCalledWith(preparedCancellation);
+    expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
       issueId,
       "Duplicate sibling closed by cleanup reconciliation.",
@@ -1652,19 +1675,25 @@ describe("agent issue mutation checkout ownership", () => {
       expect.any(Object),
       expect.any(Object),
     );
+    expect(mockHeartbeatService.prepareRunCancellationInTransaction.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockIssueService.update.mock.invocationCallOrder[0]!,
+    );
     expect(mockIssueService.update.mock.invocationCallOrder[0]!).toBeLessThan(
-      mockHeartbeatService.cancelRun.mock.invocationCallOrder[0]!,
+      mockHeartbeatService.finalizePreparedRunCancellation.mock.invocationCallOrder[0]!,
     );
 
     mockIssueService.update.mockClear();
     mockIssueService.update.mockRejectedValueOnce(new Error("cleanup write failed"));
-    mockHeartbeatService.cancelRun.mockClear();
+    mockHeartbeatService.prepareRunCancellationInTransaction.mockClear();
+    mockHeartbeatService.finalizePreparedRunCancellation.mockClear();
     mockIssueService.addComment.mockClear();
     const failedRes = await request(app)
       .patch(`/api/issues/${issueId}`)
       .send({ status: "cancelled", comment: "This cleanup transaction must roll back." });
 
     expect(failedRes.status, JSON.stringify(failedRes.body)).toBe(500);
+    expect(mockHeartbeatService.prepareRunCancellationInTransaction).toHaveBeenCalled();
+    expect(mockHeartbeatService.finalizePreparedRunCancellation).not.toHaveBeenCalled();
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
@@ -1751,6 +1780,8 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.details.code).toBe("issue_graph_cleanup_run_not_running");
     expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.prepareRunCancellationInTransaction).not.toHaveBeenCalled();
+    expect(mockHeartbeatService.finalizePreparedRunCancellation).not.toHaveBeenCalled();
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1666,7 +1666,10 @@ describe("agent issue mutation checkout ownership", () => {
       expect.any(Object),
       targetRunId,
     );
-    expect(mockHeartbeatService.finalizePreparedRunCancellation).toHaveBeenCalledWith(preparedCancellation);
+    expect(mockHeartbeatService.finalizePreparedRunCancellation).toHaveBeenCalledWith({
+      ...preparedCancellation,
+      allowPersistedProcessIdentifiers: false,
+    });
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).toHaveBeenCalledWith(
       issueId,
@@ -1710,7 +1713,10 @@ describe("agent issue mutation checkout ownership", () => {
 
     expect(finalizationFailedRes.status, JSON.stringify(finalizationFailedRes.body)).toBe(500);
     expect(mockHeartbeatService.prepareRunCancellationInTransaction).toHaveBeenCalled();
-    expect(mockHeartbeatService.finalizePreparedRunCancellation).toHaveBeenCalledWith(preparedCancellation);
+    expect(mockHeartbeatService.finalizePreparedRunCancellation).toHaveBeenCalledWith({
+      ...preparedCancellation,
+      allowPersistedProcessIdentifiers: false,
+    });
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).toHaveBeenCalled();
   });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -69,6 +69,7 @@ const {
     scanSilentActiveRuns: vi.fn(async () => ({ created: 0, escalated: 0 })),
     sweepStaleIssueLocks: vi.fn(async () => ({ cleared: 0 })),
     reconcileProductivityReviews: vi.fn(async () => ({ created: 0, updated: 0, failed: 0 })),
+    reconcilePendingRunCancellations: vi.fn(async () => ({ checked: 0, reconciled: 0, failed: 0 })),
     sweepExpiredRuntimeStatuses: vi.fn(() => 0),
     tickTimers: vi.fn(async () => ({ checked: 0, enqueued: 0, skipped: 0 })),
   };
@@ -496,6 +497,7 @@ describe("startServer feedback export wiring", () => {
       await Promise.resolve();
 
       expect(heartbeatServiceMock.tickTimers).not.toHaveBeenCalled();
+      expect(heartbeatServiceMock.reconcilePendingRunCancellations).toHaveBeenCalledTimes(1);
       expect(externalObjectsServiceMock.refreshDueObjectsForActiveCompanies).toHaveBeenCalledTimes(1);
       expect(issueThreadInteractionServiceMock.sweepMergedPullRequestConfirmations).toHaveBeenCalledTimes(1);
       expect(executionWorkspaceServiceMock.sweepTerminalWorkspaces).toHaveBeenCalledTimes(1);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1171,6 +1171,17 @@ export async function startServer(): Promise<StartedServer> {
           );
         }
 
+        trackHeartbeatSchedulerWork(heartbeat
+          .reconcilePendingRunCancellations()
+          .then((result) => {
+            if (result.reconciled > 0 || result.failed > 0) {
+              logger.info({ ...result }, "heartbeat cancellation finalization sweep completed");
+            }
+          })
+          .catch((err) => {
+            logger.error({ err }, "heartbeat cancellation finalization sweep failed");
+          }));
+
         if (!(await heartbeat.resolveSchedulingSuppression()).suppressed) {
           trackHeartbeatSchedulerWork(heartbeat
             .tickTimers(new Date())

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3927,7 +3927,7 @@ export function issueRoutes(
 
     const run = await loadActorRunContext(input.req, input.issue.companyId);
     const sourceIssueId = readRunContextIssueId(run?.contextSnapshot);
-    if (!run || !sourceIssueId || sourceIssueId === input.issue.id) return false;
+    if (!run || run.status !== "running" || !sourceIssueId || sourceIssueId === input.issue.id) return false;
 
     const sourceIssue = await svc.getById(sourceIssueId);
     if (
@@ -4594,12 +4594,7 @@ export function issueRoutes(
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
-    if (
-      !run ||
-      run.companyId !== companyId ||
-      run.agentId !== req.actor.agentId ||
-      run.status !== "running"
-    ) return null;
+    if (!run || run.companyId !== companyId || run.agentId !== req.actor.agentId) return null;
     return run;
   }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -141,6 +141,7 @@ import {
   isReviewPathRecoveryIdempotencyConflict,
   REVIEW_PATH_RECOVERY_INSTRUCTION,
 } from "../services/recovery/review-path-recovery.js";
+import { RECOVERY_ORIGIN_KINDS } from "../services/recovery/origins.js";
 import { hydrateSuccessfulRunHandoffLiveness } from "../services/successful-run-handoff-state.js";
 import {
   TASK_WATCHDOG_ORIGIN_KIND,
@@ -3933,7 +3934,8 @@ export function issueRoutes(
       !sourceIssue ||
       sourceIssue.companyId !== input.issue.companyId ||
       sourceIssue.assigneeAgentId !== actorAgentId ||
-      sourceIssue.status !== "in_progress"
+      sourceIssue.status !== "in_progress" ||
+      sourceIssue.originKind !== RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation
     ) {
       return false;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3913,21 +3913,21 @@ export function issueRoutes(
     boundaryDecision: Awaited<ReturnType<typeof decideIssueAccess>>;
     requestedUpdate: unknown;
   }) {
-    if (input.req.actor.type !== "agent") return false;
-    if (input.boundaryDecision.reason !== "deny_missing_grant") return false;
-    if (!isIssueGraphCleanupUpdateRequest(input.requestedUpdate)) return false;
+    if (input.req.actor.type !== "agent") return null;
+    if (input.boundaryDecision.reason !== "deny_missing_grant") return null;
+    if (!isIssueGraphCleanupUpdateRequest(input.requestedUpdate)) return null;
 
     const actorAgentId = input.req.actor.agentId;
     if (!actorAgentId || !input.issue.assigneeAgentId || input.issue.assigneeAgentId === actorAgentId) {
-      return false;
+      return null;
     }
     if (!(await hasActiveCheckoutManagementOverride(actorAgentId, input.issue.companyId, input.issue.assigneeAgentId))) {
-      return false;
+      return null;
     }
 
     const run = await loadActorRunContext(input.req, input.issue.companyId);
     const sourceIssueId = readRunContextIssueId(run?.contextSnapshot);
-    if (!run || run.status !== "running" || !sourceIssueId || sourceIssueId === input.issue.id) return false;
+    if (!run || run.status !== "running" || !sourceIssueId || sourceIssueId === input.issue.id) return null;
 
     const sourceIssue = await svc.getById(sourceIssueId);
     if (
@@ -3937,16 +3937,18 @@ export function issueRoutes(
       sourceIssue.status !== "in_progress" ||
       sourceIssue.originKind !== RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation
     ) {
-      return false;
+      return null;
     }
-    if (sourceIssue.checkoutRunId !== run.id && sourceIssue.executionRunId !== run.id) return false;
+    if (sourceIssue.checkoutRunId !== run.id && sourceIssue.executionRunId !== run.id) return null;
 
     const sourceAncestry = await loadIssueAncestryForCleanupOverride(input.issue.companyId, sourceIssue.id, sourceIssue);
     const targetAncestry = await loadIssueAncestryForCleanupOverride(input.issue.companyId, input.issue.id, input.issue);
-    if (!sourceAncestry || !targetAncestry || sourceAncestry.length < 2) return false;
+    if (!sourceAncestry || !targetAncestry || sourceAncestry.length < 2) return null;
 
     const sourceRootId = sourceAncestry[sourceAncestry.length - 1]?.id ?? null;
-    return Boolean(sourceRootId && targetAncestry.some((entry) => entry.id === sourceRootId));
+    return sourceRootId && targetAncestry.some((entry) => entry.id === sourceRootId)
+      ? { runId: run.id }
+      : null;
   }
 
   async function assertAgentIssueMutationAllowed(
@@ -4000,16 +4002,16 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
-      if (
-        options.allowIssueGraphCleanupOverride === true &&
-        await hasIssueGraphCleanupMutationOverride({
+      const issueGraphCleanupOverride = options.allowIssueGraphCleanupOverride === true
+        ? await hasIssueGraphCleanupMutationOverride({
           req,
           issue,
           boundaryDecision,
           requestedUpdate: options.requestedUpdate,
         })
-      ) {
-        return true;
+        : null;
+      if (issueGraphCleanupOverride) {
+        return { issueGraphCleanupRunId: issueGraphCleanupOverride.runId };
       }
       return denyIssueWrite(req, res, issue, issueWriteDenialCodeForDecision(boundaryDecision));
     }
@@ -8547,6 +8549,9 @@ export function issueRoutes(
       },
     );
     if (!issueMutationAccess) return;
+    const issueGraphCleanupRunId = typeof issueMutationAccess === "object"
+      ? issueMutationAccess.issueGraphCleanupRunId
+      : null;
     const issueMutationAuthorizationReason = req.actor.type === "agent"
       ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate"))
       : issueWriteAuthorizationReason(req, true);
@@ -9030,40 +9035,89 @@ export function issueRoutes(
         },
       }, postCommitActivityPublications);
     };
+    let issueGraphCleanupComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
+    let issueGraphCleanupCancelledRun: Awaited<ReturnType<typeof heartbeat.cancelRun>> | null = null;
+    let issueGraphCleanupCancellationError: unknown = null;
     let issue: Awaited<ReturnType<typeof svc.update>>;
     try {
-      if (transition.decision && decisionId) {
-        const decision = transition.decision;
+      if ((transition.decision && decisionId) || shouldRelayStop || issueGraphCleanupRunId) {
         issue = await db.transaction(async (tx) => {
+          if (issueGraphCleanupRunId) {
+            const lockedRun = await tx
+              .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+              .from(heartbeatRuns)
+              .where(and(
+                eq(heartbeatRuns.id, issueGraphCleanupRunId),
+                eq(heartbeatRuns.companyId, existing.companyId),
+                eq(heartbeatRuns.agentId, actor.agentId!),
+                eq(heartbeatRuns.status, "running"),
+              ))
+              .for("update")
+              .then((rows) => rows[0] ?? null);
+            if (!lockedRun) {
+              throw forbidden("Issue graph cleanup run is no longer active", {
+                code: "issue_graph_cleanup_run_not_running",
+                runId: issueGraphCleanupRunId,
+              });
+            }
+
+            // Cancel before updating the issue row. cancelRun may release the
+            // target run's issue lock through its own transaction; doing that
+            // after updateIssue(tx) would make the nested transaction wait on
+            // this transaction's issue-row lock.
+            if (runToCancelForCancelledStatus) {
+              try {
+                issueGraphCleanupCancelledRun = await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
+              } catch (err) {
+                issueGraphCleanupCancellationError = err;
+              }
+            }
+          }
+
           const updated = await updateIssue(tx);
           if (!updated) return null;
 
-          await tx.insert(issueExecutionDecisions).values({
-            id: decisionId,
-            companyId: updated.companyId,
-            issueId: updated.id,
-            stageId: decision.stageId,
-            stageType: decision.stageType,
-            actorAgentId: actor.agentId ?? null,
-            actorUserId: actor.actorType === "user" ? actor.actorId : null,
-            outcome: decision.outcome,
-            body: decision.body,
-            createdByRunId: actor.runId ?? null,
-          });
+          if (transition.decision && decisionId) {
+            const decision = transition.decision;
+            await tx.insert(issueExecutionDecisions).values({
+              id: decisionId,
+              companyId: updated.companyId,
+              issueId: updated.id,
+              stageId: decision.stageId,
+              stageType: decision.stageType,
+              actorAgentId: actor.agentId ?? null,
+              actorUserId: actor.actorType === "user" ? actor.actorId : null,
+              outcome: decision.outcome,
+              body: decision.body,
+              createdByRunId: actor.runId ?? null,
+            });
+          }
 
           if (shouldRelayStop) {
             stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
           }
 
-          await persistBoundReviewActivity(tx, updated);
+          // Keep the actor-run row locked across every mutation granted only by
+          // the cleanup override. A concurrent terminal transition must wait
+          // until the issue write, target-run cancellation, and comment finish.
+          if (issueGraphCleanupRunId && commentBody) {
+            issueGraphCleanupComment = await svc.addComment(
+              id,
+              commentBody,
+              {
+                agentId: actor.agentId ?? undefined,
+                userId: actor.actorType === "user" ? actor.actorId : undefined,
+                runId: actor.runId,
+                onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
+              },
+              {
+                authorizationReason: issueMutationAuthorizationReason,
+                sourceTrust: await sourceTrustForActorWrite(updated, actor),
+              },
+              tx,
+            );
+          }
 
-          return updated;
-        });
-      } else if (shouldRelayStop) {
-        issue = await db.transaction(async (tx) => {
-          const updated = await updateIssue(tx);
-          if (!updated) return null;
-          stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
           await persistBoundReviewActivity(tx, updated);
           return updated;
         });
@@ -9128,7 +9182,10 @@ export function issueRoutes(
     let cancelledStatusRunId: string | null = null;
     if (runToCancelForCancelledStatus) {
       try {
-        const cancelled = await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
+        if (issueGraphCleanupCancellationError) throw issueGraphCleanupCancellationError;
+        const cancelled = issueGraphCleanupRunId
+          ? issueGraphCleanupCancelledRun
+          : await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
         if (cancelled) {
           cancelledStatusRunId = cancelled.id;
           await logActivity(db, {
@@ -9500,20 +9557,25 @@ export function issueRoutes(
       }
     }
 
-    let comment = null;
+    let comment = issueGraphCleanupComment;
     let lostReviewPathRef: string | null = null;
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
-        agentId: actor.agentId ?? undefined,
-        userId: actor.actorType === "user" ? actor.actorId : undefined,
-        runId: actor.runId,
-        onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
-      }, {
-        authorizationReason: issueMutationAuthorizationReason,
-        sourceTrust: await sourceTrustForActorWrite(issue, actor),
-      });
+      comment ??= await svc.addComment(
+        id,
+        commentBody,
+        {
+          agentId: actor.agentId ?? undefined,
+          userId: actor.actorType === "user" ? actor.actorId : undefined,
+          runId: actor.runId,
+          onBehalfOfUserId: authenticatedActorResponsibleUserId(req),
+        },
+        {
+          authorizationReason: issueMutationAuthorizationReason,
+          sourceTrust: await sourceTrustForActorWrite(issue, actor),
+        },
+      );
       await issueReferencesSvc.syncComment(comment.id);
       await externalObjectsSvc.syncCommentSafely(comment.id);
       const commentReferenceSummaryAfter = await issueReferencesSvc.listIssueReferenceSummary(issue.id);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9038,7 +9038,7 @@ export function issueRoutes(
     let issueGraphCleanupComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
     const lockRunningIssueGraphCleanupRun = async (tx: NonNullable<Parameters<typeof svc.update>[2]>) => {
       if (!issueGraphCleanupRunId) return true;
-      const lockedRun = await tx
+      const lockedRuns = await tx
         .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
         .from(heartbeatRuns)
         .where(and(
@@ -9047,9 +9047,8 @@ export function issueRoutes(
           eq(heartbeatRuns.agentId, actor.agentId!),
           eq(heartbeatRuns.status, "running"),
         ))
-        .for("update")
-        .then((rows) => rows[0] ?? null);
-      return Boolean(lockedRun);
+        .for("update");
+      return lockedRuns.length > 0;
     };
     let issue: Awaited<ReturnType<typeof svc.update>>;
     try {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9036,42 +9036,30 @@ export function issueRoutes(
       }, postCommitActivityPublications);
     };
     let issueGraphCleanupComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
-    let issueGraphCleanupCancelledRun: Awaited<ReturnType<typeof heartbeat.cancelRun>> | null = null;
-    let issueGraphCleanupCancellationError: unknown = null;
+    const lockRunningIssueGraphCleanupRun = async (tx: NonNullable<Parameters<typeof svc.update>[2]>) => {
+      if (!issueGraphCleanupRunId) return true;
+      const lockedRun = await tx
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.id, issueGraphCleanupRunId),
+          eq(heartbeatRuns.companyId, existing.companyId),
+          eq(heartbeatRuns.agentId, actor.agentId!),
+          eq(heartbeatRuns.status, "running"),
+        ))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      return Boolean(lockedRun);
+    };
     let issue: Awaited<ReturnType<typeof svc.update>>;
     try {
       if ((transition.decision && decisionId) || shouldRelayStop || issueGraphCleanupRunId) {
         issue = await db.transaction(async (tx) => {
-          if (issueGraphCleanupRunId) {
-            const lockedRun = await tx
-              .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
-              .from(heartbeatRuns)
-              .where(and(
-                eq(heartbeatRuns.id, issueGraphCleanupRunId),
-                eq(heartbeatRuns.companyId, existing.companyId),
-                eq(heartbeatRuns.agentId, actor.agentId!),
-                eq(heartbeatRuns.status, "running"),
-              ))
-              .for("update")
-              .then((rows) => rows[0] ?? null);
-            if (!lockedRun) {
-              throw forbidden("Issue graph cleanup run is no longer active", {
-                code: "issue_graph_cleanup_run_not_running",
-                runId: issueGraphCleanupRunId,
-              });
-            }
-
-            // Cancel before updating the issue row. cancelRun may release the
-            // target run's issue lock through its own transaction; doing that
-            // after updateIssue(tx) would make the nested transaction wait on
-            // this transaction's issue-row lock.
-            if (runToCancelForCancelledStatus) {
-              try {
-                issueGraphCleanupCancelledRun = await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
-              } catch (err) {
-                issueGraphCleanupCancellationError = err;
-              }
-            }
+          if (issueGraphCleanupRunId && !(await lockRunningIssueGraphCleanupRun(tx))) {
+            throw forbidden("Issue graph cleanup run is no longer active", {
+              code: "issue_graph_cleanup_run_not_running",
+              runId: issueGraphCleanupRunId,
+            });
           }
 
           const updated = await updateIssue(tx);
@@ -9182,9 +9170,16 @@ export function issueRoutes(
     let cancelledStatusRunId: string | null = null;
     if (runToCancelForCancelledStatus) {
       try {
-        if (issueGraphCleanupCancellationError) throw issueGraphCleanupCancellationError;
         const cancelled = issueGraphCleanupRunId
-          ? issueGraphCleanupCancelledRun
+          ? await db.transaction(async (tx) => {
+            if (!(await lockRunningIssueGraphCleanupRun(tx))) {
+              throw forbidden("Issue graph cleanup run is no longer active", {
+                code: "issue_graph_cleanup_run_not_running",
+                runId: issueGraphCleanupRunId,
+              });
+            }
+            return heartbeat.cancelRun(runToCancelForCancelledStatus.id);
+          })
           : await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
         if (cancelled) {
           cancelledStatusRunId = cancelled.id;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9214,6 +9214,7 @@ export function issueRoutes(
           issueId: existing.id,
           details: { source: "issue_status_cancelled", issueId: existing.id },
         });
+        if (issueGraphCleanupRunId) throw err;
       }
     }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9178,9 +9178,20 @@ export function issueRoutes(
     let cancelledStatusRunId: string | null = null;
     if (runToCancelForCancelledStatus) {
       try {
+        // Assignment happens inside the transaction callback above, which
+        // TypeScript does not include in its outer control-flow analysis.
+        const preparedCleanupCancellation = preparedIssueGraphCleanupCancellation as Awaited<
+          ReturnType<typeof heartbeat.prepareRunCancellationInTransaction>
+        > | null;
         const cancelled = issueGraphCleanupRunId
-          ? preparedIssueGraphCleanupCancellation
-            ? await heartbeat.finalizePreparedRunCancellation(preparedIssueGraphCleanupCancellation)
+          ? preparedCleanupCancellation
+            ? await heartbeat.finalizePreparedRunCancellation({
+                ...preparedCleanupCancellation,
+                // The database PID/PGID may already have been recycled if the
+                // server-owned child exited before this post-commit finalizer.
+                // Only an entry still owned in runningProcesses is safe to signal.
+                allowPersistedProcessIdentifiers: false,
+              })
             : null
           : await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
         if (cancelled) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3862,6 +3862,91 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  const ISSUE_GRAPH_CLEANUP_UPDATE_FIELDS = new Set(["status", "blockedByIssueIds", "comment"]);
+  const ISSUE_GRAPH_CLEANUP_ANCESTRY_MAX_DEPTH = 50;
+
+  function isIssueGraphCleanupUpdateRequest(input: unknown) {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return false;
+    const keys = Object.keys(input as Record<string, unknown>).filter((key) =>
+      (input as Record<string, unknown>)[key] !== undefined
+    );
+    return keys.length > 0 && keys.every((key) => ISSUE_GRAPH_CLEANUP_UPDATE_FIELDS.has(key));
+  }
+
+  function readRunContextIssueId(contextSnapshot: unknown) {
+    if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return null;
+    const context = contextSnapshot as Record<string, unknown>;
+    const issueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
+    if (issueId) return issueId;
+    const taskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
+    return taskId || null;
+  }
+
+  async function loadIssueAncestryForCleanupOverride(
+    companyId: string,
+    issueId: string,
+    seed?: Pick<IssueRouteSnapshot, "id" | "companyId" | "parentId"> | null,
+  ): Promise<Array<Pick<IssueRouteSnapshot, "id" | "companyId" | "parentId">> | null> {
+    const ancestry: Array<Pick<IssueRouteSnapshot, "id" | "companyId" | "parentId">> = [];
+    const seen = new Set<string>();
+    let cursor: string | null = issueId;
+
+    for (let depth = 0; cursor && depth < ISSUE_GRAPH_CLEANUP_ANCESTRY_MAX_DEPTH; depth += 1) {
+      if (seen.has(cursor)) return null;
+      seen.add(cursor);
+
+      const issue: Pick<IssueRouteSnapshot, "id" | "companyId" | "parentId"> | null =
+        seed && cursor === seed.id ? seed : await svc.getById(cursor);
+      if (!issue || issue.companyId !== companyId) return null;
+      ancestry.push({ id: issue.id, companyId: issue.companyId, parentId: issue.parentId });
+      cursor = issue.parentId;
+    }
+
+    if (cursor) return null;
+    return ancestry;
+  }
+
+  async function hasIssueGraphCleanupMutationOverride(input: {
+    req: Request;
+    issue: Pick<IssueRouteSnapshot, "id" | "companyId" | "parentId" | "assigneeAgentId" | "status">;
+    boundaryDecision: Awaited<ReturnType<typeof decideIssueAccess>>;
+    requestedUpdate: unknown;
+  }) {
+    if (input.req.actor.type !== "agent") return false;
+    if (input.boundaryDecision.reason !== "deny_missing_grant") return false;
+    if (!isIssueGraphCleanupUpdateRequest(input.requestedUpdate)) return false;
+
+    const actorAgentId = input.req.actor.agentId;
+    if (!actorAgentId || !input.issue.assigneeAgentId || input.issue.assigneeAgentId === actorAgentId) {
+      return false;
+    }
+    if (!(await hasActiveCheckoutManagementOverride(actorAgentId, input.issue.companyId, input.issue.assigneeAgentId))) {
+      return false;
+    }
+
+    const run = await loadActorRunContext(input.req, input.issue.companyId);
+    const sourceIssueId = readRunContextIssueId(run?.contextSnapshot);
+    if (!run || !sourceIssueId || sourceIssueId === input.issue.id) return false;
+
+    const sourceIssue = await svc.getById(sourceIssueId);
+    if (
+      !sourceIssue ||
+      sourceIssue.companyId !== input.issue.companyId ||
+      sourceIssue.assigneeAgentId !== actorAgentId ||
+      sourceIssue.status !== "in_progress"
+    ) {
+      return false;
+    }
+    if (sourceIssue.checkoutRunId !== run.id && sourceIssue.executionRunId !== run.id) return false;
+
+    const sourceAncestry = await loadIssueAncestryForCleanupOverride(input.issue.companyId, sourceIssue.id, sourceIssue);
+    const targetAncestry = await loadIssueAncestryForCleanupOverride(input.issue.companyId, input.issue.id, input.issue);
+    if (!sourceAncestry || !targetAncestry || sourceAncestry.length < 2) return false;
+
+    const sourceRootId = sourceAncestry[sourceAncestry.length - 1]?.id ?? null;
+    return Boolean(sourceRootId && targetAncestry.some((entry) => entry.id === sourceRootId));
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
@@ -3876,7 +3961,11 @@ export function issueRoutes(
       /** Used only to name the task in denial copy (plan §6). */
       identifier?: string | null;
     },
-    options: { allowVisibleIssueWrite?: boolean } = {},
+    options: {
+      allowVisibleIssueWrite?: boolean;
+      allowIssueGraphCleanupOverride?: boolean;
+      requestedUpdate?: unknown;
+    } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -3909,6 +3998,17 @@ export function issueRoutes(
     }
     const boundaryDecision = await decideIssueAccess(req, issue, "issue:mutate");
     if (!boundaryDecision.allowed) {
+      if (
+        options.allowIssueGraphCleanupOverride === true &&
+        await hasIssueGraphCleanupMutationOverride({
+          req,
+          issue,
+          boundaryDecision,
+          requestedUpdate: options.requestedUpdate,
+        })
+      ) {
+        return true;
+      }
       return denyIssueWrite(req, res, issue, issueWriteDenialCodeForDecision(boundaryDecision));
     }
     if (issue.assigneeAgentId === null) {
@@ -8437,7 +8537,11 @@ export function issueRoutes(
       req,
       res,
       existing,
-      { allowVisibleIssueWrite: true },
+      {
+        allowVisibleIssueWrite: true,
+        allowIssueGraphCleanupOverride: true,
+        requestedUpdate: req.body,
+      },
     );
     if (!issueMutationAccess) return;
     const issueMutationAuthorizationReason = req.actor.type === "agent"

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9036,6 +9036,9 @@ export function issueRoutes(
       }, postCommitActivityPublications);
     };
     let issueGraphCleanupComment: Awaited<ReturnType<typeof svc.addComment>> | null = null;
+    let preparedIssueGraphCleanupCancellation: Awaited<
+      ReturnType<typeof heartbeat.prepareRunCancellationInTransaction>
+    > | null = null;
     const lockRunningIssueGraphCleanupRun = async (tx: NonNullable<Parameters<typeof svc.update>[2]>) => {
       if (!issueGraphCleanupRunId) return true;
       const lockedRuns = await tx
@@ -9059,6 +9062,12 @@ export function issueRoutes(
               code: "issue_graph_cleanup_run_not_running",
               runId: issueGraphCleanupRunId,
             });
+          }
+          if (issueGraphCleanupRunId && runToCancelForCancelledStatus) {
+            preparedIssueGraphCleanupCancellation = await heartbeat.prepareRunCancellationInTransaction(
+              tx as unknown as Db,
+              runToCancelForCancelledStatus.id,
+            );
           }
 
           const updated = await updateIssue(tx);
@@ -9084,9 +9093,9 @@ export function issueRoutes(
             stopRelayResult.value = await svc.addStopRelayCommentIfNeeded(updated, tx);
           }
 
-          // Keep the actor-run row locked across every mutation granted only by
-          // the cleanup override. A concurrent terminal transition must wait
-          // until the issue write, target-run cancellation, and comment finish.
+          // The actor-run lock and the prepared target-run cancellation stay in
+          // this transaction through every mutation granted only by the cleanup
+          // override. A failure rolls all database state back together.
           if (issueGraphCleanupRunId && commentBody) {
             issueGraphCleanupComment = await svc.addComment(
               id,
@@ -9170,15 +9179,9 @@ export function issueRoutes(
     if (runToCancelForCancelledStatus) {
       try {
         const cancelled = issueGraphCleanupRunId
-          ? await db.transaction(async (tx) => {
-            if (!(await lockRunningIssueGraphCleanupRun(tx))) {
-              throw forbidden("Issue graph cleanup run is no longer active", {
-                code: "issue_graph_cleanup_run_not_running",
-                runId: issueGraphCleanupRunId,
-              });
-            }
-            return heartbeat.cancelRun(runToCancelForCancelledStatus.id);
-          })
+          ? preparedIssueGraphCleanupCancellation
+            ? await heartbeat.finalizePreparedRunCancellation(preparedIssueGraphCleanupCancellation)
+            : null
           : await heartbeat.cancelRun(runToCancelForCancelledStatus.id);
         if (cancelled) {
           cancelledStatusRunId = cancelled.id;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4588,12 +4588,18 @@ export function issueRoutes(
         id: heartbeatRuns.id,
         companyId: heartbeatRuns.companyId,
         agentId: heartbeatRuns.agentId,
+        status: heartbeatRuns.status,
         contextSnapshot: heartbeatRuns.contextSnapshot,
       })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
-    if (!run || run.companyId !== companyId || run.agentId !== req.actor.agentId) return null;
+    if (
+      !run ||
+      run.companyId !== companyId ||
+      run.agentId !== req.actor.agentId ||
+      run.status !== "running"
+    ) return null;
     return run;
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18543,20 +18543,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function finalizePreparedRunCancellation(prepared: PreparedRunCancellation) {
     if (!prepared.cancelled) return prepared.run;
     const run = prepared.run;
+    const failedSteps: string[] = [];
+    const retryStep = async (step: string, action: () => Promise<unknown>) => {
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        try {
+          await action();
+          return;
+        } catch (err) {
+          logger.warn(
+            { err, runId: run.id, step, attempt, maxAttempts: 3 },
+            "prepared run cancellation finalization step failed",
+          );
+        }
+      }
+      failedSteps.push(step);
+    };
     const running = runningProcesses.get(run.id);
     try {
-      if (running) {
-        await terminateHeartbeatRunProcess({
-          pid: running.child.pid ?? run.processPid,
-          processGroupId: running.processGroupId ?? run.processGroupId,
-          graceMs: Math.max(1, running.graceSec) * 1000,
-        });
-      } else if (run.processPid || run.processGroupId) {
-        await terminateHeartbeatRunProcess({
-          pid: run.processPid,
-          processGroupId: run.processGroupId,
-        });
-      }
+      await retryStep("terminate_process", async () => {
+        if (running) {
+          await terminateHeartbeatRunProcess({
+            pid: running.child.pid ?? run.processPid,
+            processGroupId: running.processGroupId ?? run.processGroupId,
+            graceMs: Math.max(1, running.graceSec) * 1000,
+          });
+        } else if (run.processPid || run.processGroupId) {
+          await terminateHeartbeatRunProcess({
+            pid: run.processPid,
+            processGroupId: run.processGroupId,
+          });
+        }
+      });
     } finally {
       runningProcesses.delete(run.id);
     }
@@ -18568,18 +18585,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       payload: buildHeartbeatRunStatusLiveEventPayload(run),
     });
     publishRunLifecyclePluginEvent(run);
-    await appendRunEvent(run, 1, {
-      eventType: "lifecycle",
-      stream: "system",
-      level: "warn",
-      message: prepared.eventMessage,
-      ...(prepared.eventPayload ? { payload: prepared.eventPayload } : {}),
-    });
-    await releaseIssueExecutionAndPromote(run);
-    await finalizeAgentStatus(run.agentId, "cancelled", undefined, {
-      wasFirstHeartbeat: prepared.wasFirstHeartbeat,
-    });
-    await startNextQueuedRunForAgent(run.agentId);
+    await retryStep("append_lifecycle_event", () =>
+      appendRunEvent(run, 1, {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: prepared.eventMessage,
+        ...(prepared.eventPayload ? { payload: prepared.eventPayload } : {}),
+      }),
+    );
+    await retryStep("release_issue_execution", () => releaseIssueExecutionAndPromote(run));
+    await retryStep("finalize_agent_status", () =>
+      finalizeAgentStatus(run.agentId, "cancelled", undefined, {
+        wasFirstHeartbeat: prepared.wasFirstHeartbeat,
+      }),
+    );
+    await retryStep("start_next_queued_run", () => startNextQueuedRunForAgent(run.agentId));
+    if (failedSteps.length > 0) {
+      throw new Error(`Prepared run cancellation finalization failed: ${failedSteps.join(", ")}`);
+    }
     return run;
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18454,6 +18454,135 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     eventPayload?: Record<string, unknown>;
   };
 
+  type PreparedRunCancellation = {
+    run: typeof heartbeatRuns.$inferSelect;
+    cancelled: boolean;
+    wasFirstHeartbeat: boolean;
+    eventMessage: string;
+    eventPayload?: Record<string, unknown>;
+  };
+
+  async function prepareRunCancellationInTransaction(
+    tx: Db,
+    runId: string,
+    reason = "Cancelled by control plane",
+    options: CancelRunOptions = {},
+  ): Promise<PreparedRunCancellation> {
+    const run = await tx
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .for("update")
+      .then((rows) => rows[0] ?? null);
+    if (!run) throw notFound("Heartbeat run not found");
+
+    const wasFirstHeartbeat = Boolean(timerClaimWasFirstHeartbeat(run));
+    if (!CANCELLABLE_HEARTBEAT_RUN_STATUSES.includes(run.status as (typeof CANCELLABLE_HEARTBEAT_RUN_STATUSES)[number])) {
+      return {
+        run,
+        cancelled: false,
+        wasFirstHeartbeat,
+        eventMessage: options.eventMessage ?? "run cancelled",
+        ...(options.eventPayload ? { eventPayload: options.eventPayload } : {}),
+      };
+    }
+
+    const agent = await tx
+      .select()
+      .from(agents)
+      .where(eq(agents.id, run.agentId))
+      .then((rows) => rows[0] ?? null);
+    const errorCode = options.errorCode ?? "cancelled";
+    const resultJson = agent
+      ? {
+          ...mergeRunStopMetadataForAgent(agent, "cancelled", {
+            resultJson: parseObject(run.resultJson),
+            errorCode,
+            errorMessage: reason,
+          }),
+          ...(options.resultJson ?? {}),
+        }
+      : options.resultJson;
+    const finishedAt = new Date();
+    const cancelled = await tx
+      .update(heartbeatRuns)
+      .set({
+        status: "cancelled",
+        finishedAt,
+        error: reason,
+        errorCode,
+        ...(resultJson ? { resultJson } : {}),
+        updatedAt: finishedAt,
+      })
+      .where(eq(heartbeatRuns.id, run.id))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    if (!cancelled) throw notFound("Heartbeat run not found");
+
+    if (run.wakeupRequestId) {
+      await tx
+        .update(agentWakeupRequests)
+        .set({
+          status: "cancelled",
+          finishedAt,
+          error: reason,
+          updatedAt: finishedAt,
+        })
+        .where(eq(agentWakeupRequests.id, run.wakeupRequestId));
+    }
+
+    return {
+      run: cancelled,
+      cancelled: true,
+      wasFirstHeartbeat,
+      eventMessage: options.eventMessage ?? "run cancelled",
+      ...(options.eventPayload ? { eventPayload: options.eventPayload } : {}),
+    };
+  }
+
+  async function finalizePreparedRunCancellation(prepared: PreparedRunCancellation) {
+    if (!prepared.cancelled) return prepared.run;
+    const run = prepared.run;
+    const running = runningProcesses.get(run.id);
+    try {
+      if (running) {
+        await terminateHeartbeatRunProcess({
+          pid: running.child.pid ?? run.processPid,
+          processGroupId: running.processGroupId ?? run.processGroupId,
+          graceMs: Math.max(1, running.graceSec) * 1000,
+        });
+      } else if (run.processPid || run.processGroupId) {
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+      }
+    } finally {
+      runningProcesses.delete(run.id);
+    }
+
+    clearHeartbeatRunRuntimeStatus(run.id);
+    publishLiveEvent({
+      companyId: run.companyId,
+      type: "heartbeat.run.status",
+      payload: buildHeartbeatRunStatusLiveEventPayload(run),
+    });
+    publishRunLifecyclePluginEvent(run);
+    await appendRunEvent(run, 1, {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "warn",
+      message: prepared.eventMessage,
+      ...(prepared.eventPayload ? { payload: prepared.eventPayload } : {}),
+    });
+    await releaseIssueExecutionAndPromote(run);
+    await finalizeAgentStatus(run.agentId, "cancelled", undefined, {
+      wasFirstHeartbeat: prepared.wasFirstHeartbeat,
+    });
+    await startNextQueuedRunForAgent(run.agentId);
+    return run;
+  }
+
   async function cancelRunInternal(runId: string, reason = "Cancelled by control plane", options: CancelRunOptions = {}) {
     const run = await getRun(runId);
     if (!run) throw notFound("Heartbeat run not found");
@@ -19024,6 +19153,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     cancelRun: (runId: string, reason?: string, options?: CancelRunOptions) => cancelRunInternal(runId, reason, options),
+    prepareRunCancellationInTransaction: (
+      tx: Db,
+      runId: string,
+      reason?: string,
+      options?: CancelRunOptions,
+    ) => prepareRunCancellationInTransaction(tx, runId, reason, options),
+    finalizePreparedRunCancellation,
 
     /**
      * Pause-only. Emits errorCode "agent_paused" unconditionally; its sole caller is the

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18460,7 +18460,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     wasFirstHeartbeat: boolean;
     eventMessage: string;
     eventPayload?: Record<string, unknown>;
+    finalizationId?: string;
   };
+
+  const PENDING_CANCELLATION_FINALIZATION_KEY = "pendingCancellationFinalization";
+  // Give the request path time to finish before the scheduler treats the marker as
+  // abandoned. The marker itself is committed with cancellation, so a crash or an
+  // exhausted immediate retry always leaves durable work for a later sweep.
+  const PENDING_CANCELLATION_FINALIZATION_RETRY_DELAY_MS = 30_000;
+
+  type PendingCancellationFinalization = {
+    id: string;
+    wasFirstHeartbeat: boolean;
+    eventMessage: string;
+    eventPayload?: Record<string, unknown>;
+  };
+
+  function readPendingCancellationFinalization(run: typeof heartbeatRuns.$inferSelect) {
+    const raw = parseObject(parseObject(run.resultJson)[PENDING_CANCELLATION_FINALIZATION_KEY]);
+    const id = readNonEmptyString(raw.id);
+    const eventMessage = readNonEmptyString(raw.eventMessage);
+    if (!id || !eventMessage) return null;
+    const eventPayload = parseObject(raw.eventPayload);
+    return {
+      id,
+      wasFirstHeartbeat: raw.wasFirstHeartbeat === true,
+      eventMessage,
+      ...(Object.keys(eventPayload).length > 0 ? { eventPayload } : {}),
+    } satisfies PendingCancellationFinalization;
+  }
 
   async function prepareRunCancellationInTransaction(
     tx: Db,
@@ -18493,6 +18521,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(eq(agents.id, run.agentId))
       .then((rows) => rows[0] ?? null);
     const errorCode = options.errorCode ?? "cancelled";
+    const pendingFinalization = {
+      id: randomUUID(),
+      wasFirstHeartbeat,
+      eventMessage: options.eventMessage ?? "run cancelled",
+      ...(options.eventPayload ? { eventPayload: options.eventPayload } : {}),
+    } satisfies PendingCancellationFinalization;
     const resultJson = agent
       ? {
           ...mergeRunStopMetadataForAgent(agent, "cancelled", {
@@ -18501,8 +18535,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             errorMessage: reason,
           }),
           ...(options.resultJson ?? {}),
+          [PENDING_CANCELLATION_FINALIZATION_KEY]: pendingFinalization,
         }
-      : options.resultJson;
+      : {
+          ...(options.resultJson ?? {}),
+          [PENDING_CANCELLATION_FINALIZATION_KEY]: pendingFinalization,
+        };
     const finishedAt = new Date();
     const cancelled = await tx
       .update(heartbeatRuns)
@@ -18535,12 +18573,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       run: cancelled,
       cancelled: true,
       wasFirstHeartbeat,
-      eventMessage: options.eventMessage ?? "run cancelled",
+      eventMessage: pendingFinalization.eventMessage,
       ...(options.eventPayload ? { eventPayload: options.eventPayload } : {}),
+      finalizationId: pendingFinalization.id,
     };
   }
 
-  async function finalizePreparedRunCancellation(prepared: PreparedRunCancellation) {
+  const activePreparedCancellationFinalizations = new Map<
+    string,
+    Promise<typeof heartbeatRuns.$inferSelect>
+  >();
+
+  async function finalizePreparedRunCancellationInternal(prepared: PreparedRunCancellation) {
     if (!prepared.cancelled) return prepared.run;
     const run = prepared.run;
     const failedSteps: string[] = [];
@@ -18586,13 +18630,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
     publishRunLifecyclePluginEvent(run);
     await retryStep("append_lifecycle_event", () =>
-      appendRunEvent(run, 1, {
-        eventType: "lifecycle",
-        stream: "system",
-        level: "warn",
-        message: prepared.eventMessage,
-        ...(prepared.eventPayload ? { payload: prepared.eventPayload } : {}),
-      }),
+      db
+        .select({ id: heartbeatRunEvents.id })
+        .from(heartbeatRunEvents)
+        .where(
+          and(
+            eq(heartbeatRunEvents.runId, run.id),
+            eq(heartbeatRunEvents.eventType, "lifecycle"),
+            eq(heartbeatRunEvents.message, prepared.eventMessage),
+          ),
+        )
+        .limit(1)
+        .then((rows) =>
+          rows.length > 0
+            ? undefined
+            : appendRunEvent(run, 1, {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "warn",
+                message: prepared.eventMessage,
+                ...(prepared.eventPayload ? { payload: prepared.eventPayload } : {}),
+              }),
+        ),
     );
     await retryStep("release_issue_execution", () => releaseIssueExecutionAndPromote(run));
     await retryStep("finalize_agent_status", () =>
@@ -18601,10 +18660,83 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }),
     );
     await retryStep("start_next_queued_run", () => startNextQueuedRunForAgent(run.agentId));
+    // Clearing the durable marker is the acknowledgement for the whole workflow.
+    // Leave it in place whenever any step failed so a later scheduler pass repeats
+    // the idempotent reconciliation from a fresh service instance.
+    if (failedSteps.length === 0 && prepared.finalizationId) {
+      await retryStep("clear_finalization_marker", () =>
+        db
+          .update(heartbeatRuns)
+          .set({
+            resultJson: sql<Record<string, unknown>>`coalesce(${heartbeatRuns.resultJson}, '{}'::jsonb) - ${PENDING_CANCELLATION_FINALIZATION_KEY}`,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(heartbeatRuns.id, run.id),
+              sql`${heartbeatRuns.resultJson} -> ${PENDING_CANCELLATION_FINALIZATION_KEY} ->> 'id' = ${prepared.finalizationId}`,
+            ),
+          )
+          .then(() => undefined),
+      );
+    }
     if (failedSteps.length > 0) {
       throw new Error(`Prepared run cancellation finalization failed: ${failedSteps.join(", ")}`);
     }
     return run;
+  }
+
+  async function finalizePreparedRunCancellation(prepared: PreparedRunCancellation) {
+    const active = activePreparedCancellationFinalizations.get(prepared.run.id);
+    if (active) return active;
+    const finalization = finalizePreparedRunCancellationInternal(prepared).finally(() => {
+      activePreparedCancellationFinalizations.delete(prepared.run.id);
+    });
+    activePreparedCancellationFinalizations.set(prepared.run.id, finalization);
+    return finalization;
+  }
+
+  async function reconcilePendingRunCancellations() {
+    const pendingRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "cancelled"),
+          sql`${heartbeatRuns.resultJson} ? ${PENDING_CANCELLATION_FINALIZATION_KEY}`,
+          lt(
+            heartbeatRuns.updatedAt,
+            new Date(Date.now() - PENDING_CANCELLATION_FINALIZATION_RETRY_DELAY_MS),
+          ),
+        ),
+      )
+      .orderBy(asc(heartbeatRuns.updatedAt))
+      .limit(50);
+    let reconciled = 0;
+    let failed = 0;
+    for (const run of pendingRuns) {
+      const pending = readPendingCancellationFinalization(run);
+      if (!pending) {
+        failed += 1;
+        logger.error({ runId: run.id }, "invalid pending cancellation finalization marker");
+        continue;
+      }
+      try {
+        await finalizePreparedRunCancellation({
+          run,
+          cancelled: true,
+          wasFirstHeartbeat: pending.wasFirstHeartbeat,
+          eventMessage: pending.eventMessage,
+          ...(pending.eventPayload ? { eventPayload: pending.eventPayload } : {}),
+          finalizationId: pending.id,
+        });
+        reconciled += 1;
+      } catch (err) {
+        failed += 1;
+        logger.error({ err, runId: run.id }, "pending cancellation finalization retry failed");
+      }
+    }
+    return { checked: pendingRuns.length, reconciled, failed };
   }
 
   async function cancelRunInternal(runId: string, reason = "Cancelled by control plane", options: CancelRunOptions = {}) {
@@ -19184,6 +19316,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       options?: CancelRunOptions,
     ) => prepareRunCancellationInTransaction(tx, runId, reason, options),
     finalizePreparedRunCancellation,
+    reconcilePendingRunCancellations,
 
     /**
      * Pause-only. Emits errorCode "agent_paused" unconditionally; its sole caller is the

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18461,6 +18461,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     eventMessage: string;
     eventPayload?: Record<string, unknown>;
     finalizationId?: string;
+    allowPersistedProcessIdentifiers?: boolean;
   };
 
   const PENDING_CANCELLATION_FINALIZATION_KEY = "pendingCancellationFinalization";
@@ -18603,23 +18604,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       failedSteps.push(step);
     };
     const running = runningProcesses.get(run.id);
-    try {
-      await retryStep("terminate_process", async () => {
-        if (running) {
-          await terminateHeartbeatRunProcess({
-            pid: running.child.pid ?? run.processPid,
-            processGroupId: running.processGroupId ?? run.processGroupId,
-            graceMs: Math.max(1, running.graceSec) * 1000,
-          });
-        } else if (run.processPid || run.processGroupId) {
-          await terminateHeartbeatRunProcess({
-            pid: run.processPid,
-            processGroupId: run.processGroupId,
-          });
-        }
-      });
-    } finally {
+    await retryStep("terminate_process", async () => {
+      if (running) {
+        await terminateHeartbeatRunProcess({
+          pid: running.child.pid ?? run.processPid,
+          processGroupId: running.processGroupId ?? run.processGroupId,
+          graceMs: Math.max(1, running.graceSec) * 1000,
+        });
+      } else if (
+        prepared.allowPersistedProcessIdentifiers !== false &&
+        (run.processPid || run.processGroupId)
+      ) {
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+      }
+    });
+    if (!failedSteps.includes("terminate_process")) {
       runningProcesses.delete(run.id);
+    } else if (!running) {
+      logger.error(
+        { runId: run.id },
+        "prepared cancellation could not terminate process and has no live process ownership for retry",
+      );
     }
 
     clearHeartbeatRunRuntimeStatus(run.id);
@@ -18729,6 +18737,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           eventMessage: pending.eventMessage,
           ...(pending.eventPayload ? { eventPayload: pending.eventPayload } : {}),
           finalizationId: pending.id,
+          // Persisted PIDs and process-group IDs may have been recycled by the OS.
+          // A delayed sweep may terminate only a child still owned in memory.
+          allowPersistedProcessIdentifiers: false,
         });
         reconciled += 1;
       } catch (err) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane people use to manage AI agents and their work.
> - Recovery runs keep issue trees live when ownership or execution state becomes inconsistent.
> - Manager-chain agents can manage active checkouts, but the generic issue mutation boundary still rejected cleanup of a same-tree sibling owned by another agent.
> - That prevented a dedicated issue-graph recovery run from reconciling status or blockers and cancelling the sibling's active run.
> - A broad manager override would weaken normal issue ownership and low-trust boundaries.
> - This pull request adds a narrow recovery-origin, same-tree cleanup override while preserving every ordinary authorization denial.
> - The benefit is that issue-graph recovery can finish its assigned cleanup without granting general cross-issue mutation authority.

## Linked Issues or Issue Description

### What happened

A manager-chain agent running dedicated issue-graph liveness recovery could be authorized to manage the target assignee's active checkout but still receive a `403` when it attempted to reconcile a same-tree sibling issue. The recovery run could therefore identify duplicate or inconsistent work but could not apply the bounded status/blocker cleanup needed to restore the tree.

Related but distinct prior work: #8682 covers reconciliation of explicitly stale, non-running legacy issues. This change covers an active issue only from a dedicated, currently owned issue-graph recovery run.

### Expected behavior

A cleanup mutation should be allowed only when all of the following hold:

- The actor manages the target assignee's active checkouts.
- The actor's current run owns an `in_progress` issue-graph liveness escalation issue.
- The source and target share the same issue-tree root.
- The request contains only `status`, `blockedByIssueIds`, and/or `comment`.
- The normal denial is a missing grant, not a low-trust or policy boundary.

Ordinary manager runs, out-of-tree targets, low-trust actors, unrelated recovery origins, malformed ancestry, and broader field updates must remain denied.

### Steps to reproduce

1. Create an issue tree with a dedicated issue-graph liveness escalation issue assigned to a manager-chain agent and an active sibling assigned to a report.
2. Run the recovery issue and attempt to `PATCH` the sibling to a terminal status with a cleanup comment.
3. Observe the generic issue mutation boundary return `403` even though the actor can manage the report's active checkout.
4. Without this change, the recovery run cannot reconcile the sibling or cancel its active run.

### Paperclip version or commit

Reproduced against `paperclipai/paperclip` master before the commits in this PR.

### Deployment mode

Server authorization behavior is deployment-mode independent; reproduced in the local test environment.

## What Changed

- Added a narrowly scoped issue-graph cleanup mutation override for active, owned liveness-escalation runs.
- Required manager-chain checkout authority, matching company, shared ancestry root, bounded ancestry traversal, and a strict cleanup-field allowlist.
- Preserved current structured issue-write denial codes and low-trust fail-closed behavior.
- Locked the recovery run and prepared target-run cancellation in the same database transaction as issue, decision, relay, and cleanup-comment mutations.
- Added durable, idempotent cancellation-finalization markers and scheduler reconciliation for post-commit lifecycle work.
- Restricted process termination to server-owned in-memory children so immediate and delayed finalization cannot signal recycled persisted process identifiers.
- Added route/runtime/startup regressions for authorization boundaries, rollback, finalization retries, reconciliation, and scheduler wiring.

## Verification

- Focused issue-mutation and execution-lock suites:
  - Result: 90 tests passed.
- Focused startup scheduler regression:
  - Result: 1 test passed.
- Focused immediate-finalization safety regression after the final fix:
  - Result: 1 test passed (81 skipped).
- `git diff --check public-gh/master...HEAD`
  - Result: passed.
- GitHub PR workflow on exact head `b4ba2047d2f55d6030805e5fbee314b34808f448`:
  - Result: all 30 reported checks completed successfully, neutrally, or as intentionally skipped; no failures or pending checks.
- Greptile on exact head `b4ba2047d2f55d6030805e5fbee314b34808f448`:
  - Result: 5/5 with zero unresolved review threads.

## Risks

- The main risk is unintentionally widening cross-issue mutation authority. The override fails closed unless every recovery-origin, run-ownership, manager-chain, company, ancestry, denial-reason, and field-allowlist condition passes.
- Ancestry traversal is capped at 50 nodes and rejects cycles, missing issues, cross-company parents, or over-depth trees.
- No schema, migration, API shape, workflow, lockfile, UI, or documentation changes are included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 family (exact deployment ID and context-window size are not exposed to this runtime), with reasoning, repository editing, shell execution, and GitHub tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
