### PR TITLE
fix(api): reject unknown query params on issue/approval list endpoints

### DIFF
--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -20,6 +20,7 @@ import {
 interface ApprovalListOptions extends BaseClientOptions {
   companyId?: string;
   status?: string;
+  dedupKey?: string;
 }
 
 interface ApprovalDecisionOptions extends BaseClientOptions {
@@ -52,11 +53,13 @@ export function registerApprovalCommands(program: Command): void {
       .description("List approvals for a company")
       .requiredOption("-C, --company-id <id>", "Company ID")
       .option("--status <status>", "Status filter")
+      .option("--dedup-key <key>", "Exact match on payload.dedupKey")
       .action(async (opts: ApprovalListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
           const params = new URLSearchParams();
           if (opts.status) params.set("status", opts.status);
+          if (opts.dedupKey) params.set("dedupKey", opts.dedupKey);
           const query = params.toString();
           const rows =
             (await ctx.api.get<Approval[]>(

--- a/docs/api/approvals.md
+++ b/docs/api/approvals.md
@@ -16,6 +16,31 @@ Query parameters:
 | Param | Description |
 |-------|-------------|
 | `status` | Filter by status (e.g. `pending`) |
+| `dedupKey` | Exact match on `payload.dedupKey` |
+| `limit` | Page size, 1–500. Omit to get the full set. |
+| `offset` | Rows to skip. Requires `limit`. |
+
+Unrecognized query parameters are rejected with `400`, and the error body names
+both the offending parameters and the supported set. This endpoint never
+silently ignores a filter it does not understand, so a `200` means every
+parameter you sent was applied.
+
+Results are newest-first (`createdAt` descending, `id` breaking ties), so
+`offset` walks a stable order. Pagination is opt-in — with no `limit`, the full
+result set is returned.
+
+### Checking for a duplicate before filing
+
+`dedupKey` is the server-side check behind "one open approval per artifact".
+Query it before creating an approval and only file when the result is empty:
+
+```
+GET /api/companies/{companyId}/approvals?status=pending&dedupKey=issue:BLU-1234
+```
+
+An empty array here genuinely means "no pending approval for this artifact" —
+previously an unsupported `dedupKey` was dropped and this returned every pending
+approval, so the check passed no matter what.
 
 ## Get Approval
 

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -16,8 +16,25 @@ Query parameters:
 | Param | Description |
 |-------|-------------|
 | `status` | Filter by status (comma-separated: `todo,in_progress`) |
-| `assigneeAgentId` | Filter by assigned agent |
+| `q` | Full-text search over the issue. **Not** `search` — see below. |
+| `assigneeAgentId` | Filter by assigned agent (UUID, or `null` for unassigned) |
+| `assigneeUserId` | Filter by assigned user (`me` for the authenticated board user) |
 | `projectId` | Filter by project |
+| `parentId` / `descendantOf` | Filter by position in the issue tree |
+| `labelId` | Filter by label |
+| `attention` | `blocked` only |
+| `limit` / `offset` | Pagination (default limit 500) |
+| `sortField` / `sortDir` | `updated`, with `asc` / `desc` |
+
+The full accepted set is larger than the table above; the authoritative list is
+`ISSUE_LIST_SUPPORTED_QUERY_PARAMS` in `server/src/routes/issues.ts`, and a `400`
+response body echoes it under `supported`.
+
+Unrecognized query parameters are rejected with `400`. In particular
+**`search` is not a valid parameter — use `q`**; it used to be silently ignored,
+which returned the full unfiltered list and read exactly like a working search
+returning unrelated results. Likewise there is no `page` parameter: paginate
+with `limit` and `offset`.
 
 Results sorted by priority.
 

--- a/docs/cli/control-plane-commands.md
+++ b/docs/cli/control-plane-commands.md
@@ -100,6 +100,9 @@ pnpm paperclipai skills agent sync <agent-id> --skill github-pr-workflow --compa
 # List approvals
 pnpm paperclipai approval list [--status pending]
 
+# Check for an existing approval on an artifact before filing a new one
+pnpm paperclipai approval list --status pending --dedup-key issue:BLU-1234
+
 # Get approval
 pnpm paperclipai approval get <approval-id>
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -420,11 +420,24 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipListApprovals",
-      "List approvals in a company",
-      z.object({ companyId: companyIdOptional, status: z.string().optional() }),
-      async ({ companyId, status }) => {
-        const qs = status ? `?status=${encodeURIComponent(status)}` : "";
-        return client.requestJson("GET", `/companies/${client.resolveCompanyId(companyId)}/approvals${qs}`);
+      "List approvals in a company. Pass dedupKey to check whether an approval already exists for an artifact before filing a new one — an empty result means none is pending.",
+      z.object({
+        companyId: companyIdOptional,
+        status: z.string().optional(),
+        dedupKey: z
+          .string()
+          .optional()
+          .describe("Exact match on payload.dedupKey, e.g. issue:BLU-1234"),
+      }),
+      async ({ companyId, status, dedupKey }) => {
+        const params = new URLSearchParams();
+        if (status) params.set("status", status);
+        if (dedupKey) params.set("dedupKey", dedupKey);
+        const qs = params.toString();
+        return client.requestJson(
+          "GET",
+          `/companies/${client.resolveCompanyId(companyId)}/approvals${qs ? `?${qs}` : ""}`,
+        );
       },
     ),
     makeTool(

--- a/server/src/__tests__/approvals-list-dedup-key.test.ts
+++ b/server/src/__tests__/approvals-list-dedup-key.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { approvals, companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { approvalService } from "../services/approvals.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres approval list filter tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/**
+ * `approvalService.list` is the server-side half of Approval Hygiene Rule 1
+ * ("one open approval per artifact"). Rule 2 mandates `payload.dedupKey` so a
+ * dedup guard can key on it — but the filter did not exist, so `?dedupKey=`
+ * returned every approval in the company and a caller checking for duplicates
+ * got a non-empty answer either way.
+ */
+describeEmbeddedPostgres("approvalService.list filters", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-approval-list-filters-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(approvals);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function uniqueIssuePrefix() {
+    return `P${randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedApproval(
+    companyId: string,
+    payload: Record<string, unknown>,
+    overrides: { status?: string; createdAt?: Date } = {},
+  ) {
+    const id = randomUUID();
+    await db.insert(approvals).values({
+      id,
+      companyId,
+      type: "generic",
+      status: overrides.status ?? "pending",
+      payload,
+      ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
+    });
+    return id;
+  }
+
+  it("returns only exact dedupKey matches", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    const wanted = await seedApproval(companyId, { dedupKey: "issue:BLU-1234" });
+    await seedApproval(companyId, { dedupKey: "issue:BLU-9999" });
+    await seedApproval(companyId, { dedupKey: "issue:BLU-1234-extra" });
+    await seedApproval(companyId, { title: "no dedup key at all" });
+
+    const rows = await svc.list(companyId, { dedupKey: "issue:BLU-1234" });
+
+    expect(rows.map((row) => row.id)).toEqual([wanted]);
+  });
+
+  // The DoD assertion: a nonsense filter value yields 0 rows, not the full set.
+  it("returns 0 rows for a nonsense dedupKey rather than everything", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    await seedApproval(companyId, { dedupKey: "issue:BLU-1234" });
+    await seedApproval(companyId, { dedupKey: "issue:BLU-9999" });
+
+    expect(await svc.list(companyId, { dedupKey: "zzzznonsense" })).toHaveLength(0);
+    // ...and the unfiltered call still sees both, proving the rows were there.
+    expect(await svc.list(companyId)).toHaveLength(2);
+  });
+
+  it("surfaces a duplicated dedupKey — the case Approval Hygiene Rule 1 exists to catch", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    await seedApproval(companyId, { dedupKey: "postiz:BLU-26634:2026-08-14" });
+    await seedApproval(companyId, { dedupKey: "postiz:BLU-26634:2026-08-14" });
+
+    const rows = await svc.list(companyId, {
+      status: "pending",
+      dedupKey: "postiz:BLU-26634:2026-08-14",
+    });
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it("combines dedupKey with status", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    const pendingId = await seedApproval(companyId, { dedupKey: "shared" }, { status: "pending" });
+    await seedApproval(companyId, { dedupKey: "shared" }, { status: "approved" });
+
+    const rows = await svc.list(companyId, { status: "pending", dedupKey: "shared" });
+
+    expect(rows.map((row) => row.id)).toEqual([pendingId]);
+  });
+
+  it("scopes dedupKey matches to the requesting company", async () => {
+    const companyA = await seedCompany();
+    const companyB = await seedCompany();
+    const svc = approvalService(db);
+    const mine = await seedApproval(companyA, { dedupKey: "shared" });
+    await seedApproval(companyB, { dedupKey: "shared" });
+
+    const rows = await svc.list(companyA, { dedupKey: "shared" });
+
+    expect(rows.map((row) => row.id)).toEqual([mine]);
+  });
+
+  describe("pagination", () => {
+    async function seedThree(companyId: string) {
+      const oldest = await seedApproval(companyId, { n: 1 }, { createdAt: new Date("2026-08-01T00:00:00Z") });
+      const middle = await seedApproval(companyId, { n: 2 }, { createdAt: new Date("2026-08-02T00:00:00Z") });
+      const newest = await seedApproval(companyId, { n: 3 }, { createdAt: new Date("2026-08-03T00:00:00Z") });
+      return { oldest, middle, newest };
+    }
+
+    it("returns the full set when limit is omitted", async () => {
+      const companyId = await seedCompany();
+      const svc = approvalService(db);
+      await seedThree(companyId);
+
+      // Three UI consumers (list page, inbox feed, sidebar badge) count over the
+      // whole array, so an unrequested default page size would silently
+      // under-report them.
+      expect(await svc.list(companyId)).toHaveLength(3);
+    });
+
+    it("honours limit and offset over a stable newest-first order", async () => {
+      const companyId = await seedCompany();
+      const svc = approvalService(db);
+      const { oldest, middle, newest } = await seedThree(companyId);
+
+      expect((await svc.list(companyId, { limit: 2 })).map((r) => r.id)).toEqual([newest, middle]);
+      expect((await svc.list(companyId, { limit: 2, offset: 2 })).map((r) => r.id)).toEqual([oldest]);
+      // Distinct pages: the bug report's "page 1 re-fetched N times" inflation.
+      expect((await svc.list(companyId, { limit: 1, offset: 1 })).map((r) => r.id)).toEqual([middle]);
+    });
+  });
+});

--- a/server/src/__tests__/approvals-list-query-params.test.ts
+++ b/server/src/__tests__/approvals-list-query-params.test.ts
@@ -1,0 +1,250 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApprovalService = vi.hoisted(() => ({
+  list: vi.fn(),
+  getById: vi.fn(),
+  create: vi.fn(),
+  approve: vi.fn(),
+  reject: vi.fn(),
+  requestRevision: vi.fn(),
+  resubmit: vi.fn(),
+  listComments: vi.fn(),
+  addComment: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({ decide: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({ wakeup: vi.fn() }));
+const mockIssueApprovalService = vi.hoisted(() => ({
+  listIssuesForApproval: vi.fn(),
+  linkManyForApproval: vi.fn(),
+}));
+const mockSecretService = vi.hoisted(() => ({
+  normalizeHireApprovalPayloadForPersistence: vi.fn(),
+}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => mockAccessService,
+    approvalService: () => mockApprovalService,
+    heartbeatService: () => mockHeartbeatService,
+    issueApprovalService: () => mockIssueApprovalService,
+    logActivity: mockLogActivity,
+    secretService: () => mockSecretService,
+  }));
+}
+
+function createRouteDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          then: async (resolve: (rows: unknown[]) => unknown) => resolve([]),
+        })),
+      })),
+    })),
+  } as any;
+}
+
+async function createApp() {
+  const [{ errorHandler }, { approvalRoutes }] = await Promise.all([
+    import("../middleware/index.js"),
+    import("../routes/approvals.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", approvalRoutes(createRouteDb()));
+  app.use(errorHandler);
+  return app;
+}
+
+function approvalRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "approval-1",
+    companyId: "company-1",
+    type: "generic",
+    status: "pending",
+    payload: { dedupKey: "issue:BLU-1234" },
+    createdAt: new Date("2026-08-01T00:00:00Z"),
+    updatedAt: new Date("2026-08-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+const LIST_PATH = "/api/companies/company-1/approvals";
+
+describe("GET /companies/:companyId/approvals query params", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockApprovalService.list.mockReset();
+    mockApprovalService.list.mockResolvedValue([approvalRow()]);
+    mockAccessService.decide.mockReset();
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      action: "company_scope:read",
+      reason: "allow_test",
+      explanation: "Allowed by test mock.",
+    });
+  });
+
+  describe("unknown params fail loud instead of returning the full set", () => {
+    // The regression this endpoint is being fixed for: an unimplemented filter
+    // silently returned every row, so a caller could not tell "filter matched
+    // nothing" from "filter never ran".
+    it.each([
+      ["q", `${LIST_PATH}?q=anything`],
+      ["search", `${LIST_PATH}?search=anything`],
+      ["page", `${LIST_PATH}?page=2`],
+      ["dedupkey", `${LIST_PATH}?dedupkey=wrong-case`],
+    ])("rejects ?%s with 400", async (param, path) => {
+      const app = await createApp();
+      const res = await request(app).get(path);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain(param);
+      expect(res.body.unsupported).toEqual([param]);
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+      // Generous: the first case in the file pays the route module-graph import.
+    }, 30_000);
+
+    it("names every unsupported param and advertises the supported set", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?search=x&nonsense=y`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.unsupported).toEqual(["nonsense", "search"]);
+      expect(res.body.supported).toEqual(["dedupKey", "limit", "offset", "status"]);
+      // The hint is what lets an agent self-correct rather than retry blindly.
+      expect(res.body.error).toContain("status=");
+    });
+  });
+
+  describe("supported filters reach the service", () => {
+    it("forwards status", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?status=pending`);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ status: "pending" }),
+      );
+    });
+
+    it("forwards dedupKey", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?dedupKey=issue%3ABLU-1234`);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ dedupKey: "issue:BLU-1234" }),
+      );
+    });
+
+    it("returns an empty list — not the full set — when dedupKey matches nothing", async () => {
+      mockApprovalService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?dedupKey=zzzznonsense`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it("forwards limit and offset together", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?limit=5&offset=10`);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ limit: 5, offset: 10 }),
+      );
+    });
+
+    it("leaves limit undefined when unset so the full set is returned", async () => {
+      const app = await createApp();
+      const res = await request(app).get(LIST_PATH);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ limit: undefined, offset: undefined }),
+      );
+    });
+  });
+
+  describe("malformed pagination values are rejected, not coerced", () => {
+    it.each([
+      ["limit=0", "limit must be"],
+      ["limit=-1", "limit must be"],
+      ["limit=abc", "limit must be"],
+      ["limit=100000", "limit must be"],
+      ["offset=abc&limit=5", "offset must be"],
+    ])("rejects ?%s", async (query, expectedError) => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?${query}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain(expectedError);
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    it("rejects offset without limit rather than silently ignoring it", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?offset=100`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("offset requires limit");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    it("rejects a repeated dedupKey instead of picking one arbitrarily", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?dedupKey=a&dedupKey=b`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("dedupKey must be a single string value");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    // Express parses a repeated key into an array, which `eq()` cannot filter
+    // on. This endpoint has never supported repeated values (unlike issues,
+    // where `status` is legitimately CSV-or-repeated).
+    it("rejects a repeated status rather than building a bad query", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?status=pending&status=approved`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("status must be a single string value");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    // Bracket syntax needs no special handling: the app uses Express's simple
+    // query parser, so `status[]` arrives as a literal key the allow-list
+    // already rejects.
+    it("rejects bracketed status[] as an unsupported parameter name", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?status[]=pending`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("status[]");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1008,4 +1008,98 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       liveDescendantCount: 1,
     });
   });
+
+  describe("unknown query params fail loud instead of returning the full set", () => {
+    async function seedCompanyWithIssues(titles: string[]) {
+      const companyId = randomUUID();
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: uniqueIssuePrefix(),
+        requireBoardApprovalForNewAgents: false,
+      });
+      await seedCloudTenantMember(companyId);
+      await db.insert(issues).values(
+        titles.map((title) => ({
+          id: randomUUID(),
+          companyId,
+          title,
+          status: "todo",
+          priority: "medium",
+        })),
+      );
+      return companyId;
+    }
+
+    // The bug: `?search=` was silently dropped, so a dedup search returned every
+    // issue and read exactly like a working search returning unrelated results.
+    it("rejects ?search= (the near-miss for ?q=) rather than ignoring it", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta", "Gamma"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ search: "zzzznonsense" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.error).toContain("search");
+      expect(res.body.error).toContain("use q=");
+      expect(res.body.unsupported).toEqual(["search"]);
+    });
+
+    // The bug: `?page=` was dropped, so looping page=1..N re-fetched page 1 and
+    // inflated any count derived from the loop.
+    it("rejects ?page= rather than silently re-returning the first page", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ page: "2" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.error).toContain("page");
+      expect(res.body.error).toContain("offset=");
+    });
+
+    it("lists every unsupported param and advertises the supported set", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ nonsense: "1", search: "x" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.unsupported).toEqual(["nonsense", "search"]);
+      expect(res.body.supported).toContain("q");
+      expect(res.body.supported).toContain("limit");
+    });
+
+    it("still honours the supported params it advertises", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ status: "todo", limit: "25" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+
+    // The DoD assertion: a nonsense value on a *supported* filter must yield 0
+    // rows, never the unfiltered set.
+    it("returns 0 rows for a nonsense ?q= value, not the full list", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta", "Gamma"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ q: "zzzznonsense" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+  });
 });

--- a/server/src/__tests__/list-query-param-allowlist-drift.test.ts
+++ b/server/src/__tests__/list-query-param-allowlist-drift.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAMS,
+  ISSUE_LIST_SUPPORTED_QUERY_PARAMS,
+} from "../routes/query-params.js";
+
+/**
+ * The allow-lists in `query-params.ts` are what turn an unrecognized filter into
+ * a 400 instead of a silently-unfiltered 200. That only holds while they match
+ * the params the handlers actually read:
+ *
+ *  - a param read by the handler but missing from the list becomes unreachable,
+ *    because the guard 400s before the handler ever sees it;
+ *  - a param listed but never read is accepted and then silently does nothing —
+ *    reintroducing the exact fail-open these lists exist to close.
+ *
+ * Neither drift direction is caught by typecheck, so assert it here by reading
+ * the `req.query.<name>` accesses out of each handler body.
+ */
+function readSource(relativePath: string) {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+}
+
+function queryParamsReadBetween(source: string, startMarker: string, endMarker: string) {
+  const start = source.indexOf(startMarker);
+  expect(start, `could not locate handler start: ${startMarker}`).toBeGreaterThan(-1);
+  const end = source.indexOf(endMarker, start);
+  expect(end, `could not locate handler end: ${endMarker}`).toBeGreaterThan(start);
+
+  const body = source.slice(start, end);
+  const names = new Set<string>();
+  for (const match of body.matchAll(/req\.query\.([A-Za-z_][A-Za-z0-9_]*)/g)) {
+    names.add(match[1]!);
+  }
+  return names;
+}
+
+describe("list endpoint query-param allow-lists match their handlers", () => {
+  it("issues list allow-list matches the params the handler reads", () => {
+    const params = queryParamsReadBetween(
+      readSource("../routes/issues.ts"),
+      'router.get("/companies/:companyId/issues", async',
+      'router.get("/companies/:companyId/issues/count"',
+    );
+
+    expect([...params].sort()).toEqual([...ISSUE_LIST_SUPPORTED_QUERY_PARAMS].sort());
+  });
+
+  it("approvals list allow-list matches the params the handler reads", () => {
+    const params = queryParamsReadBetween(
+      readSource("../routes/approvals.ts"),
+      'router.get("/companies/:companyId/approvals", async',
+      'router.get("/approvals/:id"',
+    );
+
+    expect([...params].sort()).toEqual([...APPROVAL_LIST_SUPPORTED_QUERY_PARAMS].sort());
+  });
+});

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -9,6 +9,12 @@ import {
   resubmitApprovalSchema,
 } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
+import {
+  APPROVAL_LIST_QUERY_PARAM_HINTS,
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAM_SET,
+  rejectUnsupportedQueryParams,
+} from "./query-params.js";
+import { APPROVAL_LIST_MAX_LIMIT } from "../services/approvals.js";
 import { logger } from "../middleware/logger.js";
 import {
   approvalService,
@@ -208,8 +214,65 @@ export function approvalRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     if (!(await assertApprovalAccessAllowed(req, res, companyId))) return;
-    const status = req.query.status as string | undefined;
-    const result = await svc.list(companyId, status);
+    if (
+      rejectUnsupportedQueryParams(
+        req,
+        res,
+        APPROVAL_LIST_SUPPORTED_QUERY_PARAM_SET,
+        APPROVAL_LIST_QUERY_PARAM_HINTS,
+      )
+    ) {
+      return;
+    }
+
+    // Express parses `?status=a&status=b` (and `?status[]=a`) into an array,
+    // which `eq()` cannot filter on. Unlike the issues endpoint, this one has
+    // never supported repeated values — say so instead of building a bad query.
+    const rawStatus = req.query.status;
+    if (rawStatus !== undefined && typeof rawStatus !== "string") {
+      res.status(400).json({ error: "status must be a single string value" });
+      return;
+    }
+    const status = rawStatus;
+
+    const rawDedupKey = req.query.dedupKey;
+    if (rawDedupKey !== undefined && typeof rawDedupKey !== "string") {
+      res.status(400).json({ error: "dedupKey must be a single string value" });
+      return;
+    }
+
+    const rawLimit = req.query.limit as string | undefined;
+    const parsedLimit = rawLimit !== undefined && /^\d+$/.test(rawLimit)
+      ? Number.parseInt(rawLimit, 10)
+      : null;
+    if (rawLimit !== undefined && (parsedLimit === null || parsedLimit <= 0 || parsedLimit > APPROVAL_LIST_MAX_LIMIT)) {
+      res.status(400).json({
+        error: `limit must be a positive integer up to ${APPROVAL_LIST_MAX_LIMIT}`,
+      });
+      return;
+    }
+
+    const rawOffset = req.query.offset as string | undefined;
+    const parsedOffset = rawOffset !== undefined && /^\d+$/.test(rawOffset)
+      ? Number.parseInt(rawOffset, 10)
+      : null;
+    if (rawOffset !== undefined && parsedOffset === null) {
+      res.status(400).json({ error: "offset must be a non-negative integer" });
+      return;
+    }
+    // `offset` without `limit` would otherwise be silently dropped — the exact
+    // fail-open this endpoint is being fixed for.
+    if (rawOffset !== undefined && rawLimit === undefined) {
+      res.status(400).json({ error: "offset requires limit" });
+      return;
+    }
+
+    const result = await svc.list(companyId, {
+      status,
+      dedupKey: rawDedupKey,
+      limit: parsedLimit ?? undefined,
+      offset: parsedOffset ?? undefined,
+    });
     res.json(result.map((approval) => redactApprovalPayload(approval)));
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -152,6 +152,11 @@ import { logger } from "../middleware/logger.js";
 import { badRequest, conflict, forbidden, HttpError, notFound, unauthorized, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 import {
+  ISSUE_LIST_QUERY_PARAM_HINTS,
+  ISSUE_LIST_SUPPORTED_QUERY_PARAM_SET,
+  rejectUnsupportedQueryParams,
+} from "./query-params.js";
+import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
@@ -5274,6 +5279,16 @@ export function issueRoutes(
     assertCompanyAccess(req, companyId);
     if (isTaskBridgeKeyActor(req)) {
       res.status(403).json({ error: "Task bridge keys cannot use company-wide issue list APIs" });
+      return;
+    }
+    if (
+      rejectUnsupportedQueryParams(
+        req,
+        res,
+        ISSUE_LIST_SUPPORTED_QUERY_PARAM_SET,
+        ISSUE_LIST_QUERY_PARAM_HINTS,
+      )
+    ) {
       return;
     }
     const assigneeUserFilterRaw = req.query.assigneeUserId as string | undefined;

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -223,6 +223,23 @@ import {
   toolPolicyTestRequestSchema,
   createToolMcpGatewaySchema,
 } from "@paperclipai/shared";
+import {
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAMS,
+  ISSUE_LIST_SUPPORTED_QUERY_PARAMS,
+} from "./query-params.js";
+
+/**
+ * Build a query schema from a route's supported-param allow-list, so the spec
+ * and the handler's 400 guard are driven by the same source and cannot drift.
+ */
+function optionalStringQuery(names: readonly string[]) {
+  return z.object(
+    Object.fromEntries(names.map((name) => [name, z.string().optional()])) as Record<
+      string,
+      z.ZodOptional<z.ZodString>
+    >,
+  );
+}
 
 type JsonSchema = Record<string, unknown>;
 type OpenApiResponse = Record<string, unknown>;
@@ -2103,12 +2120,21 @@ registry.registerPath({
   path: "/api/companies/{companyId}/issues",
   tags: ["issues"],
   summary: "List issues in a company",
-  description: "Use `view=compact` for the board issue-list row contract. The default response remains the broad compatibility contract.",
+  description:
+    "Use `view=compact` for the board issue-list row contract. The default response remains the broad compatibility contract. "
+    + "Unrecognized query parameters are rejected with 400 — note the search parameter is `q`, not `search`, and pagination is `limit`/`offset`, not `page`.",
   request: {
     params: z.object({ companyId: z.string() }),
-    query: z.object({ view: z.enum(["compact"]).optional() }).passthrough(),
+    query: optionalStringQuery(ISSUE_LIST_SUPPORTED_QUERY_PARAMS).extend({
+      view: z.enum(["compact"]).optional(),
+    }),
   },
-  responses: { 200: r.ok(), 304: { description: "Not Modified" }, 401: r.unauthorized },
+  responses: {
+    200: r.ok(),
+    304: { description: "Not Modified" },
+    400: r.badRequest,
+    401: r.unauthorized,
+  },
 });
 
 registry.registerPath({
@@ -3057,8 +3083,14 @@ registry.registerPath({
   path: "/api/companies/{companyId}/approvals",
   tags: ["approvals"],
   summary: "List approvals in a company",
-  request: { params: z.object({ companyId: z.string() }) },
-  responses: { 200: r.ok(), 401: r.unauthorized },
+  description:
+    "Filter by `status` and/or `dedupKey` (exact match on `payload.dedupKey`, the server-side duplicate check before filing an approval). "
+    + "Pagination is opt-in: omit `limit` for the full set; `offset` requires `limit`. Unrecognized query parameters are rejected with 400.",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: optionalStringQuery(APPROVAL_LIST_SUPPORTED_QUERY_PARAMS),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
 });
 
 registry.registerPath({

--- a/server/src/routes/query-params.ts
+++ b/server/src/routes/query-params.ts
@@ -1,0 +1,119 @@
+import type { Request, Response } from "express";
+
+/**
+ * Every query param `GET /companies/:companyId/issues` actually honours.
+ *
+ * Anything outside this set is rejected with 400 rather than silently dropped.
+ * Keep this in sync when adding a filter: a param read by the handler but
+ * missing here becomes unreachable (400), and a name listed here but not read
+ * by the handler silently does nothing again — the very bug this guards.
+ *
+ * Lives here rather than beside the handler so the OpenAPI registration can
+ * import it without pulling in the whole issues route module.
+ */
+export const ISSUE_LIST_SUPPORTED_QUERY_PARAMS = [
+  "assigneeAgentId",
+  "assigneeUserId",
+  "attention",
+  "descendantOf",
+  "excludeRoutineExecutions",
+  "executionWorkspaceId",
+  "hasPlanDocument",
+  "inboxArchivedByUserId",
+  "includeBlockedBy",
+  "includeBlockedInboxAttention",
+  "includeLiveDescendantSummary",
+  "includePluginOperations",
+  "includeRoutineExecutions",
+  "labelId",
+  "limit",
+  "offset",
+  "originId",
+  "originKind",
+  "originKindPrefix",
+  "parentId",
+  "parentIssueId",
+  "participantAgentId",
+  "projectId",
+  "q",
+  "sortDir",
+  "sortField",
+  "status",
+  "touchedByUserId",
+  "unreadForUserId",
+  "view",
+  "workspaceId",
+] as const;
+
+export const ISSUE_LIST_SUPPORTED_QUERY_PARAM_SET: ReadonlySet<string> = new Set(
+  ISSUE_LIST_SUPPORTED_QUERY_PARAMS,
+);
+
+/** Nudges for the near-miss names callers have actually reached for. */
+export const ISSUE_LIST_QUERY_PARAM_HINTS: Readonly<Record<string, string>> = {
+  search: "use q= for full-text search",
+  query: "use q= for full-text search",
+  page: "use offset= with limit= for pagination",
+  pageSize: "use limit= for page size",
+  perPage: "use limit= for page size",
+  assignee: "use assigneeAgentId= or assigneeUserId=",
+};
+
+/** Every query param `GET /companies/:companyId/approvals` actually honours. */
+export const APPROVAL_LIST_SUPPORTED_QUERY_PARAMS = [
+  "dedupKey",
+  "limit",
+  "offset",
+  "status",
+] as const;
+
+export const APPROVAL_LIST_SUPPORTED_QUERY_PARAM_SET: ReadonlySet<string> = new Set(
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAMS,
+);
+
+export const APPROVAL_LIST_QUERY_PARAM_HINTS: Readonly<Record<string, string>> = {
+  q: "this endpoint has no full-text search; filter by status= or dedupKey=",
+  search: "this endpoint has no full-text search; filter by status= or dedupKey=",
+  page: "use offset= with limit= for pagination",
+  dedupkey: "parameter names are case-sensitive — use dedupKey=",
+};
+
+/**
+ * Reject query parameters a list endpoint does not understand.
+ *
+ * List endpoints historically ignored unrecognized query params and returned the
+ * full unfiltered result set. That fails *open*: a caller cannot distinguish
+ * "the filter ran and matched nothing" from "the filter was never applied", so a
+ * typo like `?search=` (instead of `?q=`) or an unimplemented `?dedupKey=` reads
+ * as a working query returning unrelated rows.
+ *
+ * Returns true when the request carried unsupported params — in which case a 400
+ * has already been written and the caller must return immediately.
+ *
+ * Mirrors the shape used by the agent list route (`GET /companies/:companyId/agents`).
+ */
+export function rejectUnsupportedQueryParams(
+  req: Request,
+  res: Response,
+  allowed: ReadonlySet<string>,
+  hints: Readonly<Record<string, string>> = {},
+): boolean {
+  const unsupported = Object.keys(req.query)
+    .filter((key) => !allowed.has(key))
+    .sort();
+  if (unsupported.length === 0) return false;
+
+  const hintText = unsupported
+    .map((key) => (hints[key] ? `${key} (${hints[key]})` : null))
+    .filter((entry): entry is string => entry !== null)
+    .join("; ");
+
+  res.status(400).json({
+    error:
+      `Unsupported query parameter${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}` +
+      (hintText ? `. ${hintText}` : ""),
+    unsupported,
+    supported: [...allowed].sort(),
+  });
+  return true;
+}

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
@@ -7,6 +7,17 @@ import { agentService } from "./agents.js";
 import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
+
+export type ApprovalListFilters = {
+  status?: string;
+  /** Exact match on `payload->>'dedupKey'` — the Approval Hygiene dedup check. */
+  dedupKey?: string;
+  /** Omit for the full result set; pagination is opt-in (see `list`). */
+  limit?: number;
+  offset?: number;
+};
+
+export const APPROVAL_LIST_MAX_LIMIT = 500;
 
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
@@ -86,10 +97,29 @@ export function approvalService(db: Db) {
   }
 
   return {
-    list: (companyId: string, status?: string) => {
+    list: (companyId: string, filters: ApprovalListFilters = {}) => {
+      const { status, dedupKey, limit, offset } = filters;
       const conditions = [eq(approvals.companyId, companyId)];
       if (status) conditions.push(eq(approvals.status, status));
-      return db.select().from(approvals).where(and(...conditions));
+      // Matched in SQL, before `redactApprovalPayload` runs over the response —
+      // a redacted payload must still be findable by its dedup key.
+      if (dedupKey !== undefined) {
+        conditions.push(sql`${approvals.payload} ->> 'dedupKey' = ${dedupKey}`);
+      }
+
+      // Newest first, with `id` breaking ties, so `offset` walks a stable order
+      // instead of whatever the heap happens to return.
+      const query = db
+        .select()
+        .from(approvals)
+        .where(and(...conditions))
+        .orderBy(desc(approvals.createdAt), asc(approvals.id));
+
+      // Pagination is deliberately opt-in. The approvals UI (list page, inbox
+      // feed, sidebar badge) fetches with no params and counts client-side over
+      // the whole array, so a default page size would silently under-report it.
+      if (limit === undefined) return query;
+      return query.limit(limit).offset(offset ?? 0);
     },
 
     getById: (id: string) =>

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2596,7 +2596,7 @@ export function buildHostServices(
       async list(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
-        const rows = await approvalSvc.list(companyId, params.status ?? undefined);
+        const rows = await approvalSvc.list(companyId, { status: params.status ?? undefined });
         // Match the web app's approval read surface: payloads are redacted so
         // the chat bridge never receives secrets the web app itself hides.
         return rows.map((approval) => redactApprovalPayload(approval)) as any;

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -616,6 +616,11 @@ GET /api/companies/{companyId}/issues?q=dockerfile
 
 Results are ranked by relevance: title matches first, then identifier, description, and comments. You can combine `q` with other filters (`status`, `assigneeAgentId`, `projectId`, `labelId`).
 
+The parameter is `q`, **not `search`**. Unrecognized query parameters are
+rejected with `400` listing the supported set, so a `200` means every filter you
+sent was applied and an empty result genuinely means "no matches". There is no
+`page` parameter — paginate with `limit` and `offset`.
+
 ## Full Reference
 
 For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `skills/paperclip/references/api-reference.md`

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1151,6 +1151,22 @@ Expiration results preserve already resolved items and omit undecided items:
 GET /api/companies/{companyId}/approvals?status=pending
 ```
 
+Accepted parameters: `status`, `dedupKey`, `limit`, `offset`. Anything else is a
+`400` naming the offender and listing the supported set — this endpoint never
+silently drops a filter, so a `200` means everything you sent was applied.
+Pagination is opt-in: omit `limit` for the full set; `offset` requires `limit`.
+
+### Checking for a duplicate before filing an approval
+
+Filter on `payload.dedupKey` and only file when the result is empty:
+
+```
+GET /api/companies/{companyId}/approvals?status=pending&dedupKey=issue:BLU-1234
+```
+
+An empty array genuinely means "nothing pending for this artifact". Do not reach
+for `q=` or `search=` here — this endpoint has no full-text search and rejects both.
+
 ### Approval follow-up (requesting agent)
 
 When board resolves your approval, you may be woken with:


### PR DESCRIPTION
Fixes the fail-open behaviour on both company-scoped list endpoints. Tracking issue: BLU-27509.

## The bug

Both endpoints silently ignored unrecognized query params and returned the full unfiltered set. That fails **open**: a caller cannot distinguish *"the filter ran and matched nothing"* from *"the filter never ran"*, so a wrong param name reads exactly like a working query returning unrelated results.

Measured against a live instance before this change:

| Request | Before |
|---|---|
| `issues?q=zzzznonsense` | 0 rows (works) |
| `issues?search=zzzznonsense` | **full list** — param dropped |
| `issues?page=2` | **page 1 again** |
| `approvals?dedupKey=zzz` | **all 1950 approvals** |
| `approvals?limit=5` | **all 276 pending** |

Three concrete consequences:

1. **It defeats the `dedupKey` duplicate check.** Callers are expected to look for an existing pending approval before filing one, keyed on `payload.dedupKey` — but no such filter existed, so the pre-flight check returned a non-empty result either way. On the instance I measured, **4 dedupKeys are currently duplicated across the 276 pending cards** (and 47 carry no `dedupKey` at all).
2. **False-negative searches.** `?search=` on issues returned everything, which looks like a search that ran and found only unrelated rows.
3. **Fabricated counts.** Looping `page=1..25` at `limit=100` against approvals yields "1932 pending". The true figure is 276 — the same page re-fetched seven times.

## The fix

- **Reject unrecognized query params with 400** on both list endpoints, echoing the offending names plus the supported set so a caller (or an agent hand-building a URL) can self-correct. This is the root fix — it converts every silent drop into a loud error at the call site. Follows the existing guard on `GET /companies/:companyId/agents`.
- **Add `?dedupKey=`** to the approvals endpoint, matched in SQL (`payload->>'dedupKey'`) *before* `redactApprovalPayload` runs, so a redacted payload stays findable.
- **Honour `limit`/`offset`** on approvals over a stable `createdAt DESC, id ASC` order.
- Drive the **OpenAPI** query schemas off the same allow-lists, replacing a `.passthrough()` that documented the opposite contract.
- Surface `dedupKey` through the **MCP** `paperclipListApprovals` tool and a `approval list --dedup-key` CLI flag.

### Pagination on approvals is deliberately opt-in

With no `limit`, the full set is returned. Three UI consumers — the approvals list page, the inbox feed, and the sidebar badge — fetch with no params and count client-side over the whole array. An unrequested default page size would have silently under-reported all three. `offset` without `limit` is a 400 rather than a silent no-op.

## Compatibility

Strict rejection is a fail-closed change on a hot endpoint, so I inventoried every caller before making it. **No first-party caller sends a param the handler ignores:**

- The UI builds both query strings from closed literal `params.set(...)` sets (`ui/src/api/issues.ts`, `ui/src/api/approvals.ts`) — no arbitrary passthrough, no cache-busting params.
- CLI, MCP server, plugin bridge, and in-repo docs all send names already in the allow-lists.
- Fleet agent-instruction files teach only `status`, `q`, `limit`, `assigneeAgentId`, `touchedByUserId`, `inboxArchivedByUserId`, `includeRoutineExecutions`, `parentId`, `projectId` — all allow-listed.

The one intentionally-affected caller class is agents hand-building URLs via the free-form API escape hatch. Those flip from silently-wrong to a 400 that names the supported set — which is the point.

## Tests

- `?search=`, `?page=`, and unknown names 400 on issues; `?q=`, `?search=`, `?page=`, `?dedupkey=` (wrong case) 400 on approvals.
- **A nonsense filter value yields 0 rows, not the full set** — asserted for both `q=` on issues and `dedupKey=` on approvals.
- `dedupKey` exact-match, company scoping, status combination, and `offset` paging asserted against **real Postgres**.
- A **drift guard** asserts each allow-list still matches the `req.query.*` names its handler actually reads — verified to fail when a param is removed, so it is not passing vacuously.

Typecheck passes for `server`, `mcp-server`, and `cli`; `check-forbidden-tokens` and `check-no-git-push` pass. Targeted suites (64 tests across the affected files) pass locally; a full unsharded local run of `server/src/__tests__` was still in flight when this PR was opened, so CI is the authoritative signal there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)