### PR TITLE
feat(sandbox-providers): pre-fill environment form with default sizing and image values

### DIFF
--- a/packages/plugins/sandbox-providers/daytona/package.json
+++ b/packages/plugins/sandbox-providers/daytona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/plugin-daytona",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Daytona sandbox provider plugin for Paperclip environments",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",

--- a/packages/plugins/sandbox-providers/daytona/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/daytona/src/manifest.ts
@@ -1,7 +1,7 @@
 import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
 
 const PLUGIN_ID = "paperclip.daytona-sandbox-provider";
-const PLUGIN_VERSION = "0.1.0";
+const PLUGIN_VERSION = "0.1.1";
 
 const manifest: PaperclipPluginManifestV1 = {
   id: PLUGIN_ID,
@@ -60,6 +60,7 @@ const manifest: PaperclipPluginManifestV1 = {
             type: "string",
             description:
               "Optional base image or Daytona Image reference. If set, the sandbox is created from this image instead of a snapshot.",
+            default: "daytonaio/sandbox:0.8.0",
           },
           language: {
             type: "string",
@@ -70,17 +71,20 @@ const manifest: PaperclipPluginManifestV1 = {
             type: "integer",
             description: "Optional CPU allocation in cores.",
             minimum: 1,
+            default: 4,
           },
           memory: {
             type: "integer",
             description:
-              "Optional memory allocation in GiB. Leave unset to use Daytona defaults; supported sandbox sizes are 1, 2, 4, and 8 GiB.",
+              "Optional memory allocation in GiB. Supported sandbox sizes are 1, 2, 4, and 8 GiB.",
             enum: [1, 2, 4, 8],
+            default: 4,
           },
           disk: {
             type: "integer",
             description: "Optional disk allocation in GiB.",
             minimum: 1,
+            default: 10,
           },
           gpu: {
             type: "integer",

--- a/packages/plugins/sandbox-providers/daytona/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/daytona/src/plugin.test.ts
@@ -3901,6 +3901,43 @@ describe("daytona manifest memory config", () => {
   });
 });
 
+describe("daytona manifest form defaults", () => {
+  const configSchema = (
+    manifest.environmentDrivers?.[0]?.configSchema as {
+      properties?: Record<
+        string,
+        { format?: string; enum?: unknown[]; minimum?: number; default?: unknown }
+      >;
+    }
+  );
+  const properties = configSchema.properties ?? {};
+
+  it("pre-fills sizing and image fields for the environment form", () => {
+    expect(properties.cpu?.default).toBe(4);
+    expect(properties.memory?.default).toBe(4);
+    expect(properties.disk?.default).toBe(10);
+    expect(properties.image?.default).toBe("daytonaio/sandbox:0.8.0");
+  });
+
+  it("keeps each default within its own schema constraints", () => {
+    expect(properties.memory?.enum).toContain(properties.memory?.default);
+    expect(properties.cpu?.default as number).toBeGreaterThanOrEqual(
+      properties.cpu?.minimum ?? 1,
+    );
+    expect(properties.disk?.default as number).toBeGreaterThanOrEqual(
+      properties.disk?.minimum ?? 1,
+    );
+  });
+
+  it("declares no default on secret-ref fields, which would be persisted as a company secret", () => {
+    for (const prop of Object.values(properties)) {
+      if (prop.format === "secret-ref") {
+        expect(prop.default).toBeUndefined();
+      }
+    }
+  });
+});
+
 describe("buildBwrapCommand advisory wrapper builder", () => {
   it("uses su to drop to sandbox user without --unshare-user", () => {
     const command = buildBwrapCommand(

--- a/packages/plugins/sandbox-providers/exe-dev/package.json
+++ b/packages/plugins/sandbox-providers/exe-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/plugin-exe-dev",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "exe.dev sandbox provider plugin for Paperclip environments",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",

--- a/packages/plugins/sandbox-providers/exe-dev/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/exe-dev/src/manifest.ts
@@ -1,7 +1,7 @@
 import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
 
 const PLUGIN_ID = "paperclip.exe-dev-sandbox-provider";
-const PLUGIN_VERSION = "0.1.1";
+const PLUGIN_VERSION = "0.1.2";
 
 const manifest: PaperclipPluginManifestV1 = {
   id: PLUGIN_ID,
@@ -80,18 +80,21 @@ const manifest: PaperclipPluginManifestV1 = {
           cpu: {
             type: "number",
             description: "Optional CPU count passed to `exe.dev new --cpu`.",
+            default: 4,
             "x-paperclip-advanced": true,
             "x-paperclip-group": "VM resources",
           },
           memory: {
             type: "string",
             description: "Optional memory size such as `4GB`.",
+            default: "4GB",
             "x-paperclip-advanced": true,
             "x-paperclip-group": "VM resources",
           },
           disk: {
             type: "string",
             description: "Optional disk size such as `20GB`.",
+            default: "20GB",
             "x-paperclip-advanced": true,
             "x-paperclip-group": "VM resources",
           },

--- a/packages/plugins/sandbox-providers/exe-dev/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/exe-dev/src/plugin.test.ts
@@ -15,6 +15,7 @@ vi.mock("node:child_process", async () => {
 });
 
 import plugin, { validateSshPrivateKey } from "./plugin.js";
+import manifest from "./manifest.js";
 
 class MockChildProcess extends EventEmitter {
   stdout = new EventEmitter();
@@ -840,5 +841,28 @@ describe("exe.dev sandbox provider plugin", () => {
 
     expect(spawnMock).not.toHaveBeenCalled();
     expect(result?.cwd).toBe("/srv/paperclip/no-vm");
+  });
+});
+
+describe("exe-dev manifest form defaults", () => {
+  const configSchema = (
+    manifest.environmentDrivers?.[0]?.configSchema as {
+      properties?: Record<string, { format?: string; default?: unknown }>;
+    }
+  );
+  const properties = configSchema.properties ?? {};
+
+  it("pre-fills VM sizing for the environment form", () => {
+    expect(properties.cpu?.default).toBe(4);
+    expect(properties.memory?.default).toBe("4GB");
+    expect(properties.disk?.default).toBe("20GB");
+  });
+
+  it("declares no default on secret-ref fields, which would be persisted as a company secret", () => {
+    for (const prop of Object.values(properties)) {
+      if (prop.format === "secret-ref") {
+        expect(prop.default).toBeUndefined();
+      }
+    }
   });
 });

--- a/packages/plugins/sandbox-providers/modal/package.json
+++ b/packages/plugins/sandbox-providers/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/plugin-modal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Modal sandbox provider plugin for Paperclip environments",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",

--- a/packages/plugins/sandbox-providers/modal/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/modal/src/manifest.ts
@@ -1,7 +1,7 @@
 import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
 
 const PLUGIN_ID = "paperclip.modal-sandbox-provider";
-const PLUGIN_VERSION = "0.1.0";
+const PLUGIN_VERSION = "0.1.1";
 
 const manifest: PaperclipPluginManifestV1 = {
   id: PLUGIN_ID,
@@ -31,11 +31,13 @@ const manifest: PaperclipPluginManifestV1 = {
             type: "string",
             description:
               "Modal App name used as the parent for sandboxes. The plugin calls `modal.apps.fromName(appName, { createIfMissing: true })`, so the App is created on first acquire if it does not already exist.",
+            default: "paperclip",
           },
           image: {
             type: "string",
             description:
-              "Container image reference passed to `modal.images.fromRegistry()`, e.g. `python:3.13` or `node:20`.",
+              "Container image reference passed to `modal.images.fromRegistry()`, e.g. `python:3.13` or `node:22`. The default `node:22` satisfies the sandbox runtime contract (node, sh, and tar on PATH).",
+            default: "node:22",
           },
           tokenId: {
             type: "string",

--- a/packages/plugins/sandbox-providers/modal/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/modal/src/plugin.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import manifest from "./manifest.js";
+
 const { MockNotFoundError, MockTimeoutError, MockSandboxTimeoutError } = vi.hoisted(() => {
   class MockNotFoundError extends Error {}
   class MockTimeoutError extends Error {}
@@ -702,5 +704,27 @@ describe("Modal sandbox provider plugin", () => {
       stdout: "",
       stderr: "No provider lease ID available for execution.",
     });
+  });
+});
+
+describe("modal manifest form defaults", () => {
+  const configSchema = (
+    manifest.environmentDrivers?.[0]?.configSchema as {
+      properties?: Record<string, { format?: string; default?: unknown }>;
+    }
+  );
+  const properties = configSchema.properties ?? {};
+
+  it("pre-fills the required app name and image so the form works out of the box", () => {
+    expect(properties.appName?.default).toBe("paperclip");
+    expect(properties.image?.default).toBe("node:22");
+  });
+
+  it("declares no default on secret-ref fields, which would be persisted as a company secret", () => {
+    for (const prop of Object.values(properties)) {
+      if (prop.format === "secret-ref") {
+        expect(prop.default).toBeUndefined();
+      }
+    }
   });
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs execute inside sandbox environments. Sandbox provider plugins (Daytona, Modal, exe.dev, and others) declare a JSON-Schema `configSchema`. The Environment configuration form renders from that schema.
> - The sizing and image fields open empty. Users must guess working values. The Modal form cannot submit at all until the user types an app name and an image by hand.
> - The form renderer already pre-fills every field that declares a JSON-Schema `default`. The manifests do not use this mechanism for sizing or image fields.
> - This pull request adds optional `default` values to the Daytona, Modal, and exe.dev manifest schemas.
> - The benefit is a form that opens with known-good values. Users can create a working environment without provider research.

## Linked Issues or Issue Description

**Current behavior**

The Environment configuration form opens with empty sizing and image fields for the Daytona, Modal, and exe.dev sandbox providers. Users must find working values in provider documentation. Modal declares `appName` and `image` as required with no default, so the form blocks submission until the user invents both values.

**Proposed behavior**

The provider manifests declare JSON-Schema `default` values. The existing form renderer pre-fills them:

- Daytona: CPU `4`, memory `4` GiB, disk `10` GiB, image `daytonaio/sandbox:0.8.0`
- exe.dev: CPU `4`, memory `4GB`, disk `20GB`
- Modal: app name `paperclip`, image `node:22`

Secret-ref fields (API keys, tokens) get no defaults on purpose. The form persists a raw string in a secret-ref field as a company secret on save. A placeholder default would become a stored secret with a bogus value. Each plugin test suite now guards this invariant.

**Reason and benefit**

New users can create a working sandbox environment without guessing. The defaults stay optional: users can clear or change every value, and the schema marks no new field as required. The Modal image default `node:22` satisfies the sandbox runtime contract in `SANDBOX-REQUIREMENTS.md` (`node`, `sh`, and `tar` on PATH).

**Subsystem affected**

Sandbox provider plugins (`packages/plugins/sandbox-providers/*`): environment driver `configSchema` manifests.

**Breaking changes**

None. Defaults only seed the create-mode form. Saved environments keep their stored config. E2B, Novita, Cloudflare, and Kubernetes manifests do not change: E2B and Novita already default to their base templates, and the Cloudflare bridge and Kubernetes cluster fields have no sensible universal value.

## What Changed

- Add `default` values for `cpu`, `memory`, `disk`, and `image` in the Daytona manifest. Trim the memory description to match.
- Add `default` values for `cpu`, `memory`, and `disk` in the exe.dev manifest.
- Add `default` values for `appName` and `image` in the Modal manifest. Extend the image description with the runtime-contract rationale.
- Add manifest tests in all three plugins: defaults match expected values, defaults satisfy their own schema constraints, and no secret-ref field declares a default.
- Bump plugin versions: daytona and modal `0.1.0` → `0.1.1`, exe-dev `0.1.1` → `0.1.2`.

## Verification

- Run `pnpm test` in `packages/plugins/sandbox-providers/daytona`, `.../modal`, and `.../exe-dev`. The new `* manifest form defaults` suites pass.
- Run `./node_modules/.bin/tsc --noEmit` in each of the three packages. Typecheck passes.
- Manual: rebuild the plugins (`pnpm build` in each package), let the plugin dev-watcher refresh the manifest, then open Environments → New environment. The Daytona form shows CPU 4, Memory 4, Disk 10, and image `daytonaio/sandbox:0.8.0`. The Modal form shows `paperclip` and `node:22`. The API key fields stay empty.
- Verified live on a local instance: the served `configSchema` in the plugin registry carries the new defaults, and existing environments are unchanged.

## Risks

- Low risk. The change touches only manifest schema metadata and tests. No runtime code path changes.
- New environments created with untouched forms now request 4 CPU / 4 GiB / 10 GiB from Daytona instead of provider minimums. This can raise cost per sandbox for users who previously saved empty fields.
- The Daytona image default pins `daytonaio/sandbox:0.8.0`. The default needs a manual bump when Daytona ships new sandbox images.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), via the Claude Code CLI, with extended thinking and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
