### PR TITLE
docs(auth): document current board API keys

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -39,13 +39,74 @@ Returns the agent record including ID, company, role, chain of command, and budg
 
 ## Board Operator Authentication
 
+Board operators can authenticate either with an interactive browser session or with a board API key. Both methods act as the board user who authenticated, but they have different lifetimes and handling requirements.
+
 ### Local Trusted Mode
 
 No authentication required. All requests are treated as the local board operator.
 
 ### Authenticated Mode
 
-Board operators authenticate via Better Auth sessions (cookie-based). The web UI handles login/logout flows automatically.
+The web UI authenticates board operators with a Better Auth cookie session. This is the preferred method for interactive use: the browser handles sign-in, sends the cookie, and logs out through the normal UI flow.
+
+### Board API Keys
+
+Board API keys are Bearer credentials for scripts and other non-interactive board automation. They belong to the board user who creates them. A user can list or revoke only their own keys; there is no instance-wide key registry or revoke-any operation.
+
+<Warning>
+  **Board API keys are currently unscoped.** A key acts with all of its owner's live board authority. A key owned by an instance administrator therefore has full instance-admin access, including every company and administrative operation available to that owner. Treat a board key like an administrator password, use it only where a short-lived session is impractical, and do not give it to agents or third parties that do not need that authority.
+</Warning>
+
+#### Create, list, and revoke with the CLI
+
+Set the API URL for the target instance. In authenticated mode, run the create command from an interactive terminal so the CLI can guide you through board sign-in if it does not already have a stored board credential.
+
+```sh
+export PAPERCLIP_API_URL="https://paperclip.example.com"
+paperclipai token board create --name "nightly automation" --never-expires
+```
+
+`--never-expires` is explicit: omitting expiration options creates a key that expires after 30 days. You can instead use `--ttl-days <days>` or `--expires-at <iso8601>`. A never-expiring key removes the automatic expiry safety net, so prefer a finite lifetime whenever the automation can rotate credentials.
+
+The successful create response prints the plaintext `pcp_board_*` token exactly once. Copy it immediately to a secret manager. Paperclip stores only a SHA-256 hash of the complete token and cannot show the plaintext again. The `pcp_board_` prefix is part of the credential; store and send the full value without removing or replacing it.
+
+List your active keys to obtain the key ID, then revoke a key by ID:
+
+```sh
+paperclipai token board list
+paperclipai token board revoke <key-id>
+```
+
+Creation and revocation write `board_api_key.created` and `board_api_key.revoked` activity records. Successful authentication also updates the key's `lastUsedAt` timestamp. Expired and revoked credentials no longer authenticate.
+
+#### Create with the REST API
+
+`POST /api/board-api-keys` creates a key for the authenticated board user. The following payload creates a never-expiring key; `expiresAt: null` is the REST equivalent of `--never-expires`:
+
+```json
+{
+  "name": "nightly automation",
+  "expiresAt": null
+}
+```
+
+Omit `expiresAt` for the 30-day default, or provide an ISO 8601 timestamp. The `token` field appears only in the successful `201` response. `GET /api/board-api-keys` lists the current user's active keys; add `?includeInactive=true` to include expired and revoked keys. `DELETE /api/board-api-keys/{keyId}` revokes one owned by that user.
+
+#### Use a board API key
+
+Load the plaintext key from a secret manager into an environment variable. Never put a literal key in source code, shell history, documentation, or logs.
+
+```sh
+curl -fsS \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  "$PAPERCLIP_API_URL/api/companies"
+```
+
+#### Rotation and compromise response
+
+Rotate without downtime by creating a replacement key, updating and testing every consumer, and then revoking the old key. Rotate never-expiring keys on a schedule even though Paperclip will not expire them automatically.
+
+If a key may be compromised, use an interactive cookie session or a separate trusted board key to revoke it immediately. Replace the credential in every consumer and review activity plus `lastUsedAt` for unexpected use. Revocation and expiry are checked on later authentication attempts, so the key fails on its next request. They cannot cancel a request that was already authenticated and is still in flight; investigate and remediate any side effects from that residual request separately.
 
 ## Company Scoping
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane that people use to manage AI-agent companies.
> - Board operators need authenticated automation as well as interactive browser access.
> - Paperclip already provides unscoped board API keys, but the authentication guide does not explain them.
> - Operators cannot use the existing key lifecycle safely when the endpoint, CLI commands, and authority model are not visible.
> - This pull request documents the current board API key behavior and its security limits.
> - The benefit is that operators can create, use, rotate, and revoke a key without treating it as a scoped credential.

## Linked Issues or Issue Description

Refs: #3479

Related implementation attempt: #4220

## What Changed

- Distinguished interactive cookie sessions from board API keys.
- Documented REST and CLI create, list, and revoke flows, including never-expiring keys.
- Documented per-user ownership, one-time plaintext display, token prefix handling, hashing, expiry, revocation, and activity records.
- Added a Bearer request example that reads the key from an environment variable.
- Added a prominent warning for current unscoped instance-admin authority and compromise response limits.

## Verification

- `npx --yes mintlify@latest validate`
- `git diff --check`

## Risks

- Low risk. This pull request changes documentation only.
- The guide intentionally describes the current unscoped behavior. A later scoped-key release must update it with the new contract.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`. The runtime did not expose its context-window size. The model used reasoning, repository tools, code execution, and GitHub CLI access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge