### PR TITLE
Suppress live state for terminal issues

### DIFF
--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -71,6 +71,7 @@ import type {
   SuggestTasksInteraction,
 } from "../lib/issue-thread-interactions";
 import { buildIssueThreadInteractionSummary, isIssueThreadInteraction } from "../lib/issue-thread-interactions";
+import { isLiveIssueRun } from "../lib/liveIssueIds";
 import { resolveIssueChatTranscriptRuns } from "../lib/issueChatTranscriptRuns";
 import {
   formatTimelineWorkspaceLabel,
@@ -4426,9 +4427,10 @@ export function IssueChatThread({
   const displayLiveRuns = useMemo(() => {
     const deduped = new Map<string, LiveRunForIssue>();
     for (const run of liveRuns) {
+      if (!isLiveIssueRun(run, issueStatus)) continue;
       deduped.set(run.id, run);
     }
-    if (activeRun) {
+    if (activeRun && isLiveIssueRun(activeRun, issueStatus)) {
       deduped.set(activeRun.id, {
         id: activeRun.id,
         status: activeRun.status,
@@ -4459,7 +4461,7 @@ export function IssueChatThread({
       });
     }
     return [...deduped.values()].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-  }, [activeRun, liveRuns]);
+  }, [activeRun, issueStatus, liveRuns]);
   const transcriptRuns = useMemo(() => {
     return resolveIssueChatTranscriptRuns({
       linkedRuns,
@@ -4524,6 +4526,7 @@ export function IssueChatThread({
         agentMap,
         currentUserId,
         userLabelMap,
+        issueStatus,
       }),
     [
       comments,
@@ -4540,6 +4543,7 @@ export function IssueChatThread({
       agentMap,
       currentUserId,
       userLabelMap,
+      issueStatus,
     ],
   );
   const stableMessagesRef = useRef<readonly ThreadMessage[]>([]);

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -29,6 +29,7 @@ import { useSidebar } from "@/context/SidebarContext";
 import { cn } from "@/lib/utils";
 import { useIssuePlanDocument } from "@/hooks/useIssuePlanDocument";
 import { latestSameRunHandoffTimestamp, type IssueChatComment } from "@/lib/issue-chat-messages";
+import { isLiveIssueRun, isTerminalIssueStatus } from "@/lib/liveIssueIds";
 import { workModeInEffectAt } from "@/lib/issue-timeline-events";
 import { workModeMetaFor } from "@/lib/work-mode-meta";
 
@@ -177,9 +178,10 @@ export function TaskChatThread(props: TaskChatThreadProps) {
 
   // The single in-flight run whose turn we stream live (non-terminal).
   const liveRun = useMemo(() => {
-    if (activeRun && !isTerminalRunStatus(activeRun.status)) return activeRun;
-    return (liveRuns ?? []).find((r) => !isTerminalRunStatus(r.status)) ?? null;
-  }, [activeRun, liveRuns]);
+    if (isTerminalIssueStatus(issueStatus)) return null;
+    if (activeRun && isLiveIssueRun(activeRun, issueStatus)) return activeRun;
+    return (liveRuns ?? []).find((r) => isLiveIssueRun(r, issueStatus)) ?? null;
+  }, [activeRun, issueStatus, liveRuns]);
 
   // Runs observed non-terminal while mounted: their turns ANIMATE the fold when
   // they settle. Runs already terminal at mount collapse instantly.

--- a/ui/src/lib/issue-chat-messages.test.ts
+++ b/ui/src/lib/issue-chat-messages.test.ts
@@ -624,6 +624,44 @@ describe("buildIssueChatMessages", () => {
     });
   });
 
+  it("suppresses live-run Working messages for terminal issues", () => {
+    const liveRun: LiveRunForIssue = {
+      id: "run-live-terminal",
+      status: "running",
+      invocationSource: "manual",
+      triggerDetail: null,
+      startedAt: "2026-04-06T12:04:00.000Z",
+      finishedAt: null,
+      createdAt: "2026-04-06T12:04:00.000Z",
+      agentId: "agent-1",
+      agentName: "CodexCoder",
+      adapterType: "codex_local",
+    };
+
+    const terminalMessages = buildIssueChatMessages({
+      comments: [],
+      timelineEvents: [],
+      linkedRuns: [],
+      liveRuns: [liveRun],
+      issueStatus: "done",
+      currentUserId: "user-1",
+    });
+    const liveMessages = buildIssueChatMessages({
+      comments: [],
+      timelineEvents: [],
+      linkedRuns: [],
+      liveRuns: [liveRun],
+      issueStatus: "in_progress",
+      currentUserId: "user-1",
+    });
+
+    expect(terminalMessages.find((message) => message.id === "run-assistant:run-live-terminal")).toBeUndefined();
+    expect(liveMessages.find((message) => message.id === "run-assistant:run-live-terminal")).toMatchObject({
+      status: { type: "running" },
+      metadata: { custom: { waitingText: "Working..." } },
+    });
+  });
+
   it("merges thread interactions into the same chronological feed as comments and runs", () => {
     const messages = buildIssueChatMessages({
       comments: [

--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -16,6 +16,7 @@ import {
   type IssueThreadInteraction,
 } from "./issue-thread-interactions";
 import type { IssueTimelineEvent } from "./issue-timeline-events";
+import { isLiveIssueRun } from "./liveIssueIds";
 import {
   summarizeNotice,
 } from "./transcriptPresentation";
@@ -954,13 +955,15 @@ export function buildAssistantPartsFromTranscript(entries: readonly IssueChatTra
 function normalizeLiveRuns(
   liveRuns: readonly LiveRunForIssue[],
   activeRun: ActiveRunForIssue | null | undefined,
-  issueId?: string,
+  issueId: string | undefined,
+  issueStatus: string | null | undefined,
 ) {
   const deduped = new Map<string, LiveRunForIssue>();
   for (const run of liveRuns) {
+    if (!isLiveIssueRun(run, issueStatus)) continue;
     deduped.set(run.id, run);
   }
-  if (activeRun) {
+  if (activeRun && isLiveIssueRun(activeRun, issueStatus)) {
     deduped.set(activeRun.id, {
       id: activeRun.id,
       status: activeRun.status,
@@ -1056,6 +1059,7 @@ export function buildIssueChatMessages(args: {
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
   userLabelMap?: ReadonlyMap<string, string> | null;
+  issueStatus?: string | null;
 }) {
   const {
     comments,
@@ -1073,6 +1077,7 @@ export function buildIssueChatMessages(args: {
     agentMap,
     currentUserId,
     userLabelMap,
+    issueStatus,
   } = args;
 
   const orderedMessages: MessageWithOrder[] = [];
@@ -1139,7 +1144,7 @@ export function buildIssueChatMessages(args: {
     });
   }
 
-  for (const run of normalizeLiveRuns(liveRuns, activeRun, issueId)) {
+  for (const run of normalizeLiveRuns(liveRuns, activeRun, issueId, issueStatus)) {
     orderedMessages.push({
       createdAtMs: toTimestamp(run.startedAt ?? run.createdAt),
       order: 3,

--- a/ui/src/lib/liveIssueIds.test.ts
+++ b/ui/src/lib/liveIssueIds.test.ts
@@ -2,6 +2,23 @@ import { describe, expect, it } from "vitest";
 import type { LiveRunForIssue } from "../api/heartbeats";
 import { collectLiveIssueIds, collectSubtreeLiveCounts } from "./liveIssueIds";
 
+function liveRun(overrides: Partial<LiveRunForIssue>): LiveRunForIssue {
+  return {
+    id: "run",
+    status: "running",
+    invocationSource: "scheduler",
+    triggerDetail: null,
+    startedAt: "2026-04-20T10:00:00.000Z",
+    finishedAt: null,
+    createdAt: "2026-04-20T10:00:00.000Z",
+    agentId: "agent",
+    agentName: "Agent",
+    adapterType: "codex_local",
+    issueId: "issue",
+    ...overrides,
+  };
+}
+
 describe("collectLiveIssueIds", () => {
   it("keeps only runs linked to issues", () => {
     const liveRuns: LiveRunForIssue[] = [
@@ -108,6 +125,22 @@ describe("collectLiveIssueIds", () => {
     expect([...collectLiveIssueIds(liveRuns, [
       { id: "issue-done", status: "done" },
       { id: "issue-open", status: "in_progress" },
+    ])]).toEqual(["issue-open"]);
+  });
+
+  it("keeps terminal snapshots sticky when stale non-terminal snapshots appear later", () => {
+    const liveRuns: LiveRunForIssue[] = [
+      liveRun({ id: "run-done", issueId: "issue-done", status: "running" }),
+      liveRun({ id: "run-cancelled", issueId: "issue-cancelled", status: "queued" }),
+      liveRun({ id: "run-open", issueId: "issue-open", status: "running" }),
+    ];
+
+    expect([...collectLiveIssueIds(liveRuns, [
+      { id: "issue-done", status: "done" },
+      { id: "issue-cancelled", status: "cancelled" },
+      { id: "issue-open", status: "in_progress" },
+      { id: "issue-done", status: "in_progress" },
+      { id: "issue-cancelled", status: "todo" },
     ])]).toEqual(["issue-open"]);
   });
 });

--- a/ui/src/lib/liveIssueIds.test.ts
+++ b/ui/src/lib/liveIssueIds.test.ts
@@ -74,6 +74,42 @@ describe("collectLiveIssueIds", () => {
 
     expect([...collectLiveIssueIds(liveRuns)]).toEqual(["issue-1", "issue-2"]);
   });
+
+  it("suppresses live ids for terminal issues while keeping non-terminal issues live", () => {
+    const liveRuns: LiveRunForIssue[] = [
+      {
+        id: "run-terminal",
+        status: "running",
+        invocationSource: "scheduler",
+        triggerDetail: null,
+        startedAt: "2026-04-20T10:00:00.000Z",
+        finishedAt: null,
+        createdAt: "2026-04-20T10:00:00.000Z",
+        agentId: "agent-1",
+        agentName: "Coder",
+        adapterType: "codex_local",
+        issueId: "issue-done",
+      },
+      {
+        id: "run-live",
+        status: "queued",
+        invocationSource: "scheduler",
+        triggerDetail: null,
+        startedAt: null,
+        finishedAt: null,
+        createdAt: "2026-04-20T10:01:00.000Z",
+        agentId: "agent-2",
+        agentName: "Builder",
+        adapterType: "codex_local",
+        issueId: "issue-open",
+      },
+    ];
+
+    expect([...collectLiveIssueIds(liveRuns, [
+      { id: "issue-done", status: "done" },
+      { id: "issue-open", status: "in_progress" },
+    ])]).toEqual(["issue-open"]);
+  });
 });
 
 describe("collectSubtreeLiveCounts", () => {

--- a/ui/src/lib/liveIssueIds.test.ts
+++ b/ui/src/lib/liveIssueIds.test.ts
@@ -128,7 +128,7 @@ describe("collectLiveIssueIds", () => {
     ])]).toEqual(["issue-open"]);
   });
 
-  it("keeps terminal snapshots sticky when stale non-terminal snapshots appear later", () => {
+  it("keeps newer terminal snapshots authoritative when stale non-terminal snapshots appear later", () => {
     const liveRuns: LiveRunForIssue[] = [
       liveRun({ id: "run-done", issueId: "issue-done", status: "running" }),
       liveRun({ id: "run-cancelled", issueId: "issue-cancelled", status: "queued" }),
@@ -136,12 +136,40 @@ describe("collectLiveIssueIds", () => {
     ];
 
     expect([...collectLiveIssueIds(liveRuns, [
-      { id: "issue-done", status: "done" },
-      { id: "issue-cancelled", status: "cancelled" },
-      { id: "issue-open", status: "in_progress" },
-      { id: "issue-done", status: "in_progress" },
-      { id: "issue-cancelled", status: "todo" },
+      { id: "issue-done", status: "done", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-cancelled", status: "cancelled", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-open", status: "in_progress", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-done", status: "in_progress", updatedAt: "2026-04-20T10:01:00.000Z" },
+      { id: "issue-cancelled", status: "todo", updatedAt: "2026-04-20T10:01:00.000Z" },
     ])]).toEqual(["issue-open"]);
+  });
+
+  it("allows a newer non-terminal snapshot to reopen an issue with a stale terminal snapshot", () => {
+    const liveRuns: LiveRunForIssue[] = [
+      liveRun({ id: "run-reopened", issueId: "issue-reopened", status: "running" }),
+      liveRun({ id: "run-terminal", issueId: "issue-terminal", status: "queued" }),
+    ];
+
+    expect([...collectLiveIssueIds(liveRuns, [
+      { id: "issue-reopened", status: "done", updatedAt: "2026-04-20T10:01:00.000Z" },
+      { id: "issue-terminal", status: "in_progress", updatedAt: "2026-04-20T10:01:00.000Z" },
+      { id: "issue-reopened", status: "in_progress", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-terminal", status: "done", updatedAt: "2026-04-20T10:02:00.000Z" },
+    ])]).toEqual(["issue-reopened"]);
+  });
+
+  it("keeps reopened issues live when conflicting snapshots have equal timestamps", () => {
+    const liveRuns: LiveRunForIssue[] = [
+      liveRun({ id: "run-reopened", issueId: "issue-reopened", status: "running" }),
+      liveRun({ id: "run-reopened-reversed", issueId: "issue-reopened-reversed", status: "queued" }),
+    ];
+
+    expect([...collectLiveIssueIds(liveRuns, [
+      { id: "issue-reopened", status: "done", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-reopened", status: "in_progress", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-reopened-reversed", status: "in_progress", updatedAt: "2026-04-20T10:02:00.000Z" },
+      { id: "issue-reopened-reversed", status: "done", updatedAt: "2026-04-20T10:02:00.000Z" },
+    ])]).toEqual(["issue-reopened", "issue-reopened-reversed"]);
   });
 });
 

--- a/ui/src/lib/liveIssueIds.ts
+++ b/ui/src/lib/liveIssueIds.ts
@@ -1,13 +1,36 @@
+import type { IssueStatus } from "@paperclipai/shared";
 import type { LiveRunForIssue } from "../api/heartbeats";
 
 function isLiveRunStatus(status: string): boolean {
   return status === "queued" || status === "running";
 }
 
-export function collectLiveIssueIds(liveRuns: readonly LiveRunForIssue[] | null | undefined): Set<string> {
+const TERMINAL_ISSUE_STATUSES = new Set<IssueStatus>(["done", "cancelled"]);
+
+export function isTerminalIssueStatus(status: string | null | undefined): status is IssueStatus {
+  return TERMINAL_ISSUE_STATUSES.has(status as IssueStatus);
+}
+
+export function isLiveIssueRun(
+  run: Pick<LiveRunForIssue, "status">,
+  issueStatus?: string | null,
+): boolean {
+  return isLiveRunStatus(run.status) && !isTerminalIssueStatus(issueStatus);
+}
+
+export interface LiveIssueStatusNode {
+  id: string;
+  status: IssueStatus | string;
+}
+
+export function collectLiveIssueIds(
+  liveRuns: readonly LiveRunForIssue[] | null | undefined,
+  issues?: readonly LiveIssueStatusNode[] | null,
+): Set<string> {
   const ids = new Set<string>();
+  const statusByIssueId = new Map((issues ?? []).map((issue) => [issue.id, issue.status]));
   for (const run of liveRuns ?? []) {
-    if (run.issueId && isLiveRunStatus(run.status)) ids.add(run.issueId);
+    if (run.issueId && isLiveIssueRun(run, statusByIssueId.get(run.issueId))) ids.add(run.issueId);
   }
   return ids;
 }

--- a/ui/src/lib/liveIssueIds.ts
+++ b/ui/src/lib/liveIssueIds.ts
@@ -23,12 +23,23 @@ export interface LiveIssueStatusNode {
   status: IssueStatus | string;
 }
 
+function collectIssueStatusById(issues: readonly LiveIssueStatusNode[] | null | undefined): Map<string, string> {
+  const statusByIssueId = new Map<string, string>();
+  for (const issue of issues ?? []) {
+    const existingStatus = statusByIssueId.get(issue.id);
+    if (!isTerminalIssueStatus(existingStatus)) {
+      statusByIssueId.set(issue.id, issue.status);
+    }
+  }
+  return statusByIssueId;
+}
+
 export function collectLiveIssueIds(
   liveRuns: readonly LiveRunForIssue[] | null | undefined,
   issues?: readonly LiveIssueStatusNode[] | null,
 ): Set<string> {
   const ids = new Set<string>();
-  const statusByIssueId = new Map((issues ?? []).map((issue) => [issue.id, issue.status]));
+  const statusByIssueId = collectIssueStatusById(issues);
   for (const run of liveRuns ?? []) {
     if (run.issueId && isLiveIssueRun(run, statusByIssueId.get(run.issueId))) ids.add(run.issueId);
   }

--- a/ui/src/lib/liveIssueIds.ts
+++ b/ui/src/lib/liveIssueIds.ts
@@ -21,17 +21,41 @@ export function isLiveIssueRun(
 export interface LiveIssueStatusNode {
   id: string;
   status: IssueStatus | string;
+  updatedAt?: Date | string | number | null;
 }
 
 function collectIssueStatusById(issues: readonly LiveIssueStatusNode[] | null | undefined): Map<string, string> {
-  const statusByIssueId = new Map<string, string>();
+  const snapshotByIssueId = new Map<string, { status: string; updatedAtMs: number | null }>();
   for (const issue of issues ?? []) {
-    const existingStatus = statusByIssueId.get(issue.id);
-    if (!isTerminalIssueStatus(existingStatus)) {
-      statusByIssueId.set(issue.id, issue.status);
-    }
+    const candidate = {
+      status: issue.status,
+      updatedAtMs: issueUpdatedAtMs(issue.updatedAt),
+    };
+    const existing = snapshotByIssueId.get(issue.id);
+    if (!existing || shouldReplaceIssueStatusSnapshot(existing, candidate)) snapshotByIssueId.set(issue.id, candidate);
   }
-  return statusByIssueId;
+  return new Map([...snapshotByIssueId].map(([issueId, snapshot]) => [issueId, snapshot.status]));
+}
+
+function issueUpdatedAtMs(updatedAt: LiveIssueStatusNode["updatedAt"]): number | null {
+  if (updatedAt === null || updatedAt === undefined) return null;
+  const timestamp = updatedAt instanceof Date ? updatedAt.getTime() : new Date(updatedAt).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function shouldReplaceIssueStatusSnapshot(
+  existing: { status: string; updatedAtMs: number | null },
+  candidate: { status: string; updatedAtMs: number | null },
+): boolean {
+  if (candidate.updatedAtMs !== null && existing.updatedAtMs !== null) {
+    if (candidate.updatedAtMs !== existing.updatedAtMs) return candidate.updatedAtMs > existing.updatedAtMs;
+    return isTerminalIssueStatus(existing.status) && !isTerminalIssueStatus(candidate.status);
+  }
+
+  if (candidate.updatedAtMs !== null) return true;
+  if (existing.updatedAtMs !== null) return false;
+
+  return !isTerminalIssueStatus(existing.status) && isTerminalIssueStatus(candidate.status);
 }
 
 export function collectLiveIssueIds(

--- a/ui/src/pages/ExecutionWorkspaceDetail.tsx
+++ b/ui/src/pages/ExecutionWorkspaceDetail.tsx
@@ -542,7 +542,7 @@ function ExecutionWorkspaceIssuesList({
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
 
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, issues), [issues, liveRuns]);
 
   const updateIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) => issuesApi.update(id, data),

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -945,7 +945,6 @@ export function Inbox() {
     refetchInterval: sharedLiveRuns.refetchInterval,
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
   const { data: companyMembers } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(selectedCompanyId!),
     queryFn: () => accessApi.listUserDirectory(selectedCompanyId!),
@@ -1001,6 +1000,15 @@ export function Inbox() {
     enabled: shouldUseIssueSearchSupplement,
     placeholderData: (previousData) => previousData,
   });
+  const liveIssueIds = useMemo(
+    () => collectLiveIssueIds(liveRuns, [
+      ...(issues ?? []),
+      ...mineIssuesRaw,
+      ...touchedIssuesRaw,
+      ...remoteIssueSearchResults,
+    ]),
+    [issues, liveRuns, mineIssuesRaw, remoteIssueSearchResults, touchedIssuesRaw],
+  );
   const inboxIssueIdsForExternalObjectSummaries = useMemo(() => {
     const issueIds = new Set<string>();
     for (const issue of mineIssues) issueIds.add(issue.id);

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1978,7 +1978,10 @@ export function IssueDetail() {
     },
     [issue?.id, rawChildIssues],
   );
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(companyLiveRuns), [companyLiveRuns]);
+  const liveIssueIds = useMemo(
+    () => collectLiveIssueIds(companyLiveRuns, issue ? [issue, ...childIssues] : childIssues),
+    [childIssues, companyLiveRuns, issue],
+  );
   const issuePanelKey = useMemo(
     () => buildIssuePropertiesPanelKey(issue ?? null, childIssues),
     [childIssues, issue],

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -115,8 +115,6 @@ export function Issues() {
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
 
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
-
   const issueLinkState = useMemo(
     () =>
       createIssueDetailLocationState(
@@ -169,6 +167,7 @@ export function Issues() {
   });
 
   const issues = useMemo(() => mergeIssuePagesStable(issuePages?.pages ?? []) as Issue[], [issuePages]);
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, issues), [issues, liveRuns]);
   const hasMoreServerIssues = syncedSearch.trim().length === 0
     && hasNextPage === true;
   const loadMoreServerIssues = useCallback(() => {

--- a/ui/src/pages/ProjectDetail.tsx
+++ b/ui/src/pages/ProjectDetail.tsx
@@ -259,13 +259,12 @@ function ProjectIssuesList({ projectId, companyId }: { projectId: string; compan
     enabled: !!companyId,
   });
 
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
-
   const { data: issues, isLoading, error } = useQuery({
     queryKey: queryKeys.issues.listByProject(companyId, projectId),
     queryFn: () => issuesApi.list(companyId, { projectId }),
     enabled: !!companyId,
   });
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, issues), [issues, liveRuns]);
 
   const updateIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
@@ -330,13 +329,12 @@ function ProjectPluginOperationsList({
     refetchInterval: sharedLiveRuns.refetchInterval,
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
-
   const { data: issues, isLoading, error } = useQuery({
     queryKey: queryKeys.issues.listPluginOperationsByProject(companyId, projectId, originKindPrefix),
     queryFn: () => issuesApi.list(companyId, { projectId, originKindPrefix }),
     enabled: !!companyId && !!projectId,
   });
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, issues), [issues, liveRuns]);
 
   const updateIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -655,7 +655,7 @@ export function Routines() {
     () => new Map((routineFolders?.folders ?? []).map((folder) => [folder.id, folder])),
     [routineFolders],
   );
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, routineExecutionIssues), [liveRuns, routineExecutionIssues]);
   const visibleRoutines = useMemo(
     () => (routines ?? []).filter((routine) => routine.status !== "archived"),
     [routines],

--- a/ui/src/plugins/bridge-init.ts
+++ b/ui/src/plugins/bridge-init.ts
@@ -289,13 +289,12 @@ function PluginSdkIssuesList({
     refetchInterval: sharedLiveRuns.refetchInterval,
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
-  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
-
   const { data: issues, isLoading, error } = useQuery({
     queryKey: issuesQueryKey,
     queryFn: () => issuesApi.list(companyId!, issueFilters),
     enabled: !!companyId,
   });
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, issues), [issues, liveRuns]);
 
   const updateIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>


### PR DESCRIPTION
## Thinking Path

> - Paperclip shows live state in the issue UI.
> - A stale running heartbeat row can remain after an issue ends.
> - That stale row can make a finished issue look live.
> - The UI should trust terminal issue status before it shows live state.
> - This pull request adds a shared guard for that rule.
> - The benefit is a stable and correct UI for finished issues.

## Linked Issues or Issue Description

No public GitHub issue exists for this change.

**What happened?**
The UI showed Live or Working for a terminal issue when a stale running heartbeat row still existed after teardown.

**Expected behavior**
The UI should hide live state after the known issue status becomes terminal.

**Steps to reproduce**
1. Open a finished issue that still has a stale running heartbeat row.
2. Load the Live badge or the issue chat.
3. See Live or Working even though the issue is terminal.

**Paperclip version or commit**
4db2b49f2952c09f850551892a71418ea096e83a

**Deployment mode**
Local dev (pnpm dev)

**Installation method**
Built from source (pnpm dev / pnpm build)

**Agent adapter(s) involved**
Not adapter-specific (core bug)

**Database mode**
Embedded PGlite (default - `DATABASE_URL` unset)

**Access context**
Agent (bearer API key via `agent_api_keys`)

**Node.js version**
v22.22.3

**Operating system**
Linux 6.17.0-1017-aws aarch64 GNU/Linux

**Additional context**
This change keeps non-terminal queued and running issues live.
It only suppresses live state when the issue status is terminal.

## What Changed

- Added a shared UI guard that blocks live state for terminal issues.
- Applied the guard to the Live badge and both issue chat render paths.
- Added regression coverage for terminal suppression and non-terminal preservation.

## Verification

- `pnpm exec vitest run ui/src/lib/liveIssueIds.test.ts ui/src/lib/issue-chat-messages.test.ts`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm check:token-gates`
- `git diff --check`

## Risks

- Low risk.
- The guard can hide live state if terminal status data is wrong.
- The regression tests cover terminal and non-terminal paths.

## Model Used

OpenAI Codex, GPT-5, tool use, code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
