### PR TITLE
fix(hermes): give each run its own AGENT_HOME, never another agent's

### DIFF
--- a/packages/adapters/hermes/src/server/execute.agent-home.test.ts
+++ b/packages/adapters/hermes/src/server/execute.agent-home.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Behavioural regression tests for AGENT_HOME isolation in the hermes adapter.
+ *
+ * The reported failure: for seven consecutive days, every run on one host
+ * started with `AGENT_HOME` pointing at a *fixed foreign agent's* home
+ * directory, regardless of which agent the run belonged to. Agent operating
+ * instructions define memory almost entirely in terms of `$AGENT_HOME`
+ * (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`), so any agent following its instructions
+ * literally would write its memory into that other agent's directory. Two
+ * distinct failures: same-day daily notes from two agents collide on one
+ * `memory/YYYY-MM-DD.md`, and a read-only oversight agent's home becomes
+ * writable by the party it audits.
+ *
+ * Root cause was twofold and both halves are asserted here:
+ *   1. This adapter never read `context.paperclipWorkspace.agentHome`, so the
+ *      only `AGENT_HOME` a child ever saw was the one inherited from the server
+ *      process environment.
+ *   2. The host's server process had a stale `export AGENT_HOME=<other agent>`
+ *      in a shell rc file, so that inherited value was a constant foreign
+ *      agent id.
+ *
+ * These assertions are behavioural: they inspect the environment actually handed
+ * to the spawned child, not the shape of a helper's return value. The core
+ * invariant — "a run for agent A never receives an AGENT_HOME belonging to agent
+ * B" — is asserted directly against that env.
+ */
+
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    })),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => ""),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  rm: vi.fn(async () => undefined),
+  access: vi.fn(async () => undefined),
+  readdir: vi.fn(async () => []),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+import { execute, resolveAgentHomeEnv } from "./execute.js";
+import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
+
+const COMPANY = "00000000-0000-4000-8000-000000000c00";
+const INSTANCE_ROOT = "/tmp/paperclip-test/instances/default";
+
+/**
+ * Three distinct agents, enough to show the defect is general rather than
+ * specific to one pair. `OVERSIGHT` stands for a read-only oversight agent,
+ * whose home is the one that leaked into every other agent's environment.
+ * `OTHER` is an ordinary third agent, included because a general defect means
+ * agents with no part in the report cross-write too.
+ */
+const REPORTER = "00000000-0000-4000-8000-0000000000a1";
+const OVERSIGHT = "00000000-0000-4000-8000-0000000000a2";
+const OTHER = "00000000-0000-4000-8000-0000000000a3";
+
+function homeOf(agentId: string): string {
+  return `${INSTANCE_ROOT}/companies/${COMPANY}/agents/${agentId}`;
+}
+
+function makeCtx(input: {
+  agentId: string;
+  agentName: string;
+  /** What the heartbeat resolved and published for this run. */
+  resolvedAgentHome?: string | null;
+}) {
+  return {
+    runId: `run-for-${input.agentId}`,
+    agent: {
+      id: input.agentId,
+      companyId: COMPANY,
+      name: input.agentName,
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: { command: "/usr/bin/hermes", timeoutSec: 60, graceSec: 5 },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "issue_assigned",
+      paperclipWake: null,
+      paperclipWorkspace:
+        input.resolvedAgentHome === undefined
+          ? { cwd: "/tmp/paperclip-test/ws", agentHome: homeOf(input.agentId) }
+          : { cwd: "/tmp/paperclip-test/ws", agentHome: input.resolvedAgentHome },
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  } as unknown as Record<string, unknown>;
+}
+
+/** The env actually handed to the spawned child on the most recent execute(). */
+function spawnedEnv(): Record<string, string> {
+  const mocked = vi.mocked(serverUtils.runChildProcess);
+  expect(mocked.mock.calls.length).toBeGreaterThan(0);
+  const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+  return (lastCall[3] as { env: Record<string, string> }).env;
+}
+
+/**
+ * The invariant, stated once: whatever AGENT_HOME the child receives, it must
+ * not be inside any *other* agent's home directory.
+ */
+function expectAgentHomeNotForeign(env: Record<string, string>, ownAgentId: string, others: string[]) {
+  const agentHome = env.AGENT_HOME;
+  for (const other of others) {
+    if (other === ownAgentId) continue;
+    expect(agentHome ?? "").not.toContain(other);
+  }
+}
+
+describe("hermes adapter AGENT_HOME isolation", () => {
+  const savedAgentHome = process.env.AGENT_HOME;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_HOME;
+  });
+
+  afterEach(() => {
+    if (savedAgentHome === undefined) delete process.env.AGENT_HOME;
+    else process.env.AGENT_HOME = savedAgentHome;
+  });
+
+  it("gives each agent its own AGENT_HOME, not a shared or foreign one", async () => {
+    const seen: Record<string, string | undefined> = {};
+    for (const [agentId, name] of [
+      [REPORTER, "Reporter"],
+      [OVERSIGHT, "Oversight"],
+      [OTHER, "Other"],
+    ] as const) {
+      vi.clearAllMocks();
+      await execute(makeCtx({ agentId, agentName: name }) as never);
+      const env = spawnedEnv();
+      seen[name] = env.AGENT_HOME;
+      // Positive: it is this agent's own home.
+      expect(env.AGENT_HOME).toBe(homeOf(agentId));
+      // Negative: it is nobody else's home.
+      expectAgentHomeNotForeign(env, agentId, [REPORTER, OVERSIGHT, OTHER]);
+    }
+    // And all three are distinct — the original bug handed every agent the
+    // same path, which this assertion alone would have caught.
+    const distinct = new Set(Object.values(seen));
+    expect(distinct.size).toBe(3);
+  });
+
+  it("a run never receives the oversight agent's AGENT_HOME even when the server process env leaks it", async () => {
+    // Reproduce the exact host condition: a stale `export AGENT_HOME=<other
+    // agent>` in a shell rc file, inherited by the server and thus every child.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+
+    await execute(makeCtx({ agentId: REPORTER, agentName: "Reporter" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(REPORTER));
+    expect(env.AGENT_HOME).not.toBe(homeOf(OVERSIGHT));
+    expect(env.AGENT_HOME).not.toContain(OVERSIGHT);
+  });
+
+  it("is not specific to the reporting agent: an ordinary agent is protected from the same leak", async () => {
+    // A general bug means other agents' memories are also cross-writing, so the
+    // fix must hold for an ordinary agent too, not just the reported pair.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+
+    await execute(makeCtx({ agentId: OTHER, agentName: "Other" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(OTHER));
+    expect(env.AGENT_HOME).not.toContain(OVERSIGHT);
+    expect(env.AGENT_HOME).not.toContain(REPORTER);
+  });
+
+  it("drops an unattributable inherited AGENT_HOME rather than passing a foreign one through", async () => {
+    // When the run resolves no home, a leaked foreign value must NOT survive:
+    // absent is a loud, recoverable failure; confidently wrong silently
+    // corrupts another agent's memory.
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+
+    await execute(
+      makeCtx({ agentId: REPORTER, agentName: "Reporter", resolvedAgentHome: null }) as never,
+    );
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("drops a run-resolved AGENT_HOME that belongs to another agent", async () => {
+    // Defence in depth. The heartbeat derives the home from the run's own agent
+    // id, so this should be unreachable — but the whole defect class is
+    // "AGENT_HOME named a foreign agent", so a bad resolved value must not be
+    // trusted merely because it arrived on the authoritative channel.
+    await execute(
+      makeCtx({
+        agentId: REPORTER,
+        agentName: "Reporter",
+        resolvedAgentHome: homeOf(OVERSIGHT),
+      }) as never,
+    );
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("keeps an inherited AGENT_HOME that is demonstrably the run's own agent home", async () => {
+    process.env.AGENT_HOME = homeOf(REPORTER);
+
+    await execute(
+      makeCtx({ agentId: REPORTER, agentName: "Reporter", resolvedAgentHome: null }) as never,
+    );
+
+    expect(spawnedEnv().AGENT_HOME).toBe(homeOf(REPORTER));
+  });
+
+  it("warns operators when it overrides a mismatched inherited AGENT_HOME", async () => {
+    process.env.AGENT_HOME = homeOf(OVERSIGHT);
+    const ctx = makeCtx({ agentId: REPORTER, agentName: "Reporter" });
+
+    await execute(ctx as never);
+
+    const onLog = vi.mocked(ctx.onLog as (channel: string, line: string) => Promise<void>);
+    const logged = onLog.mock.calls.map((call) => String(call[1])).join("\n");
+    expect(logged).toContain("AGENT_HOME");
+    expect(logged).toContain(OVERSIGHT);
+  });
+});
+
+describe("resolveAgentHomeEnv", () => {
+  it("prefers the run-resolved home over a mismatched inherited value", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(OVERSIGHT),
+      resolvedAgentHome: homeOf(REPORTER),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBe(homeOf(REPORTER));
+    expect(result.warning).toContain(OVERSIGHT);
+  });
+
+  it("does not warn when the inherited value already agrees", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(REPORTER),
+      resolvedAgentHome: homeOf(REPORTER),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBe(homeOf(REPORTER));
+    expect(result.warning).toBeNull();
+  });
+
+  it("drops a foreign inherited value when nothing was resolved", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(OVERSIGHT),
+      resolvedAgentHome: null,
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("does not belong to agent");
+  });
+
+  it("drops a resolved value that is not addressed by this agent", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: null,
+      resolvedAgentHome: homeOf(OVERSIGHT),
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("not addressed by agent");
+  });
+
+  it("accepts an inherited value whose final segment is the agent's own id", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: `${homeOf(REPORTER)}/`,
+      resolvedAgentHome: null,
+      agentId: REPORTER,
+    });
+    expect(result.agentHome).toBe(`${homeOf(REPORTER)}/`);
+    expect(result.warning).toBeNull();
+  });
+
+  it("returns nothing when there is neither an inherited nor a resolved home", () => {
+    const result = resolveAgentHomeEnv({ inherited: "", resolvedAgentHome: "", agentId: REPORTER });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -76,6 +76,106 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
 
+/**
+ * Is `candidate` demonstrably the home directory of `agentId`?
+ *
+ * An agent home is addressed by agent id, so the final path segment of a home
+ * that belongs to this agent is that agent's id. Trailing slashes are ignored
+ * and both path separators are accepted. Returns `false` when either input is
+ * empty: an unattributable path is never treated as owned.
+ */
+function agentHomeBelongsToAgent(candidate: string, agentId: string): boolean {
+  if (!candidate || !agentId) return false;
+  const segments = candidate.split(/[\\/]+/).filter(Boolean);
+  return segments[segments.length - 1] === agentId;
+}
+
+/**
+ * Resolve `AGENT_HOME` for one run and prove it belongs to the run's own agent.
+ *
+ * `AGENT_HOME` is the anchor for every memory path in an agent's operating
+ * instructions (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`). If it names another agent's directory,
+ * an agent that follows its instructions literally writes its memory into that
+ * other agent's home. Two distinct failures follow: two agents' daily notes
+ * collide on the same `memory/YYYY-MM-DD.md`, and — where the other agent is
+ * read-only oversight — the audited party gets a writable path inside the
+ * auditor's home.
+ *
+ * The heartbeat resolves the correct per-agent home and publishes it on
+ * `context.paperclipWorkspace.agentHome`. This adapter previously never read
+ * that value, so the only `AGENT_HOME` a Hermes child ever saw was whatever it
+ * inherited from the server process environment. On a host with a stale
+ * `export AGENT_HOME=...` in a shell rc file, that inherited value is a *fixed*
+ * foreign agent id, for every agent, on every run.
+ *
+ * Three rules, all required:
+ *   1. The run-resolved home wins over anything inherited.
+ *   2. A candidate home is only used when it is attributable to this agent.
+ *      This applies to the run-resolved value and the inherited value alike,
+ *      so no single trusted caller can bypass the ownership invariant.
+ *   3. A candidate that fails that check is dropped, not passed through. A
+ *      missing `AGENT_HOME` is a loud, recoverable failure; a confidently
+ *      wrong one silently corrupts another agent's memory.
+ */
+export function resolveAgentHomeEnv(input: {
+  inherited?: string | null;
+  resolvedAgentHome?: string | null;
+  agentId?: string | null;
+}): { agentHome: string | null; warning: string | null } {
+  const resolved = typeof input.resolvedAgentHome === "string" ? input.resolvedAgentHome.trim() : "";
+  const inherited = typeof input.inherited === "string" ? input.inherited.trim() : "";
+  const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
+
+  if (resolved) {
+    // The run-resolved home is the authoritative source, but it is still
+    // checked. Trusting it unconditionally would leave this helper unable to
+    // enforce the very invariant it exists for, and the failure mode is a
+    // silent write into another agent's memory.
+    if (agentId && !agentHomeBelongsToAgent(resolved, agentId)) {
+      return {
+        agentHome: null,
+        warning:
+          `Dropping run-resolved AGENT_HOME "${resolved}" — it is not addressed by agent ${agentId}. ` +
+          `Refusing to hand an agent a memory root that is not demonstrably its own.`,
+      };
+    }
+    if (inherited && inherited !== resolved) {
+      return {
+        agentHome: resolved,
+        warning:
+          `Ignoring inherited AGENT_HOME "${inherited}" — it does not match the home resolved for ` +
+          `agent ${agentId || "(unknown)"} ("${resolved}"). Using the run-resolved home.`,
+      };
+    }
+    return { agentHome: resolved, warning: null };
+  }
+
+  // No run-resolved home. An inherited value is only safe to keep if it is
+  // demonstrably this agent's own directory. Anything else belongs to some
+  // other agent and must not be handed to a process whose instructions treat
+  // it as a write target.
+  if (inherited && agentId) {
+    if (agentHomeBelongsToAgent(inherited, agentId)) {
+      return { agentHome: inherited, warning: null };
+    }
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it does not belong to agent ${agentId}, and no ` +
+        `per-run agent home was resolved. Writing memory there would cross-contaminate another agent's home.`,
+    };
+  }
+  if (inherited) {
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it could not be attributed to this run's agent.`,
+    };
+  }
+  return { agentHome: null, warning: null };
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -468,6 +568,28 @@ export async function execute(
     ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
     ...buildPaperclipEnv(ctx.agent),
   };
+
+  // AGENT_HOME must name *this* agent's home. The heartbeat publishes the
+  // resolved per-agent home on context.paperclipWorkspace.agentHome; it wins
+  // over any inherited value, and any value that cannot be attributed to this
+  // agent is dropped rather than passed through. See resolveAgentHomeEnv above.
+  {
+    const workspaceContext =
+      (ctx as any).context?.paperclipWorkspace &&
+      typeof (ctx as any).context.paperclipWorkspace === "object"
+        ? ((ctx as any).context.paperclipWorkspace as Record<string, unknown>)
+        : {};
+    const agentHomeResolution = resolveAgentHomeEnv({
+      inherited: env.AGENT_HOME,
+      resolvedAgentHome: cfgString(workspaceContext.agentHome) ?? null,
+      agentId: ctx.agent?.id ?? null,
+    });
+    if (agentHomeResolution.agentHome) env.AGENT_HOME = agentHomeResolution.agentHome;
+    else delete env.AGENT_HOME;
+    if (agentHomeResolution.warning) {
+      await ctx.onLog("stdout", `[hermes] Warning: ${agentHomeResolution.warning}\n`);
+    }
+  }
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each agent adapter builds the environment for the child process that runs the agent. `AGENT_HOME` is part of that environment.
> - Agent operating instructions define memory only in terms of `$AGENT_HOME`: `$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`, and `$AGENT_HOME/memory/YYYY-MM-DD.md`.
> - The heartbeat resolves the correct per-agent home for each run. It publishes the value on `context.paperclipWorkspace.agentHome`. The shared helper in `packages/adapter-utils/src/server-utils.ts` maps that value to `AGENT_HOME`.
> - The Hermes adapter did not read that value. The child received only the `AGENT_HOME` that it inherited from the server process environment.
> - On a host with a stale `export AGENT_HOME=<some agent path>` in a shell rc file, the inherited value is one fixed agent path for every agent and every run. Every agent then writes memory into that one agent's home.
> - Two failures follow. Two agents write to the same `memory/YYYY-MM-DD.md` file, so daily notes collide. When the named agent is read-only oversight, the audited agent receives a writable path inside the auditor's home.
> - This pull request makes the Hermes adapter use the run-resolved home. It also refuses any home that is not demonstrably the current agent's own.
> - The benefit is that an agent can only write memory into its own home, and a leaked value is visible in the run log instead of silent.

## Linked Issues or Issue Description

**Describe the bug**

The Hermes adapter gives a child process an `AGENT_HOME` that can name a different agent's home directory. Every `hermes_local` agent on the affected host received one fixed foreign path.

**To Reproduce**

1. Set `export AGENT_HOME=/path/to/instance/companies/<companyId>/agents/<agentA-id>` in a shell rc file that the Paperclip server process reads.
2. Start the Paperclip server from that shell.
3. Run any agent whose `adapterType` is `hermes_local`, where that agent is **not** `agentA`.
4. In the agent run, print `$AGENT_HOME`.

**Expected behavior**

`AGENT_HOME` names the home directory of the agent that the run belongs to. The heartbeat already resolves this path and publishes it on `context.paperclipWorkspace.agentHome`.

**Actual behavior**

`AGENT_HOME` names `agentA`'s home directory for every agent. Adapters `codex-local`, `cursor-local`, `gemini-local`, `opencode-local`, and `pi-local` all map the resolved home to `AGENT_HOME`. The Hermes adapter was the only adapter that did not, so it was the only adapter that passed the inherited value through.

**Impact**

Two agents write their daily notes to the same `memory/YYYY-MM-DD.md` path, which corrupts memory. When the named agent is read-only oversight, an audited agent gets a writable path inside the auditor's home, which breaks oversight independence.

Refs #10052 (related Hermes child-environment isolation work; that PR does not address `AGENT_HOME`).

## What Changed

- Add `resolveAgentHomeEnv()` to `packages/adapters/hermes/src/server/execute.ts`. It returns the `AGENT_HOME` to use and an optional operator warning.
- Add `agentHomeBelongsToAgent()`. It reports whether a path is addressed by a given agent id. An agent home ends with the agent id, so the helper compares the final path segment. It accepts both path separators and ignores trailing slashes.
- Apply the resolver when the adapter builds the child environment. The run-resolved home now wins over any inherited value.
- Drop any candidate home that is not attributable to the current agent. This check applies to the run-resolved value and to the inherited value. No single caller can bypass the ownership rule.
- Delete `AGENT_HOME` from the child environment when no candidate passes the check. An absent value is a loud and recoverable failure. A confidently wrong value silently corrupts another agent's memory.
- Write an operator warning to the run log on every override or drop, so a leak is visible.
- Add `packages/adapters/hermes/src/server/execute.agent-home.test.ts` with 13 tests.

## Verification

Run from `packages/adapters/hermes`:

```
npx vitest run src/server/execute.agent-home.test.ts
npx tsc --noEmit
```

Result on this branch, rebased on current `master`:

```
 ✓ src/server/execute.agent-home.test.ts (13 tests) 776ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

`tsc --noEmit` reports no errors.

Seven of the 13 tests are behavioural. They call the real `execute()` and read the environment back out of the `runChildProcess` mock, so they assert on the environment that the child actually receives. Six are unit tests on the resolver.

Covered cases:

- Each of three agents receives its own home, not a shared or foreign one.
- A run does not receive the oversight agent's home when the server process environment leaks that path.
- The same protection applies to an ordinary third agent, which shows the fix is not specific to one pair of agents.
- An unattributable inherited value is dropped instead of passed through.
- A run-resolved value that belongs to another agent is dropped.
- An inherited value that is demonstrably the run's own home is kept.
- An operator warning is emitted when a mismatched inherited value is overridden.

To confirm the ownership check on the resolved value is load-bearing, disable it and re-run:

```
# temporarily change the guard to `if (false && agentId && !agentHomeBelongsToAgent(resolved, agentId))`
npx vitest run src/server/execute.agent-home.test.ts
#  Tests  2 failed | 11 passed (13)
```

Note: `src/server/paperclip-task-bridge.test.ts` shows 2-3 timeout failures on the test host. They reproduce identically on unmodified `origin/master`. They are pre-existing and unrelated to this change.

## Risks

Low risk. The change is contained to the Hermes adapter's environment construction and one new test file. It adds 421 lines across 2 files and deletes none.

- No other adapter changes behaviour. Adapters that already map the resolved home are untouched.
- No database migration and no contract change.
- Behavioural shift: a Hermes agent that previously relied on an inherited `AGENT_HOME` from the server process environment now gets no `AGENT_HOME` when that value cannot be attributed to it. This is intentional. An unset variable fails loudly and is recoverable. A value that names another agent's home writes into that agent's memory and is not recoverable. The normal path is unaffected, because the heartbeat resolves and publishes the home for every run.
- The ownership check compares the final path segment with the agent id. A future layout that does not end an agent home with the agent id would need this helper updated. `resolveDefaultAgentWorkspaceDir()` builds the path from the agent id today, so the rule holds.
- No agent memory content is read, modified, moved, or deleted by this change.

## Model Used

Claude Opus 4.6 (Anthropic, `claude-opus-4-6`), 200K context window, extended thinking enabled, with tool use and code execution. The model diagnosed the root cause, wrote the resolver and the tests, and ran the test and typecheck commands quoted above.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
