### PR TITLE
fix(server): preserve Date instances in run secret redaction

### DIFF
--- a/server/src/__tests__/run-secret-redaction.test.ts
+++ b/server/src/__tests__/run-secret-redaction.test.ts
@@ -54,4 +54,29 @@ describe("registered run secret redaction", () => {
     expect(redactRegisteredSecretValues("token-extended token", ["token-extended", "token"]))
       .toBe(`${REDACTED_EVENT_VALUE} ${REDACTED_EVENT_VALUE}`);
   });
+
+  it("preserves Date instances instead of flattening them to {}", () => {
+    const createdAt = new Date("2026-08-06T11:21:15.340Z");
+    const result = redactRegisteredSecretValues({
+      createdAt,
+      finishedAt: null,
+      stdoutExcerpt: `stdout ${secret}`,
+    }, [secret]);
+
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.createdAt.toISOString()).toBe("2026-08-06T11:21:15.340Z");
+    expect(result.finishedAt).toBeNull();
+    expect(result.stdoutExcerpt).toBe(`stdout ${REDACTED_EVENT_VALUE}`);
+  });
+
+  it("preserves Date instances nested in arrays and objects", () => {
+    const at = new Date("2026-08-06T11:21:15.340Z");
+    const result = redactRegisteredSecretValues({
+      runs: [{ startedAt: at }],
+      nested: { deep: { updatedAt: at } },
+    }, [secret]);
+
+    expect(result.runs[0].startedAt).toBeInstanceOf(Date);
+    expect(result.nested.deep.updatedAt).toBeInstanceOf(Date);
+  });
 });

--- a/server/src/services/run-secret-redaction.ts
+++ b/server/src/services/run-secret-redaction.ts
@@ -41,6 +41,9 @@ function redactText(input: string, values: string[]) {
 
 export function redactRegisteredSecretValues<T>(input: T, values: string[]): T {
   if (typeof input === "string") return redactText(input, values) as T;
+  // Non-plain objects carry their value in internal slots, not in own enumerable
+  // properties, so the Object.entries walk below would flatten them to `{}`.
+  if (input instanceof Date) return input;
   if (Array.isArray(input)) return input.map((value) => redactRegisteredSecretValues(value, values)) as T;
   const record = asRecord(input);
   if (!record) return input;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Every heartbeat run response passes through the run secret redaction service, which scrubs registered secret values before the data reaches the client
> - That service walks the payload recursively, but it treats any non string, non array object as a plain record, so it flattens `Date` instances to `{}`
> - The web UI then calls `new Date({})`, which gives `Invalid Date`, so run timestamps are unreadable and the agent dashboard fails to render at all
> - This pull request returns `Date` instances untouched, before the record branch
> - The benefit is that run timestamps render correctly again, and the agent dashboard loads, with no change to secret redaction behaviour

## Linked Issues or Issue Description

Fixes: #10964

## What Changed

- `server/src/services/run-secret-redaction.ts`: return `Date` instances untouched in `redactRegisteredSecretValues()`, before the record branch. A comment states why, because the failure is silent.
- `server/src/__tests__/run-secret-redaction.test.ts`: add a test that a top level `Date` survives, that `null` stays `null`, and that a sibling string is still redacted.
- `server/src/__tests__/run-secret-redaction.test.ts`: add a test that a `Date` survives inside an array and inside a nested object.

## Verification

Run the unit tests:

```
pnpm --filter @paperclipai/server test run-secret-redaction
```

I could not run the repository test runner in my environment. Instead I ran the pre-fix and the post-fix implementations side by side on one payload, to confirm the new tests assert a real difference and are not vacuous:

```
before  createdAt = {}                          isDate: false
after   createdAt = "2026-08-06T11:21:15.340Z"  isDate: true
after   nested in array                         isDate: true
after   nested in object                        isDate: true
after   stdoutExcerpt = "stdout [redacted]"     redaction still applied
```

On `master` the first assertion of each new test sees `{}` and fails. Please run the suite in CI to confirm.

Manual check on a self hosted instance (`ghcr.io/paperclipai/paperclip:latest`, commit `2ea22d6`, external Postgres):

1. Open an agent that has at least one completed heartbeat run.
2. Before the fix, the run list shows `Invalid Date` on every row. The agent dashboard shows an error boundary with `Invalid time value`.
3. Apply the compiled equivalent of this change. Restart the server.
4. After the fix, the run list shows relative timestamps. The agent dashboard renders.

The rows in Postgres were correct in both cases. The corruption happened on the way out.

## Risks

Low risk.

- The change is a single early return. It cannot alter the redaction of strings, arrays, or plain objects.
- It does not widen what reaches the client. A `Date` carries no secret material, and its own enumerable property set is empty, so the previous walk never redacted anything inside it. It only destroyed the value.
- No migration. No schema change. No API contract change, other than timestamp fields returning their real value instead of `{}`.
- One behavioural shift to be aware of: any client that adapted to `{}` in these fields now receives a real date. I found no such client in this repository.

A wider variant is possible. `asRecord()` could accept only plain objects, which would also cover `Map`, `Set`, `RegExp` and `Buffer` on this path. A `Buffer` does not flatten to `{}` but to an index keyed object, which is a quieter form of the same bug. I kept the narrow fix, because the blast radius is smaller on a security sensitive function. Tell me if you prefer the wider shape.

## Model Used

Claude Opus 5, model id `claude-opus-5[1m]`, 1M context window, extended thinking enabled, with tool use and code execution. The model read the compiled bundle on a running instance, traced the root cause, wrote the fix and the tests, and verified the before and after behaviour. A human reviewed and approved each step.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass (see Verification: I verified the fix by running both implementations side by side on the same payload, but I could not run the repo test runner itself)
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user facing documentation covers this internal function)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

<sub>Duplicate search: I searched the PR list for `redaction`, `Date`, `run-secret`, `"Invalid Date"` and `redactRegisteredSecretValues`. The only other PR that touches this function is #9934 (closed), which added human approved secret proposals and is unrelated. No open or merged PR fixes this bug.</sub>
