### PR TITLE
fix(issues): reject unreachable approval stages

### DIFF
--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -18,6 +18,10 @@ const mockIssueService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTx = vi.hoisted(() => ({}));
+const mockDb = vi.hoisted(() => ({
+  transaction: vi.fn(async (callback: (tx: typeof mockTx) => Promise<unknown>) => callback(mockTx)),
+}));
 const mockAccessService = vi.hoisted(() => ({
   canUser: vi.fn(async () => false),
   hasPermission: vi.fn(async () => false),
@@ -126,7 +130,7 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp(db: unknown = {}) {
+async function createApp(db: unknown = mockDb) {
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -2115,6 +2115,7 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).toHaveBeenCalledWith(
         issueId,
         expect.objectContaining({ assigneeAgentId: peerAgentId }),
+        expect.anything(),
       );
     });
 

--- a/server/src/__tests__/issue-assignee-invokability-routes.test.ts
+++ b/server/src/__tests__/issue-assignee-invokability-routes.test.ts
@@ -15,6 +15,7 @@ const agentStatusById: Record<string, string> = {
 
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
+  getByIdForUpdate: vi.fn(),
   findOpenAncestorCreatedByAgent: vi.fn(),
   update: vi.fn(),
   create: vi.fn(),
@@ -164,7 +165,11 @@ function stubDb(): any {
     query[method] = () => query;
   }
   query.then = (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve([]));
-  return { select: () => query };
+  const tx = {};
+  return {
+    select: () => query,
+    transaction: async (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx),
+  };
 }
 
 function createApp(actor: Actor) {
@@ -203,6 +208,8 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
 describe("issue assignee invokability guard", () => {
   beforeEach(() => {
     mockIssueService.getById.mockReset();
+    mockIssueService.getByIdForUpdate.mockReset();
+    mockIssueService.getByIdForUpdate.mockImplementation(async () => mockIssueService.getById());
     mockIssueService.findOpenAncestorCreatedByAgent.mockReset();
     mockIssueService.findOpenAncestorCreatedByAgent.mockResolvedValue(null);
     mockIssueService.update.mockReset();

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -469,6 +469,7 @@ describe.sequential("issue comment reopen routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      mockTx,
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
@@ -501,6 +502,7 @@ describe.sequential("issue comment reopen routes", () => {
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
       }),
+      mockTx,
     );
   });
 
@@ -546,6 +548,7 @@ describe.sequential("issue comment reopen routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      mockTx,
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
@@ -860,6 +863,7 @@ describe.sequential("issue comment reopen routes", () => {
         assigneeAgentId: otherAgentId,
         status: "todo",
       }),
+      mockTx,
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -161,6 +161,24 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
       executionPolicy: null,
     });
 
+    const validPolicy = {
+      stages: [{ type: "approval", participants: [{ type: "agent", agentId: qa.id }] }],
+    };
+    const [assigneeOnlyPatch] = await db.insert(issues).values({
+      companyId,
+      title: "Reject assignee-only invalidation",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: coder.id,
+      executionPolicy: validPolicy,
+    }).returning();
+    await request(app)
+      .patch(`/api/issues/${assigneeOnlyPatch.id}`)
+      .send({ assigneeAgentId: qa.id })
+      .expect(400);
+    const [assigneeOnlyPersisted] = await db.select().from(issues).where(eq(issues.id, assigneeOnlyPatch.id));
+    expect(assigneeOnlyPersisted.assigneeAgentId).toBe(coder.id);
+
     const activeReviewStageId = randomUUID();
     const nullReturnPolicy = {
       stages: [

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import express from "express";
 import request from "supertest";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
@@ -217,6 +217,378 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
       .patch(`/api/issues/${nullReturnAssignee.id}`)
       .send({ executionPolicy: nullReturnPolicy })
       .expect(200);
+  });
+
+  it("serializes approval-policy narrowing with reassignment so they cannot jointly strand an approval", async () => {
+    const companyId = await seedCompany();
+    const coder = await seedAgent(companyId, "Coder");
+    const qa = await seedAgent(companyId, "QA");
+    const app = createApp();
+    const [issue] = await db.insert(issues).values({
+      companyId,
+      title: "Serialize approval eligibility",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: coder.id,
+      executionPolicy: {
+        stages: [
+          {
+            type: "approval",
+            participants: [
+              { type: "agent", agentId: coder.id },
+              { type: "agent", agentId: qa.id },
+            ],
+          },
+        ],
+      },
+    }).returning();
+    const advisoryLockKey = 28510960;
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION paperclip_test_pause_approval_policy_narrowing()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        IF NEW.execution_policy IS DISTINCT FROM OLD.execution_policy THEN
+          PERFORM pg_advisory_xact_lock(${advisoryLockKey});
+          PERFORM pg_sleep(1);
+        END IF;
+        RETURN NEW;
+      END
+      $function$;
+      CREATE TRIGGER paperclip_test_pause_approval_policy_narrowing
+      BEFORE UPDATE ON issues
+      FOR EACH ROW EXECUTE FUNCTION paperclip_test_pause_approval_policy_narrowing();
+    `));
+
+    try {
+      const narrowing = request(app)
+        .patch(`/api/issues/${issue!.id}`)
+        .send({
+          executionPolicy: {
+            stages: [{ type: "approval", participants: [{ type: "agent", agentId: qa.id }] }],
+          },
+        })
+        .then((response) => response);
+
+      let narrowingPaused = false;
+      for (let attempt = 0; attempt < 80; attempt += 1) {
+        const lockAvailable = await db.transaction(async (tx) => {
+          const [result] = await tx.execute<{ acquired: boolean }>(
+            sql`SELECT pg_try_advisory_lock(${advisoryLockKey}) AS acquired`,
+          );
+          if (result?.acquired) {
+            await tx.execute(sql`SELECT pg_advisory_unlock(${advisoryLockKey})`);
+          }
+          return result?.acquired ?? false;
+        });
+        if (!lockAvailable) {
+          narrowingPaused = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(narrowingPaused).toBe(true);
+
+      let reassignmentFinished = false;
+      const reassignment = request(app)
+        .patch(`/api/issues/${issue!.id}`)
+        .send({ assigneeAgentId: qa.id })
+        .then((response) => {
+          reassignmentFinished = true;
+          return response;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(reassignmentFinished).toBe(false);
+
+      const [narrowed, reassigned] = await Promise.all([narrowing, reassignment]);
+      expect.soft([narrowed.status, reassigned.status].sort()).toEqual([200, 400]);
+
+      const [persisted] = await db.select().from(issues).where(eq(issues.id, issue!.id));
+      expect.soft(persisted.assigneeAgentId).toBe(coder.id);
+      expect.soft(persisted.executionPolicy).toMatchObject({
+        stages: [{ type: "approval", participants: [{ type: "agent", agentId: qa.id }] }],
+      });
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS paperclip_test_pause_approval_policy_narrowing ON issues;
+        DROP FUNCTION IF EXISTS paperclip_test_pause_approval_policy_narrowing();
+      `));
+    }
+  }, 20_000);
+
+  it("rejects a workflow restart whose transition was planned from a stale policy", async () => {
+    const companyId = await seedCompany();
+    const coder = await seedAgent(companyId, "Coder");
+    const qa = await seedAgent(companyId, "QA");
+    const security = await seedAgent(companyId, "Security");
+    const reviewStageId = randomUUID();
+    const approvalStageId = randomUUID();
+    const app = createApp();
+    const [issue] = await db.insert(issues).values({
+      companyId,
+      title: "Restart from a current policy",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: coder.id,
+      executionPolicy: {
+        stages: [
+          {
+            id: reviewStageId,
+            type: "review",
+            participants: [{ type: "agent", agentId: qa.id }],
+          },
+          {
+            id: approvalStageId,
+            type: "approval",
+            participants: [{ type: "agent", agentId: qa.id }],
+          },
+        ],
+      },
+      executionState: {
+        status: "changes_requested",
+        currentStageId: reviewStageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: qa.id },
+        returnAssignee: { type: "agent", agentId: coder.id },
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: "changes_requested",
+      },
+    }).returning();
+    const advisoryLockKey = 28510961;
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION paperclip_test_pause_restart_policy_update()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        IF NEW.execution_policy IS DISTINCT FROM OLD.execution_policy THEN
+          PERFORM pg_advisory_xact_lock(${advisoryLockKey});
+          PERFORM pg_sleep(1);
+        END IF;
+        RETURN NEW;
+      END
+      $function$;
+      CREATE TRIGGER paperclip_test_pause_restart_policy_update
+      BEFORE UPDATE ON issues
+      FOR EACH ROW EXECUTE FUNCTION paperclip_test_pause_restart_policy_update();
+    `));
+
+    try {
+      const policyUpdate = request(app)
+        .patch(`/api/issues/${issue!.id}`)
+        .send({
+          executionPolicy: {
+            stages: [
+              {
+                id: reviewStageId,
+                type: "review",
+                participants: [{ type: "agent", agentId: security.id }],
+              },
+              {
+                id: approvalStageId,
+                type: "approval",
+                participants: [{ type: "agent", agentId: qa.id }],
+              },
+            ],
+          },
+        })
+        .then((response) => response);
+
+      let policyUpdatePaused = false;
+      for (let attempt = 0; attempt < 80; attempt += 1) {
+        const lockAvailable = await db.transaction(async (tx) => {
+          const [result] = await tx.execute<{ acquired: boolean }>(
+            sql`SELECT pg_try_advisory_lock(${advisoryLockKey}) AS acquired`,
+          );
+          if (result?.acquired) {
+            await tx.execute(sql`SELECT pg_advisory_unlock(${advisoryLockKey})`);
+          }
+          return result?.acquired ?? false;
+        });
+        if (!lockAvailable) {
+          policyUpdatePaused = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(policyUpdatePaused).toBe(true);
+
+      let restartFinished = false;
+      const restart = request(app)
+        .patch(`/api/issues/${issue!.id}`)
+        .send({ status: "done" })
+        .then((response) => {
+          restartFinished = true;
+          return response;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(restartFinished).toBe(false);
+
+      const [updatedPolicy, restarted] = await Promise.all([policyUpdate, restart]);
+      expect.soft([updatedPolicy.status, restarted.status].sort()).toEqual([200, 409]);
+
+      const [persisted] = await db.select().from(issues).where(eq(issues.id, issue!.id));
+      expect.soft(persisted.executionPolicy).toMatchObject({
+        stages: [
+          { participants: [{ type: "agent", agentId: security.id }] },
+          { participants: [{ type: "agent", agentId: qa.id }] },
+        ],
+      });
+      expect.soft(persisted.executionState).toMatchObject({
+        status: "changes_requested",
+        currentParticipant: { type: "agent", agentId: qa.id },
+      });
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS paperclip_test_pause_restart_policy_update ON issues;
+        DROP FUNCTION IF EXISTS paperclip_test_pause_restart_policy_update();
+      `));
+    }
+  }, 20_000);
+
+  it("rejects a workflow start whose transition was planned from a stale policy", async () => {
+    const companyId = await seedCompany();
+    const coder = await seedAgent(companyId, "Coder");
+    const qa = await seedAgent(companyId, "QA");
+    const security = await seedAgent(companyId, "Security");
+    const app = createApp();
+    const [issue] = await db.insert(issues).values({
+      companyId,
+      title: "Start from a current policy",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: coder.id,
+      executionPolicy: {
+        stages: [
+          { type: "review", participants: [{ type: "agent", agentId: qa.id }] },
+          { type: "approval", participants: [{ type: "agent", agentId: qa.id }] },
+        ],
+      },
+    }).returning();
+    const advisoryLockKey = 28510962;
+    await db.execute(sql.raw(`
+      CREATE OR REPLACE FUNCTION paperclip_test_pause_start_policy_update()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        IF NEW.execution_policy IS DISTINCT FROM OLD.execution_policy THEN
+          PERFORM pg_advisory_xact_lock(${advisoryLockKey});
+          PERFORM pg_sleep(1);
+        END IF;
+        RETURN NEW;
+      END
+      $function$;
+      CREATE TRIGGER paperclip_test_pause_start_policy_update
+      BEFORE UPDATE ON issues
+      FOR EACH ROW EXECUTE FUNCTION paperclip_test_pause_start_policy_update();
+    `));
+
+    try {
+      const policyUpdate = request(app)
+        .patch(`/api/issues/${issue!.id}`)
+        .send({
+          executionPolicy: {
+            stages: [
+              { type: "review", participants: [{ type: "agent", agentId: security.id }] },
+              { type: "approval", participants: [{ type: "agent", agentId: qa.id }] },
+            ],
+          },
+        })
+        .then((response) => response);
+
+      let policyUpdatePaused = false;
+      for (let attempt = 0; attempt < 80; attempt += 1) {
+        const lockAvailable = await db.transaction(async (tx) => {
+          const [result] = await tx.execute<{ acquired: boolean }>(
+            sql`SELECT pg_try_advisory_lock(${advisoryLockKey}) AS acquired`,
+          );
+          if (result?.acquired) {
+            await tx.execute(sql`SELECT pg_advisory_unlock(${advisoryLockKey})`);
+          }
+          return result?.acquired ?? false;
+        });
+        if (!lockAvailable) {
+          policyUpdatePaused = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(policyUpdatePaused).toBe(true);
+
+      let workflowStartFinished = false;
+      const workflowStart = request(app)
+        .patch(`/api/issues/${issue!.id}`)
+        .send({ status: "done" })
+        .then((response) => {
+          workflowStartFinished = true;
+          return response;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(workflowStartFinished).toBe(false);
+
+      const [updatedPolicy, started] = await Promise.all([policyUpdate, workflowStart]);
+      expect.soft([updatedPolicy.status, started.status].sort()).toEqual([200, 409]);
+
+      const [persisted] = await db.select().from(issues).where(eq(issues.id, issue!.id));
+      expect.soft(persisted.status).toBe("in_progress");
+      expect.soft(persisted.executionState).toBeNull();
+      expect.soft(persisted.executionPolicy).toMatchObject({
+        stages: [
+          { participants: [{ type: "agent", agentId: security.id }] },
+          { participants: [{ type: "agent", agentId: qa.id }] },
+        ],
+      });
+    } finally {
+      await db.execute(sql.raw(`
+        DROP TRIGGER IF EXISTS paperclip_test_pause_start_policy_update ON issues;
+        DROP FUNCTION IF EXISTS paperclip_test_pause_start_policy_update();
+      `));
+    }
+  }, 20_000);
+
+  it("allows unrelated status changes for legacy invalid policies but still rejects workflow starts", async () => {
+    const companyId = await seedCompany();
+    const coder = await seedAgent(companyId, "Coder");
+    const legacyInvalidPolicy = {
+      stages: [{ type: "approval", participants: [{ type: "agent", agentId: coder.id }] }],
+    };
+    const [legacyStatusIssue, legacyWorkflowStartIssue] = await db.insert(issues).values([
+      {
+        companyId,
+        title: "Legacy invalid policy status transition",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: coder.id,
+        executionPolicy: legacyInvalidPolicy,
+      },
+      {
+        companyId,
+        title: "Legacy invalid policy workflow start",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: coder.id,
+        executionPolicy: legacyInvalidPolicy,
+      },
+    ]).returning();
+    const app = createApp();
+
+    const unrelatedStatus = await request(app)
+      .patch(`/api/issues/${legacyStatusIssue!.id}`)
+      .send({ status: "cancelled" });
+    expect.soft(unrelatedStatus.status).toBe(200);
+    expect.soft((await db.select().from(issues).where(eq(issues.id, legacyStatusIssue!.id)))[0]).toMatchObject({
+      status: "cancelled",
+    });
+
+    const workflowStart = await request(app)
+      .patch(`/api/issues/${legacyWorkflowStartIssue!.id}`)
+      .send({ status: "done" });
+    expect.soft(workflowStart.status).toBe(400);
   });
 
   it("replays the existing issue for the same company idempotency key", async () => {

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -87,6 +87,120 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
     return parent;
   }
 
+  async function seedAgent(companyId: string, name: string) {
+    const [agent] = await db.insert(agents).values({
+      companyId,
+      name,
+      role: "engineer",
+      status: "active",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    }).returning();
+    return agent;
+  }
+
+  it("rejects an ineligible approval participant when a policy is created or patched", async () => {
+    const companyId = await seedCompany();
+    const coder = await seedAgent(companyId, "Coder");
+    const qa = await seedAgent(companyId, "QA");
+    const app = createApp();
+    const executionPolicy = {
+      stages: [
+        { type: "review", participants: [{ type: "agent", agentId: qa.id }] },
+        { type: "approval", participants: [{ type: "agent", agentId: coder.id }] },
+      ],
+    };
+
+    await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Reject invalid policy on create", assigneeAgentId: coder.id, executionPolicy })
+      .expect(400);
+    expect(await db.select().from(issues)).toHaveLength(0);
+
+    const [existing] = await db.insert(issues).values({
+      companyId,
+      title: "Reject invalid policy on patch",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: coder.id,
+    }).returning();
+
+    await request(app)
+      .patch(`/api/issues/${existing.id}`)
+      .send({ executionPolicy })
+      .expect(400);
+    const [persisted] = await db.select().from(issues).where(eq(issues.id, existing.id));
+    expect(persisted.executionPolicy).toBeNull();
+
+    await request(app)
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        status: "done",
+        assigneeAgentId: qa.id,
+        executionPolicy: {
+          mode: "normal",
+          stages: [
+            {
+              type: "review",
+              participants: [{ type: "agent", agentId: qa.id }],
+            },
+            {
+              type: "approval",
+              participants: [{ type: "agent", agentId: coder.id }],
+            },
+          ],
+        },
+      })
+      .expect(400);
+    const [unchanged] = await db.select().from(issues).where(eq(issues.id, existing.id));
+    expect(unchanged).toMatchObject({
+      status: "todo",
+      assigneeAgentId: coder.id,
+      executionPolicy: null,
+    });
+
+    const activeReviewStageId = randomUUID();
+    const nullReturnPolicy = {
+      stages: [
+        {
+          id: activeReviewStageId,
+          type: "review",
+          participants: [{ type: "agent", agentId: qa.id }],
+        },
+        {
+          id: randomUUID(),
+          type: "approval",
+          participants: [{ type: "agent", agentId: coder.id }],
+        },
+      ],
+    };
+    const [nullReturnAssignee] = await db.insert(issues).values({
+      companyId,
+      title: "Allow a null workflow return assignee",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: coder.id,
+      executionState: {
+        status: "pending",
+        currentStageId: activeReviewStageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: qa.id },
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    }).returning();
+    await request(app)
+      .patch(`/api/issues/${nullReturnAssignee.id}`)
+      .send({ executionPolicy: nullReturnPolicy })
+      .expect(200);
+  });
+
   it("replays the existing issue for the same company idempotency key", async () => {
     const companyId = await seedCompany();
     const parent = await seedParent(companyId);

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -1010,6 +1010,7 @@ describe("issue execution policy routes", () => {
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+      expect.anything(),
     );
     const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(updatePatch.status).toBeUndefined();

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { applyIssueExecutionPolicyTransition, normalizeIssueExecutionPolicy, parseIssueExecutionState } from "../services/issue-execution-policy.ts";
+import {
+  applyIssueExecutionPolicyTransition,
+  findFirstIneligibleApprovalStage,
+  normalizeIssueExecutionPolicy,
+  parseIssueExecutionState,
+} from "../services/issue-execution-policy.ts";
 import type { IssueExecutionPolicy, IssueExecutionState } from "@paperclipai/shared";
 
 const coderAgentId = "11111111-1111-4111-8111-111111111111";
@@ -130,6 +135,31 @@ describe("normalizeIssueExecutionPolicy", () => {
         scheduledBy: "assignee",
         externalRef: "[redacted]",
       },
+    });
+  });
+
+  it("identifies an approval stage whose only participant is the issue executor", () => {
+    const policy = makePolicy([
+      { type: "review", participants: [{ type: "agent", agentId: qaAgentId }] },
+      { type: "approval", participants: [{ type: "agent", agentId: coderAgentId }] },
+    ]);
+
+    expect(findFirstIneligibleApprovalStage(policy, { type: "agent", agentId: coderAgentId })).toMatchObject({
+      type: "approval",
+      participants: [{ type: "agent", agentId: coderAgentId }],
+    });
+    expect(findFirstIneligibleApprovalStage(twoStagePolicy(), { type: "agent", agentId: coderAgentId })).toBeNull();
+  });
+
+  it("uses the active workflow return assignee rather than the current reviewer", () => {
+    const policy = makePolicy([
+      { type: "review", participants: [{ type: "agent", agentId: qaAgentId }] },
+      { type: "approval", participants: [{ type: "agent", agentId: coderAgentId }] },
+    ]);
+
+    expect(findFirstIneligibleApprovalStage(policy, { type: "agent", agentId: coderAgentId })).toMatchObject({
+      type: "approval",
+      participants: [{ type: "agent", agentId: coderAgentId }],
     });
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9029,15 +9029,20 @@ export function issueRoutes(
       updateFields.executionPolicy !== undefined
         ? (updateFields.executionPolicy as NormalizedExecutionPolicy | null)
         : previousExecutionPolicy;
+    const workflowStartRequested = updateFields.status === "done" || updateFields.status === "in_review";
+    const existingExecutionState = parseIssueExecutionState(existing.executionState);
+    const workflowStartsWithThisPatch = existingExecutionState === null && workflowStartRequested;
+    const workflowRestartsWithThisPatch =
+      existingExecutionState?.status === "changes_requested" && workflowStartRequested;
     const policyEligibilityInputsChanged =
       req.body.executionPolicy !== undefined ||
       normalizedAssigneeAgentId !== undefined ||
       req.body.assigneeUserId !== undefined ||
-      req.body.status !== undefined;
+      workflowStartsWithThisPatch ||
+      workflowRestartsWithThisPatch;
+    const policyEligibilityMayNeedLockedValidation =
+      policyEligibilityInputsChanged || workflowStartRequested;
     if (policyEligibilityInputsChanged) {
-      const existingExecutionState = parseIssueExecutionState(existing.executionState);
-      const workflowStartsWithThisPatch = existingExecutionState === null
-        && (updateFields.status === "done" || updateFields.status === "in_review");
       const plannedAssignee = assigneePrincipal({
         assigneeAgentId:
           normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId,
@@ -9283,6 +9288,51 @@ export function issueRoutes(
       }
       return true;
     };
+    const assertLockedExecutionPolicyApprovalEligibility = async (
+      tx: Parameters<typeof svc.update>[2],
+    ) => {
+      const lockedExisting = await svc.getByIdForUpdate(id, tx);
+      if (!lockedExisting) return false;
+      const lockedExecutionState = parseIssueExecutionState(lockedExisting.executionState);
+      const lockedWorkflowStartsWithThisPatch = lockedExecutionState === null && workflowStartRequested;
+      const lockedWorkflowRestartsWithThisPatch =
+        lockedExecutionState?.status === "changes_requested" && workflowStartRequested;
+      const lockedPolicyEligibilityInputsChanged =
+        req.body.executionPolicy !== undefined ||
+        normalizedAssigneeAgentId !== undefined ||
+        req.body.assigneeUserId !== undefined ||
+        lockedWorkflowStartsWithThisPatch ||
+        lockedWorkflowRestartsWithThisPatch;
+      if (lockedPolicyEligibilityInputsChanged) {
+        const lockedNextExecutionPolicy = req.body.executionPolicy !== undefined
+          ? nextExecutionPolicy
+          : normalizeIssueExecutionPolicy(lockedExisting.executionPolicy ?? null);
+        const lockedPlannedAssignee = assigneePrincipal({
+          assigneeAgentId:
+            normalizedAssigneeAgentId === undefined ? lockedExisting.assigneeAgentId : normalizedAssigneeAgentId,
+          assigneeUserId:
+            req.body.assigneeUserId === undefined
+              ? lockedExisting.assigneeUserId
+              : (req.body.assigneeUserId as string | null),
+        });
+        assertExecutionPolicyApprovalEligibility(
+          lockedNextExecutionPolicy,
+          lockedExecutionState
+            ? lockedExecutionState.returnAssignee
+            : (lockedWorkflowStartsWithThisPatch ? assigneePrincipal(lockedExisting) : lockedPlannedAssignee),
+        );
+      }
+      const executionInputsChanged =
+        lockedExisting.status !== existing.status ||
+        lockedExisting.assigneeAgentId !== existing.assigneeAgentId ||
+        lockedExisting.assigneeUserId !== existing.assigneeUserId ||
+        JSON.stringify(lockedExisting.executionPolicy ?? null) !== JSON.stringify(existing.executionPolicy ?? null) ||
+        JSON.stringify(lockedExisting.executionState ?? null) !== JSON.stringify(existing.executionState ?? null);
+      if (executionInputsChanged) {
+        throw conflict("Issue execution inputs changed before the update could be applied; retry the update");
+      }
+      return true;
+    };
     const persistReviewTransitionActivity = async (
       tx: Parameters<typeof svc.update>[2],
       updated: NonNullable<Awaited<ReturnType<typeof svc.update>>>,
@@ -9358,10 +9408,15 @@ export function issueRoutes(
       Boolean(decision)
       || shouldRelayStop
       || persistReviewActivityTransactionally
-      || reviewPolicySensitiveMutationRequested;
+      || reviewPolicySensitiveMutationRequested
+      || policyEligibilityMayNeedLockedValidation;
     try {
       if (shouldUseTransactionalIssueUpdate) {
         issue = await db.transaction(async (tx) => {
+          if (
+            policyEligibilityMayNeedLockedValidation
+            && !(await assertLockedExecutionPolicyApprovalEligibility(tx))
+          ) return null;
           if (
             reviewPolicySensitiveMutationRequested
             && !(await assertLockedReviewPolicyAllowsMutation(tx))

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -203,7 +203,9 @@ import {
   type CompanySearchRateLimiter,
 } from "../services/company-search-rate-limit.js";
 import {
+  assigneePrincipal,
   applyIssueExecutionPolicyTransition,
+  findFirstIneligibleApprovalStage,
   normalizeIssueExecutionPolicy,
   parseIssueExecutionState,
   redactIssueMonitorExternalRef,
@@ -305,6 +307,16 @@ async function listIssueLinkedCases(db: Db, companyId: string, issueId: string) 
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
 type IssueRouteSnapshot = typeof issueRows.$inferSelect;
+
+function assertExecutionPolicyApprovalEligibility(
+  policy: NormalizedExecutionPolicy | null,
+  returnAssignee: ParsedExecutionState["returnAssignee"],
+) {
+  if (findFirstIneligibleApprovalStage(policy, returnAssignee)) {
+    throw badRequest("No eligible approval participant is configured for this issue");
+  }
+}
+
 type RecoveryRevalidationTrigger =
   | "issue_update"
   | "comment"
@@ -7992,6 +8004,10 @@ export function issueRoutes(
       normalizeIssueExecutionPolicy(createBody.executionPolicy),
       actor.actorType,
     );
+    assertExecutionPolicyApprovalEligibility(executionPolicy, assigneePrincipal({
+      assigneeAgentId: createBody.assigneeAgentId ?? null,
+      assigneeUserId: rawCreateBody.assigneeUserId ?? null,
+    }));
     await assertCanManageIssueMonitor(access, req, companyId, createBody.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
     const issueId = randomUUID();
     const sourceTrust = await sourceTrustForActorWrite({
@@ -8229,6 +8245,10 @@ export function issueRoutes(
       normalizeIssueExecutionPolicy(createBody.executionPolicy),
       actor.actorType,
     );
+    assertExecutionPolicyApprovalEligibility(executionPolicy, assigneePrincipal({
+      assigneeAgentId: createBody.assigneeAgentId ?? null,
+      assigneeUserId: createBody.assigneeUserId ?? null,
+    }));
     await assertCanManageIssueMonitor(access, req, parent.companyId, createBody.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
     const issueId = randomUUID();
     const sourceTrust = await sourceTrustForActorWrite({
@@ -8405,6 +8425,10 @@ export function issueRoutes(
         normalizeIssueExecutionPolicy(child.executionPolicy),
         actor.actorType,
       );
+      assertExecutionPolicyApprovalEligibility(executionPolicy, assigneePrincipal({
+        assigneeAgentId: child.assigneeAgentId ?? null,
+        assigneeUserId: child.assigneeUserId ?? null,
+      }));
       await assertCanManageIssueMonitor(access, req, sourceIssue.companyId, child.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
       const childIssueId = randomUUID();
       const sourceTrust = await sourceTrustForActorWrite({
@@ -9005,6 +9029,23 @@ export function issueRoutes(
       updateFields.executionPolicy !== undefined
         ? (updateFields.executionPolicy as NormalizedExecutionPolicy | null)
         : previousExecutionPolicy;
+    if (req.body.executionPolicy !== undefined) {
+      const existingExecutionState = parseIssueExecutionState(existing.executionState);
+      const workflowStartsWithThisPatch = existingExecutionState === null
+        && (updateFields.status === "done" || updateFields.status === "in_review");
+      const plannedAssignee = assigneePrincipal({
+        assigneeAgentId:
+          normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId,
+        assigneeUserId:
+          req.body.assigneeUserId === undefined ? existing.assigneeUserId : (req.body.assigneeUserId as string | null),
+      });
+      assertExecutionPolicyApprovalEligibility(
+        nextExecutionPolicy,
+        existingExecutionState
+          ? existingExecutionState.returnAssignee
+          : (workflowStartsWithThisPatch ? assigneePrincipal(existing) : plannedAssignee),
+      );
+    }
     if (normalizedAssigneeAgentId !== undefined) {
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -9029,7 +9029,12 @@ export function issueRoutes(
       updateFields.executionPolicy !== undefined
         ? (updateFields.executionPolicy as NormalizedExecutionPolicy | null)
         : previousExecutionPolicy;
-    if (req.body.executionPolicy !== undefined) {
+    const policyEligibilityInputsChanged =
+      req.body.executionPolicy !== undefined ||
+      normalizedAssigneeAgentId !== undefined ||
+      req.body.assigneeUserId !== undefined ||
+      req.body.status !== undefined;
+    if (policyEligibilityInputsChanged) {
       const existingExecutionState = parseIssueExecutionState(existing.executionState);
       const workflowStartsWithThisPatch = existingExecutionState === null
         && (updateFields.status === "done" || updateFields.status === "in_review");

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -498,6 +498,22 @@ function selectStageParticipant(
   return first ? { type: first.type, agentId: first.agentId ?? null, userId: first.userId ?? null } : null;
 }
 
+/**
+ * Finds an approval stage that cannot be reached because all of its
+ * participants are excluded as the issue's return executor. Callers use this
+ * at policy-write time; legacy persisted policies retain the transition-time
+ * 422 so they can be repaired without unrelated writes being blocked.
+ */
+export function findFirstIneligibleApprovalStage(
+  policy: IssueExecutionPolicy | null | undefined,
+  returnAssignee: IssueExecutionStagePrincipal | null,
+): IssueExecutionStage | null {
+  if (!policy) return null;
+  return policy.stages.find(
+    (stage) => stage.type === "approval" && !selectStageParticipant(stage, { exclude: returnAssignee }),
+  ) ?? null;
+}
+
 function stageHasParticipant(stage: IssueExecutionStage, participant: IssueExecutionStagePrincipal | null): boolean {
   if (!participant) return false;
   return stage.participants.some((candidate) => principalsEqual(candidate, participant));


### PR DESCRIPTION
## Thinking Path

> - Paperclip excludes an issue's execution return assignee when it selects approval participants.
> - A policy narrowing and an assignee/restart PATCH can read different stale snapshots and otherwise commit a configuration that has no reachable approval path or a transition planned from an obsolete policy.
> - The write path must use a locked current issue row for final eligibility validation and reject stale execution inputs before persistence.

## Linked Issues or Issue Description

**What happened?**

An execution policy could be created or updated with an approval stage whose only participant was the return executor. Concurrent policy and assignment writes could also jointly persist that unreachable policy. Separately, validating every explicit status change blocked unrelated transitions on legacy invalid policies.

**Expected behavior**

New policy/assignee writes and actual workflow starts or `changes_requested` restarts validate approval eligibility from the locked current row. If the status, assignee, execution policy, or execution state changed after preflight, the stale execution update is rejected and retried. Unrelated explicit status changes on legacy invalid policies remain compatible.

**Steps to reproduce**

1. Assign an issue to agent A with approval participants A and B.
2. Concurrently narrow the policy to only B and reassign the issue to B.
3. Before this fix, both PATCHes return success and persist an unreachable approval stage.
4. For a legacy invalid policy, PATCH the issue to `cancelled`; before this fix, the unrelated transition incorrectly returns HTTP 400.

**Paperclip version or commit**

Reproduced on current `master` at `38752c4e5e31495889000f199bd35d4b7945d356`.

**Deployment mode**

Local development test environment with embedded Postgres.

## Summary

- Revalidate approval eligibility inside the existing row-lock transaction before the issue write.
- Treat only policy/assignee changes plus real workflow starts and `changes_requested` restarts as eligibility triggers; legacy unrelated explicit statuses are allowed.
- Reject stale execution-policy/status/assignee/execution-state snapshots so starts and restarts cannot persist a transition planned from an obsolete policy.

## What Changed

- Serialize policy narrowing with reassignment using the current locked issue row.
- Add deterministic database-trigger regressions for the policy/reassignment race, stale workflow restart, and stale workflow start.
- Update the existing route mock expectation because policy writes now execute in the lock transaction.

## Test plan

- `corepack pnpm exec vitest run --project @paperclipai/server --no-file-parallelism --maxWorkers=1 server/src/__tests__/issue-create-deduplication-routes.test.ts server/src/__tests__/issue-execution-policy.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts`
  - 104 passed.
- `git diff --check` and the staged security scan passed.
- `corepack pnpm exec tsc --noEmit --project server/tsconfig.json` was attempted but killed with SIGKILL because this host exhausted available memory/swap; CI remains the authoritative typecheck gate.

## Verification

- Deterministic RED→GREEN coverage proved the original policy/reassignment race initially returned `[200, 200]` and persisted invalid state, then passes as `[200, 400]` with valid persisted state.
- The legacy unrelated-status regression initially returned HTTP 400 and now passes with HTTP 200; a real workflow start remains rejected.
- Independent exact-snapshot review passed for staged digest `6cb3831d09dcd265d1a6d3f970c4114faff02319402a12c7120f7121fab33cbd` before publication.

## Safety and rollback

- **Risk level:** Low to moderate. Concurrent execution-input changes now return a retryable HTTP 409 rather than persisting a stale execution transition; impossible approval configurations return HTTP 400.
- **Rollback:** Revert this PR. No migration or data repair is required.

## Risks

A client can receive a conflict under concurrent execution-policy/status/assignment updates and must retry against the latest issue state. This is intentional to preserve policy correctness.

## Model Used

OpenAI Codex `gpt-5.6-terra`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change.
- [x] I have specified the model used with version and capability details.
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work.
- [x] I have searched GitHub for duplicate or related PRs and linked or described the result above.
- [x] I have described the issue in-PR following the bug-report template.
- [x] I have not referenced internal or instance-local Paperclip issues or links.
- [x] My branch name describes the change and contains no internal ticket id.
- [x] I have run tests locally and they pass.
- [x] I have added or updated tests where applicable.
- [x] I have considered and documented risks above.
- [ ] All Paperclip CI gates are green.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups.
- [x] I will address all Greptile and reviewer comments before requesting merge.
