### PR TITLE
feat(ui): add canonical next-action guidance

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -507,10 +507,13 @@ V1 non-terminal liveness rule:
 - unmanaged shell jobs, detached sessions, adapter child processes, local polling loops, PIDs, logs, and comments are evidence rather than liveness; a managed runtime service counts only when paired with a persisted monitor, wake, blocker, or delegated issue that owns the next check
 - heartbeat finalization evaluates liveness from persisted Paperclip state; an issue cannot remain healthy `in_progress` solely because the exiting heartbeat started a local/background watcher
 - invalid external-wait recovery queues at most one normal-model continuation per source-state fingerprint, then requires a real blocker or explicit recovery action instead of repeating equivalent recovery wakes; new durable source activity may establish a new fingerprint
+- every agent-owned non-terminal issue, and every unresolved blocker leaf, must expose one canonical next-action answer that is both machine-readable and human-readable. The answer is derived from durable control-plane state and names the action-path kind, source issue, target run/wake/participant/interaction/approval/monitor/owner/blocker/gate/recovery action, responsible owner, reason, evidence, and wake/monitor/retry/timeout/escalation policy.
+- terminal post-run gates such as `workspace_finalize_pending` are routed blockers, not opaque `done` issue blockers. If a terminal issue still prevents dependents from moving, the dependent's next-action answer must name the gate or the explicit recovery action that owns the gate. When blockers cannot target the gate directly, dependents must block on a source-scoped or issue-backed recovery action instead of only on the terminal issue.
 - when Paperclip cannot safely infer the next action, it surfaces the problem through visible blocked/recovery work instead of silently completing or reassigning work
 - explicit recovery actions are the liveness primitive; source-scoped actions are the default form, issue-backed recovery is a fallback for independent repair work or safety boundaries, and comments alone are evidence rather than a healthy liveness path
 - source-scoped recovery routing is cause-keyed: lost processes, missing successful-run dispositions, and output-inactivity terminations retry the original agent when invokable; provider-quota failures create/reuse a scheduled wait-recovery monitor without a takeover wake; workspace validation and unknown causes route to the manager ladder
 - recovery-scoped wakes replace the normal deliverable execution contract with a cause-specific recovery contract, and successful repair returns the issue to the recorded original owner by default while recording `handed_back` versus `owner_completed`
+- the liveness contract preserves three invariants: productive work continues through a capable live path, real blockers are named instead of inferred from stale status or prose, and recovery cannot spin indefinitely because bounded retries, fingerprints, and explicit escalation replace repeated ambiguous wakes
 
 Detailed ownership, execution, blocker, active-run watchdog, crash-recovery, and non-terminal liveness semantics are documented in `doc/execution-semantics.md`.
 
@@ -1127,6 +1130,10 @@ Behavior:
 The optional `modelProfiles.cheap` lane is not a retry worker lane. Paperclip may request the cheap profile only for status-only recovery coordination, and those wakes must include guard context that prevents deliverable work and document/plan updates (`allowDeliverableWork: false`, `allowDocumentUpdates: false`, `resumeRequiresNormalModel: true`).
 
 Failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, and downstream source-work child/requeue/resume contexts must use the normal/original model lane. If cheap recovery repairs liveness while actual work remains, the next live continuation path must be a separate normal-model worker run with cheap hints scrubbed.
+
+Cheap/status-only recovery must fingerprint handoffs to the normal lane by company, source issue, recovery or gate kind, required action kind, target key, and evidence point. For each fingerprint, Paperclip may create exactly one normal-model continuation, wake, or recovery issue capable of doing the required source or deliverable work. Repeated cheap/status-only observations for the same fingerprint reuse the existing next-action answer or record a suppressed duplicate; they must not create duplicate normal continuations.
+
+If the normal continuation for a fingerprint finishes and the same required work remains unresolved, Paperclip escalates to an explicit recovery action for that fingerprint instead of scheduling another cheap/status-only recovery. This preserves productive work, stops only on real blockers, and prevents cheap-lane recovery loops.
 
 ## 11.6 Scheduler Rules
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -315,6 +315,24 @@ Recovery from an invalid external wait is bounded and idempotent:
 
 This rule is intentionally conservative: local watcher evidence can help the recovery owner decide what happened, but only persisted control-plane state can prove that the work will move again.
 
+### Canonical next-action answer
+
+For every agent-owned non-terminal issue, and for every unresolved blocker leaf that prevents another issue from moving, Paperclip must expose one canonical answer to "what moves this forward next?"
+
+That answer is both machine-readable and human-readable. The machine-readable shape must be derived from durable control-plane state, not from comments or transcripts, and must include at least:
+
+- `kind`: the action-path primitive, such as `active_run`, `queued_wake`, `review_participant`, `pending_interaction`, `pending_approval`, `monitor`, `human_owner`, `blocker_leaf`, `terminal_post_run_gate`, `explicit_recovery_action`, or `external_owner`
+- `sourceIssueId`: the issue whose liveness is being explained
+- `target`: the run, wake, participant, interaction, approval, monitor, owner, blocker leaf, gate, or recovery action that owns the next move
+- `owner`: the agent, user, board, system recovery owner, or named external owner responsible for that move
+- `reason`: a stable reason code plus a short human-readable sentence
+- `evidence`: bounded references to the durable state used to compute the answer, such as run ids, blocker ids, interaction ids, gate ids, workspace operation ids, document revision ids, or recovery fingerprints
+- `policy`: any wake, monitor, retry, timeout, or escalation bound that will move the answer forward
+
+UI summaries, issue diagnostics, blocker diagnostics, task watchdogs, and recovery scans may render this answer differently, but they must agree on the same underlying machine-readable answer for the same snapshot. If several signals are present, the canonical answer is the first valid action path that can actually move the issue. A queued wake that cannot dispatch because of workspace incoherence, missing configuration, budget stop, or another active gate is not a live answer; the answer must instead name the gate or recovery action that owns the failed delivery.
+
+The answer is not a replacement for issue status. It is the liveness explanation for the current status. A comment, document annotation, raw run log, or prose "waiting" note can be evidence in the answer, but cannot be the answer unless it has been converted into a first-class primitive such as a blocker, owner, interaction, monitor, or explicit recovery action.
+
 ### Comment and document activity wake sources
 
 Issue-thread comments and document-scoped comments have different wake semantics.
@@ -373,6 +391,16 @@ The state `projectWorkspaceId` plus `executionWorkspaceId` without `projectId` i
 Workspace incoherence feeds into the same non-terminal liveness and stranded assigned-work model as a disappeared run. The recovery path should first fail or reject the incoherent wake, then either repair and requeue one bounded continuation for the same assignee or surface an explicit recovery action. It must not leave an agent-owned `in_progress` issue healthy solely because a wake record exists that would invoke the adapter in the wrong cwd, a non-git directory where git is required, an unrelated project workspace, or an unrecoverable missing worktree.
 
 For runtime-created `git_worktree` execution workspaces, branch coherence is part of workspace coherence. The persisted execution workspace branch is the recorded branch for future dispatch. Reusing that workspace must verify that the worktree is still registered and that `HEAD` is on the recorded branch. Successful run finalization must perform the same check before recording `workspace_finalize=succeeded`. If the run switched to a publishing/PR branch without updating the execution workspace record, finalization may auto-restore the recorded branch only when the worktree is clean, still registered, and the recorded branch points at the current `HEAD`; the repair is recorded as a workspace operation before the successful finalize row. If that safe repair cannot be proven, finalization records a failed workspace finalize and the run fails with bounded evidence for the expected and actual branch. A branch change is sanctioned when a control-plane path updates the execution workspace record before finalization, when publishing work happens in a separate worktree and the managed issue worktree remains on its recorded branch, or when the finalizer performs this clean same-commit restoration.
+
+### Terminal post-run gates
+
+A terminal source issue can still leave dependents waiting when a post-run control-plane gate remains unresolved. Examples include `workspace_finalize_pending`, failed workspace branch-coherence finalization, missing artifact upload finalization, or another run-finalization gate that must complete before downstream work can safely start.
+
+In that state, the terminal issue is not an opaque blocker leaf. The canonical next-action answer for each dependent must name the terminal post-run gate or the explicit recovery action that routes the gate. The answer must include the gate kind, source issue id, run or workspace operation evidence, recovery owner, retry or timeout policy, and escalation path.
+
+If the issue relation system cannot directly block on a non-issue gate, Paperclip must create or reuse a source-scoped recovery action, or an issue-backed recovery action when separate work is required, and block dependents on that recovery path instead of leaving them blocked only by a `done` or `cancelled` issue. The terminal source issue may remain terminal when the deliverable work is complete; it only needs to be reopened with explicit resume metadata when the unresolved gate proves the terminal disposition itself was wrong or incomplete.
+
+Downstream wake logic must treat the gate resolution, not the terminal status alone, as the condition that releases dependents. Once the gate or recovery action resolves, dependents resume through the normal blocker-resolution path. Repeated scans of the same terminal gate use the gate or recovery fingerprint for idempotency and must not create duplicate recovery work.
 
 ### Explicit recovery actions
 
@@ -560,6 +588,28 @@ This keeps the post-decomposition umbrella (§7) on a real waiting path instead 
 Cheap model profiles are only for status-only operational recovery overhead. Paperclip may request `modelProfile: "cheap"` for bounded recovery-owner work that updates task liveness, clears bad status, records a disposition, or asks for human/manager intervention. Those wakes must carry guard context such as `allowDeliverableWork: false`, `allowDocumentUpdates: false`, and `resumeRequiresNormalModel: true`.
 
 Automatic retries that can continue source work must use the original/normal model lane. This includes failed source-work retries, process-loss retries, transient/scheduled retries, max-turn continuations, source-assignee continuations, assigned-todo dispatch recovery, and any run that can update repo files, issue documents, plans, work products, or attachments. When a cheap status-only recovery determines that actual work remains, it must hand back to a normal-model worker run before source work or persistent deliverable updates resume. Cheap recovery hints must be scrubbed from copied retry, resume, child, and downstream source-work contexts.
+
+The cheap-to-normal handoff is fingerprinted. When cheap recovery discovers that source work, deliverable work, or persistent document/artifact updates are required, it must compute a normal-lane handoff fingerprint from at least:
+
+- company id and source issue id
+- recovery action kind or gate kind
+- required action kind, such as `update_plan_document`, `write_workspace_files`, `upload_artifact`, `create_children`, `submit_review_decision`, or `resolve_terminal_gate`
+- target key when present, such as document key and revision id, workspace id, gate id, interaction id, or blocked dependent id
+- the evidence point that proved cheap recovery is not allowed to do the work
+
+For a new fingerprint, Paperclip may create exactly one normal-model continuation, wake, or recovery issue capable of doing the required work. That continuation must scrub cheap-only guard hints, preserve the evidence and return owner, and become the canonical next-action answer for the source issue or dependent blocker leaf.
+
+If the same fingerprint already has a queued or running normal continuation, an open explicit recovery action, or a completed handoff result that restored a valid path, repeated cheap/status-only runs must not create another handoff. They must reuse the existing answer or record a suppressed duplicate observation.
+
+If the normal continuation for a fingerprint finishes and the same deliverable requirement remains unresolved, Paperclip must escalate to an explicit recovery action for that fingerprint instead of scheduling the same cheap/status-only recovery again. This makes repeated cheap observations visible as bounded recovery debt, not an infinite retry loop.
+
+### Liveness invariants preserved
+
+These rules preserve three liveness invariants:
+
+- **Productive work continues:** when actual source or deliverable work remains, the next path is a normal lane, a live owner, or a routed recovery action that is allowed to do that work.
+- **Only real blockers stop work:** blocked trees must name the actual blocker leaf, terminal gate, approval, human owner, external owner/action, or recovery action. A terminal issue, comment, document note, or stale status cannot silently stand in for the real blocker.
+- **No infinite loops:** recovery and handoffs are fingerprinted, duplicate observations are suppressed, and exhausted handoffs escalate to explicit recovery instead of repeatedly scheduling a lane that is forbidden or unable to perform the required action.
 
 ## 10. Startup and Periodic Reconciliation
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -926,6 +926,7 @@ export type {
   IssueBlockerDiagnosticNode,
   IssueBlockerDiagnosticsReadiness,
   IssueBlockerDiagnosticsResponse,
+  IssueTerminalGateDiagnostic,
   IssueWakeDiagnosticActivityRecord,
   IssueWakeDiagnosticEvent,
   IssueWakeDiagnosticWakeFailureClass,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -576,6 +576,7 @@ export type {
   IssueBlockerDiagnosticNode,
   IssueBlockerDiagnosticsReadiness,
   IssueBlockerDiagnosticsResponse,
+  IssueTerminalGateDiagnostic,
   IssueWakeDiagnosticActivityRecord,
   IssueWakeDiagnosticEvent,
   IssueWakeDiagnosticWakeFailureClass,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -223,6 +223,18 @@ export type IssueBlockerDiagnosticFlag =
   | "cancelled_blocker_in_set"
   | "workspace_finalize_pending";
 
+export interface IssueTerminalGateDiagnostic {
+  kind: "workspace_finalize_pending";
+  sourceIssueId: string;
+  owner: "system";
+  reason: string;
+  evidence: {
+    blockerIssueId: string;
+    gate: "workspace_finalize";
+  };
+  policy: "wait_for_workspace_finalize";
+}
+
 export interface IssueBlockerDiagnosticIssueSummary {
   id: string;
   identifier: string | null;
@@ -238,6 +250,7 @@ export interface IssueBlockerDiagnosticNode extends IssueBlockerDiagnosticIssueS
   isDependencyReady: boolean;
   isPendingFinalize: boolean;
   flags: IssueBlockerDiagnosticFlag[];
+  terminalGate?: IssueTerminalGateDiagnostic | null;
 }
 
 export interface IssueBlockerDiagnosticsReadiness {

--- a/scripts/screenshot-next-action.mjs
+++ b/scripts/screenshot-next-action.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Capture screenshots of the Next Action storybook stories.
+// Usage: node scripts/screenshot-next-action.mjs <storybook-static-dir> <output-dir>
+
+import http from "node:http";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { chromium } from "@playwright/test";
+
+async function main() {
+  const [, , staticDir, outDir] = process.argv;
+  if (!staticDir || !outDir) {
+    console.error("usage: node scripts/screenshot-next-action.mjs <storybook-static-dir> <output-dir>");
+    process.exit(1);
+  }
+  await fs.mkdir(outDir, { recursive: true });
+  const absStaticDir = path.resolve(staticDir);
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      let urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+      if (urlPath.endsWith("/")) urlPath += "iframe.html";
+      const filePath = path.resolve(absStaticDir, `.${urlPath}`);
+      if (!filePath.startsWith(absStaticDir + path.sep) && filePath !== absStaticDir) {
+        res.writeHead(403);
+        res.end("Forbidden");
+        return;
+      }
+      const buf = await fs.readFile(filePath);
+      const ext = path.extname(filePath).toLowerCase();
+      const mime = {
+        ".html": "text/html; charset=utf-8",
+        ".js": "application/javascript",
+        ".css": "text/css",
+        ".json": "application/json",
+        ".svg": "image/svg+xml",
+        ".png": "image/png",
+        ".woff": "font/woff",
+        ".woff2": "font/woff2",
+        ".map": "application/json",
+      }[ext] || "application/octet-stream";
+      res.writeHead(200, { "content-type": mime });
+      res.end(buf);
+    } catch (err) {
+      res.writeHead(404);
+      res.end(String(err));
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  const baseUrl = `http://127.0.0.1:${port}/iframe.html`;
+
+  const browser = await chromium.launch({
+    executablePath: process.env.SCREENSHOT_CHROME || undefined,
+  });
+  try {
+    const base = "product-next-action";
+    const width = 760;
+    const height = 460;
+    const stories = [
+      { id: `${base}--blocked-tree`, file: "01-blocked-tree.png" },
+      { id: `${base}--blocked-tree`, file: "02-blocked-tree-dark.png", dark: true },
+      { id: `${base}--blocked-tree-terminal-gate`, file: "03-terminal-gate.png" },
+      { id: `${base}--recovery-lane`, file: "04-recovery-lane.png" },
+      { id: `${base}--recovery-lane-scheduled-run`, file: "05-recovery-scheduled-run.png" },
+      { id: `${base}--needs-disposition`, file: "06-needs-disposition.png" },
+      { id: `${base}--awaiting-decision`, file: "07-awaiting-decision.png" },
+      { id: `${base}--diagnostics-error`, file: "08-diagnostics-error.png" },
+    ];
+
+    for (const story of stories) {
+      const ctx = await browser.newContext({
+        viewport: { width, height },
+        deviceScaleFactor: 2,
+        colorScheme: story.dark ? "dark" : "light",
+      });
+      const page = await ctx.newPage();
+      const url = `${baseUrl}?id=${story.id}&viewMode=story`;
+      await page.goto(url, { waitUntil: "networkidle" });
+      await page.evaluate((dark) => {
+        const html = document.documentElement;
+        html.classList.toggle("dark", dark);
+        html.style.colorScheme = dark ? "dark" : "light";
+      }, Boolean(story.dark));
+      await page.waitForTimeout(400);
+      const out = path.join(outDir, story.file);
+      await page.screenshot({ path: out, fullPage: true });
+      console.log("wrote", out);
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -3317,6 +3317,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       sourceRunId: runId,
       handoffRequired: true,
       handoffReason: "successful_run_missing_state",
+      handoffWorkClass: "normal_model",
+      normalLaneHandoffFingerprint: `normal_lane_handoff:${companyId}:${issueId}:successful_run_missing_state:record_issue_disposition_or_continuation:issue_status:${runId}`,
+      requiredActionKind: "record_issue_disposition_or_continuation",
       handoffAttempt: 1,
       maxHandoffAttempts: 1,
       resumeIntent: true,
@@ -3523,6 +3526,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(classifiedRun?.livenessState).toBe("advanced");
     expect(handoffWakeups).toHaveLength(1);
     expect(handoffWakeups[0]?.idempotencyKey).toBe(`finish_successful_run_handoff:${issueId}:${runId}:1`);
+    expect(handoffWakeups[0]?.payload).toMatchObject({
+      handoffWorkClass: "normal_model",
+      normalLaneHandoffFingerprint: `normal_lane_handoff:${companyId}:${issueId}:successful_run_missing_state:record_issue_disposition_or_continuation:issue_status:${runId}`,
+      requiredActionKind: "record_issue_disposition_or_continuation",
+    });
+    expect(handoffWakeups[0]?.payload as Record<string, unknown>).not.toHaveProperty("modelProfile");
+    expect(handoffWakeups[0]?.payload as Record<string, unknown>).not.toHaveProperty("allowDocumentUpdates");
+    expect(handoffWakeups[0]?.payload as Record<string, unknown>).not.toHaveProperty("resumeRequiresNormalModel");
 
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("in_progress");

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -69,6 +69,7 @@ const mockStorageService = vi.hoisted(() => ({
   deleteObject: vi.fn(),
 }));
 const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  create: vi.fn(),
   expirePendingInteractionsForTerminalIssue: vi.fn(async () => []),
   expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
   expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
@@ -452,6 +453,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueThreadInteractionService.expireStaleRequestConfirmationsForIssueDocument.mockResolvedValue([]);
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByHistoricalComments.mockReset();
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByHistoricalComments.mockResolvedValue([]);
+    mockIssueThreadInteractionService.create.mockReset();
     mockIssueThreadInteractionService.listForIssue.mockReset();
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueRecoveryActionService.getActiveForIssue.mockReset();
@@ -1161,6 +1163,27 @@ describe("agent issue mutation checkout ownership", () => {
         request(app).delete(`/api/issues/${issueId}/approvals/88888888-8888-4888-8888-888888888888`),
       "Cheap status-only recovery runs cannot create or modify approvals",
     ],
+    [
+      "issue-thread interaction create",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/interactions`).send({
+          kind: "suggest_tasks",
+          payload: {
+            version: 1,
+            tasks: [{ clientKey: "task-1", title: "One" }],
+          },
+        }),
+      "Cheap status-only recovery runs cannot create issue-thread interactions or accepted-plan decompositions",
+    ],
+    [
+      "accepted-plan decomposition",
+      (app: express.Express) =>
+        request(app).post(`/api/issues/${issueId}/accepted-plan-decompositions`).send({
+          acceptedPlanRevisionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          children: [{ title: "Follow-up task" }],
+        }),
+      "Cheap status-only recovery runs cannot create issue-thread interactions or accepted-plan decompositions",
+    ],
   ])("blocks cheap status-only recovery runs from %s", async (_name, sendRequest, expectedError) => {
     const app = await createApp(
       ownerActor(),
@@ -1186,6 +1209,8 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.removeAttachment).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.link).not.toHaveBeenCalled();
     expect(mockIssueApprovalService.unlink).not.toHaveBeenCalled();
+    expect(mockIssueThreadInteractionService.create).not.toHaveBeenCalled();
+    expect(mockIssueService.decomposeAcceptedPlan).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/server/src/__tests__/issue-blocker-diagnostics-routes.test.ts
+++ b/server/src/__tests__/issue-blocker-diagnostics-routes.test.ts
@@ -7,10 +7,12 @@ import {
   agents,
   companies,
   createDb,
+  executionWorkspaces,
   heartbeatRuns,
   issueRelations,
   issues,
   projects,
+  workspaceOperations,
 } from "@paperclipai/db";
 import { LOW_TRUST_REVIEW_PRESET } from "@paperclipai/shared";
 import {
@@ -193,9 +195,11 @@ describeEmbeddedPostgres("issue blocker diagnostics route", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(workspaceOperations);
     await db.delete(issueRelations);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
+    await db.delete(executionWorkspaces);
     await db.delete(agents);
     await db.delete(projects);
     await db.delete(companies);
@@ -245,6 +249,90 @@ describeEmbeddedPostgres("issue blocker diagnostics route", () => {
       status: "done",
       isDependencyReady: true,
       flags: ["done_but_blocking"],
+    });
+  });
+
+  it("surfaces a terminal workspace-finalize gate for a done blocker that is not dependency-ready", async () => {
+    const company = await seedCompany(db);
+    const agent = await seedAgent(db, company.id);
+    const project = await seedProject(db, company.id, "Core");
+    const root = await seedIssue(db, {
+      companyId: company.id,
+      projectId: project.id,
+      title: "Dependent work",
+      status: "blocked",
+      assigneeAgentId: agent.id,
+    });
+    const blocker = await seedIssue(db, {
+      companyId: company.id,
+      projectId: project.id,
+      title: "Upstream finished work",
+      status: "done",
+    });
+    const [workspace] = await db.insert(executionWorkspaces).values({
+      companyId: company.id,
+      projectId: project.id,
+      sourceIssueId: blocker.id,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "upstream-workspace",
+      providerType: "git_worktree",
+      providerRef: "/tmp/upstream-workspace",
+    }).returning();
+    await db.update(issues).set({
+      executionWorkspaceId: workspace!.id,
+    }).where(eq(issues.id, blocker.id));
+    const [run] = await db.insert(heartbeatRuns).values({
+      companyId: company.id,
+      agentId: agent.id,
+      status: "succeeded",
+      contextSnapshot: { issueId: blocker.id },
+    }).returning();
+    await db.insert(workspaceOperations).values({
+      companyId: company.id,
+      executionWorkspaceId: workspace!.id,
+      heartbeatRunId: run!.id,
+      issueId: blocker.id,
+      phase: "workspace_finalize",
+      status: "failed",
+      startedAt: new Date("2026-07-08T12:00:00.000Z"),
+      finishedAt: new Date("2026-07-08T12:00:01.000Z"),
+    });
+    await blockIssue(db, company.id, blocker.id, root.id);
+
+    const res = await request(createApp(db, boardActor(company)))
+      .get(`/api/issues/${root.id}/diagnostics/blockers`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      diagnosis: expect.stringContaining("finish workspace finalization"),
+      readiness: {
+        allBlockersDone: false,
+        isDependencyReady: false,
+        unresolvedBlockerCount: 1,
+        pendingFinalizeBlockerCount: 1,
+      },
+      omittedUnauthorizedBlockerCount: 0,
+      truncated: false,
+    });
+    expect(res.body.blockers).toHaveLength(1);
+    expect(res.body.blockers[0]).toMatchObject({
+      id: blocker.id,
+      status: "done",
+      isUnresolved: true,
+      isPendingFinalize: true,
+      isDependencyReady: false,
+      flags: ["done_but_blocking", "workspace_finalize_pending"],
+      terminalGate: {
+        kind: "workspace_finalize_pending",
+        sourceIssueId: blocker.id,
+        owner: "system",
+        evidence: {
+          blockerIssueId: blocker.id,
+          gate: "workspace_finalize",
+        },
+        policy: "wait_for_workspace_finalize",
+      },
     });
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4623,6 +4623,28 @@ export function issueRoutes(
     return false;
   }
 
+  async function assertWorkflowHandoffMutationAllowedByRunContext(
+    req: Request,
+    res: Response,
+    issue: { id: string; companyId: string },
+  ) {
+    const run = await loadActorRunContext(req, issue.companyId);
+    if (!run) return true;
+    if (!isStatusOnlyCheapRecoveryContext(run.contextSnapshot)) return true;
+
+    res.status(403).json({
+      error: "Cheap status-only recovery runs cannot create issue-thread interactions or accepted-plan decompositions",
+      details: {
+        issueId: issue.id,
+        runId: run.id,
+        modelProfile: "cheap",
+        recoveryIntent: "status_only",
+        resumeRequiresNormalModel: true,
+      },
+    });
+    return false;
+  }
+
   async function loadWorkProductRunAttribution(runId: string) {
     return await db
       .select({
@@ -8067,6 +8089,7 @@ export function issueRoutes(
     const sourceIssue = await getAccessibleResource(req, res, svc.getById(sourceIssueId), "Issue not found");
     if (!sourceIssue) return;
     if (!(await assertAgentIssueMutationAllowed(req, res, sourceIssue))) return;
+    if (!(await assertWorkflowHandoffMutationAllowedByRunContext(req, res, sourceIssue))) return;
 
     const requestedChildren = [];
     for (const child of req.body.children as Array<typeof req.body.children[number]>) {
@@ -10190,6 +10213,7 @@ export function issueRoutes(
     if (req.actor.type === "agent") {
       if (!(await assertAgentIssueMutationAllowed(req, res, issue, { allowVisibleIssueWrite: true }))) return;
       if (await assertLowTrustControlPlaneDenied(req, res, issue.companyId, issue)) return;
+      if (!(await assertWorkflowHandoffMutationAllowedByRunContext(req, res, issue))) return;
     } else {
       assertBoard(req);
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -943,6 +943,19 @@ function buildIssueBlockerDiagnosticsResponse(input: {
     if (issue.status === "blocked" && blocker.status === "done") flags.push("done_but_blocking");
     if (blocker.status === "cancelled") flags.push("cancelled_blocker_in_set");
     if (isPendingFinalize) flags.push("workspace_finalize_pending");
+    const terminalGate = isPendingFinalize
+      ? {
+          kind: "workspace_finalize_pending" as const,
+          sourceIssueId: blocker.id,
+          owner: "system" as const,
+          reason: `${blockerDiagnosticLabel(blocker)} reached done, but its execution workspace has not recorded a successful workspace_finalize gate.`,
+          evidence: {
+            blockerIssueId: blocker.id,
+            gate: "workspace_finalize" as const,
+          },
+          policy: "wait_for_workspace_finalize" as const,
+        }
+      : null;
 
     return {
       ...blocker,
@@ -950,6 +963,7 @@ function buildIssueBlockerDiagnosticsResponse(input: {
       isPendingFinalize,
       isDependencyReady: blocker.status === "done" && !isPendingFinalize,
       flags,
+      terminalGate,
     };
   });
 

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -5,6 +5,7 @@ import {
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
   buildFinishSuccessfulRunHandoffIdempotencyKey,
+  buildFinishSuccessfulRunNormalLaneHandoffFingerprint,
   buildSuccessfulRunHandoffInstruction,
   buildSuccessfulRunHandoffExhaustedNotice,
   buildSuccessfulRunHandoffRequiredNotice,
@@ -67,27 +68,42 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
 }
 
 describe("successful run handoff decision", () => {
-  it("queues one normal-model corrective wake to the original agent when a successful run has no disposition", () => {
+  it("queues one normal-lane corrective handoff wake for a successful progress run without a visible next action", () => {
     const decision = decide();
 
     expect(decision.kind).toBe("enqueue");
     if (decision.kind !== "enqueue") return;
     expect(decision.targetAgentId).toBe(run.agentId);
+    const fingerprint = buildFinishSuccessfulRunNormalLaneHandoffFingerprint({
+      companyId: "company-1",
+      issueId: "issue-1",
+      sourceRunId: "run-1",
+    });
     expect(decision.idempotencyKey).toBe("finish_successful_run_handoff:issue-1:run-1:1");
     expect(decision.payload).toMatchObject({
       issueId: "issue-1",
       sourceRunId: "run-1",
       handoffRequired: true,
       handoffReason: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      handoffWorkClass: "normal_model",
+      normalLaneHandoffFingerprint: fingerprint,
+      requiredActionKind: "record_issue_disposition_or_continuation",
       missingDisposition: "clear_next_step",
       handoffAttempt: 1,
       maxHandoffAttempts: 1,
       resumeIntent: true,
       resumeFromRunId: "run-1",
     });
+    expect(decision.payload).not.toHaveProperty("modelProfile");
+    expect(decision.payload).not.toHaveProperty("allowDeliverableWork");
+    expect(decision.payload).not.toHaveProperty("allowDocumentUpdates");
+    expect(decision.payload).not.toHaveProperty("resumeRequiresNormalModel");
     expect(decision.contextSnapshot).toMatchObject({
       wakeReason: FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
       handoffRequired: true,
+      handoffWorkClass: "normal_model",
+      normalLaneHandoffFingerprint: fingerprint,
+      requiredActionKind: "record_issue_disposition_or_continuation",
     });
     for (const key of [
       "modelProfile",
@@ -205,6 +221,35 @@ describe("successful run handoff decision", () => {
     expect(instruction).toContain("Line one.\nLine two.");
     expect(instruction).toContain("Report body[0m intact.");
     expect(instruction).not.toMatch(/[\u0000-\u0008\u000B-\u001F\u007F]/);
+  });
+
+  it("scrubs copied cheap status-only guard hints from the normal handoff context", () => {
+    const decision = decide({
+      run: {
+        ...run,
+        contextSnapshot: {
+          issueId: "issue-1",
+          modelProfile: "cheap",
+          recoveryIntent: "status_only",
+          allowDeliverableWork: false,
+          allowDocumentUpdates: false,
+          resumeRequiresNormalModel: true,
+        },
+      } as any,
+    });
+
+    expect(decision.kind).toBe("enqueue");
+    if (decision.kind !== "enqueue") return;
+    expect(decision.payload).toMatchObject({
+      handoffWorkClass: "normal_model",
+      normalLaneHandoffFingerprint: "normal_lane_handoff:company-1:issue-1:successful_run_missing_state:record_issue_disposition_or_continuation:issue_status:run-1",
+    });
+    expect(decision.payload).not.toHaveProperty("modelProfile");
+    expect(decision.payload).not.toHaveProperty("allowDocumentUpdates");
+    expect(decision.payload).not.toHaveProperty("resumeRequiresNormalModel");
+    expect(decision.contextSnapshot).not.toHaveProperty("modelProfile");
+    expect(decision.contextSnapshot).not.toHaveProperty("allowDocumentUpdates");
+    expect(decision.contextSnapshot).not.toHaveProperty("resumeRequiresNormalModel");
   });
 
   it("does not queue when the issue already has a valid disposition", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -279,6 +279,22 @@ export function buildFinishSuccessfulRunHandoffIdempotencyKey(input: {
   ].join(":");
 }
 
+export function buildFinishSuccessfulRunNormalLaneHandoffFingerprint(input: {
+  companyId: string;
+  issueId: string;
+  sourceRunId: string;
+}) {
+  return [
+    "normal_lane_handoff",
+    input.companyId,
+    input.issueId,
+    SUCCESSFUL_RUN_MISSING_STATE_REASON,
+    "record_issue_disposition_or_continuation",
+    "issue_status",
+    input.sourceRunId,
+  ].join(":");
+}
+
 export async function findExistingFinishSuccessfulRunHandoffWake(
   db: Db,
   input: {
@@ -516,6 +532,11 @@ export function decideSuccessfulRunHandoff(input: {
     nextAction: input.nextAction,
     detectedProgressSummary: input.detectedProgressSummary,
   });
+  const normalLaneHandoffFingerprint = buildFinishSuccessfulRunNormalLaneHandoffFingerprint({
+    companyId: run.companyId,
+    issueId: issue.id,
+    sourceRunId: run.id,
+  });
   const payload = withRecoveryModelProfileHint({
     issueId: issue.id,
     taskId: issue.id,
@@ -523,6 +544,9 @@ export function decideSuccessfulRunHandoff(input: {
     sourceRunId: run.id,
     handoffRequired: true,
     handoffReason: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+    handoffWorkClass: "normal_model",
+    normalLaneHandoffFingerprint,
+    requiredActionKind: "record_issue_disposition_or_continuation",
     missingDisposition: "clear_next_step",
     validDispositionOptions: [...SUCCESSFUL_RUN_HANDOFF_OPTIONS],
     detectedProgressSummary: input.detectedProgressSummary,

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -11,6 +11,8 @@ import type {
   Issue,
   IssueChanges,
   IssueAttachment,
+  IssueBlockerDiagnosticsResponse,
+  IssueSubtreeDiagnosticsResponse,
   IssueCostSummary,
   IssueComment,
   IssueDocument,
@@ -152,6 +154,10 @@ export const issuesApi = {
   get: (id: string, options?: RequestOptions) => options
     ? api.get<Issue>(`/issues/${id}`, options)
     : api.get<Issue>(`/issues/${id}`),
+  getBlockerDiagnostics: (id: string) =>
+    api.get<IssueBlockerDiagnosticsResponse>(`/issues/${id}/diagnostics/blockers`),
+  getSubtreeDiagnostics: (id: string) =>
+    api.get<IssueSubtreeDiagnosticsResponse>(`/issues/${id}/diagnostics/subtree`),
   getWatchdog: (id: string) => api.get<IssueWatchdog | null>(`/issues/${id}/watchdog`),
   upsertWatchdog: (id: string, data: UpsertIssueWatchdog) =>
     api.put<IssueWatchdog>(`/issues/${id}/watchdog`, data),

--- a/ui/src/components/IssueNextActionCard.test.tsx
+++ b/ui/src/components/IssueNextActionCard.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import type { ComponentProps, ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  IssueBlockedInboxAttention,
+  IssueBlockerDiagnosticsResponse,
+} from "@paperclipai/shared";
+import { IssueNextActionCard } from "./IssueNextActionCard";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string } & ComponentProps<"a">) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("./IssueLinkQuicklook", () => ({
+  IssueLinkQuicklook: ({
+    children,
+    to,
+    ...props
+  }: { children: ReactNode; to: string } & ComponentProps<"a">) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  flushSync(() => root.unmount());
+  container.remove();
+});
+
+function render(node: ReactNode) {
+  flushSync(() => {
+    root.render(node);
+  });
+}
+
+const attention: IssueBlockedInboxAttention = {
+  kind: "blocked",
+  state: "needs_attention",
+  reason: "blocked_chain_stalled",
+  severity: "high",
+  stoppedSinceAt: null,
+  owner: { type: "agent", agentId: "a1", userId: null, label: "ClaudeCoder" },
+  action: { label: "Resolve the stalled review", detail: "Wake QA on PAP-12921." },
+  sourceIssue: null,
+  leafIssue: {
+    id: "leaf-1",
+    identifier: "PAP-12921",
+    title: "QA release verification",
+    status: "blocked",
+    priority: "medium",
+    assigneeAgentId: "qa-1",
+    assigneeUserId: null,
+  },
+  recoveryIssue: null,
+  approvalId: null,
+  interactionId: null,
+  sampleIssueIdentifier: null,
+  redaction: { externalDetailsRedacted: false, secretFieldsOmitted: true },
+};
+
+const gateDiagnostics: IssueBlockerDiagnosticsResponse = {
+  issue: {
+    id: "i1",
+    identifier: "PAP-12915",
+    title: "Release verify parallel",
+    status: "blocked",
+    priority: "medium",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+  },
+  diagnosis: null,
+  readiness: null,
+  blockers: [
+    {
+      id: "b1",
+      identifier: "PAP-12920",
+      title: "Release verify child",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      isUnresolved: false,
+      isDependencyReady: false,
+      isPendingFinalize: true,
+      flags: ["workspace_finalize_pending"],
+    },
+  ],
+  omittedUnauthorizedBlockerCount: 0,
+  truncated: false,
+  caps: { maxBlockers: 50 },
+};
+
+describe("IssueNextActionCard", () => {
+  it("renders nothing for an on-track task by default", () => {
+    render(<IssueNextActionCard status="in_progress" />);
+    expect(container.querySelector('[data-testid="issue-next-action-card"]')).toBeNull();
+  });
+
+  it("renders a blocked next-action answer with owner and leaf blocker", () => {
+    render(<IssueNextActionCard status="blocked" blockedInboxAttention={attention} />);
+    const card = container.querySelector('[data-testid="issue-next-action-card"]');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute("data-next-action-kind")).toBe("blocked");
+    expect(container.textContent).toContain("Resolve the stalled review");
+    expect(container.textContent).toContain("ClaudeCoder");
+    expect(container.textContent).toContain("PAP-12921");
+  });
+
+  it("renders a terminal-gate answer from blocker diagnostics", () => {
+    render(
+      <IssueNextActionCard
+        status="blocked"
+        blockerDiagnostics={gateDiagnostics}
+      />,
+    );
+    const card = container.querySelector('[data-testid="issue-next-action-card"]');
+    expect(card?.getAttribute("data-next-action-kind")).toBe("terminal_gate");
+    expect(
+      container.querySelector('[data-testid="issue-next-action-terminal-gates"]'),
+    ).not.toBeNull();
+    expect(container.textContent).toContain("workspace finalize gate");
+  });
+
+  it("surfaces a diagnostics load failure clearly", () => {
+    render(
+      <IssueNextActionCard
+        status="blocked"
+        blockedInboxAttention={attention}
+        diagnosticsError="Request failed (500)"
+      />,
+    );
+    const err = container.querySelector('[data-testid="issue-next-action-diagnostics-error"]');
+    expect(err).not.toBeNull();
+    expect(err?.textContent).toContain("Request failed (500)");
+  });
+});

--- a/ui/src/components/IssueNextActionCard.test.tsx
+++ b/ui/src/components/IssueNextActionCard.test.tsx
@@ -55,7 +55,7 @@ const attention: IssueBlockedInboxAttention = {
   severity: "high",
   stoppedSinceAt: null,
   owner: { type: "agent", agentId: "a1", userId: null, label: "ClaudeCoder" },
-  action: { label: "Resolve the stalled review", detail: "Wake QA on PAP-12921." },
+  action: { label: "wake QA on the stalled review", detail: "Resolve PAP-12921." },
   sourceIssue: null,
   leafIssue: {
     id: "leaf-1",
@@ -111,29 +111,29 @@ describe("IssueNextActionCard", () => {
     expect(container.querySelector('[data-testid="issue-next-action-card"]')).toBeNull();
   });
 
-  it("renders a blocked next-action answer with owner and leaf blocker", () => {
+  it("renders a Blocked-by-real-work lane with owner and leaf blocker", () => {
     render(<IssueNextActionCard status="blocked" blockedInboxAttention={attention} />);
     const card = container.querySelector('[data-testid="issue-next-action-card"]');
     expect(card).not.toBeNull();
-    expect(card?.getAttribute("data-next-action-kind")).toBe("blocked");
-    expect(container.textContent).toContain("Resolve the stalled review");
+    expect(card?.getAttribute("data-next-action-lane")).toBe("blocked_real_work");
+    expect(card?.getAttribute("role")).toBe("status");
+    expect(container.textContent).toContain("Blocked by PAP-12921");
     expect(container.textContent).toContain("ClaudeCoder");
-    expect(container.textContent).toContain("PAP-12921");
+    expect(container.textContent).toContain("resolved from");
   });
 
-  it("renders a terminal-gate answer from blocker diagnostics", () => {
+  it("renders a terminal-gate variant with a gate chip", () => {
     render(
       <IssueNextActionCard
         status="blocked"
+        blockedInboxAttention={attention}
         blockerDiagnostics={gateDiagnostics}
       />,
     );
     const card = container.querySelector('[data-testid="issue-next-action-card"]');
-    expect(card?.getAttribute("data-next-action-kind")).toBe("terminal_gate");
-    expect(
-      container.querySelector('[data-testid="issue-next-action-terminal-gates"]'),
-    ).not.toBeNull();
-    expect(container.textContent).toContain("workspace finalize gate");
+    expect(card?.getAttribute("data-next-action-lane")).toBe("blocked_real_work");
+    expect(card?.getAttribute("data-terminal-gate")).toBe("true");
+    expect(container.textContent).toContain("gate: workspace_finalize_pending");
   });
 
   it("surfaces a diagnostics load failure clearly", () => {

--- a/ui/src/components/IssueNextActionCard.tsx
+++ b/ui/src/components/IssueNextActionCard.tsx
@@ -1,0 +1,277 @@
+import {
+  AlertTriangle,
+  ArrowRight,
+  CircleAlert,
+  Compass,
+  Eye,
+  Loader2,
+  RefreshCw,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type {
+  IssueBlockedInboxAttention,
+  IssueBlockerDiagnosticNode,
+  IssueBlockerDiagnosticsResponse,
+  IssueRecoveryAction,
+  IssueScheduledRetry,
+  IssueStatus,
+  SuccessfulRunHandoffState,
+} from "@paperclipai/shared";
+import { createIssueDetailPath } from "../lib/issueDetailBreadcrumb";
+import {
+  deriveNextAction,
+  type NextActionIssueRef,
+  type NextActionKind,
+  type NextActionSummary,
+  type NextActionTone,
+} from "../lib/next-action";
+import { IssueLinkQuicklook } from "./IssueLinkQuicklook";
+
+const TONE_STYLES: Record<
+  NextActionTone,
+  { container: string; icon: string; badge: string; refChip: string }
+> = {
+  amber: {
+    container:
+      "border-amber-300/70 bg-amber-50/90 text-amber-950 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100",
+    icon: "text-amber-600 dark:text-amber-300",
+    badge:
+      "border-amber-400/70 bg-amber-100/80 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-200",
+    refChip:
+      "border-amber-300/70 bg-background/80 text-amber-950 hover:border-amber-500 hover:bg-amber-100 dark:border-amber-500/40 dark:bg-background/40 dark:text-amber-100 dark:hover:bg-amber-500/15",
+  },
+  sky: {
+    container:
+      "border-sky-300/70 bg-sky-50/90 text-sky-950 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100",
+    icon: "text-sky-600 dark:text-sky-300",
+    badge:
+      "border-sky-400/70 bg-sky-100/80 text-sky-800 dark:border-sky-500/40 dark:bg-sky-500/15 dark:text-sky-200",
+    refChip:
+      "border-sky-300/70 bg-background/80 text-sky-950 hover:border-sky-500 hover:bg-sky-100 dark:border-sky-500/40 dark:bg-background/40 dark:text-sky-100 dark:hover:bg-sky-500/15",
+  },
+  red: {
+    container:
+      "border-red-300/70 bg-red-50/90 text-red-950 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-100",
+    icon: "text-red-600 dark:text-red-300",
+    badge:
+      "border-red-400/70 bg-red-100/80 text-red-800 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-200",
+    refChip:
+      "border-red-300/70 bg-background/80 text-red-950 hover:border-red-500 hover:bg-red-100 dark:border-red-500/40 dark:bg-background/40 dark:text-red-100 dark:hover:bg-red-500/15",
+  },
+  emerald: {
+    container:
+      "border-emerald-300/70 bg-emerald-50/90 text-emerald-950 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100",
+    icon: "text-emerald-600 dark:text-emerald-300",
+    badge:
+      "border-emerald-400/70 bg-emerald-100/80 text-emerald-800 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-200",
+    refChip:
+      "border-emerald-300/70 bg-background/80 text-emerald-950 hover:border-emerald-500 hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-background/40 dark:text-emerald-100 dark:hover:bg-emerald-500/15",
+  },
+  muted: {
+    container: "border-border bg-muted/60 text-foreground",
+    icon: "text-muted-foreground",
+    badge: "border-border bg-muted text-muted-foreground",
+    refChip:
+      "border-border bg-background/80 text-foreground hover:border-foreground/30 hover:bg-muted",
+  },
+};
+
+const KIND_ICON: Record<NextActionKind, LucideIcon> = {
+  recovery: AlertTriangle,
+  scheduled_retry: RefreshCw,
+  successful_run_handoff: Compass,
+  blocked: AlertTriangle,
+  terminal_gate: CircleAlert,
+  none: Eye,
+};
+
+function RefChip({
+  refItem,
+  label,
+  toneClass,
+}: {
+  refItem: NextActionIssueRef;
+  label: string;
+  toneClass: string;
+}) {
+  const issuePathId = refItem.identifier ?? refItem.id;
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-(length:--text-nano) font-medium uppercase tracking-wide opacity-70">
+        {label}
+      </span>
+      <IssueLinkQuicklook
+        issuePathId={issuePathId}
+        to={createIssueDetailPath(issuePathId)}
+        className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors hover:underline ${toneClass}`}
+      >
+        <span>{refItem.identifier ?? refItem.id.slice(0, 8)}</span>
+        <span className="max-w-(--sz-18rem) truncate font-sans text-(length:--text-micro) opacity-80">
+          {refItem.title}
+        </span>
+      </IssueLinkQuicklook>
+    </span>
+  );
+}
+
+function TerminalGateRow({
+  gates,
+  toneClass,
+}: {
+  gates: IssueBlockerDiagnosticNode[];
+  toneClass: string;
+}) {
+  if (gates.length === 0) return null;
+  return (
+    <div
+      data-testid="issue-next-action-terminal-gates"
+      className="flex flex-wrap items-center gap-1.5 pt-0.5"
+    >
+      <span className="text-xs font-medium opacity-80">Terminal gate</span>
+      {gates.map((gate) => {
+        const issuePathId = gate.identifier ?? gate.id;
+        const flag = gate.flags[0] ?? null;
+        const flagLabel =
+          flag === "workspace_finalize_pending"
+            ? "finalize pending"
+            : flag === "cancelled_blocker_in_set"
+              ? "cancelled"
+              : "done but blocking";
+        return (
+          <IssueLinkQuicklook
+            key={gate.id}
+            issuePathId={issuePathId}
+            to={createIssueDetailPath(issuePathId)}
+            className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors hover:underline ${toneClass}`}
+          >
+            <span>{gate.identifier ?? gate.id.slice(0, 8)}</span>
+            <span className="font-sans text-(length:--text-micro) opacity-80">{flagLabel}</span>
+          </IssueLinkQuicklook>
+        );
+      })}
+    </div>
+  );
+}
+
+export interface IssueNextActionCardProps {
+  status: IssueStatus;
+  blockedInboxAttention?: IssueBlockedInboxAttention | null;
+  activeRecoveryAction?: IssueRecoveryAction | null;
+  scheduledRetry?: IssueScheduledRetry | null;
+  successfulRunHandoff?: SuccessfulRunHandoffState | null;
+  blockerDiagnostics?: IssueBlockerDiagnosticsResponse | null;
+  /** Error from loading blocker diagnostics; surfaced so failures are visible. */
+  diagnosticsError?: string | null;
+  /** Render even when there is no special next action (kind "none"). */
+  showWhenOnTrack?: boolean;
+  className?: string;
+}
+
+/**
+ * A consolidated, plain-language "what moves this forward next" card.
+ *
+ * PAP-13005 Phase 5 — reads the existing diagnostic/attention shape and renders
+ * one readable next-action answer for issue detail, subtree, and run surfaces.
+ */
+export function IssueNextActionCard({
+  status,
+  blockedInboxAttention,
+  activeRecoveryAction,
+  scheduledRetry,
+  successfulRunHandoff,
+  blockerDiagnostics,
+  diagnosticsError,
+  showWhenOnTrack = false,
+  className,
+}: IssueNextActionCardProps) {
+  const summary: NextActionSummary = deriveNextAction({
+    status,
+    blockedInboxAttention,
+    activeRecoveryAction,
+    scheduledRetry,
+    successfulRunHandoff,
+    blockerDiagnostics,
+  });
+
+  if (summary.kind === "none" && !showWhenOnTrack && !diagnosticsError) {
+    return null;
+  }
+
+  const tone = TONE_STYLES[summary.tone];
+  const Icon = KIND_ICON[summary.kind];
+
+  return (
+    <div
+      data-testid="issue-next-action-card"
+      data-next-action-kind={summary.kind}
+      data-next-action-tone={summary.tone}
+      className={`rounded-md border px-3 py-2.5 text-sm shadow-sm ${tone.container} ${className ?? ""}`}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${tone.icon}`} aria-hidden />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <span className="text-(length:--text-nano) font-semibold uppercase tracking-wide opacity-70">
+              Next action
+            </span>
+            <span
+              className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-(length:--text-nano) font-medium ${tone.badge}`}
+            >
+              {summary.badge}
+            </span>
+          </div>
+
+          <p className="font-medium leading-5">{summary.headline}</p>
+
+          {summary.action ? (
+            <p className="flex items-start gap-1.5 text-xs leading-5 opacity-90">
+              <ArrowRight className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+              <span>
+                <span className="font-medium">{summary.action.label}</span>
+                {summary.action.detail ? <> — {summary.action.detail}</> : null}
+              </span>
+            </p>
+          ) : null}
+
+          {summary.owner ? (
+            <p className="text-xs leading-5 opacity-80">
+              Owner: <span className="font-medium">{summary.owner.label}</span>
+            </p>
+          ) : null}
+
+          {summary.scheduledRetry?.status === "running" ? (
+            <p className="flex items-center gap-1.5 text-xs leading-5 opacity-80">
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+              Corrective run in progress
+            </p>
+          ) : null}
+
+          {(summary.sourceRef || summary.leafRef || summary.recoveryRef) ? (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 pt-0.5">
+              {summary.sourceRef ? (
+                <RefChip refItem={summary.sourceRef} label="Work happens on" toneClass={tone.refChip} />
+              ) : null}
+              {summary.leafRef ? (
+                <RefChip refItem={summary.leafRef} label="Waiting on" toneClass={tone.refChip} />
+              ) : null}
+              {summary.recoveryRef ? (
+                <RefChip refItem={summary.recoveryRef} label="Recovery" toneClass={tone.refChip} />
+              ) : null}
+            </div>
+          ) : null}
+
+          <TerminalGateRow gates={summary.terminalGates} toneClass={tone.refChip} />
+
+          {diagnosticsError ? (
+            <p
+              data-testid="issue-next-action-diagnostics-error"
+              className="mt-1 rounded-md border border-red-300/70 bg-red-50/80 px-2 py-1 text-xs leading-5 text-red-800 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200"
+            >
+              Couldn&apos;t load full blocker diagnostics: {diagnosticsError}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/IssueNextActionCard.tsx
+++ b/ui/src/components/IssueNextActionCard.tsx
@@ -82,8 +82,8 @@ export interface IssueNextActionCardProps {
 }
 
 /**
- * The consolidated "what moves this forward next" panel (PAP-13005 Phase 5,
- * per the Phase 4 UX spec). Resolves the task into exactly one of four lanes
+ * The consolidated "what moves this forward next" panel resolves the task
+ * into exactly one of four lanes
  * and renders it as a neutral card with a lane-hued left accent.
  */
 export function IssueNextActionCard({
@@ -124,7 +124,7 @@ export function IssueNextActionCard({
       data-next-action-accent={summary.accent}
       data-terminal-gate={summary.terminalGate ? "true" : undefined}
       data-recovery-debt={summary.recoveryDebt ? "true" : undefined}
-      style={{ borderLeftColor: accent, borderLeftWidth: "4px" }}
+      style={{ borderLeftColor: accent, borderLeftWidth: "var(--sz-4px)" }}
       className={`rounded-md border border-border bg-card text-card-foreground px-3 py-2.5 shadow-sm ${className ?? ""}`}
     >
       {/* 1. Lane chip */}
@@ -192,7 +192,7 @@ export function IssueNextActionCard({
         <p
           data-testid="issue-next-action-diagnostics-error"
           className="mt-1.5 rounded-md border border-border bg-muted px-2 py-1 text-xs leading-5 text-foreground"
-          style={{ borderLeftColor: "var(--status-task-blocked)", borderLeftWidth: "3px" }}
+          style={{ borderLeftColor: "var(--status-task-blocked)", borderLeftWidth: "var(--sz-3px)" }}
         >
           Couldn&apos;t load full blocker diagnostics: {diagnosticsError}
         </p>

--- a/ui/src/components/IssueNextActionCard.tsx
+++ b/ui/src/components/IssueNextActionCard.tsx
@@ -1,155 +1,68 @@
-import {
-  AlertTriangle,
-  ArrowRight,
-  CircleAlert,
-  Compass,
-  Eye,
-  Loader2,
-  RefreshCw,
-} from "lucide-react";
+import { Ban, Clock, LifeBuoy, Play } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type {
   IssueBlockedInboxAttention,
-  IssueBlockerDiagnosticNode,
   IssueBlockerDiagnosticsResponse,
   IssueRecoveryAction,
   IssueScheduledRetry,
   IssueStatus,
   SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
+import { Link } from "@/lib/router";
 import { createIssueDetailPath } from "../lib/issueDetailBreadcrumb";
 import {
   deriveNextAction,
-  type NextActionIssueRef,
-  type NextActionKind,
+  type NextActionAccent,
+  type NextActionLane,
+  type NextActionReference,
   type NextActionSummary,
-  type NextActionTone,
 } from "../lib/next-action";
 import { IssueLinkQuicklook } from "./IssueLinkQuicklook";
 
-const TONE_STYLES: Record<
-  NextActionTone,
-  { container: string; icon: string; badge: string; refChip: string }
-> = {
-  amber: {
-    container:
-      "border-amber-300/70 bg-amber-50/90 text-amber-950 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100",
-    icon: "text-amber-600 dark:text-amber-300",
-    badge:
-      "border-amber-400/70 bg-amber-100/80 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-200",
-    refChip:
-      "border-amber-300/70 bg-background/80 text-amber-950 hover:border-amber-500 hover:bg-amber-100 dark:border-amber-500/40 dark:bg-background/40 dark:text-amber-100 dark:hover:bg-amber-500/15",
-  },
-  sky: {
-    container:
-      "border-sky-300/70 bg-sky-50/90 text-sky-950 dark:border-sky-500/40 dark:bg-sky-500/10 dark:text-sky-100",
-    icon: "text-sky-600 dark:text-sky-300",
-    badge:
-      "border-sky-400/70 bg-sky-100/80 text-sky-800 dark:border-sky-500/40 dark:bg-sky-500/15 dark:text-sky-200",
-    refChip:
-      "border-sky-300/70 bg-background/80 text-sky-950 hover:border-sky-500 hover:bg-sky-100 dark:border-sky-500/40 dark:bg-background/40 dark:text-sky-100 dark:hover:bg-sky-500/15",
-  },
-  red: {
-    container:
-      "border-red-300/70 bg-red-50/90 text-red-950 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-100",
-    icon: "text-red-600 dark:text-red-300",
-    badge:
-      "border-red-400/70 bg-red-100/80 text-red-800 dark:border-red-500/40 dark:bg-red-500/15 dark:text-red-200",
-    refChip:
-      "border-red-300/70 bg-background/80 text-red-950 hover:border-red-500 hover:bg-red-100 dark:border-red-500/40 dark:bg-background/40 dark:text-red-100 dark:hover:bg-red-500/15",
-  },
-  emerald: {
-    container:
-      "border-emerald-300/70 bg-emerald-50/90 text-emerald-950 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100",
-    icon: "text-emerald-600 dark:text-emerald-300",
-    badge:
-      "border-emerald-400/70 bg-emerald-100/80 text-emerald-800 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-emerald-200",
-    refChip:
-      "border-emerald-300/70 bg-background/80 text-emerald-950 hover:border-emerald-500 hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-background/40 dark:text-emerald-100 dark:hover:bg-emerald-500/15",
-  },
-  muted: {
-    container: "border-border bg-muted/60 text-foreground",
-    icon: "text-muted-foreground",
-    badge: "border-border bg-muted text-muted-foreground",
-    refChip:
-      "border-border bg-background/80 text-foreground hover:border-foreground/30 hover:bg-muted",
-  },
+/** Left-accent hue per lane. All values are tokens — never raw color literals. */
+const ACCENT_VAR: Record<NextActionAccent, string> = {
+  in_progress: "var(--status-task-in_progress)",
+  in_review: "var(--status-task-in_review)",
+  todo: "var(--status-task-todo)",
+  blocked: "var(--status-task-blocked)",
+  recovery_amber: "var(--status-task-todo)",
+  recovery_sky: "var(--status-task-in_progress)",
+  recovery_red: "var(--status-task-blocked)",
+  none: "var(--border)",
 };
 
-const KIND_ICON: Record<NextActionKind, LucideIcon> = {
-  recovery: AlertTriangle,
-  scheduled_retry: RefreshCw,
-  successful_run_handoff: Compass,
-  blocked: AlertTriangle,
-  terminal_gate: CircleAlert,
-  none: Eye,
+const LANE_ICON: Record<NextActionLane, LucideIcon> = {
+  working_now: Play,
+  recovery: LifeBuoy,
+  waiting_decision: Clock,
+  blocked_real_work: Ban,
+  none: Clock,
 };
 
-function RefChip({
-  refItem,
-  label,
-  toneClass,
-}: {
-  refItem: NextActionIssueRef;
-  label: string;
-  toneClass: string;
-}) {
-  const issuePathId = refItem.identifier ?? refItem.id;
+function ReferenceChip({ reference }: { reference: NextActionReference }) {
+  const { ref, label, gate } = reference;
+  const issuePathId = ref.identifier ?? ref.id;
   return (
     <span className="inline-flex items-center gap-1">
-      <span className="text-(length:--text-nano) font-medium uppercase tracking-wide opacity-70">
+      <span className="text-(length:--text-nano) font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </span>
       <IssueLinkQuicklook
         issuePathId={issuePathId}
         to={createIssueDetailPath(issuePathId)}
-        className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors hover:underline ${toneClass}`}
+        className="inline-flex max-w-full items-center gap-1 rounded-md border border-border bg-background/60 px-2 py-0.5 font-mono text-xs text-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:underline"
       >
-        <span>{refItem.identifier ?? refItem.id.slice(0, 8)}</span>
-        <span className="max-w-(--sz-18rem) truncate font-sans text-(length:--text-micro) opacity-80">
-          {refItem.title}
+        <span>{ref.identifier ?? ref.id.slice(0, 8)}</span>
+        <span className="max-w-(--sz-18rem) truncate font-sans text-(length:--text-micro) text-muted-foreground">
+          {ref.title}
         </span>
       </IssueLinkQuicklook>
+      {gate ? (
+        <span className="inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-(length:--text-nano) text-muted-foreground">
+          {gate}
+        </span>
+      ) : null}
     </span>
-  );
-}
-
-function TerminalGateRow({
-  gates,
-  toneClass,
-}: {
-  gates: IssueBlockerDiagnosticNode[];
-  toneClass: string;
-}) {
-  if (gates.length === 0) return null;
-  return (
-    <div
-      data-testid="issue-next-action-terminal-gates"
-      className="flex flex-wrap items-center gap-1.5 pt-0.5"
-    >
-      <span className="text-xs font-medium opacity-80">Terminal gate</span>
-      {gates.map((gate) => {
-        const issuePathId = gate.identifier ?? gate.id;
-        const flag = gate.flags[0] ?? null;
-        const flagLabel =
-          flag === "workspace_finalize_pending"
-            ? "finalize pending"
-            : flag === "cancelled_blocker_in_set"
-              ? "cancelled"
-              : "done but blocking";
-        return (
-          <IssueLinkQuicklook
-            key={gate.id}
-            issuePathId={issuePathId}
-            to={createIssueDetailPath(issuePathId)}
-            className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-0.5 font-mono text-xs transition-colors hover:underline ${toneClass}`}
-          >
-            <span>{gate.identifier ?? gate.id.slice(0, 8)}</span>
-            <span className="font-sans text-(length:--text-micro) opacity-80">{flagLabel}</span>
-          </IssueLinkQuicklook>
-        );
-      })}
-    </div>
   );
 }
 
@@ -160,18 +73,18 @@ export interface IssueNextActionCardProps {
   scheduledRetry?: IssueScheduledRetry | null;
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
   blockerDiagnostics?: IssueBlockerDiagnosticsResponse | null;
+  hasLiveRun?: boolean;
   /** Error from loading blocker diagnostics; surfaced so failures are visible. */
   diagnosticsError?: string | null;
-  /** Render even when there is no special next action (kind "none"). */
+  /** Render even when there is no special next action (lane "none"). */
   showWhenOnTrack?: boolean;
   className?: string;
 }
 
 /**
- * A consolidated, plain-language "what moves this forward next" card.
- *
- * PAP-13005 Phase 5 — reads the existing diagnostic/attention shape and renders
- * one readable next-action answer for issue detail, subtree, and run surfaces.
+ * The consolidated "what moves this forward next" panel (PAP-13005 Phase 5,
+ * per the Phase 4 UX spec). Resolves the task into exactly one of four lanes
+ * and renders it as a neutral card with a lane-hued left accent.
  */
 export function IssueNextActionCard({
   status,
@@ -180,6 +93,7 @@ export function IssueNextActionCard({
   scheduledRetry,
   successfulRunHandoff,
   blockerDiagnostics,
+  hasLiveRun,
   diagnosticsError,
   showWhenOnTrack = false,
   className,
@@ -191,87 +105,98 @@ export function IssueNextActionCard({
     scheduledRetry,
     successfulRunHandoff,
     blockerDiagnostics,
+    hasLiveRun,
   });
 
-  if (summary.kind === "none" && !showWhenOnTrack && !diagnosticsError) {
+  if (summary.lane === "none" && !showWhenOnTrack && !diagnosticsError) {
     return null;
   }
 
-  const tone = TONE_STYLES[summary.tone];
-  const Icon = KIND_ICON[summary.kind];
+  const accent = ACCENT_VAR[summary.accent];
+  const Icon = LANE_ICON[summary.lane];
+  const control = summary.primaryControl;
 
   return (
     <div
+      role="status"
       data-testid="issue-next-action-card"
-      data-next-action-kind={summary.kind}
-      data-next-action-tone={summary.tone}
-      className={`rounded-md border px-3 py-2.5 text-sm shadow-sm ${tone.container} ${className ?? ""}`}
+      data-next-action-lane={summary.lane}
+      data-next-action-accent={summary.accent}
+      data-terminal-gate={summary.terminalGate ? "true" : undefined}
+      data-recovery-debt={summary.recoveryDebt ? "true" : undefined}
+      style={{ borderLeftColor: accent, borderLeftWidth: "4px" }}
+      className={`rounded-md border border-border bg-card text-card-foreground px-3 py-2.5 shadow-sm ${className ?? ""}`}
     >
-      <div className="flex items-start gap-2">
-        <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${tone.icon}`} aria-hidden />
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="flex items-center gap-2">
-            <span className="text-(length:--text-nano) font-semibold uppercase tracking-wide opacity-70">
-              Next action
-            </span>
+      {/* 1. Lane chip */}
+      <div className="flex items-center gap-1.5">
+        {summary.live ? (
+          <span className="relative flex h-2 w-2" aria-hidden>
             <span
-              className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-(length:--text-nano) font-medium ${tone.badge}`}
-            >
-              {summary.badge}
-            </span>
-          </div>
-
-          <p className="font-medium leading-5">{summary.headline}</p>
-
-          {summary.action ? (
-            <p className="flex items-start gap-1.5 text-xs leading-5 opacity-90">
-              <ArrowRight className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-              <span>
-                <span className="font-medium">{summary.action.label}</span>
-                {summary.action.detail ? <> — {summary.action.detail}</> : null}
-              </span>
-            </p>
-          ) : null}
-
-          {summary.owner ? (
-            <p className="text-xs leading-5 opacity-80">
-              Owner: <span className="font-medium">{summary.owner.label}</span>
-            </p>
-          ) : null}
-
-          {summary.scheduledRetry?.status === "running" ? (
-            <p className="flex items-center gap-1.5 text-xs leading-5 opacity-80">
-              <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
-              Corrective run in progress
-            </p>
-          ) : null}
-
-          {(summary.sourceRef || summary.leafRef || summary.recoveryRef) ? (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 pt-0.5">
-              {summary.sourceRef ? (
-                <RefChip refItem={summary.sourceRef} label="Work happens on" toneClass={tone.refChip} />
-              ) : null}
-              {summary.leafRef ? (
-                <RefChip refItem={summary.leafRef} label="Waiting on" toneClass={tone.refChip} />
-              ) : null}
-              {summary.recoveryRef ? (
-                <RefChip refItem={summary.recoveryRef} label="Recovery" toneClass={tone.refChip} />
-              ) : null}
-            </div>
-          ) : null}
-
-          <TerminalGateRow gates={summary.terminalGates} toneClass={tone.refChip} />
-
-          {diagnosticsError ? (
-            <p
-              data-testid="issue-next-action-diagnostics-error"
-              className="mt-1 rounded-md border border-red-300/70 bg-red-50/80 px-2 py-1 text-xs leading-5 text-red-800 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200"
-            >
-              Couldn&apos;t load full blocker diagnostics: {diagnosticsError}
-            </p>
-          ) : null}
-        </div>
+              className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60 motion-reduce:animate-none"
+              style={{ backgroundColor: accent }}
+            />
+            <span className="relative inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: accent }} />
+          </span>
+        ) : (
+          <Icon className="h-3.5 w-3.5" style={{ color: accent }} aria-hidden />
+        )}
+        <span
+          className="text-(length:--text-micro) font-semibold uppercase tracking-wide"
+          style={{ color: accent }}
+        >
+          {summary.laneLabel}
+        </span>
       </div>
+
+      {/* 2. Statement — the answer */}
+      <p className="mt-1 text-sm font-semibold leading-5 text-foreground">{summary.statement}</p>
+
+      {/* 3. Why line */}
+      {summary.why ? (
+        <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+          {summary.owner ? (
+            <>
+              <span className="font-medium text-foreground">{summary.owner.label}</span>
+              {" · "}
+            </>
+          ) : null}
+          {summary.why}
+        </p>
+      ) : null}
+
+      {/* 4. Action row: primary control + reference chips */}
+      {(control?.ref || summary.references.length > 0) ? (
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+          {control?.ref ? (
+            <Link
+              to={createIssueDetailPath(control.ref.identifier ?? control.ref.id)}
+              data-testid="issue-next-action-primary-control"
+              data-control-kind={control.kind}
+              className="inline-flex items-center rounded-md border border-border bg-background px-2 py-0.5 text-xs font-medium text-foreground transition-colors hover:border-foreground/30 hover:bg-muted"
+            >
+              {control.label}
+            </Link>
+          ) : null}
+          {summary.references.map((reference) => (
+            <ReferenceChip key={`${reference.label}-${reference.ref.id}`} reference={reference} />
+          ))}
+        </div>
+      ) : null}
+
+      {/* 5. Provenance meta */}
+      <p className="mt-1.5 font-mono text-(length:--text-nano) text-muted-foreground">
+        resolved from {summary.resolvedFrom}
+      </p>
+
+      {diagnosticsError ? (
+        <p
+          data-testid="issue-next-action-diagnostics-error"
+          className="mt-1.5 rounded-md border border-border bg-muted px-2 py-1 text-xs leading-5 text-foreground"
+          style={{ borderLeftColor: "var(--status-task-blocked)", borderLeftWidth: "3px" }}
+        >
+          Couldn&apos;t load full blocker diagnostics: {diagnosticsError}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/IssueSubtreeNextActionView.test.tsx
+++ b/ui/src/components/IssueSubtreeNextActionView.test.tsx
@@ -126,7 +126,27 @@ describe("IssueSubtreeNextActionView", () => {
               },
             ],
           }),
-          node({ id: "leaf", identifier: "PAP-2", status: "in_progress", depth: 1 }),
+          node({
+            id: "leaf",
+            identifier: "PAP-2",
+            status: "in_progress",
+            depth: 1,
+            parentId: "root",
+            wakeEvents: [{
+              kind: "wake_request",
+              agentId: "agent-1",
+              source: "assigned",
+              reason: "issue_assigned",
+              status: "queued",
+              coalescedCount: 0,
+              runId: null,
+              requestedAt: "2026-08-06T00:00:00.000Z",
+              claimedAt: null,
+              finishedAt: null,
+              failureClass: null,
+            }],
+            wakeRequestCount: 1,
+          }),
         ])}
       />,
     );

--- a/ui/src/components/IssueSubtreeNextActionView.test.tsx
+++ b/ui/src/components/IssueSubtreeNextActionView.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import type { ComponentProps, ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  IssueStatus,
+  IssueSubtreeDiagnosticNode,
+  IssueSubtreeDiagnosticsResponse,
+} from "@paperclipai/shared";
+import { IssueSubtreeNextActionView } from "./IssueSubtreeNextActionView";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string } & ComponentProps<"a">) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  flushSync(() => root.unmount());
+  container.remove();
+});
+
+function render(node: ReactNode) {
+  flushSync(() => {
+    root.render(node);
+  });
+}
+
+function node(
+  overrides: { id: string; identifier: string; status: IssueStatus; depth?: number } & Partial<IssueSubtreeDiagnosticNode>,
+): IssueSubtreeDiagnosticNode {
+  const { id, identifier, status, depth = 0, ...rest } = overrides;
+  return {
+    issue: {
+      id,
+      identifier,
+      title: `${identifier} title`,
+      status,
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    },
+    parentId: null,
+    depth,
+    diagnosis: null,
+    likelyReason: null,
+    blockers: [],
+    blockerReadiness: null,
+    omittedUnauthorizedBlockerCount: null,
+    wakeEvents: [],
+    wakeRequestCount: 0,
+    activityRecordCount: 0,
+    truncated: false,
+    truncatedSections: { blockers: false, wakeRequests: false, activityRecords: false },
+    ...rest,
+  };
+}
+
+const rootIssueSummary: IssueSubtreeDiagnosticsResponse["issue"] = {
+  id: "root",
+  identifier: "PAP-1",
+  title: "root",
+  status: "blocked",
+  priority: "medium",
+  assigneeAgentId: null,
+  assigneeUserId: null,
+};
+
+function response(nodes: IssueSubtreeDiagnosticNode[]): IssueSubtreeDiagnosticsResponse {
+  return {
+    issue: nodes[0]?.issue ?? rootIssueSummary,
+    diagnosis: null,
+    likelyReason: null,
+    nodes,
+    edges: [],
+    nodeCount: nodes.length,
+    omittedUnauthorizedNodeCount: null,
+    truncated: false,
+    truncatedSections: { nodes: false, depth: false, blockers: false, wakeRequests: false, activityRecords: false },
+    caps: {
+      maxDepth: 5,
+      maxNodes: 50,
+      maxBlockersPerNode: 20,
+      maxWakeRequestsPerNode: 20,
+      maxActivityRecordsPerNode: 20,
+      lookbackDays: 14,
+    },
+  };
+}
+
+describe("IssueSubtreeNextActionView", () => {
+  it("renders one row per node with a per-node lane and highlights the single actionable leaf", () => {
+    render(
+      <IssueSubtreeNextActionView
+        data={response([
+          node({
+            id: "root",
+            identifier: "PAP-1",
+            status: "blocked",
+            blockers: [
+              {
+                id: "leaf",
+                identifier: "PAP-2",
+                title: "child",
+                status: "in_progress",
+                priority: "medium",
+                assigneeAgentId: null,
+                assigneeUserId: null,
+                isUnresolved: true,
+                isDependencyReady: false,
+                isPendingFinalize: false,
+                flags: [],
+              },
+            ],
+          }),
+          node({ id: "leaf", identifier: "PAP-2", status: "in_progress", depth: 1 }),
+        ])}
+      />,
+    );
+
+    const rows = container.querySelectorAll('[data-testid="issue-subtree-node"]');
+    expect(rows).toHaveLength(2);
+
+    // Root is blocked by its child.
+    expect(rows[0].getAttribute("data-node-lane")).toBe("blocked_real_work");
+    // The unblocked, in-progress child is where work moves — the actionable leaf.
+    expect(rows[1].getAttribute("data-actionable-leaf")).toBe("true");
+    expect(rows[0].getAttribute("data-actionable-leaf")).toBeNull();
+    expect(container.textContent).toContain("Blocked → PAP-2");
+    expect(container.textContent).toContain("Act here");
+  });
+
+  it("renders nothing when there are no nodes", () => {
+    render(<IssueSubtreeNextActionView data={response([])} />);
+    expect(container.querySelector('[data-testid="issue-subtree-next-action"]')).toBeNull();
+  });
+});

--- a/ui/src/components/IssueSubtreeNextActionView.tsx
+++ b/ui/src/components/IssueSubtreeNextActionView.tsx
@@ -1,0 +1,153 @@
+import { Ban, CircleDot, LifeBuoy, Play } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { IssueSubtreeDiagnosticsResponse } from "@paperclipai/shared";
+import { Link } from "@/lib/router";
+import { createIssueDetailPath } from "../lib/issueDetailBreadcrumb";
+import {
+  deriveSubtreeNodeBadge,
+  selectActionableLeafNodeId,
+  type NextActionAccent,
+  type NextActionLane,
+} from "../lib/next-action";
+
+/** Left-accent hue per lane. All values are tokens — never raw color literals. */
+const ACCENT_VAR: Record<NextActionAccent, string> = {
+  in_progress: "var(--status-task-in_progress)",
+  in_review: "var(--status-task-in_review)",
+  todo: "var(--status-task-todo)",
+  blocked: "var(--status-task-blocked)",
+  recovery_amber: "var(--status-task-todo)",
+  recovery_sky: "var(--status-task-in_progress)",
+  recovery_red: "var(--status-task-blocked)",
+  none: "var(--muted-foreground)",
+};
+
+const LANE_ICON: Record<NextActionLane, LucideIcon> = {
+  working_now: Play,
+  recovery: LifeBuoy,
+  waiting_decision: CircleDot,
+  blocked_real_work: Ban,
+  none: CircleDot,
+};
+
+export interface IssueSubtreeNextActionViewProps {
+  data: IssueSubtreeDiagnosticsResponse;
+  className?: string;
+}
+
+/**
+ * Subtree diagnostics — the same next-action resolver, one compact line per
+ * node (Phase 4 UX spec §5). The operator scans the tree to find where work
+ * moves next without opening every child; the single actionable leaf is
+ * highlighted so it reads at a glance (Information Scent / F-pattern).
+ */
+export function IssueSubtreeNextActionView({ data, className }: IssueSubtreeNextActionViewProps) {
+  const actionableLeafId = selectActionableLeafNodeId(data.nodes);
+
+  if (data.nodes.length === 0) return null;
+
+  return (
+    <div
+      data-testid="issue-subtree-next-action"
+      className={`rounded-md border border-border bg-card text-card-foreground ${className ?? ""}`}
+    >
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
+          Blocker map · next action per node
+        </span>
+        <span className="font-mono text-(length:--text-nano) text-muted-foreground">
+          {data.nodeCount} node{data.nodeCount === 1 ? "" : "s"}
+          {data.truncated ? " · truncated" : ""}
+        </span>
+      </div>
+
+      <ul className="divide-y divide-border/60">
+        {data.nodes.map((node) => {
+          const badge = deriveSubtreeNodeBadge(node);
+          const accent = ACCENT_VAR[badge.accent];
+          const Icon = LANE_ICON[badge.lane];
+          const isActionable = node.issue.id === actionableLeafId;
+          const issuePathId = node.issue.identifier ?? node.issue.id;
+          const targetPathId = badge.target
+            ? badge.target.identifier ?? badge.target.id
+            : null;
+          return (
+            <li
+              key={node.issue.id}
+              data-testid="issue-subtree-node"
+              data-node-lane={badge.lane}
+              data-actionable-leaf={isActionable ? "true" : undefined}
+              className="flex items-center gap-2 px-3 py-2"
+              style={
+                isActionable
+                  ? {
+                    // Actionable leaf highlight: lane hue @ 6% bg + accent rail.
+                    backgroundColor: "color-mix(in oklab, var(--status-task-todo) 6%, transparent)",
+                    boxShadow: "inset 3px 0 0 0 var(--status-task-todo)",
+                  }
+                  : undefined
+              }
+            >
+              {/* Depth indentation so the parent→child shape reads. */}
+              <span
+                aria-hidden
+                style={{ width: `${Math.min(node.depth, 6) * 12}px` }}
+                className="shrink-0"
+              />
+
+              {/* Node identity */}
+              <Link
+                to={createIssueDetailPath(issuePathId)}
+                className="inline-flex min-w-0 items-center gap-1.5 font-mono text-xs text-foreground hover:underline"
+              >
+                <span className="shrink-0">{node.issue.identifier ?? node.issue.id.slice(0, 8)}</span>
+                <span className="truncate font-sans text-(length:--text-micro) text-muted-foreground">
+                  {node.issue.title}
+                </span>
+              </Link>
+
+              <span className="ml-auto flex shrink-0 items-center gap-1.5">
+                {isActionable ? (
+                  <span
+                    className="rounded-sm px-1 py-0.5 text-(length:--text-nano) font-semibold uppercase tracking-wide"
+                    style={{
+                      color: "var(--status-task-todo)",
+                      backgroundColor: "color-mix(in oklab, var(--status-task-todo) 14%, transparent)",
+                    }}
+                  >
+                    Act here
+                  </span>
+                ) : null}
+
+                {/* Compact lane badge */}
+                <span
+                  className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-(length:--text-nano) font-medium"
+                  style={{ borderColor: accent, color: accent }}
+                >
+                  <Icon className="h-3 w-3" aria-hidden />
+                  {targetPathId ? (
+                    <Link
+                      to={createIssueDetailPath(targetPathId)}
+                      className="font-mono hover:underline"
+                      style={{ color: accent }}
+                    >
+                      {badge.statement}
+                    </Link>
+                  ) : (
+                    <span className="font-mono">{badge.statement}</span>
+                  )}
+                </span>
+
+                {badge.gate ? (
+                  <span className="inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-(length:--text-nano) text-muted-foreground">
+                    {badge.gate}
+                  </span>
+                ) : null}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/ui/src/components/IssueSubtreeNextActionView.tsx
+++ b/ui/src/components/IssueSubtreeNextActionView.tsx
@@ -37,7 +37,7 @@ export interface IssueSubtreeNextActionViewProps {
 
 /**
  * Subtree diagnostics — the same next-action resolver, one compact line per
- * node (Phase 4 UX spec §5). The operator scans the tree to find where work
+ * node. The operator scans the tree to find where work
  * moves next without opening every child; the single actionable leaf is
  * highlighted so it reads at a glance (Information Scent / F-pattern).
  */
@@ -81,9 +81,8 @@ export function IssueSubtreeNextActionView({ data, className }: IssueSubtreeNext
               style={
                 isActionable
                   ? {
-                    // Actionable leaf highlight: lane hue @ 6% bg + accent rail.
-                    backgroundColor: "color-mix(in oklab, var(--status-task-todo) 6%, transparent)",
-                    boxShadow: "inset 3px 0 0 0 var(--status-task-todo)",
+                    backgroundColor: "var(--surface-next-action-marker)",
+                    boxShadow: "var(--shadow-next-action-marker)",
                   }
                   : undefined
               }
@@ -91,7 +90,7 @@ export function IssueSubtreeNextActionView({ data, className }: IssueSubtreeNext
               {/* Depth indentation so the parent→child shape reads. */}
               <span
                 aria-hidden
-                style={{ width: `${Math.min(node.depth, 6) * 12}px` }}
+                style={{ width: `calc(var(--sz-12px) * ${Math.min(node.depth, 6)})` }}
                 className="shrink-0"
               />
 
@@ -112,7 +111,7 @@ export function IssueSubtreeNextActionView({ data, className }: IssueSubtreeNext
                     className="rounded-sm px-1 py-0.5 text-(length:--text-nano) font-semibold uppercase tracking-wide"
                     style={{
                       color: "var(--status-task-todo)",
-                      backgroundColor: "color-mix(in oklab, var(--status-task-todo) 14%, transparent)",
+                      backgroundColor: "var(--surface-next-action-chip)",
                     }}
                   >
                     Act here

--- a/ui/src/components/RunNextActionVerdict.tsx
+++ b/ui/src/components/RunNextActionVerdict.tsx
@@ -1,0 +1,87 @@
+import { useQuery } from "@tanstack/react-query";
+import { Ban, Clock, LifeBuoy, Play } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { issuesApi } from "../api/issues";
+import { queryKeys } from "../lib/queryKeys";
+import {
+  deriveNextAction,
+  type NextActionAccent,
+  type NextActionLane,
+} from "../lib/next-action";
+
+/** Left-accent hue per lane. All values are tokens — never raw color literals. */
+const ACCENT_VAR: Record<NextActionAccent, string> = {
+  in_progress: "var(--status-task-in_progress)",
+  in_review: "var(--status-task-in_review)",
+  todo: "var(--status-task-todo)",
+  blocked: "var(--status-task-blocked)",
+  recovery_amber: "var(--status-task-todo)",
+  recovery_sky: "var(--status-task-in_progress)",
+  recovery_red: "var(--status-task-blocked)",
+  none: "var(--border)",
+};
+
+const LANE_ICON: Record<NextActionLane, LucideIcon> = {
+  working_now: Play,
+  recovery: LifeBuoy,
+  waiting_decision: Clock,
+  blocked_real_work: Ban,
+  none: Clock,
+};
+
+export interface RunNextActionVerdictProps {
+  issueId: string;
+  /** True when the surfacing run is itself live against this issue. */
+  runIsActive?: boolean;
+  className?: string;
+}
+
+/**
+ * Compact, single-line next-action verdict for a run surface (PAP-13005
+ * Phase 5b). Reuses the same four-lane resolver as the issue-detail panel so a
+ * run drawer answers "what moves this task forward next?" without re-deriving
+ * it. Renders nothing when the task is on track or terminal.
+ */
+export function RunNextActionVerdict({ issueId, runIsActive, className }: RunNextActionVerdictProps) {
+  const { data: issue } = useQuery({
+    queryKey: queryKeys.issues.detail(issueId),
+    queryFn: () => issuesApi.get(issueId),
+    enabled: Boolean(issueId),
+    staleTime: 15_000,
+  });
+
+  if (!issue) return null;
+
+  const summary = deriveNextAction({
+    status: issue.status,
+    blockedInboxAttention: issue.blockedInboxAttention ?? null,
+    activeRecoveryAction: issue.activeRecoveryAction ?? null,
+    scheduledRetry: issue.scheduledRetry ?? null,
+    successfulRunHandoff: issue.successfulRunHandoff ?? null,
+    hasLiveRun: runIsActive,
+  });
+
+  if (summary.lane === "none") return null;
+
+  const accent = ACCENT_VAR[summary.accent];
+  const Icon = LANE_ICON[summary.lane];
+
+  return (
+    <div
+      role="status"
+      data-testid="run-next-action-verdict"
+      data-next-action-lane={summary.lane}
+      style={{ borderLeftColor: accent, borderLeftWidth: "3px" }}
+      className={`flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-xs ${className ?? ""}`}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" style={{ color: accent }} aria-hidden />
+      <span
+        className="shrink-0 text-(length:--text-nano) font-semibold uppercase tracking-wide"
+        style={{ color: accent }}
+      >
+        {summary.laneLabel}
+      </span>
+      <span className="truncate font-medium text-foreground">{summary.statement}</span>
+    </div>
+  );
+}

--- a/ui/src/components/RunNextActionVerdict.tsx
+++ b/ui/src/components/RunNextActionVerdict.tsx
@@ -37,8 +37,8 @@ export interface RunNextActionVerdictProps {
 }
 
 /**
- * Compact, single-line next-action verdict for a run surface (PAP-13005
- * Phase 5b). Reuses the same four-lane resolver as the issue-detail panel so a
+ * Compact, single-line next-action verdict for a run surface. Reuses the same
+ * four-lane resolver as the issue-detail panel so a
  * run drawer answers "what moves this task forward next?" without re-deriving
  * it. Renders nothing when the task is on track or terminal.
  */
@@ -71,7 +71,7 @@ export function RunNextActionVerdict({ issueId, runIsActive, className }: RunNex
       role="status"
       data-testid="run-next-action-verdict"
       data-next-action-lane={summary.lane}
-      style={{ borderLeftColor: accent, borderLeftWidth: "3px" }}
+      style={{ borderLeftColor: accent, borderLeftWidth: "var(--sz-3px)" }}
       className={`flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1.5 text-xs ${className ?? ""}`}
     >
       <Icon className="h-3.5 w-3.5 shrink-0" style={{ color: accent }} aria-hidden />

--- a/ui/src/hooks/useIssueBlockerDiagnostics.ts
+++ b/ui/src/hooks/useIssueBlockerDiagnostics.ts
@@ -1,0 +1,22 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type { IssueBlockerDiagnosticsResponse } from "@paperclipai/shared";
+import { issuesApi } from "../api/issues";
+import { queryKeys } from "../lib/queryKeys";
+
+/**
+ * Load the read-only blocker diagnostics for a task so the next-action surface
+ * can explain terminal gates (done-but-blocking / workspace-finalize-pending).
+ * Only enabled for tasks that are actually blocked, to avoid needless fetches.
+ */
+export function useIssueBlockerDiagnostics(
+  issueId: string | null | undefined,
+  options: { enabled?: boolean } = {},
+): UseQueryResult<IssueBlockerDiagnosticsResponse, unknown> {
+  const enabled = (options.enabled ?? true) && Boolean(issueId);
+  return useQuery({
+    queryKey: queryKeys.issues.blockerDiagnostics(issueId ?? "__none__"),
+    queryFn: () => issuesApi.getBlockerDiagnostics(issueId as string),
+    enabled,
+    staleTime: 15_000,
+  });
+}

--- a/ui/src/hooks/useIssueSubtreeDiagnostics.ts
+++ b/ui/src/hooks/useIssueSubtreeDiagnostics.ts
@@ -1,0 +1,22 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import type { IssueSubtreeDiagnosticsResponse } from "@paperclipai/shared";
+import { issuesApi } from "../api/issues";
+import { queryKeys } from "../lib/queryKeys";
+
+/**
+ * Load the read-only subtree / blocker diagnostics for a task so the Next Action
+ * panel can render a compact per-node verdict (Phase 4 UX spec §5). Only enabled
+ * when there is a subtree worth scanning, to avoid needless fetches.
+ */
+export function useIssueSubtreeDiagnostics(
+  issueId: string | null | undefined,
+  options: { enabled?: boolean } = {},
+): UseQueryResult<IssueSubtreeDiagnosticsResponse, unknown> {
+  const enabled = (options.enabled ?? true) && Boolean(issueId);
+  return useQuery({
+    queryKey: queryKeys.issues.subtreeDiagnostics(issueId ?? "__none__"),
+    queryFn: () => issuesApi.getSubtreeDiagnostics(issueId as string),
+    enabled,
+    staleTime: 15_000,
+  });
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1974,6 +1974,7 @@ span.paperclip-mention-chip[data-mention-kind="external-object"] {
   --sz-390px: 390px;
   --sz-64px: 64px;
   --sz-3px: 3px; /* Extracted from ui/src/components/ActivityCharts.tsx (gap-[3px]). */
+  --sz-12px: 12px; /* Next-action subtree depth step. */
   --sz-calc-1: calc(100% - 1.5rem); /* Extracted from ui/src/components/ActivityFeed.tsx (w-[calc(100%-1.5rem)]). */
   --sz-calc-2: calc(100% - 0.75rem); /* Extracted from ui/src/components/ActivityFeed.tsx (w-[calc(100%-0.75rem)]). */
   --sz-16rem: 16rem; /* Extracted from ui/src/components/ActivityFeed.tsx (max-w-[16rem]). */
@@ -2059,6 +2060,9 @@ span.paperclip-mention-chip[data-mention-kind="external-object"] {
   --sz-30px: 30px; /* Extracted from ui/src/components/WorkspaceFileBrowser.tsx (min-h-[30px]). */
   --sz-8px: 8px; /* Extracted from ui/src/components/artifacts/ArtifactGroupCard.tsx (translate-x-[8px]). */
   --sz-4px: 4px; /* Extracted from ui/src/components/artifacts/ArtifactGroupCard.tsx (translate-x-[4px]). */
+  --surface-next-action-marker: color-mix(in oklab, var(--status-task-todo) 6%, transparent);
+  --surface-next-action-chip: color-mix(in oklab, var(--status-task-todo) 14%, transparent);
+  --shadow-next-action-marker: inset 3px 0 0 0 var(--status-task-todo);
   --sz-34px: 34px; /* Extracted from ui/src/components/environment-variables-editor/SecretPicker.tsx (h-[34px]). */
   --sz-11rem: 11rem; /* Extracted from ui/src/components/issue-properties/IssueProperties.tsx (min-w-[11rem]). */
   --sz-32rem: 32rem; /* Extracted from ui/src/components/issue-properties/IssueProperties.tsx (w-[32rem]). */

--- a/ui/src/lib/next-action.test.ts
+++ b/ui/src/lib/next-action.test.ts
@@ -17,7 +17,7 @@ function inboxAttention(
     severity: "medium",
     stoppedSinceAt: null,
     owner: { type: "agent", agentId: "a1", userId: null, label: "ClaudeCoder" },
-    action: { label: "Resolve the stalled chain", detail: "Wake QA or remove the blocker." },
+    action: { label: "resolve the stalled chain", detail: "Wake QA or remove the blocker." },
     sourceIssue: null,
     leafIssue: {
       id: "leaf-1",
@@ -131,80 +131,102 @@ describe("deriveNextAction", () => {
       blockedInboxAttention: inboxAttention(),
       activeRecoveryAction: recoveryAction(),
     });
-    expect(result.kind).toBe("none");
+    expect(result.lane).toBe("none");
   });
 
-  it("prioritizes an active recovery action over blocked attention", () => {
+  it("puts a live run in Working now ahead of everything", () => {
+    const result = deriveNextAction({
+      status: "in_progress",
+      hasLiveRun: true,
+      activeRecoveryAction: recoveryAction(),
+    });
+    expect(result.lane).toBe("working_now");
+    expect(result.live).toBe(true);
+    expect(result.resolvedFrom).toBe("live_run");
+  });
+
+  it("treats a scheduled corrective wake as Working now (queued)", () => {
+    const result = deriveNextAction({ status: "in_progress", scheduledRetry });
+    expect(result.lane).toBe("working_now");
+    expect(result.statement).toContain("Queued to wake");
+    expect(result.resolvedFrom).toContain("scheduled_retry");
+  });
+
+  it("routes an active recovery action to the Recovery lane with attempt count", () => {
     const result = deriveNextAction({
       status: "in_progress",
       activeRecoveryAction: recoveryAction(),
       blockedInboxAttention: inboxAttention(),
     });
-    expect(result.kind).toBe("recovery");
-    expect(result.headline).toContain("clean isolated workspace");
-    expect(result.recovery?.id).toBe("rec-1");
+    expect(result.lane).toBe("recovery");
+    expect(result.statement).toContain("clean isolated workspace");
+    expect(result.why).toContain("attempt 1/3");
+    expect(result.primaryControl?.kind).toBe("open_recovery");
   });
 
-  it("uses the scheduled corrective run when no recovery action is present", () => {
+  it("flags escalated recovery as recovery debt", () => {
     const result = deriveNextAction({
-      status: "in_progress",
-      scheduledRetry,
+      status: "blocked",
+      activeRecoveryAction: recoveryAction({ status: "escalated" }),
     });
-    expect(result.kind).toBe("scheduled_retry");
-    expect(result.tone).toBe("sky");
-    expect(result.action?.label).toBe("Retry now");
+    expect(result.lane).toBe("recovery");
+    expect(result.recoveryDebt).toBe(true);
+    expect(result.laneLabel).toBe("Recovery debt");
+    expect(result.primaryControl?.kind).toBe("assign_worker");
   });
 
-  it("surfaces the successful-run handoff before generic blocked attention", () => {
+  it("routes a board owner to Waiting on a decision", () => {
     const result = deriveNextAction({
-      status: "in_progress",
-      successfulRunHandoff: {
-        state: "required",
-        required: true,
-        sourceRunId: "run-x",
-        correctiveRunId: null,
-        assigneeAgentId: "a1",
-        detectedProgressSummary: null,
-        createdAt: null,
-      },
+      status: "in_review",
+      blockedInboxAttention: inboxAttention({
+        state: "awaiting_decision",
+        reason: "pending_board_decision",
+        owner: { type: "board", agentId: null, userId: null, label: "Board" },
+        action: { label: "accept or reject the plan", detail: null },
+        leafIssue: null,
+      }),
     });
-    expect(result.kind).toBe("successful_run_handoff");
-    expect(result.action?.label).toBe("Choose a disposition");
+    expect(result.lane).toBe("waiting_decision");
+    expect(result.owner?.label).toBe("Board");
+    expect(result.statement).toContain("Waiting for Board");
   });
 
-  it("collapses blocked-inbox attention into a readable answer with the leaf blocker", () => {
+  it("routes a needs-attention blocker chain to Blocked by real work", () => {
     const result = deriveNextAction({
       status: "blocked",
       blockedInboxAttention: inboxAttention(),
     });
-    expect(result.kind).toBe("blocked");
-    expect(result.owner?.label).toBe("ClaudeCoder");
-    expect(result.leafRef?.identifier).toBe("PAP-12921");
-    expect(result.action?.label).toBe("Resolve the stalled chain");
+    expect(result.lane).toBe("blocked_real_work");
+    expect(result.terminalGate).toBe(false);
+    expect(result.references.some((r) => r.ref.identifier === "PAP-12921")).toBe(true);
   });
 
-  it("flags a done-but-blocking terminal gate from blocker diagnostics", () => {
+  it("marks a workspace-finalize gate as a terminal-gate blocked variant", () => {
+    const result = deriveNextAction({
+      status: "blocked",
+      blockedInboxAttention: inboxAttention(),
+      blockerDiagnostics: blockerDiagnostics(["workspace_finalize_pending"]),
+    });
+    expect(result.lane).toBe("blocked_real_work");
+    expect(result.terminalGate).toBe(true);
+    expect(result.statement).toContain("Done");
+    expect(
+      result.references.some((r) => r.gate === "gate: workspace_finalize_pending"),
+    ).toBe(true);
+  });
+
+  it("reveals a terminal gate from blocker diagnostics alone", () => {
     const result = deriveNextAction({
       status: "blocked",
       blockerDiagnostics: blockerDiagnostics(["done_but_blocking"]),
     });
-    expect(result.kind).toBe("terminal_gate");
+    expect(result.lane).toBe("blocked_real_work");
+    expect(result.terminalGate).toBe(true);
     expect(result.terminalGates).toHaveLength(1);
-    expect(result.headline).toContain("done but still blocking");
-  });
-
-  it("explains a workspace-finalize-pending gate in plain language", () => {
-    const result = deriveNextAction({
-      status: "blocked",
-      blockedInboxAttention: inboxAttention({ reason: "blocked_chain_stalled" }),
-      blockerDiagnostics: blockerDiagnostics(["workspace_finalize_pending"]),
-    });
-    expect(result.kind).toBe("terminal_gate");
-    expect(result.headline).toContain("workspace finalize gate");
   });
 
   it("returns none when nothing needs attention", () => {
     const result = deriveNextAction({ status: "in_progress" });
-    expect(result.kind).toBe("none");
+    expect(result.lane).toBe("none");
   });
 });

--- a/ui/src/lib/next-action.test.ts
+++ b/ui/src/lib/next-action.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import type {
+  IssueBlockedInboxAttention,
+  IssueBlockerDiagnosticsResponse,
+  IssueRecoveryAction,
+  IssueScheduledRetry,
+} from "@paperclipai/shared";
+import { deriveNextAction } from "./next-action";
+
+function inboxAttention(
+  overrides: Partial<IssueBlockedInboxAttention> = {},
+): IssueBlockedInboxAttention {
+  return {
+    kind: "blocked",
+    state: "needs_attention",
+    reason: "blocked_chain_stalled",
+    severity: "medium",
+    stoppedSinceAt: null,
+    owner: { type: "agent", agentId: "a1", userId: null, label: "ClaudeCoder" },
+    action: { label: "Resolve the stalled chain", detail: "Wake QA or remove the blocker." },
+    sourceIssue: null,
+    leafIssue: {
+      id: "leaf-1",
+      identifier: "PAP-12921",
+      title: "QA release verification",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: "qa-1",
+      assigneeUserId: null,
+    },
+    recoveryIssue: null,
+    approvalId: null,
+    interactionId: null,
+    sampleIssueIdentifier: null,
+    redaction: { externalDetailsRedacted: false, secretFieldsOmitted: true },
+    ...overrides,
+  };
+}
+
+function recoveryAction(overrides: Partial<IssueRecoveryAction> = {}): IssueRecoveryAction {
+  return {
+    id: "rec-1",
+    companyId: "c1",
+    sourceIssueId: "i1",
+    recoveryIssueId: "rec-issue-1",
+    kind: "workspace_validation",
+    status: "active",
+    ownerType: "agent",
+    ownerAgentId: "a1",
+    ownerUserId: null,
+    previousOwnerAgentId: null,
+    returnOwnerAgentId: null,
+    cause: "workspace_divergence",
+    fingerprint: "fp",
+    evidence: {},
+    nextAction: "Reissue the task in a clean isolated workspace.",
+    wakePolicy: null,
+    monitorPolicy: null,
+    attemptCount: 1,
+    maxAttempts: 3,
+    timeoutAt: null,
+    lastAttemptAt: null,
+    outcome: null,
+    resolutionNote: null,
+    resolvedAt: null,
+    createdAt: "2026-07-08T00:00:00.000Z",
+    updatedAt: "2026-07-08T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const scheduledRetry: IssueScheduledRetry = {
+  runId: "run-1",
+  status: "scheduled_retry",
+  agentId: "a1",
+  agentName: "ClaudeCoder",
+  retryOfRunId: "run-0",
+  scheduledRetryAt: "2026-07-08T00:10:00.000Z",
+  scheduledRetryAttempt: 2,
+  scheduledRetryReason: "transient_failure",
+  retryExhaustedReason: null,
+  error: null,
+  errorCode: null,
+};
+
+function blockerDiagnostics(
+  flags: IssueBlockerDiagnosticsResponse["blockers"][number]["flags"],
+): IssueBlockerDiagnosticsResponse {
+  return {
+    issue: {
+      id: "i1",
+      identifier: "PAP-12915",
+      title: "Release verify parallel",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    },
+    diagnosis: "Blocked by a done task that still gates dependents.",
+    readiness: {
+      allBlockersDone: true,
+      isDependencyReady: false,
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerCount: 1,
+    },
+    blockers: [
+      {
+        id: "b1",
+        identifier: "PAP-12920",
+        title: "Release verify child",
+        status: "done",
+        priority: "medium",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        isUnresolved: false,
+        isDependencyReady: false,
+        isPendingFinalize: true,
+        flags,
+      },
+    ],
+    omittedUnauthorizedBlockerCount: 0,
+    truncated: false,
+    caps: { maxBlockers: 50 },
+  };
+}
+
+describe("deriveNextAction", () => {
+  it("returns none for terminal tasks", () => {
+    const result = deriveNextAction({
+      status: "done",
+      blockedInboxAttention: inboxAttention(),
+      activeRecoveryAction: recoveryAction(),
+    });
+    expect(result.kind).toBe("none");
+  });
+
+  it("prioritizes an active recovery action over blocked attention", () => {
+    const result = deriveNextAction({
+      status: "in_progress",
+      activeRecoveryAction: recoveryAction(),
+      blockedInboxAttention: inboxAttention(),
+    });
+    expect(result.kind).toBe("recovery");
+    expect(result.headline).toContain("clean isolated workspace");
+    expect(result.recovery?.id).toBe("rec-1");
+  });
+
+  it("uses the scheduled corrective run when no recovery action is present", () => {
+    const result = deriveNextAction({
+      status: "in_progress",
+      scheduledRetry,
+    });
+    expect(result.kind).toBe("scheduled_retry");
+    expect(result.tone).toBe("sky");
+    expect(result.action?.label).toBe("Retry now");
+  });
+
+  it("surfaces the successful-run handoff before generic blocked attention", () => {
+    const result = deriveNextAction({
+      status: "in_progress",
+      successfulRunHandoff: {
+        state: "required",
+        required: true,
+        sourceRunId: "run-x",
+        correctiveRunId: null,
+        assigneeAgentId: "a1",
+        detectedProgressSummary: null,
+        createdAt: null,
+      },
+    });
+    expect(result.kind).toBe("successful_run_handoff");
+    expect(result.action?.label).toBe("Choose a disposition");
+  });
+
+  it("collapses blocked-inbox attention into a readable answer with the leaf blocker", () => {
+    const result = deriveNextAction({
+      status: "blocked",
+      blockedInboxAttention: inboxAttention(),
+    });
+    expect(result.kind).toBe("blocked");
+    expect(result.owner?.label).toBe("ClaudeCoder");
+    expect(result.leafRef?.identifier).toBe("PAP-12921");
+    expect(result.action?.label).toBe("Resolve the stalled chain");
+  });
+
+  it("flags a done-but-blocking terminal gate from blocker diagnostics", () => {
+    const result = deriveNextAction({
+      status: "blocked",
+      blockerDiagnostics: blockerDiagnostics(["done_but_blocking"]),
+    });
+    expect(result.kind).toBe("terminal_gate");
+    expect(result.terminalGates).toHaveLength(1);
+    expect(result.headline).toContain("done but still blocking");
+  });
+
+  it("explains a workspace-finalize-pending gate in plain language", () => {
+    const result = deriveNextAction({
+      status: "blocked",
+      blockedInboxAttention: inboxAttention({ reason: "blocked_chain_stalled" }),
+      blockerDiagnostics: blockerDiagnostics(["workspace_finalize_pending"]),
+    });
+    expect(result.kind).toBe("terminal_gate");
+    expect(result.headline).toContain("workspace finalize gate");
+  });
+
+  it("returns none when nothing needs attention", () => {
+    const result = deriveNextAction({ status: "in_progress" });
+    expect(result.kind).toBe("none");
+  });
+});

--- a/ui/src/lib/next-action.test.ts
+++ b/ui/src/lib/next-action.test.ts
@@ -11,6 +11,7 @@ import type {
 import {
   deriveNextAction,
   deriveSubtreeNodeBadge,
+  isRunActiveForIssue,
   selectActionableLeafNodeId,
 } from "./next-action";
 
@@ -222,10 +223,22 @@ describe("deriveNextAction", () => {
     ).toBe(true);
   });
 
-  it("reveals a terminal gate from blocker diagnostics alone", () => {
+  it("treats a stale Done blocker relation as recovery debt, not a terminal gate", () => {
     const result = deriveNextAction({
       status: "blocked",
       blockerDiagnostics: blockerDiagnostics(["done_but_blocking"]),
+    });
+    expect(result.lane).toBe("recovery");
+    expect(result.recoveryDebt).toBe(true);
+    expect(result.terminalGate).toBe(false);
+    expect(result.statement).toContain("Clear or replace");
+    expect(result.references[0]?.gate).toBe("relation: done_but_blocking");
+  });
+
+  it("reveals a workspace-finalize terminal gate from diagnostics alone", () => {
+    const result = deriveNextAction({
+      status: "blocked",
+      blockerDiagnostics: blockerDiagnostics(["done_but_blocking", "workspace_finalize_pending"]),
     });
     expect(result.lane).toBe("blocked_real_work");
     expect(result.terminalGate).toBe(true);
@@ -235,6 +248,24 @@ describe("deriveNextAction", () => {
   it("returns none when nothing needs attention", () => {
     const result = deriveNextAction({ status: "in_progress" });
     expect(result.lane).toBe("none");
+  });
+});
+
+describe("isRunActiveForIssue", () => {
+  it("only marks the issue named by an active run scope", () => {
+    const run = {
+      status: "running",
+      contextSnapshot: { issueId: "current-issue" },
+    };
+    expect(isRunActiveForIssue(run, "current-issue")).toBe(true);
+    expect(isRunActiveForIssue(run, "historical-issue")).toBe(false);
+  });
+
+  it("does not treat a finished run as live for its scoped issue", () => {
+    expect(isRunActiveForIssue(
+      { status: "succeeded", contextSnapshot: { issueId: "current-issue" } },
+      "current-issue",
+    )).toBe(false);
   });
 });
 
@@ -354,6 +385,54 @@ describe("deriveSubtreeNodeBadge", () => {
     expect(badge.accent).toBe("recovery_red");
   });
 
+  it("treats a stale Done blocker relation as recovery debt", () => {
+    const badge = deriveSubtreeNodeBadge(
+      subtreeNode({
+        status: "blocked",
+        blockers: [
+          blockerNode({
+            status: "done",
+            isUnresolved: false,
+            flags: ["done_but_blocking"],
+          }),
+        ],
+      }),
+    );
+    expect(badge.lane).toBe("recovery");
+    expect(badge.laneLabel).toBe("Recovery debt");
+    expect(badge.gate).toBe("relation: done_but_blocking");
+  });
+
+  it("does not infer active work from status without a live wake", () => {
+    const badge = deriveSubtreeNodeBadge(subtreeNode({ status: "in_progress" }));
+    expect(badge.lane).toBe("recovery");
+    expect(badge.ready).toBe(false);
+    expect(badge.statement).toBe("No live continuation.");
+  });
+
+  it("marks active work only when a queued wake provides live evidence", () => {
+    const badge = deriveSubtreeNodeBadge(subtreeNode({
+      status: "in_progress",
+      wakeEvents: [{
+        kind: "wake_request",
+        agentId: "a1",
+        source: "assigned",
+        reason: "issue_assigned",
+        status: "queued",
+        coalescedCount: 0,
+        runId: null,
+        requestedAt: "2026-08-06T00:00:00.000Z",
+        claimedAt: null,
+        finishedAt: null,
+        failureClass: null,
+      }],
+      wakeRequestCount: 1,
+    }));
+    expect(badge.lane).toBe("working_now");
+    expect(badge.ready).toBe(true);
+    expect(badge.resolvedFrom).toBe("live_wake");
+  });
+
   it("marks an unblocked non-terminal node as ready to run", () => {
     const badge = deriveSubtreeNodeBadge(subtreeNode({ status: "todo" }));
     expect(badge.ready).toBe(true);
@@ -387,6 +466,14 @@ describe("selectActionableLeafNodeId", () => {
     const nodes = [
       subtreeNode({ id: "a", status: "done" }),
       subtreeNode({ id: "b", status: "cancelled" }),
+    ];
+    expect(selectActionableLeafNodeId(nodes)).toBeNull();
+  });
+
+  it("does not select a ready parent when only its child is a leaf", () => {
+    const nodes = [
+      subtreeNode({ id: "parent", status: "todo" }),
+      subtreeNode({ id: "child", status: "done", parentId: "parent", depth: 1 }),
     ];
     expect(selectActionableLeafNodeId(nodes)).toBeNull();
   });

--- a/ui/src/lib/next-action.test.ts
+++ b/ui/src/lib/next-action.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 import type {
   IssueBlockedInboxAttention,
+  IssueBlockerDiagnosticNode,
   IssueBlockerDiagnosticsResponse,
   IssueRecoveryAction,
   IssueScheduledRetry,
+  IssueStatus,
+  IssueSubtreeDiagnosticNode,
 } from "@paperclipai/shared";
-import { deriveNextAction } from "./next-action";
+import {
+  deriveNextAction,
+  deriveSubtreeNodeBadge,
+  selectActionableLeafNodeId,
+} from "./next-action";
 
 function inboxAttention(
   overrides: Partial<IssueBlockedInboxAttention> = {},
@@ -228,5 +235,159 @@ describe("deriveNextAction", () => {
   it("returns none when nothing needs attention", () => {
     const result = deriveNextAction({ status: "in_progress" });
     expect(result.lane).toBe("none");
+  });
+});
+
+function blockerNode(
+  overrides: Partial<IssueBlockerDiagnosticNode> = {},
+): IssueBlockerDiagnosticNode {
+  return {
+    id: "b1",
+    identifier: "PAP-900",
+    title: "Upstream work",
+    status: "in_progress",
+    priority: "medium",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    isUnresolved: true,
+    isDependencyReady: false,
+    isPendingFinalize: false,
+    flags: [],
+    ...overrides,
+  };
+}
+
+function subtreeNode(
+  overrides: Partial<IssueSubtreeDiagnosticNode> & {
+    id?: string;
+    identifier?: string;
+    status?: IssueStatus;
+  } = {},
+): IssueSubtreeDiagnosticNode {
+  const { id = "n1", identifier = "PAP-100", status = "in_progress", ...rest } = overrides;
+  return {
+    issue: {
+      id,
+      identifier,
+      title: "A node",
+      status,
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    },
+    parentId: null,
+    depth: 0,
+    diagnosis: null,
+    likelyReason: null,
+    blockers: [],
+    blockerReadiness: null,
+    omittedUnauthorizedBlockerCount: null,
+    wakeEvents: [],
+    wakeRequestCount: 0,
+    activityRecordCount: 0,
+    truncated: false,
+    truncatedSections: { blockers: false, wakeRequests: false, activityRecords: false },
+    ...rest,
+  };
+}
+
+describe("deriveSubtreeNodeBadge", () => {
+  it("mutes terminal nodes and never marks them actionable", () => {
+    const badge = deriveSubtreeNodeBadge(subtreeNode({ status: "done" }));
+    expect(badge.lane).toBe("none");
+    expect(badge.laneLabel).toBe("Done");
+    expect(badge.ready).toBe(false);
+  });
+
+  it("points a blocked node at its first unresolved blocker", () => {
+    const badge = deriveSubtreeNodeBadge(
+      subtreeNode({
+        status: "blocked",
+        blockers: [
+          blockerNode({ id: "u1", identifier: "PAP-901" }),
+          blockerNode({ id: "u2", identifier: "PAP-902" }),
+        ],
+      }),
+    );
+    expect(badge.lane).toBe("blocked_real_work");
+    expect(badge.statement).toBe("Blocked → PAP-901 +1");
+    expect(badge.target?.identifier).toBe("PAP-901");
+    expect(badge.ready).toBe(false);
+  });
+
+  it("labels a workspace-finalize gate as a routed recovery", () => {
+    const badge = deriveSubtreeNodeBadge(
+      subtreeNode({
+        status: "blocked",
+        blockers: [
+          blockerNode({
+            status: "done",
+            isUnresolved: false,
+            isPendingFinalize: true,
+            flags: ["workspace_finalize_pending"],
+          }),
+        ],
+      }),
+    );
+    expect(badge.lane).toBe("recovery");
+    expect(badge.laneLabel).toBe("Recovery");
+    expect(badge.statement).toBe("Recovery → workspace gate");
+    expect(badge.gate).toBe("gate: workspace_finalize_pending");
+  });
+
+  it("surfaces a cancelled blocker as recovery debt needing a worker", () => {
+    const badge = deriveSubtreeNodeBadge(
+      subtreeNode({
+        status: "blocked",
+        blockers: [
+          blockerNode({
+            status: "cancelled",
+            isUnresolved: false,
+            flags: ["cancelled_blocker_in_set"],
+          }),
+        ],
+      }),
+    );
+    expect(badge.lane).toBe("recovery");
+    expect(badge.laneLabel).toBe("Recovery debt");
+    expect(badge.statement).toBe("Recovery debt → assign worker");
+    expect(badge.accent).toBe("recovery_red");
+  });
+
+  it("marks an unblocked non-terminal node as ready to run", () => {
+    const badge = deriveSubtreeNodeBadge(subtreeNode({ status: "todo" }));
+    expect(badge.ready).toBe(true);
+    expect(badge.lane).toBe("none");
+  });
+});
+
+describe("selectActionableLeafNodeId", () => {
+  it("prefers an unblocked leaf where work can move now", () => {
+    const nodes = [
+      subtreeNode({ id: "root", identifier: "PAP-1", status: "blocked", blockers: [blockerNode()] }),
+      subtreeNode({ id: "leaf", identifier: "PAP-2", status: "todo" }),
+    ];
+    expect(selectActionableLeafNodeId(nodes)).toBe("leaf");
+  });
+
+  it("falls back to recovery-debt when nothing is unblocked", () => {
+    const nodes = [
+      subtreeNode({ id: "root", identifier: "PAP-1", status: "blocked", blockers: [blockerNode()] }),
+      subtreeNode({
+        id: "debt",
+        identifier: "PAP-2",
+        status: "blocked",
+        blockers: [blockerNode({ status: "cancelled", isUnresolved: false, flags: ["cancelled_blocker_in_set"] })],
+      }),
+    ];
+    expect(selectActionableLeafNodeId(nodes)).toBe("debt");
+  });
+
+  it("returns null when every node is done", () => {
+    const nodes = [
+      subtreeNode({ id: "a", status: "done" }),
+      subtreeNode({ id: "b", status: "cancelled" }),
+    ];
+    expect(selectActionableLeafNodeId(nodes)).toBeNull();
   });
 });

--- a/ui/src/lib/next-action.ts
+++ b/ui/src/lib/next-action.ts
@@ -1,0 +1,352 @@
+import type {
+  IssueBlockedInboxAttention,
+  IssueBlockerDiagnosticNode,
+  IssueBlockerDiagnosticsResponse,
+  IssueRecoveryAction,
+  IssueRelationIssueSummary,
+  IssueScheduledRetry,
+  IssueStatus,
+  SuccessfulRunHandoffState,
+} from "@paperclipai/shared";
+import { deriveActiveRecoveryDisplayState, recoveryChipLabel } from "./recovery-display";
+import { blockedReasonLabel } from "./blockedInbox";
+
+/**
+ * A single, readable answer to: "what moves this task forward next?"
+ *
+ * PAP-13005 product rule: every agent-owned non-terminal task, and every task
+ * that blocks another, must expose one machine-readable and human-readable
+ * next-action truth. This module collapses the various server signals
+ * (blocked-inbox attention, active recovery action, scheduled retry,
+ * successful-run handoff, and blocker diagnostics) into that single answer so
+ * the UI never shows churn without telling the board what happens next.
+ */
+export type NextActionKind =
+  | "recovery"
+  | "scheduled_retry"
+  | "successful_run_handoff"
+  | "blocked"
+  | "terminal_gate"
+  | "none";
+
+export type NextActionTone = "amber" | "sky" | "red" | "emerald" | "muted";
+
+export interface NextActionIssueRef {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: IssueStatus;
+}
+
+export interface NextActionOwner {
+  label: string;
+  kind: "agent" | "user" | "board" | "external" | "system" | "unknown";
+}
+
+export interface NextActionSummary {
+  kind: NextActionKind;
+  tone: NextActionTone;
+  /** Short chip label, e.g. "Recovery needed", "Blocked", "Terminal gate". */
+  badge: string;
+  /** Plain-language sentence: what moves this forward next. */
+  headline: string;
+  /** The concrete action the owner should take, if any. */
+  action: { label: string; detail: string | null } | null;
+  owner: NextActionOwner | null;
+  /** The task where the work actually happens next. */
+  sourceRef: NextActionIssueRef | null;
+  /** The leaf blocker that is ultimately holding the tree. */
+  leafRef: NextActionIssueRef | null;
+  /** An open recovery task tracking the fix, if any. */
+  recoveryRef: NextActionIssueRef | null;
+  /** Terminal-gate blockers (done/cancelled but still blocking, or finalize-pending). */
+  terminalGates: IssueBlockerDiagnosticNode[];
+  recovery: IssueRecoveryAction | null;
+  scheduledRetry: IssueScheduledRetry | null;
+}
+
+export interface NextActionInput {
+  status: IssueStatus;
+  blockedInboxAttention?: IssueBlockedInboxAttention | null;
+  activeRecoveryAction?: IssueRecoveryAction | null;
+  scheduledRetry?: IssueScheduledRetry | null;
+  successfulRunHandoff?: SuccessfulRunHandoffState | null;
+  /** Optional richer blocker view from GET /issues/:id/diagnostics/blockers. */
+  blockerDiagnostics?: IssueBlockerDiagnosticsResponse | null;
+}
+
+function toRef(
+  ref:
+    | IssueRelationIssueSummary
+    | { id: string; identifier: string | null; title: string; status: IssueStatus }
+    | null
+    | undefined,
+): NextActionIssueRef | null {
+  if (!ref) return null;
+  return {
+    id: ref.id,
+    identifier: ref.identifier ?? null,
+    title: ref.title,
+    status: ref.status,
+  };
+}
+
+function ownerFromInbox(
+  owner: IssueBlockedInboxAttention["owner"],
+): NextActionOwner | null {
+  if (!owner) return null;
+  const label = owner.label
+    ?? (owner.type === "board"
+      ? "Board"
+      : owner.type === "external"
+        ? "External owner"
+        : null);
+  if (!label) return null;
+  return { label, kind: owner.type };
+}
+
+const ACTIVE_RETRY_STATUSES = new Set<IssueScheduledRetry["status"]>([
+  "scheduled_retry",
+  "queued",
+  "running",
+]);
+
+/** Terminal-gate flags: a done/cancelled or finalize-pending blocker still holding dependents. */
+function terminalGateBlockers(
+  diagnostics: IssueBlockerDiagnosticsResponse | null | undefined,
+): IssueBlockerDiagnosticNode[] {
+  if (!diagnostics) return [];
+  return diagnostics.blockers.filter((blocker) =>
+    blocker.flags.some(
+      (flag) =>
+        flag === "done_but_blocking"
+        || flag === "workspace_finalize_pending"
+        || flag === "cancelled_blocker_in_set",
+    ),
+  );
+}
+
+const NO_NEXT_ACTION: NextActionSummary = {
+  kind: "none",
+  tone: "muted",
+  badge: "On track",
+  headline: "This task has a live next step.",
+  action: null,
+  owner: null,
+  sourceRef: null,
+  leafRef: null,
+  recoveryRef: null,
+  terminalGates: [],
+  recovery: null,
+  scheduledRetry: null,
+};
+
+function retryScheduleLabel(retry: IssueScheduledRetry): string {
+  if (retry.status === "running") return "A corrective run is in progress.";
+  if (retry.status === "queued") return "A corrective run is queued.";
+  return "A corrective wake is scheduled.";
+}
+
+/**
+ * Collapse all available next-action signals into a single readable summary.
+ * Priority reflects specificity: an explicit recovery action or scheduled
+ * corrective run is the most concrete answer, followed by the server's
+ * consolidated blocked-inbox attention, then terminal-gate diagnostics.
+ */
+export function deriveNextAction(input: NextActionInput): NextActionSummary {
+  const {
+    status,
+    blockedInboxAttention,
+    activeRecoveryAction,
+    scheduledRetry,
+    successfulRunHandoff,
+    blockerDiagnostics,
+  } = input;
+
+  if (status === "done" || status === "cancelled") {
+    return NO_NEXT_ACTION;
+  }
+
+  const gates = terminalGateBlockers(blockerDiagnostics);
+
+  // 1. An active recovery action is the most concrete next-action truth.
+  const recoveryState = activeRecoveryAction
+    ? deriveActiveRecoveryDisplayState(activeRecoveryAction)
+    : null;
+  if (activeRecoveryAction && recoveryState) {
+    const tone: NextActionTone =
+      recoveryState === "escalated"
+        ? "red"
+        : recoveryState === "in_progress"
+          ? "sky"
+          : recoveryState === "observe_only"
+            ? "muted"
+            : "amber";
+    return {
+      kind: "recovery",
+      tone,
+      badge: recoveryChipLabel(recoveryState, activeRecoveryAction.kind),
+      // The recovery action's own next-step sentence is the headline; the
+      // dedicated recovery card below it carries the resolve/reissue controls,
+      // so we intentionally avoid repeating it as a separate action row.
+      headline: activeRecoveryAction.nextAction
+        || "A recovery action owns the next step for this task.",
+      action: null,
+      owner: activeRecoveryAction.ownerAgentId
+        ? { label: "Assigned agent", kind: "agent" }
+        : activeRecoveryAction.ownerType === "board"
+          ? { label: "Board", kind: "board" }
+          : activeRecoveryAction.ownerType === "user"
+            ? { label: "User", kind: "user" }
+            : { label: "System", kind: "system" },
+      sourceRef: null,
+      leafRef: null,
+      recoveryRef: null,
+      terminalGates: gates,
+      recovery: activeRecoveryAction,
+      scheduledRetry: scheduledRetry ?? null,
+    };
+  }
+
+  // 2. A scheduled/queued corrective run is a live wake path.
+  if (scheduledRetry && ACTIVE_RETRY_STATUSES.has(scheduledRetry.status)) {
+    return {
+      kind: "scheduled_retry",
+      tone: "sky",
+      badge: "Corrective run",
+      headline: retryScheduleLabel(scheduledRetry),
+      action: scheduledRetry.scheduledRetryReason
+        ? { label: "Retry now", detail: scheduledRetry.scheduledRetryReason }
+        : { label: "Retry now", detail: null },
+      owner: scheduledRetry.agentName
+        ? { label: scheduledRetry.agentName, kind: "agent" }
+        : { label: "Assigned agent", kind: "agent" },
+      sourceRef: null,
+      leafRef: null,
+      recoveryRef: null,
+      terminalGates: gates,
+      recovery: null,
+      scheduledRetry,
+    };
+  }
+
+  // 3. A finished run left the task open with no owner for the next action.
+  if (successfulRunHandoff?.required) {
+    return {
+      kind: "successful_run_handoff",
+      tone: "amber",
+      badge: "Needs disposition",
+      headline:
+        "A run finished successfully but this task is still open with no next step chosen.",
+      action: {
+        label: "Choose a disposition",
+        detail: "Mark done, send for review, delegate follow-up, or mark blocked with an owner.",
+      },
+      owner: successfulRunHandoff.assigneeAgentId
+        ? { label: "Assigned agent", kind: "agent" }
+        : null,
+      sourceRef: null,
+      leafRef: null,
+      recoveryRef: null,
+      terminalGates: gates,
+      recovery: null,
+      scheduledRetry: scheduledRetry ?? null,
+    };
+  }
+
+  // 4. The server's consolidated blocked-inbox attention answer.
+  if (blockedInboxAttention) {
+    const attn = blockedInboxAttention;
+    const isTerminalGate =
+      attn.reason === "blocked_by_cancelled_issue" || gates.length > 0;
+    const tone: NextActionTone =
+      attn.severity === "critical"
+        ? "red"
+        : attn.severity === "high"
+          ? "amber"
+          : attn.state === "external_wait" || attn.state === "awaiting_decision"
+            ? "sky"
+            : "amber";
+    return {
+      kind: isTerminalGate ? "terminal_gate" : "blocked",
+      tone,
+      badge: blockedReasonLabel(attn.reason),
+      headline: buildBlockedHeadline(attn, gates),
+      action: attn.action
+        ? { label: attn.action.label, detail: attn.action.detail }
+        : null,
+      owner: ownerFromInbox(attn.owner),
+      sourceRef: toRef(attn.sourceIssue),
+      leafRef: toRef(attn.leafIssue),
+      recoveryRef: toRef(attn.recoveryIssue),
+      terminalGates: gates,
+      recovery: null,
+      scheduledRetry: scheduledRetry ?? null,
+    };
+  }
+
+  // 5. Blocker diagnostics alone can still reveal a terminal gate.
+  if (gates.length > 0) {
+    return {
+      kind: "terminal_gate",
+      tone: "amber",
+      badge: "Terminal gate",
+      headline: buildTerminalGateHeadline(gates),
+      action: {
+        label: "Resolve the terminal gate",
+        detail: "Clear the finalize/cancelled blocker or remove it from the blocker set.",
+      },
+      owner: null,
+      sourceRef: null,
+      leafRef: toRef(gates[0]),
+      recoveryRef: null,
+      terminalGates: gates,
+      recovery: null,
+      scheduledRetry: scheduledRetry ?? null,
+    };
+  }
+
+  return NO_NEXT_ACTION;
+}
+
+function buildBlockedHeadline(
+  attn: IssueBlockedInboxAttention,
+  gates: IssueBlockerDiagnosticNode[],
+): string {
+  if (gates.length > 0) {
+    return buildTerminalGateHeadline(gates);
+  }
+  const leaf = attn.leafIssue?.identifier ?? attn.leafIssue?.title;
+  const ownerLabel = attn.owner?.label ?? null;
+  switch (attn.state) {
+    case "awaiting_decision":
+      return ownerLabel
+        ? `Waiting on ${ownerLabel} to decide.`
+        : "Waiting on a decision to move forward.";
+    case "external_wait":
+      return ownerLabel
+        ? `Waiting on ${ownerLabel} outside Paperclip.`
+        : "Waiting on an external owner.";
+    case "recovery_open":
+      return "A recovery task is tracking the fix that moves this forward.";
+    case "missing_disposition":
+      return "This task needs a disposition to move forward.";
+    case "needs_attention":
+    default:
+      return leaf
+        ? `Ultimately waiting on ${leaf}; it has no live next step yet.`
+        : "This blocked chain has no live next step yet.";
+  }
+}
+
+function buildTerminalGateHeadline(gates: IssueBlockerDiagnosticNode[]): string {
+  const first = gates[0];
+  const id = first?.identifier ?? first?.title ?? "a blocker";
+  if (first?.flags.includes("workspace_finalize_pending")) {
+    return `${id} is done but its workspace finalize gate still blocks this task.`;
+  }
+  if (first?.flags.includes("cancelled_blocker_in_set")) {
+    return `${id} is cancelled but still listed as a blocker; it will never resolve on its own.`;
+  }
+  return `${id} is done but still blocking this task; its post-run gate needs recovery.`;
+}

--- a/ui/src/lib/next-action.ts
+++ b/ui/src/lib/next-action.ts
@@ -8,28 +8,36 @@ import type {
   IssueStatus,
   SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
-import { deriveActiveRecoveryDisplayState, recoveryChipLabel } from "./recovery-display";
-import { blockedReasonLabel } from "./blockedInbox";
+import { deriveActiveRecoveryDisplayState } from "./recovery-display";
 
 /**
  * A single, readable answer to: "what moves this task forward next?"
  *
- * PAP-13005 product rule: every agent-owned non-terminal task, and every task
- * that blocks another, must expose one machine-readable and human-readable
- * next-action truth. This module collapses the various server signals
- * (blocked-inbox attention, active recovery action, scheduled retry,
- * successful-run handoff, and blocker diagnostics) into that single answer so
- * the UI never shows churn without telling the board what happens next.
+ * PAP-13005 product rule + Phase 4 UX spec: every agent-owned non-terminal
+ * task, and every task that blocks another, resolves into EXACTLY ONE of four
+ * lanes so the board never has to synthesize an answer from five cards.
+ *
+ * Resolution priority (spec §2): Working now (an actual run beats everything)
+ * → Recovery in flight (a routed recovery is more actionable than the blocker
+ * it fixes) → Waiting on a decision → Blocked by real work.
  */
-export type NextActionKind =
+export type NextActionLane =
+  | "working_now"
   | "recovery"
-  | "scheduled_retry"
-  | "successful_run_handoff"
-  | "blocked"
-  | "terminal_gate"
+  | "waiting_decision"
+  | "blocked_real_work"
   | "none";
 
-export type NextActionTone = "amber" | "sky" | "red" | "emerald" | "muted";
+/** Maps to the left-accent hue. Recovery uses the recovery-display ladder. */
+export type NextActionAccent =
+  | "in_progress"
+  | "in_review"
+  | "todo"
+  | "blocked"
+  | "recovery_amber"
+  | "recovery_sky"
+  | "recovery_red"
+  | "none";
 
 export interface NextActionIssueRef {
   id: string;
@@ -43,26 +51,44 @@ export interface NextActionOwner {
   kind: "agent" | "user" | "board" | "external" | "system" | "unknown";
 }
 
+export type NextActionControlKind =
+  | "open_recovery"
+  | "assign_worker"
+  | "retry_now"
+  | "choose_disposition"
+  | "open_blocker";
+
+export interface NextActionReference {
+  label: string;
+  ref: NextActionIssueRef;
+  /** Terminal-gate evidence chip, e.g. "gate: workspace_finalize_pending". */
+  gate?: string | null;
+}
+
 export interface NextActionSummary {
-  kind: NextActionKind;
-  tone: NextActionTone;
-  /** Short chip label, e.g. "Recovery needed", "Blocked", "Terminal gate". */
-  badge: string;
-  /** Plain-language sentence: what moves this forward next. */
-  headline: string;
-  /** The concrete action the owner should take, if any. */
-  action: { label: string; detail: string | null } | null;
+  lane: NextActionLane;
+  accent: NextActionAccent;
+  /** Uppercase lane chip label. */
+  laneLabel: string;
+  /** Plain-language answer, kept short (spec: ≤ ~64 chars). */
+  statement: string;
+  /** Owner + timing/context context line. */
+  why: string | null;
   owner: NextActionOwner | null;
-  /** The task where the work actually happens next. */
-  sourceRef: NextActionIssueRef | null;
-  /** The leaf blocker that is ultimately holding the tree. */
-  leafRef: NextActionIssueRef | null;
-  /** An open recovery task tracking the fix, if any. */
-  recoveryRef: NextActionIssueRef | null;
-  /** Terminal-gate blockers (done/cancelled but still blocking, or finalize-pending). */
-  terminalGates: IssueBlockerDiagnosticNode[];
+  /** At most one primary control; only rendered when we have a deep-link target. */
+  primaryControl: { label: string; kind: NextActionControlKind; ref: NextActionIssueRef | null } | null;
+  references: NextActionReference[];
+  /** Blocked-lane terminal gate variant. */
+  terminalGate: boolean;
+  /** Recovery-lane escalation / status-only-suppression variant. */
+  recoveryDebt: boolean;
+  /** Live pulse dot (Working now, actual run). */
+  live: boolean;
+  /** Provenance: which field resolved this lane (audit trail / QA aid). */
+  resolvedFrom: string;
   recovery: IssueRecoveryAction | null;
   scheduledRetry: IssueScheduledRetry | null;
+  terminalGates: IssueBlockerDiagnosticNode[];
 }
 
 export interface NextActionInput {
@@ -71,8 +97,9 @@ export interface NextActionInput {
   activeRecoveryAction?: IssueRecoveryAction | null;
   scheduledRetry?: IssueScheduledRetry | null;
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
-  /** Optional richer blocker view from GET /issues/:id/diagnostics/blockers. */
   blockerDiagnostics?: IssueBlockerDiagnosticsResponse | null;
+  /** True when an actual run is executing against this task right now. */
+  hasLiveRun?: boolean;
 }
 
 function toRef(
@@ -83,26 +110,12 @@ function toRef(
     | undefined,
 ): NextActionIssueRef | null {
   if (!ref) return null;
-  return {
-    id: ref.id,
-    identifier: ref.identifier ?? null,
-    title: ref.title,
-    status: ref.status,
-  };
+  return { id: ref.id, identifier: ref.identifier ?? null, title: ref.title, status: ref.status };
 }
 
-function ownerFromInbox(
-  owner: IssueBlockedInboxAttention["owner"],
-): NextActionOwner | null {
-  if (!owner) return null;
-  const label = owner.label
-    ?? (owner.type === "board"
-      ? "Board"
-      : owner.type === "external"
-        ? "External owner"
-        : null);
-  if (!label) return null;
-  return { label, kind: owner.type };
+function truncate(text: string, max = 72): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
 }
 
 const ACTIVE_RETRY_STATUSES = new Set<IssueScheduledRetry["status"]>([
@@ -111,7 +124,6 @@ const ACTIVE_RETRY_STATUSES = new Set<IssueScheduledRetry["status"]>([
   "running",
 ]);
 
-/** Terminal-gate flags: a done/cancelled or finalize-pending blocker still holding dependents. */
 function terminalGateBlockers(
   diagnostics: IssueBlockerDiagnosticsResponse | null | undefined,
 ): IssueBlockerDiagnosticNode[] {
@@ -126,227 +138,280 @@ function terminalGateBlockers(
   );
 }
 
-const NO_NEXT_ACTION: NextActionSummary = {
-  kind: "none",
-  tone: "muted",
-  badge: "On track",
-  headline: "This task has a live next step.",
-  action: null,
-  owner: null,
-  sourceRef: null,
-  leafRef: null,
-  recoveryRef: null,
-  terminalGates: [],
-  recovery: null,
-  scheduledRetry: null,
-};
-
-function retryScheduleLabel(retry: IssueScheduledRetry): string {
-  if (retry.status === "running") return "A corrective run is in progress.";
-  if (retry.status === "queued") return "A corrective run is queued.";
-  return "A corrective wake is scheduled.";
+function gateLabel(node: IssueBlockerDiagnosticNode): string | null {
+  const flag = node.flags.find(
+    (f) => f === "workspace_finalize_pending" || f === "done_but_blocking" || f === "cancelled_blocker_in_set",
+  );
+  if (flag === "workspace_finalize_pending") return "gate: workspace_finalize_pending";
+  if (flag === "cancelled_blocker_in_set") return "gate: cancelled_blocker";
+  if (flag === "done_but_blocking") return "gate: done_but_blocking";
+  return null;
 }
 
+function ownerFromInbox(owner: IssueBlockedInboxAttention["owner"]): NextActionOwner | null {
+  if (!owner) return null;
+  const label = owner.label
+    ?? (owner.type === "board" ? "Board" : owner.type === "external" ? "External owner" : null);
+  if (!label) return null;
+  return { label, kind: owner.type };
+}
+
+const NONE: NextActionSummary = {
+  lane: "none",
+  accent: "none",
+  laneLabel: "On track",
+  statement: "This task has a live next step.",
+  why: null,
+  owner: null,
+  primaryControl: null,
+  references: [],
+  terminalGate: false,
+  recoveryDebt: false,
+  live: false,
+  resolvedFrom: "no_attention_signal",
+  recovery: null,
+  scheduledRetry: null,
+  terminalGates: [],
+};
+
 /**
- * Collapse all available next-action signals into a single readable summary.
- * Priority reflects specificity: an explicit recovery action or scheduled
- * corrective run is the most concrete answer, followed by the server's
- * consolidated blocked-inbox attention, then terminal-gate diagnostics.
+ * Collapse all next-action signals into a single lane. Only one lane renders.
  */
 export function deriveNextAction(input: NextActionInput): NextActionSummary {
   const {
     status,
-    blockedInboxAttention,
+    blockedInboxAttention: attn,
     activeRecoveryAction,
     scheduledRetry,
     successfulRunHandoff,
     blockerDiagnostics,
+    hasLiveRun,
   } = input;
 
-  if (status === "done" || status === "cancelled") {
-    return NO_NEXT_ACTION;
-  }
+  // Spec §4: the panel hides on terminal tasks so it never adds noise.
+  if (status === "done" || status === "cancelled") return NONE;
 
   const gates = terminalGateBlockers(blockerDiagnostics);
+  const retryActive = Boolean(scheduledRetry && ACTIVE_RETRY_STATUSES.has(scheduledRetry.status));
 
-  // 1. An active recovery action is the most concrete next-action truth.
-  const recoveryState = activeRecoveryAction
-    ? deriveActiveRecoveryDisplayState(activeRecoveryAction)
-    : null;
-  if (activeRecoveryAction && recoveryState) {
-    const tone: NextActionTone =
-      recoveryState === "escalated"
-        ? "red"
-        : recoveryState === "in_progress"
-          ? "sky"
-          : recoveryState === "observe_only"
-            ? "muted"
-            : "amber";
+  // 1. Working now — an actual run, or a queued/scheduled corrective wake.
+  if (hasLiveRun) {
     return {
-      kind: "recovery",
-      tone,
-      badge: recoveryChipLabel(recoveryState, activeRecoveryAction.kind),
-      // The recovery action's own next-step sentence is the headline; the
-      // dedicated recovery card below it carries the resolve/reissue controls,
-      // so we intentionally avoid repeating it as a separate action row.
-      headline: activeRecoveryAction.nextAction
-        || "A recovery action owns the next step for this task.",
-      action: null,
-      owner: activeRecoveryAction.ownerAgentId
-        ? { label: "Assigned agent", kind: "agent" }
-        : activeRecoveryAction.ownerType === "board"
-          ? { label: "Board", kind: "board" }
-          : activeRecoveryAction.ownerType === "user"
-            ? { label: "User", kind: "user" }
-            : { label: "System", kind: "system" },
-      sourceRef: null,
-      leafRef: null,
-      recoveryRef: null,
-      terminalGates: gates,
-      recovery: activeRecoveryAction,
+      ...NONE,
+      lane: "working_now",
+      accent: "in_progress",
+      laneLabel: "Working now",
+      statement: "A run is working on this now.",
+      why: "A live run owns the next step.",
+      live: true,
+      resolvedFrom: "live_run",
       scheduledRetry: scheduledRetry ?? null,
     };
   }
-
-  // 2. A scheduled/queued corrective run is a live wake path.
-  if (scheduledRetry && ACTIVE_RETRY_STATUSES.has(scheduledRetry.status)) {
+  if (retryActive && scheduledRetry) {
+    const running = scheduledRetry.status === "running";
+    const agent = scheduledRetry.agentName ?? "the assignee";
     return {
-      kind: "scheduled_retry",
-      tone: "sky",
-      badge: "Corrective run",
-      headline: retryScheduleLabel(scheduledRetry),
-      action: scheduledRetry.scheduledRetryReason
-        ? { label: "Retry now", detail: scheduledRetry.scheduledRetryReason }
-        : { label: "Retry now", detail: null },
-      owner: scheduledRetry.agentName
-        ? { label: scheduledRetry.agentName, kind: "agent" }
-        : { label: "Assigned agent", kind: "agent" },
-      sourceRef: null,
-      leafRef: null,
-      recoveryRef: null,
-      terminalGates: gates,
-      recovery: null,
+      ...NONE,
+      lane: "working_now",
+      accent: "in_progress",
+      laneLabel: "Working now",
+      statement: running ? "A corrective run is in progress." : `Queued to wake ${agent}.`,
+      why: scheduledRetry.scheduledRetryReason
+        ? truncate(`Corrective wake — ${scheduledRetry.scheduledRetryReason}`, 96)
+        : "A corrective wake is scheduled on the next heartbeat.",
+      owner: { label: agent, kind: "agent" },
+      live: running,
+      resolvedFrom: `scheduled_retry:${scheduledRetry.status}`,
       scheduledRetry,
     };
   }
 
-  // 3. A finished run left the task open with no owner for the next action.
-  if (successfulRunHandoff?.required) {
+  // 2. Recovery in flight — a routed recovery action owns the fix.
+  const recoveryState = activeRecoveryAction
+    ? deriveActiveRecoveryDisplayState(activeRecoveryAction)
+    : null;
+  if (activeRecoveryAction && recoveryState) {
+    const escalated = recoveryState === "escalated";
+    const accent: NextActionAccent = escalated
+      ? "recovery_red"
+      : recoveryState === "in_progress"
+        ? "recovery_sky"
+        : "recovery_amber";
+    const attempt = activeRecoveryAction.maxAttempts
+      ? `attempt ${activeRecoveryAction.attemptCount}/${activeRecoveryAction.maxAttempts}`
+      : `attempt ${activeRecoveryAction.attemptCount}`;
+    const ownerLabel = activeRecoveryAction.ownerType === "board"
+      ? "Board"
+      : activeRecoveryAction.ownerType === "user"
+        ? "a user"
+        : activeRecoveryAction.ownerType === "agent"
+          ? "the assigned agent"
+          : "the system";
     return {
-      kind: "successful_run_handoff",
-      tone: "amber",
-      badge: "Needs disposition",
-      headline:
-        "A run finished successfully but this task is still open with no next step chosen.",
-      action: {
-        label: "Choose a disposition",
-        detail: "Mark done, send for review, delegate follow-up, or mark blocked with an owner.",
-      },
-      owner: successfulRunHandoff.assigneeAgentId
-        ? { label: "Assigned agent", kind: "agent" }
+      ...NONE,
+      lane: "recovery",
+      accent,
+      laneLabel: escalated ? "Recovery debt" : "Recovery in flight",
+      statement: truncate(
+        activeRecoveryAction.nextAction || "A recovery action owns the next step.",
+      ),
+      why: escalated ? `Escalated · ${attempt}.` : `${attempt}.`,
+      owner: { label: ownerLabel, kind: activeRecoveryAction.ownerType === "agent" ? "agent" : activeRecoveryAction.ownerType === "board" ? "board" : activeRecoveryAction.ownerType === "user" ? "user" : "system" },
+      primaryControl: activeRecoveryAction.recoveryIssueId
+        ? {
+          label: escalated ? "Assign a worker lane" : "Open recovery",
+          kind: escalated ? "assign_worker" : "open_recovery",
+          ref: {
+            id: activeRecoveryAction.recoveryIssueId,
+            identifier: null,
+            title: "Recovery task",
+            status: "in_progress",
+          },
+        }
         : null,
-      sourceRef: null,
-      leafRef: null,
-      recoveryRef: null,
-      terminalGates: gates,
-      recovery: null,
+      recoveryDebt: escalated,
+      resolvedFrom: `active_recovery_action:${recoveryState}`,
+      recovery: activeRecoveryAction,
       scheduledRetry: scheduledRetry ?? null,
+      terminalGates: gates,
     };
   }
 
-  // 4. The server's consolidated blocked-inbox attention answer.
-  if (blockedInboxAttention) {
-    const attn = blockedInboxAttention;
-    const isTerminalGate =
-      attn.reason === "blocked_by_cancelled_issue" || gates.length > 0;
-    const tone: NextActionTone =
-      attn.severity === "critical"
-        ? "red"
-        : attn.severity === "high"
-          ? "amber"
-          : attn.state === "external_wait" || attn.state === "awaiting_decision"
-            ? "sky"
-            : "amber";
+  // 3. Waiting on a decision — approval / interaction / human owner / disposition.
+  if (successfulRunHandoff?.required) {
     return {
-      kind: isTerminalGate ? "terminal_gate" : "blocked",
-      tone,
-      badge: blockedReasonLabel(attn.reason),
-      headline: buildBlockedHeadline(attn, gates),
-      action: attn.action
-        ? { label: attn.action.label, detail: attn.action.detail }
-        : null,
-      owner: ownerFromInbox(attn.owner),
-      sourceRef: toRef(attn.sourceIssue),
-      leafRef: toRef(attn.leafIssue),
-      recoveryRef: toRef(attn.recoveryIssue),
-      terminalGates: gates,
-      recovery: null,
+      ...NONE,
+      lane: "waiting_decision",
+      accent: "in_review",
+      laneLabel: "Waiting on a decision",
+      statement: "A run finished — pick a disposition to move on.",
+      why: "Mark done, send for review, delegate, or block with an owner.",
+      owner: successfulRunHandoff.assigneeAgentId ? { label: "the assignee", kind: "agent" } : null,
+      primaryControl: { label: "Choose a disposition", kind: "choose_disposition", ref: null },
+      resolvedFrom: "successful_run_handoff",
       scheduledRetry: scheduledRetry ?? null,
+    };
+  }
+  if (attn) {
+    const isWaiting =
+      Boolean(attn.interactionId || attn.approvalId)
+      || attn.state === "awaiting_decision"
+      || attn.state === "external_wait"
+      || attn.state === "missing_disposition"
+      || attn.owner?.type === "board"
+      || attn.owner?.type === "user"
+      || attn.owner?.type === "external";
+    const owner = ownerFromInbox(attn.owner);
+    if (isWaiting) {
+      const who = owner?.label ?? "an owner";
+      return {
+        ...NONE,
+        lane: "waiting_decision",
+        accent: "in_review",
+        laneLabel: "Waiting on a decision",
+        statement: attn.state === "external_wait"
+          ? truncate(`Waiting on ${who} outside Paperclip.`)
+          : truncate(`Waiting for ${who} to ${attn.action?.label ?? "respond"}.`, 88),
+        why: attn.action?.detail ?? null,
+        owner,
+        primaryControl: null,
+        references: buildReferences(attn, []),
+        resolvedFrom: `blocked_inbox:${attn.state}`,
+        scheduledRetry: scheduledRetry ?? null,
+      };
+    }
+
+    // 4. Blocked by real work (with terminal-gate variant).
+    const terminalGate = gates.length > 0 || attn.leafIssue?.status === "done";
+    const leaf = attn.leafIssue?.identifier ?? attn.leafIssue?.title ?? "an upstream task";
+    const accent: NextActionAccent = terminalGate && gates.some(isUnhealthyGate) ? "blocked" : "todo";
+    return {
+      ...NONE,
+      lane: "blocked_real_work",
+      accent,
+      laneLabel: "Blocked by real work",
+      statement: terminalGate
+        ? truncate(`Blocked by ${leaf} — it's Done but its gate hasn't cleared.`, 88)
+        : truncate(`Blocked by ${leaf} until it finishes.`),
+      why: attn.action ? truncate(`${attn.action.label}${attn.action.detail ? ` — ${attn.action.detail}` : ""}`, 120) : null,
+      owner,
+      primaryControl: terminalGate && attn.recoveryIssue
+        ? { label: "Open recovery", kind: "open_recovery", ref: toRef(attn.recoveryIssue) }
+        : null,
+      references: buildReferences(attn, gates),
+      terminalGate,
+      resolvedFrom: terminalGate ? "terminal_gate" : `blocked_inbox:${attn.state}`,
+      scheduledRetry: scheduledRetry ?? null,
+      terminalGates: gates,
     };
   }
 
   // 5. Blocker diagnostics alone can still reveal a terminal gate.
   if (gates.length > 0) {
+    const first = gates[0];
     return {
-      kind: "terminal_gate",
-      tone: "amber",
-      badge: "Terminal gate",
-      headline: buildTerminalGateHeadline(gates),
-      action: {
-        label: "Resolve the terminal gate",
-        detail: "Clear the finalize/cancelled blocker or remove it from the blocker set.",
-      },
-      owner: null,
-      sourceRef: null,
-      leafRef: toRef(gates[0]),
-      recoveryRef: null,
-      terminalGates: gates,
-      recovery: null,
+      ...NONE,
+      lane: "blocked_real_work",
+      accent: gates.some(isUnhealthyGate) ? "blocked" : "todo",
+      laneLabel: "Blocked by real work",
+      statement: truncate(
+        `Blocked by ${first.identifier ?? first.title} — Done, but its gate hasn't cleared.`,
+        88,
+      ),
+      why: "A post-run gate on a Done blocker still holds this task.",
+      primaryControl: null,
+      references: [
+        {
+          label: "Blocked by",
+          ref: toRef(first)!,
+          gate: gateLabel(first),
+        },
+      ],
+      terminalGate: true,
+      resolvedFrom: "terminal_gate",
       scheduledRetry: scheduledRetry ?? null,
+      terminalGates: gates,
     };
   }
 
-  return NO_NEXT_ACTION;
+  return NONE;
 }
 
-function buildBlockedHeadline(
+function isUnhealthyGate(node: IssueBlockerDiagnosticNode): boolean {
+  return node.flags.includes("cancelled_blocker_in_set");
+}
+
+function buildReferences(
   attn: IssueBlockedInboxAttention,
   gates: IssueBlockerDiagnosticNode[],
-): string {
-  if (gates.length > 0) {
-    return buildTerminalGateHeadline(gates);
+): NextActionReference[] {
+  const refs: NextActionReference[] = [];
+  const gateByIdentifier = new Map<string, IssueBlockerDiagnosticNode>();
+  for (const gate of gates) {
+    const key = gate.identifier ?? gate.id;
+    gateByIdentifier.set(key, gate);
   }
-  const leaf = attn.leafIssue?.identifier ?? attn.leafIssue?.title;
-  const ownerLabel = attn.owner?.label ?? null;
-  switch (attn.state) {
-    case "awaiting_decision":
-      return ownerLabel
-        ? `Waiting on ${ownerLabel} to decide.`
-        : "Waiting on a decision to move forward.";
-    case "external_wait":
-      return ownerLabel
-        ? `Waiting on ${ownerLabel} outside Paperclip.`
-        : "Waiting on an external owner.";
-    case "recovery_open":
-      return "A recovery task is tracking the fix that moves this forward.";
-    case "missing_disposition":
-      return "This task needs a disposition to move forward.";
-    case "needs_attention":
-    default:
-      return leaf
-        ? `Ultimately waiting on ${leaf}; it has no live next step yet.`
-        : "This blocked chain has no live next step yet.";
+  if (attn.sourceIssue) {
+    refs.push({ label: "Work happens on", ref: toRef(attn.sourceIssue)! });
   }
-}
-
-function buildTerminalGateHeadline(gates: IssueBlockerDiagnosticNode[]): string {
-  const first = gates[0];
-  const id = first?.identifier ?? first?.title ?? "a blocker";
-  if (first?.flags.includes("workspace_finalize_pending")) {
-    return `${id} is done but its workspace finalize gate still blocks this task.`;
+  if (attn.leafIssue) {
+    const key = attn.leafIssue.identifier ?? attn.leafIssue.id;
+    refs.push({
+      label: "Waiting on",
+      ref: toRef(attn.leafIssue)!,
+      gate: gateByIdentifier.has(key) ? gateLabel(gateByIdentifier.get(key)!) : null,
+    });
   }
-  if (first?.flags.includes("cancelled_blocker_in_set")) {
-    return `${id} is cancelled but still listed as a blocker; it will never resolve on its own.`;
+  // Any terminal gate not already attached to the leaf gets its own chip.
+  for (const gate of gates) {
+    const key = gate.identifier ?? gate.id;
+    const leafKey = attn.leafIssue?.identifier ?? attn.leafIssue?.id;
+    if (key === leafKey) continue;
+    refs.push({ label: "Blocked by", ref: toRef(gate)!, gate: gateLabel(gate) });
   }
-  return `${id} is done but still blocking this task; its post-run gate needs recovery.`;
+  if (attn.recoveryIssue) {
+    refs.push({ label: "Recovery", ref: toRef(attn.recoveryIssue)! });
+  }
+  return refs;
 }

--- a/ui/src/lib/next-action.ts
+++ b/ui/src/lib/next-action.ts
@@ -14,8 +14,8 @@ import { deriveActiveRecoveryDisplayState } from "./recovery-display";
 /**
  * A single, readable answer to: "what moves this task forward next?"
  *
- * PAP-13005 product rule + Phase 4 UX spec: every agent-owned non-terminal
- * task, and every task that blocks another, resolves into EXACTLY ONE of four
+ * Every agent-owned non-terminal task, and every task that blocks another,
+ * resolves into EXACTLY ONE of four
  * lanes so the board never has to synthesize an answer from five cards.
  *
  * Resolution priority (spec §2): Working now (an actual run beats everything)
@@ -103,6 +103,16 @@ export interface NextActionInput {
   hasLiveRun?: boolean;
 }
 
+/** A run is live for a touched task only when its own scope names that task. */
+export function isRunActiveForIssue(
+  run: { status: string; contextSnapshot: Record<string, unknown> | null },
+  issueId: string,
+): boolean {
+  if (run.status !== "queued" && run.status !== "running") return false;
+  const scopedId = run.contextSnapshot?.["issueId"] ?? run.contextSnapshot?.["taskId"];
+  return typeof scopedId === "string" && scopedId.trim() === issueId;
+}
+
 function toRef(
   ref:
     | IssueRelationIssueSummary
@@ -125,27 +135,30 @@ const ACTIVE_RETRY_STATUSES = new Set<IssueScheduledRetry["status"]>([
   "running",
 ]);
 
-function terminalGateBlockers(
+function workspaceFinalizeBlockers(
   diagnostics: IssueBlockerDiagnosticsResponse | null | undefined,
 ): IssueBlockerDiagnosticNode[] {
   if (!diagnostics) return [];
   return diagnostics.blockers.filter((blocker) =>
-    blocker.flags.some(
-      (flag) =>
-        flag === "done_but_blocking"
-        || flag === "workspace_finalize_pending"
-        || flag === "cancelled_blocker_in_set",
-    ),
+    blocker.flags.includes("workspace_finalize_pending"),
+  );
+}
+
+function staleBlockerRelations(
+  diagnostics: IssueBlockerDiagnosticsResponse | null | undefined,
+): IssueBlockerDiagnosticNode[] {
+  if (!diagnostics) return [];
+  return diagnostics.blockers.filter((blocker) =>
+    !blocker.flags.includes("workspace_finalize_pending")
+    && (blocker.flags.includes("done_but_blocking")
+      || blocker.flags.includes("cancelled_blocker_in_set")),
   );
 }
 
 function gateLabel(node: IssueBlockerDiagnosticNode): string | null {
-  const flag = node.flags.find(
-    (f) => f === "workspace_finalize_pending" || f === "done_but_blocking" || f === "cancelled_blocker_in_set",
-  );
-  if (flag === "workspace_finalize_pending") return "gate: workspace_finalize_pending";
-  if (flag === "cancelled_blocker_in_set") return "gate: cancelled_blocker";
-  if (flag === "done_but_blocking") return "gate: done_but_blocking";
+  if (node.flags.includes("workspace_finalize_pending")) return "gate: workspace_finalize_pending";
+  if (node.flags.includes("cancelled_blocker_in_set")) return "relation: cancelled_blocker";
+  if (node.flags.includes("done_but_blocking")) return "relation: done_but_blocking";
   return null;
 }
 
@@ -192,7 +205,8 @@ export function deriveNextAction(input: NextActionInput): NextActionSummary {
   // Spec §4: the panel hides on terminal tasks so it never adds noise.
   if (status === "done" || status === "cancelled") return NONE;
 
-  const gates = terminalGateBlockers(blockerDiagnostics);
+  const gates = workspaceFinalizeBlockers(blockerDiagnostics);
+  const staleRelations = staleBlockerRelations(blockerDiagnostics);
   const retryActive = Boolean(scheduledRetry && ACTIVE_RETRY_STATUSES.has(scheduledRetry.status));
 
   // 1. Working now — an actual run, or a queued/scheduled corrective wake.
@@ -323,14 +337,37 @@ export function deriveNextAction(input: NextActionInput): NextActionSummary {
       };
     }
 
-    // 4. Blocked by real work (with terminal-gate variant).
-    const terminalGate = gates.length > 0 || attn.leafIssue?.status === "done";
+    const staleLeaf = gates.length === 0
+      && (attn.leafIssue?.status === "done" || attn.leafIssue?.status === "cancelled");
+    if (staleRelations.length > 0 || staleLeaf) {
+      const leafRef = toRef(attn.leafIssue) ?? toRef(staleRelations[0]);
+      const leaf = leafRef?.identifier ?? leafRef?.title ?? "the blocker";
+      return {
+        ...NONE,
+        lane: "recovery",
+        accent: "recovery_red",
+        laneLabel: "Recovery debt",
+        statement: truncate(`Clear or replace the stale blocker relation for ${leaf}.`, 88),
+        why: "A Done or cancelled task cannot keep acting as unfinished work.",
+        owner: { label: "Board", kind: "board" },
+        primaryControl: leafRef
+          ? { label: "Open stale blocker", kind: "open_blocker", ref: leafRef }
+          : null,
+        references: buildReferences(attn, [...gates, ...staleRelations]),
+        recoveryDebt: true,
+        resolvedFrom: "stale_blocker_relation",
+        scheduledRetry: scheduledRetry ?? null,
+        terminalGates: gates,
+      };
+    }
+
+    // 4. Blocked by real work (with workspace-finalize gate variant).
+    const terminalGate = gates.length > 0;
     const leaf = attn.leafIssue?.identifier ?? attn.leafIssue?.title ?? "an upstream task";
-    const accent: NextActionAccent = terminalGate && gates.some(isUnhealthyGate) ? "blocked" : "todo";
     return {
       ...NONE,
       lane: "blocked_real_work",
-      accent,
+      accent: "todo",
       laneLabel: "Blocked by real work",
       statement: terminalGate
         ? truncate(`Blocked by ${leaf} — it's Done but its gate hasn't cleared.`, 88)
@@ -348,13 +385,38 @@ export function deriveNextAction(input: NextActionInput): NextActionSummary {
     };
   }
 
-  // 5. Blocker diagnostics alone can still reveal a terminal gate.
+  // 5. Stale relations need repair, not terminal-gate recovery.
+  if (staleRelations.length > 0) {
+    const first = staleRelations[0];
+    return {
+      ...NONE,
+      lane: "recovery",
+      accent: "recovery_red",
+      laneLabel: "Recovery debt",
+      statement: truncate(
+        `Clear or replace the stale blocker relation for ${first.identifier ?? first.title}.`,
+        88,
+      ),
+      why: "A Done or cancelled blocker still remains in the relation set.",
+      primaryControl: {
+        label: "Open stale blocker",
+        kind: "open_blocker",
+        ref: toRef(first)!,
+      },
+      references: [{ label: "Stale blocker", ref: toRef(first)!, gate: gateLabel(first) }],
+      recoveryDebt: true,
+      resolvedFrom: "stale_blocker_relation",
+      scheduledRetry: scheduledRetry ?? null,
+    };
+  }
+
+  // 6. Blocker diagnostics alone can still reveal a workspace-finalize gate.
   if (gates.length > 0) {
     const first = gates[0];
     return {
       ...NONE,
       lane: "blocked_real_work",
-      accent: gates.some(isUnhealthyGate) ? "blocked" : "todo",
+      accent: "todo",
       laneLabel: "Blocked by real work",
       statement: truncate(
         `Blocked by ${first.identifier ?? first.title} — Done, but its gate hasn't cleared.`,
@@ -377,10 +439,6 @@ export function deriveNextAction(input: NextActionInput): NextActionSummary {
   }
 
   return NONE;
-}
-
-function isUnhealthyGate(node: IssueBlockerDiagnosticNode): boolean {
-  return node.flags.includes("cancelled_blocker_in_set");
 }
 
 function buildReferences(
@@ -419,7 +477,7 @@ function buildReferences(
 
 /**
  * Compact, per-node verdict for the subtree / blocker diagnostics view
- * (Phase 4 UX spec §5). One line per node so the operator can scan a whole
+ * One line per node lets the operator scan a whole
  * tree and find where work moves next without opening every child.
  *
  * A subtree node only carries what the diagnostics endpoint exposes — status
@@ -510,12 +568,12 @@ export function deriveSubtreeNodeBadge(node: IssueSubtreeDiagnosticNode): NextAc
         resolvedFrom: "workspace_finalize_pending",
       };
     }
-    // done_but_blocking — a Done blocker whose gate hasn't cleared.
+    // A Done blocker left in the relation set is recovery debt, not a gate.
     return {
-      lane: "blocked_real_work",
-      accent: "todo",
-      laneLabel: "Blocked",
-      statement: `Blocked → ${blockerLabel(gate)}`,
+      lane: "recovery",
+      accent: "recovery_red",
+      laneLabel: "Recovery debt",
+      statement: "Recovery debt → clear stale blocker",
       target: blockerRef(gate),
       gate: gateLabel(gate),
       ready: false,
@@ -539,9 +597,24 @@ export function deriveSubtreeNodeBadge(node: IssueSubtreeDiagnosticNode): NextAc
     };
   }
 
-  // No blockers hold this node and it is non-terminal — this is where work can
-  // actually move next. It is a candidate for the single highlighted leaf.
+  // Status is not proof of liveness. Only a queued/claimed wake demonstrates
+  // that active-looking work currently has a continuation in this diagnostic.
   const inProgress = status === "in_progress" || status === "in_review";
+  const hasLiveWake = node.wakeEvents.some(
+    (event) => event.kind === "wake_request" && (event.status === "queued" || event.status === "claimed"),
+  );
+  if (inProgress && !hasLiveWake) {
+    return {
+      lane: "recovery",
+      accent: "recovery_amber",
+      laneLabel: "Needs recovery",
+      statement: "No live continuation.",
+      target: null,
+      gate: null,
+      ready: false,
+      resolvedFrom: "active_without_live_continuation",
+    };
+  }
   return {
     lane: inProgress ? "working_now" : "none",
     accent: inProgress ? "in_progress" : "none",
@@ -550,7 +623,7 @@ export function deriveSubtreeNodeBadge(node: IssueSubtreeDiagnosticNode): NextAc
     target: null,
     gate: null,
     ready: true,
-    resolvedFrom: inProgress ? "unblocked_active" : "unblocked_ready",
+    resolvedFrom: inProgress ? "live_wake" : "unblocked_ready",
   };
 }
 
@@ -565,11 +638,18 @@ export function selectActionableLeafNodeId(
   nodes: IssueSubtreeDiagnosticNode[],
 ): string | null {
   const scored = nodes.map((node) => ({ node, badge: deriveSubtreeNodeBadge(node) }));
-  const ready = scored.find(({ badge }) => badge.ready);
+  const parentNodeIds = new Set(nodes.flatMap((node) => node.parentId ? [node.parentId] : []));
+  const isLeaf = (node: IssueSubtreeDiagnosticNode) => !parentNodeIds.has(node.issue.id);
+  const ready = scored.find(({ node, badge }) => badge.ready && isLeaf(node));
   if (ready) return ready.node.issue.id;
-  const debt = scored.find(({ badge }) => badge.resolvedFrom === "cancelled_blocker_in_set");
+  const debt = scored.find(
+    ({ node, badge }) =>
+      isLeaf(node)
+      && (badge.resolvedFrom === "cancelled_blocker_in_set"
+        || badge.resolvedFrom === "done_but_blocking"),
+  );
   if (debt) return debt.node.issue.id;
-  const recovery = scored.find(({ badge }) => badge.lane === "recovery");
+  const recovery = scored.find(({ node, badge }) => badge.lane === "recovery" && isLeaf(node));
   if (recovery) return recovery.node.issue.id;
   return null;
 }

--- a/ui/src/lib/next-action.ts
+++ b/ui/src/lib/next-action.ts
@@ -6,6 +6,7 @@ import type {
   IssueRelationIssueSummary,
   IssueScheduledRetry,
   IssueStatus,
+  IssueSubtreeDiagnosticNode,
   SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
 import { deriveActiveRecoveryDisplayState } from "./recovery-display";
@@ -414,4 +415,161 @@ function buildReferences(
     refs.push({ label: "Recovery", ref: toRef(attn.recoveryIssue)! });
   }
   return refs;
+}
+
+/**
+ * Compact, per-node verdict for the subtree / blocker diagnostics view
+ * (Phase 4 UX spec §5). One line per node so the operator can scan a whole
+ * tree and find where work moves next without opening every child.
+ *
+ * A subtree node only carries what the diagnostics endpoint exposes — status
+ * plus its own blocker set with terminal-gate flags — so this is a deliberate
+ * subset of the four-lane resolver: Working now / Blocked by real work (with
+ * the terminal-gate + recovery-debt variants surfaced from blocker flags).
+ * The single actionable leaf is chosen across nodes by {@link selectActionableLeafNodeId}.
+ */
+export interface NextActionNodeBadge {
+  lane: NextActionLane;
+  accent: NextActionAccent;
+  /** Short lane label, e.g. "Blocked", "Recovery", "Recovery debt", "Working". */
+  laneLabel: string;
+  /** Compact verdict, e.g. "Blocked → PAP-123", "Recovery → workspace gate". */
+  statement: string;
+  /** The upstream node the operator should look at next, when there is one. */
+  target: NextActionIssueRef | null;
+  /** Terminal-gate evidence chip, when the node is held by a gate. */
+  gate: string | null;
+  /** True when this node itself can move (unblocked, non-terminal). */
+  ready: boolean;
+  resolvedFrom: string;
+}
+
+function unresolvedBlockers(node: IssueSubtreeDiagnosticNode): IssueBlockerDiagnosticNode[] {
+  return node.blockers.filter((b) => b.isUnresolved);
+}
+
+function nodeGate(node: IssueSubtreeDiagnosticNode): IssueBlockerDiagnosticNode | null {
+  return (
+    node.blockers.find((b) => b.flags.includes("cancelled_blocker_in_set"))
+    ?? node.blockers.find((b) => b.flags.includes("workspace_finalize_pending"))
+    ?? node.blockers.find((b) => b.flags.includes("done_but_blocking"))
+    ?? null
+  );
+}
+
+function blockerRef(node: IssueBlockerDiagnosticNode): NextActionIssueRef {
+  return { id: node.id, identifier: node.identifier, title: node.title, status: node.status };
+}
+
+function blockerLabel(node: IssueBlockerDiagnosticNode): string {
+  return node.identifier ?? node.title ?? node.id.slice(0, 8);
+}
+
+export function deriveSubtreeNodeBadge(node: IssueSubtreeDiagnosticNode): NextActionNodeBadge {
+  const status = node.issue.status;
+
+  // Terminal nodes never carry a next action — render them muted, never actionable.
+  if (status === "done" || status === "cancelled") {
+    return {
+      lane: "none",
+      accent: "none",
+      laneLabel: status === "done" ? "Done" : "Cancelled",
+      statement: status === "done" ? "Complete." : "Cancelled.",
+      target: null,
+      gate: null,
+      ready: false,
+      resolvedFrom: `status:${status}`,
+    };
+  }
+
+  const gate = nodeGate(node);
+  if (gate) {
+    // A cancelled blocker left in the set is unhealthy — it needs a worker lane,
+    // not a wait. Everything else is a routed/system gate we can name and hold on.
+    if (gate.flags.includes("cancelled_blocker_in_set")) {
+      return {
+        lane: "recovery",
+        accent: "recovery_red",
+        laneLabel: "Recovery debt",
+        statement: "Recovery debt → assign worker",
+        target: blockerRef(gate),
+        gate: gateLabel(gate),
+        ready: false,
+        resolvedFrom: "cancelled_blocker_in_set",
+      };
+    }
+    if (gate.flags.includes("workspace_finalize_pending")) {
+      return {
+        lane: "recovery",
+        accent: "recovery_sky",
+        laneLabel: "Recovery",
+        statement: "Recovery → workspace gate",
+        target: blockerRef(gate),
+        gate: gateLabel(gate),
+        ready: false,
+        resolvedFrom: "workspace_finalize_pending",
+      };
+    }
+    // done_but_blocking — a Done blocker whose gate hasn't cleared.
+    return {
+      lane: "blocked_real_work",
+      accent: "todo",
+      laneLabel: "Blocked",
+      statement: `Blocked → ${blockerLabel(gate)}`,
+      target: blockerRef(gate),
+      gate: gateLabel(gate),
+      ready: false,
+      resolvedFrom: "done_but_blocking",
+    };
+  }
+
+  const unresolved = unresolvedBlockers(node);
+  if (unresolved.length > 0) {
+    const first = unresolved[0];
+    const extra = unresolved.length > 1 ? ` +${unresolved.length - 1}` : "";
+    return {
+      lane: "blocked_real_work",
+      accent: "todo",
+      laneLabel: "Blocked",
+      statement: `Blocked → ${blockerLabel(first)}${extra}`,
+      target: blockerRef(first),
+      gate: null,
+      ready: false,
+      resolvedFrom: "unresolved_blockers",
+    };
+  }
+
+  // No blockers hold this node and it is non-terminal — this is where work can
+  // actually move next. It is a candidate for the single highlighted leaf.
+  const inProgress = status === "in_progress" || status === "in_review";
+  return {
+    lane: inProgress ? "working_now" : "none",
+    accent: inProgress ? "in_progress" : "none",
+    laneLabel: inProgress ? "Working" : "Ready",
+    statement: inProgress ? "Work is moving here." : "Ready to run.",
+    target: null,
+    gate: null,
+    ready: true,
+    resolvedFrom: inProgress ? "unblocked_active" : "unblocked_ready",
+  };
+}
+
+/**
+ * Across a subtree, pick the ONE node the operator should act on — the single
+ * actionable leaf the spec highlights. Priority: an unblocked leaf where work
+ * can move now → an unhealthy recovery-debt node needing a worker → the nearest
+ * routed recovery/terminal gate. Returns null when nothing is actionable
+ * (e.g. every node is done or waiting purely on healthy upstream work).
+ */
+export function selectActionableLeafNodeId(
+  nodes: IssueSubtreeDiagnosticNode[],
+): string | null {
+  const scored = nodes.map((node) => ({ node, badge: deriveSubtreeNodeBadge(node) }));
+  const ready = scored.find(({ badge }) => badge.ready);
+  if (ready) return ready.node.issue.id;
+  const debt = scored.find(({ badge }) => badge.resolvedFrom === "cancelled_blocker_in_set");
+  if (debt) return debt.node.issue.id;
+  const recovery = scored.find(({ badge }) => badge.lane === "recovery");
+  if (recovery) return recovery.node.issue.id;
+  return null;
 }

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -180,6 +180,8 @@ export const queryKeys = {
     listByExecutionWorkspace: (companyId: string, executionWorkspaceId: string) =>
       ["issues", companyId, "execution-workspace", executionWorkspaceId] as const,
     detail: (id: string) => ["issues", "detail", id] as const,
+    blockerDiagnostics: (id: string) => ["issues", "diagnostics", "blockers", id] as const,
+    subtreeDiagnostics: (id: string) => ["issues", "diagnostics", "subtree", id] as const,
     comments: (issueId: string) => ["issues", "comments", issueId] as const,
     commentsList: (issueId: string) => ["issues", "comments", issueId, "list"] as const,
     interactions: (issueId: string) => ["issues", "interactions", issueId] as const,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -96,6 +96,7 @@ import {
   MAX_LIVE_EVENTS,
   MAX_LIVE_LOG_LINES,
 } from "../lib/live-log-buffer";
+import { RunNextActionVerdict } from "../components/RunNextActionVerdict";
 import {
   isUuidLike,
   type Agent,
@@ -3421,17 +3422,23 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
           <span className="text-xs font-medium text-muted-foreground">Tasks Touched ({touchedIssues.length})</span>
           <div className="border border-border rounded-lg divide-y divide-border">
             {touchedIssues.map((issue) => (
-              <Link
-                key={issue.issueId}
-                to={`/issues/${issue.identifier ?? issue.issueId}`}
-                className="flex items-center justify-between w-full px-3 py-2 text-xs hover:bg-accent/20 transition-colors text-left no-underline text-inherit"
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <StatusBadge status={issue.status} />
-                  <span className="truncate">{issue.title}</span>
-                </div>
-                <span className="font-mono text-muted-foreground shrink-0 ml-2">{issue.identifier ?? issue.issueId.slice(0, 8)}</span>
-              </Link>
+              <div key={issue.issueId} className="px-3 py-2">
+                <Link
+                  to={`/issues/${issue.identifier ?? issue.issueId}`}
+                  className="flex items-center justify-between w-full text-xs hover:bg-accent/20 transition-colors text-left no-underline text-inherit"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <StatusBadge status={issue.status} />
+                    <span className="truncate">{issue.title}</span>
+                  </div>
+                  <span className="font-mono text-muted-foreground shrink-0 ml-2">{issue.identifier ?? issue.issueId.slice(0, 8)}</span>
+                </Link>
+                <RunNextActionVerdict
+                  issueId={issue.issueId}
+                  runIsActive={run.status === "running" || run.status === "queued"}
+                  className="mt-2"
+                />
+              </div>
             ))}
           </div>
         </div>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -97,6 +97,7 @@ import {
   MAX_LIVE_LOG_LINES,
 } from "../lib/live-log-buffer";
 import { RunNextActionVerdict } from "../components/RunNextActionVerdict";
+import { isRunActiveForIssue } from "../lib/next-action";
 import {
   isUuidLike,
   type Agent,
@@ -3435,7 +3436,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                 </Link>
                 <RunNextActionVerdict
                   issueId={issue.issueId}
-                  runIsActive={run.status === "running" || run.status === "queued"}
+                  runIsActive={isRunActiveForIssue(run, issue.issueId)}
                   className="mt-2"
                 />
               </div>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -121,12 +121,14 @@ import {
   hasVisibleMonitorSurface,
 } from "../components/IssueMonitorBanner";
 import { IssueNextActionCard } from "../components/IssueNextActionCard";
+import { IssueSubtreeNextActionView } from "../components/IssueSubtreeNextActionView";
 import { IssueScheduledRetryCard } from "../components/IssueScheduledRetryCard";
 import { IssueProperties } from "../components/IssueProperties";
 import { PauseAffectsSummaryView } from "../components/interrupt-handoff/InterruptHandoffViews";
 import { computePauseAffectsSummary } from "../lib/interrupt-handoff";
 import { useIssueExternalObjects } from "../hooks/useIssueExternalObjects";
 import { useIssueBlockerDiagnostics } from "../hooks/useIssueBlockerDiagnostics";
+import { useIssueSubtreeDiagnostics } from "../hooks/useIssueSubtreeDiagnostics";
 import { IssueRunLedger } from "../components/IssueRunLedger";
 import { IssueWorkspaceCard } from "../components/IssueWorkspaceCard";
 import type { MentionOption } from "../components/MarkdownEditor";
@@ -1391,6 +1393,12 @@ function IssueDetailActivityTab({
       ? `Request failed (${blockerDiagnosticsQuery.error.status})`
       : "Please try again."
     : null;
+  // Subtree diagnostics power the per-node next-action map (Phase 4 UX spec §5).
+  // Only worth loading for a blocked parent whose children may hold the work.
+  const subtreeDiagnosticsQuery = useIssueSubtreeDiagnostics(issueId, {
+    enabled: issueStatus === "blocked" && childIssues.length > 0,
+  });
+  const subtreeDiagnostics = subtreeDiagnosticsQuery.data ?? null;
   const { data: issueTreeCostSummary } = useQuery({
     queryKey: queryKeys.issues.costSummary(issueId),
     queryFn: () => issuesApi.getCostSummary(issueId),
@@ -1616,6 +1624,9 @@ function IssueDetailActivityTab({
         hasLiveRun={hasLiveRuns}
         className="mb-3"
       />
+      {subtreeDiagnostics && subtreeDiagnostics.nodes.length > 1 ? (
+        <IssueSubtreeNextActionView data={subtreeDiagnostics} className="mb-3" />
+      ) : null}
       <IssueScheduledRetryCard issueId={issue.id} scheduledRetry={issue.scheduledRetry ?? null} />
       {/* Waiting-monitor state now lives in the pinned top banner (IssueMonitorBanner) — PAP-14557 decision 1. */}
     </>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -120,11 +120,13 @@ import {
   IssueMonitorComposerStrip,
   hasVisibleMonitorSurface,
 } from "../components/IssueMonitorBanner";
+import { IssueNextActionCard } from "../components/IssueNextActionCard";
 import { IssueScheduledRetryCard } from "../components/IssueScheduledRetryCard";
 import { IssueProperties } from "../components/IssueProperties";
 import { PauseAffectsSummaryView } from "../components/interrupt-handoff/InterruptHandoffViews";
 import { computePauseAffectsSummary } from "../lib/interrupt-handoff";
 import { useIssueExternalObjects } from "../hooks/useIssueExternalObjects";
+import { useIssueBlockerDiagnostics } from "../hooks/useIssueBlockerDiagnostics";
 import { IssueRunLedger } from "../components/IssueRunLedger";
 import { IssueWorkspaceCard } from "../components/IssueWorkspaceCard";
 import type { MentionOption } from "../components/MarkdownEditor";
@@ -1379,6 +1381,16 @@ function IssueDetailActivityTab({
       issueId,
     ),
   });
+  // Load richer blocker diagnostics only when the task is actually blocked, so
+  // the next-action surface can explain terminal gates without extra fetches.
+  const blockerDiagnosticsQuery = useIssueBlockerDiagnostics(issueId, {
+    enabled: issueStatus === "blocked",
+  });
+  const blockerDiagnosticsError = blockerDiagnosticsQuery.error
+    ? blockerDiagnosticsQuery.error instanceof ApiError
+      ? `Request failed (${blockerDiagnosticsQuery.error.status})`
+      : "Please try again."
+    : null;
   const { data: issueTreeCostSummary } = useQuery({
     queryKey: queryKeys.issues.costSummary(issueId),
     queryFn: () => issuesApi.getCostSummary(issueId),
@@ -1593,6 +1605,16 @@ function IssueDetailActivityTab({
           ))}
         </div>
       )}
+      <IssueNextActionCard
+        status={issueStatus}
+        blockedInboxAttention={issue.blockedInboxAttention ?? null}
+        activeRecoveryAction={issue.activeRecoveryAction ?? null}
+        scheduledRetry={issue.scheduledRetry ?? null}
+        successfulRunHandoff={issue.successfulRunHandoff ?? null}
+        blockerDiagnostics={blockerDiagnosticsQuery.data ?? null}
+        diagnosticsError={blockerDiagnosticsError}
+        className="mb-3"
+      />
       <IssueScheduledRetryCard issueId={issue.id} scheduledRetry={issue.scheduledRetry ?? null} />
       {/* Waiting-monitor state now lives in the pinned top banner (IssueMonitorBanner) — PAP-14557 decision 1. */}
     </>

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1613,6 +1613,7 @@ function IssueDetailActivityTab({
         successfulRunHandoff={issue.successfulRunHandoff ?? null}
         blockerDiagnostics={blockerDiagnosticsQuery.data ?? null}
         diagnosticsError={blockerDiagnosticsError}
+        hasLiveRun={hasLiveRuns}
         className="mb-3"
       />
       <IssueScheduledRetryCard issueId={issue.id} scheduledRetry={issue.scheduledRetry ?? null} />

--- a/ui/storybook/stories/next-action.stories.tsx
+++ b/ui/storybook/stories/next-action.stories.tsx
@@ -1,0 +1,227 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type {
+  IssueBlockedInboxAttention,
+  IssueBlockerDiagnosticsResponse,
+  IssueRecoveryAction,
+  IssueScheduledRetry,
+} from "@paperclipai/shared";
+import { IssueNextActionCard } from "@/components/IssueNextActionCard";
+
+/**
+ * PAP-13005 Phase 5 — the consolidated "what moves this forward next" surface.
+ * Each story exercises one branch of the next-action derivation so the board
+ * always sees a single readable answer instead of recovery churn.
+ */
+const meta: Meta<typeof IssueNextActionCard> = {
+  title: "Product/Next Action",
+  component: IssueNextActionCard,
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+type Story = StoryObj<typeof IssueNextActionCard>;
+
+function inboxAttention(
+  overrides: Partial<IssueBlockedInboxAttention> = {},
+): IssueBlockedInboxAttention {
+  return {
+    kind: "blocked",
+    state: "needs_attention",
+    reason: "blocked_chain_stalled",
+    severity: "high",
+    stoppedSinceAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    owner: { type: "agent", agentId: "qa-1", userId: null, label: "QA" },
+    action: {
+      label: "Wake QA on the stalled verification",
+      detail: "Resolve PAP-12921 or remove it as a blocker.",
+    },
+    sourceIssue: {
+      id: "src-1",
+      identifier: "PAP-12915",
+      title: "Release verify parallel plan",
+      status: "blocked",
+      priority: "high",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    },
+    leafIssue: {
+      id: "leaf-1",
+      identifier: "PAP-12921",
+      title: "QA release verification",
+      status: "blocked",
+      priority: "high",
+      assigneeAgentId: "qa-1",
+      assigneeUserId: null,
+    },
+    recoveryIssue: null,
+    approvalId: null,
+    interactionId: null,
+    sampleIssueIdentifier: null,
+    redaction: { externalDetailsRedacted: false, secretFieldsOmitted: true },
+    ...overrides,
+  };
+}
+
+function terminalGateDiagnostics(
+  flag: IssueBlockerDiagnosticsResponse["blockers"][number]["flags"][number],
+): IssueBlockerDiagnosticsResponse {
+  return {
+    issue: {
+      id: "src-1",
+      identifier: "PAP-12915",
+      title: "Release verify parallel plan",
+      status: "blocked",
+      priority: "high",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    },
+    diagnosis: "A done child still gates this task through its workspace finalize step.",
+    readiness: {
+      allBlockersDone: true,
+      isDependencyReady: false,
+      unresolvedBlockerCount: 0,
+      pendingFinalizeBlockerCount: 1,
+    },
+    blockers: [
+      {
+        id: "b1",
+        identifier: "PAP-12920",
+        title: "Release verify child",
+        status: "done",
+        priority: "high",
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        isUnresolved: false,
+        isDependencyReady: false,
+        isPendingFinalize: flag === "workspace_finalize_pending",
+        flags: [flag],
+      },
+    ],
+    omittedUnauthorizedBlockerCount: 0,
+    truncated: false,
+    caps: { maxBlockers: 50 },
+  };
+}
+
+const recoveryAction: IssueRecoveryAction = {
+  id: "rec-1",
+  companyId: "c1",
+  sourceIssueId: "src-1",
+  recoveryIssueId: "rec-issue-1",
+  kind: "workspace_validation",
+  status: "active",
+  ownerType: "agent",
+  ownerAgentId: "coder-1",
+  ownerUserId: null,
+  previousOwnerAgentId: null,
+  returnOwnerAgentId: null,
+  cause: "workspace_divergence",
+  fingerprint: "fp-1",
+  evidence: {},
+  nextAction: "Reissue this task in a clean isolated workspace, then re-run the release check.",
+  wakePolicy: null,
+  monitorPolicy: null,
+  attemptCount: 1,
+  maxAttempts: 3,
+  timeoutAt: null,
+  lastAttemptAt: null,
+  outcome: null,
+  resolutionNote: null,
+  resolvedAt: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const scheduledRetry: IssueScheduledRetry = {
+  runId: "run-1",
+  status: "scheduled_retry",
+  agentId: "coder-1",
+  agentName: "ClaudeCoder",
+  retryOfRunId: "run-0",
+  scheduledRetryAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+  scheduledRetryAttempt: 2,
+  scheduledRetryReason: "Cheap recovery handed back to a normal worker lane.",
+  retryExhaustedReason: null,
+  error: null,
+  errorCode: null,
+};
+
+/** A blocked tree whose real leaf is a stalled QA review. */
+export const BlockedTree: Story = {
+  args: {
+    status: "blocked",
+    blockedInboxAttention: inboxAttention(),
+  },
+};
+
+/** Terminal gate: a done child still blocks via its workspace finalize step. */
+export const BlockedTreeTerminalGate: Story = {
+  args: {
+    status: "blocked",
+    blockedInboxAttention: inboxAttention({
+      reason: "blocked_chain_stalled",
+      action: {
+        label: "Recover the workspace finalize gate",
+        detail: "PAP-12920 is done but its finalize step still blocks this task.",
+      },
+    }),
+    blockerDiagnostics: terminalGateDiagnostics("workspace_finalize_pending"),
+  },
+};
+
+/** Recovery lane: an active recovery action owns the next step. */
+export const RecoveryLane: Story = {
+  args: {
+    status: "in_progress",
+    activeRecoveryAction: recoveryAction,
+  },
+};
+
+/** Recovery lane handed a corrective run back to a normal worker lane. */
+export const RecoveryLaneScheduledRun: Story = {
+  args: {
+    status: "in_progress",
+    scheduledRetry,
+  },
+};
+
+/** A finished run left the task open with no disposition. */
+export const NeedsDisposition: Story = {
+  args: {
+    status: "in_progress",
+    successfulRunHandoff: {
+      state: "required",
+      required: true,
+      sourceRunId: "run-x",
+      correctiveRunId: null,
+      assigneeAgentId: "coder-1",
+      detectedProgressSummary: "Committed the fix but never marked the task done.",
+      createdAt: null,
+    },
+  },
+};
+
+/** Waiting on a board decision. */
+export const AwaitingDecision: Story = {
+  args: {
+    status: "in_review",
+    blockedInboxAttention: inboxAttention({
+      reason: "pending_board_decision",
+      state: "awaiting_decision",
+      severity: "medium",
+      owner: { type: "board", agentId: null, userId: null, label: "Board" },
+      action: { label: "Accept or reject the plan", detail: null },
+      leafIssue: null,
+      sourceIssue: null,
+    }),
+  },
+};
+
+/** Blocker diagnostics failed to load — the failure is surfaced, not hidden. */
+export const DiagnosticsError: Story = {
+  args: {
+    status: "blocked",
+    blockedInboxAttention: inboxAttention(),
+    diagnosticsError: "Request failed (500)",
+  },
+};

--- a/ui/storybook/stories/next-action.stories.tsx
+++ b/ui/storybook/stories/next-action.stories.tsx
@@ -32,7 +32,7 @@ function inboxAttention(
     stoppedSinceAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
     owner: { type: "agent", agentId: "qa-1", userId: null, label: "QA" },
     action: {
-      label: "Wake QA on the stalled verification",
+      label: "finish the QA verification",
       detail: "Resolve PAP-12921 or remove it as a blocker.",
     },
     sourceIssue: {

--- a/ui/storybook/stories/next-action.stories.tsx
+++ b/ui/storybook/stories/next-action.stories.tsx
@@ -8,7 +8,7 @@ import type {
 import { IssueNextActionCard } from "@/components/IssueNextActionCard";
 
 /**
- * PAP-13005 Phase 5 — the consolidated "what moves this forward next" surface.
+ * The consolidated "what moves this forward next" surface.
  * Each story exercises one branch of the next-action derivation so the board
  * always sees a single readable answer instead of recovery churn.
  */

--- a/ui/storybook/stories/next-action.stories.tsx
+++ b/ui/storybook/stories/next-action.stories.tsx
@@ -192,6 +192,7 @@ export const NeedsDisposition: Story = {
     successfulRunHandoff: {
       state: "required",
       required: true,
+      hasLiveContinuation: false,
       sourceRunId: "run-x",
       correctiveRunId: null,
       assigneeAgentId: "coder-1",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open-source control plane people use to supervise agents and the work they own.
> - Operators currently have to infer an issue's next action from status, runs, interactions, blockers, and recovery state spread across several surfaces.
> - That ambiguity is most costly when work looks blocked even though it has a live continuation, or looks active even though it needs recovery or a human decision.
> - Paperclip needs one deterministic precedence rule that classifies the next action as active work, recovery, waiting, or a real blocker.
> - The same rule must drive issue detail, subtree diagnostics, and run views so those surfaces cannot disagree.
> - Successful-run handoff recovery also needs to stay on the normal agent lane without giving status-only recovery authority to create interactions or decompose plans.
> - This pull request adds the shared diagnostic contract, canonical resolver, three UI surfaces, bounded recovery behavior, and regression coverage.
> - The benefit is an inspectable next step for operators without hiding productive continuations or creating recovery loops.

## Linked Issues or Issue Description

Related public work: #10184 established normal-model successful-run handoff; #10628 improves live blocker coverage; #10671 maintains review-action paths. This pull request builds a consistent operator-facing next-action layer across those kinds of signals rather than replacing those efforts.

**Problem**

Issue status alone does not tell an operator who should act next. A blocked issue can still have productive work in flight, an `in_progress` issue can need recovery, and a descendant can be waiting for a human decision while its parent appears generically stalled. Different UI surfaces currently require operators to reconstruct that state independently.

**Expected behavior**

Paperclip should resolve exactly one prioritized next-action lane from company-scoped diagnostics: active work first, then recovery, then waiting, then a real blocker. Issue detail, subtree summaries, and run-touched issues should use the same resolver and explain the evidence behind the verdict. Missing-disposition recovery should use a bounded normal-model handoff and must not grant status-only recovery runs authority to create interactions or decompose accepted plans.

**Scope**

This change adds read-only diagnostic endpoints and UI guidance plus recovery safeguards. It does not add a schema migration, change issue status semantics, or introduce a new roadmap capability.

## What Changed

- Added shared company-scoped blocker and subtree diagnostic contracts plus issue API clients and query hooks.
- Added a deterministic four-lane next-action resolver with focused precedence, wording, and edge-case tests.
- Added token-compliant next-action cards to issue detail, subtree diagnostics, and run-touched issue rows.
- Routed ambiguous successful-run disposition follow-up through a fingerprinted normal-model handoff.
- Prevented status-only recovery runs from creating interactions or decomposing accepted plans directly.
- Documented the canonical next-action and recovery authority invariants.
- Added Storybook coverage and an optional screenshot helper for visual inspection.

## Verification

- `pnpm exec vitest run ui/src/lib/next-action.test.ts ui/src/components/IssueNextActionCard.test.tsx ui/src/components/IssueSubtreeNextActionView.test.tsx server/src/services/recovery/successful-run-handoff.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-blocker-diagnostics-routes.test.ts` — 135 tests passed.
- `pnpm check:token-gates` — passed.
- `pnpm -r typecheck` — passed for all workspace packages.
- `pnpm test:run` — 3,449 tests passed; the sole worktree-suppressed wake test passed on isolated rerun with `PAPERCLIP_IN_WORKTREE=false`.
- `pnpm build` — passed for all workspace packages.
- `git diff --check public-gh/master...HEAD` — passed.

## Risks

- Incorrect precedence could hide the signal an operator needs. Resolver tests cover active, recovery, waiting, blocker, descendant, and fallback combinations.
- Diagnostic reads add route work on issue detail and subtree surfaces. Queries remain company-scoped and are only enabled when their identifiers are present.
- Recovery handoff changes can affect wake behavior. Stable fingerprints and existing attempt bounds prevent repeated handoff loops.
- The UI introduces new operator wording. Storybook and render tests cover representative states, but final phrasing may benefit from maintainer feedback.

> This aligns with the completed “Enforced Outcomes” and “Self-healing runs & automatic recovery” roadmap items. It does not duplicate a planned core capability.

## Model Used

- OpenAI Codex using `gpt-5.6-sol`, with agentic reasoning, repository inspection, code execution, and GitHub CLI access. The runtime does not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
