### PR TITLE
fix(ui): add app-wide ErrorBoundary to prevent blackscreen on render throws

### DIFF
--- a/ui/src/components/AppErrorBoundary.test.tsx
+++ b/ui/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppErrorBoundary } from "./AppErrorBoundary";
+
+function Boom(): never {
+  throw new Error("Cannot read properties of undefined (reading 'title')");
+}
+
+describe("AppErrorBoundary", () => {
+  let container: HTMLDivElement;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    // React logs caught render errors to console.error; silence the expected noise.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    container.remove();
+  });
+
+  it("renders visible fallback UI instead of an empty tree when a descendant throws", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppErrorBoundary>
+          <Boom />
+        </AppErrorBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain("Something went wrong");
+    expect(container.textContent).toContain("Cannot read properties of undefined (reading 'title')");
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(container.children.length).toBeGreaterThan(0);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("logs the error and component stack via console.error", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppErrorBoundary>
+          <Boom />
+        </AppErrorBoundary>,
+      );
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Unhandled render error crashed the app",
+      expect.objectContaining({
+        error: expect.any(Error),
+        componentStack: expect.stringContaining("Boom"),
+      }),
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("renders children normally when nothing throws", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppErrorBoundary>
+          <div>All good</div>
+        </AppErrorBoundary>,
+      );
+    });
+
+    expect(container.textContent).toBe("All good");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("exposes the component stack in a collapsible details section", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <AppErrorBoundary>
+          <Boom />
+        </AppErrorBoundary>,
+      );
+    });
+
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details?.textContent).toContain("Boom");
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/AppErrorBoundary.tsx
+++ b/ui/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,125 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type AppErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  error: Error | null;
+  componentStack: string | null;
+};
+
+// Sits above <App /> in main.tsx, outside routing/layout, so it catches
+// render throws from ANY component in the tree -- including ones that
+// currently have no local boundary (route-less providers, Layout chrome,
+// etc). Without this, an uncaught render error unmounts the whole React
+// tree and leaves `<div id="root">` empty; since the app defaults to a dark
+// theme, that reads to users as a plain black screen with no clue anything
+// went wrong (RENA-52061 / RENA-55148).
+//
+// The fallback below intentionally does NOT rely on Tailwind theme classes
+// or CSS custom properties (--background, --foreground, etc). If a theme
+// variable is itself the reason for a crash, or the app crashed before the
+// theme's CSS variables were applied to <html>, class-based styling could
+// render invisible-on-invisible. Inline styles with hardcoded colors always
+// render legibly regardless of theme state.
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  override state: AppErrorBoundaryState = { error: null, componentStack: null };
+
+  static getDerivedStateFromError(error: unknown): AppErrorBoundaryState {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      componentStack: null,
+    };
+  }
+
+  override componentDidCatch(error: unknown, info: ErrorInfo): void {
+    this.setState({ componentStack: info.componentStack ?? null });
+    console.error("Unhandled render error crashed the app", { error, componentStack: info.componentStack });
+  }
+
+  override render() {
+    const { error, componentStack } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div
+        role="alert"
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 2147483647,
+          overflow: "auto",
+          background: "#18181b",
+          color: "#f4f4f5",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
+          padding: "2rem 1.5rem",
+          boxSizing: "border-box",
+        }}
+      >
+        <div style={{ maxWidth: "42rem", margin: "0 auto" }}>
+          <h1 style={{ fontSize: "1.25rem", fontWeight: 600, margin: 0 }}>Something went wrong</h1>
+          <p style={{ marginTop: "0.5rem", fontSize: "0.875rem", color: "#a1a1aa" }}>
+            The app hit an unexpected error while rendering and can&apos;t continue. Reloading usually
+            fixes this; if it keeps happening, please share the details below.
+          </p>
+          <pre
+            style={{
+              marginTop: "1rem",
+              overflow: "auto",
+              borderRadius: "0.375rem",
+              border: "1px solid #f87171",
+              background: "rgba(248, 113, 113, 0.12)",
+              color: "#fca5a5",
+              padding: "0.75rem",
+              fontSize: "0.75rem",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {error.message}
+          </pre>
+          {componentStack ? (
+            <details style={{ marginTop: "0.75rem" }}>
+              <summary style={{ cursor: "pointer", fontSize: "0.8125rem", color: "#a1a1aa" }}>
+                Component stack
+              </summary>
+              <pre
+                style={{
+                  marginTop: "0.5rem",
+                  overflow: "auto",
+                  borderRadius: "0.375rem",
+                  border: "1px solid #3f3f46",
+                  background: "#27272a",
+                  color: "#d4d4d8",
+                  padding: "0.75rem",
+                  fontSize: "0.75rem",
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {componentStack}
+              </pre>
+            </details>
+          ) : null}
+          <div style={{ marginTop: "1.25rem" }}>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              style={{
+                border: "1px solid #52525b",
+                borderRadius: "0.375rem",
+                background: "#3f3f46",
+                color: "#f4f4f5",
+                padding: "0.5rem 1rem",
+                fontSize: "0.875rem",
+                cursor: "pointer",
+              }}
+            >
+              Reload page
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "@/lib/router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./App";
+import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { CompanyProvider, useCompany } from "./context/CompanyContext";
 import { LiveUpdatesProvider } from "./context/LiveUpdatesProvider";
 import { BreadcrumbProvider } from "./context/BreadcrumbContext";
@@ -54,32 +55,34 @@ function CompanyAwareBreadcrumbProvider({ children }: { children: React.ReactNod
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <BrowserRouter>
-          <CompanyProvider>
-            <EditorAutocompleteProvider>
-              <ToastProvider>
-                <LiveUpdatesProvider>
-                  <TooltipProvider>
-                    <CompanyAwareBreadcrumbProvider>
-                      <SidebarProvider>
-                        <PanelProvider>
-                          <PluginLauncherProvider>
-                            <DialogProvider>
-                              <App />
-                            </DialogProvider>
-                          </PluginLauncherProvider>
-                        </PanelProvider>
-                      </SidebarProvider>
-                    </CompanyAwareBreadcrumbProvider>
-                  </TooltipProvider>
-                </LiveUpdatesProvider>
-              </ToastProvider>
-            </EditorAutocompleteProvider>
-          </CompanyProvider>
-        </BrowserRouter>
-      </ThemeProvider>
-    </QueryClientProvider>
+    <AppErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <BrowserRouter>
+            <CompanyProvider>
+              <EditorAutocompleteProvider>
+                <ToastProvider>
+                  <LiveUpdatesProvider>
+                    <TooltipProvider>
+                      <CompanyAwareBreadcrumbProvider>
+                        <SidebarProvider>
+                          <PanelProvider>
+                            <PluginLauncherProvider>
+                              <DialogProvider>
+                                <App />
+                              </DialogProvider>
+                            </PluginLauncherProvider>
+                          </PanelProvider>
+                        </SidebarProvider>
+                      </CompanyAwareBreadcrumbProvider>
+                    </TooltipProvider>
+                  </LiveUpdatesProvider>
+                </ToastProvider>
+              </EditorAutocompleteProvider>
+            </CompanyProvider>
+          </BrowserRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </AppErrorBoundary>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- Adds `AppErrorBoundary`, a top-level React error boundary wrapping `<App />` in `ui/src/main.tsx`, outside routing/layout, so it catches render throws from any component that isn't already covered by a local boundary.
- The fallback UI uses hardcoded inline styles (not Tailwind theme classes) so it stays visible even if a theme variable is implicated in the crash, or the app crashed before theme classes were applied to `<html>`. It shows the error message, a collapsible component stack, and a reload button.
- Logs the caught error + component stack via `console.error`. No client-error-reporting backend endpoint exists yet, so per the linked issue's scope this stays console-only — no new backend route added.
- Adds `AppErrorBoundary.test.tsx` covering: visible fallback on throw, console.error logging, normal passthrough when nothing throws, and the collapsible stack section.

## Context (RENA-55148 / RENA-52061)
RENA-52061 was reported as rendering pure black in the Paperclip UI despite the API returning valid data. Root cause: there was no app-wide error boundary, so any render throw outside the existing local boundaries (`PluginSlotErrorBoundary`, `LauncherErrorBoundary`, `IssueChatErrorBoundary`) unmounted the whole React tree, leaving `<div id="root">` empty — indistinguishable from a black screen on this app's dark-by-default theme.

Investigation notes:
- `RouteErrorBoundary` (added 2026-06-19, wraps `<Outlet/>` inside `Layout.tsx`) already covers board routes, but the **currently deployed bundle predates that commit** (verified: the deployed JS at the time of this fix contains no `"This page hit an error"` string). The live UI was running with *zero* error boundaries of any kind.
- Reproduced the two prime suspects named in the issue against the real RENA-52061 production payloads (fetched via `GET /api/issues/RENA-52061`, `/interactions`, `/runs`) in isolated jsdom render harnesses:
  - `IssueThreadInteractionCard` rendering the real `request_checkbox_confirmation` interaction (`f6c356af-ba2a-4414-b644-0540d2cf7529`) — renders cleanly, no throw.
  - `IssueRunLedgerContent` rendering the real 9-run history (including `timed_out`/`failed`/`cancelled` runs) — renders cleanly, no throw.
  - Neither reproduces a crash in isolation, so the specific still-live render throw (if any survives on current `master`) wasn't pinpointed from these two components. This PR's boundary makes any *remaining* throw surface as a readable error instead of a black screen, which is the primary ask.

## Test plan
- [x] `pnpm --filter @paperclipai/ui exec vitest run src/components/AppErrorBoundary.test.tsx` — 4/4 passing
- [x] `pnpm --filter @paperclipai/ui exec tsc -b --force` — clean
- [x] `pnpm --filter @paperclipai/ui build` — succeeds; verified `"Something went wrong"` fallback string present in the built bundle
- [ ] Manual browser verification against RENA-52061 after deploy (not done in this session — no browser/DevTools access; deploying to the live instance that also runs this agent session needs separate authorization, tracked on RENA-55148)
