### PR TITLE
fix(heartbeat): skip wake dispatch for done/cancelled issues

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -17431,6 +17431,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return { kind: "skipped" as const };
         }
 
+        // A card that reached a terminal status is not work. Every wake path
+        // (comment, mention, dependency-resolved, child-completion, recovery,
+        // timer) funnels through here, so one guard covers all of them — the
+        // callers that already pre-filter on `["backlog","done","cancelled"]`
+        // are belt-and-braces, not the enforcement point. Reopen/resume writes
+        // the issue back to `todo` before dispatching its wake, so this does
+        // not strand the revive path.
+        //
+        // ponytail: this returns before `cancelStaleScheduledRetry`, so a
+        // pending scheduled_retry on a cancelled issue is no longer torn down
+        // eagerly here. It is still suppressed when it becomes due
+        // (`shouldStartScheduledRetry` rejects terminal statuses), so no wake
+        // fires either way — only the tombstone row is written later.
+        if (issue.status === "done" || issue.status === "cancelled") {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_terminal_status",
+            payload: { ...(payload ?? {}), issueId, issueStatus: issue.status },
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
         if (worktreeExecutionCutoff && issue.createdAt < worktreeExecutionCutoff) {
           await tx.insert(agentWakeupRequests).values({
             companyId: agent.companyId,


### PR DESCRIPTION
## Problem

`enqueueWakeup` in `server/src/services/heartbeat.ts` is the single funnel every wake path routes through — comment, mention, dependency-resolved, child-completion, recovery, timer. It gates on company status, budget, pause holds, dependency readiness and the execution lock, but never on the **issue's own terminal status**.

Several callers pre-filter on `["backlog", "done", "cancelled"]` (`services/issues.ts` `getWakeableDependents` / `getWakeableParentAfterChildCompletion`, `plugin-host-services.ts` `requestWakeup(s)`), but the comment / mention / interaction-continuation paths in `routes/issues.ts` do not. So a card that is already `done` or `cancelled` can still be dispatched and burn a full agent run.

Observed in production: a probe card whose body read "No action needed. Will be deleted." consumed 369k tokens across 5 runs.

## Fix

One guard at the convergence point, immediately after the row is `SELECT ... FOR UPDATE`-locked and before any execution-lock work. It writes a `skipped` `agent_wakeup_requests` row with `reason: "issue_terminal_status"` rather than returning silently, so the suppression is visible in `GET /issues/:id/diagnostics/wakes`.

The per-caller pre-filters are left in place — they short-circuit earlier and avoid a pointless transaction; this is the enforcement point, not a replacement.

## Why not a new `deletionPending` column

A card slated for deletion is exactly what `cancelled` already means, and the status enum, the UI, and every existing pre-filter already understand it. A parallel boolean would be a second source of truth for "don't work this" that every one of those call sites would then have to learn.

## Reopen / resume is unaffected

Both revive paths (`reopen: true`, `resume: true`) write the issue back to `todo` *before* dispatching their wake — see `reopenFromStatus` capture at `routes/issues.ts:9121` and `:11096`, where `existing.status` is snapshotted precisely because the live row has already moved off the terminal status. The guard reads the locked row inside the transaction, so it sees `todo` and lets the wake through.

## Note on scheduled retries

The early return lands before `cancelStaleScheduledRetry`, so a pending `scheduled_retry` against a cancelled issue is no longer torn down eagerly on this path. It is still suppressed when it becomes due — `shouldStartScheduledRetry` rejects `cancelled` / `done` — so no wake fires either way; only the tombstone row is written later. Flagged in a comment at the call site.
