### PR TITLE
perf(db): index context_snapshot/payload issueId lookups used by recovery sweeps

### DIFF
--- a/packages/db/src/heartbeat-context-snapshot-index-migration.test.ts
+++ b/packages/db/src/heartbeat-context-snapshot-index-migration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, afterEach } from "vitest";
+import postgres from "postgres";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./test-embedded-postgres.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+const support = await getEmbeddedPostgresTestSupport();
+const d = support.supported ? describe : describe.skip;
+
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()?.();
+});
+
+d("heartbeat context_snapshot expression index migration", () => {
+  it("applies full migration chain and uses the new indexes", async () => {
+    const dbh = await startEmbeddedPostgresTestDatabase("pap16575-idx-");
+    cleanups.push(() => dbh.cleanup());
+    const sql = postgres(dbh.connectionString, { max: 1 });
+    cleanups.push(async () => { await sql.end(); });
+
+    const idx = await sql`SELECT indexname FROM pg_indexes WHERE tablename IN ('heartbeat_runs','agent_wakeup_requests')`;
+    const names = idx.map((r) => r.indexname as string);
+    expect(names).toContain("heartbeat_runs_company_ctx_issue_created_idx");
+    expect(names).toContain("heartbeat_runs_company_ctx_task_created_idx");
+    expect(names).toContain("agent_wakeup_requests_company_payload_issue_idx");
+
+    await sql.unsafe("SET enable_seqscan = off");
+    const plan = await sql.unsafe(
+      "EXPLAIN SELECT id FROM heartbeat_runs WHERE company_id = '00000000-0000-0000-0000-000000000001' AND context_snapshot ->> 'issueId' = 'x' ORDER BY created_at DESC, id DESC LIMIT 1",
+    );
+    const planText = plan.map((r) => Object.values(r)[0]).join("\n");
+    expect(planText).toContain("heartbeat_runs_company_ctx_issue_created_idx");
+
+    const wakePlan = await sql.unsafe(
+      "EXPLAIN SELECT id FROM agent_wakeup_requests WHERE company_id = '00000000-0000-0000-0000-000000000001' AND status = 'deferred_issue_execution' AND payload ->> 'issueId' = 'x' LIMIT 1",
+    );
+    const wakeText = wakePlan.map((r) => Object.values(r)[0]).join("\n");
+    expect(wakeText).toContain("agent_wakeup_requests_company_payload_issue_idx");
+  }, 240_000);
+});

--- a/packages/db/src/migrations/0209_heartbeat_context_snapshot_indexes.sql
+++ b/packages/db/src/migrations/0209_heartbeat_context_snapshot_indexes.sql
@@ -1,0 +1,4 @@
+CREATE INDEX "heartbeat_runs_company_ctx_issue_created_idx" ON "heartbeat_runs" USING btree ("company_id", ("context_snapshot" ->> 'issueId'), "created_at" DESC);--> statement-breakpoint
+CREATE INDEX "heartbeat_runs_company_ctx_task_created_idx" ON "heartbeat_runs" USING btree ("company_id", ("context_snapshot" ->> 'taskId'), "created_at" DESC);--> statement-breakpoint
+-- paperclip:migration-safety-ignore large-create-index-not-concurrently: Drizzle migrations run transactionally, so CONCURRENTLY is unavailable. This expression index removes per-issue full scans of agent_wakeup_requests in recovery sweeps (hasActiveExecutionPath), which currently dominate server load; the one-time build lock is the lesser cost.
+CREATE INDEX "agent_wakeup_requests_company_payload_issue_idx" ON "agent_wakeup_requests" USING btree ("company_id", ("payload" ->> 'issueId'));

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1450,6 +1450,13 @@
       "when": 1785988680096,
       "tag": "0208_keen_sharon_carter",
       "breakpoints": true
+    },
+    {
+      "idx": 209,
+      "version": "7",
+      "when": 1786020026023,
+      "tag": "0209_heartbeat_context_snapshot_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_wakeup_requests.ts
+++ b/packages/db/src/schema/agent_wakeup_requests.ts
@@ -40,5 +40,9 @@ export const agentWakeupRequests = pgTable(
     reviewPathRecoveryIdempotencyUq: uniqueIndex("agent_wakeup_requests_review_path_recovery_idempotency_uq")
       .on(table.companyId, table.idempotencyKey)
       .where(sql`${table.idempotencyKey} LIKE 'issue_review_path_lost:%' AND ${table.status} <> 'skipped'`),
+    companyPayloadIssueIdx: index("agent_wakeup_requests_company_payload_issue_idx").on(
+      table.companyId,
+      sql`(${table.payload} ->> 'issueId')`,
+    ),
   }),
 );

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { type AnyPgColumn, pgTable, uuid, text, timestamp, jsonb, index, integer, bigint, boolean } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -86,6 +87,16 @@ export const heartbeatRuns = pgTable(
     ),
     companyCreatedAtDescIdx: index("heartbeat_runs_company_created_at_desc_idx").on(
       table.companyId,
+      table.createdAt.desc(),
+    ),
+    companyCtxIssueCreatedIdx: index("heartbeat_runs_company_ctx_issue_created_idx").on(
+      table.companyId,
+      sql`(${table.contextSnapshot} ->> 'issueId')`,
+      table.createdAt.desc(),
+    ),
+    companyCtxTaskCreatedIdx: index("heartbeat_runs_company_ctx_task_created_idx").on(
+      table.companyId,
+      sql`(${table.contextSnapshot} ->> 'taskId')`,
       table.createdAt.desc(),
     ),
   }),


### PR DESCRIPTION
## Why the server was slow (PAP-16575)

The 30-second heartbeat scheduler tick runs `reconcileStrandedAssignedIssues`, which iterates every candidate issue (currently **462**: 304 in_review + 76 in_progress + 82 todo) and, per issue, calls `getLatestIssueRun` / `getLatestIssueRunForAgent` / `hasActiveExecutionPath`. All of these filter `heartbeat_runs` on `context_snapshot ->> 'issueId'`, which has **no matching index**.

Measured on the live instance:

- Each `getLatestIssueRun` call walks ~26k rows via `heartbeat_runs_company_created_at_desc_idx` and **detoasts every row's `context_snapshot`** (the table is 84 MB heap + **2.1 GB TOAST**) to evaluate the JSONB filter: **645 ms per query** (`EXPLAIN ANALYZE`: `Rows Removed by Filter: 25816`, 130k buffers).
- ~766 such queries per sweep ≈ **500 s of DB work scheduled every 30 s** — the sweep can never finish before the next tick. `pg_stat_activity` sampling shows these two queries running in 15/15 and 12/15 samples; `heartbeat_runs` has accumulated 10.8 **billion** seq tuples read.
- `hasActiveExecutionPath` additionally scans `agent_wakeup_requests` (**1.8M rows**, 1 GB) on `payload ->> 'issueId'`, also unindexed.

## Fix

Add expression indexes (mirrored in the drizzle schema, hand-written migration 0209 following the 0206 precedent):

- `heartbeat_runs (company_id, (context_snapshot ->> 'issueId'), created_at DESC)`
- `heartbeat_runs (company_id, (context_snapshot ->> 'taskId'), created_at DESC)`
- `agent_wakeup_requests (company_id, (payload ->> 'issueId'))` (large-table pragma with justification)

These turn the per-issue lookups into index scans; the recovery sweep drops from ~500 s of DB work per tick to milliseconds.

## Verification

- `check:migrations` (numbering + safety) passes.
- New `heartbeat-context-snapshot-index-migration.test.ts` boots a fresh embedded Postgres, applies the full migration chain (0000→0209), asserts all three indexes exist, and asserts via `EXPLAIN` that the planner uses them for the exact hot query shapes.
- `tsc --noEmit` clean for packages/db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)