### PR TITLE
fix(api): reject unknown query params on issue and approval list endpoints

### DIFF
--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -20,6 +20,7 @@ import {
 interface ApprovalListOptions extends BaseClientOptions {
   companyId?: string;
   status?: string;
+  dedupKey?: string;
 }
 
 interface ApprovalDecisionOptions extends BaseClientOptions {
@@ -52,11 +53,13 @@ export function registerApprovalCommands(program: Command): void {
       .description("List approvals for a company")
       .requiredOption("-C, --company-id <id>", "Company ID")
       .option("--status <status>", "Status filter")
+      .option("--dedup-key <key>", "Exact match on payload.dedupKey")
       .action(async (opts: ApprovalListOptions) => {
         try {
           const ctx = resolveCommandContext(opts, { requireCompany: true });
           const params = new URLSearchParams();
           if (opts.status) params.set("status", opts.status);
+          if (opts.dedupKey) params.set("dedupKey", opts.dedupKey);
           const query = params.toString();
           const rows =
             (await ctx.api.get<Approval[]>(

--- a/docs/api/approvals.md
+++ b/docs/api/approvals.md
@@ -16,6 +16,31 @@ Query parameters:
 | Param | Description |
 |-------|-------------|
 | `status` | Filter by status (e.g. `pending`) |
+| `dedupKey` | Exact match on `payload.dedupKey` |
+| `limit` | Page size, 1–500. Omit to get the full set. |
+| `offset` | Rows to skip. Requires `limit`. |
+
+Unrecognized query parameters are rejected with `400`, and the error body names
+both the offending parameters and the supported set. This endpoint never
+silently ignores a filter it does not understand, so a `200` means every
+parameter you sent was applied.
+
+Results are newest-first (`createdAt` descending, `id` breaking ties), so
+`offset` walks a stable order. Pagination is opt-in — with no `limit`, the full
+result set is returned.
+
+### Checking for a duplicate before filing
+
+`dedupKey` is the server-side check behind "one open approval per artifact".
+Query it before creating an approval and only file when the result is empty:
+
+```
+GET /api/companies/{companyId}/approvals?status=pending&dedupKey=issue:ENG-1234
+```
+
+An empty array here genuinely means "no pending approval for this artifact" —
+previously an unsupported `dedupKey` was dropped and this returned every pending
+approval, so the check passed no matter what.
 
 ## Get Approval
 

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -16,8 +16,25 @@ Query parameters:
 | Param | Description |
 |-------|-------------|
 | `status` | Filter by status (comma-separated: `todo,in_progress`) |
-| `assigneeAgentId` | Filter by assigned agent |
+| `q` | Full-text search over the issue. **Not** `search` — see below. |
+| `assigneeAgentId` | Filter by assigned agent (UUID, or `null` for unassigned) |
+| `assigneeUserId` | Filter by assigned user (`me` for the authenticated board user) |
 | `projectId` | Filter by project |
+| `parentId` / `descendantOf` | Filter by position in the issue tree |
+| `labelId` | Filter by label |
+| `attention` | `blocked` only |
+| `limit` / `offset` | Pagination (default limit 500) |
+| `sortField` / `sortDir` | `updated`, with `asc` / `desc` |
+
+The full accepted set is larger than the table above; the authoritative list is
+`ISSUE_LIST_SUPPORTED_QUERY_PARAMS` in `server/src/routes/issues.ts`, and a `400`
+response body echoes it under `supported`.
+
+Unrecognized query parameters are rejected with `400`. In particular
+**`search` is not a valid parameter — use `q`**; it used to be silently ignored,
+which returned the full unfiltered list and read exactly like a working search
+returning unrelated results. Likewise there is no `page` parameter: paginate
+with `limit` and `offset`.
 
 Results sorted by priority.
 

--- a/docs/cli/control-plane-commands.md
+++ b/docs/cli/control-plane-commands.md
@@ -100,6 +100,9 @@ pnpm paperclipai skills agent sync <agent-id> --skill github-pr-workflow --mode 
 # List approvals
 pnpm paperclipai approval list [--status pending]
 
+# Check for an existing approval on an artifact before filing a new one
+pnpm paperclipai approval list --status pending --dedup-key issue:ENG-1234
+
 # Get approval
 pnpm paperclipai approval get <approval-id>
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -420,11 +420,24 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipListApprovals",
-      "List approvals in a company",
-      z.object({ companyId: companyIdOptional, status: z.string().optional() }),
-      async ({ companyId, status }) => {
-        const qs = status ? `?status=${encodeURIComponent(status)}` : "";
-        return client.requestJson("GET", `/companies/${client.resolveCompanyId(companyId)}/approvals${qs}`);
+      "List approvals in a company. Pass dedupKey to check whether an approval already exists for an artifact before filing a new one — an empty result means none is pending.",
+      z.object({
+        companyId: companyIdOptional,
+        status: z.string().optional(),
+        dedupKey: z
+          .string()
+          .optional()
+          .describe("Exact match on payload.dedupKey, e.g. issue:ENG-1234"),
+      }),
+      async ({ companyId, status, dedupKey }) => {
+        const params = new URLSearchParams();
+        if (status) params.set("status", status);
+        if (dedupKey) params.set("dedupKey", dedupKey);
+        const qs = params.toString();
+        return client.requestJson(
+          "GET",
+          `/companies/${client.resolveCompanyId(companyId)}/approvals${qs ? `?${qs}` : ""}`,
+        );
       },
     ),
     makeTool(

--- a/server/src/__tests__/approvals-list-dedup-key.test.ts
+++ b/server/src/__tests__/approvals-list-dedup-key.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { approvals, companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { approvalService } from "../services/approvals.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres approval list filter tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+/**
+ * `approvalService.list` backs the "is there already an open approval for this
+ * artifact?" check. Callers stamp a stable `payload.dedupKey` so that check can
+ * key on it, but no such filter existed: `?dedupKey=` returned every approval in
+ * the company, so a caller looking for duplicates got a non-empty answer either
+ * way and filed a second approval anyway.
+ */
+describeEmbeddedPostgres("approvalService.list filters", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-approval-list-filters-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(approvals);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function uniqueIssuePrefix() {
+    return `P${randomUUID().replace(/-/g, "").slice(0, 4).toUpperCase()}`;
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedApproval(
+    companyId: string,
+    payload: Record<string, unknown>,
+    overrides: { status?: string; createdAt?: Date } = {},
+  ) {
+    const id = randomUUID();
+    await db.insert(approvals).values({
+      id,
+      companyId,
+      type: "generic",
+      status: overrides.status ?? "pending",
+      payload,
+      ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
+    });
+    return id;
+  }
+
+  it("returns only exact dedupKey matches", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    const wanted = await seedApproval(companyId, { dedupKey: "issue:ENG-1234" });
+    await seedApproval(companyId, { dedupKey: "issue:ENG-9999" });
+    await seedApproval(companyId, { dedupKey: "issue:ENG-1234-extra" });
+    await seedApproval(companyId, { title: "no dedup key at all" });
+
+    const rows = await svc.list(companyId, { dedupKey: "issue:ENG-1234" });
+
+    expect(rows.map((row) => row.id)).toEqual([wanted]);
+  });
+
+  // The core assertion: a nonsense filter value yields 0 rows, not the full set.
+  it("returns 0 rows for a nonsense dedupKey rather than everything", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    await seedApproval(companyId, { dedupKey: "issue:ENG-1234" });
+    await seedApproval(companyId, { dedupKey: "issue:ENG-9999" });
+
+    expect(await svc.list(companyId, { dedupKey: "zzzznonsense" })).toHaveLength(0);
+    // ...and the unfiltered call still sees both, proving the rows were there.
+    expect(await svc.list(companyId)).toHaveLength(2);
+  });
+
+  it("surfaces a duplicated dedupKey — the case a duplicate check exists to catch", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    await seedApproval(companyId, { dedupKey: "social-post:ENG-4242:2026-08-14" });
+    await seedApproval(companyId, { dedupKey: "social-post:ENG-4242:2026-08-14" });
+
+    const rows = await svc.list(companyId, {
+      status: "pending",
+      dedupKey: "social-post:ENG-4242:2026-08-14",
+    });
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it("combines dedupKey with status", async () => {
+    const companyId = await seedCompany();
+    const svc = approvalService(db);
+    const pendingId = await seedApproval(companyId, { dedupKey: "shared" }, { status: "pending" });
+    await seedApproval(companyId, { dedupKey: "shared" }, { status: "approved" });
+
+    const rows = await svc.list(companyId, { status: "pending", dedupKey: "shared" });
+
+    expect(rows.map((row) => row.id)).toEqual([pendingId]);
+  });
+
+  it("scopes dedupKey matches to the requesting company", async () => {
+    const companyA = await seedCompany();
+    const companyB = await seedCompany();
+    const svc = approvalService(db);
+    const mine = await seedApproval(companyA, { dedupKey: "shared" });
+    await seedApproval(companyB, { dedupKey: "shared" });
+
+    const rows = await svc.list(companyA, { dedupKey: "shared" });
+
+    expect(rows.map((row) => row.id)).toEqual([mine]);
+  });
+
+  describe("pagination", () => {
+    async function seedThree(companyId: string) {
+      const oldest = await seedApproval(companyId, { n: 1 }, { createdAt: new Date("2026-08-01T00:00:00Z") });
+      const middle = await seedApproval(companyId, { n: 2 }, { createdAt: new Date("2026-08-02T00:00:00Z") });
+      const newest = await seedApproval(companyId, { n: 3 }, { createdAt: new Date("2026-08-03T00:00:00Z") });
+      return { oldest, middle, newest };
+    }
+
+    it("returns the full set when limit is omitted", async () => {
+      const companyId = await seedCompany();
+      const svc = approvalService(db);
+      await seedThree(companyId);
+
+      // Three UI consumers (list page, inbox feed, sidebar badge) count over the
+      // whole array, so an unrequested default page size would silently
+      // under-report them.
+      expect(await svc.list(companyId)).toHaveLength(3);
+    });
+
+    it("honours limit and offset over a stable newest-first order", async () => {
+      const companyId = await seedCompany();
+      const svc = approvalService(db);
+      const { oldest, middle, newest } = await seedThree(companyId);
+
+      expect((await svc.list(companyId, { limit: 2 })).map((r) => r.id)).toEqual([newest, middle]);
+      expect((await svc.list(companyId, { limit: 2, offset: 2 })).map((r) => r.id)).toEqual([oldest]);
+      // Distinct pages — paging used to re-return page 1 and inflate counts.
+      expect((await svc.list(companyId, { limit: 1, offset: 1 })).map((r) => r.id)).toEqual([middle]);
+    });
+  });
+});

--- a/server/src/__tests__/approvals-list-query-params.test.ts
+++ b/server/src/__tests__/approvals-list-query-params.test.ts
@@ -196,6 +196,10 @@ describe("GET /companies/:companyId/approvals query params", () => {
       ["limit=abc", "limit must be"],
       ["limit=100000", "limit must be"],
       ["offset=abc&limit=5", "offset must be"],
+      // Digit-only but past Number.MAX_SAFE_INTEGER: parseInt yields an imprecise
+      // float that Postgres rejects outright, so an unguarded value 500s instead of
+      // returning the documented 400.
+      ["offset=99999999999999999999&limit=5", "offset must be"],
     ])("rejects ?%s", async (query, expectedError) => {
       const app = await createApp();
       const res = await request(app).get(`${LIST_PATH}?${query}`);

--- a/server/src/__tests__/approvals-list-query-params.test.ts
+++ b/server/src/__tests__/approvals-list-query-params.test.ts
@@ -1,0 +1,250 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApprovalService = vi.hoisted(() => ({
+  list: vi.fn(),
+  getById: vi.fn(),
+  create: vi.fn(),
+  approve: vi.fn(),
+  reject: vi.fn(),
+  requestRevision: vi.fn(),
+  resubmit: vi.fn(),
+  listComments: vi.fn(),
+  addComment: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({ decide: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({ wakeup: vi.fn() }));
+const mockIssueApprovalService = vi.hoisted(() => ({
+  listIssuesForApproval: vi.fn(),
+  linkManyForApproval: vi.fn(),
+}));
+const mockSecretService = vi.hoisted(() => ({
+  normalizeHireApprovalPayloadForPersistence: vi.fn(),
+}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => mockAccessService,
+    approvalService: () => mockApprovalService,
+    heartbeatService: () => mockHeartbeatService,
+    issueApprovalService: () => mockIssueApprovalService,
+    logActivity: mockLogActivity,
+    secretService: () => mockSecretService,
+  }));
+}
+
+function createRouteDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          then: async (resolve: (rows: unknown[]) => unknown) => resolve([]),
+        })),
+      })),
+    })),
+  } as any;
+}
+
+async function createApp() {
+  const [{ errorHandler }, { approvalRoutes }] = await Promise.all([
+    import("../middleware/index.js"),
+    import("../routes/approvals.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "user-1",
+      companyIds: ["company-1"],
+      source: "session",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", approvalRoutes(createRouteDb()));
+  app.use(errorHandler);
+  return app;
+}
+
+function approvalRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "approval-1",
+    companyId: "company-1",
+    type: "generic",
+    status: "pending",
+    payload: { dedupKey: "issue:ENG-1234" },
+    createdAt: new Date("2026-08-01T00:00:00Z"),
+    updatedAt: new Date("2026-08-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+const LIST_PATH = "/api/companies/company-1/approvals";
+
+describe("GET /companies/:companyId/approvals query params", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockApprovalService.list.mockReset();
+    mockApprovalService.list.mockResolvedValue([approvalRow()]);
+    mockAccessService.decide.mockReset();
+    mockAccessService.decide.mockResolvedValue({
+      allowed: true,
+      action: "company_scope:read",
+      reason: "allow_test",
+      explanation: "Allowed by test mock.",
+    });
+  });
+
+  describe("unknown params fail loud instead of returning the full set", () => {
+    // The regression this endpoint is being fixed for: an unimplemented filter
+    // silently returned every row, so a caller could not tell "filter matched
+    // nothing" from "filter never ran".
+    it.each([
+      ["q", `${LIST_PATH}?q=anything`],
+      ["search", `${LIST_PATH}?search=anything`],
+      ["page", `${LIST_PATH}?page=2`],
+      ["dedupkey", `${LIST_PATH}?dedupkey=wrong-case`],
+    ])("rejects ?%s with 400", async (param, path) => {
+      const app = await createApp();
+      const res = await request(app).get(path);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain(param);
+      expect(res.body.unsupported).toEqual([param]);
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+      // Generous: the first case in the file pays the route module-graph import.
+    }, 30_000);
+
+    it("names every unsupported param and advertises the supported set", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?search=x&nonsense=y`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.unsupported).toEqual(["nonsense", "search"]);
+      expect(res.body.supported).toEqual(["dedupKey", "limit", "offset", "status"]);
+      // The hint is what lets an agent self-correct rather than retry blindly.
+      expect(res.body.error).toContain("status=");
+    });
+  });
+
+  describe("supported filters reach the service", () => {
+    it("forwards status", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?status=pending`);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ status: "pending" }),
+      );
+    });
+
+    it("forwards dedupKey", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?dedupKey=issue%3AENG-1234`);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ dedupKey: "issue:ENG-1234" }),
+      );
+    });
+
+    it("returns an empty list — not the full set — when dedupKey matches nothing", async () => {
+      mockApprovalService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?dedupKey=zzzznonsense`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it("forwards limit and offset together", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?limit=5&offset=10`);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ limit: 5, offset: 10 }),
+      );
+    });
+
+    it("leaves limit undefined when unset so the full set is returned", async () => {
+      const app = await createApp();
+      const res = await request(app).get(LIST_PATH);
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.list).toHaveBeenCalledWith(
+        "company-1",
+        expect.objectContaining({ limit: undefined, offset: undefined }),
+      );
+    });
+  });
+
+  describe("malformed pagination values are rejected, not coerced", () => {
+    it.each([
+      ["limit=0", "limit must be"],
+      ["limit=-1", "limit must be"],
+      ["limit=abc", "limit must be"],
+      ["limit=100000", "limit must be"],
+      ["offset=abc&limit=5", "offset must be"],
+    ])("rejects ?%s", async (query, expectedError) => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?${query}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain(expectedError);
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    it("rejects offset without limit rather than silently ignoring it", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?offset=100`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("offset requires limit");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    it("rejects a repeated dedupKey instead of picking one arbitrarily", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?dedupKey=a&dedupKey=b`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("dedupKey must be a single string value");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    // Express parses a repeated key into an array, which `eq()` cannot filter
+    // on. This endpoint has never supported repeated values (unlike issues,
+    // where `status` is legitimately CSV-or-repeated).
+    it("rejects a repeated status rather than building a bad query", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?status=pending&status=approved`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("status must be a single string value");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+
+    // Bracket syntax needs no special handling: the app uses Express's simple
+    // query parser, so `status[]` arrives as a literal key the allow-list
+    // already rejects.
+    it("rejects bracketed status[] as an unsupported parameter name", async () => {
+      const app = await createApp();
+      const res = await request(app).get(`${LIST_PATH}?status[]=pending`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("status[]");
+      expect(mockApprovalService.list).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1008,4 +1008,98 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       liveDescendantCount: 1,
     });
   });
+
+  describe("unknown query params fail loud instead of returning the full set", () => {
+    async function seedCompanyWithIssues(titles: string[]) {
+      const companyId = randomUUID();
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: uniqueIssuePrefix(),
+        requireBoardApprovalForNewAgents: false,
+      });
+      await seedCloudTenantMember(companyId);
+      await db.insert(issues).values(
+        titles.map((title) => ({
+          id: randomUUID(),
+          companyId,
+          title,
+          status: "todo",
+          priority: "medium",
+        })),
+      );
+      return companyId;
+    }
+
+    // The bug: `?search=` was silently dropped, so a dedup search returned every
+    // issue and read exactly like a working search returning unrelated results.
+    it("rejects ?search= (the near-miss for ?q=) rather than ignoring it", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta", "Gamma"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ search: "zzzznonsense" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.error).toContain("search");
+      expect(res.body.error).toContain("use q=");
+      expect(res.body.unsupported).toEqual(["search"]);
+    });
+
+    // The bug: `?page=` was dropped, so looping page=1..N re-fetched page 1 and
+    // inflated any count derived from the loop.
+    it("rejects ?page= rather than silently re-returning the first page", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ page: "2" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.error).toContain("page");
+      expect(res.body.error).toContain("offset=");
+    });
+
+    it("lists every unsupported param and advertises the supported set", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ nonsense: "1", search: "x" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.unsupported).toEqual(["nonsense", "search"]);
+      expect(res.body.supported).toContain("q");
+      expect(res.body.supported).toContain("limit");
+    });
+
+    it("still honours the supported params it advertises", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ status: "todo", limit: "25" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(res.body).toHaveLength(2);
+    });
+
+    // A nonsense value on a *supported* filter must yield 0 rows, never the
+    // unfiltered set.
+    it("returns 0 rows for a nonsense ?q= value, not the full list", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha", "Beta", "Gamma"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ q: "zzzznonsense" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(res.body).toHaveLength(0);
+    });
+  });
 });

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1062,6 +1062,21 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       expect(res.body.error).toContain("offset=");
     });
 
+    // Number.isInteger(1e20) is true, so a digit-only offset past MAX_SAFE_INTEGER
+    // cleared the guard and reached Postgres, which rejects it outright — a 500
+    // where this endpoint documents a 400.
+    it("rejects an offset past the safe-integer range instead of failing in the database", async () => {
+      const companyId = await seedCompanyWithIssues(["Alpha"]);
+
+      const app = createApp(companyId);
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ offset: "99999999999999999999", limit: "5" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(400);
+      expect(res.body.error).toContain("offset must be");
+    });
+
     it("lists every unsupported param and advertises the supported set", async () => {
       const companyId = await seedCompanyWithIssues(["Alpha"]);
 

--- a/server/src/__tests__/list-query-param-allowlist-drift.test.ts
+++ b/server/src/__tests__/list-query-param-allowlist-drift.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAMS,
+  ISSUE_LIST_SUPPORTED_QUERY_PARAMS,
+} from "../routes/query-params.js";
+
+/**
+ * The allow-lists in `query-params.ts` are what turn an unrecognized filter into
+ * a 400 instead of a silently-unfiltered 200. That only holds while they match
+ * the params the handlers actually read:
+ *
+ *  - a param read by the handler but missing from the list becomes unreachable,
+ *    because the guard 400s before the handler ever sees it;
+ *  - a param listed but never read is accepted and then silently does nothing —
+ *    reintroducing the exact fail-open these lists exist to close.
+ *
+ * Neither drift direction is caught by typecheck, so assert it here by reading
+ * the `req.query.<name>` accesses out of each handler body.
+ */
+function readSource(relativePath: string) {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+}
+
+function queryParamsReadBetween(source: string, startMarker: string, endMarker: string) {
+  const start = source.indexOf(startMarker);
+  expect(start, `could not locate handler start: ${startMarker}`).toBeGreaterThan(-1);
+  const end = source.indexOf(endMarker, start);
+  expect(end, `could not locate handler end: ${endMarker}`).toBeGreaterThan(start);
+
+  const body = source.slice(start, end);
+  const names = new Set<string>();
+  for (const match of body.matchAll(/req\.query\.([A-Za-z_][A-Za-z0-9_]*)/g)) {
+    names.add(match[1]!);
+  }
+  return names;
+}
+
+describe("list endpoint query-param allow-lists match their handlers", () => {
+  it("issues list allow-list matches the params the handler reads", () => {
+    const params = queryParamsReadBetween(
+      readSource("../routes/issues.ts"),
+      'router.get("/companies/:companyId/issues", async',
+      'router.get("/companies/:companyId/issues/count"',
+    );
+
+    expect([...params].sort()).toEqual([...ISSUE_LIST_SUPPORTED_QUERY_PARAMS].sort());
+  });
+
+  it("approvals list allow-list matches the params the handler reads", () => {
+    const params = queryParamsReadBetween(
+      readSource("../routes/approvals.ts"),
+      'router.get("/companies/:companyId/approvals", async',
+      'router.get("/approvals/:id"',
+    );
+
+    expect([...params].sort()).toEqual([...APPROVAL_LIST_SUPPORTED_QUERY_PARAMS].sort());
+  });
+});

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -9,6 +9,12 @@ import {
   resubmitApprovalSchema,
 } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
+import {
+  APPROVAL_LIST_QUERY_PARAM_HINTS,
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAM_SET,
+  rejectUnsupportedQueryParams,
+} from "./query-params.js";
+import { APPROVAL_LIST_MAX_LIMIT } from "../services/approvals.js";
 import { logger } from "../middleware/logger.js";
 import {
   approvalService,
@@ -208,8 +214,65 @@ export function approvalRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     if (!(await assertApprovalAccessAllowed(req, res, companyId))) return;
-    const status = req.query.status as string | undefined;
-    const result = await svc.list(companyId, status);
+    if (
+      rejectUnsupportedQueryParams(
+        req,
+        res,
+        APPROVAL_LIST_SUPPORTED_QUERY_PARAM_SET,
+        APPROVAL_LIST_QUERY_PARAM_HINTS,
+      )
+    ) {
+      return;
+    }
+
+    // Express parses `?status=a&status=b` (and `?status[]=a`) into an array,
+    // which `eq()` cannot filter on. Unlike the issues endpoint, this one has
+    // never supported repeated values — say so instead of building a bad query.
+    const rawStatus = req.query.status;
+    if (rawStatus !== undefined && typeof rawStatus !== "string") {
+      res.status(400).json({ error: "status must be a single string value" });
+      return;
+    }
+    const status = rawStatus;
+
+    const rawDedupKey = req.query.dedupKey;
+    if (rawDedupKey !== undefined && typeof rawDedupKey !== "string") {
+      res.status(400).json({ error: "dedupKey must be a single string value" });
+      return;
+    }
+
+    const rawLimit = req.query.limit as string | undefined;
+    const parsedLimit = rawLimit !== undefined && /^\d+$/.test(rawLimit)
+      ? Number.parseInt(rawLimit, 10)
+      : null;
+    if (rawLimit !== undefined && (parsedLimit === null || parsedLimit <= 0 || parsedLimit > APPROVAL_LIST_MAX_LIMIT)) {
+      res.status(400).json({
+        error: `limit must be a positive integer up to ${APPROVAL_LIST_MAX_LIMIT}`,
+      });
+      return;
+    }
+
+    const rawOffset = req.query.offset as string | undefined;
+    const parsedOffset = rawOffset !== undefined && /^\d+$/.test(rawOffset)
+      ? Number.parseInt(rawOffset, 10)
+      : null;
+    if (rawOffset !== undefined && parsedOffset === null) {
+      res.status(400).json({ error: "offset must be a non-negative integer" });
+      return;
+    }
+    // `offset` without `limit` would otherwise be silently dropped — the exact
+    // fail-open this endpoint is being fixed for.
+    if (rawOffset !== undefined && rawLimit === undefined) {
+      res.status(400).json({ error: "offset requires limit" });
+      return;
+    }
+
+    const result = await svc.list(companyId, {
+      status,
+      dedupKey: rawDedupKey,
+      limit: parsedLimit ?? undefined,
+      offset: parsedOffset ?? undefined,
+    });
     res.json(result.map((approval) => redactApprovalPayload(approval)));
   });
 

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -256,7 +256,10 @@ export function approvalRoutes(
     const parsedOffset = rawOffset !== undefined && /^\d+$/.test(rawOffset)
       ? Number.parseInt(rawOffset, 10)
       : null;
-    if (rawOffset !== undefined && parsedOffset === null) {
+    // isSafeInteger, not just a digit check: `?offset=99999999999999999999` parses
+    // to an imprecise float that Postgres rejects, turning a malformed request into
+    // a 500 instead of the 400 this endpoint documents.
+    if (rawOffset !== undefined && (parsedOffset === null || !Number.isSafeInteger(parsedOffset))) {
       res.status(400).json({ error: "offset must be a non-negative integer" });
       return;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5408,7 +5408,10 @@ export function issueRoutes(
       res.status(400).json({ error: `limit must be a positive integer up to ${ISSUE_LIST_MAX_LIMIT}` });
       return;
     }
-    if (rawOffset !== undefined && (parsedOffset === null || !Number.isInteger(parsedOffset) || parsedOffset < 0)) {
+    // isSafeInteger, not isInteger: Number.isInteger(1e20) is true, so a digit-only
+    // offset past MAX_SAFE_INTEGER cleared this guard and reached Postgres, which
+    // rejects it — a 500 where the endpoint documents a 400.
+    if (rawOffset !== undefined && (parsedOffset === null || !Number.isSafeInteger(parsedOffset) || parsedOffset < 0)) {
       res.status(400).json({ error: "offset must be a non-negative integer" });
       return;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -156,6 +156,11 @@ import { privateJsonEtag } from "../middleware/private-json-etag.js";
 import { createRequestPromiseMemo } from "../lib/request-promise-memo.js";
 import { assertBoard, assertCompanyAccess, getAccessibleResource, getActorInfo } from "./authz.js";
 import {
+  ISSUE_LIST_QUERY_PARAM_HINTS,
+  ISSUE_LIST_SUPPORTED_QUERY_PARAM_SET,
+  rejectUnsupportedQueryParams,
+} from "./query-params.js";
+import {
   assertNoAgentHostWorkspaceCommandMutation,
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
@@ -5324,6 +5329,16 @@ export function issueRoutes(
     assertCompanyAccess(req, companyId);
     if (isTaskBridgeKeyActor(req)) {
       res.status(403).json({ error: "Task bridge keys cannot use company-wide issue list APIs" });
+      return;
+    }
+    if (
+      rejectUnsupportedQueryParams(
+        req,
+        res,
+        ISSUE_LIST_SUPPORTED_QUERY_PARAM_SET,
+        ISSUE_LIST_QUERY_PARAM_HINTS,
+      )
+    ) {
       return;
     }
     const assigneeUserFilterRaw = req.query.assigneeUserId as string | undefined;

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -229,6 +229,23 @@ import {
   COMPANY_IMPORT_TRANSFERS_API_PATH,
   companyImportTransferDeclarationSchema,
 } from "@paperclipai/shared/company-import-transfer";
+import {
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAMS,
+  ISSUE_LIST_SUPPORTED_QUERY_PARAMS,
+} from "./query-params.js";
+
+/**
+ * Build a query schema from a route's supported-param allow-list, so the spec
+ * and the handler's 400 guard are driven by the same source and cannot drift.
+ */
+function optionalStringQuery(names: readonly string[]) {
+  return z.object(
+    Object.fromEntries(names.map((name) => [name, z.string().optional()])) as Record<
+      string,
+      z.ZodOptional<z.ZodString>
+    >,
+  );
+}
 
 type JsonSchema = Record<string, unknown>;
 type OpenApiResponse = Record<string, unknown>;
@@ -2110,12 +2127,21 @@ registry.registerPath({
   path: "/api/companies/{companyId}/issues",
   tags: ["issues"],
   summary: "List issues in a company",
-  description: "Use `view=compact` for the board issue-list row contract. The default response remains the broad compatibility contract.",
+  description:
+    "Use `view=compact` for the board issue-list row contract. The default response remains the broad compatibility contract. "
+    + "Unrecognized query parameters are rejected with 400 — note the search parameter is `q`, not `search`, and pagination is `limit`/`offset`, not `page`.",
   request: {
     params: z.object({ companyId: z.string() }),
-    query: z.object({ view: z.enum(["compact"]).optional() }).passthrough(),
+    query: optionalStringQuery(ISSUE_LIST_SUPPORTED_QUERY_PARAMS).extend({
+      view: z.enum(["compact"]).optional(),
+    }),
   },
-  responses: { 200: r.ok(), 304: { description: "Not Modified" }, 401: r.unauthorized },
+  responses: {
+    200: r.ok(),
+    304: { description: "Not Modified" },
+    400: r.badRequest,
+    401: r.unauthorized,
+  },
 });
 
 registry.registerPath({
@@ -3086,8 +3112,14 @@ registry.registerPath({
   path: "/api/companies/{companyId}/approvals",
   tags: ["approvals"],
   summary: "List approvals in a company",
-  request: { params: z.object({ companyId: z.string() }) },
-  responses: { 200: r.ok(), 401: r.unauthorized },
+  description:
+    "Filter by `status` and/or `dedupKey` (exact match on `payload.dedupKey`, the server-side duplicate check before filing an approval). "
+    + "Pagination is opt-in: omit `limit` for the full set; `offset` requires `limit`. Unrecognized query parameters are rejected with 400.",
+  request: {
+    params: z.object({ companyId: z.string() }),
+    query: optionalStringQuery(APPROVAL_LIST_SUPPORTED_QUERY_PARAMS),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
 });
 
 registry.registerPath({

--- a/server/src/routes/query-params.ts
+++ b/server/src/routes/query-params.ts
@@ -1,0 +1,119 @@
+import type { Request, Response } from "express";
+
+/**
+ * Every query param `GET /companies/:companyId/issues` actually honours.
+ *
+ * Anything outside this set is rejected with 400 rather than silently dropped.
+ * Keep this in sync when adding a filter: a param read by the handler but
+ * missing here becomes unreachable (400), and a name listed here but not read
+ * by the handler silently does nothing again — the very bug this guards.
+ *
+ * Lives here rather than beside the handler so the OpenAPI registration can
+ * import it without pulling in the whole issues route module.
+ */
+export const ISSUE_LIST_SUPPORTED_QUERY_PARAMS = [
+  "assigneeAgentId",
+  "assigneeUserId",
+  "attention",
+  "descendantOf",
+  "excludeRoutineExecutions",
+  "executionWorkspaceId",
+  "hasPlanDocument",
+  "inboxArchivedByUserId",
+  "includeBlockedBy",
+  "includeBlockedInboxAttention",
+  "includeLiveDescendantSummary",
+  "includePluginOperations",
+  "includeRoutineExecutions",
+  "labelId",
+  "limit",
+  "offset",
+  "originId",
+  "originKind",
+  "originKindPrefix",
+  "parentId",
+  "parentIssueId",
+  "participantAgentId",
+  "projectId",
+  "q",
+  "sortDir",
+  "sortField",
+  "status",
+  "touchedByUserId",
+  "unreadForUserId",
+  "view",
+  "workspaceId",
+] as const;
+
+export const ISSUE_LIST_SUPPORTED_QUERY_PARAM_SET: ReadonlySet<string> = new Set(
+  ISSUE_LIST_SUPPORTED_QUERY_PARAMS,
+);
+
+/** Nudges for the near-miss names callers have actually reached for. */
+export const ISSUE_LIST_QUERY_PARAM_HINTS: Readonly<Record<string, string>> = {
+  search: "use q= for full-text search",
+  query: "use q= for full-text search",
+  page: "use offset= with limit= for pagination",
+  pageSize: "use limit= for page size",
+  perPage: "use limit= for page size",
+  assignee: "use assigneeAgentId= or assigneeUserId=",
+};
+
+/** Every query param `GET /companies/:companyId/approvals` actually honours. */
+export const APPROVAL_LIST_SUPPORTED_QUERY_PARAMS = [
+  "dedupKey",
+  "limit",
+  "offset",
+  "status",
+] as const;
+
+export const APPROVAL_LIST_SUPPORTED_QUERY_PARAM_SET: ReadonlySet<string> = new Set(
+  APPROVAL_LIST_SUPPORTED_QUERY_PARAMS,
+);
+
+export const APPROVAL_LIST_QUERY_PARAM_HINTS: Readonly<Record<string, string>> = {
+  q: "this endpoint has no full-text search; filter by status= or dedupKey=",
+  search: "this endpoint has no full-text search; filter by status= or dedupKey=",
+  page: "use offset= with limit= for pagination",
+  dedupkey: "parameter names are case-sensitive — use dedupKey=",
+};
+
+/**
+ * Reject query parameters a list endpoint does not understand.
+ *
+ * List endpoints historically ignored unrecognized query params and returned the
+ * full unfiltered result set. That fails *open*: a caller cannot distinguish
+ * "the filter ran and matched nothing" from "the filter was never applied", so a
+ * typo like `?search=` (instead of `?q=`) or an unimplemented `?dedupKey=` reads
+ * as a working query returning unrelated rows.
+ *
+ * Returns true when the request carried unsupported params — in which case a 400
+ * has already been written and the caller must return immediately.
+ *
+ * Mirrors the shape used by the agent list route (`GET /companies/:companyId/agents`).
+ */
+export function rejectUnsupportedQueryParams(
+  req: Request,
+  res: Response,
+  allowed: ReadonlySet<string>,
+  hints: Readonly<Record<string, string>> = {},
+): boolean {
+  const unsupported = Object.keys(req.query)
+    .filter((key) => !allowed.has(key))
+    .sort();
+  if (unsupported.length === 0) return false;
+
+  const hintText = unsupported
+    .map((key) => (hints[key] ? `${key} (${hints[key]})` : null))
+    .filter((entry): entry is string => entry !== null)
+    .join("; ");
+
+  res.status(400).json({
+    error:
+      `Unsupported query parameter${unsupported.length === 1 ? "" : "s"}: ${unsupported.join(", ")}` +
+      (hintText ? `. ${hintText}` : ""),
+    unsupported,
+    supported: [...allowed].sort(),
+  });
+  return true;
+}

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
@@ -7,6 +7,17 @@ import { agentService } from "./agents.js";
 import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
+
+export type ApprovalListFilters = {
+  status?: string;
+  /** Exact match on `payload->>'dedupKey'` — the duplicate check before filing a new approval. */
+  dedupKey?: string;
+  /** Omit for the full result set; pagination is opt-in (see `list`). */
+  limit?: number;
+  offset?: number;
+};
+
+export const APPROVAL_LIST_MAX_LIMIT = 500;
 
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
@@ -86,10 +97,29 @@ export function approvalService(db: Db) {
   }
 
   return {
-    list: (companyId: string, status?: string) => {
+    list: (companyId: string, filters: ApprovalListFilters = {}) => {
+      const { status, dedupKey, limit, offset } = filters;
       const conditions = [eq(approvals.companyId, companyId)];
       if (status) conditions.push(eq(approvals.status, status));
-      return db.select().from(approvals).where(and(...conditions));
+      // Matched in SQL, before `redactApprovalPayload` runs over the response —
+      // a redacted payload must still be findable by its dedup key.
+      if (dedupKey !== undefined) {
+        conditions.push(sql`${approvals.payload} ->> 'dedupKey' = ${dedupKey}`);
+      }
+
+      // Newest first, with `id` breaking ties, so `offset` walks a stable order
+      // instead of whatever the heap happens to return.
+      const query = db
+        .select()
+        .from(approvals)
+        .where(and(...conditions))
+        .orderBy(desc(approvals.createdAt), asc(approvals.id));
+
+      // Pagination is deliberately opt-in. The approvals UI (list page, inbox
+      // feed, sidebar badge) fetches with no params and counts client-side over
+      // the whole array, so a default page size would silently under-report it.
+      if (limit === undefined) return query;
+      return query.limit(limit).offset(offset ?? 0);
     },
 
     getById: (id: string) =>

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2609,7 +2609,7 @@ export function buildHostServices(
       async list(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
-        const rows = await approvalSvc.list(companyId, params.status ?? undefined);
+        const rows = await approvalSvc.list(companyId, { status: params.status ?? undefined });
         // Match the web app's approval read surface: payloads are redacted so
         // the chat bridge never receives secrets the web app itself hides.
         return rows.map((approval) => redactApprovalPayload(approval)) as any;

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -616,6 +616,11 @@ GET /api/companies/{companyId}/issues?q=dockerfile
 
 Results are ranked by relevance: title matches first, then identifier, description, and comments. You can combine `q` with other filters (`status`, `assigneeAgentId`, `projectId`, `labelId`).
 
+The parameter is `q`, **not `search`**. Unrecognized query parameters are
+rejected with `400` listing the supported set, so a `200` means every filter you
+sent was applied and an empty result genuinely means "no matches". There is no
+`page` parameter — paginate with `limit` and `offset`.
+
 ## Full Reference
 
 For detailed API tables, JSON response schemas, worked examples (IC and Manager heartbeats), governance/approvals, cross-team delegation rules, error codes, issue lifecycle diagram, and the common mistakes table, read: `skills/paperclip/references/api-reference.md`

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1151,6 +1151,22 @@ Expiration results preserve already resolved items and omit undecided items:
 GET /api/companies/{companyId}/approvals?status=pending
 ```
 
+Accepted parameters: `status`, `dedupKey`, `limit`, `offset`. Anything else is a
+`400` naming the offender and listing the supported set — this endpoint never
+silently drops a filter, so a `200` means everything you sent was applied.
+Pagination is opt-in: omit `limit` for the full set; `offset` requires `limit`.
+
+### Checking for a duplicate before filing an approval
+
+Filter on `payload.dedupKey` and only file when the result is empty:
+
+```
+GET /api/companies/{companyId}/approvals?status=pending&dedupKey=issue:ENG-1234
+```
+
+An empty array genuinely means "nothing pending for this artifact". Do not reach
+for `q=` or `search=` here — this endpoint has no full-text search and rejects both.
+
 ### Approval follow-up (requesting agent)
 
 When board resolves your approval, you may be woken with:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents and the web app read work through the company-scoped list endpoints, `GET /companies/:companyId/issues` and `GET /companies/:companyId/approvals`
> - Both endpoints ignored any query param they did not recognize, and returned the full unfiltered set
> - This fails open. A caller cannot tell "the filter ran and matched nothing" from "the filter never ran", so a wrong param name looks like a working query that returns unrelated rows
> - The damage is quiet: `?search=` reads as a search that found nothing relevant, a duplicate check on `?dedupKey=` always looks satisfied, and a `?page=` loop re-reads page 1 and reports a count that is many times too high
> - This pull request rejects unrecognized query params with 400, implements the `dedupKey` filter that callers already assume exists, and honours `limit` and `offset` on approvals
> - The benefit is that every list request now either applies all the filters you sent, or tells you which one it does not understand

## Linked Issues or Issue Description

No public GitHub issue exists. Description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

Related open PRs found while searching (neither supersedes this one):
- Refs #1964 — normalizes duplicate issue-list query params to avoid 500s. It overlaps this PR in `routes/issues.ts` and `routes/approvals.ts` and will need a rebase whichever lands second. It normalizes repeated values to a single string; this PR rejects a repeated `status` on approvals instead. Worth a maintainer call on which behaviour is wanted.
- Refs #8068 — returns 400/404 instead of 500 for invalid inputs. Same "fail loud, not open" direction, different endpoints.
- Refs #4450 — adds a `status` param to the company agent list, the endpoint whose existing strict-param guard this PR copies.

**What happened?**

`GET /api/companies/{companyId}/issues` and `GET /api/companies/{companyId}/approvals` accept any query param. They use the ones they know and drop the rest without an error. The response is a 200 with the full unfiltered result set.

**Steps to reproduce**

Run these against any instance with more than a few issues and approvals:

```
GET /api/companies/{companyId}/issues?q=zzzznonsense
GET /api/companies/{companyId}/issues?search=zzzznonsense
GET /api/companies/{companyId}/issues?page=2
GET /api/companies/{companyId}/approvals?dedupKey=zzzznonsense
GET /api/companies/{companyId}/approvals?limit=5
```

**Expected behavior**

A filter either applies or the request fails. `?search=` is not a supported param, so it must return 400 and name `q`. `?dedupKey=` must return only exact matches. `?limit=5` must return 5 rows.

**Actual behavior**

| Request | Result |
|---|---|
| `issues?q=zzzznonsense` | 0 rows — correct, `q` is supported |
| `issues?search=zzzznonsense` | the full list — param dropped |
| `issues?page=2` | page 1 again — param dropped |
| `approvals?dedupKey=zzzznonsense` | every approval in the company |
| `approvals?limit=5` | every approval in the company |

Three consequences:

1. **Duplicate detection never fires.** Callers stamp a stable `payload.dedupKey` and query it before filing a new approval, but no such filter existed. The check returned a non-empty result either way, so a duplicate was filed anyway. On the instance I measured, 4 dedup keys were duplicated across 276 pending approvals.
2. **Searches return false negatives.** A dedup search with `?search=` returned unrelated rows and read as "no match found". The same query with `?q=` immediately found the record.
3. **Paged counts are wrong.** A loop over `page=1..25` at `limit=100` reports 2500 rows when the true total is one page, because it re-reads the same page 25 times.

**Version**

Reproduced on `master` at 814cb33.

## What Changed

- Added `server/src/routes/query-params.ts`. It holds the supported-param allow-list for each list endpoint and a shared `rejectUnsupportedQueryParams` helper.
- `GET /companies/:companyId/issues` now returns 400 for unrecognized params. The error body names the offenders and lists the supported set. Hints point `search` to `q` and `page` to `limit`/`offset`.
- `GET /companies/:companyId/approvals` now returns 400 for unrecognized params, with the same body shape.
- Added `?dedupKey=` to the approvals endpoint. The match runs in SQL as `payload->>'dedupKey'`, before payload redaction, so a redacted payload stays findable.
- Added `limit` and `offset` to the approvals endpoint, over a stable `createdAt DESC, id ASC` order. Pagination is opt-in. An `offset` without a `limit` returns 400.
- Rejected a repeated `?status=` on approvals. Express turns a repeated key into an array, which `eq()` cannot filter on.
- Built the OpenAPI query schemas from the same allow-lists. The issues entry previously used `passthrough()`, which documented the opposite contract.
- Exposed `dedupKey` through the MCP `paperclipListApprovals` tool and a new `approval list --dedup-key` CLI flag.
- Updated `docs/api/issues.md`, `docs/api/approvals.md`, `docs/cli/control-plane-commands.md`, and the agent-facing skill reference.

### Note on the opt-in pagination

The approvals endpoint returns the full set when you omit `limit`. This is deliberate. The approvals page, the inbox feed and the sidebar badge each fetch with no params and count client-side over the whole array. A default page size would have made all three counts too low, which replaces one silent wrong number with another.

## Verification

Run the tests:

```
npx vitest run server/src/__tests__/approvals-list-query-params.test.ts
npx vitest run server/src/__tests__/approvals-list-dedup-key.test.ts
npx vitest run server/src/__tests__/issue-list-assignee-filter-routes.test.ts
npx vitest run server/src/__tests__/list-query-param-allowlist-drift.test.ts
pnpm --filter @paperclipai/server typecheck
```

What the tests assert:

- Unknown params return 400 on both endpoints: `search`, `page` and arbitrary names on issues; `q`, `search`, `page` and a wrong-case `dedupkey` on approvals.
- A nonsense value on a supported filter returns 0 rows and not the full set. Asserted for `q=` on issues and `dedupKey=` on approvals. The same test then reads the rows back unfiltered, to prove they were present.
- `dedupKey` exact match, company scoping, combination with `status`, and `offset` paging run against real Postgres.
- A drift guard asserts each allow-list still matches the `req.query.*` names its handler reads. I removed a param to confirm the guard fails, so it does not pass vacuously.

Manual check:

```
curl "$BASE/api/companies/$CID/issues?search=x"        # 400, names q
curl "$BASE/api/companies/$CID/approvals?dedupKey=zzz" # 200, empty array
```

## Risks

- **This is a fail-closed change on a hot endpoint.** A caller that sends an unknown param moves from a misleading 200 to a 400. I inventoried the callers first. The web app builds both query strings from closed literal `params.set(...)` sets, with no passthrough and no cache-busting params. The CLI, the MCP server, the plugin bridge and the in-repo docs all send allow-listed names. No first-party caller sends a param that the handlers ignore.
- **Agents that hand-build URLs are affected on purpose.** A free-form API call with an invented param now returns 400 instead of a misleading 200. The error body lists the supported params so the caller can correct itself.
- **The allow-list can drift.** A new filter added to a handler but not to the list would become unreachable. The drift guard test covers this in both directions.
- **`payload->>'dedupKey'` is not indexed.** It scans within the company and status range. This is fine at current row counts. A partial index would help if dedup lookups become hot.
- Not addressed: `?status=` with an empty value still returns everything on approvals, because the existing check is `if (status)`. This is pre-existing and outside this change. `?dedupKey=` with an empty value fails closed and returns 0 rows.
- No migration. No schema change. No change to any response shape.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`), extended thinking, with tool use and code execution. Used for the caller inventory, the implementation and the tests. All test runs, the typecheck and the live before/after measurements were executed and verified rather than predicted.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
