### PR TITLE
feat(shared): expose canReassignOwnedCards in agent permissions schema

### DIFF
--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -13,6 +13,7 @@ import { agentDesiredSkillSelectionSchema } from "./adapter-skills.js";
 export const agentPermissionsSchema = z.object({
   canCreateAgents: z.boolean().optional().default(false),
   canCreateSkills: z.boolean().optional().default(true),
+  canReassignOwnedCards: z.boolean().optional().default(true),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),
 }).catchall(z.unknown());
@@ -226,6 +227,7 @@ export const updateAgentPermissionsSchema = z.object({
   canCreateAgents: z.boolean(),
   canCreateSkills: z.boolean().optional(),
   canAssignTasks: z.boolean(),
+  canReassignOwnedCards: z.boolean().optional(),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),
 });


### PR DESCRIPTION
## Summary

The `canReassignOwnedCards` permission flag is written and persisted correctly (the schema's `.catchall(z.unknown())` accepts it), but it never round-trips through `GET /api/agents/{id}.permissions` because the zod schemas strip unknown keys before serialization. This patch adds it as a first-class optional field on both schemas so the flag is visible to operators and the UI.

## Change

Two additive lines in `packages/shared/src/validators/agent.ts`:

- `agentPermissionsSchema`: `canReassignOwnedCards: z.boolean().optional().default(true)` — defaults true to preserve current behavior (today only the run-ownership check gates PATCH `assigneeAgentId`, which is the correct behavior).
- `updateAgentPermissionsSchema`: `canReassignOwnedCards: z.boolean().optional()` — optional on update, like its siblings.

## Why

- **Non-breaking.** Both fields are optional with defaults; existing callers and persisted documents are unaffected.
- **Read-echo only.** The write path already accepts the value via the catchall; this only adds round-trip visibility.
- **No behavior change.** No server-side guard is introduced or removed. The existing run-ownership check remains the real gate.

## Verification

- TypeScript types regenerate via the standard `pnpm build` in the shared package.
- Round-trip test: `PATCH /api/agents/{id}/permissions { canReassignOwnedCards: true }` followed by `GET /api/agents/{id}.permissions` returns the flag.

## Context

- SPA-2064 (verdict + 403 repro evidence) — the Spark Mojo workflow that motivated this
- SPA-2086 (recipe-handoff) — the two-line recipe this PR implements
- SPA-2092 (this upstream filing) — provisioning + PR

Filed by Ty (Spark Mojo Tech Lead) on behalf of the paperclipai downstream that needed the flag visible.