### PR TITLE
test(ui): make date fixtures deterministic across time zones

### DIFF
--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -2102,10 +2102,14 @@ describe("IssueProperties", () => {
   });
 
   it("renders scheduled, retrying, due, overdue, cleared, and empty monitor row states", async () => {
-    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-17T13:56:00.000Z").getTime());
+    // Monitor timestamps are stored as UTC instants but displayed in the user's
+    // local time zone. Build the fixtures from an explicit local wall clock so
+    // the same user-facing labels are asserted in every test-runner time zone.
+    const localIso = (hour: number, minute: number) => new Date(2026, 6, 17, hour, minute).toISOString();
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date(2026, 6, 17, 13, 56).getTime());
     const baseMonitorState = {
       status: "scheduled" as const,
-      nextCheckAt: "2026-07-17T16:08:00.000Z",
+      nextCheckAt: localIso(16, 8),
       lastTriggeredAt: null,
       attemptCount: 1,
       notes: "Verify deployment",
@@ -2136,9 +2140,9 @@ describe("IssueProperties", () => {
     expect(monitorRowText()).toContain("Today, 4:08 PM · Attempt 1");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T18:08:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T16:08:00.000Z" } }),
-      monitorNextCheckAt: new Date("2026-07-17T17:08:00.000Z"),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: localIso(18, 8) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: localIso(16, 8) } }),
+      monitorNextCheckAt: new Date(localIso(17, 8)),
     }));
     await flush();
     expect(monitorRowText()).toContain("In 2h 12m");
@@ -2153,16 +2157,16 @@ describe("IssueProperties", () => {
     expect(monitorRowText()).toContain("Attempt 3");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:56:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:56:00.000Z" } }),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: localIso(13, 56) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: localIso(13, 56) } }),
     }));
     await flush();
     expect(monitorRowText()).toContain("Due now");
     expect(monitorRowText()).toContain("checking momentarily…");
 
     renderMonitor(createIssue({
-      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:38:00.000Z" } }),
-      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: "2026-07-17T13:38:00.000Z" } }),
+      executionPolicy: createExecutionPolicy({ monitor: { ...baseMonitorState, nextCheckAt: localIso(13, 38) } }),
+      executionState: createExecutionState({ monitor: { ...baseMonitorState, nextCheckAt: localIso(13, 38) } }),
     }));
     await flush();
     expect(monitorRowText()).toContain("Overdue by 18m");
@@ -2174,13 +2178,13 @@ describe("IssueProperties", () => {
         ...baseMonitorState,
         status: "cleared",
         nextCheckAt: null,
-        lastTriggeredAt: "2026-07-17T11:56:00.000Z",
+        lastTriggeredAt: localIso(11, 56),
         attemptCount: 2,
         clearedAt: "2026-07-17T12:00:00.000Z",
         clearReason: "manual",
       } }),
       monitorAttemptCount: 2,
-      monitorLastTriggeredAt: new Date("2026-07-17T11:56:00.000Z"),
+      monitorLastTriggeredAt: new Date(localIso(11, 56)),
     }));
     await flush();
     expect(monitorRowText()).toContain("Cleared");

--- a/ui/src/pages/StatusCards/format.test.ts
+++ b/ui/src/pages/StatusCards/format.test.ts
@@ -7,6 +7,8 @@ import {
   rollupUpdatesToday,
 } from "./format";
 
+const UTC_NOW = new Date("2026-07-23T12:00:00.000Z");
+
 function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
   return {
     id: "00000000-0000-0000-0000-000000000000",
@@ -22,7 +24,7 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
     model: null,
     queryVersion: 1,
     changeSummary: null,
-    startedAt: new Date().toISOString(),
+    startedAt: UTC_NOW.toISOString(),
     finishedAt: null,
     status: "ok",
     error: null,
@@ -31,10 +33,10 @@ function update(overrides: Partial<StatusCardUpdate>): StatusCardUpdate {
 }
 
 function iso(daysAgo: number): string {
-  const d = new Date();
-  d.setDate(d.getDate() - daysAgo);
-  // Noon avoids DST/midnight edge cases in the local-day filter.
-  d.setHours(12, 0, 0, 0);
+  const d = new Date(UTC_NOW);
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  // Keep all general ledger fixtures on an explicit UTC calendar day.
+  d.setUTCHours(12, 0, 0, 0);
   return d.toISOString();
 }
 
@@ -61,7 +63,7 @@ describe("rollupUpdatesToday", () => {
       // yesterday + last week — must not be counted as "today"
       update({ kind: "full", inputTokens: 9999, outputTokens: 9999, costCents: 99, startedAt: iso(1) }),
       update({ kind: "incremental", inputTokens: 9999, outputTokens: 9999, costCents: 99, startedAt: iso(7) }),
-    ]);
+    ], UTC_NOW);
     // Only today's full rebuild counts as an update (compile excluded).
     expect(rollup.updateCount).toBe(1);
     // Today's tokens/cost include today's compile but not older days.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The board UI shows local times and calculates daily status-card usage
> - The UI stores monitor times as UTC instants but shows them in the user's local time zone
> - The status-card daily usage boundary is midnight UTC
> - Two tests mixed these two time models and depended on the test-runner time zone
> - This pull request gives each test a fixed clock and time-zone-safe fixtures
> - The benefit is stable tests without a change to production behavior

## Linked Issues or Issue Description

**What happened?**

Two UI tests depended on the host time zone. The monitor test expected a UTC hour as a local display hour. The status-card test derived UTC-day fixtures with local date operations.

**Expected behavior**

The tests must pass in UTC and America/Los_Angeles. The monitor test must continue to check local display behavior. The status-card test must continue to check the UTC daily boundary.

**Steps to reproduce**

1. Check out the current `master` branch.
2. Run the two test files with `TZ=America/Los_Angeles`.
3. Observe that the monitor test expects `4:08 PM` for a stored `16:08Z` instant.

**Paperclip version or commit**

Current `master` before this change.

**Deployment mode**

Local development from source.

## What Changed

- Build monitor fixtures from fixed local wall-clock values.
- Build status-card fixtures from a fixed UTC clock.
- Use UTC date operations for the status-card ledger dates.
- Pass the fixed clock to the UTC daily rollup.

## Verification

- `TZ=UTC pnpm exec vitest run ui/src/components/IssueProperties.test.tsx ui/src/pages/StatusCards/format.test.ts`
- `TZ=America/Los_Angeles pnpm exec vitest run ui/src/components/IssueProperties.test.tsx ui/src/pages/StatusCards/format.test.ts`
- `pnpm check:token-gates`

Both time-zone runs pass all 56 tests. The token gate is clean.

## Risks

Low risk. This change updates test fixtures only. Production date formatting and rollup code do not change.

> I checked `ROADMAP.md`. This test-only fix does not duplicate planned core work.

## Model Used

OpenAI Codex with the `gpt-5` model. The run used agentic reasoning, repository tools, shell commands, code edits, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

