### PR TITLE
fix(server): preserve managed instruction drift during sync

### DIFF
--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { agentInstructionsService } from "../services/agent-instructions.js";
 
 type TestAgent = {
@@ -357,5 +357,165 @@ describe("agent instructions service", () => {
       "Recovered managed instructions entry file from disk as AGENTS.md; previous entry docs/MISSING.md was missing.",
     ]);
     expect(exported.files).toEqual({ "AGENTS.md": "# Managed Agent\n" });
+  });
+
+  it("preserves the whole operator-modified tree during routine materialization", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-drift-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+
+    const initial = await svc.materializeManagedBundle(agent, {
+      "AGENTS.md": "# Stock v1\n",
+      "docs/STOCK.md": "Stock docs\n",
+    });
+    expect(initial.materialization).toMatchObject({ stockStatus: "missing", action: "added" });
+    const managedRoot = initial.bundle.managedRootPath;
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Operator edit\n", "utf8");
+    await fs.writeFile(path.join(managedRoot, "OPERATOR.md"), "Operator-added file\n", "utf8");
+
+    const rebuilt = await svc.materializeManagedBundle(
+      { ...agent, adapterConfig: initial.adapterConfig },
+      {
+        "AGENTS.md": "# Stock v2\n",
+        "docs/STOCK.md": "Updated stock docs\n",
+      },
+    );
+
+    expect(rebuilt.materialization).toMatchObject({
+      stockStatus: "operator_modified",
+      action: "skipped",
+      skipped: ["AGENTS.md", "OPERATOR.md", "docs/STOCK.md"],
+      backupPath: null,
+    });
+    expect(rebuilt.adapterConfig.instructionsStockHash).toBe(initial.adapterConfig.instructionsStockHash);
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toBe("# Operator edit\n");
+    await expect(fs.readFile(path.join(managedRoot, "OPERATOR.md"), "utf8")).resolves.toBe("Operator-added file\n");
+    await expect(fs.readFile(path.join(managedRoot, "docs", "STOCK.md"), "utf8")).resolves.toBe("Stock docs\n");
+  });
+
+  it("atomically advances a clean stock tree and its recorded hash", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-update-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const initial = await svc.materializeManagedBundle(agent, {
+      "AGENTS.md": "# Stock v1\n",
+      "docs/OLD.md": "Old\n",
+    });
+
+    const updated = await svc.materializeManagedBundle(
+      { ...agent, adapterConfig: initial.adapterConfig },
+      {
+        "AGENTS.md": "# Stock v2\n",
+        "docs/NEW.md": "New\n",
+      },
+    );
+
+    expect(updated.materialization).toMatchObject({
+      stockStatus: "stock_update_available",
+      action: "updated",
+      added: ["docs/NEW.md"],
+      removed: ["docs/OLD.md"],
+      updated: ["AGENTS.md"],
+      backupPath: null,
+    });
+    expect(updated.adapterConfig.instructionsStockHash).toBe(updated.materialization.stockHash);
+    expect(updated.adapterConfig.instructionsStockHash).not.toBe(initial.adapterConfig.instructionsStockHash);
+    await expect(fs.readFile(path.join(updated.bundle.managedRootPath, "AGENTS.md"), "utf8")).resolves.toBe("# Stock v2\n");
+    await expect(fs.readFile(path.join(updated.bundle.managedRootPath, "docs", "NEW.md"), "utf8")).resolves.toBe("New\n");
+    await expect(fs.stat(path.join(updated.bundle.managedRootPath, "docs", "OLD.md"))).rejects.toThrow();
+  });
+
+  it("canonicalizes line endings and ignores transient files when classifying drift", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-canonical-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const initial = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\nLine\n" });
+    const managedRoot = initial.bundle.managedRootPath;
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Stock\r\nLine\r\n", "utf8");
+    await fs.writeFile(path.join(managedRoot, ".DS_Store"), "transient", "utf8");
+
+    const unchanged = await svc.materializeManagedBundle(
+      { ...agent, adapterConfig: initial.adapterConfig },
+      { "AGENTS.md": "# Stock\nLine\n" },
+    );
+
+    expect(unchanged.materialization).toMatchObject({ stockStatus: "stock_current", action: "unchanged" });
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toBe("# Stock\r\nLine\r\n");
+    await expect(fs.readFile(path.join(managedRoot, ".DS_Store"), "utf8")).resolves.toBe("transient");
+  });
+
+  it("rolls the live tree back when the staged atomic swap fails", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-rollback-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const initial = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock v1\n" });
+    const originalRename = fs.rename.bind(fs);
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (path.basename(String(source)) === "staged") throw new Error("simulated swap failure");
+      return originalRename(source, destination);
+    });
+
+    try {
+      await expect(svc.materializeManagedBundle(
+        { ...agent, adapterConfig: initial.adapterConfig },
+        { "AGENTS.md": "# Stock v2\n" },
+      )).rejects.toThrow("simulated swap failure");
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    await expect(fs.readFile(path.join(initial.bundle.managedRootPath, "AGENTS.md"), "utf8")).resolves.toBe("# Stock v1\n");
+  });
+
+  it("backs up operator state before an explicitly requested force reset", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-reset-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const initial = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock v1\n" });
+    const managedRoot = initial.bundle.managedRootPath;
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Operator edit\n", "utf8");
+    await fs.writeFile(path.join(managedRoot, "OPERATOR.md"), "Keep me\n", "utf8");
+
+    const reset = await svc.forceResetManagedBundle(
+      { ...agent, adapterConfig: initial.adapterConfig },
+      { "AGENTS.md": "# Stock v2\n" },
+    );
+
+    expect(reset.materialization).toMatchObject({
+      stockStatus: "operator_modified",
+      action: "reset",
+      backupPath: `${managedRoot}.backup-1`,
+      backedUp: ["AGENTS.md", "OPERATOR.md"],
+    });
+    await expect(fs.readFile(path.join(`${managedRoot}.backup-1`, "AGENTS.md"), "utf8")).resolves.toBe("# Operator edit\n");
+    await expect(fs.readFile(path.join(`${managedRoot}.backup-1`, "OPERATOR.md"), "utf8")).resolves.toBe("Keep me\n");
+    await expect(fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8")).resolves.toBe("# Stock v2\n");
+    await expect(fs.stat(path.join(managedRoot, "OPERATOR.md"))).rejects.toThrow();
+
+    await fs.writeFile(path.join(managedRoot, "AGENTS.md"), "# Second operator edit\n", "utf8");
+    const secondReset = await svc.forceResetManagedBundle(
+      { ...agent, adapterConfig: reset.adapterConfig },
+      { "AGENTS.md": "# Stock v3\n" },
+    );
+    expect(secondReset.materialization.backupPath).toBe(`${managedRoot}.backup-2`);
+    await expect(fs.readFile(path.join(`${managedRoot}.backup-1`, "AGENTS.md"), "utf8")).resolves.toBe("# Operator edit\n");
+    await expect(fs.readFile(path.join(`${managedRoot}.backup-2`, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Second operator edit\n",
+    );
   });
 });

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -489,6 +489,48 @@ describe("agent instructions service", () => {
     await expect(fs.stat(lockPath)).rejects.toThrow();
   });
 
+  it("lets only one contender reap a stale managed materialization lock", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-stale-lock-race-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        pid: 2_147_483_647,
+        token: "00000000-0000-4000-8000-000000000000",
+        createdAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, index) => agentInstructionsService().materializeManagedBundle(
+        agent,
+        { "AGENTS.md": `# Stock ${index}\n` },
+      )),
+    );
+
+    expect(results.filter((result) => result.materialization.action === "added")).toHaveLength(1);
+    expect(results.filter((result) => result.materialization.action === "skipped")).toHaveLength(7);
+    await expect(fs.stat(lockPath)).rejects.toThrow();
+    const live = await fs.readFile(path.join(managedRoot, "AGENTS.md"), "utf8");
+    expect(Array.from({ length: 8 }, (_, index) => `# Stock ${index}\n`)).toContain(live);
+  });
+
   it("does not evict an old materialization lock owned by a live process", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-live-lock-");
     cleanupDirs.add(paperclipHome);

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -552,7 +552,9 @@ describe("agent instructions service", () => {
       `${JSON.stringify({
         pid: process.pid,
         token,
-        processStartMarker: "not-the-current-process-start",
+        processStartMarker: process.platform === "linux"
+          ? "linux:not-the-current-process-start"
+          : "ps:not-the-current-process-start",
         createdAt: new Date().toISOString(),
       })}\n`,
       "utf8",
@@ -564,6 +566,54 @@ describe("agent instructions service", () => {
     expect(result.materialization.action).toBe("added");
     await expect(fs.stat(lockPath)).rejects.toThrow();
   });
+
+  it.skipIf(process.platform !== "linux")(
+    "does not evict a live lock when process identity falls back to another scheme",
+    async () => {
+      const paperclipHome = await makeTempDir("paperclip-agent-instructions-marker-fallback-");
+      cleanupDirs.add(paperclipHome);
+      process.env.PAPERCLIP_HOME = paperclipHome;
+      process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+      const svc = agentInstructionsService();
+      const agent = makeAgent({});
+      const managedRoot = path.join(
+        paperclipHome,
+        "instances",
+        "test-instance",
+        "companies",
+        "company-1",
+        "agents",
+        "agent-1",
+        "instructions",
+      );
+      const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+      const token = "00000000-0000-4000-8000-000000000000";
+      await fs.mkdir(lockPath, { recursive: true });
+      await fs.writeFile(
+        path.join(lockPath, "owner.json"),
+        `${JSON.stringify({
+          pid: process.pid,
+          token,
+          processStartMarker: "ps:same-live-process-in-another-format",
+          createdAt: new Date().toISOString(),
+        })}\n`,
+        "utf8",
+      );
+      await fs.writeFile(path.join(lockPath, `heartbeat-${token}`), "", "utf8");
+
+      const materialization = svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+      const firstOutcome = await Promise.race([
+        materialization.then(() => "materialized"),
+        new Promise<"waiting">((resolve) => setTimeout(() => resolve("waiting"), 75)),
+      ]);
+
+      expect(firstOutcome).toBe("waiting");
+      await fs.rm(lockPath, { recursive: true, force: true });
+      await expect(materialization).resolves.toMatchObject({
+        materialization: { action: "added" },
+      });
+    },
+  );
 
   it("canonicalizes line endings and ignores transient files when classifying drift", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-canonical-");

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -431,6 +431,33 @@ describe("agent instructions service", () => {
     await expect(fs.stat(path.join(updated.bundle.managedRootPath, "docs", "OLD.md"))).rejects.toThrow();
   });
 
+  it("serializes concurrent routine materializations for the same agent", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-concurrent-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const initial = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock v1\n" });
+    const configuredAgent = { ...agent, adapterConfig: initial.adapterConfig };
+
+    const [first, second] = await Promise.all([
+      svc.materializeManagedBundle(configuredAgent, { "AGENTS.md": "# Stock v2\n" }),
+      agentInstructionsService().materializeManagedBundle(configuredAgent, {
+        "AGENTS.md": "# Stock v3\n",
+      }),
+    ]);
+
+    expect(first.materialization.action).toBe("updated");
+    expect(second.materialization).toMatchObject({
+      stockStatus: "operator_modified",
+      action: "skipped",
+    });
+    await expect(fs.readFile(path.join(initial.bundle.managedRootPath, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Stock v2\n",
+    );
+  });
+
   it("canonicalizes line endings and ignores transient files when classifying drift", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-canonical-");
     cleanupDirs.add(paperclipHome);
@@ -516,6 +543,36 @@ describe("agent instructions service", () => {
     await expect(fs.readFile(path.join(`${managedRoot}.backup-1`, "AGENTS.md"), "utf8")).resolves.toBe("# Operator edit\n");
     await expect(fs.readFile(path.join(`${managedRoot}.backup-2`, "AGENTS.md"), "utf8")).resolves.toBe(
       "# Second operator edit\n",
+    );
+  });
+
+  it("allocates distinct backups for concurrent force resets", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-concurrent-reset-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const initial = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock v1\n" });
+    const configuredAgent = { ...agent, adapterConfig: initial.adapterConfig };
+
+    const [first, second] = await Promise.all([
+      svc.forceResetManagedBundle(configuredAgent, { "AGENTS.md": "# Stock v2\n" }),
+      agentInstructionsService().forceResetManagedBundle(configuredAgent, {
+        "AGENTS.md": "# Stock v3\n",
+      }),
+    ]);
+
+    expect(first.materialization.backupPath).toBe(`${initial.bundle.managedRootPath}.backup-1`);
+    expect(second.materialization.backupPath).toBe(`${initial.bundle.managedRootPath}.backup-2`);
+    await expect(
+      fs.readFile(path.join(`${initial.bundle.managedRootPath}.backup-1`, "AGENTS.md"), "utf8"),
+    ).resolves.toBe("# Stock v1\n");
+    await expect(
+      fs.readFile(path.join(`${initial.bundle.managedRootPath}.backup-2`, "AGENTS.md"), "utf8"),
+    ).resolves.toBe("# Stock v2\n");
+    await expect(fs.readFile(path.join(initial.bundle.managedRootPath, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Stock v3\n",
     );
   });
 });

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -458,6 +458,37 @@ describe("agent instructions service", () => {
     );
   });
 
+  it("recovers a managed materialization lock left by a dead process", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-stale-lock-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: 2_147_483_647, token: "stale", createdAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+
+    const result = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+
+    expect(result.materialization.action).toBe("added");
+    await expect(fs.stat(lockPath)).rejects.toThrow();
+  });
+
   it("canonicalizes line endings and ignores transient files when classifying drift", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-canonical-");
     cleanupDirs.add(paperclipHome);

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -489,6 +489,44 @@ describe("agent instructions service", () => {
     await expect(fs.stat(lockPath)).rejects.toThrow();
   });
 
+  it("does not evict an old materialization lock owned by a live process", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-live-lock-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, token: "live", createdAt: "1970-01-01T00:00:00.000Z" })}\n`,
+      "utf8",
+    );
+
+    const materialization = svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+    const firstOutcome = await Promise.race([
+      materialization.then(() => "materialized"),
+      new Promise<"waiting">((resolve) => setTimeout(() => resolve("waiting"), 75)),
+    ]);
+
+    expect(firstOutcome).toBe("waiting");
+    await fs.rm(lockPath, { recursive: true, force: true });
+    await expect(materialization).resolves.toMatchObject({
+      materialization: { action: "added" },
+    });
+  });
+
   it("canonicalizes line endings and ignores transient files when classifying drift", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-canonical-");
     cleanupDirs.add(paperclipHome);

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -531,6 +531,63 @@ describe("agent instructions service", () => {
     expect(Array.from({ length: 8 }, (_, index) => `# Stock ${index}\n`)).toContain(live);
   });
 
+  it("publishes owner metadata atomically with the materialization lock", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-lock-publish-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    const originalRename = fs.rename.bind(fs);
+    let pendingLockPath: string | null = null;
+    let publish: (() => void) | null = null;
+    const publishAllowed = new Promise<void>((resolve) => {
+      publish = resolve;
+    });
+    let pendingReady: (() => void) | null = null;
+    const pendingPrepared = new Promise<void>((resolve) => {
+      pendingReady = resolve;
+    });
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (String(source).startsWith(`${lockPath}.pending-`) && String(destination) === lockPath) {
+        pendingLockPath = String(source);
+        pendingReady?.();
+        await publishAllowed;
+      }
+      return originalRename(source, destination);
+    });
+    const materialization = agentInstructionsService().materializeManagedBundle(
+      agent,
+      { "AGENTS.md": "# Stock\n" },
+    );
+
+    try {
+      await pendingPrepared;
+      await expect(fs.stat(lockPath)).rejects.toThrow();
+      expect(pendingLockPath).not.toBeNull();
+      await expect(fs.readFile(path.join(pendingLockPath!, "owner.json"), "utf8")).resolves.toContain(
+        `"pid":${process.pid}`,
+      );
+      const pendingFiles = await fs.readdir(pendingLockPath!);
+      expect(pendingFiles.some((file) => file.startsWith("heartbeat-"))).toBe(true);
+    } finally {
+      publish?.();
+    }
+
+    await expect(materialization).resolves.toMatchObject({ materialization: { action: "added" } });
+    renameSpy.mockRestore();
+  });
+
   it("does not evict an old materialization lock owned by a live process", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-live-lock-");
     cleanupDirs.add(paperclipHome);

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -527,6 +527,44 @@ describe("agent instructions service", () => {
     });
   });
 
+  it("recovers a stale lock whose PID was reused by another process", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-reused-pid-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    const token = "00000000-0000-4000-8000-000000000000";
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({
+        pid: process.pid,
+        token,
+        processStartMarker: "not-the-current-process-start",
+        createdAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(lockPath, `heartbeat-${token}`), "", "utf8");
+
+    const result = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+
+    expect(result.materialization.action).toBe("added");
+    await expect(fs.stat(lockPath)).rejects.toThrow();
+  });
+
   it("canonicalizes line endings and ignores transient files when classifying drift", async () => {
     const paperclipHome = await makeTempDir("paperclip-agent-instructions-canonical-");
     cleanupDirs.add(paperclipHome);

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -720,16 +720,19 @@ describe("agent instructions service", () => {
       }),
     ]);
 
-    expect(first.materialization.backupPath).toBe(`${initial.bundle.managedRootPath}.backup-1`);
-    expect(second.materialization.backupPath).toBe(`${initial.bundle.managedRootPath}.backup-2`);
+    expect(new Set([first.materialization.backupPath, second.materialization.backupPath])).toEqual(
+      new Set([
+        `${initial.bundle.managedRootPath}.backup-1`,
+        `${initial.bundle.managedRootPath}.backup-2`,
+      ]),
+    );
     await expect(
       fs.readFile(path.join(`${initial.bundle.managedRootPath}.backup-1`, "AGENTS.md"), "utf8"),
     ).resolves.toBe("# Stock v1\n");
-    await expect(
+    const [secondBackup, live] = await Promise.all([
       fs.readFile(path.join(`${initial.bundle.managedRootPath}.backup-2`, "AGENTS.md"), "utf8"),
-    ).resolves.toBe("# Stock v2\n");
-    await expect(fs.readFile(path.join(initial.bundle.managedRootPath, "AGENTS.md"), "utf8")).resolves.toBe(
-      "# Stock v3\n",
-    );
+      fs.readFile(path.join(initial.bundle.managedRootPath, "AGENTS.md"), "utf8"),
+    ]);
+    expect(new Set([secondBackup, live])).toEqual(new Set(["# Stock v2\n", "# Stock v3\n"]));
   });
 });

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -667,7 +667,7 @@ describe("agent instructions service", () => {
   });
 
   it.skipIf(process.platform !== "linux")(
-    "does not evict a live lock when process identity falls back to another scheme",
+    "does not evict a live lock with a stale heartbeat when identity falls back to another scheme",
     async () => {
       const paperclipHome = await makeTempDir("paperclip-agent-instructions-marker-fallback-");
       cleanupDirs.add(paperclipHome);
@@ -698,7 +698,10 @@ describe("agent instructions service", () => {
         })}\n`,
         "utf8",
       );
-      await fs.writeFile(path.join(lockPath, `heartbeat-${token}`), "", "utf8");
+      const heartbeatPath = path.join(lockPath, `heartbeat-${token}`);
+      await fs.writeFile(heartbeatPath, "", "utf8");
+      const staleHeartbeat = new Date(Date.now() - 60_000);
+      await fs.utimes(heartbeatPath, staleHeartbeat, staleHeartbeat);
 
       const materialization = svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
       const firstOutcome = await Promise.race([

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -814,6 +814,87 @@ describe("agent instructions service", () => {
   );
 
   it.skipIf(process.platform !== "linux")(
+    "does not evict a live lock after a transient probe connection error",
+    async () => {
+      const paperclipHome = await makeTempDir("paperclip-agent-instructions-probe-retry-");
+      cleanupDirs.add(paperclipHome);
+      process.env.PAPERCLIP_HOME = paperclipHome;
+      process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+      const svc = agentInstructionsService();
+      const agent = makeAgent({});
+      const managedRoot = path.join(
+        paperclipHome,
+        "instances",
+        "test-instance",
+        "companies",
+        "company-1",
+        "agents",
+        "agent-1",
+        "instructions",
+      );
+      const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+      const token = randomUUID();
+      const probePath = `\0paperclip-managed-bundle-${token}`;
+      const probe = net.createServer((socket) => socket.destroy());
+      await new Promise<void>((resolve, reject) => {
+        probe.once("error", reject);
+        probe.listen(probePath, resolve);
+      });
+      probe.unref();
+      await fs.mkdir(lockPath, { recursive: true });
+      await fs.writeFile(
+        path.join(lockPath, "owner.json"),
+        `${JSON.stringify({
+          pid: process.pid,
+          token,
+          probePath,
+          createdAt: new Date().toISOString(),
+        })}\n`,
+        "utf8",
+      );
+      await fs.writeFile(path.join(lockPath, `heartbeat-${token}`), "", "utf8");
+
+      const originalCreateConnection = net.createConnection.bind(net);
+      let connectionAttempts = 0;
+      const createConnectionSpy = vi
+        .spyOn(net, "createConnection")
+        .mockImplementation(((...args: Parameters<typeof net.createConnection>) => {
+          connectionAttempts += 1;
+          if (connectionAttempts === 1) {
+            const socket = new net.Socket();
+            queueMicrotask(() => {
+              socket.emit("error", Object.assign(new Error("transient probe failure"), {
+                code: "EAGAIN",
+              }));
+            });
+            return socket;
+          }
+          return originalCreateConnection(...args);
+        }) as typeof net.createConnection);
+      const materialization = svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+
+      try {
+        const firstOutcome = await Promise.race([
+          materialization.then(() => "materialized"),
+          new Promise<"waiting">((resolve) => setTimeout(() => resolve("waiting"), 100)),
+        ]);
+        expect(firstOutcome).toBe("waiting");
+        expect(connectionAttempts).toBeGreaterThanOrEqual(2);
+      } finally {
+        createConnectionSpy.mockRestore();
+        const releasedLockPath = `${lockPath}.released`;
+        await fs.rename(lockPath, releasedLockPath);
+        await new Promise<void>((resolve) => probe.close(() => resolve()));
+        await fs.rm(releasedLockPath, { recursive: true, force: true });
+      }
+
+      await expect(materialization).resolves.toMatchObject({
+        materialization: { action: "added" },
+      });
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
     "recovers a reused PID after its liveness probe is released",
     async () => {
       const paperclipHome = await makeTempDir("paperclip-agent-instructions-ps-reused-pid-");

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -688,13 +690,21 @@ describe("agent instructions service", () => {
         "instructions",
       );
       const lockPath = `${managedRoot}.paperclip-materialize.lock`;
-      const token = "00000000-0000-4000-8000-000000000000";
+      const token = randomUUID();
+      const probePath = `\0paperclip-managed-bundle-${token}`;
+      const probe = net.createServer((socket) => socket.destroy());
+      await new Promise<void>((resolve, reject) => {
+        probe.once("error", reject);
+        probe.listen(probePath, resolve);
+      });
+      probe.unref();
       await fs.mkdir(lockPath, { recursive: true });
       await fs.writeFile(
         path.join(lockPath, "owner.json"),
         `${JSON.stringify({
           pid: process.pid,
           token,
+          probePath,
           processStartMarker: "unavailable:same-live-process-in-another-format",
           createdAt: new Date().toISOString(),
         })}\n`,
@@ -714,6 +724,7 @@ describe("agent instructions service", () => {
       expect(firstOutcome).toBe("waiting");
       const releasedLockPath = `${lockPath}.released`;
       await fs.rename(lockPath, releasedLockPath);
+      await new Promise<void>((resolve) => probe.close(() => resolve()));
       await fs.rm(releasedLockPath, { recursive: true, force: true });
       await expect(materialization).resolves.toMatchObject({
         materialization: { action: "added" },
@@ -722,7 +733,7 @@ describe("agent instructions service", () => {
   );
 
   it.skipIf(process.platform !== "linux")(
-    "recovers a reused PID when the owner recorded the ps fallback scheme",
+    "recovers a reused PID after its liveness probe is released",
     async () => {
       const paperclipHome = await makeTempDir("paperclip-agent-instructions-ps-reused-pid-");
       cleanupDirs.add(paperclipHome);
@@ -741,14 +752,16 @@ describe("agent instructions service", () => {
         "instructions",
       );
       const lockPath = `${managedRoot}.paperclip-materialize.lock`;
-      const token = "00000000-0000-4000-8000-000000000000";
+      const token = randomUUID();
+      const probePath = `\0paperclip-managed-bundle-${token}`;
       await fs.mkdir(lockPath, { recursive: true });
       await fs.writeFile(
         path.join(lockPath, "owner.json"),
         `${JSON.stringify({
           pid: process.pid,
           token,
-          processStartMarker: "ps:not-the-current-process-start",
+          probePath,
+          processStartMarker: "unavailable:not-the-current-process-start",
           createdAt: new Date().toISOString(),
         })}\n`,
         "utf8",

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -620,7 +620,9 @@ describe("agent instructions service", () => {
     ]);
 
     expect(firstOutcome).toBe("waiting");
-    await fs.rm(lockPath, { recursive: true, force: true });
+    const releasedLockPath = `${lockPath}.released`;
+    await fs.rename(lockPath, releasedLockPath);
+    await fs.rm(releasedLockPath, { recursive: true, force: true });
     await expect(materialization).resolves.toMatchObject({
       materialization: { action: "added" },
     });
@@ -667,7 +669,7 @@ describe("agent instructions service", () => {
   });
 
   it.skipIf(process.platform !== "linux")(
-    "does not evict a live lock with a stale heartbeat when identity falls back to another scheme",
+    "does not evict a live lock with a stale heartbeat when its identity scheme is unavailable",
     async () => {
       const paperclipHome = await makeTempDir("paperclip-agent-instructions-marker-fallback-");
       cleanupDirs.add(paperclipHome);
@@ -693,7 +695,7 @@ describe("agent instructions service", () => {
         `${JSON.stringify({
           pid: process.pid,
           token,
-          processStartMarker: "ps:same-live-process-in-another-format",
+          processStartMarker: "unavailable:same-live-process-in-another-format",
           createdAt: new Date().toISOString(),
         })}\n`,
         "utf8",
@@ -710,10 +712,53 @@ describe("agent instructions service", () => {
       ]);
 
       expect(firstOutcome).toBe("waiting");
-      await fs.rm(lockPath, { recursive: true, force: true });
+      const releasedLockPath = `${lockPath}.released`;
+      await fs.rename(lockPath, releasedLockPath);
+      await fs.rm(releasedLockPath, { recursive: true, force: true });
       await expect(materialization).resolves.toMatchObject({
         materialization: { action: "added" },
       });
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "recovers a reused PID when the owner recorded the ps fallback scheme",
+    async () => {
+      const paperclipHome = await makeTempDir("paperclip-agent-instructions-ps-reused-pid-");
+      cleanupDirs.add(paperclipHome);
+      process.env.PAPERCLIP_HOME = paperclipHome;
+      process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+      const svc = agentInstructionsService();
+      const agent = makeAgent({});
+      const managedRoot = path.join(
+        paperclipHome,
+        "instances",
+        "test-instance",
+        "companies",
+        "company-1",
+        "agents",
+        "agent-1",
+        "instructions",
+      );
+      const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+      const token = "00000000-0000-4000-8000-000000000000";
+      await fs.mkdir(lockPath, { recursive: true });
+      await fs.writeFile(
+        path.join(lockPath, "owner.json"),
+        `${JSON.stringify({
+          pid: process.pid,
+          token,
+          processStartMarker: "ps:not-the-current-process-start",
+          createdAt: new Date().toISOString(),
+        })}\n`,
+        "utf8",
+      );
+      await fs.writeFile(path.join(lockPath, `heartbeat-${token}`), "", "utf8");
+
+      const result = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+
+      expect(result.materialization.action).toBe("added");
+      await expect(fs.stat(lockPath)).rejects.toThrow();
     },
   );
 

--- a/server/src/__tests__/agent-instructions-service.test.ts
+++ b/server/src/__tests__/agent-instructions-service.test.ts
@@ -611,7 +611,7 @@ describe("agent instructions service", () => {
     await fs.mkdir(lockPath, { recursive: true });
     await fs.writeFile(
       path.join(lockPath, "owner.json"),
-      `${JSON.stringify({ pid: process.pid, token: "live", createdAt: "1970-01-01T00:00:00.000Z" })}\n`,
+      `${JSON.stringify({ pid: process.pid, token: "live", createdAt: new Date().toISOString() })}\n`,
       "utf8",
     );
 
@@ -668,6 +668,87 @@ describe("agent instructions service", () => {
 
     expect(result.materialization.action).toBe("added");
     await expect(fs.stat(lockPath)).rejects.toThrow();
+  });
+
+  it("recovers a probe-less legacy lock after its PID is reused", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-legacy-stale-lock-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    const token = randomUUID();
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, token, createdAt: "1970-01-01T00:00:00.000Z" })}\n`,
+      "utf8",
+    );
+    const heartbeatPath = path.join(lockPath, `heartbeat-${token}`);
+    await fs.writeFile(heartbeatPath, "", "utf8");
+    const staleHeartbeat = new Date(Date.now() - 60_000);
+    await fs.utimes(heartbeatPath, staleHeartbeat, staleHeartbeat);
+
+    const result = await svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+
+    expect(result.materialization.action).toBe("added");
+    await expect(fs.stat(lockPath)).rejects.toThrow();
+  });
+
+  it("preserves a probe-less legacy lock when its live owner heartbeat is stale", async () => {
+    const paperclipHome = await makeTempDir("paperclip-agent-instructions-legacy-live-lock-");
+    cleanupDirs.add(paperclipHome);
+    process.env.PAPERCLIP_HOME = paperclipHome;
+    process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+    const svc = agentInstructionsService();
+    const agent = makeAgent({});
+    const managedRoot = path.join(
+      paperclipHome,
+      "instances",
+      "test-instance",
+      "companies",
+      "company-1",
+      "agents",
+      "agent-1",
+      "instructions",
+    );
+    const lockPath = `${managedRoot}.paperclip-materialize.lock`;
+    const token = randomUUID();
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(
+      path.join(lockPath, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+    const heartbeatPath = path.join(lockPath, `heartbeat-${token}`);
+    await fs.writeFile(heartbeatPath, "", "utf8");
+    const staleHeartbeat = new Date(Date.now() - 60_000);
+    await fs.utimes(heartbeatPath, staleHeartbeat, staleHeartbeat);
+
+    const materialization = svc.materializeManagedBundle(agent, { "AGENTS.md": "# Stock\n" });
+    const firstOutcome = await Promise.race([
+      materialization.then(() => "materialized"),
+      new Promise<"waiting">((resolve) => setTimeout(() => resolve("waiting"), 75)),
+    ]);
+
+    expect(firstOutcome).toBe("waiting");
+    const releasedLockPath = `${lockPath}.released`;
+    await fs.rename(lockPath, releasedLockPath);
+    await fs.rm(releasedLockPath, { recursive: true, force: true });
+    await expect(materialization).resolves.toMatchObject({
+      materialization: { action: "added" },
+    });
   });
 
   it.skipIf(process.platform !== "linux")(

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -1084,7 +1084,7 @@ describe.sequential("agent skill routes", () => {
         "SOUL.md": expect.stringContaining("CEO Persona"),
         "TOOLS.md": expect.stringContaining("# Tools"),
       }),
-      { entryFile: "AGENTS.md", replaceExisting: false },
+      { entryFile: "AGENTS.md" },
     );
   });
 
@@ -1110,7 +1110,7 @@ describe.sequential("agent skill routes", () => {
         expect.objectContaining({
           "AGENTS.md": expect.stringMatching(/Start actionable work in the same heartbeat\.[\s\S]*Keep the work moving until it is done\./),
         }),
-        { entryFile: "AGENTS.md", replaceExisting: false },
+        { entryFile: "AGENTS.md" },
       );
       expect(mockAgentInstructionsService.materializeManagedBundle).toHaveBeenCalledWith(
         expect.any(Object),

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -797,6 +798,7 @@ describeEmbeddedPostgres("built-in agents", () => {
     const instructions = agentInstructionsService();
 
     await instructions.writeFile(created.agent!, "AGENTS.md", "# Custom Reflection Coach\n\nOperator edit.\n");
+    await instructions.writeFile(created.agent!, "OPERATOR.md", "Operator-added file.\n");
 
     const reconciled = await builtIns.ensure(companyId, "reflection-coach");
     const drift = reconciled.resources.find((resource) => resource.resourceKind === "instructions");
@@ -804,12 +806,16 @@ describeEmbeddedPostgres("built-in agents", () => {
       stockStatus: "operator_modified",
       updateAvailable: true,
       resetAvailable: true,
-      changedFiles: ["AGENTS.md"],
+      changedFiles: ["AGENTS.md", "OPERATOR.md"],
     });
     await expect(instructions.readFile(reconciled.agent!, "AGENTS.md")).resolves.toMatchObject({
       content: "# Custom Reflection Coach\n\nOperator edit.\n",
     });
+    await expect(instructions.readFile(reconciled.agent!, "OPERATOR.md")).resolves.toMatchObject({
+      content: "Operator-added file.\n",
+    });
 
+    const managedRoot = String(reconciled.agent?.adapterConfig.instructionsRootPath);
     const reset = await builtIns.reset(companyId, "reflection-coach");
     expect(reset.resources.find((resource) => resource.resourceKind === "instructions")).toMatchObject({
       stockStatus: "stock_current",
@@ -818,6 +824,12 @@ describeEmbeddedPostgres("built-in agents", () => {
     const resetFile = await instructions.readFile(reset.agent!, "AGENTS.md");
     expect(resetFile.content).toContain("Reflection Coach");
     expect(resetFile.content).not.toContain("Operator edit.");
+    await expect(fs.readFile(path.join(`${managedRoot}.backup-1`, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Custom Reflection Coach\n\nOperator edit.\n",
+    );
+    await expect(fs.readFile(path.join(`${managedRoot}.backup-1`, "OPERATOR.md"), "utf8")).resolves.toBe(
+      "Operator-added file.\n",
+    );
   });
 
   it("blocks deleting a built-in agent", async () => {

--- a/server/src/__tests__/company-portability.test.ts
+++ b/server/src/__tests__/company-portability.test.ts
@@ -454,6 +454,19 @@ describe("company portability", () => {
         instructionsEntryFile: "AGENTS.md",
         instructionsFilePath: `/tmp/${agent.id}/AGENTS.md`,
       },
+      materialization: {
+        stockStatus: "missing",
+        action: "added",
+        stockHash: "sha256:stock",
+        previousHash: null,
+        recordedStockHash: null,
+        added: ["AGENTS.md"],
+        removed: [],
+        updated: [],
+        skipped: [],
+        backedUp: [],
+        backupPath: null,
+      },
     }));
   });
 
@@ -3428,7 +3441,6 @@ describe("company portability", () => {
       }),
       expect.objectContaining({
         clearLegacyPromptTemplate: true,
-        replaceExisting: true,
       }),
     );
     const materializedFiles = agentInstructionsSvc.materializeManagedBundle.mock.calls[0]?.[1] as Record<string, string>;
@@ -5213,6 +5225,15 @@ describe("company portability", () => {
       },
     });
 
+    agentSvc.list.mockResolvedValue([{
+      id: "agent-1",
+      name: "ClaudeCoder",
+      status: "idle",
+      adapterConfig: {
+        instructionsStockHash: "sha256:previous-stock",
+      },
+    }]);
+
     secretSvc.normalizeAdapterConfigForPersistence.mockResolvedValueOnce({
       normalized: "updated",
     });
@@ -5222,8 +5243,32 @@ describe("company portability", () => {
       adapterType: patch.adapterType,
       adapterConfig: patch.adapterConfig,
     }));
+    agentInstructionsSvc.materializeManagedBundle.mockImplementationOnce(async (agent: { id: string; adapterConfig: Record<string, unknown> }) => ({
+      bundle: null,
+      adapterConfig: {
+        ...agent.adapterConfig,
+        instructionsBundleMode: "managed",
+        instructionsRootPath: `/tmp/${agent.id}`,
+        instructionsEntryFile: "AGENTS.md",
+        instructionsFilePath: `/tmp/${agent.id}/AGENTS.md`,
+        instructionsStockHash: "sha256:previous-stock",
+      },
+      materialization: {
+        stockStatus: "operator_modified",
+        action: "skipped",
+        stockHash: "sha256:imported-stock",
+        previousHash: "sha256:operator-tree",
+        recordedStockHash: "sha256:previous-stock",
+        added: [],
+        removed: ["OPERATOR.md"],
+        updated: ["AGENTS.md"],
+        skipped: ["AGENTS.md", "OPERATOR.md"],
+        backedUp: [],
+        backupPath: null,
+      },
+    }));
 
-    await portability.importBundle({
+    const result = await portability.importBundle({
       source: {
         type: "inline",
         rootPath: exported.rootPath,
@@ -5263,8 +5308,22 @@ describe("company portability", () => {
       adapterType: "codex_local",
       adapterConfig: {
         normalized: "updated",
+        instructionsStockHash: "sha256:previous-stock",
       },
     }));
+    expect(agentInstructionsSvc.materializeManagedBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "agent-1",
+        adapterConfig: expect.objectContaining({
+          instructionsStockHash: "sha256:previous-stock",
+        }),
+      }),
+      expect.any(Object),
+      { clearLegacyPromptTemplate: true },
+    );
+    expect(result.warnings).toContain(
+      "Preserved operator-modified instructions bundle for claudecoder; imported stock files were skipped.",
+    );
   });
 
   it("nameOverrides applied after collision detection do not re-validate uniqueness", async () => {

--- a/server/src/__tests__/plugin-managed-agents.test.ts
+++ b/server/src/__tests__/plugin-managed-agents.test.ts
@@ -301,6 +301,21 @@ describeEmbeddedPostgres("plugin-managed agents", () => {
       expect(content).toContain("You are the LLM Wiki Maintainer.");
       expect(content).toContain(`Wiki root: \`${wikiRoot}\``);
       expect(content).toContain(`Wiki schema: \`${path.join(wikiRoot, "AGENTS.md")}\``);
+
+      const instructionsRoot = path.dirname(instructionsFilePath as string);
+      await fs.writeFile(instructionsFilePath as string, "# Operator plugin edit\n", "utf8");
+      await fs.writeFile(path.join(instructionsRoot, "OPERATOR.md"), "Operator-added plugin file\n", "utf8");
+      await services.agents.managedReset({ companyId, agentKey: "wiki-maintainer" });
+
+      await expect(fs.readFile(path.join(`${instructionsRoot}.backup-1`, "AGENTS.md"), "utf8")).resolves.toBe(
+        "# Operator plugin edit\n",
+      );
+      await expect(fs.readFile(path.join(`${instructionsRoot}.backup-1`, "OPERATOR.md"), "utf8")).resolves.toBe(
+        "Operator-added plugin file\n",
+      );
+      await expect(fs.readFile(instructionsFilePath as string, "utf8")).resolves.toContain(
+        "You are the LLM Wiki Maintainer.",
+      );
     } finally {
       if (previousHome === undefined) delete process.env.PAPERCLIP_HOME;
       else process.env.PAPERCLIP_HOME = previousHome;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1438,7 +1438,7 @@ export function agentRoutes(
     const materialized = await instructions.materializeManagedBundle(
       agent,
       files,
-      { entryFile: input?.entryFile ?? "AGENTS.md", replaceExisting: false },
+      { entryFile: input?.entryFile ?? "AGENTS.md" },
     );
     const nextAdapterConfig = { ...materialized.adapterConfig };
     delete nextAdapterConfig.promptTemplate;

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { notFound, unprocessable } from "../errors.js";
@@ -28,7 +28,9 @@ const IGNORED_INSTRUCTIONS_DIRECTORY_NAMES = new Set([
   "node_modules",
   "venv",
 ]);
-const managedBundleMaterializationTails = new Map<string, Promise<void>>();
+const MANAGED_BUNDLE_LOCK_SUFFIX = ".paperclip-materialize.lock";
+const MANAGED_BUNDLE_LOCK_TIMEOUT_MS = 30_000;
+const MANAGED_BUNDLE_LOCK_STALE_MS = 5 * 60_000;
 
 type BundleMode = "managed" | "external";
 
@@ -175,25 +177,79 @@ async function statIfExists(targetPath: string) {
   return fs.stat(targetPath).catch(() => null);
 }
 
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> {
+  let shouldRemove = false;
+  try {
+    const owner = JSON.parse(await fs.readFile(path.join(lockPath, "owner.json"), "utf8")) as {
+      pid?: unknown;
+      createdAt?: unknown;
+    };
+    const pid = typeof owner.pid === "number" ? owner.pid : 0;
+    const createdAt = typeof owner.createdAt === "string" ? Date.parse(owner.createdAt) : Number.NaN;
+    const ageMs = Number.isFinite(createdAt)
+      ? Date.now() - createdAt
+      : MANAGED_BUNDLE_LOCK_STALE_MS + 1;
+    shouldRemove = !isProcessAlive(pid) || ageMs > MANAGED_BUNDLE_LOCK_STALE_MS;
+  } catch {
+    const stat = await statIfExists(lockPath);
+    shouldRemove = !stat || Date.now() - stat.mtimeMs > MANAGED_BUNDLE_LOCK_STALE_MS;
+  }
+  if (!shouldRemove) return false;
+  await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+  return true;
+}
+
 async function withManagedBundleMaterializationLock<T>(
   rootPath: string,
   operation: () => Promise<T>,
 ): Promise<T> {
-  const previous = managedBundleMaterializationTails.get(rootPath) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const tail = previous.catch(() => undefined).then(() => current);
-  managedBundleMaterializationTails.set(rootPath, tail);
+  const lockPath = `${rootPath}${MANAGED_BUNDLE_LOCK_SUFFIX}`;
+  const ownerPath = path.join(lockPath, "owner.json");
+  const token = randomUUID();
+  const deadline = Date.now() + MANAGED_BUNDLE_LOCK_TIMEOUT_MS;
+  await fs.mkdir(path.dirname(rootPath), { recursive: true });
+  while (true) {
+    try {
+      await fs.mkdir(lockPath);
+      try {
+        await fs.writeFile(
+          ownerPath,
+          `${JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() })}\n`,
+          "utf8",
+        );
+      } catch (error) {
+        await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+        throw error;
+      }
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (await removeStaleManagedBundleLock(lockPath)) continue;
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for managed instructions lock at ${lockPath}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
 
-  await previous.catch(() => undefined);
   try {
     return await operation();
   } finally {
-    release();
-    if (managedBundleMaterializationTails.get(rootPath) === tail) {
-      managedBundleMaterializationTails.delete(rootPath);
+    const owner = await fs.readFile(ownerPath, "utf8")
+      .then((raw) => JSON.parse(raw) as { token?: unknown })
+      .catch(() => null);
+    if (owner?.token === token) {
+      await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
     }
   }
 }

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -28,6 +28,7 @@ const IGNORED_INSTRUCTIONS_DIRECTORY_NAMES = new Set([
   "node_modules",
   "venv",
 ]);
+const managedBundleMaterializationTails = new Map<string, Promise<void>>();
 
 type BundleMode = "managed" | "external";
 
@@ -172,6 +173,29 @@ function resolveLegacyInstructionsPath(candidatePath: string, config: Record<str
 
 async function statIfExists(targetPath: string) {
   return fs.stat(targetPath).catch(() => null);
+}
+
+async function withManagedBundleMaterializationLock<T>(
+  rootPath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = managedBundleMaterializationTails.get(rootPath) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.catch(() => undefined).then(() => current);
+  managedBundleMaterializationTails.set(rootPath, tail);
+
+  await previous.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (managedBundleMaterializationTails.get(rootPath) === tail) {
+      managedBundleMaterializationTails.delete(rootPath);
+    }
+  }
 }
 
 function shouldIgnoreInstructionsEntry(entry: { name: string; isDirectory(): boolean; isFile(): boolean }) {
@@ -937,7 +961,10 @@ export function agentInstructionsService() {
       recordedStockHash?: string | null;
     },
   ) {
-    return materializeManagedBundleInternal(agent, files, options);
+    const rootPath = resolveManagedInstructionsRoot(agent);
+    return withManagedBundleMaterializationLock(rootPath, () =>
+      materializeManagedBundleInternal(agent, files, options),
+    );
   }
 
   async function forceResetManagedBundle(
@@ -949,7 +976,10 @@ export function agentInstructionsService() {
       recordedStockHash?: string | null;
     },
   ) {
-    return materializeManagedBundleInternal(agent, files, { ...options, forceReset: true });
+    const rootPath = resolveManagedInstructionsRoot(agent);
+    return withManagedBundleMaterializationLock(rootPath, () =>
+      materializeManagedBundleInternal(agent, files, { ...options, forceReset: true }),
+    );
   }
 
   return {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -223,6 +223,46 @@ async function managedBundleLockAgeMs(targetPath: string): Promise<number> {
   return stat ? Date.now() - stat.mtimeMs : Number.POSITIVE_INFINITY;
 }
 
+async function restoreManagedBundleLockOwner(ownerPath: string, claimedOwnerPath: string): Promise<void> {
+  await fs.rename(claimedOwnerPath, ownerPath).catch(() => undefined);
+}
+
+async function claimManagedBundleLockOwner(
+  lockPath: string,
+  expectedOwner: string,
+  purpose: "release" | "reap",
+): Promise<string | null> {
+  const ownerPath = path.join(lockPath, "owner.json");
+  const claimedOwnerPath = path.join(lockPath, `owner.${purpose}-${randomUUID()}.json`);
+  try {
+    await fs.rename(ownerPath, claimedOwnerPath);
+  } catch {
+    return null;
+  }
+
+  const claimedOwner = await fs.readFile(claimedOwnerPath, "utf8").catch(() => null);
+  if (claimedOwner !== expectedOwner) {
+    await restoreManagedBundleLockOwner(ownerPath, claimedOwnerPath);
+    return null;
+  }
+  return claimedOwnerPath;
+}
+
+async function claimOwnerlessManagedBundleLock(lockPath: string): Promise<string | null> {
+  const ownerPath = path.join(lockPath, "owner.json");
+  const claimPath = path.join(lockPath, "owner.reaping");
+  try {
+    await fs.writeFile(claimPath, randomUUID(), { encoding: "utf8", flag: "wx" });
+  } catch {
+    return null;
+  }
+  if (await statIfExists(ownerPath)) {
+    await fs.rm(claimPath, { force: true }).catch(() => undefined);
+    return null;
+  }
+  return claimPath;
+}
+
 function processStartMarkersComparable(left: string, right: string): boolean {
   const leftSeparator = left.indexOf(":");
   const rightSeparator = right.indexOf(":");
@@ -233,8 +273,10 @@ function processStartMarkersComparable(left: string, right: string): boolean {
 
 async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> {
   let shouldRemove = false;
+  let ownerSnapshot: string | null = null;
   try {
-    const owner = JSON.parse(await fs.readFile(path.join(lockPath, "owner.json"), "utf8")) as {
+    ownerSnapshot = await fs.readFile(path.join(lockPath, "owner.json"), "utf8");
+    const owner = JSON.parse(ownerSnapshot) as {
       pid?: unknown;
       token?: unknown;
       processStartMarker?: unknown;
@@ -272,8 +314,20 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
     shouldRemove = await managedBundleLockAgeMs(lockPath) > MANAGED_BUNDLE_LOCK_STALE_MS;
   }
   if (!shouldRemove) return false;
-  await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
-  return true;
+  const claimPath = ownerSnapshot === null
+    ? await claimOwnerlessManagedBundleLock(lockPath)
+    : await claimManagedBundleLockOwner(lockPath, ownerSnapshot, "reap");
+  if (!claimPath) return false;
+  return fs.rm(lockPath, { recursive: true, force: true })
+    .then(() => true)
+    .catch(async () => {
+      if (ownerSnapshot !== null) {
+        await restoreManagedBundleLockOwner(path.join(lockPath, "owner.json"), claimPath);
+      } else {
+        await fs.rm(claimPath, { force: true }).catch(() => undefined);
+      }
+      return false;
+    });
 }
 
 async function withManagedBundleMaterializationLock<T>(
@@ -326,11 +380,23 @@ async function withManagedBundleMaterializationLock<T>(
     return await operation();
   } finally {
     clearInterval(heartbeat);
-    const owner = await fs.readFile(ownerPath, "utf8")
-      .then((raw) => JSON.parse(raw) as { token?: unknown })
-      .catch(() => null);
-    if (owner?.token === token) {
-      await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
+    const ownerSnapshot = await fs.readFile(ownerPath, "utf8").catch(() => null);
+    const owner = ownerSnapshot === null
+      ? null
+      : (() => {
+          try {
+            return JSON.parse(ownerSnapshot) as { token?: unknown };
+          } catch {
+            return null;
+          }
+        })();
+    if (owner?.token === token && ownerSnapshot !== null) {
+      const claimPath = await claimManagedBundleLockOwner(lockPath, ownerSnapshot, "release");
+      if (claimPath) {
+        await fs.rm(lockPath, { recursive: true, force: true }).catch(async () => {
+          await restoreManagedBundleLockOwner(ownerPath, claimPath);
+        });
+      }
     }
   }
 }

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { notFound, unprocessable } from "../errors.js";
@@ -30,7 +31,8 @@ const IGNORED_INSTRUCTIONS_DIRECTORY_NAMES = new Set([
 ]);
 const MANAGED_BUNDLE_LOCK_SUFFIX = ".paperclip-materialize.lock";
 const MANAGED_BUNDLE_LOCK_TIMEOUT_MS = 30_000;
-const MANAGED_BUNDLE_LOCK_STALE_MS = 5 * 60_000;
+const MANAGED_BUNDLE_LOCK_HEARTBEAT_MS = 1_000;
+const MANAGED_BUNDLE_LOCK_STALE_MS = 10_000;
 
 type BundleMode = "managed" | "external";
 
@@ -187,24 +189,75 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+async function processStartMarker(pid: number): Promise<string | null> {
+  if (!isProcessAlive(pid)) return null;
+  if (process.platform === "linux") {
+    try {
+      const stat = await fs.readFile(`/proc/${pid}/stat`, "utf8");
+      const commandEnd = stat.lastIndexOf(")");
+      const fieldsAfterCommand = commandEnd >= 0
+        ? stat.slice(commandEnd + 1).trim().split(/\s+/)
+        : [];
+      const startTime = fieldsAfterCommand[19];
+      if (startTime) return `linux:${startTime}`;
+    } catch {
+      // Fall through to ps for non-standard procfs environments.
+    }
+  }
+
+  return new Promise((resolve) => {
+    execFile(
+      "ps",
+      ["-o", "lstart=", "-p", String(pid)],
+      { timeout: 1_000 },
+      (error, stdout) => {
+        const startedAt = error ? "" : stdout.trim();
+        resolve(startedAt ? `ps:${startedAt}` : null);
+      },
+    );
+  });
+}
+
+async function managedBundleLockAgeMs(targetPath: string): Promise<number> {
+  const stat = await statIfExists(targetPath);
+  return stat ? Date.now() - stat.mtimeMs : Number.POSITIVE_INFINITY;
+}
+
 async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> {
   let shouldRemove = false;
   try {
     const owner = JSON.parse(await fs.readFile(path.join(lockPath, "owner.json"), "utf8")) as {
       pid?: unknown;
+      token?: unknown;
+      processStartMarker?: unknown;
     };
     const pid = typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0
       ? owner.pid
       : null;
-    if (pid === null) {
-      const stat = await statIfExists(lockPath);
-      shouldRemove = !stat || Date.now() - stat.mtimeMs > MANAGED_BUNDLE_LOCK_STALE_MS;
+    const token = typeof owner.token === "string" && /^[0-9a-f-]{36}$/i.test(owner.token)
+      ? owner.token
+      : null;
+    if (pid !== null && isProcessAlive(pid)) {
+      const recordedStart = typeof owner.processStartMarker === "string"
+        ? owner.processStartMarker
+        : null;
+      const currentStart = await processStartMarker(pid);
+      if (recordedStart && currentStart) {
+        shouldRemove = recordedStart !== currentStart;
+      } else if (token) {
+        shouldRemove = await managedBundleLockAgeMs(
+          path.join(lockPath, `heartbeat-${token}`),
+        ) > MANAGED_BUNDLE_LOCK_STALE_MS;
+      } else {
+        shouldRemove = await managedBundleLockAgeMs(lockPath) > MANAGED_BUNDLE_LOCK_STALE_MS;
+      }
+    } else if (pid !== null) {
+      shouldRemove = true;
     } else {
-      shouldRemove = !isProcessAlive(pid);
+      shouldRemove = await managedBundleLockAgeMs(lockPath) > MANAGED_BUNDLE_LOCK_STALE_MS;
     }
   } catch {
-    const stat = await statIfExists(lockPath);
-    shouldRemove = !stat || Date.now() - stat.mtimeMs > MANAGED_BUNDLE_LOCK_STALE_MS;
+    shouldRemove = await managedBundleLockAgeMs(lockPath) > MANAGED_BUNDLE_LOCK_STALE_MS;
   }
   if (!shouldRemove) return false;
   await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
@@ -218,6 +271,8 @@ async function withManagedBundleMaterializationLock<T>(
   const lockPath = `${rootPath}${MANAGED_BUNDLE_LOCK_SUFFIX}`;
   const ownerPath = path.join(lockPath, "owner.json");
   const token = randomUUID();
+  const heartbeatPath = path.join(lockPath, `heartbeat-${token}`);
+  const ownerProcessStartMarker = await processStartMarker(process.pid);
   const deadline = Date.now() + MANAGED_BUNDLE_LOCK_TIMEOUT_MS;
   await fs.mkdir(path.dirname(rootPath), { recursive: true });
   while (true) {
@@ -226,9 +281,15 @@ async function withManagedBundleMaterializationLock<T>(
       try {
         await fs.writeFile(
           ownerPath,
-          `${JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() })}\n`,
+          `${JSON.stringify({
+            pid: process.pid,
+            token,
+            processStartMarker: ownerProcessStartMarker,
+            createdAt: new Date().toISOString(),
+          })}\n`,
           "utf8",
         );
+        await fs.writeFile(heartbeatPath, "", "utf8");
       } catch (error) {
         await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
         throw error;
@@ -244,9 +305,15 @@ async function withManagedBundleMaterializationLock<T>(
     }
   }
 
+  const heartbeat = setInterval(() => {
+    const now = new Date();
+    void fs.utimes(heartbeatPath, now, now).catch(() => undefined);
+  }, MANAGED_BUNDLE_LOCK_HEARTBEAT_MS);
+  heartbeat.unref?.();
   try {
     return await operation();
   } finally {
+    clearInterval(heartbeat);
     const owner = await fs.readFile(ownerPath, "utf8")
       .then((raw) => JSON.parse(raw) as { token?: unknown })
       .catch(() => null);

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -223,6 +223,14 @@ async function managedBundleLockAgeMs(targetPath: string): Promise<number> {
   return stat ? Date.now() - stat.mtimeMs : Number.POSITIVE_INFINITY;
 }
 
+function processStartMarkersComparable(left: string, right: string): boolean {
+  const leftSeparator = left.indexOf(":");
+  const rightSeparator = right.indexOf(":");
+  return leftSeparator > 0
+    && rightSeparator > 0
+    && left.slice(0, leftSeparator) === right.slice(0, rightSeparator);
+}
+
 async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> {
   let shouldRemove = false;
   try {
@@ -242,7 +250,11 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
         ? owner.processStartMarker
         : null;
       const currentStart = await processStartMarker(pid);
-      if (recordedStart && currentStart) {
+      if (
+        recordedStart
+        && currentStart
+        && processStartMarkersComparable(recordedStart, currentStart)
+      ) {
         shouldRemove = recordedStart !== currentStart;
       } else if (token) {
         shouldRemove = await managedBundleLockAgeMs(

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -338,37 +338,39 @@ async function withManagedBundleMaterializationLock<T>(
   const ownerPath = path.join(lockPath, "owner.json");
   const token = randomUUID();
   const heartbeatPath = path.join(lockPath, `heartbeat-${token}`);
+  const pendingLockPath = `${lockPath}.pending-${token}`;
   const ownerProcessStartMarker = await processStartMarker(process.pid);
   const deadline = Date.now() + MANAGED_BUNDLE_LOCK_TIMEOUT_MS;
   await fs.mkdir(path.dirname(rootPath), { recursive: true });
-  while (true) {
-    try {
-      await fs.mkdir(lockPath);
+  try {
+    await fs.mkdir(pendingLockPath);
+    await fs.writeFile(
+      path.join(pendingLockPath, "owner.json"),
+      `${JSON.stringify({
+        pid: process.pid,
+        token,
+        processStartMarker: ownerProcessStartMarker,
+        createdAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(pendingLockPath, `heartbeat-${token}`), "", "utf8");
+    while (true) {
       try {
-        await fs.writeFile(
-          ownerPath,
-          `${JSON.stringify({
-            pid: process.pid,
-            token,
-            processStartMarker: ownerProcessStartMarker,
-            createdAt: new Date().toISOString(),
-          })}\n`,
-          "utf8",
-        );
-        await fs.writeFile(heartbeatPath, "", "utf8");
+        await fs.rename(pendingLockPath, lockPath);
+        break;
       } catch (error) {
-        await fs.rm(lockPath, { recursive: true, force: true }).catch(() => undefined);
-        throw error;
+        if (!(await statIfExists(lockPath))) throw error;
+        if (await removeStaleManagedBundleLock(lockPath)) continue;
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for managed instructions lock at ${lockPath}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
       }
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      if (await removeStaleManagedBundleLock(lockPath)) continue;
-      if (Date.now() >= deadline) {
-        throw new Error(`Timed out waiting for managed instructions lock at ${lockPath}`);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 25));
     }
+  } catch (error) {
+    await fs.rm(pendingLockPath, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
   }
 
   const heartbeat = setInterval(() => {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -192,14 +192,16 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
   try {
     const owner = JSON.parse(await fs.readFile(path.join(lockPath, "owner.json"), "utf8")) as {
       pid?: unknown;
-      createdAt?: unknown;
     };
-    const pid = typeof owner.pid === "number" ? owner.pid : 0;
-    const createdAt = typeof owner.createdAt === "string" ? Date.parse(owner.createdAt) : Number.NaN;
-    const ageMs = Number.isFinite(createdAt)
-      ? Date.now() - createdAt
-      : MANAGED_BUNDLE_LOCK_STALE_MS + 1;
-    shouldRemove = !isProcessAlive(pid) || ageMs > MANAGED_BUNDLE_LOCK_STALE_MS;
+    const pid = typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0
+      ? owner.pid
+      : null;
+    if (pid === null) {
+      const stat = await statIfExists(lockPath);
+      shouldRemove = !stat || Date.now() - stat.mtimeMs > MANAGED_BUNDLE_LOCK_STALE_MS;
+    } else {
+      shouldRemove = !isProcessAlive(pid);
+    }
   } catch {
     const stat = await statIfExists(lockPath);
     shouldRemove = !stat || Date.now() - stat.mtimeMs > MANAGED_BUNDLE_LOCK_STALE_MS;

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { notFound, unprocessable } from "../errors.js";
 import { resolveHomeAwarePath, resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { resourceStatus } from "./managed-resource-drift.js";
+import type { ManagedResourceStockStatus } from "./managed-resource-drift.js";
 
 const ENTRY_FILE_DEFAULT = "AGENTS.md";
 const MODE_KEY = "instructionsBundleMode";
@@ -9,6 +12,7 @@ const ROOT_KEY = "instructionsRootPath";
 const ENTRY_KEY = "instructionsEntryFile";
 const FILE_KEY = "instructionsFilePath";
 const PROMPT_KEY = "promptTemplate";
+const STOCK_HASH_KEY = "instructionsStockHash";
 /** @deprecated Use the managed instructions bundle system instead. */
 const BOOTSTRAP_PROMPT_KEY = "bootstrapPromptTemplate";
 const LEGACY_PROMPT_TEMPLATE_PATH = "promptTemplate.legacy.md";
@@ -63,6 +67,20 @@ type AgentInstructionsBundle = {
   legacyPromptTemplateActive: boolean;
   legacyBootstrapPromptTemplateActive: boolean;
   files: AgentInstructionsFileSummary[];
+};
+
+export type ManagedBundleMaterialization = {
+  stockStatus: ManagedResourceStockStatus;
+  action: "added" | "updated" | "unchanged" | "skipped" | "reset";
+  stockHash: string;
+  previousHash: string | null;
+  recordedStockHash: string | null;
+  added: string[];
+  removed: string[];
+  updated: string[];
+  skipped: string[];
+  backedUp: string[];
+  backupPath: string | null;
 };
 
 type BundleState = {
@@ -191,7 +209,80 @@ async function listFilesRecursive(rootPath: string): Promise<string[]> {
   }
 
   await walk(rootPath, "");
-  return output.sort((left, right) => left.localeCompare(right));
+  return output.sort(compareInstructionPaths);
+}
+
+function canonicalizeInstructionsContent(content: string) {
+  return content.replace(/\r\n?/g, "\n");
+}
+
+function compareInstructionPaths(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function managedInstructionsTreeHash(files: Record<string, string>) {
+  const canonicalEntries = Object.entries(files)
+    .map(([relativePath, content]) => [
+      normalizeRelativeFilePath(relativePath),
+      canonicalizeInstructionsContent(content),
+    ] as const)
+    .sort(([left], [right]) => compareInstructionPaths(left, right));
+  const canonicalJson = `{${canonicalEntries
+    .map(([relativePath, content]) => `${JSON.stringify(relativePath)}:${JSON.stringify(content)}`)
+    .join(",")}}`;
+  return `sha256:${createHash("sha256").update(canonicalJson).digest("hex")}`;
+}
+
+async function readInstructionsTree(rootPath: string): Promise<Record<string, string> | null> {
+  const rootStat = await statIfExists(rootPath);
+  if (!rootStat) return null;
+  if (!rootStat.isDirectory()) return {};
+  const relativePaths = await listFilesRecursive(rootPath);
+  return Object.fromEntries(await Promise.all(relativePaths.map(async (relativePath) => [
+    relativePath,
+    await fs.readFile(resolvePathWithinRoot(rootPath, relativePath), "utf8"),
+  ] as const)));
+}
+
+function normalizeMaterializedFiles(files: Record<string, string>, entryFile: string) {
+  const normalized = new Map<string, string>();
+  for (const [relativePath, content] of Object.entries(files)) {
+    const normalizedPath = normalizeRelativeFilePath(relativePath);
+    if (normalized.has(normalizedPath)) {
+      throw unprocessable(`Duplicate instructions file path after normalization: ${normalizedPath}`);
+    }
+    normalized.set(normalizedPath, content);
+  }
+  if (!normalized.has(entryFile)) normalized.set(entryFile, "");
+  return Object.fromEntries(
+    [...normalized.entries()].sort(([left], [right]) => compareInstructionPaths(left, right)),
+  );
+}
+
+function changedInstructionFiles(current: Record<string, string>, prospective: Record<string, string>) {
+  const added: string[] = [];
+  const removed: string[] = [];
+  const updated: string[] = [];
+  const paths = [...new Set([...Object.keys(current), ...Object.keys(prospective)])]
+    .sort(compareInstructionPaths);
+  for (const relativePath of paths) {
+    const hasCurrent = Object.prototype.hasOwnProperty.call(current, relativePath);
+    const hasProspective = Object.prototype.hasOwnProperty.call(prospective, relativePath);
+    if (!hasCurrent && hasProspective) added.push(relativePath);
+    else if (hasCurrent && !hasProspective) removed.push(relativePath);
+    else if (
+      canonicalizeInstructionsContent(current[relativePath]!)
+      !== canonicalizeInstructionsContent(prospective[relativePath]!)
+    ) updated.push(relativePath);
+  }
+  return { added, removed, updated };
+}
+
+async function nextInstructionsBackupPath(rootPath: string) {
+  for (let index = 1; ; index += 1) {
+    const candidate = `${rootPath}.backup-${index}`;
+    if (!(await statIfExists(candidate))) return candidate;
+  }
 }
 
 async function readFileSummary(rootPath: string, relativePath: string, entryFile: string): Promise<AgentInstructionsFileSummary> {
@@ -344,7 +435,7 @@ function toBundle(agent: AgentLike, state: BundleState, files: AgentInstructions
       virtual: true,
     });
   }
-  nextFiles.sort((left, right) => left.path.localeCompare(right.path));
+  nextFiles.sort((left, right) => compareInstructionPaths(left.path, right.path));
   return {
     agentId: agent.id,
     companyId: agent.companyId,
@@ -381,6 +472,7 @@ function applyBundleConfig(
     delete next[PROMPT_KEY];
     delete next[BOOTSTRAP_PROMPT_KEY];
   }
+  if (input.mode === "external") delete next[STOCK_HASH_KEY];
   return next;
 }
 
@@ -439,6 +531,7 @@ export function syncInstructionsBundleConfigFromFilePath(
     delete next[MODE_KEY];
     delete next[ROOT_KEY];
     delete next[ENTRY_KEY];
+    delete next[STOCK_HASH_KEY];
     return next;
   }
   const resolvedPath = resolveLegacyInstructionsPath(instructionsFilePath, adapterConfig);
@@ -682,44 +775,181 @@ export function agentInstructionsService() {
     };
   }
 
+  async function materializeManagedBundleInternal(
+    agent: AgentLike,
+    files: Record<string, string>,
+    options?: {
+      clearLegacyPromptTemplate?: boolean;
+      entryFile?: string;
+      recordedStockHash?: string | null;
+      forceReset?: boolean;
+    },
+  ): Promise<{
+    bundle: AgentInstructionsBundle;
+    adapterConfig: Record<string, unknown>;
+    materialization: ManagedBundleMaterialization;
+  }> {
+    const rootPath = resolveManagedInstructionsRoot(agent);
+    const entryFile = options?.entryFile ? normalizeRelativeFilePath(options.entryFile) : ENTRY_FILE_DEFAULT;
+    await fs.mkdir(path.dirname(rootPath), { recursive: true });
+
+    const prospectiveFiles = normalizeMaterializedFiles(files, entryFile);
+    const stockHash = managedInstructionsTreeHash(prospectiveFiles);
+    const configuredStockHash = asString(asRecord(agent.adapterConfig)[STOCK_HASH_KEY]);
+    const recordedStockHash = options?.recordedStockHash ?? configuredStockHash;
+    const initialFiles = await readInstructionsTree(rootPath);
+    const initialHash = initialFiles === null ? null : managedInstructionsTreeHash(initialFiles);
+    const initialStatus = resourceStatus({
+      resourceId: initialFiles === null ? null : agent.id,
+      currentHash: initialHash,
+      bindingStockHash: recordedStockHash,
+      latestStockHash: stockHash,
+    });
+    const configuredEntryFile = deriveBundleState(agent).entryFile;
+    const preservedEntryFile = (currentFiles: Record<string, string>) => {
+      if (Object.prototype.hasOwnProperty.call(currentFiles, entryFile)) return entryFile;
+      if (Object.prototype.hasOwnProperty.call(currentFiles, configuredEntryFile)) return configuredEntryFile;
+      if (Object.prototype.hasOwnProperty.call(currentFiles, ENTRY_FILE_DEFAULT)) return ENTRY_FILE_DEFAULT;
+      return Object.keys(currentFiles).sort(compareInstructionPaths)[0] ?? entryFile;
+    };
+    const configFor = (advanceStockHash: boolean, currentFiles: Record<string, string>) => {
+      const next = applyBundleConfig(asRecord(agent.adapterConfig), {
+        mode: "managed",
+        rootPath,
+        entryFile: advanceStockHash ? entryFile : preservedEntryFile(currentFiles),
+        clearLegacyPromptTemplate: options?.clearLegacyPromptTemplate,
+      });
+      if (advanceStockHash) next[STOCK_HASH_KEY] = stockHash;
+      return next;
+    };
+
+    const finish = async (
+      action: ManagedBundleMaterialization["action"],
+      stockStatus: ManagedResourceStockStatus,
+      currentFiles: Record<string, string>,
+      currentHash: string | null,
+      input: { advanceStockHash: boolean; backupPath?: string | null },
+    ) => {
+      const changes = changedInstructionFiles(currentFiles, prospectiveFiles);
+      const backupPath = input.backupPath ?? null;
+      const adapterConfig = configFor(input.advanceStockHash, currentFiles);
+      const bundle = await getBundle({ ...agent, adapterConfig });
+      const changedPaths = [...changes.added, ...changes.removed, ...changes.updated]
+        .sort(compareInstructionPaths);
+      return {
+        bundle,
+        adapterConfig,
+        materialization: {
+          stockStatus,
+          action,
+          stockHash,
+          previousHash: currentHash,
+          recordedStockHash,
+          ...changes,
+          skipped: action === "skipped" ? changedPaths : [],
+          backedUp: backupPath ? Object.keys(currentFiles).sort(compareInstructionPaths) : [],
+          backupPath,
+        },
+      };
+    };
+
+    if (!options?.forceReset && initialStatus === "operator_modified") {
+      return finish("skipped", initialStatus, initialFiles ?? {}, initialHash, { advanceStockHash: false });
+    }
+    if (!options?.forceReset && initialStatus === "stock_current") {
+      return finish("unchanged", initialStatus, initialFiles ?? {}, initialHash, { advanceStockHash: true });
+    }
+
+    const stagingRoot = await fs.mkdtemp(path.join(path.dirname(rootPath), ".instructions-materialize-"));
+    const stagedPath = path.join(stagingRoot, "staged");
+    await fs.mkdir(stagedPath, { recursive: true });
+    try {
+      await writeBundleFiles(stagedPath, prospectiveFiles, { overwriteExisting: true });
+      const stagedFiles = await readInstructionsTree(stagedPath);
+      if (!stagedFiles || managedInstructionsTreeHash(stagedFiles) !== stockHash) {
+        throw new Error("Staged instructions bundle hash did not match the prospective stock hash");
+      }
+
+      const recheckedFiles = await readInstructionsTree(rootPath);
+      const recheckedHash = recheckedFiles === null ? null : managedInstructionsTreeHash(recheckedFiles);
+      const recheckedStatus = resourceStatus({
+        resourceId: recheckedFiles === null ? null : agent.id,
+        currentHash: recheckedHash,
+        bindingStockHash: recordedStockHash,
+        latestStockHash: stockHash,
+      });
+      if (!options?.forceReset && recheckedStatus === "operator_modified") {
+        return finish("skipped", recheckedStatus, recheckedFiles ?? {}, recheckedHash, { advanceStockHash: false });
+      }
+      if (!options?.forceReset && recheckedStatus === "stock_current") {
+        return finish("unchanged", recheckedStatus, recheckedFiles ?? {}, recheckedHash, { advanceStockHash: true });
+      }
+
+      const backupPath = options?.forceReset && recheckedFiles !== null
+        ? await nextInstructionsBackupPath(rootPath)
+        : null;
+      const displacedPath = recheckedFiles === null
+        ? null
+        : backupPath ?? path.join(stagingRoot, "previous");
+      if (displacedPath) {
+        await fs.rename(rootPath, displacedPath);
+        if (!options?.forceReset) {
+          const displacedFiles = await readInstructionsTree(displacedPath);
+          const displacedHash = displacedFiles === null ? null : managedInstructionsTreeHash(displacedFiles);
+          if (displacedHash !== recheckedHash) {
+            await fs.rename(displacedPath, rootPath);
+            return finish("skipped", "operator_modified", displacedFiles ?? {}, displacedHash, {
+              advanceStockHash: false,
+            });
+          }
+        }
+      }
+
+      try {
+        await fs.rename(stagedPath, rootPath);
+      } catch (error) {
+        if (displacedPath && !(await statIfExists(rootPath))) {
+          await fs.rename(displacedPath, rootPath).catch(() => undefined);
+        }
+        throw error;
+      }
+
+      const action: ManagedBundleMaterialization["action"] = options?.forceReset
+        ? "reset"
+        : recheckedStatus === "missing"
+          ? "added"
+          : "updated";
+      return finish(action, recheckedStatus, recheckedFiles ?? {}, recheckedHash, {
+        advanceStockHash: true,
+        backupPath,
+      });
+    } finally {
+      await fs.rm(stagingRoot, { recursive: true, force: true });
+    }
+  }
+
   async function materializeManagedBundle(
     agent: AgentLike,
     files: Record<string, string>,
     options?: {
       clearLegacyPromptTemplate?: boolean;
-      replaceExisting?: boolean;
       entryFile?: string;
+      recordedStockHash?: string | null;
     },
-  ): Promise<{ bundle: AgentInstructionsBundle; adapterConfig: Record<string, unknown> }> {
-    const rootPath = resolveManagedInstructionsRoot(agent);
-    const entryFile = options?.entryFile ? normalizeRelativeFilePath(options.entryFile) : ENTRY_FILE_DEFAULT;
+  ) {
+    return materializeManagedBundleInternal(agent, files, options);
+  }
 
-    if (options?.replaceExisting) {
-      await fs.rm(rootPath, { recursive: true, force: true });
-    }
-    await fs.mkdir(rootPath, { recursive: true });
-
-    const normalizedEntries = Object.entries(files).map(([relativePath, content]) => [
-      normalizeRelativeFilePath(relativePath),
-      content,
-    ] as const);
-    for (const [relativePath, content] of normalizedEntries) {
-      const absolutePath = resolvePathWithinRoot(rootPath, relativePath);
-      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fs.writeFile(absolutePath, content, "utf8");
-    }
-    if (!normalizedEntries.some(([relativePath]) => relativePath === entryFile)) {
-      await fs.writeFile(resolvePathWithinRoot(rootPath, entryFile), "", "utf8");
-    }
-
-    const adapterConfig = applyBundleConfig(asRecord(agent.adapterConfig), {
-      mode: "managed",
-      rootPath,
-      entryFile,
-      clearLegacyPromptTemplate: options?.clearLegacyPromptTemplate,
-    });
-    const bundle = await getBundle({ ...agent, adapterConfig });
-    return { bundle, adapterConfig };
+  async function forceResetManagedBundle(
+    agent: AgentLike,
+    files: Record<string, string>,
+    options?: {
+      clearLegacyPromptTemplate?: boolean;
+      entryFile?: string;
+      recordedStockHash?: string | null;
+    },
+  ) {
+    return materializeManagedBundleInternal(agent, files, { ...options, forceReset: true });
   }
 
   return {
@@ -731,5 +961,6 @@ export function agentInstructionsService() {
     exportFiles,
     ensureManagedBundle: ensureWritableBundle,
     materializeManagedBundle,
+    forceResetManagedBundle,
   };
 }

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -189,9 +189,20 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function processStartMarker(pid: number): Promise<string | null> {
+type ProcessStartMarkerScheme = "linux" | "ps";
+
+function processStartMarkerScheme(marker: string): ProcessStartMarkerScheme | null {
+  if (marker.startsWith("linux:")) return "linux";
+  if (marker.startsWith("ps:")) return "ps";
+  return null;
+}
+
+async function processStartMarker(
+  pid: number,
+  preferredScheme?: ProcessStartMarkerScheme,
+): Promise<string | null> {
   if (!isProcessAlive(pid)) return null;
-  if (process.platform === "linux") {
+  if (process.platform === "linux" && preferredScheme !== "ps") {
     try {
       const stat = await fs.readFile(`/proc/${pid}/stat`, "utf8");
       const commandEnd = stat.lastIndexOf(")");
@@ -203,7 +214,10 @@ async function processStartMarker(pid: number): Promise<string | null> {
     } catch {
       // Fall through to ps for non-standard procfs environments.
     }
+    if (preferredScheme === "linux") return null;
   }
+
+  if (preferredScheme === "linux") return null;
 
   return new Promise((resolve) => {
     execFile(
@@ -287,7 +301,8 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
       const recordedStart = typeof owner.processStartMarker === "string"
         ? owner.processStartMarker
         : null;
-      const currentStart = await processStartMarker(pid);
+      const recordedScheme = recordedStart ? processStartMarkerScheme(recordedStart) : null;
+      const currentStart = await processStartMarker(pid, recordedScheme ?? undefined);
       if (
         recordedStart
         && currentStart

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
 import { notFound, unprocessable } from "../errors.js";
 import { resolveHomeAwarePath, resolvePaperclipInstanceRoot } from "../home-paths.js";
@@ -33,6 +34,8 @@ const MANAGED_BUNDLE_LOCK_SUFFIX = ".paperclip-materialize.lock";
 const MANAGED_BUNDLE_LOCK_TIMEOUT_MS = 30_000;
 const MANAGED_BUNDLE_LOCK_HEARTBEAT_MS = 1_000;
 const MANAGED_BUNDLE_LOCK_STALE_MS = 10_000;
+const MANAGED_BUNDLE_LOCK_PROBE_CACHE_MS = 1_000;
+const managedBundleProbeConfirmedAt = new Map<string, number>();
 
 type BundleMode = "managed" | "external";
 
@@ -237,6 +240,75 @@ async function managedBundleLockAgeMs(targetPath: string): Promise<number> {
   return stat ? Date.now() - stat.mtimeMs : Number.POSITIVE_INFINITY;
 }
 
+function managedBundleLockProbePath(token: string): string {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\paperclip-managed-bundle-${token}`;
+  }
+  if (process.platform === "linux") {
+    return `\0paperclip-managed-bundle-${token}`;
+  }
+  return path.join("/tmp", `.paperclip-managed-bundle-${token}.sock`);
+}
+
+function managedBundleLockProbeHasFilesystemPath(): boolean {
+  return process.platform !== "win32" && process.platform !== "linux";
+}
+
+async function startManagedBundleLockProbe(token: string): Promise<{
+  path: string;
+  server: net.Server;
+}> {
+  const probePath = managedBundleLockProbePath(token);
+  const server = net.createServer((socket) => socket.destroy());
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(probePath, () => {
+      server.off("error", onError);
+      server.on("error", () => undefined);
+      server.unref();
+      resolve();
+    });
+  });
+  return { path: probePath, server };
+}
+
+async function stopManagedBundleLockProbe(probe: {
+  path: string;
+  server: net.Server;
+}): Promise<void> {
+  await new Promise<void>((resolve) => probe.server.close(() => resolve()));
+  managedBundleProbeConfirmedAt.delete(probe.path);
+  if (managedBundleLockProbeHasFilesystemPath()) {
+    await fs.rm(probe.path, { force: true }).catch(() => undefined);
+  }
+}
+
+async function managedBundleLockProbeIsAlive(probePath: string): Promise<boolean> {
+  const confirmedAt = managedBundleProbeConfirmedAt.get(probePath);
+  if (confirmedAt !== undefined && Date.now() - confirmedAt < MANAGED_BUNDLE_LOCK_PROBE_CACHE_MS) {
+    return true;
+  }
+
+  const alive = await new Promise<boolean>((resolve) => {
+    const socket = net.createConnection(probePath);
+    let settled = false;
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(result);
+    };
+    socket.unref();
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+    socket.setTimeout(250, () => finish(false));
+  });
+  if (alive) managedBundleProbeConfirmedAt.set(probePath, Date.now());
+  else managedBundleProbeConfirmedAt.delete(probePath);
+  return alive;
+}
+
 async function restoreManagedBundleLockOwner(ownerPath: string, claimedOwnerPath: string): Promise<void> {
   await fs.rename(claimedOwnerPath, ownerPath).catch(() => undefined);
 }
@@ -288,16 +360,29 @@ function processStartMarkersComparable(left: string, right: string): boolean {
 async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> {
   let shouldRemove = false;
   let ownerSnapshot: string | null = null;
+  let staleProbePath: string | null = null;
   try {
     ownerSnapshot = await fs.readFile(path.join(lockPath, "owner.json"), "utf8");
     const owner = JSON.parse(ownerSnapshot) as {
       pid?: unknown;
+      token?: unknown;
+      probePath?: unknown;
       processStartMarker?: unknown;
     };
     const pid = typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0
       ? owner.pid
       : null;
-    if (pid !== null && isProcessAlive(pid)) {
+    const token = typeof owner.token === "string" && /^[0-9a-f-]{36}$/i.test(owner.token)
+      ? owner.token
+      : null;
+    const probePath = token !== null
+      && owner.probePath === managedBundleLockProbePath(token)
+      ? owner.probePath
+      : null;
+    if (probePath !== null) {
+      shouldRemove = !(await managedBundleLockProbeIsAlive(probePath));
+      if (shouldRemove) staleProbePath = probePath;
+    } else if (pid !== null && isProcessAlive(pid)) {
       const recordedStart = typeof owner.processStartMarker === "string"
         ? owner.processStartMarker
         : null;
@@ -329,7 +414,15 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
     : await claimManagedBundleLockOwner(lockPath, ownerSnapshot, "reap");
   if (!claimPath) return false;
   return fs.rm(lockPath, { recursive: true, force: true })
-    .then(() => true)
+    .then(async () => {
+      if (staleProbePath !== null) {
+        managedBundleProbeConfirmedAt.delete(staleProbePath);
+        if (managedBundleLockProbeHasFilesystemPath()) {
+          await fs.rm(staleProbePath, { force: true }).catch(() => undefined);
+        }
+      }
+      return true;
+    })
     .catch(async () => {
       if (ownerSnapshot !== null) {
         await restoreManagedBundleLockOwner(path.join(lockPath, "owner.json"), claimPath);
@@ -351,6 +444,7 @@ async function withManagedBundleMaterializationLock<T>(
   const pendingLockPath = `${lockPath}.pending-${token}`;
   const ownerProcessStartMarker = await processStartMarker(process.pid);
   const deadline = Date.now() + MANAGED_BUNDLE_LOCK_TIMEOUT_MS;
+  const probe = await startManagedBundleLockProbe(token);
   await fs.mkdir(path.dirname(rootPath), { recursive: true });
   try {
     await fs.mkdir(pendingLockPath);
@@ -359,6 +453,7 @@ async function withManagedBundleMaterializationLock<T>(
       `${JSON.stringify({
         pid: process.pid,
         token,
+        probePath: probe.path,
         processStartMarker: ownerProcessStartMarker,
         createdAt: new Date().toISOString(),
       })}\n`,
@@ -380,6 +475,7 @@ async function withManagedBundleMaterializationLock<T>(
     }
   } catch (error) {
     await fs.rm(pendingLockPath, { recursive: true, force: true }).catch(() => undefined);
+    await stopManagedBundleLockProbe(probe);
     throw error;
   }
 
@@ -410,6 +506,7 @@ async function withManagedBundleMaterializationLock<T>(
         });
       }
     }
+    await stopManagedBundleLockProbe(probe);
   }
 }
 

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -278,14 +278,10 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
     ownerSnapshot = await fs.readFile(path.join(lockPath, "owner.json"), "utf8");
     const owner = JSON.parse(ownerSnapshot) as {
       pid?: unknown;
-      token?: unknown;
       processStartMarker?: unknown;
     };
     const pid = typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0
       ? owner.pid
-      : null;
-    const token = typeof owner.token === "string" && /^[0-9a-f-]{36}$/i.test(owner.token)
-      ? owner.token
       : null;
     if (pid !== null && isProcessAlive(pid)) {
       const recordedStart = typeof owner.processStartMarker === "string"
@@ -298,12 +294,11 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
         && processStartMarkersComparable(recordedStart, currentStart)
       ) {
         shouldRemove = recordedStart !== currentStart;
-      } else if (token) {
-        shouldRemove = await managedBundleLockAgeMs(
-          path.join(lockPath, `heartbeat-${token}`),
-        ) > MANAGED_BUNDLE_LOCK_STALE_MS;
       } else {
-        shouldRemove = await managedBundleLockAgeMs(lockPath) > MANAGED_BUNDLE_LOCK_STALE_MS;
+        // A delayed heartbeat does not prove that a live process has stopped
+        // materializing. Only a comparable process-start marker can safely
+        // distinguish a reused PID from the original owner.
+        shouldRemove = false;
       }
     } else if (pid !== null) {
       shouldRemove = true;

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -357,6 +357,20 @@ function processStartMarkersComparable(left: string, right: string): boolean {
     && left.slice(0, leftSeparator) === right.slice(0, rightSeparator);
 }
 
+function processStartMarkerTimestamp(marker: string | null): number | null {
+  if (!marker?.startsWith("ps:")) return null;
+  const timestamp = Date.parse(marker.slice("ps:".length));
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+async function processStartedAfterLockCreation(pid: number, createdAt: unknown): Promise<boolean> {
+  if (typeof createdAt !== "string") return false;
+  const lockCreatedAt = Date.parse(createdAt);
+  if (!Number.isFinite(lockCreatedAt)) return false;
+  const processStartedAt = processStartMarkerTimestamp(await processStartMarker(pid, "ps"));
+  return processStartedAt !== null && processStartedAt > lockCreatedAt;
+}
+
 async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> {
   let shouldRemove = false;
   let ownerSnapshot: string | null = null;
@@ -368,6 +382,7 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
       token?: unknown;
       probePath?: unknown;
       processStartMarker?: unknown;
+      createdAt?: unknown;
     };
     const pid = typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0
       ? owner.pid
@@ -395,10 +410,11 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
       ) {
         shouldRemove = recordedStart !== currentStart;
       } else {
-        // A delayed heartbeat does not prove that a live process has stopped
-        // materializing. Only a comparable process-start marker can safely
-        // distinguish a reused PID from the original owner.
-        shouldRemove = false;
+        // Probe-less legacy locks still record when they were created. A live
+        // process that started later cannot be the original owner, which lets
+        // us recover a reused PID without ever evicting an owner merely because
+        // its heartbeat was delayed.
+        shouldRemove = await processStartedAfterLockCreation(pid, owner.createdAt);
       }
     } else if (pid !== null) {
       shouldRemove = true;

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -35,6 +35,9 @@ const MANAGED_BUNDLE_LOCK_TIMEOUT_MS = 30_000;
 const MANAGED_BUNDLE_LOCK_HEARTBEAT_MS = 1_000;
 const MANAGED_BUNDLE_LOCK_STALE_MS = 10_000;
 const MANAGED_BUNDLE_LOCK_PROBE_CACHE_MS = 1_000;
+const MANAGED_BUNDLE_LOCK_PROBE_ATTEMPTS = 3;
+const MANAGED_BUNDLE_LOCK_PROBE_RETRY_MS = 25;
+const MANAGED_BUNDLE_LOCK_PROBE_TIMEOUT_MS = 250;
 const managedBundleProbeConfirmedAt = new Map<string, number>();
 
 type BundleMode = "managed" | "external";
@@ -284,29 +287,62 @@ async function stopManagedBundleLockProbe(probe: {
   }
 }
 
-async function managedBundleLockProbeIsAlive(probePath: string): Promise<boolean> {
-  const confirmedAt = managedBundleProbeConfirmedAt.get(probePath);
-  if (confirmedAt !== undefined && Date.now() - confirmedAt < MANAGED_BUNDLE_LOCK_PROBE_CACHE_MS) {
-    return true;
-  }
+type ManagedBundleLockProbeStatus = "alive" | "absent" | "indeterminate";
 
-  const alive = await new Promise<boolean>((resolve) => {
+function managedBundleLockProbeErrorStatus(error: Error): ManagedBundleLockProbeStatus {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ECONNREFUSED" || code === "ENOENT"
+    ? "absent"
+    : "indeterminate";
+}
+
+async function probeManagedBundleLockOnce(
+  probePath: string,
+): Promise<ManagedBundleLockProbeStatus> {
+  return new Promise<ManagedBundleLockProbeStatus>((resolve) => {
     const socket = net.createConnection(probePath);
     let settled = false;
-    const finish = (result: boolean) => {
+    const finish = (result: ManagedBundleLockProbeStatus) => {
       if (settled) return;
       settled = true;
       socket.destroy();
       resolve(result);
     };
     socket.unref();
-    socket.once("connect", () => finish(true));
-    socket.once("error", () => finish(false));
-    socket.setTimeout(250, () => finish(false));
+    socket.once("connect", () => finish("alive"));
+    socket.once("error", (error) => finish(managedBundleLockProbeErrorStatus(error)));
+    // A timeout does not prove the listener is absent. Under load, evicting on
+    // this ambiguous result could let two processes displace the live tree.
+    socket.setTimeout(MANAGED_BUNDLE_LOCK_PROBE_TIMEOUT_MS, () => finish("indeterminate"));
   });
-  if (alive) managedBundleProbeConfirmedAt.set(probePath, Date.now());
-  else managedBundleProbeConfirmedAt.delete(probePath);
-  return alive;
+}
+
+async function managedBundleLockProbeStatus(
+  probePath: string,
+): Promise<ManagedBundleLockProbeStatus> {
+  const confirmedAt = managedBundleProbeConfirmedAt.get(probePath);
+  if (confirmedAt !== undefined && Date.now() - confirmedAt < MANAGED_BUNDLE_LOCK_PROBE_CACHE_MS) {
+    return "alive";
+  }
+
+  let sawIndeterminateResult = false;
+  for (let attempt = 0; attempt < MANAGED_BUNDLE_LOCK_PROBE_ATTEMPTS; attempt += 1) {
+    const status = await probeManagedBundleLockOnce(probePath);
+    if (status === "alive") {
+      managedBundleProbeConfirmedAt.set(probePath, Date.now());
+      return status;
+    }
+    if (status === "indeterminate") sawIndeterminateResult = true;
+    if (attempt + 1 < MANAGED_BUNDLE_LOCK_PROBE_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, MANAGED_BUNDLE_LOCK_PROBE_RETRY_MS));
+    }
+  }
+
+  managedBundleProbeConfirmedAt.delete(probePath);
+  // Reap only after every attempt definitively reports no listener. Any
+  // transient socket error or timeout keeps the lock, preferring a bounded
+  // acquisition timeout over concurrent materialization of the same tree.
+  return sawIndeterminateResult ? "indeterminate" : "absent";
 }
 
 async function restoreManagedBundleLockOwner(ownerPath: string, claimedOwnerPath: string): Promise<void> {
@@ -395,7 +431,7 @@ async function removeStaleManagedBundleLock(lockPath: string): Promise<boolean> 
       ? owner.probePath
       : null;
     if (probePath !== null) {
-      shouldRemove = !(await managedBundleLockProbeIsAlive(probePath));
+      shouldRemove = await managedBundleLockProbeStatus(probePath) === "absent";
       if (shouldRemove) staleProbePath = probePath;
     } else if (pid !== null && isProcessAlive(pid)) {
       const recordedStart = typeof owner.processStartMarker === "string"

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -10,7 +10,7 @@ import { syncRoutineVariablesWithTemplate } from "@paperclipai/shared";
 import type { Agent, Approval, CompanySkill, PermissionKey, Routine, RoutineTrigger, RoutineVariable } from "@paperclipai/shared";
 import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
-import { agentInstructionsService } from "./agent-instructions.js";
+import { agentInstructionsService, managedInstructionsTreeHash } from "./agent-instructions.js";
 import { agentService } from "./agents.js";
 import { approvalService } from "./approvals.js";
 import {
@@ -936,11 +936,17 @@ export function builtInAgentService(db: Db) {
 
   async function currentInstructionFiles(agent: Agent, bundle: BuiltInAgentBundleDefinition) {
     const currentFiles: Record<string, string | null> = {};
-    for (const filePath of Object.keys(bundle.instructions.files)) {
+    const currentBundle = await instructionsSvc.getBundle(agent);
+    const diskFiles = currentBundle.files.filter((file) => !file.virtual);
+    if (diskFiles.length === 0) {
+      for (const filePath of Object.keys(bundle.instructions.files)) currentFiles[filePath] = null;
+      return currentFiles;
+    }
+    for (const file of diskFiles) {
       try {
-        currentFiles[filePath] = (await instructionsSvc.readFile(agent, filePath)).content;
+        currentFiles[file.path] = (await instructionsSvc.readFile(agent, file.path)).content;
       } catch {
-        currentFiles[filePath] = null;
+        currentFiles[file.path] = null;
       }
     }
     return currentFiles;
@@ -948,10 +954,12 @@ export function builtInAgentService(db: Db) {
 
   async function materializeInstructions(agent: Agent, definition: BuiltInAgentDefinition, mode: "reconcile" | "reset") {
     const bundle = definition.bundle!;
-    const stock = stockHash(bundle.instructions.files);
+    const stock = managedInstructionsTreeHash(bundle.instructions.files);
     const binding = await getManagedResourceBinding(agent.companyId, definition.key, "instructions", "AGENTS.md");
     const currentFiles = await currentInstructionFiles(agent, bundle);
-    const currentHash = Object.values(currentFiles).some((value) => value === null) ? null : stockHash(currentFiles);
+    const currentHash = Object.values(currentFiles).some((value) => value === null)
+      ? null
+      : managedInstructionsTreeHash(currentFiles as Record<string, string>);
     const currentState = stockState({
       resourceKind: "instructions",
       resourceKey: "AGENTS.md",
@@ -963,54 +971,55 @@ export function builtInAgentService(db: Db) {
       changedFiles: changedFileList(currentFiles, bundle.instructions.files),
     });
 
-    const shouldWrite =
-      mode === "reset"
-      || currentState.stockStatus === "missing"
-      || currentState.stockStatus === "stock_update_available";
-    if (!shouldWrite) {
-      if (!binding && currentHash === stock) {
-        await upsertManagedResourceBinding({
-          companyId: agent.companyId,
-          bundleKey: definition.key,
-          resourceKind: "instructions",
-          resourceKey: "AGENTS.md",
-          resourceId: agent.id,
-          stockVersion: bundle.stockVersion,
-          stockHash: stock,
-          defaultsJson: {
-            entryFile: bundle.instructions.entryFile,
-            files: Object.keys(bundle.instructions.files),
-          },
-        });
-      }
-      return currentState;
-    }
-
-    const materialized = await instructionsSvc.materializeManagedBundle(agent, bundle.instructions.files, {
+    const materializeOptions = {
       entryFile: bundle.instructions.entryFile,
-      replaceExisting: true,
       clearLegacyPromptTemplate: true,
-    });
-    const updated = await agentSvc.update(agent.id, {
-      adapterConfig: materialized.adapterConfig,
-    }, {
-      allowBuiltInAgentMetadata: true,
-      recordRevision: { source: `built-in-bundle:${mode}:instructions` },
-    });
-    if (!updated) throw notFound("Built-in agent not found");
-    await upsertManagedResourceBinding({
-      companyId: agent.companyId,
-      bundleKey: definition.key,
-      resourceKind: "instructions",
-      resourceKey: "AGENTS.md",
-      resourceId: agent.id,
-      stockVersion: bundle.stockVersion,
-      stockHash: stock,
-      defaultsJson: {
-        entryFile: bundle.instructions.entryFile,
-        files: Object.keys(bundle.instructions.files),
-      },
-    });
+      recordedStockHash: binding?.stockHash ?? null,
+    };
+    const materialized = mode === "reset"
+      ? await instructionsSvc.forceResetManagedBundle(agent, bundle.instructions.files, materializeOptions)
+      : await instructionsSvc.materializeManagedBundle(agent, bundle.instructions.files, materializeOptions);
+    if (stableJson(materialized.adapterConfig) !== stableJson(agent.adapterConfig)) {
+      const updated = await agentSvc.update(agent.id, {
+        adapterConfig: materialized.adapterConfig,
+      }, {
+        allowBuiltInAgentMetadata: true,
+        recordRevision: { source: `built-in-bundle:${mode}:instructions` },
+      });
+      if (!updated) throw notFound("Built-in agent not found");
+    }
+    const stockControlled = materialized.materialization.action !== "skipped";
+    if (stockControlled) {
+      await upsertManagedResourceBinding({
+        companyId: agent.companyId,
+        bundleKey: definition.key,
+        resourceKind: "instructions",
+        resourceKey: "AGENTS.md",
+        resourceId: agent.id,
+        stockVersion: bundle.stockVersion,
+        stockHash: stock,
+        defaultsJson: {
+          entryFile: bundle.instructions.entryFile,
+          files: Object.keys(bundle.instructions.files),
+        },
+      });
+    }
+    if (materialized.materialization.action !== "unchanged") {
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "system",
+        actorId: "built-in-agents",
+        action: "built_in_agent.instructions_materialized",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          key: definition.key,
+          mode,
+          ...materialized.materialization,
+        },
+      });
+    }
+    if (!stockControlled) return currentState;
     return stockState({
       resourceKind: "instructions",
       resourceKey: "AGENTS.md",
@@ -1423,7 +1432,7 @@ export function builtInAgentService(db: Db) {
     const { routine, triggers } = await getRoutineByBinding(companyId, definition);
     const proposal = await pendingUpdateProposal(agent);
     const instructionHash = Object.values(instructionFiles).every((value) => value !== null)
-      ? stockHash(instructionFiles)
+      ? managedInstructionsTreeHash(instructionFiles as Record<string, string>)
       : null;
     const skillHash = skill && Object.values(skillFiles).every((value) => value !== null)
       ? stockHash(skillFiles)
@@ -1442,7 +1451,7 @@ export function builtInAgentService(db: Db) {
         resourceKey: "AGENTS.md",
         resourceId: agent.id,
         stockVersion: bundle.stockVersion,
-        latestStockHash: stockHash(bundle.instructions.files),
+        latestStockHash: managedInstructionsTreeHash(bundle.instructions.files),
         currentHash: instructionHash,
         bindingStockHash: instructionBinding?.stockHash ?? null,
         changedFiles: changedFileList(instructionFiles, bundle.instructions.files),

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2154,6 +2154,7 @@ function normalizePortableConfig(
       key === "instructionsBundleMode" ||
       key === "instructionsRootPath" ||
       key === "instructionsEntryFile" ||
+      key === "instructionsStockHash" ||
       key === "promptTemplate" ||
       key === "bootstrapPromptTemplate" || // deprecated — kept for backward compat
       key === "paperclipSkillSync"
@@ -3510,6 +3511,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
     delete nextAdapterConfig.instructionsBundleMode;
     delete nextAdapterConfig.instructionsRootPath;
     delete nextAdapterConfig.instructionsEntryFile;
+    delete nextAdapterConfig.instructionsStockHash;
     const normalizedAdapterConfig = await secrets.normalizeAdapterConfigForPersistence(
       companyId,
       nextAdapterConfig,
@@ -5303,6 +5305,7 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
       const preImportExistingAgentIds = new Set<string>();
       const agentStatusById = new Map<string, string | null | undefined>();
       const existingAgents = await agents.list(targetCompany.id);
+      const existingAgentById = new Map(existingAgents.map((agent) => [agent.id, agent]));
       for (const existing of existingAgents) {
         const slug = normalizeAgentUrlKey(existing.name) ?? existing.id;
         existingSlugToAgentId.set(slug, existing.id);
@@ -5418,8 +5421,18 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             : {};
 
           if (planAgent.action === "update" && planAgent.existingAgentId) {
+            const existingTarget = existingAgentById.get(planAgent.existingAgentId);
+            const existingTargetConfig = isPlainRecord(existingTarget?.adapterConfig)
+              ? existingTarget.adapterConfig
+              : {};
+            const targetInstructionsStockHash = asString(existingTargetConfig.instructionsStockHash);
+            const updateAdapterConfig = { ...patch.adapterConfig };
+            if (targetInstructionsStockHash) {
+              updateAdapterConfig.instructionsStockHash = targetInstructionsStockHash;
+            }
             let updated = await agents.update(planAgent.existingAgentId, {
               ...patch,
+              adapterConfig: updateAdapterConfig,
               ...automationPausePatch,
             });
             if (!updated) {
@@ -5436,8 +5449,10 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
             try {
               const materialized = await instructions.materializeManagedBundle(updated, bundleFiles, {
                 clearLegacyPromptTemplate: true,
-                replaceExisting: true,
               });
+              if (materialized.materialization.action === "skipped") {
+                warnings.push(`Preserved operator-modified instructions bundle for ${manifestAgent.slug}; imported stock files were skipped.`);
+              }
               updated = await agents.update(updated.id, { adapterConfig: materialized.adapterConfig }) ?? updated;
             } catch (err) {
               warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);
@@ -5483,8 +5498,10 @@ export function companyPortabilityService(db: Db, storage?: StorageService) {
           try {
             const materialized = await instructions.materializeManagedBundle(created, bundleFiles, {
               clearLegacyPromptTemplate: true,
-              replaceExisting: true,
             });
+            if (materialized.materialization.action === "skipped") {
+              warnings.push(`Preserved operator-modified instructions bundle for ${manifestAgent.slug}; imported stock files were skipped.`);
+            }
             created = await agents.update(created.id, { adapterConfig: materialized.adapterConfig }) ?? created;
           } catch (err) {
             warnings.push(`Failed to materialize instructions bundle for ${manifestAgent.slug}: ${err instanceof Error ? err.message : String(err)}`);

--- a/server/src/services/managed-resource-drift.ts
+++ b/server/src/services/managed-resource-drift.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-
 export type ManagedResourceStockStatus =
   | "missing"
   | "stock_current"
@@ -20,7 +19,6 @@ export function stableJson(value: unknown): string {
 export function stockHash(value: unknown) {
   return `sha256:${createHash("sha256").update(stableJson(value)).digest("hex")}`;
 }
-
 export function resourceStatus(input: {
   resourceId: string | null;
   currentHash: string | null;

--- a/server/src/services/plugin-managed-agents.ts
+++ b/server/src/services/plugin-managed-agents.ts
@@ -326,26 +326,37 @@ export function pluginManagedAgentService(
     companyId: string,
     agent: Agent,
     declaration: PluginManagedAgentDeclaration,
-    materializeOptions: { replaceExisting: boolean },
+    materializeOptions: { forceReset?: boolean } = {},
   ): Promise<Agent> {
     const variables = await optionsForInstructionVariables(companyId);
     const declared = declaredInstructionFiles(declaration, variables);
     if (!declared) return agent;
 
-    const materialized = await instructions.materializeManagedBundle(
-      agent,
-      declared.files,
-      {
-        entryFile: declared.entryFile,
-        replaceExisting: materializeOptions.replaceExisting,
-        clearLegacyPromptTemplate: true,
-      },
-    );
+    const instructionOptions = {
+      entryFile: declared.entryFile,
+      clearLegacyPromptTemplate: true,
+    };
+    const materialized = materializeOptions.forceReset
+      ? await instructions.forceResetManagedBundle(agent, declared.files, instructionOptions)
+      : await instructions.materializeManagedBundle(agent, declared.files, instructionOptions);
     const updated = await agentSvc.update(agent.id, {
       adapterConfig: materialized.adapterConfig,
     }, {
       recordRevision: {
         source: `plugin:${optionsForRevisionSource()}:managed-agent-instructions`,
+      },
+    });
+    await logActivity(db, {
+      companyId,
+      actorType: "plugin",
+      actorId: options.pluginId,
+      action: "plugin.managed_agent.instructions_materialized",
+      entityType: "agent",
+      entityId: agent.id,
+      details: {
+        sourcePluginKey: options.pluginKey,
+        managedResourceKey: declaration.agentKey,
+        ...materialized.materialization,
       },
     });
     return (updated as Agent | null) ?? { ...agent, adapterConfig: materialized.adapterConfig };
@@ -423,7 +434,7 @@ export function pluginManagedAgentService(
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,
     }) as Agent;
-    created = await materializeDeclaredInstructions(companyId, created, declaration, { replaceExisting: true });
+    created = await materializeDeclaredInstructions(companyId, created, declaration);
 
     let approvalId: string | null = null;
     if (requiresApproval) {
@@ -537,7 +548,7 @@ export function pluginManagedAgentService(
         },
       });
       if (!updated) throw notFound("Managed agent not found");
-      const updatedAgent = await materializeDeclaredInstructions(companyId, updated as Agent, declaration, { replaceExisting: true });
+      const updatedAgent = await materializeDeclaredInstructions(companyId, updated as Agent, declaration, { forceReset: true });
       await upsertBinding(companyId, declaration, updatedAgent.id, {}, adapterType);
       await logActivity(db, {
         companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages platform-owned agent instruction trees.
> - Setup, plugin sync, route actions, and company import all rebuild those trees.
> - Their drift checks were inconsistent, so routine rebuilds could delete operator edits or added files.
> - The shared materialization service is the correct invariant boundary.
> - This pull request centralizes drift classification, safe replacement, outcome reporting, and explicit reset behavior there.

## Linked Issues or Issue Description

No public issue tracks this bug. Related work: Refs: #8990 and Refs: #8951.

**What happened?**

Some managed-instruction callers replaced the full tree without comparing it with the recorded stock hash. Routine synchronization could therefore remove operator work.

**Expected behavior**

Every caller preserves an operator-modified tree by default. Clean stock updates use a staged same-filesystem swap. Destructive reset is explicit and retains a backup.

**Steps to reproduce**

1. Materialize a managed instruction bundle.
2. Edit its entry file or add another file.
3. Run plugin reconcile, company import, built-in reconcile, or the agent route rebuild.
4. On the old code, an unguarded caller can replace the operator files.

**Paperclip version or commit**

Reproduces on `2ea22d6cea`.

**Deployment mode**

Local dev and self-hosted server modes are affected.

## What Changed

- Moved the shared `resourceStatus` classifier into a reusable service and made bundle materialization enforce it.
- Added canonical whole-tree hashes with normalized line endings, deterministic path ordering, and transient-file exclusions.
- Added staged same-filesystem swaps, a final drift recheck, rollback, and structured added/removed/updated/skipped/backed-up results.
- Serialized swaps across processes with atomically published owner metadata, probes, process-identity checks, and ownership-claimed stale recovery.
- Made probe checks retry and distinguish definitive absence from transient errors/timeouts, so one failed connection cannot evict a live lock.
- Preserved probe-less legacy locks safely while recovering proven PID reuse from lock-creation and OS process-start timestamps.
- Added explicit force reset that saves the old tree as `instructions.backup-N`.
- Updated built-in, plugin-managed, route, and company-portability callers to use and report the shared behavior.
- Added regression coverage for every caller, operator-added files, clean updates, canonical hashes, rollback, backups, transient probes, and concurrent lock recovery.

## Verification

- Current exact head `d89c6570b7c792216503961f18e7d4749bb94d72`: `agent-instructions-service.test.ts` — 25/25 passed.
- Current exact head: managed-instructions caller matrix — 5 files / 172 tests passed.
- Current exact head: targeted `@paperclipai/server` typecheck passed.
- Current exact head: `pnpm -r typecheck` passed across 31 workspace projects.
- Current exact head: `pnpm build` passed.
- The sanitized local `pnpm test:run` baseline passed server (347 files / 3,734 tests, 4 skipped), UI (438 / 3,679), CLI (54 / 335), shared (51 / 425), and skills catalog (5 / 20) before unrelated embedded-Postgres migration tests timed out under host load.
- Exact-head GitHub CI passed every build, general-test, serialized-test, typecheck/release-registry, canary, e2e, policy, reviewer, and security gate.
- Greptile reviewed exact head `d89c6570b7c792216503961f18e7d4749bb94d72` at 5/5 with zero unresolved threads.

## Risks

- Routine rebuild now preserves the whole tree when it differs from recorded stock; that is the intended safety change.
- Explicit resets retain sibling backup directories for operator inspection.
- Swaps rely on same-filesystem rename and restore the prior tree if installation fails.
- Probe timeouts and ambiguous socket errors retain the lock and can delay a contender until the bounded acquisition timeout; this is intentionally safer than allowing concurrent tree replacement.
- Legacy probe-less locks are reaped only when process timing proves PID reuse; ambiguous live ownership remains protected.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with `gpt-5`, high-reasoning agent mode, shell tool use, and code-editing tools. The runtime did not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
