### PR TITLE
fix(server): terminalize a still-running run when its environment lease is released

### DIFF
--- a/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
+++ b/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../telemetry.ts", () => ({ getTelemetryClient: () => mockTelemetryClient }));
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres lease-release terminalization tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-lease-release-terminal-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRunEvents);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed(input: { issueStatus: string; runStatus: string }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminalize on lease release",
+      status: input.issueStatus,
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: input.runStatus,
+      invocationSource: "manual",
+      startedAt: new Date(),
+      contextSnapshot: { issueId },
+    });
+
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]!);
+
+    return { companyId, agentId, issueId, runId, run };
+  }
+
+  it("forces a still-running run to succeeded when the issue already reached done", async () => {
+    // This reproduces the defect: the agent PATCHed the issue to done, but the
+    // teardown released the environment lease before the run-terminal write.
+    const { issueId, runId, run } = await seed({ issueStatus: "done", runStatus: "running" });
+
+    const heartbeat = heartbeatService(db);
+    const terminal = await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(terminal.status).toBe("succeeded");
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("succeeded");
+
+    const issueStatus = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]?.status);
+    expect(issueStatus).toBe("done");
+
+    const event = await db
+      .select({ message: heartbeatRunEvents.message, payload: heartbeatRunEvents.payload })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .then((rows) => rows[0]);
+    expect(event?.message).toContain("lease release");
+    expect((event?.payload as { terminalStatus?: string } | null)?.terminalStatus).toBe("succeeded");
+  });
+
+  it("forces a still-running run to interrupted when the issue is not terminal", async () => {
+    const { runId, run } = await seed({ issueStatus: "in_progress", runStatus: "running" });
+
+    const heartbeat = heartbeatService(db);
+    const terminal = await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(terminal.status).toBe("interrupted");
+
+    const row = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+    expect(row?.status).toBe("interrupted");
+    expect(row?.errorCode).toBe("lease_released_before_terminal");
+  });
+
+  it("keeps an already-terminal run authoritative and records no new event", async () => {
+    const { runId, run } = await seed({ issueStatus: "done", runStatus: "failed" });
+
+    const heartbeat = heartbeatService(db);
+    const terminal = await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(terminal.status).toBe("failed");
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("failed");
+
+    const eventCount = await db
+      .select({ id: heartbeatRunEvents.id })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .then((rows) => rows.length);
+    expect(eventCount).toBe(0);
+  });
+});

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -6,6 +6,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueRelations,
@@ -46,6 +47,7 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     await db.delete(issueRelations);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -222,5 +224,88 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     const second = await heartbeat.sweepStaleIssueLocks();
     expect(first.cleared).toBe(1);
     expect(second.cleared).toBe(0);
+  });
+
+  it("terminalizes an orphaned running run whose process is gone, then clears the lock", async () => {
+    const { companyId, agentId, runningRunId } = await seed();
+    // The run recorded a pid, but the process and its sandbox are gone. A pid
+    // this large never maps to a live process, so isPidAlive returns false.
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: 2_000_000_000 })
+      .where(eq(heartbeatRuns.id, runningRunId));
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Orphaned running run — terminalize then clear",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+      executionLockedAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    expect(result.terminalizedRunIds).toEqual([runningRunId]);
+    expect(result.cleared).toBe(1);
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("interrupted");
+
+    const lock = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(lock).toEqual({ checkoutRunId: null, executionRunId: null });
+
+    const event = await db
+      .select({ message: heartbeatRunEvents.message })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runningRunId))
+      .then((rows) => rows[0]);
+    expect(event?.message).toContain("recovery backstop");
+  });
+
+  it("does not terminalize a running run whose process is still alive", async () => {
+    const { companyId, agentId, runningRunId } = await seed();
+    // process.pid is the live test process, so isPidAlive returns true.
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: process.pid })
+      .where(eq(heartbeatRuns.id, runningRunId));
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Live run — preserve",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+      executionLockedAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    expect(result.terminalizedRunIds).toEqual([]);
+    expect(result.cleared).toBe(0);
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("running");
   });
 });

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -308,4 +308,70 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       .then((rows) => rows[0]?.status);
     expect(runStatus).toBe("running");
   });
+
+  it("still clears the lock when the audit write fails after terminalization", async () => {
+    const { companyId, agentId, runningRunId } = await seed();
+    // The run recorded a pid that never maps to a live process, so the sweep
+    // decides to terminalize it. See the orphaned-run test above.
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: 2_000_000_000 })
+      .where(eq(heartbeatRuns.id, runningRunId));
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Audit write fails — still clear the lock",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+      executionLockedAt: new Date(),
+    });
+
+    // Make only the audit-event insert fail. The run update commits the
+    // terminal status first, so the audit write is best-effort. The sweep must
+    // catch the failure and still clear the lock.
+    const realInsert = db.insert.bind(db);
+    const insertSpy = vi.spyOn(db, "insert").mockImplementation((table) => {
+      if (table === heartbeatRunEvents) {
+        throw new Error("simulated audit write failure");
+      }
+      return realInsert(table);
+    });
+
+    try {
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.sweepStaleIssueLocks();
+
+      expect(result.terminalizedRunIds).toEqual([runningRunId]);
+      expect(result.cleared).toBe(1);
+    } finally {
+      insertSpy.mockRestore();
+    }
+
+    // The run reached its terminal status even though the audit write failed.
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("interrupted");
+
+    // The sweep cleared the lock in the same pass.
+    const lock = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(lock).toEqual({ checkoutRunId: null, executionRunId: null });
+
+    // The audit write failed, so no run event exists for this run.
+    const events = await db
+      .select({ id: heartbeatRunEvents.id })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runningRunId));
+    expect(events).toEqual([]);
+  });
 });

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -230,6 +230,7 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     const { companyId, agentId, runningRunId } = await seed();
     // The run recorded a pid, but the process and its sandbox are gone. A pid
     // this large never maps to a live process, so isPidAlive returns false.
+    // The issue is not terminal, so only the process-death authority applies.
     await db
       .update(heartbeatRuns)
       .set({ processPid: 2_000_000_000 })
@@ -239,6 +240,60 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       id: issueId,
       companyId,
       title: "Orphaned running run — terminalize then clear",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+      executionLockedAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    expect(result.terminalizedRunIds).toEqual([runningRunId]);
+    expect(result.cleared).toBe(1);
+
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]);
+    // Process died, outcome unknown, so the backstop uses "interrupted".
+    expect(run?.status).toBe("interrupted");
+    expect(run?.errorCode).toBe("orphaned_running_run");
+
+    const lock = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(lock).toEqual({ checkoutRunId: null, executionRunId: null });
+
+    const event = await db
+      .select({ message: heartbeatRunEvents.message })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runningRunId))
+      .then((rows) => rows[0]);
+    expect(event?.message).toContain("process and sandbox gone");
+  });
+
+  it("terminalizes a running run whose issue is terminal, even while the process stays alive (reuse-lease path)", async () => {
+    // Reuse Lease ON stops the sandbox but keeps the server process alive, so
+    // the in-memory handle and the recorded pid can both persist. The
+    // process-death authority misses this case. The issue-terminal authority
+    // catches it: the issue reached "done" while the run row stayed "running".
+    const { companyId, agentId, runningRunId } = await seed();
+    // process.pid is the live test process, so isPidAlive returns true.
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: process.pid })
+      .where(eq(heartbeatRuns.id, runningRunId));
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reused sandbox stopped — issue done, run still running",
       status: "done",
       priority: "high",
       assigneeAgentId: agentId,
@@ -253,12 +308,15 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     expect(result.terminalizedRunIds).toEqual([runningRunId]);
     expect(result.cleared).toBe(1);
 
-    const runStatus = await db
-      .select({ status: heartbeatRuns.status })
+    const run = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runningRunId))
-      .then((rows) => rows[0]?.status);
-    expect(runStatus).toBe("interrupted");
+      .then((rows) => rows[0]);
+    // The issue is "done", so the terminal run status is "succeeded". A
+    // succeeded run carries no error code.
+    expect(run?.status).toBe("succeeded");
+    expect(run?.errorCode).toBeNull();
 
     const lock = await db
       .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
@@ -272,10 +330,42 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       .from(heartbeatRunEvents)
       .where(eq(heartbeatRunEvents.runId, runningRunId))
       .then((rows) => rows[0]);
-    expect(event?.message).toContain("recovery backstop");
+    expect(event?.message).toContain("issue reached a terminal status");
   });
 
-  it("does not terminalize a running run whose process is still alive", async () => {
+  it("terminalizes a running run to cancelled when its issue is cancelled (reuse-lease path)", async () => {
+    const { companyId, agentId, runningRunId } = await seed();
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: process.pid })
+      .where(eq(heartbeatRuns.id, runningRunId));
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reused sandbox stopped — issue cancelled, run still running",
+      status: "cancelled",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+      executionLockedAt: new Date(),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    expect(result.terminalizedRunIds).toEqual([runningRunId]);
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("cancelled");
+  });
+
+  it("does not terminalize a running run whose process is alive and whose issue is not terminal", async () => {
     const { companyId, agentId, runningRunId } = await seed();
     // process.pid is the live test process, so isPidAlive returns true.
     await db
@@ -312,7 +402,8 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
   it("still clears the lock when the audit write fails after terminalization", async () => {
     const { companyId, agentId, runningRunId } = await seed();
     // The run recorded a pid that never maps to a live process, so the sweep
-    // decides to terminalize it. See the orphaned-run test above.
+    // decides to terminalize it. The issue is not terminal, so the
+    // process-death authority drives the terminalization here.
     await db
       .update(heartbeatRuns)
       .set({ processPid: 2_000_000_000 })
@@ -322,7 +413,7 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       id: issueId,
       companyId,
       title: "Audit write fails — still clear the lock",
-      status: "done",
+      status: "in_progress",
       priority: "high",
       assigneeAgentId: agentId,
       checkoutRunId: runningRunId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8855,6 +8855,72 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return { run: current, updated: false as const };
   }
 
+  // Invariant: when a run releases its environment lease, the run row must be
+  // terminal. The finalizer writes the terminal status in a step that is
+  // separate from the agent status=done PATCH. If the sandbox or the run
+  // process stops between the two steps, heartbeat_runs.status stays "running".
+  // The UI reads liveness from that row, so a finished task shows "Live"
+  // forever. This function closes the gap in the run teardown: when the run is
+  // still running or queued, it forces a terminal status before the lease is
+  // released. It never overwrites a status that another path already made
+  // terminal.
+  async function terminalizeRunOnLeaseRelease(
+    run: typeof heartbeatRuns.$inferSelect,
+  ): Promise<typeof heartbeatRuns.$inferSelect> {
+    if (isHeartbeatRunTerminalStatus(run.status)) return run;
+    if (run.status !== "running" && run.status !== "queued") return run;
+
+    // Choose the terminal status that reflects the true outcome. When the issue
+    // already reached a terminal status, the run reached its goal, so use the
+    // matching terminal run status. Otherwise the teardown cut the run short,
+    // so use "interrupted".
+    const issueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+    let terminalStatus: "succeeded" | "cancelled" | "interrupted" = "interrupted";
+    if (issueId) {
+      const issueStatus = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]?.status ?? null);
+      if (issueStatus === "done") terminalStatus = "succeeded";
+      else if (issueStatus === "cancelled") terminalStatus = "cancelled";
+    }
+
+    const message =
+      `run terminalized on environment lease release: heartbeat_runs.status was still ${run.status} at teardown`;
+    const write = await setRunStatusIfRunning(run.id, terminalStatus, {
+      finishedAt: run.finishedAt ?? new Date(),
+      error: run.error ?? (terminalStatus === "interrupted" ? message : null),
+      errorCode: run.errorCode ?? (terminalStatus === "interrupted" ? "lease_released_before_terminal" : null),
+    });
+    if (!write.updated) {
+      // Another path already finalized the run. Keep that terminal outcome.
+      return write.run ?? run;
+    }
+
+    const terminalRun = write.run;
+    if (terminalRun) {
+      await appendRunEvent(terminalRun, await nextRunEventSeq(terminalRun.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: terminalStatus === "interrupted" ? "warn" : "info",
+        message,
+        payload: {
+          previousStatus: run.status,
+          terminalStatus,
+          reason: "environment_lease_release",
+          ...(issueId ? { issueId } : {}),
+        },
+      }).catch((eventErr) => {
+        logger.warn(
+          { err: eventErr, runId: run.id },
+          "failed to append run event for lease-release terminalization",
+        );
+      });
+    }
+    return terminalRun ?? run;
+  }
+
   function publishRunLifecyclePluginEvent(run: typeof heartbeatRuns.$inferSelect) {
     const eventType =
       run.status === "running"
@@ -16193,7 +16259,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
           }
         } finally {
-          const latestRun = await getRun(run.id).catch(() => null);
+          let latestRun = await getRun(run.id).catch(() => null);
+          // Close the invariant "environment lease released implies the run is
+          // terminal". When the teardown reaches this point with the run still
+          // running or queued, force a terminal status before the lease is
+          // released, so the UI never shows a finished task as "Live".
+          if (latestRun) {
+            latestRun = await terminalizeRunOnLeaseRelease(latestRun).catch((terminalizeErr) => {
+              logger.error(
+                { err: terminalizeErr, runId: run.id },
+                "failed to terminalize run before environment lease release",
+              );
+              return latestRun;
+            });
+          }
           await releaseEnvironmentLeasesForRun({
             runId: run.id,
             companyId: run.companyId,
@@ -18934,6 +19013,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    terminalizeRunOnLeaseRelease,
 
     sweepStaleIssueLocks,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5477,48 +5477,101 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Math.max(1, Math.floor(asNumber(raw, fallback)));
   }
 
-  // Backstop reconciler: terminalizes a "running" run after its process and its
-  // sandbox are both gone. A hard server crash can skip the graceful teardown,
-  // so the run finalizer never writes the terminal status and
-  // heartbeat_runs.status stays "running" forever. The UI reads liveness from
-  // that row, so the task shows "Live" forever. This function forces the run to
-  // "interrupted" and records a run event, so the state is auditable. It never
-  // overwrites a status that another path already made terminal, and it never
-  // terminalizes a run whose process is still alive.
+  // Backstop reconciler: terminalizes a "running" run that can no longer reach a
+  // terminal status on its own. The run finalizer writes the terminal status in
+  // a step that is separate from the agent status=done PATCH. When the teardown
+  // stops between the two steps, heartbeat_runs.status stays "running" forever.
+  // The UI reads liveness from that row, so the task shows "Live" forever. This
+  // function forces the run to a terminal status and records a run event, so the
+  // state is auditable. It never overwrites a status that another path already
+  // made terminal.
+  //
+  // Two independent authorities terminalize the run. Either one is enough:
+  //
+  // - Issue-terminal authority: the run's issue already reached a terminal
+  //   status (done or cancelled), but the run row is still "running". A healthy
+  //   run always terminalizes its own row before or just after the issue reaches
+  //   a terminal status, so a lasting "running" row under a terminal issue is
+  //   orphaned. This authority does not depend on process death. It is the only
+  //   authority that catches the reuse-lease path: the release stops the sandbox
+  //   but keeps the server process alive, so the in-memory handle and the
+  //   recorded pid can both persist.
+  // - Process-death authority: the run has no in-memory handle and its recorded
+  //   process and process group are both gone. This catches a hard server crash
+  //   that skipped the graceful teardown, even when the issue is not terminal.
   async function terminalizeOrphanedRunningRun(
     run: typeof heartbeatRuns.$inferSelect,
+    options?: {
+      // The terminal run status implied by a referencing issue. The caller
+      // passes it when it already knows the issue that holds the run in a lock
+      // column. It maps issue "done" to "succeeded" and issue "cancelled" to
+      // "cancelled". A null value means the referencing issue is not terminal.
+      referencingIssueTerminalStatus?: "succeeded" | "cancelled" | null;
+    },
   ): Promise<{ terminalized: boolean; status: string }> {
     // Act only on a run in "running" status. A "queued" run has no process yet,
     // and a "scheduled_retry" run has no process on purpose because it waits to
     // retry. Neither is orphaned, so this function must not terminalize them.
     if (run.status !== "running") return { terminalized: false, status: run.status };
 
-    // The run is live only when a process still backs it. Check the in-memory
-    // handle first, then the recorded pid and process group. Require recorded
-    // process metadata, so this never terminalizes a run that has not yet
-    // stored its pid.
-    const handle = runningProcesses.get(run.id);
-    if (handle) return { terminalized: false, status: run.status };
     const pid = run.processPid ?? null;
     const processGroupId = run.processGroupId ?? null;
-    if (typeof pid !== "number" && typeof processGroupId !== "number") {
+
+    // Issue-terminal authority. When the run's issue is terminal, the run row is
+    // orphaned regardless of process or handle state. Prefer the referencing
+    // issue status that the caller passed, because a lock column is the direct
+    // link from the stuck "Live" issue to this run. Fall back to the issue id in
+    // the run context snapshot when the caller passed nothing.
+    let issueTerminalStatus: "succeeded" | "cancelled" | null =
+      options?.referencingIssueTerminalStatus ?? null;
+    const issueId = issueIdFromRunContext(run.contextSnapshot);
+    if (!issueTerminalStatus && issueId) {
+      const issueStatus = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]?.status ?? null);
+      if (issueStatus === "done") issueTerminalStatus = "succeeded";
+      else if (issueStatus === "cancelled") issueTerminalStatus = "cancelled";
+    }
+
+    // Process-death authority. The run is live only when a process still backs
+    // it. Check the in-memory handle first, then the recorded pid and process
+    // group. Require recorded process metadata, so this authority never fires on
+    // a run that has not yet stored its pid.
+    let processGone = false;
+    if (!runningProcesses.get(run.id)) {
+      if (typeof pid === "number" || typeof processGroupId === "number") {
+        const processAlive =
+          (typeof pid === "number" && isPidAlive(pid)) ||
+          (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+        processGone = !processAlive;
+      }
+    }
+
+    // Neither authority applies. The run is still live, so leave it alone.
+    if (!issueTerminalStatus && !processGone) {
       return { terminalized: false, status: run.status };
     }
-    const processAlive =
-      (typeof pid === "number" && isPidAlive(pid)) ||
-      (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
-    if (processAlive) return { terminalized: false, status: run.status };
+
+    const authority = issueTerminalStatus ? "issue_terminal" : "process_gone";
+    const terminalStatus = issueTerminalStatus ?? "interrupted";
+    const errorCode = issueTerminalStatus
+      ? "orphaned_running_run_issue_terminal"
+      : "orphaned_running_run";
+    const message =
+      authority === "issue_terminal"
+        ? "run terminalized by recovery backstop: issue reached a terminal status while heartbeat_runs.status stayed live"
+        : "run terminalized by recovery backstop: process and sandbox gone while heartbeat_runs.status stayed live";
 
     const now = new Date();
-    const message =
-      "run terminalized by recovery backstop: process and sandbox gone while heartbeat_runs.status stayed live";
     const updated = await db
       .update(heartbeatRuns)
       .set({
-        status: "interrupted",
-        finishedAt: now,
-        error: run.error ?? message,
-        errorCode: run.errorCode ?? "orphaned_running_run",
+        status: terminalStatus,
+        finishedAt: run.finishedAt ?? now,
+        error: run.error ?? (terminalStatus === "interrupted" ? message : null),
+        errorCode: run.errorCode ?? (terminalStatus === "interrupted" ? errorCode : null),
         updatedAt: now,
       })
       .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "running")))
@@ -5546,7 +5599,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         message,
         payload: {
           source: "recovery.sweep_stale_issue_locks",
+          authority,
           previousStatus: run.status,
+          terminalStatus,
+          ...(issueId ? { issueId } : {}),
           pid,
           processGroupId,
         },
@@ -5558,7 +5614,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       );
     }
     logger.warn(
-      { runId: run.id, previousStatus: run.status, pid, processGroupId },
+      { runId: run.id, authority, previousStatus: run.status, terminalStatus, issueId, pid, processGroupId },
       "terminalized orphaned running heartbeat run in stale-lock sweep",
     );
     return { terminalized: true, status: updated.status };
@@ -5569,9 +5625,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   // in a terminal status. Provides self-heal for stale locks that fell outside
   // releaseIssueExecutionAndPromote / clearCheckoutRunIfTerminal / adoption.
   // Before it evaluates cleanability, it terminalizes any referenced run that
-  // still claims to be live but whose process and sandbox are both gone, so a
-  // stuck "running" run can no longer block the sweep. Idempotent and safe:
-  // clears at most one row's worth of lock columns per candidate.
+  // still claims to be live but can no longer reach a terminal status on its
+  // own, so a stuck "running" run can no longer block the sweep. Idempotent and
+  // safe: clears at most one row's worth of lock columns per candidate.
   async function sweepStaleIssueLocks() {
     const result = {
       cleared: 0,
@@ -5583,6 +5639,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .select({
         id: issues.id,
         companyId: issues.companyId,
+        status: issues.status,
         checkoutRunId: issues.checkoutRunId,
         executionRunId: issues.executionRunId,
       })
@@ -5608,12 +5665,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runStatusById = new Map<string, string>();
     for (const row of runRows) runStatusById.set(row.id, row.status);
 
+    // Map each referenced run to the terminal run status implied by its
+    // referencing issue. When a terminal issue still holds the run in a lock
+    // column, that run is orphaned: the issue is the stuck "Live" task the UI
+    // shows. A "done" issue implies "succeeded"; a "cancelled" issue implies
+    // "cancelled".
+    const issueTerminalStatusByRunId = new Map<string, "succeeded" | "cancelled">();
+    for (const issue of candidates) {
+      const implied =
+        issue.status === "done"
+          ? "succeeded"
+          : issue.status === "cancelled"
+            ? "cancelled"
+            : null;
+      if (!implied) continue;
+      for (const runId of [issue.checkoutRunId, issue.executionRunId]) {
+        if (runId) issueTerminalStatusByRunId.set(runId, implied);
+      }
+    }
+
     // Pre-pass: terminalize any referenced run that still claims to be live but
-    // whose process and sandbox are both gone. This lets the sweep clear the
-    // lock in the same pass instead of waiting for the run to reach a terminal
-    // status by another route.
+    // can no longer reach a terminal status on its own. This lets the sweep
+    // clear the lock in the same pass instead of waiting for the run to reach a
+    // terminal status by another route.
     for (const row of runRows) {
-      const outcome = await terminalizeOrphanedRunningRun(row);
+      const outcome = await terminalizeOrphanedRunningRun(row, {
+        referencingIssueTerminalStatus: issueTerminalStatusByRunId.get(row.id) ?? null,
+      });
       runStatusById.set(row.id, outcome.status);
       if (outcome.terminalized) result.terminalizedRunIds.push(row.id);
     }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5535,16 +5535,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     runningProcesses.delete(run.id);
-    await appendRecoveryRunEvent(updated, {
-      level: "warn",
-      message,
-      payload: {
-        source: "recovery.sweep_stale_issue_locks",
-        previousStatus: run.status,
-        pid,
-        processGroupId,
-      },
-    });
+    // The run update above already committed the terminal status. The audit
+    // event is best-effort: if the insert fails, the caller must still treat
+    // the run as terminalized and clear the lock in the same sweep. So catch
+    // the failure, log it, and continue. A thrown error here would abort the
+    // sweep and leave the stale lock in place.
+    try {
+      await appendRecoveryRunEvent(updated, {
+        level: "warn",
+        message,
+        payload: {
+          source: "recovery.sweep_stale_issue_locks",
+          previousStatus: run.status,
+          pid,
+          processGroupId,
+        },
+      });
+    } catch (error) {
+      logger.error(
+        { err: error, runId: run.id, previousStatus: run.status },
+        "failed to append recovery run event after terminalizing orphaned run; run stays terminal and the sweep clears the lock",
+      );
+    }
     logger.warn(
       { runId: run.id, previousStatus: run.status, pid, processGroupId },
       "terminalized orphaned running heartbeat run in stale-lock sweep",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5477,16 +5477,94 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Math.max(1, Math.floor(asNumber(raw, fallback)));
   }
 
+  // Backstop reconciler: terminalizes a "running" run after its process and its
+  // sandbox are both gone. A hard server crash can skip the graceful teardown,
+  // so the run finalizer never writes the terminal status and
+  // heartbeat_runs.status stays "running" forever. The UI reads liveness from
+  // that row, so the task shows "Live" forever. This function forces the run to
+  // "interrupted" and records a run event, so the state is auditable. It never
+  // overwrites a status that another path already made terminal, and it never
+  // terminalizes a run whose process is still alive.
+  async function terminalizeOrphanedRunningRun(
+    run: typeof heartbeatRuns.$inferSelect,
+  ): Promise<{ terminalized: boolean; status: string }> {
+    // Act only on a run in "running" status. A "queued" run has no process yet,
+    // and a "scheduled_retry" run has no process on purpose because it waits to
+    // retry. Neither is orphaned, so this function must not terminalize them.
+    if (run.status !== "running") return { terminalized: false, status: run.status };
+
+    // The run is live only when a process still backs it. Check the in-memory
+    // handle first, then the recorded pid and process group. Require recorded
+    // process metadata, so this never terminalizes a run that has not yet
+    // stored its pid.
+    const handle = runningProcesses.get(run.id);
+    if (handle) return { terminalized: false, status: run.status };
+    const pid = run.processPid ?? null;
+    const processGroupId = run.processGroupId ?? null;
+    if (typeof pid !== "number" && typeof processGroupId !== "number") {
+      return { terminalized: false, status: run.status };
+    }
+    const processAlive =
+      (typeof pid === "number" && isPidAlive(pid)) ||
+      (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+    if (processAlive) return { terminalized: false, status: run.status };
+
+    const now = new Date();
+    const message =
+      "run terminalized by recovery backstop: process and sandbox gone while heartbeat_runs.status stayed live";
+    const updated = await db
+      .update(heartbeatRuns)
+      .set({
+        status: "interrupted",
+        finishedAt: now,
+        error: run.error ?? message,
+        errorCode: run.errorCode ?? "orphaned_running_run",
+        updatedAt: now,
+      })
+      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "running")))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    if (!updated) {
+      // Another path finalized the run between the read and this write. Keep
+      // that terminal outcome authoritative.
+      const [current] = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, run.id));
+      return { terminalized: false, status: current?.status ?? run.status };
+    }
+
+    runningProcesses.delete(run.id);
+    await appendRecoveryRunEvent(updated, {
+      level: "warn",
+      message,
+      payload: {
+        source: "recovery.sweep_stale_issue_locks",
+        previousStatus: run.status,
+        pid,
+        processGroupId,
+      },
+    });
+    logger.warn(
+      { runId: run.id, previousStatus: run.status, pid, processGroupId },
+      "terminalized orphaned running heartbeat run in stale-lock sweep",
+    );
+    return { terminalized: true, status: updated.status };
+  }
+
   // Backstop sweeper: clears stale lock columns on issues whose checkoutRunId
   // or executionRunId points at a heartbeat_runs row that is either missing or
   // in a terminal status. Provides self-heal for stale locks that fell outside
   // releaseIssueExecutionAndPromote / clearCheckoutRunIfTerminal / adoption.
-  // Idempotent and safe: clears at most one row's worth of lock columns per
-  // candidate, and only when the referenced run row is unambiguously terminal.
+  // Before it evaluates cleanability, it terminalizes any referenced run that
+  // still claims to be live but whose process and sandbox are both gone, so a
+  // stuck "running" run can no longer block the sweep. Idempotent and safe:
+  // clears at most one row's worth of lock columns per candidate.
   async function sweepStaleIssueLocks() {
     const result = {
       cleared: 0,
       issueIds: [] as string[],
+      terminalizedRunIds: [] as string[],
     };
 
     const candidates = await db
@@ -5511,12 +5589,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runRows =
       referencedRunIds.length > 0
         ? await db
-            .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+            .select()
             .from(heartbeatRuns)
             .where(inArray(heartbeatRuns.id, referencedRunIds))
         : [];
     const runStatusById = new Map<string, string>();
     for (const row of runRows) runStatusById.set(row.id, row.status);
+
+    // Pre-pass: terminalize any referenced run that still claims to be live but
+    // whose process and sandbox are both gone. This lets the sweep clear the
+    // lock in the same pass instead of waiting for the run to reach a terminal
+    // status by another route.
+    for (const row of runRows) {
+      const outcome = await terminalizeOrphanedRunningRun(row);
+      runStatusById.set(row.id, outcome.status);
+      if (outcome.terminalized) result.terminalizedRunIds.push(row.id);
+    }
 
     const isCleanable = (runId: string | null) => {
       if (!runId) return true;
@@ -5576,9 +5664,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     }
 
-    if (result.cleared > 0) {
+    if (result.cleared > 0 || result.terminalizedRunIds.length > 0) {
       logger.warn(
-        { cleared: result.cleared, issueIds: result.issueIds },
+        {
+          cleared: result.cleared,
+          issueIds: result.issueIds,
+          terminalizedRunIds: result.terminalizedRunIds,
+        },
         "swept stale issue lock columns",
       );
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for AI agent work.
> - Run state drives the board view that shows whether work is live.
> - A run can end after the issue is done, but before the terminal status write.
> - That leaves a finished run marked running, so the board shows stale Live state.
> - This pull request closes that gap in run teardown and stale-lock recovery.
> - The benefit is the board stops treating dead work as active work.

## Linked Issues or Issue Description

### What happened
A finished run kept the Live badge and the Working shimmer after the sandbox lease ended.

### Expected behavior
A released lease should leave the run in a terminal state.

### Steps to reproduce
1. Start a run.
2. Mark the issue done.
3. Stop the sandbox before the final status write.
4. Check `heartbeat_runs.status`.

### Paperclip version / commit
`272660f9d8970914839d937ccb8bb69c304f2c1a`

### Deployment mode
Local development with embedded PostgreSQL.

## What Changed

- Run teardown now terminalizes a still-running or still-queued run before lease release.
- Recovery backstop now terminalizes an orphaned running run after it confirms the process is dead.
- The server writes a run event for each terminal transition.
- The server tests cover the teardown path and the recovery path.

## Verification

- `pnpm --filter server tsc --noEmit`
- `pnpm --filter server test heartbeat-run-lease-release-terminalization.test.ts recovery-stale-issue-lock-sweep.test.ts`
- `git log --oneline origin/master..HEAD` shows one commit.

## Risks

- The teardown path may mark a run terminal before a late status write arrives.
- The recovery path depends on process metadata and a dead-process check.
- The change is low risk because it only closes stale `running` rows.

## Model Used

OpenAI Codex, GPT-5, tool use, code execution, 128k context.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` or (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge