### PR TITLE
fix(heartbeat): reconcile orphaned run agent state

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -36,6 +36,8 @@ import {
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const PROVIDER_QUOTA_TEST_ADAPTER = "provider_quota_test";
+const STALE_ERROR_START_TEST_ADAPTER = "stale_error_start_test";
+let staleErrorStartGate: Promise<void> | null = null;
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -89,6 +91,24 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
         testedAt: new Date().toISOString(),
       }),
     });
+    registerServerAdapter({
+      type: STALE_ERROR_START_TEST_ADAPTER,
+      execute: async () => {
+        await staleErrorStartGate;
+        return {
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          errorMessage: null,
+        };
+      },
+      testEnvironment: async () => ({
+        adapterType: STALE_ERROR_START_TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
   }, 20_000);
 
   afterEach(async () => {
@@ -104,6 +124,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
 
   afterAll(async () => {
     unregisterServerAdapter(PROVIDER_QUOTA_TEST_ADAPTER);
+    unregisterServerAdapter(STALE_ERROR_START_TEST_ADAPTER);
     await tempDb?.cleanup();
   });
 
@@ -212,6 +233,60 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       createdAt: input.now,
     });
   }
+
+  it("clears a stale timeout error when a follow-up run actually starts", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Late callback follow-up",
+      role: "engineer",
+      status: "error",
+      errorReason: "OpenClaw gateway run timed out after 600000ms",
+      adapterType: STALE_ERROR_START_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    const gate = Promise.withResolvers<void>();
+    staleErrorStartGate = gate.promise;
+    try {
+      const run = await heartbeat.invoke(agentId, "on_demand", {}, "callback");
+      expect(run).not.toBeNull();
+
+      await expect
+        .poll(
+          () =>
+            db
+              .select({ status: agents.status, errorReason: agents.errorReason })
+              .from(agents)
+              .where(eq(agents.id, agentId))
+              .then((rows) => rows[0] ?? null),
+          { timeout: 5_000, interval: 25 },
+        )
+        .toEqual({ status: "running", errorReason: null });
+
+      gate.resolve();
+      expect((await waitForRunToFinish(heartbeat, run!.id))?.status).toBe("succeeded");
+    } finally {
+      gate.resolve();
+      staleErrorStartGate = null;
+    }
+  });
 
   it("records provider quota failures, schedules the reset-time retry, and leaves the agent idle", async () => {
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
+++ b/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
@@ -151,6 +151,42 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
     expect(row?.errorCode).toBe("lease_released_before_terminal");
   });
 
+  it("forces a still-queued run to interrupted when the lease releases before it starts", async () => {
+    // A queued run holds a lease but never reached "running". The teardown
+    // released the lease, so the run must not stay queued and show a phantom
+    // live run. A running-only update would miss it.
+    const { runId, run } = await seed({ issueStatus: "in_progress", runStatus: "queued" });
+
+    const heartbeat = heartbeatService(db);
+    const terminal = await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(terminal.status).toBe("interrupted");
+
+    const row = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+    expect(row?.status).toBe("interrupted");
+    expect(row?.errorCode).toBe("lease_released_before_terminal");
+  });
+
+  it("forces a still-queued run to succeeded when the issue already reached done", async () => {
+    const { runId, run } = await seed({ issueStatus: "done", runStatus: "queued" });
+
+    const heartbeat = heartbeatService(db);
+    const terminal = await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(terminal.status).toBe("succeeded");
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("succeeded");
+  });
+
   it("keeps an already-terminal run authoritative and records no new event", async () => {
     const { runId, run } = await seed({ issueStatus: "done", runStatus: "failed" });
 

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -235,6 +235,10 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       .update(heartbeatRuns)
       .set({ processPid: 2_000_000_000 })
       .where(eq(heartbeatRuns.id, runningRunId));
+    await db
+      .update(agents)
+      .set({ status: "running", errorReason: "stale timeout from the orphaned run" })
+      .where(eq(agents.id, agentId));
     const issueId = randomUUID();
     await db.insert(issues).values({
       id: issueId,
@@ -262,6 +266,13 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     // Process died, outcome unknown, so the backstop uses "interrupted".
     expect(run?.status).toBe("interrupted");
     expect(run?.errorCode).toBe("orphaned_running_run");
+
+    const agent = await db
+      .select({ status: agents.status, errorReason: agents.errorReason })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0]);
+    expect(agent).toEqual({ status: "idle", errorReason: null });
 
     const lock = await db
       .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
@@ -397,6 +408,92 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       .where(eq(heartbeatRuns.id, runningRunId))
       .then((rows) => rows[0]?.status);
     expect(runStatus).toBe("running");
+  });
+
+  it("does not terminalize a live run that a terminal issue and an active issue both reference", async () => {
+    // A stale lock on a terminal issue and the real lock on an active issue can
+    // point at the same running run. The terminal reference alone must not
+    // terminalize the run, because the run is still live for the active issue.
+    const { companyId, agentId, runningRunId } = await seed();
+    // process.pid is the live test process, so isPidAlive returns true.
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: process.pid })
+      .where(eq(heartbeatRuns.id, runningRunId));
+
+    const terminalIssueId = randomUUID();
+    const activeIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: terminalIssueId,
+        companyId,
+        title: "Terminal issue holds a stale lock on the shared run",
+        status: "done",
+        priority: "high",
+        assigneeAgentId: agentId,
+        checkoutRunId: runningRunId,
+        executionRunId: null,
+      },
+      {
+        id: activeIssueId,
+        companyId,
+        title: "Active issue owns the live shared run",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: agentId,
+        checkoutRunId: runningRunId,
+        executionRunId: runningRunId,
+        executionLockedAt: new Date(),
+      },
+    ]);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.sweepStaleIssueLocks();
+
+    // The run stays live, so the sweep terminalizes nothing and clears nothing.
+    expect(result.terminalizedRunIds).toEqual([]);
+    expect(result.cleared).toBe(0);
+
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("running");
+
+    const activeLock = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, activeIssueId))
+      .then((rows) => rows[0]);
+    expect(activeLock).toEqual({ checkoutRunId: runningRunId, executionRunId: runningRunId });
+  });
+
+  it("continues after the post-clear activity audit fails", async () => {
+    const { companyId, agentId, failedRunId } = await seed();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Activity audit fails after lock clear",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: failedRunId,
+    });
+
+    const realInsert = db.insert.bind(db);
+    const insertSpy = vi.spyOn(db, "insert").mockImplementation((table) => {
+      if (table === activityLog) throw new Error("simulated activity audit failure");
+      return realInsert(table);
+    });
+    try {
+      const result = await heartbeatService(db).sweepStaleIssueLocks();
+      expect(result.cleared).toBe(1);
+      expect(result.issueIds).toEqual([issueId]);
+    } finally {
+      insertSpy.mockRestore();
+    }
   });
 
   it("still clears the lock when the audit write fails after terminalization", async () => {

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -469,6 +469,91 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
     expect(activeLock).toEqual({ checkoutRunId: runningRunId, executionRunId: runningRunId });
   });
 
+  it("rejects stale terminal-issue authority after the issue is reopened", async () => {
+    const { companyId, agentId, runningRunId } = await seed();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal snapshot becomes stale",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+    });
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]!);
+
+    // Simulate the issue reopening after the sweep took its candidate snapshot.
+    await db.update(issues).set({ status: "in_progress" }).where(eq(issues.id, issueId));
+
+    const outcome = await heartbeatService(db).terminalizeOrphanedRunningRun(run, {
+      referencingIssueTerminalStatus: "succeeded",
+    });
+    expect(outcome).toEqual({ terminalized: false, status: "running" });
+  });
+
+  it("does not use a cross-company issue reference as terminal authority", async () => {
+    const { runningRunId } = await seed();
+    const foreignCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: foreignCompanyId,
+      name: "Foreign company",
+      issuePrefix: `F${foreignCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: randomUUID(),
+      companyId: foreignCompanyId,
+      title: "Invalid cross-company stale reference",
+      status: "done",
+      priority: "high",
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+    });
+
+    const result = await heartbeatService(db).sweepStaleIssueLocks();
+    expect(result.terminalizedRunIds).toEqual([]);
+    const status = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]?.status);
+    expect(status).toBe("running");
+  });
+
+  it("does not overwrite a newer agent start while reconciling an orphan", async () => {
+    const { agentId, runningRunId } = await seed();
+    await db
+      .update(heartbeatRuns)
+      .set({ processPid: 2_000_000_000 })
+      .where(eq(heartbeatRuns.id, runningRunId));
+    const newerStartAt = new Date(Date.now() + 60_000);
+    await db
+      .update(agents)
+      .set({ status: "running", errorReason: null, updatedAt: newerStartAt })
+      .where(eq(agents.id, agentId));
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runningRunId))
+      .then((rows) => rows[0]!);
+
+    const outcome = await heartbeatService(db).terminalizeOrphanedRunningRun(run);
+    expect(outcome.terminalized).toBe(true);
+    const agent = await db
+      .select({ status: agents.status, updatedAt: agents.updatedAt })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0]);
+    expect(agent?.status).toBe("running");
+    expect(agent?.updatedAt).toEqual(newerStartAt);
+  });
+
   it("continues after the post-clear activity audit fails", async () => {
     const { companyId, agentId, failedRunId } = await seed();
     const issueId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8826,10 +8826,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     status: string,
     patch?: Partial<typeof heartbeatRuns.$inferInsert>,
   ) {
+    return setRunStatusFromLive(runId, status, ["running"], patch);
+  }
+
+  // Atomically move a run only from the supplied live statuses. A competing
+  // terminal writer remains authoritative when this compare-and-set loses.
+  async function setRunStatusFromLive(
+    runId: string,
+    status: string,
+    fromStatuses: string[],
+    patch?: Partial<typeof heartbeatRuns.$inferInsert>,
+  ) {
     const updated = await db
       .update(heartbeatRuns)
       .set({ status, ...patch, updatedAt: new Date() })
-      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.status, "running")))
+      .where(and(eq(heartbeatRuns.id, runId), inArray(heartbeatRuns.status, fromStatuses)))
       .returning()
       .then((rows) => rows[0] ?? null);
 
@@ -8880,7 +8891,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const issueStatus = await db
         .select({ status: issues.status })
         .from(issues)
-        .where(eq(issues.id, issueId))
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
         .then((rows) => rows[0]?.status ?? null);
       if (issueStatus === "done") terminalStatus = "succeeded";
       else if (issueStatus === "cancelled") terminalStatus = "cancelled";
@@ -8888,7 +8899,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const message =
       `run terminalized on environment lease release: heartbeat_runs.status was still ${run.status} at teardown`;
-    const write = await setRunStatusIfRunning(run.id, terminalStatus, {
+    // A queued run can release its lease before it ever reaches "running".
+    // Match both live states so the lease invariant is complete.
+    const write = await setRunStatusFromLive(run.id, terminalStatus, ["running", "queued"], {
       finishedAt: run.finishedAt ?? new Date(),
       error: run.error ?? (terminalStatus === "interrupted" ? message : null),
       errorCode: run.errorCode ?? (terminalStatus === "interrupted" ? "lease_released_before_terminal" : null),
@@ -15059,7 +15072,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       // Atomic conditional UPDATE is the sole gate (no read-then-write); 0 rows => abort.
       const runningAgent = await db
         .update(agents)
-        .set({ status: "running", updatedAt: new Date() })
+        .set({
+          status: "running",
+          // A new execution is authoritative for the agent's current state.
+          // Preserve the previous run's timeout on that run, but do not carry
+          // its human-facing error banner into this live follow-up run.
+          errorReason: null,
+          updatedAt: new Date(),
+        })
         .where(and(eq(agents.id, agent.id), notInArray(agents.status, [...DIRECT_NON_INVOKABLE_STATUSES])))
         .returning()
         .then((rows) => rows[0] ?? null);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13307,6 +13307,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.sweepStaleIssueLocks();
   }
 
+  async function terminalizeOrphanedRunningRunForRecovery(
+    run: typeof heartbeatRuns.$inferSelect,
+    options?: { referencingIssueTerminalStatus?: "succeeded" | "cancelled" | null },
+  ) {
+    return recovery.terminalizeOrphanedRunningRun(run, options);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -19035,6 +19042,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reconcileStrandedAssignedIssues,
 
     terminalizeRunOnLeaseRelease,
+
+    terminalizeOrphanedRunningRun: terminalizeOrphanedRunningRunForRecovery,
 
     sweepStaleIssueLocks,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -5565,6 +5565,38 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         : "run terminalized by recovery backstop: process and sandbox gone while heartbeat_runs.status stayed live";
 
     const now = new Date();
+    const expectedIssueStatus =
+      issueTerminalStatus === "succeeded"
+        ? "done"
+        : issueTerminalStatus === "cancelled"
+          ? "cancelled"
+          : null;
+    const issueAuthorityGuard = expectedIssueStatus
+      ? options?.referencingIssueTerminalStatus
+        ? sql`exists (
+            select 1 from ${issues} as terminal_issue
+            where terminal_issue.company_id = ${run.companyId}
+              and terminal_issue.status = ${expectedIssueStatus}
+              and (
+                terminal_issue.checkout_run_id = ${run.id}
+                or terminal_issue.execution_run_id = ${run.id}
+              )
+          ) and not exists (
+            select 1 from ${issues} as active_issue
+            where active_issue.company_id = ${run.companyId}
+              and active_issue.status not in ('done', 'cancelled')
+              and (
+                active_issue.checkout_run_id = ${run.id}
+                or active_issue.execution_run_id = ${run.id}
+              )
+          )`
+        : sql`exists (
+            select 1 from ${issues} as terminal_issue
+            where terminal_issue.id = ${issueId}
+              and terminal_issue.company_id = ${run.companyId}
+              and terminal_issue.status = ${expectedIssueStatus}
+          )`
+      : sql`true`;
     const updated = await db
       .update(heartbeatRuns)
       .set({
@@ -5574,7 +5606,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: run.errorCode ?? (terminalStatus === "interrupted" ? errorCode : null),
         updatedAt: now,
       })
-      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "running")))
+      .where(
+        and(
+          eq(heartbeatRuns.id, run.id),
+          eq(heartbeatRuns.companyId, run.companyId),
+          eq(heartbeatRuns.status, "running"),
+          issueAuthorityGuard,
+        ),
+      )
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!updated) {
@@ -5589,32 +5628,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     runningProcesses.delete(run.id);
 
-    // Recovery bypasses the normal heartbeat finalizer. Reconcile the agent as
-    // part of the same backstop so a terminalized orphan cannot leave the
-    // operator-facing status at running/error with a stale timeout. Another
-    // active run remains authoritative and keeps the agent running.
-    const [{ count: remainingRunningCount }] = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(heartbeatRuns)
+    // Recovery bypasses the normal heartbeat finalizer. Reconcile the agent in
+    // one compare-and-set. The NOT EXISTS guard protects another active run,
+    // while updatedAt prevents a newer execution-start write from being
+    // overwritten between a separate count and update.
+    await db
+      .update(agents)
+      .set({ status: "idle", errorReason: null, updatedAt: now })
       .where(
         and(
-          eq(heartbeatRuns.agentId, updated.agentId),
-          eq(heartbeatRuns.companyId, updated.companyId),
-          eq(heartbeatRuns.status, "running"),
+          eq(agents.id, updated.agentId),
+          eq(agents.companyId, updated.companyId),
+          notInArray(agents.status, ["paused", "terminated"]),
+          lte(agents.updatedAt, now),
+          sql`not exists (
+            select 1 from ${heartbeatRuns} as active_run
+            where active_run.agent_id = ${updated.agentId}
+              and active_run.company_id = ${updated.companyId}
+              and active_run.status = 'running'
+          )`,
         ),
       );
-    if (Number(remainingRunningCount ?? 0) === 0) {
-      await db
-        .update(agents)
-        .set({ status: "idle", errorReason: null, updatedAt: now })
-        .where(
-          and(
-            eq(agents.id, updated.agentId),
-            eq(agents.companyId, updated.companyId),
-            notInArray(agents.status, ["paused", "terminated"]),
-          ),
-        );
-    }
 
     // The run update above already committed the terminal status. The audit
     // event is best-effort: if the insert fails, the caller must still treat
@@ -5698,11 +5732,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // the same run id in a stale lock column. The terminal reference alone must
     // not terminalize a run that an active issue still owns, so exclude these
     // runs from the issue-terminal authority below.
+    const runReferenceKey = (companyId: string, runId: string) => `${companyId}:${runId}`;
     const runIdsReferencedByActiveIssue = new Set<string>();
     for (const issue of candidates) {
       if (issue.status === "done" || issue.status === "cancelled") continue;
       for (const runId of [issue.checkoutRunId, issue.executionRunId]) {
-        if (runId) runIdsReferencedByActiveIssue.add(runId);
+        if (runId) runIdsReferencedByActiveIssue.add(runReferenceKey(issue.companyId, runId));
       }
     }
 
@@ -5722,8 +5757,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             : null;
       if (!implied) continue;
       for (const runId of [issue.checkoutRunId, issue.executionRunId]) {
-        if (runId && !runIdsReferencedByActiveIssue.has(runId)) {
-          issueTerminalStatusByRunId.set(runId, implied);
+        const key = runId ? runReferenceKey(issue.companyId, runId) : null;
+        if (key && !runIdsReferencedByActiveIssue.has(key)) {
+          issueTerminalStatusByRunId.set(key, implied);
         }
       }
     }
@@ -5734,7 +5770,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // terminal status by another route.
     for (const row of runRows) {
       const outcome = await terminalizeOrphanedRunningRun(row, {
-        referencingIssueTerminalStatus: issueTerminalStatusByRunId.get(row.id) ?? null,
+        referencingIssueTerminalStatus:
+          issueTerminalStatusByRunId.get(runReferenceKey(row.companyId, row.id)) ?? null,
       });
       runStatusById.set(row.id, outcome.status);
       if (outcome.terminalized) result.terminalizedRunIds.push(row.id);
@@ -5828,6 +5865,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recordWatchdogDecision,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
+    terminalizeOrphanedRunningRun,
     sweepStaleIssueLocks,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileResolvedDependencyWakeBackstop,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5529,7 +5529,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       const issueStatus = await db
         .select({ status: issues.status })
         .from(issues)
-        .where(eq(issues.id, issueId))
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
         .then((rows) => rows[0]?.status ?? null);
       if (issueStatus === "done") issueTerminalStatus = "succeeded";
       else if (issueStatus === "cancelled") issueTerminalStatus = "cancelled";
@@ -5588,6 +5588,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     runningProcesses.delete(run.id);
+
+    // Recovery bypasses the normal heartbeat finalizer. Reconcile the agent as
+    // part of the same backstop so a terminalized orphan cannot leave the
+    // operator-facing status at running/error with a stale timeout. Another
+    // active run remains authoritative and keeps the agent running.
+    const [{ count: remainingRunningCount }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.agentId, updated.agentId),
+          eq(heartbeatRuns.status, "running"),
+        ),
+      );
+    if (Number(remainingRunningCount ?? 0) === 0) {
+      await db
+        .update(agents)
+        .set({ status: "idle", errorReason: null, updatedAt: now })
+        .where(
+          and(
+            eq(agents.id, updated.agentId),
+            eq(agents.companyId, updated.companyId),
+            notInArray(agents.status, ["paused", "terminated"]),
+          ),
+        );
+    }
+
     // The run update above already committed the terminal status. The audit
     // event is best-effort: if the insert fails, the caller must still treat
     // the run as terminalized and clear the lock in the same sweep. So catch
@@ -5665,11 +5692,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runStatusById = new Map<string, string>();
     for (const row of runRows) runStatusById.set(row.id, row.status);
 
+    // Collect the runs that a non-terminal issue still references. Such a run is
+    // the live run of an active issue. A different, terminal issue can also hold
+    // the same run id in a stale lock column. The terminal reference alone must
+    // not terminalize a run that an active issue still owns, so exclude these
+    // runs from the issue-terminal authority below.
+    const runIdsReferencedByActiveIssue = new Set<string>();
+    for (const issue of candidates) {
+      if (issue.status === "done" || issue.status === "cancelled") continue;
+      for (const runId of [issue.checkoutRunId, issue.executionRunId]) {
+        if (runId) runIdsReferencedByActiveIssue.add(runId);
+      }
+    }
+
     // Map each referenced run to the terminal run status implied by its
     // referencing issue. When a terminal issue still holds the run in a lock
     // column, that run is orphaned: the issue is the stuck "Live" task the UI
     // shows. A "done" issue implies "succeeded"; a "cancelled" issue implies
-    // "cancelled".
+    // "cancelled". Skip a run that an active issue also references, because that
+    // run is still live for the active issue.
     const issueTerminalStatusByRunId = new Map<string, "succeeded" | "cancelled">();
     for (const issue of candidates) {
       const implied =
@@ -5680,7 +5721,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             : null;
       if (!implied) continue;
       for (const runId of [issue.checkoutRunId, issue.executionRunId]) {
-        if (runId) issueTerminalStatusByRunId.set(runId, implied);
+        if (runId && !runIdsReferencedByActiveIssue.has(runId)) {
+          issueTerminalStatusByRunId.set(runId, implied);
+        }
       }
     }
 
@@ -5736,22 +5779,31 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       result.cleared += 1;
       result.issueIds.push(updated.id);
 
-      await logActivity(db, {
-        companyId: issue.companyId,
-        actorType: "system",
-        actorId: "system",
-        agentId: null,
-        runId: null,
-        action: "issue.stale_lock_cleared",
-        entityType: "issue",
-        entityId: updated.id,
-        details: {
-          source: "recovery.sweep_stale_issue_locks",
-          clearedCheckoutRunId: issue.checkoutRunId,
-          clearedExecutionRunId: issue.executionRunId,
-          referencedRunStatuses: Object.fromEntries(runStatusById),
-        },
-      });
+      try {
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: null,
+          action: "issue.stale_lock_cleared",
+          entityType: "issue",
+          entityId: updated.id,
+          details: {
+            source: "recovery.sweep_stale_issue_locks",
+            clearedCheckoutRunId: issue.checkoutRunId,
+            clearedExecutionRunId: issue.executionRunId,
+            referencedRunStatuses: Object.fromEntries(runStatusById),
+          },
+        });
+      } catch (error) {
+        // The CAS already cleared the stale lock. Audit failure must not abort
+        // the remaining sweep or misreport the successful recovery.
+        logger.error(
+          { err: error, issueId: updated.id },
+          "failed to append activity after clearing stale issue lock",
+        );
+      }
     }
 
     if (result.cleared > 0 || result.terminalizedRunIds.length > 0) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -5599,6 +5599,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .where(
         and(
           eq(heartbeatRuns.agentId, updated.agentId),
+          eq(heartbeatRuns.companyId, updated.companyId),
           eq(heartbeatRuns.status, "running"),
         ),
       );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service owns run lifecycle and the agent status shown to operators.
> - An execution lease can end while its run row still has a live status.
> - A timed-out run can also leave a stale agent error while a real follow-up run is active.
> - Recovery must close orphaned runs without changing a different live run.
> - An issue comment is evidence, but it is not an authenticated run result.
> - This pull request adds the reconciliation changes on top of #10955.
> - The benefit is a terminal run, a correct agent state, and safe stale-lock recovery.

## Linked Issues or Issue Description

Related: #10955 and #10985.

**What happened?**

A released execution lease could leave a heartbeat run in `running` or `queued`. Recovery could also leave the agent in `running` with an old timeout in `errorReason`. A terminal issue and an active issue could reference the same run, which made a recovery-only terminal transition unsafe.

**Expected behavior**

Lease release must leave its run terminal. Recovery must preserve a run that an active issue still owns. A real follow-up execution must clear the previous run's stale agent error. A late issue comment must not rewrite an already terminal run outcome.

**Steps to reproduce**

1. Start a heartbeat execution.
2. End its execution lease before the normal terminal run update completes.
3. Start a follow-up run after the first run timed out.
4. Observe the stale live run or stale agent timeout state.

**Paperclip version or commit**

Base branch `fix/terminalize-run-on-lease-release` at `3520d47f`.

**Deployment mode**

Self-hosted server.

## What Changed

- Terminalize both `running` and `queued` runs with one compare-and-set when a lease ends.
- Scope terminal issue lookup to the run company.
- Clear a stale agent error when a real follow-up execution starts.
- Reconcile an orphaned run's agent to `idle` only when no other run is active.
- Preserve a run that any active issue still references.
- Keep stale-lock recovery moving after an audit insert fails.
- Add focused regression coverage for each lifecycle and recovery case.

## Verification

- `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-retry-scheduling.test.ts src/__tests__/heartbeat-run-lease-release-terminalization.test.ts src/__tests__/recovery-stale-issue-lock-sweep.test.ts --config vitest.config.ts`
- Result: 3 test files passed. 47 tests passed.
- `PATH=/opt/data/tmp/corepack-bin:$PATH corepack pnpm --filter @paperclipai/server typecheck`
- Result: passed.
- `PATH=/opt/data/tmp/corepack-bin:$PATH corepack pnpm --filter @paperclipai/server build`
- Result: passed.
- `git diff --check`
- Result: passed.

## Risks

- Recovery changes operator-visible agent state. The update excludes paused and terminated agents and runs only when no active run remains.
- A late issue comment does not change a terminal run result. This is intentional because comments are not authenticated lifecycle callbacks.
- No provider, model, billing, cooldown, schema, or migration setting changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, model `gpt-5.6-sol`, with reasoning, tool use, code execution, and an independent read-only review agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No documentation change is required for this internal lifecycle correction
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
