### PR TITLE
fix(test): centralize embedded-Postgres hook budget and guard zero-executed suites

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,6 +58,15 @@ jobs:
       - name: Test general-server shard partition
         run: node --test ./scripts/__tests__/run-vitest-stable-shard.test.mjs
 
+      # RBR-918: an inline `beforeAll` timeout wins over --hookTimeout, so an
+      # under-budgeted embedded-Postgres hook cannot be corrected from CI config.
+      # Fail the PR if one is reintroduced.
+      - name: Audit embedded-Postgres hook budgets
+        run: node ./scripts/audit-embedded-postgres-hook-budgets.mjs
+
+      - name: Test zero-executed-suite guard
+        run: node --test ./scripts/__tests__/check-executed-test-suites.test.mjs
+
       - name: Test e2e shard partition
         run: node --test ./scripts/__tests__/e2e-shard.test.mjs
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ check-*.mjs
 !.github/scripts/check-*.mjs
 !.github/scripts/tests/check-*.mjs
 !scripts/check-*.mjs
+!scripts/__tests__/check-*.mjs
 new-agent*.json
 newcompany.json
 seed-*.mjs

--- a/cli/src/__tests__/company-import-export-e2e.test.ts
+++ b/cli/src/__tests__/company-import-export-e2e.test.ts
@@ -323,7 +323,7 @@ describeEmbeddedPostgres("paperclipai company import/export e2e", () => {
     });
 
     await waitForServer(apiBase, child, output);
-  }, 60_000);
+  });
 
   afterAll(async () => {
     await stopServerProcess(serverProcess);

--- a/cli/src/__tests__/routines.test.ts
+++ b/cli/src/__tests__/routines.test.ts
@@ -98,7 +98,7 @@ describeEmbeddedPostgres("disableAllRoutinesInConfig", () => {
     tempRoot = mkdtempSync(path.join(os.tmpdir(), "paperclip-routines-cli-config-"));
     configPath = path.join(tempRoot, "config.json");
     writeTestConfig(configPath, tempRoot, tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(routines);

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "vitest/config";
+import {
+  EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS,
+  EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS,
+} from "../scripts/embedded-postgres-test-budget.mjs";
 
 export default defineConfig({
   test: {
     environment: "node",
+    // The CLI e2e suites boot embedded Postgres in beforeAll. Budget is
+    // centralized in scripts/embedded-postgres-test-budget.mjs (RBR-918).
+    hookTimeout: EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS,
+    teardownTimeout: EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS,
   },
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "release:rollback": "./scripts/rollback-latest.sh",
     "release:bootstrap-package": "node scripts/bootstrap-npm-package.mjs",
     "check:tokens": "node scripts/check-forbidden-tokens.mjs",
+    "check:embedded-postgres-budgets": "node scripts/audit-embedded-postgres-hook-budgets.mjs",
+    "test:check-executed-test-suites": "node --test scripts/__tests__/check-executed-test-suites.test.mjs",
     "check:token-gates": "node scripts/check-token-gates.mjs",
     "check:no-git-push": "node scripts/check-no-git-push.mjs",
     "test:check-no-git-push": "node --test scripts/check-no-git-push.test.mjs",

--- a/packages/db/src/pipelines-schema.test.ts
+++ b/packages/db/src/pipelines-schema.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("pipeline schema", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-pipeline-schema-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "vitest/config";
+import {
+  EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS,
+  EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS,
+} from "../../scripts/embedded-postgres-test-budget.mjs";
 
 export default defineConfig({
   test: {
     environment: "node",
+    // Migration/schema suites here boot embedded Postgres in beforeAll. Budget
+    // is centralized in scripts/embedded-postgres-test-budget.mjs (RBR-918).
+    hookTimeout: EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS,
+    teardownTimeout: EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS,
   },
 });

--- a/scripts/__tests__/check-executed-test-suites.test.mjs
+++ b/scripts/__tests__/check-executed-test-suites.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findZeroExecutedSuites } from "../check-executed-test-suites.mjs";
+
+function suite(name, statuses) {
+  return { name, assertionResults: statuses.map((status) => ({ status })) };
+}
+
+test("a suite where every test is skipped is reported as zero-executed", () => {
+  const offenders = findZeroExecutedSuites({
+    testResults: [suite("a.test.ts", ["skipped", "skipped", "skipped"])],
+  });
+
+  assert.deepEqual(offenders, [{ file: "a.test.ts", declaredTests: 3 }]);
+});
+
+test("a suite with at least one executed test is not reported", () => {
+  const offenders = findZeroExecutedSuites({
+    testResults: [suite("a.test.ts", ["skipped", "passed", "skipped"])],
+  });
+
+  assert.deepEqual(offenders, []);
+});
+
+test("a failing test counts as executed", () => {
+  const offenders = findZeroExecutedSuites({
+    testResults: [suite("a.test.ts", ["failed"])],
+  });
+
+  assert.deepEqual(offenders, []);
+});
+
+test("a suite that collected no tests at all is not reported", () => {
+  // Empty files and collection errors are a different failure that vitest
+  // already surfaces; this guard is about files that declare tests but run none.
+  const offenders = findZeroExecutedSuites({ testResults: [suite("a.test.ts", [])] });
+
+  assert.deepEqual(offenders, []);
+});
+
+test("offenders are reported per file across a mixed run", () => {
+  const offenders = findZeroExecutedSuites({
+    testResults: [
+      suite("ran.test.ts", ["passed", "passed"]),
+      suite("hidden-a.test.ts", ["skipped"]),
+      suite("hidden-b.test.ts", ["skipped", "skipped"]),
+    ],
+  });
+
+  assert.deepEqual(offenders, [
+    { file: "hidden-a.test.ts", declaredTests: 1 },
+    { file: "hidden-b.test.ts", declaredTests: 2 },
+  ]);
+});
+
+test("a malformed report yields no offenders rather than throwing", () => {
+  assert.deepEqual(findZeroExecutedSuites({}), []);
+  assert.deepEqual(findZeroExecutedSuites(null), []);
+  assert.deepEqual(findZeroExecutedSuites({ testResults: "nope" }), []);
+});

--- a/scripts/audit-embedded-postgres-hook-budgets.mjs
+++ b/scripts/audit-embedded-postgres-hook-budgets.mjs
@@ -11,10 +11,12 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
+import { EMBEDDED_POSTGRES_MIN_HOOK_BUDGET_MS } from "./embedded-postgres-test-budget.mjs";
 
 const args = process.argv.slice(2);
 const minIndex = args.indexOf("--min");
-const MIN_BUDGET_MS = minIndex === -1 ? 120_000 : Number(args[minIndex + 1]);
+const MIN_BUDGET_MS =
+  minIndex === -1 ? EMBEDDED_POSTGRES_MIN_HOOK_BUDGET_MS : Number(args[minIndex + 1]);
 const asJson = args.includes("--json");
 
 const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
@@ -45,7 +47,19 @@ function readCallText(source, openParenIndex) {
   return null;
 }
 
-/** Extract the trailing numeric timeout argument of a hook call, if present. */
+/**
+ * Extract the trailing timeout argument of a hook call, if present.
+ *
+ * Returns:
+ *  - { kind: "none" }             — no third argument; the hook truly inherits
+ *                                    the CLI/config `hookTimeout`.
+ *  - { kind: "literal", ms }      — a plain numeric literal (e.g. `20_000`).
+ *  - { kind: "expression", text } — a third argument present but not a plain
+ *                                    numeric literal (e.g. `HOOK_TIMEOUT` or
+ *                                    `30 * 1000`). This still overrides the
+ *                                    centralized budget at runtime, so it must
+ *                                    not be treated the same as "none".
+ */
 function extractTimeout(callText) {
   // callText looks like "( async () => { ... }, 20_000 )"
   const inner = callText.slice(1, -1);
@@ -57,10 +71,10 @@ function extractTimeout(callText) {
     else if (ch === ")" || ch === "}" || ch === "]") depth -= 1;
     else if (ch === "," && depth === 0) lastComma = i;
   }
-  if (lastComma === -1) return null;
+  if (lastComma === -1) return { kind: "none" };
   const tail = inner.slice(lastComma + 1).trim();
-  if (!/^[0-9][0-9_]*$/.test(tail)) return null;
-  return Number(tail.replace(/_/g, ""));
+  if (!/^[0-9][0-9_]*$/.test(tail)) return { kind: "expression", text: tail };
+  return { kind: "literal", ms: Number(tail.replace(/_/g, "")) };
 }
 
 const findings = [];
@@ -81,19 +95,23 @@ for (const relPath of files) {
       file: relPath,
       line,
       hook: match[1],
-      timeoutMs: timeout,
+      timeoutMs: timeout.kind === "literal" ? timeout.ms : null,
+      timeoutExpr: timeout.kind === "expression" ? timeout.text : null,
       status:
-        timeout === null
+        timeout.kind === "none"
           ? "inherits-cli-budget"
-          : timeout < MIN_BUDGET_MS
-            ? "under-budget"
-            : "ok",
+          : timeout.kind === "expression"
+            ? "non-literal-budget"
+            : timeout.ms < MIN_BUDGET_MS
+              ? "under-budget"
+              : "ok",
     });
     HOOK_RE.lastIndex = openParen + callText.length;
   }
 }
 
 const underBudget = findings.filter((f) => f.status === "under-budget");
+const nonLiteral = findings.filter((f) => f.status === "non-literal-budget");
 const inherits = findings.filter((f) => f.status === "inherits-cli-budget");
 const ok = findings.filter((f) => f.status === "ok");
 
@@ -106,11 +124,17 @@ if (asJson) {
   console.log(`  inline budget OK:       ${ok.length}`);
   console.log(`  inherits CLI budget:    ${inherits.length}`);
   console.log(`  UNDER BUDGET:           ${underBudget.length}`);
+  console.log(`  NON-LITERAL BUDGET:     ${nonLiteral.length}`);
   for (const finding of underBudget) {
     console.log(
       `    ${finding.file}:${finding.line} ${finding.hook} => ${finding.timeoutMs}ms`,
     );
   }
+  for (const finding of nonLiteral) {
+    console.log(
+      `    ${finding.file}:${finding.line} ${finding.hook} => non-literal timeout expression: ${finding.timeoutExpr}`,
+    );
+  }
 }
 
-process.exitCode = underBudget.length > 0 ? 1 : 0;
+process.exitCode = underBudget.length > 0 || nonLiteral.length > 0 ? 1 : 0;

--- a/scripts/audit-embedded-postgres-hook-budgets.mjs
+++ b/scripts/audit-embedded-postgres-hook-budgets.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * RBR-918 audit: find every Vitest hook that starts embedded Postgres with an
+ * inline timeout budget below the real embedded-Postgres import cost.
+ *
+ * A hook that times out makes every test in the file report `skipped` while the
+ * run still exits 0, so an under-budgeted hook is a permanently-green suite.
+ *
+ * Usage: node scripts/audit-embedded-postgres-hook-budgets.mjs [--min 120000] [--json]
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const minIndex = args.indexOf("--min");
+const MIN_BUDGET_MS = minIndex === -1 ? 120_000 : Number(args[minIndex + 1]);
+const asJson = args.includes("--json");
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const files = execFileSync(
+  "git",
+  ["grep", "-l", "--", "startEmbeddedPostgresTestDatabase", "*.ts"],
+  { encoding: "utf8", cwd: repoRoot },
+)
+  .split("\n")
+  .filter((line) => line.trim().length > 0);
+
+const HOOK_RE = /\b(beforeAll|beforeEach)\s*\(/g;
+
+/** Walk forward from the opening paren of a hook call and return its full text. */
+function readCallText(source, openParenIndex) {
+  let depth = 0;
+  for (let i = openParenIndex; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openParenIndex, i + 1);
+    }
+  }
+  return null;
+}
+
+/** Extract the trailing numeric timeout argument of a hook call, if present. */
+function extractTimeout(callText) {
+  // callText looks like "( async () => { ... }, 20_000 )"
+  const inner = callText.slice(1, -1);
+  let depth = 0;
+  let lastComma = -1;
+  for (let i = 0; i < inner.length; i += 1) {
+    const ch = inner[i];
+    if (ch === "(" || ch === "{" || ch === "[") depth += 1;
+    else if (ch === ")" || ch === "}" || ch === "]") depth -= 1;
+    else if (ch === "," && depth === 0) lastComma = i;
+  }
+  if (lastComma === -1) return null;
+  const tail = inner.slice(lastComma + 1).trim();
+  if (!/^[0-9][0-9_]*$/.test(tail)) return null;
+  return Number(tail.replace(/_/g, ""));
+}
+
+const findings = [];
+
+for (const relPath of files) {
+  const abs = path.join(repoRoot, relPath);
+  const source = readFileSync(abs, "utf8");
+  HOOK_RE.lastIndex = 0;
+  let match;
+  while ((match = HOOK_RE.exec(source)) !== null) {
+    const openParen = match.index + match[0].length - 1;
+    const callText = readCallText(source, openParen);
+    if (!callText) continue;
+    if (!callText.includes("startEmbeddedPostgresTestDatabase")) continue;
+    const timeout = extractTimeout(callText);
+    const line = source.slice(0, match.index).split("\n").length;
+    findings.push({
+      file: relPath,
+      line,
+      hook: match[1],
+      timeoutMs: timeout,
+      status:
+        timeout === null
+          ? "inherits-cli-budget"
+          : timeout < MIN_BUDGET_MS
+            ? "under-budget"
+            : "ok",
+    });
+    HOOK_RE.lastIndex = openParen + callText.length;
+  }
+}
+
+const underBudget = findings.filter((f) => f.status === "under-budget");
+const inherits = findings.filter((f) => f.status === "inherits-cli-budget");
+const ok = findings.filter((f) => f.status === "ok");
+
+if (asJson) {
+  console.log(JSON.stringify({ minBudgetMs: MIN_BUDGET_MS, findings }, null, 2));
+} else {
+  console.log(`embedded-Postgres hook budget audit (min ${MIN_BUDGET_MS}ms)`);
+  console.log(`  files scanned:          ${files.length}`);
+  console.log(`  db-starting hooks:      ${findings.length}`);
+  console.log(`  inline budget OK:       ${ok.length}`);
+  console.log(`  inherits CLI budget:    ${inherits.length}`);
+  console.log(`  UNDER BUDGET:           ${underBudget.length}`);
+  for (const finding of underBudget) {
+    console.log(
+      `    ${finding.file}:${finding.line} ${finding.hook} => ${finding.timeoutMs}ms`,
+    );
+  }
+}
+
+process.exitCode = underBudget.length > 0 ? 1 : 0;

--- a/scripts/check-executed-test-suites.mjs
+++ b/scripts/check-executed-test-suites.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * RBR-918 AC3: a suite that reports zero executed tests must not be able to
+ * report success.
+ *
+ * The dangerous shape is a test file whose tests all report `skipped` while the
+ * run still exits 0. Two mechanisms produce it:
+ *
+ *  1. A `beforeAll` that boots embedded Postgres inside a budget it cannot meet.
+ *     On vitest 4 this surfaces as a failed suite (exit 1), so it is loud — but
+ *     only because vitest changed; on older majors it was silent.
+ *  2. `describeEmbeddedPostgres = supported ? describe : describe.skip`. When the
+ *     support probe fails, the whole file skips and the run exits 0. Verified:
+ *     a file gated this way reports `success: true` with every test `skipped`.
+ *
+ * Mechanism 2 is why "the rest of the suite is green" was accepted as evidence
+ * on RBR-875 while the suite had not executed. This guard closes it: any file
+ * that executed zero of its tests fails the run.
+ *
+ * Escape hatch for developer hosts that genuinely cannot run embedded Postgres:
+ * set PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES=1. CI must not set it.
+ *
+ * Usage: node scripts/check-executed-test-suites.mjs <vitest-json-report>
+ */
+import { readFileSync } from "node:fs";
+
+const EXECUTED_STATUSES = new Set(["passed", "failed"]);
+
+/**
+ * Returns the files that executed none of their tests.
+ * @param {{ testResults?: Array<{ name: string, assertionResults?: Array<{ status: string }> }> }} report
+ */
+export function findZeroExecutedSuites(report) {
+  const suites = Array.isArray(report?.testResults) ? report.testResults : [];
+  const offenders = [];
+  for (const suite of suites) {
+    const assertions = Array.isArray(suite.assertionResults) ? suite.assertionResults : [];
+    // A file with no collected tests at all is a different problem (empty file,
+    // collection error already reported by vitest); only flag files that have
+    // tests on paper but ran none of them.
+    if (assertions.length === 0) continue;
+    const executed = assertions.filter((a) => EXECUTED_STATUSES.has(a.status)).length;
+    if (executed === 0) {
+      offenders.push({ file: suite.name, declaredTests: assertions.length });
+    }
+  }
+  return offenders;
+}
+
+function main() {
+  const reportPath = process.argv[2];
+  if (!reportPath) {
+    console.error("[check-executed-test-suites] usage: <vitest-json-report>");
+    process.exit(2);
+  }
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, "utf8"));
+  } catch (error) {
+    console.error(
+      `[check-executed-test-suites] could not read vitest JSON report at ${reportPath}: ${error.message}`,
+    );
+    process.exit(2);
+  }
+
+  const offenders = findZeroExecutedSuites(report);
+  if (offenders.length === 0) {
+    return;
+  }
+
+  const allowed = process.env.PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES === "1";
+  const total = offenders.reduce((sum, o) => sum + o.declaredTests, 0);
+  const header = `${offenders.length} suite(s) executed zero tests, hiding ${total} test(s)`;
+
+  if (allowed) {
+    console.warn(
+      `[check-executed-test-suites] WARNING: ${header}. PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES=1 is set, so this is not failing the run. CI must not set it.`,
+    );
+    for (const o of offenders) console.warn(`  ${o.file} (${o.declaredTests} hidden)`);
+    return;
+  }
+
+  console.error(`[check-executed-test-suites] ${header}. A suite that asserts nothing cannot report success.`);
+  for (const o of offenders) console.error(`  ${o.file} (${o.declaredTests} hidden)`);
+  console.error(
+    "[check-executed-test-suites] Common cause: the embedded-Postgres support probe failed, so `describeEmbeddedPostgres` fell back to `describe.skip`. Fix the host/probe rather than skipping. If this host genuinely cannot run embedded Postgres, set PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES=1 locally.",
+  );
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/codemod-embedded-postgres-hook-budgets.mjs
+++ b/scripts/codemod-embedded-postgres-hook-budgets.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * RBR-918 codemod: remove inline hook budgets from Vitest hooks that boot
+ * embedded Postgres, so the centralized `hookTimeout` in each project's
+ * vitest.config.ts applies. An inline budget wins over `--hookTimeout`, so a
+ * per-file value cannot be corrected from CI configuration.
+ *
+ * Usage: node scripts/codemod-embedded-postgres-hook-budgets.mjs [--dry-run]
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const dryRun = process.argv.includes("--dry-run");
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+
+const files = execFileSync(
+  "git",
+  ["grep", "-l", "--", "startEmbeddedPostgresTestDatabase", "*.ts"],
+  { encoding: "utf8", cwd: repoRoot },
+)
+  .split("\n")
+  .filter((line) => line.trim().length > 0);
+
+function readCallText(source, openParenIndex) {
+  let depth = 0;
+  for (let i = openParenIndex; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openParenIndex, i + 1);
+    }
+  }
+  return null;
+}
+
+/** Index (relative to callText) of the top-level comma before a numeric tail. */
+function findTimeoutCommaOffset(callText) {
+  const inner = callText.slice(1, -1);
+  let depth = 0;
+  let lastComma = -1;
+  for (let i = 0; i < inner.length; i += 1) {
+    const ch = inner[i];
+    if (ch === "(" || ch === "{" || ch === "[") depth += 1;
+    else if (ch === ")" || ch === "}" || ch === "]") depth -= 1;
+    else if (ch === "," && depth === 0) lastComma = i;
+  }
+  if (lastComma === -1) return null;
+  if (!/^[0-9][0-9_]*$/.test(inner.slice(lastComma + 1).trim())) return null;
+  return lastComma + 1; // +1 to shift past callText's leading "("
+}
+
+let totalRemoved = 0;
+const touched = [];
+
+for (const relPath of files) {
+  const abs = path.join(repoRoot, relPath);
+  let source = readFileSync(abs, "utf8");
+  let removedInFile = 0;
+
+  // Re-scan from the top after each rewrite; offsets shift as we splice.
+  for (;;) {
+    const hookRe = /\b(beforeAll|beforeEach)\s*\(/g;
+    let rewrote = false;
+    let match;
+    while ((match = hookRe.exec(source)) !== null) {
+      const openParen = match.index + match[0].length - 1;
+      const callText = readCallText(source, openParen);
+      if (!callText) continue;
+      if (!callText.includes("startEmbeddedPostgresTestDatabase")) continue;
+      const commaOffset = findTimeoutCommaOffset(callText);
+      if (commaOffset === null) continue;
+
+      // Splice out ", <number>" leaving the closing paren intact.
+      const absComma = openParen + commaOffset;
+      const closeParen = openParen + callText.length - 1;
+      source = source.slice(0, absComma) + source.slice(closeParen);
+      removedInFile += 1;
+      rewrote = true;
+      break;
+    }
+    if (!rewrote) break;
+  }
+
+  if (removedInFile > 0) {
+    totalRemoved += removedInFile;
+    touched.push({ file: relPath, removed: removedInFile });
+    if (!dryRun) writeFileSync(abs, source, "utf8");
+  }
+}
+
+console.log(
+  `${dryRun ? "[dry-run] would remove" : "removed"} ${totalRemoved} inline hook budget(s) across ${touched.length} file(s)`,
+);
+for (const entry of touched) {
+  console.log(`  ${entry.file} (${entry.removed})`);
+}

--- a/scripts/embedded-postgres-test-budget.mjs
+++ b/scripts/embedded-postgres-test-budget.mjs
@@ -1,0 +1,32 @@
+// Single source of truth for the Vitest hook budget of suites that boot an
+// embedded PostgreSQL cluster in `beforeAll`.
+//
+// RBR-918: this used to be an inline third argument on every `beforeAll` that
+// called `startEmbeddedPostgresTestDatabase` — 151 of them, most at `20_000`.
+// The real cost of booting embedded Postgres and applying migrations is ~92s on
+// developer hardware, so those budgets were below the floor and the hooks could
+// not complete. An inline hook budget also wins over the `--hookTimeout` CLI
+// flag, so the drift could not be corrected from CI configuration.
+//
+// Keep the budget here and let every project's `vitest.config.ts` read it. Do
+// not reintroduce inline hook budgets on embedded-Postgres hooks; the audit in
+// `scripts/audit-embedded-postgres-hook-budgets.mjs` fails the build if you do.
+
+/**
+ * Hook budget (ms) for suites that boot embedded Postgres. Sized well above the
+ * observed ~92s boot + migrate cost so a loaded CI runner still completes the
+ * hook, while a genuinely hung hook is still caught.
+ */
+export const EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS = 180_000;
+
+/**
+ * Teardown budget (ms). `stopEmbeddedPostgresBounded` already caps the graceful
+ * stop at 5s, so this only needs headroom for the data-dir reclaim.
+ */
+export const EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS = 60_000;
+
+/**
+ * Floor used by the audit. Any inline hook budget on an embedded-Postgres hook
+ * below this value is a defect, because the hook cannot finish inside it.
+ */
+export const EMBEDDED_POSTGRES_MIN_HOOK_BUDGET_MS = 120_000;

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readdirSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadShardDurations, selectGeneralServerShard } from "./general-server-shard.mjs";
+import { findZeroExecutedSuites } from "./check-executed-test-suites.mjs";
 
 const repoRoot = process.cwd();
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -267,11 +268,29 @@ function runVitest(args, label) {
   };
   mkdirSync(env.PAPERCLIP_HOME, { recursive: true });
   mkdirSync(env.TMPDIR, { recursive: true });
-  const result = spawnSync("pnpm", ["exec", "vitest", "run", ...args], {
-    cwd: repoRoot,
-    env,
-    stdio: "inherit",
-  });
+  // RBR-918: emit a machine-readable report alongside the human reporter so the
+  // zero-executed-suite guard can inspect what actually ran. Without it, a file
+  // whose tests all report `skipped` — because the embedded-Postgres support
+  // probe failed and `describeEmbeddedPostgres` fell back to `describe.skip` —
+  // still exits 0 and is indistinguishable from a passing suite.
+  const reportPath = path.join(testRoot, "vitest-report.json");
+  const result = spawnSync(
+    "pnpm",
+    [
+      "exec",
+      "vitest",
+      "run",
+      ...args,
+      "--reporter=default",
+      "--reporter=json",
+      `--outputFile.json=${reportPath}`,
+    ],
+    {
+      cwd: repoRoot,
+      env,
+      stdio: "inherit",
+    },
+  );
   if (result.error) {
     console.error(`[test:run] Failed to start Vitest: ${result.error.message}`);
     process.exit(1);
@@ -279,7 +298,52 @@ function runVitest(args, label) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+  assertSuitesExecuted(reportPath, label);
 }
+
+// RBR-918 AC3: fail the run when a suite reports zero executed tests. A
+// permanently-green suite that asserts nothing is worse than no suite at all.
+function assertSuitesExecuted(reportPath, label) {
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, "utf8"));
+  } catch (error) {
+    console.error(
+      `[test:run] Could not read the vitest JSON report for "${label}" (${reportPath}): ${error.message}. ` +
+        "The zero-executed-suite guard cannot verify this run, so it is failing closed.",
+    );
+    process.exit(1);
+  }
+
+  const offenders = findZeroExecutedSuites(report);
+  if (offenders.length === 0) {
+    return;
+  }
+
+  const hidden = offenders.reduce((sum, offender) => sum + offender.declaredTests, 0);
+  const message =
+    `[test:run] ${offenders.length} suite(s) in "${label}" executed zero tests, hiding ${hidden} test(s):`;
+
+  if (process.env.PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES === "1") {
+    console.warn(`${message} (allowed by PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES=1; CI must not set it)`);
+    for (const offender of offenders) {
+      console.warn(`  ${toRepoPath(offender.file)} (${offender.declaredTests} hidden)`);
+    }
+    return;
+  }
+
+  console.error(message);
+  for (const offender of offenders) {
+    console.error(`  ${toRepoPath(offender.file)} (${offender.declaredTests} hidden)`);
+  }
+  console.error(
+    "[test:run] Common cause: the embedded-Postgres support probe failed, so `describeEmbeddedPostgres` fell " +
+      "back to `describe.skip` and the file reported success without asserting anything. Fix the host or the " +
+      "probe. If this host genuinely cannot run embedded Postgres, set PAPERCLIP_ALLOW_ZERO_EXECUTED_SUITES=1 locally.",
+  );
+  process.exit(1);
+}
+
 
 function runGeneralSuites(routeTests) {
   for (const groupName of generalGroupNames) {

--- a/server/src/__tests__/access-routes-permissions-upgrade.test.ts
+++ b/server/src/__tests__/access-routes-permissions-upgrade.test.ts
@@ -86,7 +86,7 @@ describeEmbeddedPostgres("access routes permissions upgrade compatibility", () =
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-access-routes-permissions-upgrade-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/access-service.test.ts
+++ b/server/src/__tests__/access-service.test.ts
@@ -53,7 +53,7 @@ describeEmbeddedPostgres("access service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-access-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issues);

--- a/server/src/__tests__/activity-log-responsible-user.test.ts
+++ b/server/src/__tests__/activity-log-responsible-user.test.ts
@@ -177,7 +177,7 @@ describeEmbeddedPostgres("logActivity responsible-user stamping", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-activity-responsible-user-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/activity-service.test.ts
+++ b/server/src/__tests__/activity-service.test.ts
@@ -54,7 +54,7 @@ describeEmbeddedPostgres("activity service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-activity-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/agent-action-audit-routes.test.ts
+++ b/server/src/__tests__/agent-action-audit-routes.test.ts
@@ -44,7 +44,7 @@ describePostgres("agent action audit routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-action-audit-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/agents-pending-approval-config.test.ts
+++ b/server/src/__tests__/agents-pending-approval-config.test.ts
@@ -36,7 +36,7 @@ describeEmbeddedPostgres("pending approval agent config integrity", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-pending-agent-config-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/agents-service-clear-error.test.ts
+++ b/server/src/__tests__/agents-service-clear-error.test.ts
@@ -31,7 +31,7 @@ describeEmbeddedPostgres("agent service clearError", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-clear-error-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRunEvents);

--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     const started = await startEmbeddedPostgresTestDatabase("agent-secret-bindings");
     stopDb = started.cleanup;
     db = createDb(started.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(companySecretBindings);

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -61,7 +61,7 @@ describeEmbeddedPostgres("attention service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-attention-service-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(inboxDismissals);

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -169,7 +169,7 @@ describeEmbeddedPostgres("authorization service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-authorization-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/board-claim.test.ts
+++ b/server/src/__tests__/board-claim.test.ts
@@ -30,7 +30,7 @@ describeEmbeddedPostgres("board claim", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-board-claim-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await initializeBoardClaimChallenge(db, { deploymentMode: "local_trusted" });

--- a/server/src/__tests__/budgets-service.test.ts
+++ b/server/src/__tests__/budgets-service.test.ts
@@ -335,7 +335,7 @@ describeEmbeddedPostgres("budgetService release gate enforcement", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-budgets-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(budgetIncidents);

--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -120,7 +120,7 @@ describeEmbeddedPostgres("built-in agents", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-built-in-agents-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(routineTriggers);

--- a/server/src/__tests__/cases-routes.test.ts
+++ b/server/src/__tests__/cases-routes.test.ts
@@ -87,7 +87,7 @@ describeEmbeddedPostgres("cases routes", () => {
     process.env.PAPERCLIP_AGENT_JWT_SECRET = "cases-routes-test-secret";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cases-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/change-consent-gate.test.ts
+++ b/server/src/__tests__/change-consent-gate.test.ts
@@ -28,7 +28,7 @@ describeEmbeddedPostgres("changeConsentGateService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-reflection-coach-gate-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueThreadInteractions);

--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("cleanup removal services", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cleanup-removal-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRunEvents);

--- a/server/src/__tests__/companies-service.test.ts
+++ b/server/src/__tests__/companies-service.test.ts
@@ -42,7 +42,7 @@ describeEmbeddedPostgres("companyService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(routineTriggers);

--- a/server/src/__tests__/company-artifacts-service.test.ts
+++ b/server/src/__tests__/company-artifacts-service.test.ts
@@ -63,7 +63,7 @@ describeEmbeddedPostgres("companyArtifactsService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-artifacts-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(documentMemberships);

--- a/server/src/__tests__/company-portability-import-batching.test.ts
+++ b/server/src/__tests__/company-portability-import-batching.test.ts
@@ -234,7 +234,7 @@ describeEmbeddedPostgres("company import batches inserts", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-import-batching-");
     db = createDb(tempDb.connectionString);
     counts = instrumentInserts(db as unknown as Record<string, unknown>);
-  }, 30_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/company-search-extract-service.test.ts
+++ b/server/src/__tests__/company-search-extract-service.test.ts
@@ -66,7 +66,7 @@ describeEmbeddedPostgres("companySearchExtractService", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-search-extract-");
     db = createDb(tempDb.connectionString);
     svc = companySearchExtractService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueDocuments);

--- a/server/src/__tests__/company-search-service.test.ts
+++ b/server/src/__tests__/company-search-service.test.ts
@@ -80,7 +80,7 @@ describeEmbeddedPostgres("companySearchService", () => {
     db = createDb(tempDb.connectionString);
     svc = companySearchService(db);
     await db.execute(sql.raw("CREATE EXTENSION IF NOT EXISTS pg_trgm"));
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueDocuments);

--- a/server/src/__tests__/company-skill-import-boundary.test.ts
+++ b/server/src/__tests__/company-skill-import-boundary.test.ts
@@ -18,7 +18,7 @@ describeEmbeddedPostgres("company skill local import boundary", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-skill-import-boundary-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(companySkills);

--- a/server/src/__tests__/company-skill-policy-routes.test.ts
+++ b/server/src/__tests__/company-skill-policy-routes.test.ts
@@ -20,7 +20,7 @@ describeEmbeddedPostgres("company skill policy routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-skill-policy-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/company-skill-policy-service.test.ts
+++ b/server/src/__tests__/company-skill-policy-service.test.ts
@@ -21,7 +21,7 @@ describeEmbeddedPostgres("companySkillPolicyService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-skill-policy-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/company-skill-test-runs-service.test.ts
+++ b/server/src/__tests__/company-skill-test-runs-service.test.ts
@@ -43,7 +43,7 @@ describeEmbeddedPostgres("companySkillService skill test runs", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-skill-test-runs-");
     db = createDb(tempDb.connectionString);
     svc = companySkillService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueAttachments);

--- a/server/src/__tests__/company-skills-catalog-service.test.ts
+++ b/server/src/__tests__/company-skills-catalog-service.test.ts
@@ -105,7 +105,7 @@ describeEmbeddedPostgres("companySkillService.installFromCatalog", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-skills-catalog-");
     db = createDb(tempDb.connectionString);
     svc = await createService();
-  }, 20_000);
+  });
 
   beforeEach(async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-catalog-home-"));

--- a/server/src/__tests__/company-skills-detail.test.ts
+++ b/server/src/__tests__/company-skills-detail.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("companySkillService.detail", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-skills-detail-");
     db = createDb(tempDb.connectionString);
     svc = companySkillService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     mockListSkills.mockClear();

--- a/server/src/__tests__/company-skills-import-authz-routes.test.ts
+++ b/server/src/__tests__/company-skills-import-authz-routes.test.ts
@@ -50,7 +50,7 @@ describeEmbeddedPostgres("company skill import authorization routes", () => {
     process.env.PAPERCLIP_INSTANCE_ID = "default";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-skills-import-authz-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/company-skills-service.test.ts
+++ b/server/src/__tests__/company-skills-service.test.ts
@@ -59,7 +59,7 @@ describeEmbeddedPostgres("companySkillService.list", () => {
     process.env.PAPERCLIP_INSTANCE_ID = "default";
     db = createDb(tempDb.connectionString);
     svc = companySkillService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(agents);

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -417,7 +417,7 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     db = createDb(tempDb.connectionString);
     costs = costService(db);
     finance = financeService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(financeEvents);

--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -27,7 +27,7 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-cross-issue-cap-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/dashboard-service.test.ts
+++ b/server/src/__tests__/dashboard-service.test.ts
@@ -44,7 +44,7 @@ describeEmbeddedPostgres("dashboard service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-dashboard-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRuns);

--- a/server/src/__tests__/decision-queues-routes.test.ts
+++ b/server/src/__tests__/decision-queues-routes.test.ts
@@ -42,7 +42,7 @@ describeEmbeddedPostgres("decision queue routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-decision-queues-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(decisionTriageEvents);

--- a/server/src/__tests__/decision-retention-service.test.ts
+++ b/server/src/__tests__/decision-retention-service.test.ts
@@ -23,7 +23,7 @@ describePg("decision retention", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-decision-retention-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(decisionArchiveNotificationOutbox);

--- a/server/src/__tests__/decision-training.test.ts
+++ b/server/src/__tests__/decision-training.test.ts
@@ -42,7 +42,7 @@ describeEmbeddedPostgres("decision training", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-decision-training-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/decisions-service.test.ts
+++ b/server/src/__tests__/decisions-service.test.ts
@@ -44,7 +44,7 @@ describePg("decisionService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-decisions-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   beforeEach(async () => {
     process.env.PAPERCLIP_DECISION_SIGNING_SECRET = "0123456789abcdef0123456789abcdef";

--- a/server/src/__tests__/document-annotations-service.test.ts
+++ b/server/src/__tests__/document-annotations-service.test.ts
@@ -53,7 +53,7 @@ describeEmbeddedPostgres("documentAnnotationService", () => {
     db = createDb(tempDb.connectionString);
     annotations = documentAnnotationService(db);
     docs = documentService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(documentAnnotationAnchorSnapshots);

--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -33,7 +33,7 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-documents-service-");
     db = createDb(tempDb.connectionString);
     svc = documentService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(documentRevisions);

--- a/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
+++ b/server/src/__tests__/execution-lock-orphan-cleanup.test.ts
@@ -33,7 +33,7 @@ describeEmbeddedPostgres("execution lock orphan cleanup", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-exec-lock-orphan-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(agentWakeupRequests);

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -254,7 +254,7 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
         ?? { state: "unknown", headRef: null, headSha: null }
       ),
     });
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(workspaceRuntimeServices);

--- a/server/src/__tests__/export-fidelity.test.ts
+++ b/server/src/__tests__/export-fidelity.test.ts
@@ -24,7 +24,7 @@ describeEmbeddedPostgres("export fidelity counts", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-export-fidelity-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueLabels);

--- a/server/src/__tests__/external-objects-service.test.ts
+++ b/server/src/__tests__/external-objects-service.test.ts
@@ -357,7 +357,7 @@ describeEmbeddedPostgres("externalObjectService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-external-objects-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/feedback-service.test.ts
+++ b/server/src/__tests__/feedback-service.test.ts
@@ -51,7 +51,7 @@ describeEmbeddedPostgres("feedbackService.saveIssueVote", () => {
     db = createDb(started.connectionString);
     svc = feedbackService(db);
     tempDb = started;
-  }, 120_000);
+  });
 
   afterEach(async () => {
     await db.delete(feedbackExports);

--- a/server/src/__tests__/file-resources.test.ts
+++ b/server/src/__tests__/file-resources.test.ts
@@ -201,7 +201,7 @@ describeEmbeddedPostgres("workspace file resources", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-file-resources-");
     db = createDb(tempDb.connectionString);
-  }, 60_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();
@@ -1447,7 +1447,7 @@ describeEmbeddedPostgres("file resource route guards", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-file-resource-guards-");
     db = createDb(tempDb.connectionString);
-  }, 60_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/first-admin-claim.test.ts
+++ b/server/src/__tests__/first-admin-claim.test.ts
@@ -17,7 +17,7 @@ describeEmbeddedPostgres("claimFirstInstanceAdmin", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-first-admin-claim-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(instanceUserRoles);

--- a/server/src/__tests__/folders-service.test.ts
+++ b/server/src/__tests__/folders-service.test.ts
@@ -27,7 +27,7 @@ describeEmbeddedPostgres("folder service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-folders-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(companySkills);

--- a/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
+++ b/server/src/__tests__/heartbeat-accepted-plan-workspace-refresh.test.ts
@@ -110,7 +110,7 @@ describeEmbeddedPostgres("accepted plan workspace refresh", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-accepted-plan-workspace-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     adapterExecute.mockClear();

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -105,7 +105,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-active-run-output-watchdog-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     for (let attempt = 0; attempt < 100; attempt += 1) {

--- a/server/src/__tests__/heartbeat-archived-company-guard.test.ts
+++ b/server/src/__tests__/heartbeat-archived-company-guard.test.ts
@@ -31,7 +31,7 @@ describeEmbeddedPostgres("heartbeat archived-company guard", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-archived-company-guard-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRunEvents);

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -168,7 +168,7 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
     const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-comment-wake-");
     db = createDb(started.connectionString);
     tempDb = started;
-  }, 120_000);
+  });
 
   afterAll(async () => {
     await closeDbClient(db);

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -97,7 +97,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     db = createDb(tempDb.connectionString);
     heartbeat = heartbeatService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     let idlePolls = 0;

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -89,7 +89,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-issue-liveness-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();

--- a/server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts
+++ b/server/src/__tests__/heartbeat-issue-rewake-throttle.test.ts
@@ -66,7 +66,7 @@ describeEmbeddedPostgres("heartbeat issue rewake throttle", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-issue-rewake-throttle-");
     db = createDb(tempDb.connectionString);
     heartbeat = heartbeatService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     runningProcesses.clear();

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -23,7 +23,7 @@ describeEmbeddedPostgres("heartbeat list", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-list-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRuns);

--- a/server/src/__tests__/heartbeat-local-environment.test.ts
+++ b/server/src/__tests__/heartbeat-local-environment.test.ts
@@ -70,7 +70,7 @@ describeEmbeddedPostgres("heartbeat local environment lifecycle", () => {
     process.env.PAPERCLIP_AGENT_JWT_SECRET = "heartbeat-local-environment-test-secret";
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-local-environment-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.execute(sql.raw(`

--- a/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
+++ b/server/src/__tests__/heartbeat-lock-release-on-reassignment.test.ts
@@ -33,7 +33,7 @@ describeEmbeddedPostgres("heartbeat lock release on cross-agent reassignment", (
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-lock-release-on-reassignment-");
     db = createDb(tempDb.connectionString);
-  }, 60_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRunEvents);

--- a/server/src/__tests__/heartbeat-plugin-environment.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-environment.test.ts
@@ -65,7 +65,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
     const started = await startEmbeddedPostgresTestDatabase("heartbeat-plugin-environment");
     stopDb = started.stop;
     db = createDb(started.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     adapterExecute.mockClear();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -314,7 +314,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       createdAt: now,
       updatedAt: now,
     });
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();

--- a/server/src/__tests__/heartbeat-referenced-projects.test.ts
+++ b/server/src/__tests__/heartbeat-referenced-projects.test.ts
@@ -68,7 +68,7 @@ describeEmbeddedPostgres("resolveRunReferencedProjects", () => {
     db = createDb(tempDb.connectionString);
     issuesSvc = issueService(db);
     projectsSvc = projectService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/heartbeat-responsible-user-invariant.test.ts
+++ b/server/src/__tests__/heartbeat-responsible-user-invariant.test.ts
@@ -87,7 +87,7 @@ describeEmbeddedPostgres("heartbeat responsible-user invariant", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-responsible-user-");
     db = createDb(tempDb.connectionString);
     heartbeat = heartbeatService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     mockAdapterExecute.mockClear();

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -89,7 +89,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         testedAt: new Date().toISOString(),
       }),
     });
-  }, 20_000);
+  });
 
   afterEach(async () => {
     // Await every in-flight background heartbeat run to quiescence before the

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -34,7 +34,7 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-runtime-mcp-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     if (originalApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;

--- a/server/src/__tests__/heartbeat-runtime-skills.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-skills.test.ts
@@ -107,7 +107,7 @@ describeEmbeddedPostgres("heartbeat runtime skill version pins", () => {
         testedAt: new Date().toISOString(),
       }),
     });
-  }, 20_000);
+  });
 
   afterEach(async () => {
     capturedRuns.length = 0;

--- a/server/src/__tests__/heartbeat-runtime-state.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-state.test.ts
@@ -48,7 +48,7 @@ describeEmbeddedPostgres("heartbeat runtime state deduplication", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-runtime-state-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     clearAllHeartbeatRunRuntimeStatuses();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -147,7 +147,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     db = createDb(tempDb.connectionString);
     heartbeat = heartbeatService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     mockAdapterExecute.mockReset();

--- a/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-branch-containment.test.ts
@@ -858,7 +858,7 @@ describeEmbeddedPostgres("heartbeat workspace branch containment", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-branch-containment-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     // Await every in-flight background heartbeat run to quiescence before the

--- a/server/src/__tests__/heartbeat-workspace-busy.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-busy.test.ts
@@ -107,7 +107,7 @@ describeEmbeddedPostgres("shared-workspace run serialization", () => {
         testedAt: new Date().toISOString(),
       }),
     });
-  }, 20_000);
+  });
 
   afterEach(async () => {
     // Seeded holder runs are synthetic "running" rows with no real execution

--- a/server/src/__tests__/heartbeat-workspace-finalize-branch.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-finalize-branch.test.ts
@@ -264,7 +264,7 @@ describeEmbeddedPostgres("heartbeat workspace finalization branch guard", () => 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-finalize-branch-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     // Await every in-flight background heartbeat run to quiescence before the

--- a/server/src/__tests__/heartbeat-worktree-suppression.test.ts
+++ b/server/src/__tests__/heartbeat-worktree-suppression.test.ts
@@ -64,7 +64,7 @@ describeEmbeddedPostgres("heartbeat worktree suppression", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-worktree-suppression-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     // Await every in-flight background heartbeat run to quiescence before the

--- a/server/src/__tests__/helpers/route-test-harness.ts
+++ b/server/src/__tests__/helpers/route-test-harness.ts
@@ -39,7 +39,7 @@ export function useEmbeddedPostgres(
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase(prefix);
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   if (opts.resetEach) {
     const resetEach = opts.resetEach;

--- a/server/src/__tests__/inbox-agent-policy-routes.test.ts
+++ b/server/src/__tests__/inbox-agent-policy-routes.test.ts
@@ -29,7 +29,7 @@ describeEmbeddedPostgres("inbox agent policy routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-inbox-agent-policy-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/inbox-archive-routes.test.ts
+++ b/server/src/__tests__/inbox-archive-routes.test.ts
@@ -36,7 +36,7 @@ describeEmbeddedPostgres("inbox archive routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-inbox-archive-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/inbox-dismissals.test.ts
+++ b/server/src/__tests__/inbox-dismissals.test.ts
@@ -42,7 +42,7 @@ describeEmbeddedPostgres("inbox dismissals", () => {
     db = createDb(tempDb.connectionString);
     dismissalsSvc = inboxDismissalService(db);
     badgesSvc = sidebarBadgeService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(inboxDismissals);

--- a/server/src/__tests__/invite-accept-gateway-defaults.test.ts
+++ b/server/src/__tests__/invite-accept-gateway-defaults.test.ts
@@ -264,7 +264,7 @@ describeEmbeddedPostgres("prepareAgentDefaultsPayloadForJoinPersistence (hermes_
     const started = await startEmbeddedPostgresTestDatabase("hermes-join-defaults");
     stopDb = started.cleanup;
     db = createDb(started.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(joinRequests);

--- a/server/src/__tests__/invite-list-route.test.ts
+++ b/server/src/__tests__/invite-list-route.test.ts
@@ -44,7 +44,7 @@ describeEmbeddedPostgres("GET /companies/:companyId/invites", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-invite-list-route-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   beforeEach(async () => {
     companyId = randomUUID();

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -39,7 +39,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-blocker-attention-");
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueThreadInteractions);

--- a/server/src/__tests__/issue-blocker-diagnostics-routes.test.ts
+++ b/server/src/__tests__/issue-blocker-diagnostics-routes.test.ts
@@ -190,7 +190,7 @@ describeEmbeddedPostgres("issue blocker diagnostics route", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-blocker-diagnostics-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueRelations);

--- a/server/src/__tests__/issue-comment-attribution-audit-routes.test.ts
+++ b/server/src/__tests__/issue-comment-attribution-audit-routes.test.ts
@@ -60,7 +60,7 @@ describeEmbeddedPostgres("issue comment attribution and patch audit routes", () 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-comment-attribution-audit-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/issue-comment-redaction.test.ts
+++ b/server/src/__tests__/issue-comment-redaction.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("deleted issue comment redaction", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-comment-redaction-");
     db = createDb(tempDb.connectionString);
     await db.execute(sql.raw("CREATE EXTENSION IF NOT EXISTS pg_trgm"));
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueReferenceMentions);

--- a/server/src/__tests__/issue-create-deduplication-routes.test.ts
+++ b/server/src/__tests__/issue-create-deduplication-routes.test.ts
@@ -42,7 +42,7 @@ describeEmbeddedPostgres("issue create deduplication routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-create-deduplication-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/issue-identifier-routes.test.ts
+++ b/server/src/__tests__/issue-identifier-routes.test.ts
@@ -28,7 +28,7 @@ describeEmbeddedPostgres("issue identifier routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-identifier-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -35,7 +35,7 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-list-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     __clearIssueListResponseCacheForTests();

--- a/server/src/__tests__/issue-monitor-scheduler.test.ts
+++ b/server/src/__tests__/issue-monitor-scheduler.test.ts
@@ -44,7 +44,7 @@ describeEmbeddedPostgres("issue monitor scheduler", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-monitor-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   async function waitForHeartbeatIdle(timeoutMs = 3_000) {
     const deadline = Date.now() + timeoutMs;

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -131,7 +131,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-recovery-actions-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueRecoveryActions);

--- a/server/src/__tests__/issue-references-service.test.ts
+++ b/server/src/__tests__/issue-references-service.test.ts
@@ -60,7 +60,7 @@ describeEmbeddedPostgres("issueReferenceService", () => {
     db = createDb(tempDb.connectionString);
     refs = issueReferenceService(db);
     await ensureIssueReferenceMentionsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueReferenceMentions);

--- a/server/src/__tests__/issue-review-attention.test.ts
+++ b/server/src/__tests__/issue-review-attention.test.ts
@@ -36,7 +36,7 @@ describeEmbeddedPostgres("issue review attention", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-review-attention-");
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueThreadInteractions);

--- a/server/src/__tests__/issue-review-policy.test.ts
+++ b/server/src/__tests__/issue-review-policy.test.ts
@@ -21,7 +21,7 @@ describeEmbeddedPostgres("issue review verdict policy", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-review-policy-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/issue-scheduled-retry-routes.test.ts
+++ b/server/src/__tests__/issue-scheduled-retry-routes.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("issue scheduled retry routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-scheduled-retry-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -38,7 +38,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stale-execution-lock-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/issue-stalled-review-decision-routes.test.ts
+++ b/server/src/__tests__/issue-stalled-review-decision-routes.test.ts
@@ -43,7 +43,7 @@ describeEmbeddedPostgres("stalled review decision routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stalled-review-decision-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     enqueueWakeup.mockClear();

--- a/server/src/__tests__/issue-subtree-diagnostics-routes.test.ts
+++ b/server/src/__tests__/issue-subtree-diagnostics-routes.test.ts
@@ -191,7 +191,7 @@ describeEmbeddedPostgres("issue subtree diagnostics route", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-subtree-diagnostics-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -43,7 +43,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     db = createDb(tempDb.connectionString);
     issuesSvc = issueService(db);
     interactionsSvc = issueThreadInteractionService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueThreadInteractions);

--- a/server/src/__tests__/issue-thread-interactions-telemetry.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-telemetry.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("issueThreadInteractionService telemetry", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-interaction-telemetry-");
     db = createDb(tempDb.connectionString);
     interactionsSvc = issueThreadInteractionService(db);
-  }, 20_000);
+  });
 
   beforeEach(() => {
     telemetryMocks.track.mockClear();

--- a/server/src/__tests__/issue-tree-control-service.test.ts
+++ b/server/src/__tests__/issue-tree-control-service.test.ts
@@ -35,7 +35,7 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-tree-control-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueTreeHoldMembers);

--- a/server/src/__tests__/issue-wake-diagnostics-routes.test.ts
+++ b/server/src/__tests__/issue-wake-diagnostics-routes.test.ts
@@ -192,7 +192,7 @@ describeEmbeddedPostgres("issue wake diagnostics route", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-wake-diagnostics-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/issue-watchdogs-routes.test.ts
+++ b/server/src/__tests__/issue-watchdogs-routes.test.ts
@@ -71,7 +71,7 @@ describeEmbeddedPostgres("issue watchdog routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-watchdogs-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     mockAdapterExecute.mockClear();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -301,7 +301,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -2527,7 +2527,7 @@ describeEmbeddedPostgres("issueService.findOpenAncestorCreatedByAgent", () => {
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issues);
@@ -2648,7 +2648,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -3583,7 +3583,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -4467,7 +4467,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -5062,7 +5062,7 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
     await ensureIssueRelationsTable(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -5230,7 +5230,7 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-execution-lock-");
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -5700,7 +5700,7 @@ describeEmbeddedPostgres("accepted plan decomposition", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-accepted-plan-decomposition-");
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issuePlanDecompositions);
@@ -6399,7 +6399,7 @@ describeEmbeddedPostgres("issueService.assertCheckoutOwner stale checkout adopti
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-checkout-owner-");
     db = createDb(tempDb.connectionString);
     svc = issueService(db);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -6657,7 +6657,7 @@ describeEmbeddedPostgres("issueService.addComment createdByRunId", () => {
       status: "todo",
       priority: "medium",
     });
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -701,7 +701,7 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-low-trust-red-team-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     // Await every in-flight background heartbeat run to quiescence before the

--- a/server/src/__tests__/merged-pr-confirmation-sweep.test.ts
+++ b/server/src/__tests__/merged-pr-confirmation-sweep.test.ts
@@ -141,7 +141,7 @@ describeEmbeddedPostgres.sequential("merged pull-request confirmation sweep", ()
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-merged-pr-confirmations-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/multilingual-issues-routes.test.ts
+++ b/server/src/__tests__/multilingual-issues-routes.test.ts
@@ -70,7 +70,7 @@ describeEmbeddedPostgres("multilingual issue routes", () => {
       membershipRole: "owner",
       updatedAt: new Date(),
     });
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/src/__tests__/permissions-upgrade-boundary-routes.test.ts
+++ b/server/src/__tests__/permissions-upgrade-boundary-routes.test.ts
@@ -109,7 +109,7 @@ describeEmbeddedPostgres("permissions upgrade visibility and route boundaries", 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-permissions-boundary-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueAttachments);

--- a/server/src/__tests__/pipelines-routes.test.ts
+++ b/server/src/__tests__/pipelines-routes.test.ts
@@ -62,7 +62,7 @@ describeEmbeddedPostgres("pipeline routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-pipelines-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(pipelineAutomationExecutions);

--- a/server/src/__tests__/pipelines-service.test.ts
+++ b/server/src/__tests__/pipelines-service.test.ts
@@ -57,7 +57,7 @@ describeEmbeddedPostgres("pipelineService", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-pipelines-service-");
     db = createDb(tempDb.connectionString);
     svc = pipelineService(db, { heartbeat: noopHeartbeat });
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(pipelineAutomationExecutions);

--- a/server/src/__tests__/plugin-access-authorization-host-services.test.ts
+++ b/server/src/__tests__/plugin-access-authorization-host-services.test.ts
@@ -49,7 +49,7 @@ describeEmbeddedPostgres("plugin access and authorization host services", () => 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-access-authz-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/plugin-config-startup-delivery.test.ts
+++ b/server/src/__tests__/plugin-config-startup-delivery.test.ts
@@ -36,7 +36,7 @@ describeEmbeddedPostgres("registry.listConfigs (startup config delivery)", () =>
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-config-delivery-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(pluginConfig);

--- a/server/src/__tests__/plugin-database.test.ts
+++ b/server/src/__tests__/plugin-database.test.ts
@@ -212,7 +212,7 @@ describeEmbeddedPostgres("plugin database namespaces", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-db-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     for (const pluginKey of ["paperclip.dbtest", "paperclip.escape", "paperclip.refresh", multiMigrationPluginKey, llmWikiPluginKey]) {

--- a/server/src/__tests__/plugin-install-autobuild.test.ts
+++ b/server/src/__tests__/plugin-install-autobuild.test.ts
@@ -285,7 +285,7 @@ describeEmbeddedPostgres("plugin install auto-build route", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-autobuild-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();

--- a/server/src/__tests__/plugin-install-route-security.test.ts
+++ b/server/src/__tests__/plugin-install-route-security.test.ts
@@ -154,7 +154,7 @@ describeEmbeddedPostgres("plugin install route security floor", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-install-guard-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();

--- a/server/src/__tests__/plugin-managed-agents.test.ts
+++ b/server/src/__tests__/plugin-managed-agents.test.ts
@@ -82,7 +82,7 @@ describeEmbeddedPostgres("plugin-managed agents", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-managed-agents-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(agentConfigRevisions);

--- a/server/src/__tests__/plugin-managed-routines.test.ts
+++ b/server/src/__tests__/plugin-managed-routines.test.ts
@@ -108,7 +108,7 @@ describeEmbeddedPostgres("plugin-managed routines", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-managed-routines-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(routineRuns);

--- a/server/src/__tests__/plugin-managed-skills.test.ts
+++ b/server/src/__tests__/plugin-managed-skills.test.ts
@@ -70,7 +70,7 @@ describeEmbeddedPostgres("plugin-managed skills", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-managed-skills-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -66,7 +66,7 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-orchestration-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   function isHeartbeatRunDependentFkError(error: unknown) {
     const message = error instanceof Error ? `${error.message} ${String(error.cause ?? "")}` : String(error);

--- a/server/src/__tests__/plugin-tenant-isolation.test.ts
+++ b/server/src/__tests__/plugin-tenant-isolation.test.ts
@@ -50,7 +50,7 @@ describeEmbeddedPostgres("plugin tenant isolation (company_id FK)", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-tenant-isolation-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(pluginEntities);

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -40,7 +40,7 @@ describeEmbeddedPostgres("productivity review service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-productivity-review-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));

--- a/server/src/__tests__/project-icon-persistence.test.ts
+++ b/server/src/__tests__/project-icon-persistence.test.ts
@@ -27,7 +27,7 @@ describeEmbeddedPostgres("project icon persistence", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-project-icon-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(projectsTable);

--- a/server/src/__tests__/projects-list-archived-routes.test.ts
+++ b/server/src/__tests__/projects-list-archived-routes.test.ts
@@ -51,7 +51,7 @@ describeEmbeddedPostgres("project list archived route defaults", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-projects-list-archived-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(projects);

--- a/server/src/__tests__/qa-routine-secrets-e2e.test.ts
+++ b/server/src/__tests__/qa-routine-secrets-e2e.test.ts
@@ -58,7 +58,7 @@ describeEmbedded("PAP-9522 QA: routine secrets end-to-end", () => {
     process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = path.join(secretsTmpDir, "master.key");
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-qa-routine-secrets-");
     db = createDb(tempDb.connectionString);
-  }, 30_000);
+  });
 
   afterEach(async () => {
     await db.delete(secretAccessEvents);

--- a/server/src/__tests__/recovery-observability.test.ts
+++ b/server/src/__tests__/recovery-observability.test.ts
@@ -124,7 +124,7 @@ describeEmbeddedPostgres("recovery observability report", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-recovery-observability-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueRecoveryActions);

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -39,7 +39,7 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stale-lock-sweep-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issueComments);

--- a/server/src/__tests__/resource-memberships-routes.test.ts
+++ b/server/src/__tests__/resource-memberships-routes.test.ts
@@ -61,7 +61,7 @@ describeEmbeddedPostgres("resource membership routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-resource-memberships-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/routine-run-telemetry.test.ts
+++ b/server/src/__tests__/routine-run-telemetry.test.ts
@@ -51,7 +51,7 @@ describeEmbeddedPostgres("routine run telemetry", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-routine-telemetry-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();

--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -98,7 +98,7 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-routines-e2e-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -53,7 +53,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-routines-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     if (originalSecretsProviderEnv === undefined) {

--- a/server/src/__tests__/smoke-lab.test.ts
+++ b/server/src/__tests__/smoke-lab.test.ts
@@ -105,7 +105,7 @@ describeEmbeddedPostgres("smoke lab service pack and results API", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-smoke-lab-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.unstubAllEnvs();

--- a/server/src/__tests__/source-trust.test.ts
+++ b/server/src/__tests__/source-trust.test.ts
@@ -98,7 +98,7 @@ describeEmbeddedPostgres("resolveActorSourceTrustForIssue", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-source-trust-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(heartbeatRuns);

--- a/server/src/__tests__/status-cards.test.ts
+++ b/server/src/__tests__/status-cards.test.ts
@@ -79,7 +79,7 @@ describeEmbeddedPostgres("status card routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-status-cards-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(costEvents);

--- a/server/src/__tests__/summary-slots.test.ts
+++ b/server/src/__tests__/summary-slots.test.ts
@@ -42,7 +42,7 @@ describeEmbeddedPostgres("summary slot service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-summary-slots-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(summarySlots);

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -40,7 +40,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-task-watchdogs-scheduler-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/teams-catalog-install-no-overrides.test.ts
+++ b/server/src/__tests__/teams-catalog-install-no-overrides.test.ts
@@ -32,7 +32,7 @@ describeEmbeddedPostgres("teams catalog install with no caller adapter overrides
     process.env.PAPERCLIP_HOME = tempHome;
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-teams-catalog-no-overrides-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     if (oldPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;

--- a/server/src/__tests__/tool-access-policy-service.test.ts
+++ b/server/src/__tests__/tool-access-policy-service.test.ts
@@ -156,7 +156,7 @@ describeEmbeddedPostgres("tool access policy service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-tool-access-policy-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(toolRateLimitCounters);

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -426,7 +426,7 @@ describeEmbeddedPostgres("tool access service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-tool-access-service-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.restoreAllMocks();

--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -145,7 +145,7 @@ describeEmbeddedPostgres("tool gateway service", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-tool-gateway-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.unstubAllEnvs();

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -486,7 +486,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-tool-gateway-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/tool-oauth-legacy-backfill.test.ts
+++ b/server/src/__tests__/tool-oauth-legacy-backfill.test.ts
@@ -41,7 +41,7 @@ describeEmbeddedPostgres("tool OAuth legacy backfill", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-tool-oauth-backfill-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     vi.restoreAllMocks();

--- a/server/src/__tests__/user-profile-routes.test.ts
+++ b/server/src/__tests__/user-profile-routes.test.ts
@@ -39,7 +39,7 @@ describeEmbeddedPostgres("GET /companies/:companyId/users/:userSlug/profile", ()
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-user-profile-route-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   beforeEach(async () => {
     vi.resetModules();

--- a/server/src/__tests__/work-timeline-service.test.ts
+++ b/server/src/__tests__/work-timeline-service.test.ts
@@ -38,7 +38,7 @@ describeEmbeddedPostgres("work timeline aggregation", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-work-timeline-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(activityLog);

--- a/server/src/__tests__/workspace-runtime-service-authz.test.ts
+++ b/server/src/__tests__/workspace-runtime-service-authz.test.ts
@@ -37,7 +37,7 @@ describeEmbeddedPostgres("workspace runtime service authz helper", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-runtime-authz-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterEach(async () => {
     await db.delete(issues);

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -4714,7 +4714,7 @@ describeEmbeddedPostgres("workspace dirty quarantine branch repair", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-dirty-quarantine-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();
@@ -5356,7 +5356,7 @@ describeEmbeddedPostgres("workspace runtime service control persistence", () => 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-runtime-control-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();
@@ -5593,7 +5593,7 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-workspace-runtime-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  });
 
   afterAll(async () => {
     await tempDb?.cleanup();

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,17 +1,21 @@
 import { defineConfig } from "vitest/config";
+import {
+  EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS,
+  EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS,
+} from "../scripts/embedded-postgres-test-budget.mjs";
 
 export default defineConfig({
   test: {
     environment: "node",
     // Each server suite boots + tears down its own embedded Postgres in
-    // beforeAll/afterAll. Under the loaded serial shard (maxWorkers=1) the
-    // graceful shutdown can occasionally cross vitest's default 10s hookTimeout,
-    // producing flaky "Hook timed out in 10000ms" afterAll failures on CI. Give
-    // the boot/teardown hooks generous headroom; 30s is far above the observed
-    // worst-case teardown yet still catches a genuinely hung hook. teardownTimeout
-    // mirrors it for the same reason.
-    hookTimeout: 30000,
-    teardownTimeout: 30000,
+    // beforeAll/afterAll. The boot (initdb + start + applyPendingMigrations)
+    // costs ~92s on developer hardware, and the graceful shutdown under the
+    // loaded serial shard (maxWorkers=1) can also run long. The budget is
+    // centralized in scripts/embedded-postgres-test-budget.mjs (RBR-918) so it
+    // cannot drift per-file: inline hook budgets win over --hookTimeout, so a
+    // per-file value could not be corrected from CI configuration.
+    hookTimeout: EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS,
+    teardownTimeout: EMBEDDED_POSTGRES_TEARDOWN_TIMEOUT_MS,
     isolate: true,
     maxConcurrency: 1,
     maxWorkers: 1,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work. Its server holds the control-plane invariants: company scoping, atomic issue checkout, approval gates, budget stops.
> - Those invariants are guarded by DB-backed Vitest suites, each of which boots an embedded Postgres cluster inside `beforeAll`.
> - An inline `beforeAll(fn, timeoutMs)` argument silently overrides both the `hookTimeout` config value and the `--hookTimeout` CLI flag, so a per-file budget cannot be corrected from CI configuration.
> - Auditing every `startEmbeddedPostgresTestDatabase` call site found 150 of 152 inline hook budgets were set below the real ~92s import/boot cost (132 files at 20s, 14 at 30s, 4 at 60s). Two suites (`issue-thread-interactions-service.test.ts`, `issue-thread-interactions-telemetry.test.ts`) never reached their first assertion; Vitest reports a `beforeAll` failure of this kind as `skipped`, not failed, so the run still exited 0 and ~56 control-plane tests looked green while executing nothing.
> - A suite that cannot fail is worse than no suite: a real regression (an `issue-thread-interactions` default flip) shipped unchallenged because the file guarding it never ran.
> - This pull request centralizes the embedded-Postgres hook/teardown budget in one module, removes every inline per-file override so the centralized value always wins, and adds a CI-wired audit that fails the moment an inline budget reappears, plus a guard that fails a run reporting zero executed tests instead of letting it report success.
> - The benefit is that the previously-inert suites now execute, the budget can no longer drift per file, and a future zero-executed-suite regression fails loudly instead of silently.

## Linked Issues or Issue Description

No public GitHub issue tracks this. The underlying bug is described inline below, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

Related: #10961 also touches embedded-Postgres test bootstrapping (a shared-cluster-per-run approach) but is unmerged as of this PR and does not remove the inline hook-budget overrides across the wider codebase — the two changes address adjacent but distinct parts of the same defect class and should be reconciled by whichever lands second.

**What happened?**
Two DB-backed server suites gave their embedded-Postgres `beforeAll` a 20-second inline budget while the real boot took ~92s. The hook always timed out. Vitest reports a suite whose `beforeAll` fails this way as `skipped`, not failed, and the run still exits 0 — so ~56 tests reported green while never executing. Auditing every embedded-Postgres call site for the same defect class found 150 of 152 inline hook budgets below the real cost, not just the two originally reported.

**Expected behavior**
Every suite that boots embedded Postgres actually executes its tests, the hook/teardown budget cannot drift per file, and a suite that reports zero executed tests fails the run instead of reporting success.

**Steps to reproduce**
1. Check out `master` before this change.
2. Run `server/src/__tests__/issue-thread-interactions-service.test.ts` or `issue-thread-interactions-telemetry.test.ts` in isolation.
3. Observe every test in the file reports `skipped` and the process exits 0.

**Paperclip version or commit**
Reproduces on `master` at `dea7c4e274` ("add company work timeline endpoint") onward — the commit that introduced the `beforeAll` inline timeout pattern for embedded Postgres.

**Agent adapter(s) involved**
Not adapter-specific (server test infrastructure).

## What Changed

- Add `scripts/embedded-postgres-test-budget.mjs` as the single source of truth for the embedded-Postgres hook budget (180s hook, 60s teardown, 120s audit floor) so per-file drift is structurally impossible.
- Have every project's `vitest.config.ts` (`server/`, `packages/db/`, others) read the centralized budget instead of hardcoding an inline value.
- Remove all 152 inline `beforeAll`/`afterAll` hook-budget arguments across the affected test files, including the shared route-test-harness, so the centralized config value is always the one that applies.
- Add `scripts/audit-embedded-postgres-hook-budgets.mjs`, which fails when an inline budget reappears below the floor, and wire it into `pr.yml` CI and `pnpm check:embedded-postgres-budgets`.
- Add a zero-executed-suites guard (`scripts/check-executed-test-suites.test.mjs` + implementation) so a suite that reports no executed tests fails the run instead of silently passing.
- This un-hides 58 previously-inert tests. Note for reviewers: 8 of those newly-live tests are expected to fail once a separate in-flight default-flip change (`supersedeOnUserComment`) lands — that is the guard correctly catching a real behavior change, not a regression in this PR. This PR does not touch that flip; it stays a pure test-infrastructure fix.

## Verification

- `node scripts/audit-embedded-postgres-hook-budgets.mjs` → exits 0, 164 db-starting hooks scanned, 0 under budget.
- `node --test scripts/__tests__/check-executed-test-suites.test.mjs` → 6/6 passing.
- Rebased cleanly onto current `origin/master` tip with 0 merge conflicts (`git merge-tree` reported zero conflict markers before and after rebase).

## Risks

- Low-to-moderate. The change is mechanical (remove inline overrides, read from one shared constant) and does not alter any embedded-Postgres boot/teardown logic itself, but it touches 151 files, so the surface area for a stray typo is nontrivial — mitigated by the audit script exiting 0 across the full tree.
- Un-hiding 58 previously-skipped tests is intentional and expected to surface real, previously-invisible failures (documented above). Do not treat a red run on those specific 8 tests as caused by this PR — it is the guard working as designed once the unrelated default-flip change lands.
- Overlaps `server/vitest.config.ts` with the still-open #10961. Whichever of the two merges second will need a small rebase; flagging this now so it is not a surprise.

## Model Used

Claude Opus 4.8 (Anthropic), model id `claude-opus-4-8` — original fix authored on a prior heartbeat with extended thinking and tool use / code execution. This PR (rebase, verification, and submission) was executed by Claude Sonnet (Anthropic), model id `claude-sonnet-5`, standard reasoning mode, with tool use / code execution, acting as release engineering on the already-authored and verified commit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
