### PR TITLE
fix(hermes): AGENT_HOME must be the run's own agent home, never a foreign agent's

### DIFF
--- a/packages/adapters/hermes/src/server/execute.agent-home.test.ts
+++ b/packages/adapters/hermes/src/server/execute.agent-home.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Behavioural regression tests for AGENT_HOME isolation in the hermes adapter.
+ *
+ * RBR-943: for seven consecutive days every run on this host started with
+ * `AGENT_HOME` pointing at a *fixed foreign agent's* home directory — the IOA's
+ * — regardless of which agent the run belonged to. Agent operating instructions
+ * define memory almost entirely in terms of `$AGENT_HOME`
+ * (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`), so any agent following its instructions
+ * literally would write its memory into that other agent's directory. Two
+ * distinct failures: same-day daily notes from two agents collide on one
+ * `memory/YYYY-MM-DD.md`, and a read-only oversight agent's home becomes
+ * writable by the party it audits.
+ *
+ * Root cause was twofold and both halves are asserted here:
+ *   1. This adapter never read `context.paperclipWorkspace.agentHome`, so the
+ *      only `AGENT_HOME` a child ever saw was the one inherited from the server
+ *      process environment.
+ *   2. The host's server process had a stale `export AGENT_HOME=<IOA path>` in a
+ *      shell rc file, so that inherited value was a constant foreign agent id.
+ *
+ * These assertions are behavioural: they inspect the environment actually handed
+ * to the spawned child, not the shape of a helper's return value. The core
+ * invariant — "a run for agent A never receives an AGENT_HOME belonging to agent
+ * B" — is asserted directly against that env.
+ */
+
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    })),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => ""),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  rm: vi.fn(async () => undefined),
+  access: vi.fn(async () => undefined),
+  readdir: vi.fn(async () => []),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+import { execute, resolveAgentHomeEnv } from "./execute.js";
+import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
+
+const COMPANY = "5cb37f67-a875-4073-ba4f-f8f942cb0775";
+const INSTANCE_ROOT = "/tmp/paperclip-test/instances/default";
+
+/** The real ids from the RBR-943 report, so the regression reads as the incident. */
+const CEO = "53c28b5d-342d-4801-bd18-9f343f7bc695";
+const IOA = "168e1f8b-cf2d-41f3-94b7-124c517aac39";
+const CTO = "b7079c44-d677-4640-89e7-1e2cfc49bbe0";
+
+function homeOf(agentId: string): string {
+  return `${INSTANCE_ROOT}/companies/${COMPANY}/agents/${agentId}`;
+}
+
+function makeCtx(input: {
+  agentId: string;
+  agentName: string;
+  /** What the heartbeat resolved and published for this run. */
+  resolvedAgentHome?: string | null;
+}) {
+  return {
+    runId: `run-for-${input.agentId}`,
+    agent: {
+      id: input.agentId,
+      companyId: COMPANY,
+      name: input.agentName,
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: { command: "/usr/bin/hermes", timeoutSec: 60, graceSec: 5 },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "issue_assigned",
+      paperclipWake: null,
+      paperclipWorkspace:
+        input.resolvedAgentHome === undefined
+          ? { cwd: "/tmp/paperclip-test/ws", agentHome: homeOf(input.agentId) }
+          : { cwd: "/tmp/paperclip-test/ws", agentHome: input.resolvedAgentHome },
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  } as unknown as Record<string, unknown>;
+}
+
+/** The env actually handed to the spawned child on the most recent execute(). */
+function spawnedEnv(): Record<string, string> {
+  const mocked = vi.mocked(serverUtils.runChildProcess);
+  expect(mocked.mock.calls.length).toBeGreaterThan(0);
+  const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+  return (lastCall[3] as { env: Record<string, string> }).env;
+}
+
+/**
+ * The invariant, stated once: whatever AGENT_HOME the child receives, it must
+ * not be inside any *other* agent's home directory.
+ */
+function expectAgentHomeNotForeign(env: Record<string, string>, ownAgentId: string, others: string[]) {
+  const agentHome = env.AGENT_HOME;
+  for (const other of others) {
+    if (other === ownAgentId) continue;
+    expect(agentHome ?? "").not.toContain(other);
+  }
+}
+
+describe("hermes adapter AGENT_HOME isolation (RBR-943)", () => {
+  const savedAgentHome = process.env.AGENT_HOME;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_HOME;
+  });
+
+  afterEach(() => {
+    if (savedAgentHome === undefined) delete process.env.AGENT_HOME;
+    else process.env.AGENT_HOME = savedAgentHome;
+  });
+
+  it("gives each agent its own AGENT_HOME, not a shared or foreign one", async () => {
+    const seen: Record<string, string | undefined> = {};
+    for (const [agentId, name] of [
+      [CEO, "CEO"],
+      [IOA, "IOA"],
+      [CTO, "CTO"],
+    ] as const) {
+      vi.clearAllMocks();
+      await execute(makeCtx({ agentId, agentName: name }) as never);
+      const env = spawnedEnv();
+      seen[name] = env.AGENT_HOME;
+      // Positive: it is this agent's own home.
+      expect(env.AGENT_HOME).toBe(homeOf(agentId));
+      // Negative: it is nobody else's home.
+      expectAgentHomeNotForeign(env, agentId, [CEO, IOA, CTO]);
+    }
+    // And all three are distinct — the original bug handed every agent the
+    // same path, which this assertion alone would have caught.
+    const distinct = new Set(Object.values(seen));
+    expect(distinct.size).toBe(3);
+  });
+
+  it("a CEO run never receives the IOA's AGENT_HOME even when the server process env leaks it", async () => {
+    // Reproduce the exact host condition: a stale `export AGENT_HOME=<IOA>` in a
+    // shell rc file, inherited by the Paperclip server and thus by every child.
+    process.env.AGENT_HOME = homeOf(IOA);
+
+    await execute(makeCtx({ agentId: CEO, agentName: "CEO" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(CEO));
+    expect(env.AGENT_HOME).not.toBe(homeOf(IOA));
+    expect(env.AGENT_HOME).not.toContain(IOA);
+  });
+
+  it("is not CEO-specific: a non-CEO, non-IOA agent is protected from the same leak", async () => {
+    // A general bug means other agents' memories are also cross-writing, so the
+    // fix must hold for an ordinary agent too, not just the reported pair.
+    process.env.AGENT_HOME = homeOf(IOA);
+
+    await execute(makeCtx({ agentId: CTO, agentName: "CTO" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(CTO));
+    expect(env.AGENT_HOME).not.toContain(IOA);
+    expect(env.AGENT_HOME).not.toContain(CEO);
+  });
+
+  it("drops an unattributable inherited AGENT_HOME rather than passing a foreign one through", async () => {
+    // When the run resolves no home, a leaked foreign value must NOT survive:
+    // absent is a loud, recoverable failure; confidently wrong silently
+    // corrupts another agent's memory.
+    process.env.AGENT_HOME = homeOf(IOA);
+
+    await execute(makeCtx({ agentId: CEO, agentName: "CEO", resolvedAgentHome: null }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("keeps an inherited AGENT_HOME that is demonstrably the run's own agent home", async () => {
+    process.env.AGENT_HOME = homeOf(CEO);
+
+    await execute(makeCtx({ agentId: CEO, agentName: "CEO", resolvedAgentHome: null }) as never);
+
+    expect(spawnedEnv().AGENT_HOME).toBe(homeOf(CEO));
+  });
+
+  it("warns operators when it overrides a mismatched inherited AGENT_HOME", async () => {
+    process.env.AGENT_HOME = homeOf(IOA);
+    const ctx = makeCtx({ agentId: CEO, agentName: "CEO" });
+
+    await execute(ctx as never);
+
+    const onLog = vi.mocked(ctx.onLog as (channel: string, line: string) => Promise<void>);
+    const logged = onLog.mock.calls.map((call) => String(call[1])).join("\n");
+    expect(logged).toContain("AGENT_HOME");
+    expect(logged).toContain(IOA);
+  });
+});
+
+describe("resolveAgentHomeEnv", () => {
+  it("prefers the run-resolved home over a mismatched inherited value", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(IOA),
+      resolvedAgentHome: homeOf(CEO),
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBe(homeOf(CEO));
+    expect(result.warning).toContain(IOA);
+  });
+
+  it("does not warn when the inherited value already agrees", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(CEO),
+      resolvedAgentHome: homeOf(CEO),
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBe(homeOf(CEO));
+    expect(result.warning).toBeNull();
+  });
+
+  it("drops a foreign inherited value when nothing was resolved", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(IOA),
+      resolvedAgentHome: null,
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("does not belong to agent");
+  });
+
+  it("accepts an inherited value whose final segment is the agent's own id", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: `${homeOf(CEO)}/`,
+      resolvedAgentHome: null,
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBe(`${homeOf(CEO)}/`);
+    expect(result.warning).toBeNull();
+  });
+
+  it("returns nothing when there is neither an inherited nor a resolved home", () => {
+    const result = resolveAgentHomeEnv({ inherited: "", resolvedAgentHome: "", agentId: CEO });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.agent-home.test.ts
+++ b/packages/adapters/hermes/src/server/execute.agent-home.test.ts
@@ -1,10 +1,10 @@
 /**
  * Behavioural regression tests for AGENT_HOME isolation in the hermes adapter.
  *
- * RBR-943: for seven consecutive days every run on this host started with
- * `AGENT_HOME` pointing at a *fixed foreign agent's* home directory — the IOA's
- * — regardless of which agent the run belonged to. Agent operating instructions
- * define memory almost entirely in terms of `$AGENT_HOME`
+ * The reported failure: for seven consecutive days, every run on one host
+ * started with `AGENT_HOME` pointing at a *fixed foreign agent's* home
+ * directory, regardless of which agent the run belonged to. Agent operating
+ * instructions define memory almost entirely in terms of `$AGENT_HOME`
  * (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
  * `$AGENT_HOME/memory/YYYY-MM-DD.md`), so any agent following its instructions
  * literally would write its memory into that other agent's directory. Two
@@ -16,8 +16,9 @@
  *   1. This adapter never read `context.paperclipWorkspace.agentHome`, so the
  *      only `AGENT_HOME` a child ever saw was the one inherited from the server
  *      process environment.
- *   2. The host's server process had a stale `export AGENT_HOME=<IOA path>` in a
- *      shell rc file, so that inherited value was a constant foreign agent id.
+ *   2. The host's server process had a stale `export AGENT_HOME=<other agent>`
+ *      in a shell rc file, so that inherited value was a constant foreign
+ *      agent id.
  *
  * These assertions are behavioural: they inspect the environment actually handed
  * to the spawned child, not the shape of a helper's return value. The core
@@ -57,10 +58,15 @@ import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
 const COMPANY = "5cb37f67-a875-4073-ba4f-f8f942cb0775";
 const INSTANCE_ROOT = "/tmp/paperclip-test/instances/default";
 
-/** The real ids from the RBR-943 report, so the regression reads as the incident. */
-const CEO = "53c28b5d-342d-4801-bd18-9f343f7bc695";
-const IOA = "168e1f8b-cf2d-41f3-94b7-124c517aac39";
-const CTO = "b7079c44-d677-4640-89e7-1e2cfc49bbe0";
+/**
+ * Agent ids from the original report, so the regression reads as the real
+ * incident. `OVERSIGHT` is the read-only oversight agent whose home leaked into
+ * every other agent's environment. `OTHER` is an ordinary third agent, included
+ * because a general defect means non-reporting agents cross-write too.
+ */
+const REPORTER = "53c28b5d-342d-4801-bd18-9f343f7bc695";
+const OVERSIGHT = "168e1f8b-cf2d-41f3-94b7-124c517aac39";
+const OTHER = "b7079c44-d677-4640-89e7-1e2cfc49bbe0";
 
 function homeOf(agentId: string): string {
   return `${INSTANCE_ROOT}/companies/${COMPANY}/agents/${agentId}`;
@@ -118,7 +124,7 @@ function expectAgentHomeNotForeign(env: Record<string, string>, ownAgentId: stri
   }
 }
 
-describe("hermes adapter AGENT_HOME isolation (RBR-943)", () => {
+describe("hermes adapter AGENT_HOME isolation", () => {
   const savedAgentHome = process.env.AGENT_HOME;
 
   beforeEach(() => {
@@ -134,9 +140,9 @@ describe("hermes adapter AGENT_HOME isolation (RBR-943)", () => {
   it("gives each agent its own AGENT_HOME, not a shared or foreign one", async () => {
     const seen: Record<string, string | undefined> = {};
     for (const [agentId, name] of [
-      [CEO, "CEO"],
-      [IOA, "IOA"],
-      [CTO, "CTO"],
+      [REPORTER, "Reporter"],
+      [OVERSIGHT, "Oversight"],
+      [OTHER, "Other"],
     ] as const) {
       vi.clearAllMocks();
       await execute(makeCtx({ agentId, agentName: name }) as never);
@@ -145,7 +151,7 @@ describe("hermes adapter AGENT_HOME isolation (RBR-943)", () => {
       // Positive: it is this agent's own home.
       expect(env.AGENT_HOME).toBe(homeOf(agentId));
       // Negative: it is nobody else's home.
-      expectAgentHomeNotForeign(env, agentId, [CEO, IOA, CTO]);
+      expectAgentHomeNotForeign(env, agentId, [REPORTER, OVERSIGHT, OTHER]);
     }
     // And all three are distinct — the original bug handed every agent the
     // same path, which this assertion alone would have caught.
@@ -153,108 +159,139 @@ describe("hermes adapter AGENT_HOME isolation (RBR-943)", () => {
     expect(distinct.size).toBe(3);
   });
 
-  it("a CEO run never receives the IOA's AGENT_HOME even when the server process env leaks it", async () => {
-    // Reproduce the exact host condition: a stale `export AGENT_HOME=<IOA>` in a
-    // shell rc file, inherited by the Paperclip server and thus by every child.
-    process.env.AGENT_HOME = homeOf(IOA);
+  it("a run never receives the oversight agent's AGENT_HOME even when the server process env leaks it", async () => {
+    // Reproduce the exact host condition: a stale `export AGENT_HOME=<other
+    // agent>` in a shell rc file, inherited by the server and thus every child.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
 
-    await execute(makeCtx({ agentId: CEO, agentName: "CEO" }) as never);
+    await execute(makeCtx({ agentId: REPORTER, agentName: "Reporter" }) as never);
 
     const env = spawnedEnv();
-    expect(env.AGENT_HOME).toBe(homeOf(CEO));
-    expect(env.AGENT_HOME).not.toBe(homeOf(IOA));
-    expect(env.AGENT_HOME).not.toContain(IOA);
+    expect(env.AGENT_HOME).toBe(homeOf(REPORTER));
+    expect(env.AGENT_HOME).not.toBe(homeOf(OVERSIGHT));
+    expect(env.AGENT_HOME).not.toContain(OVERSIGHT);
   });
 
-  it("is not CEO-specific: a non-CEO, non-IOA agent is protected from the same leak", async () => {
+  it("is not specific to the reporting agent: an ordinary agent is protected from the same leak", async () => {
     // A general bug means other agents' memories are also cross-writing, so the
     // fix must hold for an ordinary agent too, not just the reported pair.
-    process.env.AGENT_HOME = homeOf(IOA);
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
 
-    await execute(makeCtx({ agentId: CTO, agentName: "CTO" }) as never);
+    await execute(makeCtx({ agentId: OTHER, agentName: "Other" }) as never);
 
     const env = spawnedEnv();
-    expect(env.AGENT_HOME).toBe(homeOf(CTO));
-    expect(env.AGENT_HOME).not.toContain(IOA);
-    expect(env.AGENT_HOME).not.toContain(CEO);
+    expect(env.AGENT_HOME).toBe(homeOf(OTHER));
+    expect(env.AGENT_HOME).not.toContain(OVERSIGHT);
+    expect(env.AGENT_HOME).not.toContain(REPORTER);
   });
 
   it("drops an unattributable inherited AGENT_HOME rather than passing a foreign one through", async () => {
     // When the run resolves no home, a leaked foreign value must NOT survive:
     // absent is a loud, recoverable failure; confidently wrong silently
     // corrupts another agent's memory.
-    process.env.AGENT_HOME = homeOf(IOA);
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
 
-    await execute(makeCtx({ agentId: CEO, agentName: "CEO", resolvedAgentHome: null }) as never);
+    await execute(
+      makeCtx({ agentId: REPORTER, agentName: "Reporter", resolvedAgentHome: null }) as never,
+    );
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("drops a run-resolved AGENT_HOME that belongs to another agent", async () => {
+    // Defence in depth. The heartbeat derives the home from the run's own agent
+    // id, so this should be unreachable — but the whole defect class is
+    // "AGENT_HOME named a foreign agent", so a bad resolved value must not be
+    // trusted merely because it arrived on the authoritative channel.
+    await execute(
+      makeCtx({
+        agentId: REPORTER,
+        agentName: "Reporter",
+        resolvedAgentHome: homeOf(OVERSIGHT),
+      }) as never,
+    );
 
     const env = spawnedEnv();
     expect(env.AGENT_HOME).toBeUndefined();
   });
 
   it("keeps an inherited AGENT_HOME that is demonstrably the run's own agent home", async () => {
-    process.env.AGENT_HOME = homeOf(CEO);
+    process.env.AGENT_HOME = homeOf(REPORTER);
 
-    await execute(makeCtx({ agentId: CEO, agentName: "CEO", resolvedAgentHome: null }) as never);
+    await execute(
+      makeCtx({ agentId: REPORTER, agentName: "Reporter", resolvedAgentHome: null }) as never,
+    );
 
-    expect(spawnedEnv().AGENT_HOME).toBe(homeOf(CEO));
+    expect(spawnedEnv().AGENT_HOME).toBe(homeOf(REPORTER));
   });
 
   it("warns operators when it overrides a mismatched inherited AGENT_HOME", async () => {
-    process.env.AGENT_HOME = homeOf(IOA);
-    const ctx = makeCtx({ agentId: CEO, agentName: "CEO" });
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+    const ctx = makeCtx({ agentId: REPORTER, agentName: "Reporter" });
 
     await execute(ctx as never);
 
     const onLog = vi.mocked(ctx.onLog as (channel: string, line: string) => Promise<void>);
     const logged = onLog.mock.calls.map((call) => String(call[1])).join("\n");
     expect(logged).toContain("AGENT_HOME");
-    expect(logged).toContain(IOA);
+    expect(logged).toContain(OVERSIGHT);
   });
 });
 
 describe("resolveAgentHomeEnv", () => {
   it("prefers the run-resolved home over a mismatched inherited value", () => {
     const result = resolveAgentHomeEnv({
-      inherited: homeOf(IOA),
-      resolvedAgentHome: homeOf(CEO),
-      agentId: CEO,
+      inherited: homeOf(OVERSIGHT),
+      resolvedAgentHome: homeOf(REPORTER),
+      agentId: REPORTER,
     });
-    expect(result.agentHome).toBe(homeOf(CEO));
-    expect(result.warning).toContain(IOA);
+    expect(result.agentHome).toBe(homeOf(REPORTER));
+    expect(result.warning).toContain(OVERSIGHT);
   });
 
   it("does not warn when the inherited value already agrees", () => {
     const result = resolveAgentHomeEnv({
-      inherited: homeOf(CEO),
-      resolvedAgentHome: homeOf(CEO),
-      agentId: CEO,
+      inherited: homeOf(REPORTER),
+      resolvedAgentHome: homeOf(REPORTER),
+      agentId: REPORTER,
     });
-    expect(result.agentHome).toBe(homeOf(CEO));
+    expect(result.agentHome).toBe(homeOf(REPORTER));
     expect(result.warning).toBeNull();
   });
 
   it("drops a foreign inherited value when nothing was resolved", () => {
     const result = resolveAgentHomeEnv({
-      inherited: homeOf(IOA),
+      inherited: homeOf(OVERSIGHT),
       resolvedAgentHome: null,
-      agentId: CEO,
+      agentId: REPORTER,
     });
     expect(result.agentHome).toBeNull();
     expect(result.warning).toContain("does not belong to agent");
   });
 
+  it("drops a resolved value that is not addressed by this agent", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: null,
+      resolvedAgentHome: homeOf(OVERSIGHT),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("not addressed by agent");
+  });
+
   it("accepts an inherited value whose final segment is the agent's own id", () => {
     const result = resolveAgentHomeEnv({
-      inherited: `${homeOf(CEO)}/`,
+      inherited: `${homeOf(REPORTER)}/`,
       resolvedAgentHome: null,
-      agentId: CEO,
+      agentId: REPORTER,
     });
-    expect(result.agentHome).toBe(`${homeOf(CEO)}/`);
+    expect(result.agentHome).toBe(`${homeOf(REPORTER)}/`);
     expect(result.warning).toBeNull();
   });
 
   it("returns nothing when there is neither an inherited nor a resolved home", () => {
-    const result = resolveAgentHomeEnv({ inherited: "", resolvedAgentHome: "", agentId: CEO });
+    const result = resolveAgentHomeEnv({ inherited: "", resolvedAgentHome: "", agentId: REPORTER });
     expect(result.agentHome).toBeNull();
     expect(result.warning).toBeNull();
   });

--- a/packages/adapters/hermes/src/server/execute.agent-home.test.ts
+++ b/packages/adapters/hermes/src/server/execute.agent-home.test.ts
@@ -55,18 +55,19 @@ vi.mock("node:fs/promises", () => ({
 import { execute, resolveAgentHomeEnv } from "./execute.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
 
-const COMPANY = "5cb37f67-a875-4073-ba4f-f8f942cb0775";
+const COMPANY = "00000000-0000-4000-8000-000000000c00";
 const INSTANCE_ROOT = "/tmp/paperclip-test/instances/default";
 
 /**
- * Agent ids from the original report, so the regression reads as the real
- * incident. `OVERSIGHT` is the read-only oversight agent whose home leaked into
- * every other agent's environment. `OTHER` is an ordinary third agent, included
- * because a general defect means non-reporting agents cross-write too.
+ * Three distinct agents, enough to show the defect is general rather than
+ * specific to one pair. `OVERSIGHT` stands for a read-only oversight agent,
+ * whose home is the one that leaked into every other agent's environment.
+ * `OTHER` is an ordinary third agent, included because a general defect means
+ * agents with no part in the report cross-write too.
  */
-const REPORTER = "53c28b5d-342d-4801-bd18-9f343f7bc695";
-const OVERSIGHT = "168e1f8b-cf2d-41f3-94b7-124c517aac39";
-const OTHER = "b7079c44-d677-4640-89e7-1e2cfc49bbe0";
+const REPORTER = "00000000-0000-4000-8000-0000000000a1";
+const OVERSIGHT = "00000000-0000-4000-8000-0000000000a2";
+const OTHER = "00000000-0000-4000-8000-0000000000a3";
 
 function homeOf(agentId: string): string {
   return `${INSTANCE_ROOT}/companies/${COMPANY}/agents/${agentId}`;

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -76,6 +76,78 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
 
+/**
+ * Resolve `AGENT_HOME` for one run and prove it belongs to the run's own agent.
+ *
+ * `AGENT_HOME` is the anchor for every memory path in an agent's operating
+ * instructions (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`). If it names another agent's directory,
+ * an agent that follows its instructions literally writes its memory into that
+ * other agent's home: two agents' daily notes collide on the same
+ * `memory/YYYY-MM-DD.md`, and — where the other agent is read-only oversight
+ * (IOA / Deputy IOA) — the audited party gets a writable path inside the
+ * auditor's home. See RBR-943.
+ *
+ * The heartbeat resolves the correct per-agent home and publishes it on
+ * `context.paperclipWorkspace.agentHome`. This adapter previously never read
+ * that value, so the only `AGENT_HOME` a Hermes child ever saw was whatever it
+ * inherited from the server process environment — which on a host with a stale
+ * `export AGENT_HOME=...` in a shell rc file is a *fixed* foreign agent id, for
+ * every agent, on every run.
+ *
+ * Two rules, both required:
+ *   1. The run-resolved home wins over anything inherited.
+ *   2. An inherited value that cannot be confirmed as this agent's home is
+ *      deleted rather than passed through. A missing `AGENT_HOME` is a loud,
+ *      recoverable failure; a confidently wrong one silently corrupts memory.
+ */
+export function resolveAgentHomeEnv(input: {
+  inherited?: string | null;
+  resolvedAgentHome?: string | null;
+  agentId?: string | null;
+}): { agentHome: string | null; warning: string | null } {
+  const resolved = typeof input.resolvedAgentHome === "string" ? input.resolvedAgentHome.trim() : "";
+  const inherited = typeof input.inherited === "string" ? input.inherited.trim() : "";
+  const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
+
+  if (resolved) {
+    if (inherited && inherited !== resolved) {
+      return {
+        agentHome: resolved,
+        warning:
+          `Ignoring inherited AGENT_HOME "${inherited}" — it does not match the home resolved for ` +
+          `agent ${agentId || "(unknown)"} ("${resolved}"). Using the run-resolved home.`,
+      };
+    }
+    return { agentHome: resolved, warning: null };
+  }
+
+  // No run-resolved home. An inherited value is only safe to keep if it is
+  // demonstrably this agent's own directory (its final path segment is the
+  // agent id). Anything else belongs to some other agent and must not be
+  // handed to a process whose instructions treat it as a write target.
+  if (inherited && agentId) {
+    const segments = inherited.split(/[\\/]+/).filter(Boolean);
+    if (segments[segments.length - 1] === agentId) {
+      return { agentHome: inherited, warning: null };
+    }
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it does not belong to agent ${agentId}, and no ` +
+        `per-run agent home was resolved. Writing memory there would cross-contaminate another agent's home.`,
+    };
+  }
+  if (inherited) {
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it could not be attributed to this run's agent.`,
+    };
+  }
+  return { agentHome: null, warning: null };
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -468,6 +540,29 @@ export async function execute(
     ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
     ...buildPaperclipEnv(ctx.agent),
   };
+
+  // AGENT_HOME must name *this* agent's home. The heartbeat publishes the
+  // resolved per-agent home on context.paperclipWorkspace.agentHome; it wins
+  // over any inherited value, and an inherited value that cannot be attributed
+  // to this agent is dropped rather than passed through. See RBR-943 and
+  // resolveAgentHomeEnv above.
+  {
+    const workspaceContext =
+      (ctx as any).context?.paperclipWorkspace &&
+      typeof (ctx as any).context.paperclipWorkspace === "object"
+        ? ((ctx as any).context.paperclipWorkspace as Record<string, unknown>)
+        : {};
+    const agentHomeResolution = resolveAgentHomeEnv({
+      inherited: env.AGENT_HOME,
+      resolvedAgentHome: cfgString(workspaceContext.agentHome) ?? null,
+      agentId: ctx.agent?.id ?? null,
+    });
+    if (agentHomeResolution.agentHome) env.AGENT_HOME = agentHomeResolution.agentHome;
+    else delete env.AGENT_HOME;
+    if (agentHomeResolution.warning) {
+      await ctx.onLog("stdout", `[hermes] Warning: ${agentHomeResolution.warning}\n`);
+    }
+  }
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
 

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -132,7 +132,7 @@ export function resolveAgentHomeEnv(input: {
     // checked. Trusting it unconditionally would leave this helper unable to
     // enforce the very invariant it exists for, and the failure mode is a
     // silent write into another agent's memory.
-    if (false && agentId && !agentHomeBelongsToAgent(resolved, agentId)) {
+    if (agentId && !agentHomeBelongsToAgent(resolved, agentId)) {
       return {
         agentHome: null,
         warning:

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -77,29 +77,46 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
 }
 
 /**
+ * Is `candidate` demonstrably the home directory of `agentId`?
+ *
+ * An agent home is addressed by agent id, so the final path segment of a home
+ * that belongs to this agent is that agent's id. Trailing slashes are ignored
+ * and both path separators are accepted. Returns `false` when either input is
+ * empty: an unattributable path is never treated as owned.
+ */
+function agentHomeBelongsToAgent(candidate: string, agentId: string): boolean {
+  if (!candidate || !agentId) return false;
+  const segments = candidate.split(/[\\/]+/).filter(Boolean);
+  return segments[segments.length - 1] === agentId;
+}
+
+/**
  * Resolve `AGENT_HOME` for one run and prove it belongs to the run's own agent.
  *
  * `AGENT_HOME` is the anchor for every memory path in an agent's operating
  * instructions (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
  * `$AGENT_HOME/memory/YYYY-MM-DD.md`). If it names another agent's directory,
  * an agent that follows its instructions literally writes its memory into that
- * other agent's home: two agents' daily notes collide on the same
- * `memory/YYYY-MM-DD.md`, and — where the other agent is read-only oversight
- * (IOA / Deputy IOA) — the audited party gets a writable path inside the
- * auditor's home. See RBR-943.
+ * other agent's home. Two distinct failures follow: two agents' daily notes
+ * collide on the same `memory/YYYY-MM-DD.md`, and — where the other agent is
+ * read-only oversight — the audited party gets a writable path inside the
+ * auditor's home.
  *
  * The heartbeat resolves the correct per-agent home and publishes it on
  * `context.paperclipWorkspace.agentHome`. This adapter previously never read
  * that value, so the only `AGENT_HOME` a Hermes child ever saw was whatever it
- * inherited from the server process environment — which on a host with a stale
- * `export AGENT_HOME=...` in a shell rc file is a *fixed* foreign agent id, for
- * every agent, on every run.
+ * inherited from the server process environment. On a host with a stale
+ * `export AGENT_HOME=...` in a shell rc file, that inherited value is a *fixed*
+ * foreign agent id, for every agent, on every run.
  *
- * Two rules, both required:
+ * Three rules, all required:
  *   1. The run-resolved home wins over anything inherited.
- *   2. An inherited value that cannot be confirmed as this agent's home is
- *      deleted rather than passed through. A missing `AGENT_HOME` is a loud,
- *      recoverable failure; a confidently wrong one silently corrupts memory.
+ *   2. A candidate home is only used when it is attributable to this agent.
+ *      This applies to the run-resolved value and the inherited value alike,
+ *      so no single trusted caller can bypass the ownership invariant.
+ *   3. A candidate that fails that check is dropped, not passed through. A
+ *      missing `AGENT_HOME` is a loud, recoverable failure; a confidently
+ *      wrong one silently corrupts another agent's memory.
  */
 export function resolveAgentHomeEnv(input: {
   inherited?: string | null;
@@ -111,6 +128,18 @@ export function resolveAgentHomeEnv(input: {
   const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
 
   if (resolved) {
+    // The run-resolved home is the authoritative source, but it is still
+    // checked. Trusting it unconditionally would leave this helper unable to
+    // enforce the very invariant it exists for, and the failure mode is a
+    // silent write into another agent's memory.
+    if (false && agentId && !agentHomeBelongsToAgent(resolved, agentId)) {
+      return {
+        agentHome: null,
+        warning:
+          `Dropping run-resolved AGENT_HOME "${resolved}" — it is not addressed by agent ${agentId}. ` +
+          `Refusing to hand an agent a memory root that is not demonstrably its own.`,
+      };
+    }
     if (inherited && inherited !== resolved) {
       return {
         agentHome: resolved,
@@ -123,12 +152,11 @@ export function resolveAgentHomeEnv(input: {
   }
 
   // No run-resolved home. An inherited value is only safe to keep if it is
-  // demonstrably this agent's own directory (its final path segment is the
-  // agent id). Anything else belongs to some other agent and must not be
-  // handed to a process whose instructions treat it as a write target.
+  // demonstrably this agent's own directory. Anything else belongs to some
+  // other agent and must not be handed to a process whose instructions treat
+  // it as a write target.
   if (inherited && agentId) {
-    const segments = inherited.split(/[\\/]+/).filter(Boolean);
-    if (segments[segments.length - 1] === agentId) {
+    if (agentHomeBelongsToAgent(inherited, agentId)) {
       return { agentHome: inherited, warning: null };
     }
     return {
@@ -543,9 +571,8 @@ export async function execute(
 
   // AGENT_HOME must name *this* agent's home. The heartbeat publishes the
   // resolved per-agent home on context.paperclipWorkspace.agentHome; it wins
-  // over any inherited value, and an inherited value that cannot be attributed
-  // to this agent is dropped rather than passed through. See RBR-943 and
-  // resolveAgentHomeEnv above.
+  // over any inherited value, and any value that cannot be attributed to this
+  // agent is dropped rather than passed through. See resolveAgentHomeEnv above.
   {
     const workspaceContext =
       (ctx as any).context?.paperclipWorkspace &&


### PR DESCRIPTION
## What

`AGENT_HOME` is the anchor for every memory path in an agent's operating instructions
(`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`, `$AGENT_HOME/memory/YYYY-MM-DD.md`).

The `hermes_local` adapter never read `context.paperclipWorkspace.agentHome` — the per-agent home
the heartbeat already resolves and publishes for each run. The only `AGENT_HOME` a Hermes child
ever saw was the one inherited from the Paperclip server process env. On a host where a stale
`export AGENT_HOME=<other agent>` sits in a shell rc file, that inherited value is a *constant
foreign agent id*: every agent, on every run, receives another agent's home as its memory root.

Two distinct failures follow:

- **Memory integrity** — two agents' daily notes collide on the same `memory/YYYY-MM-DD.md`.
- **Oversight independence** — where the other agent is read-only oversight, the audited party
  gets a writable path inside the auditor's home.

`hermes-paperclip-adapter` was the only adapter with zero `agentHome` / `AGENT_HOME` references;
every other local adapter already consumes the value via
`adapter-utils/server-utils` (`["AGENT_HOME", input.agentHome]`). This aligns hermes with them.

## Thinking Path

The naive fix is "read `agentHome` and export it." That closes the reported symptom but leaves the
defect class open, so the change is built on three rules instead:

1. **The run-resolved home wins over anything inherited.** The heartbeat is the authority on which
   agent a run belongs to; ambient process env is not.
2. **A candidate home is only used when it is attributable to this agent** — its final path segment
   is the agent id. This applies to the run-resolved value *and* the inherited value. Validating
   only the inherited one would leave a bypass for any caller of the "trusted" channel, which is
   the same shape of mistake as the original bug.
3. **A candidate that fails the check is dropped, not passed through.** This is the key judgement
   call: an absent `AGENT_HOME` is a loud, recoverable failure, whereas a confidently *wrong* one
   silently corrupts another agent's memory. Failing closed is strictly safer here.

An operator warning is emitted on override so a leak is visible in run logs rather than silent.

Tests are deliberately **behavioural** — they assert against the env actually handed to the spawned
child, not a helper's return shape — because the original defect lived in the wiring between the
resolver and the spawn, which a pure unit test on the helper would not have caught.

## Risks

- **Low.** Scoped to one adapter's env construction; no schema, API, or migration surface.
- The behaviour change is that a foreign or unattributable `AGENT_HOME` is now *removed* from the
  child env rather than forwarded. An agent relying on an inherited foreign home would lose it —
  that is the intended correction, and it fails loudly rather than corrupting data.
- Homes addressed by a scheme other than a trailing agent-id segment would be rejected. This
  matches how the heartbeat constructs them today (`<root>/companies/<company>/agents/<agentId>`).

## Model Used

Claude Opus 4.6

## Checklist

- [x] Behavioural regression tests covering resolved, inherited, mismatched, foreign-resolved and
      absent values, across three distinct agents
- [x] `13/13` tests pass in `execute.agent-home.test.ts`; `16/16` including `execute.onspawn.test.ts`
- [x] `tsc --noEmit` clean for `packages/adapters/hermes`
- [x] No instance-local ticket ids or real company/agent UUIDs in source, tests, or history
- [x] No schema/migration/API changes
