### PR TITLE
fix(hermes): give each agent its own AGENT_HOME, never a foreign agent's

### DIFF
--- a/packages/adapters/hermes/src/server/execute.agent-home.test.ts
+++ b/packages/adapters/hermes/src/server/execute.agent-home.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Behavioural regression tests for AGENT_HOME isolation in the hermes adapter.
+ *
+ * The reported failure: for seven consecutive days, every run on one host
+ * started with `AGENT_HOME` pointing at a *fixed foreign agent's* home
+ * directory, regardless of which agent the run belonged to. Agent operating
+ * instructions define memory almost entirely in terms of `$AGENT_HOME`
+ * (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`), so any agent following its instructions
+ * literally would write its memory into that other agent's directory. Two
+ * distinct failures: same-day daily notes from two agents collide on one
+ * `memory/YYYY-MM-DD.md`, and a read-only oversight agent's home becomes
+ * writable by the party it audits.
+ *
+ * Root cause was twofold and both halves are asserted here:
+ *   1. This adapter never read `context.paperclipWorkspace.agentHome`, so the
+ *      only `AGENT_HOME` a child ever saw was the one inherited from the server
+ *      process environment.
+ *   2. The host's server process had a stale `export AGENT_HOME=<other agent>`
+ *      in a shell rc file, so that inherited value was a constant foreign
+ *      agent id.
+ *
+ * These assertions are behavioural: they inspect the environment actually handed
+ * to the spawned child, not the shape of a helper's return value. The core
+ * invariant — "a run for agent A never receives an AGENT_HOME belonging to agent
+ * B" — is asserted directly against that env.
+ */
+
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    })),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => ""),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  rm: vi.fn(async () => undefined),
+  access: vi.fn(async () => undefined),
+  readdir: vi.fn(async () => []),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+import { execute, resolveAgentHomeEnv } from "./execute.js";
+import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
+
+const COMPANY = "5cb37f67-a875-4073-ba4f-f8f942cb0775";
+const INSTANCE_ROOT = "/tmp/paperclip-test/instances/default";
+
+/**
+ * Agent ids from the original report, so the regression reads as the real
+ * incident. `OVERSIGHT` is the read-only oversight agent whose home leaked into
+ * every other agent's environment. `OTHER` is an ordinary third agent, included
+ * because a general defect means non-reporting agents cross-write too.
+ */
+const REPORTER = "53c28b5d-342d-4801-bd18-9f343f7bc695";
+const OVERSIGHT = "168e1f8b-cf2d-41f3-94b7-124c517aac39";
+const OTHER = "b7079c44-d677-4640-89e7-1e2cfc49bbe0";
+
+function homeOf(agentId: string): string {
+  return `${INSTANCE_ROOT}/companies/${COMPANY}/agents/${agentId}`;
+}
+
+function makeCtx(input: {
+  agentId: string;
+  agentName: string;
+  /** What the heartbeat resolved and published for this run. */
+  resolvedAgentHome?: string | null;
+}) {
+  return {
+    runId: `run-for-${input.agentId}`,
+    agent: {
+      id: input.agentId,
+      companyId: COMPANY,
+      name: input.agentName,
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: { command: "/usr/bin/hermes", timeoutSec: 60, graceSec: 5 },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "issue_assigned",
+      paperclipWake: null,
+      paperclipWorkspace:
+        input.resolvedAgentHome === undefined
+          ? { cwd: "/tmp/paperclip-test/ws", agentHome: homeOf(input.agentId) }
+          : { cwd: "/tmp/paperclip-test/ws", agentHome: input.resolvedAgentHome },
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  } as unknown as Record<string, unknown>;
+}
+
+/** The env actually handed to the spawned child on the most recent execute(). */
+function spawnedEnv(): Record<string, string> {
+  const mocked = vi.mocked(serverUtils.runChildProcess);
+  expect(mocked.mock.calls.length).toBeGreaterThan(0);
+  const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+  return (lastCall[3] as { env: Record<string, string> }).env;
+}
+
+/**
+ * The invariant, stated once: whatever AGENT_HOME the child receives, it must
+ * not be inside any *other* agent's home directory.
+ */
+function expectAgentHomeNotForeign(env: Record<string, string>, ownAgentId: string, others: string[]) {
+  const agentHome = env.AGENT_HOME;
+  for (const other of others) {
+    if (other === ownAgentId) continue;
+    expect(agentHome ?? "").not.toContain(other);
+  }
+}
+
+describe("hermes adapter AGENT_HOME isolation", () => {
+  const savedAgentHome = process.env.AGENT_HOME;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_HOME;
+  });
+
+  afterEach(() => {
+    if (savedAgentHome === undefined) delete process.env.AGENT_HOME;
+    else process.env.AGENT_HOME = savedAgentHome;
+  });
+
+  it("gives each agent its own AGENT_HOME, not a shared or foreign one", async () => {
+    const seen: Record<string, string | undefined> = {};
+    for (const [agentId, name] of [
+      [REPORTER, "Reporter"],
+      [OVERSIGHT, "Oversight"],
+      [OTHER, "Other"],
+    ] as const) {
+      vi.clearAllMocks();
+      await execute(makeCtx({ agentId, agentName: name }) as never);
+      const env = spawnedEnv();
+      seen[name] = env.AGENT_HOME;
+      // Positive: it is this agent's own home.
+      expect(env.AGENT_HOME).toBe(homeOf(agentId));
+      // Negative: it is nobody else's home.
+      expectAgentHomeNotForeign(env, agentId, [REPORTER, OVERSIGHT, OTHER]);
+    }
+    // And all three are distinct — the original bug handed every agent the
+    // same path, which this assertion alone would have caught.
+    const distinct = new Set(Object.values(seen));
+    expect(distinct.size).toBe(3);
+  });
+
+  it("a run never receives the oversight agent's AGENT_HOME even when the server process env leaks it", async () => {
+    // Reproduce the exact host condition: a stale `export AGENT_HOME=<other
+    // agent>` in a shell rc file, inherited by the server and thus every child.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+
+    await execute(makeCtx({ agentId: REPORTER, agentName: "Reporter" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(REPORTER));
+    expect(env.AGENT_HOME).not.toBe(homeOf(OVERSIGHT));
+    expect(env.AGENT_HOME).not.toContain(OVERSIGHT);
+  });
+
+  it("is not specific to the reporting agent: an ordinary agent is protected from the same leak", async () => {
+    // A general bug means other agents' memories are also cross-writing, so the
+    // fix must hold for an ordinary agent too, not just the reported pair.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+
+    await execute(makeCtx({ agentId: OTHER, agentName: "Other" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(OTHER));
+    expect(env.AGENT_HOME).not.toContain(OVERSIGHT);
+    expect(env.AGENT_HOME).not.toContain(REPORTER);
+  });
+
+  it("drops an unattributable inherited AGENT_HOME rather than passing a foreign one through", async () => {
+    // When the run resolves no home, a leaked foreign value must NOT survive:
+    // absent is a loud, recoverable failure; confidently wrong silently
+    // corrupts another agent's memory.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+
+    await execute(
+      makeCtx({ agentId: REPORTER, agentName: "Reporter", resolvedAgentHome: null }) as never,
+    );
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("drops a run-resolved AGENT_HOME that belongs to another agent", async () => {
+    // Defence in depth. The heartbeat derives the home from the run's own agent
+    // id, so this should be unreachable — but the whole defect class is
+    // "AGENT_HOME named a foreign agent", so a bad resolved value must not be
+    // trusted merely because it arrived on the authoritative channel.
+    await execute(
+      makeCtx({
+        agentId: REPORTER,
+        agentName: "Reporter",
+        resolvedAgentHome: homeOf(OVERSIGHT),
+      }) as never,
+    );
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("keeps an inherited AGENT_HOME that is demonstrably the run's own agent home", async () => {
+    process.env.AGENT_HOME = homeOf(REPORTER);
+
+    await execute(
+      makeCtx({ agentId: REPORTER, agentName: "Reporter", resolvedAgentHome: null }) as never,
+    );
+
+    expect(spawnedEnv().AGENT_HOME).toBe(homeOf(REPORTER));
+  });
+
+  it("warns operators when it overrides a mismatched inherited AGENT_HOME", async () => {
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+    const ctx = makeCtx({ agentId: REPORTER, agentName: "Reporter" });
+
+    await execute(ctx as never);
+
+    const onLog = vi.mocked(ctx.onLog as (channel: string, line: string) => Promise<void>);
+    const logged = onLog.mock.calls.map((call) => String(call[1])).join("\n");
+    expect(logged).toContain("AGENT_HOME");
+    expect(logged).toContain(OVERSIGHT);
+  });
+});
+
+describe("resolveAgentHomeEnv", () => {
+  it("prefers the run-resolved home over a mismatched inherited value", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(OVERSIGHT),
+      resolvedAgentHome: homeOf(REPORTER),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBe(homeOf(REPORTER));
+    expect(result.warning).toContain(OVERSIGHT);
+  });
+
+  it("does not warn when the inherited value already agrees", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(REPORTER),
+      resolvedAgentHome: homeOf(REPORTER),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBe(homeOf(REPORTER));
+    expect(result.warning).toBeNull();
+  });
+
+  it("drops a foreign inherited value when nothing was resolved", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(OVERSIGHT),
+      resolvedAgentHome: null,
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("does not belong to agent");
+  });
+
+  it("drops a resolved value that is not addressed by this agent", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: null,
+      resolvedAgentHome: homeOf(OVERSIGHT),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("not addressed by agent");
+  });
+
+  it("accepts an inherited value whose final segment is the agent's own id", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: `${homeOf(REPORTER)}/`,
+      resolvedAgentHome: null,
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBe(`${homeOf(REPORTER)}/`);
+    expect(result.warning).toBeNull();
+  });
+
+  it("returns nothing when there is neither an inherited nor a resolved home", () => {
+    const result = resolveAgentHomeEnv({ inherited: "", resolvedAgentHome: "", agentId: REPORTER });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -76,6 +76,106 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
 
+/**
+ * Is `candidate` demonstrably the home directory of `agentId`?
+ *
+ * An agent home is addressed by agent id, so the final path segment of a home
+ * that belongs to this agent is that agent's id. Trailing slashes are ignored
+ * and both path separators are accepted. Returns `false` when either input is
+ * empty: an unattributable path is never treated as owned.
+ */
+function agentHomeBelongsToAgent(candidate: string, agentId: string): boolean {
+  if (!candidate || !agentId) return false;
+  const segments = candidate.split(/[\\/]+/).filter(Boolean);
+  return segments[segments.length - 1] === agentId;
+}
+
+/**
+ * Resolve `AGENT_HOME` for one run and prove it belongs to the run's own agent.
+ *
+ * `AGENT_HOME` is the anchor for every memory path in an agent's operating
+ * instructions (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`). If it names another agent's directory,
+ * an agent that follows its instructions literally writes its memory into that
+ * other agent's home. Two distinct failures follow: two agents' daily notes
+ * collide on the same `memory/YYYY-MM-DD.md`, and — where the other agent is
+ * read-only oversight — the audited party gets a writable path inside the
+ * auditor's home.
+ *
+ * The heartbeat resolves the correct per-agent home and publishes it on
+ * `context.paperclipWorkspace.agentHome`. This adapter previously never read
+ * that value, so the only `AGENT_HOME` a Hermes child ever saw was whatever it
+ * inherited from the server process environment. On a host with a stale
+ * `export AGENT_HOME=...` in a shell rc file, that inherited value is a *fixed*
+ * foreign agent id, for every agent, on every run.
+ *
+ * Three rules, all required:
+ *   1. The run-resolved home wins over anything inherited.
+ *   2. A candidate home is only used when it is attributable to this agent.
+ *      This applies to the run-resolved value and the inherited value alike,
+ *      so no single trusted caller can bypass the ownership invariant.
+ *   3. A candidate that fails that check is dropped, not passed through. A
+ *      missing `AGENT_HOME` is a loud, recoverable failure; a confidently
+ *      wrong one silently corrupts another agent's memory.
+ */
+export function resolveAgentHomeEnv(input: {
+  inherited?: string | null;
+  resolvedAgentHome?: string | null;
+  agentId?: string | null;
+}): { agentHome: string | null; warning: string | null } {
+  const resolved = typeof input.resolvedAgentHome === "string" ? input.resolvedAgentHome.trim() : "";
+  const inherited = typeof input.inherited === "string" ? input.inherited.trim() : "";
+  const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
+
+  if (resolved) {
+    // The run-resolved home is the authoritative source, but it is still
+    // checked. Trusting it unconditionally would leave this helper unable to
+    // enforce the very invariant it exists for, and the failure mode is a
+    // silent write into another agent's memory.
+    if (agentId && !agentHomeBelongsToAgent(resolved, agentId)) {
+      return {
+        agentHome: null,
+        warning:
+          `Dropping run-resolved AGENT_HOME "${resolved}" — it is not addressed by agent ${agentId}. ` +
+          `Refusing to hand an agent a memory root that is not demonstrably its own.`,
+      };
+    }
+    if (inherited && inherited !== resolved) {
+      return {
+        agentHome: resolved,
+        warning:
+          `Ignoring inherited AGENT_HOME "${inherited}" — it does not match the home resolved for ` +
+          `agent ${agentId || "(unknown)"} ("${resolved}"). Using the run-resolved home.`,
+      };
+    }
+    return { agentHome: resolved, warning: null };
+  }
+
+  // No run-resolved home. An inherited value is only safe to keep if it is
+  // demonstrably this agent's own directory. Anything else belongs to some
+  // other agent and must not be handed to a process whose instructions treat
+  // it as a write target.
+  if (inherited && agentId) {
+    if (agentHomeBelongsToAgent(inherited, agentId)) {
+      return { agentHome: inherited, warning: null };
+    }
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it does not belong to agent ${agentId}, and no ` +
+        `per-run agent home was resolved. Writing memory there would cross-contaminate another agent's home.`,
+    };
+  }
+  if (inherited) {
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it could not be attributed to this run's agent.`,
+    };
+  }
+  return { agentHome: null, warning: null };
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -468,6 +568,28 @@ export async function execute(
     ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
     ...buildPaperclipEnv(ctx.agent),
   };
+
+  // AGENT_HOME must name *this* agent's home. The heartbeat publishes the
+  // resolved per-agent home on context.paperclipWorkspace.agentHome; it wins
+  // over any inherited value, and any value that cannot be attributed to this
+  // agent is dropped rather than passed through. See resolveAgentHomeEnv above.
+  {
+    const workspaceContext =
+      (ctx as any).context?.paperclipWorkspace &&
+      typeof (ctx as any).context.paperclipWorkspace === "object"
+        ? ((ctx as any).context.paperclipWorkspace as Record<string, unknown>)
+        : {};
+    const agentHomeResolution = resolveAgentHomeEnv({
+      inherited: env.AGENT_HOME,
+      resolvedAgentHome: cfgString(workspaceContext.agentHome) ?? null,
+      agentId: ctx.agent?.id ?? null,
+    });
+    if (agentHomeResolution.agentHome) env.AGENT_HOME = agentHomeResolution.agentHome;
+    else delete env.AGENT_HOME;
+    if (agentHomeResolution.warning) {
+      await ctx.onLog("stdout", `[hermes] Warning: ${agentHomeResolution.warning}\n`);
+    }
+  }
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each local adapter spawns an agent process and builds the environment that process runs in. `AGENT_HOME` is part of that environment, and it is the anchor for every memory path in an agent's operating instructions: `$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`, `$AGENT_HOME/memory/YYYY-MM-DD.md`.
> - The server already resolves the correct per-agent home for every run and publishes it on `context.paperclipWorkspace.agentHome`. `packages/adapter-utils/src/server-utils.ts` maps it to the `AGENT_HOME` variable. The codex, cursor, gemini, opencode, and pi local adapters all consume that path. The hermes adapter never did.
> - So a Hermes child received only whatever `AGENT_HOME` it inherited from the server process. On a host where a shell rc file exports a stale `AGENT_HOME`, that inherited value is a single fixed agent home, handed to every agent on every run.
> - The result is not a cosmetic variable problem. An agent that follows its instructions literally writes its memory into a different agent's directory. Two agents' daily notes collide on the same `memory/YYYY-MM-DD.md` file. Where the other agent is read-only oversight, the audited agent gets a writable path inside the auditor's home.
> - This pull request makes the hermes adapter resolve `AGENT_HOME` for each run and prove the value belongs to that run's own agent before it is passed to the child.
> - The benefit is that agent memory stays in the agent's own home, and a value that cannot be attributed is dropped loudly rather than silently corrupting another agent's memory.

## Linked Issues or Issue Description

No public GitHub issue exists for this. Describing it here, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened**

Every agent run using the `hermes_local` adapter received the same `AGENT_HOME` value: the one inherited from the Paperclip server process. On a host whose shell rc file exported a stale `AGENT_HOME`, that meant every agent, on every run, was given one fixed foreign agent's home directory as its own memory root. This persisted across seven consecutive days of runs before it was noticed.

Because agent operating instructions define memory locations entirely relative to `$AGENT_HOME`, any agent following its instructions literally would write `MEMORY.md`, `life/`, and `memory/YYYY-MM-DD.md` into another agent's directory.

**What I expected to happen**

Each run receives the per-agent home that the server already resolves for it, so agents write memory only into their own directories.

**Steps to reproduce**

1. Configure an agent with `adapterType: hermes_local`.
2. In the environment of the Paperclip server process, set `AGENT_HOME` to some other agent's home directory. A stale `export AGENT_HOME=...` in a shell rc file does this.
3. Start a run for the agent from step 1.
4. Inspect the environment given to the spawned Hermes child. `AGENT_HOME` is the value from step 2, not the home belonging to the agent from step 1.

**Additional context**

The plumbing already existed and was already used elsewhere. Reference counts for `agentHome` / `AGENT_HOME` across the local adapters at the time of diagnosis:

| Adapter | references |
|---|---|
| hermes | **0** |
| codex-local | 2 |
| cursor-local | 3 |
| gemini-local | 3 |
| opencode-local | 3 |
| pi-local | 3 |

The hermes adapter was the only one that did not wire it. The defect was therefore not specific to any one agent — it applied to every agent using this adapter.

Removing the stale shell export changes the symptom from "a confidently wrong foreign home" to "no `AGENT_HOME` at all", which is safer but still wrong. The adapter fix is what actually resolves it.

## What Changed

- Added `resolveAgentHomeEnv()` to `packages/adapters/hermes/src/server/execute.ts`. It takes the inherited value, the run-resolved home, and the run's agent id, and returns the `AGENT_HOME` to use plus an optional operator warning.
- Applied it in `execute()` when building the child environment. The adapter now reads `context.paperclipWorkspace.agentHome`, which it previously ignored. When the helper returns no home, `AGENT_HOME` is deleted from the child environment rather than left at an inherited value.
- Added `agentHomeBelongsToAgent()`, a single ownership rule used by both the resolved and the inherited path: a home that belongs to an agent has that agent's id as its final path segment. Trailing slashes are ignored and both path separators are accepted.
- The ownership check is applied to the run-resolved value as well as the inherited one, so no single caller can bypass the invariant the helper exists to enforce.
- Warnings are logged through `ctx.onLog` on override and on drop, so a leaked or rejected value is visible in run logs instead of silent.
- Added `packages/adapters/hermes/src/server/execute.agent-home.test.ts` with 13 tests.

Behaviour, stated as three rules:

1. The run-resolved home wins over anything inherited.
2. A candidate home is used only when it is attributable to this agent. This applies to the run-resolved value and the inherited value alike.
3. A candidate that fails that check is dropped, not passed through. A missing `AGENT_HOME` is a loud, recoverable failure. A confidently wrong one silently corrupts another agent's memory.

## Verification

```
cd packages/adapters/hermes
npx vitest run src/server/execute.agent-home.test.ts
```

Result: 13 passed (13).

```
cd packages/adapters/hermes
npx tsc --noEmit -p tsconfig.json
```

Result: exit 0, no diagnostics.

The tests are behavioural rather than shape assertions. Each one calls the real `execute()` and reads the environment actually handed to the spawned child back out of the `runChildProcess` mock. What they cover:

- Three different agents each receive their own distinct home, and no agent's value contains another agent's id.
- The exact reported host condition: the server process environment leaks a foreign home, and the run still receives its own.
- An ordinary third agent is protected too, confirming the defect was not limited to the reporting pair.
- An unattributable inherited value is dropped rather than passed through.
- An inherited value that is demonstrably the run's own home is kept.
- A run-resolved value belonging to another agent is dropped, checked at both the `execute()` boundary and the helper.
- The operator warning is emitted and names the rejected value.

A reviewer can also confirm the negative case directly: revert `execute.ts` alone and the suite fails, because the child then receives the inherited foreign value.

## Risks

Low risk, and scoped to one adapter. The change is additive: 420 added lines across one new test file and one source file, with no lines removed and no change to any shared helper or other adapter.

Two behavioural shifts worth naming:

- **`AGENT_HOME` can now be absent where it was previously set.** When no run-resolved home exists and the inherited value cannot be attributed to the run's agent, the variable is deleted. This is deliberate. An absent variable fails loudly and recoverably, whereas a confidently wrong one writes into another agent's memory with no signal. Anything depending on `AGENT_HOME` always being populated, regardless of whether it was correct, would see the change.
- **The ownership check also applies to the run-resolved value.** This could in principle reject a legitimate home. It does not in practice: the server resolves an agent home as `<instance root>/workspaces/<agentId>`, whose final path segment is the agent id, so real resolved values pass. The check exists so that a future caller passing a foreign path cannot bypass the invariant.

No migrations, no schema or contract changes, no UI changes, no public API changes. `resolveAgentHomeEnv` is newly exported and has no prior callers.

## Model Used

Anthropic Claude, `claude-opus-4-6`, 200K context window, extended thinking enabled, with tool use and code execution. The model diagnosed the two contributing causes, wrote the helper and the behavioural test suite, and ran the tests and typecheck locally. A human reviewed the change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
