### PR TITLE
feat(db): journal-consistency guard for migrations (RBR-968 / RBR-927 AC3)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,11 +49,22 @@ jobs:
       - name: Validate Dockerfile deps stage
         run: node ./scripts/check-docker-deps-stage.mjs
 
+      - name: Validate migration journal consistency
+        # RBR-968: an orphaned .sql or a duplicate journal idx makes
+        # embedded-Postgres bootstrap throw inside beforeAll, which Vitest
+        # reports as a *skipped* suite rather than a failure. Check it here in
+        # the fast policy job — no install needed — so the offending filename
+        # surfaces in seconds instead of as silent-green test lanes.
+        run: node ./scripts/check-migration-journal.mjs
+
       - name: Reject git push in adapter/runtime code
         run: node ./scripts/check-no-git-push.mjs
 
       - name: Test no-git-push check
         run: node --test ./scripts/check-no-git-push.test.mjs
+
+      - name: Test migration journal guard
+        run: node --test ./scripts/__tests__/check-migration-journal.test.mjs
 
       - name: Test general-server shard partition
         run: node --test ./scripts/__tests__/run-vitest-stable-shard.test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ check-*.mjs
 !.github/scripts/check-*.mjs
 !.github/scripts/tests/check-*.mjs
 !scripts/check-*.mjs
+!scripts/__tests__/check-*.mjs
 new-agent*.json
 newcompany.json
 seed-*.mjs

--- a/doc/DATABASE.md
+++ b/doc/DATABASE.md
@@ -167,6 +167,51 @@ When authoring migrations or one-time backfills:
 - Split schema changes, index creation, and data backfill into separate phases so each step has clear locking and rollback behavior.
 - Treat the `check:migrations` CI gate as the enforcement backstop for these rules. If it flags a migration, rewrite the migration or add a suppression comment with the indexed predicate, batch bound, and reason the remaining scan is safe.
 
+## Migration journal consistency guard
+
+`packages/db/src/migrations/meta/_journal.json` is the only list drizzle's
+`migrate()` reads. The migrations *folder* is what folder-enumerating checks
+read. When the two disagree the failure is silent and confusing: an orphaned
+`.sql` (in the folder, not in the journal) is never applied, yet it is counted
+as permanently pending, so `applyPendingMigrations` throws — and because that
+throw happens in a suite's `beforeAll`, Vitest reports the whole suite as
+`skipped` rather than `failed`.
+
+The guard that prevents this lives in `packages/db/src/migration-journal-consistency.ts`
+and is enforced at three points:
+
+| Where | What it enforces |
+|---|---|
+| `applyPendingMigrations()` (runtime/bootstrap) | File↔journal bijection only, so a defect can never degrade into a skipped suite. Deliberately does *not* check `idx`, so pre-existing shipped journal history cannot brick startup. |
+| `pnpm --filter @paperclipai/db check:migrations` (gates build/typecheck/generate/migrate) | Full audit: bijection, `idx` uniqueness, `idx` continuity. |
+| `scripts/run-vitest-stable.mjs` preflight | Same full audit, run once before any embedded-Postgres suite starts. |
+
+Run it directly:
+
+```sh
+pnpm --filter @paperclipai/db check:migration-journal          # baseline honoured
+pnpm --filter @paperclipai/db exec tsx src/check-migration-journal.ts --strict
+```
+
+Rules the guard applies:
+
+- **Bijection violations are always hard errors** and always name the offending filename.
+- **A duplicate `idx` is a hard error**, except for groups recorded in
+  `packages/db/src/migration-journal-idx-baseline.json`, which are reported as
+  warnings so the guard could be adopted without first rewriting shipped
+  history. `origin/master` currently carries one: idx 178 is claimed by both
+  `0177_activity_log_responsible_user` and `0178_summary_slots`.
+- **`idx` gaps are warnings.** `origin/master` currently has gaps at 126, 130
+  and 177 — usually a migration dropped before merge. They are tolerated, but
+  they make "latest idx" an unreliable count of applied migrations.
+
+The baseline file is a ratchet, not an excuse list. A baselined group is
+excused only when its `idx` *and* its exact tag set still match, so a third
+entry joining a baselined group is a fresh error; and a baseline entry that no
+longer matches the journal is itself a hard error, so the file cannot rot. Do
+not add entries to unblock your own change — if your change introduces a
+duplicate `idx`, fix the journal.
+
 ## Resource membership tables
 
 Paperclip stores current-user sidebar membership state in:

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -38,7 +38,8 @@
     "embedded-postgres"
   ],
   "scripts": {
-    "check:migrations": "tsx src/check-migration-numbering.ts && tsx src/check-migration-safety.ts",
+    "check:migrations": "tsx src/check-migration-journal.ts && tsx src/check-migration-numbering.ts && tsx src/check-migration-safety.ts",
+    "check:migration-journal": "tsx src/check-migration-journal.ts",
     "build": "pnpm run check:migrations && tsc && cp -r src/migrations dist/migrations",
     "clean": "rm -rf dist",
     "typecheck": "pnpm run check:migrations && tsc --noEmit",

--- a/packages/db/src/check-migration-journal.ts
+++ b/packages/db/src/check-migration-journal.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Journal-consistency guard (RBR-968 / RBR-927 AC3).
+ *
+ * Asserts, against packages/db/src/migrations:
+ *   1. file <-> journal bijection — every `.sql` has a `meta/_journal.json`
+ *      entry and every entry has a `.sql`. Violations are always hard errors
+ *      naming the offending filename.
+ *   2. `idx` uniqueness — no two journal entries share an `idx`. Hard error,
+ *      except for the pre-existing groups recorded in
+ *      migration-journal-idx-baseline.json, which are reported as warnings so
+ *      they stay visible without blocking unrelated work.
+ *   3. `idx` continuity — gaps are reported as warnings.
+ *
+ * Runs before any embedded-Postgres suite (scripts/run-vitest-stable.mjs
+ * preflight) and as part of `check:migrations`, which already gates
+ * build / typecheck / generate / migrate.
+ *
+ * Usage:
+ *   tsx src/check-migration-journal.ts            # baseline honoured
+ *   tsx src/check-migration-journal.ts --strict   # every defect is an error
+ */
+import { fileURLToPath } from "node:url";
+import {
+  auditMigrationJournal,
+  EMPTY_MIGRATION_JOURNAL_IDX_BASELINE,
+  loadMigrationJournalIdxBaseline,
+} from "./migration-journal-consistency.js";
+
+const migrationsDir = fileURLToPath(new URL("./migrations", import.meta.url));
+const journalPath = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
+
+const strict = process.argv.slice(2).includes("--strict");
+
+const baseline = strict
+  ? EMPTY_MIGRATION_JOURNAL_IDX_BASELINE
+  : await loadMigrationJournalIdxBaseline();
+
+const { errors, warnings, result } = await auditMigrationJournal({
+  migrationsDir,
+  journalPath,
+  baseline,
+  strict,
+});
+
+for (const warning of warnings) {
+  console.warn(`[check:migration-journal] WARN ${warning}`);
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`[check:migration-journal] ERROR ${error}`);
+  }
+  console.error(
+    `[check:migration-journal] FAILED — ${errors.length} error(s) across ${result.migrationFiles.length} migration file(s) and ${result.journalFiles.length} journal entry/entries.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check:migration-journal] OK — ${result.migrationFiles.length} migration file(s) match ${result.journalFiles.length} journal entry/entries${
+    warnings.length > 0 ? `, ${warnings.length} warning(s)` : ""
+  }${strict ? " (strict)" : ""}.`,
+);

--- a/packages/db/src/check-migration-numbering.ts
+++ b/packages/db/src/check-migration-numbering.ts
@@ -1,5 +1,9 @@
 import { readdir, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import {
+  checkMigrationJournalConsistency,
+  formatMigrationJournalInconsistencies,
+} from "./migration-journal-consistency.js";
 
 const migrationsDir = fileURLToPath(new URL("./migrations", import.meta.url));
 const journalPath = fileURLToPath(new URL("./migrations/meta/_journal.json", import.meta.url));
@@ -64,6 +68,15 @@ function ensureJournalMatchesFiles(migrationFiles: string[], journalTags: string
 }
 
 async function main() {
+  // Journal/folder set comparison runs first so an orphaned or missing file is
+  // always reported by filename, even when its name would also trip the
+  // numbering rules below (e.g. a duplicate slot number or a non-4-digit
+  // prefix). The orphan is the root cause; the numbering complaint is noise.
+  const consistency = await checkMigrationJournalConsistency({ migrationsDir, journalPath });
+  if (consistency.inconsistencies.length > 0) {
+    throw new Error(formatMigrationJournalInconsistencies(consistency.inconsistencies));
+  }
+
   const migrationFiles = (await readdir(migrationsDir))
     .filter((entry) => entry.endsWith(".sql"))
     .sort();

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -4,6 +4,7 @@ import { migrate as migratePg } from "drizzle-orm/postgres-js/migrator";
 import { readFile, readdir } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
+import { assertMigrationJournalConsistency } from "./migration-journal-consistency.js";
 import * as schema from "./schema/index.js";
 
 const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
@@ -722,6 +723,13 @@ export async function inspectMigrations(url: string): Promise<MigrationState> {
 }
 
 export async function applyPendingMigrations(url: string): Promise<void> {
+  // Fail loudly and early when the migrations folder and meta/_journal.json
+  // disagree. Without this, an orphaned .sql file is skipped by drizzle's
+  // journal-driven migrator yet counted as pending by inspectMigrations, so
+  // bootstrap dies with an unactionable "Failed to bootstrap migrations" that
+  // no repair path can resolve.
+  await assertMigrationJournalConsistency();
+
   const initialState = await inspectMigrations(url);
   if (initialState.status === "upToDate") return;
 

--- a/packages/db/src/migration-journal-consistency.test.ts
+++ b/packages/db/src/migration-journal-consistency.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertMigrationJournalConsistency,
+  checkMigrationJournalConsistency,
+  formatMigrationJournalInconsistencies,
+} from "./migration-journal-consistency.js";
+
+// RBR-927: an orphaned .sql file (present in the migrations folder, absent from
+// meta/_journal.json) is invisible to drizzle's journal-driven migrator but is
+// reported as permanently pending by folder-enumerating checks. That made
+// database bootstrap fail with an unactionable message, and because bootstrap
+// runs in `beforeAll`, whole suites reported `skipped` rather than `failed`.
+// These tests pin the guard that turns that class of defect into a hard error
+// naming the offending filename.
+
+const createdDirs: string[] = [];
+
+function makeFixture(options: {
+  readonly files: readonly string[];
+  readonly journalTags: readonly string[];
+}): { migrationsDir: string; journalPath: string } {
+  const migrationsDir = mkdtempSync(join(tmpdir(), "paperclip-journal-consistency-"));
+  createdDirs.push(migrationsDir);
+  mkdirSync(join(migrationsDir, "meta"), { recursive: true });
+
+  for (const fileName of options.files) {
+    writeFileSync(join(migrationsDir, fileName), "SELECT 1;\n", "utf8");
+  }
+
+  const journalPath = join(migrationsDir, "meta", "_journal.json");
+  writeFileSync(
+    journalPath,
+    JSON.stringify({
+      version: "7",
+      dialect: "postgresql",
+      entries: options.journalTags.map((tag, index) => ({
+        idx: index,
+        version: "7",
+        when: 1_700_000_000_000 + index,
+        tag,
+        breakpoints: true,
+      })),
+    }),
+    "utf8",
+  );
+
+  return { migrationsDir, journalPath };
+}
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("checkMigrationJournalConsistency", () => {
+  it("reports no inconsistencies when every file has a journal entry", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql", "0002_second.sql"],
+      journalTags: ["0001_first", "0002_second"],
+    });
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([]);
+    expect(result.migrationFiles).toEqual(["0001_first.sql", "0002_second.sql"]);
+    expect(result.journalFiles).toEqual(["0001_first.sql", "0002_second.sql"]);
+  });
+
+  it("flags an orphaned file whose number collides with a journalled slot", async () => {
+    // The exact RBR-927 shape: 0128_force_reassign.sql left behind after the
+    // migration was renumbered to 0131, with slot 0128 already taken.
+    const fixture = makeFixture({
+      files: ["0128_force_reassign.sql", "0128_user_specific_secrets.sql", "0131_force_reassign.sql"],
+      journalTags: ["0128_user_specific_secrets", "0131_force_reassign"],
+    });
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([
+      { kind: "orphaned-migration-file", fileName: "0128_force_reassign.sql" },
+    ]);
+  });
+
+  it("flags an orphaned file that occupies an otherwise-unused number", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql", "0300_orphan_never_journalled.sql"],
+      journalTags: ["0001_first"],
+    });
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([
+      { kind: "orphaned-migration-file", fileName: "0300_orphan_never_journalled.sql" },
+    ]);
+  });
+
+  it("flags an orphaned file whose name does not use a 4-digit prefix", async () => {
+    // The numbering checks reject this on prefix shape alone; the journal
+    // comparison must still identify it as the orphan it is.
+    const fixture = makeFixture({
+      files: ["0001_first.sql", "0130a_orphan_mid.sql"],
+      journalTags: ["0001_first"],
+    });
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([
+      { kind: "orphaned-migration-file", fileName: "0130a_orphan_mid.sql" },
+    ]);
+  });
+
+  it("flags a journal entry with no matching file", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql"],
+      journalTags: ["0001_first", "0002_deleted_by_mistake"],
+    });
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([
+      { kind: "missing-migration-file", fileName: "0002_deleted_by_mistake.sql" },
+    ]);
+  });
+
+  it("reports orphaned and missing files together", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql", "0009_orphan.sql"],
+      journalTags: ["0001_first", "0002_missing"],
+    });
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([
+      { kind: "orphaned-migration-file", fileName: "0009_orphan.sql" },
+      { kind: "missing-migration-file", fileName: "0002_missing.sql" },
+    ]);
+  });
+
+  it("ignores non-.sql entries in the migrations folder", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql"],
+      journalTags: ["0001_first"],
+    });
+    writeFileSync(join(fixture.migrationsDir, "README.md"), "notes\n", "utf8");
+
+    const result = await checkMigrationJournalConsistency(fixture);
+
+    expect(result.inconsistencies).toEqual([]);
+  });
+});
+
+describe("assertMigrationJournalConsistency", () => {
+  it("throws naming the orphaned filename", async () => {
+    const fixture = makeFixture({
+      files: ["0128_force_reassign.sql", "0128_user_specific_secrets.sql"],
+      journalTags: ["0128_user_specific_secrets"],
+    });
+
+    await expect(assertMigrationJournalConsistency(fixture)).rejects.toThrow(
+      /0128_force_reassign\.sql/,
+    );
+  });
+
+  it("resolves for the real shipped migrations folder", async () => {
+    // Guards the repository itself: packages/db/src/migrations must stay in
+    // agreement with meta/_journal.json.
+    await expect(assertMigrationJournalConsistency()).resolves.toBeUndefined();
+  });
+});
+
+describe("formatMigrationJournalInconsistencies", () => {
+  it("names the offending file and explains the failure mode", () => {
+    const message = formatMigrationJournalInconsistencies([
+      { kind: "orphaned-migration-file", fileName: "0128_force_reassign.sql" },
+    ]);
+
+    expect(message).toContain("0128_force_reassign.sql");
+    expect(message).toContain("meta/_journal.json");
+    expect(message).toContain("Orphaned migration file");
+  });
+
+  it("names a missing file separately from an orphan", () => {
+    const message = formatMigrationJournalInconsistencies([
+      { kind: "missing-migration-file", fileName: "0002_missing.sql" },
+    ]);
+
+    expect(message).toContain("0002_missing.sql");
+    expect(message).not.toContain("Orphaned migration file");
+  });
+});

--- a/packages/db/src/migration-journal-consistency.test.ts
+++ b/packages/db/src/migration-journal-consistency.test.ts
@@ -4,8 +4,13 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   assertMigrationJournalConsistency,
+  auditMigrationJournal,
   checkMigrationJournalConsistency,
+  findDuplicateJournalIdxGroups,
+  findJournalIdxGaps,
   formatMigrationJournalInconsistencies,
+  loadMigrationJournalIdxBaseline,
+  parseMigrationJournalIdxBaseline,
 } from "./migration-journal-consistency.js";
 
 // RBR-927: an orphaned .sql file (present in the migrations folder, absent from
@@ -21,6 +26,8 @@ const createdDirs: string[] = [];
 function makeFixture(options: {
   readonly files: readonly string[];
   readonly journalTags: readonly string[];
+  /** Explicit idx per journal tag. Defaults to the tag's position. */
+  readonly journalIdx?: readonly number[];
 }): { migrationsDir: string; journalPath: string } {
   const migrationsDir = mkdtempSync(join(tmpdir(), "paperclip-journal-consistency-"));
   createdDirs.push(migrationsDir);
@@ -37,7 +44,7 @@ function makeFixture(options: {
       version: "7",
       dialect: "postgresql",
       entries: options.journalTags.map((tag, index) => ({
-        idx: index,
+        idx: options.journalIdx?.[index] ?? index,
         version: "7",
         when: 1_700_000_000_000 + index,
         tag,
@@ -191,5 +198,263 @@ describe("formatMigrationJournalInconsistencies", () => {
 
     expect(message).toContain("0002_missing.sql");
     expect(message).not.toContain("Orphaned migration file");
+  });
+});
+
+// RBR-968: the guard also owns `idx` health. A duplicate `idx` does not stop
+// drizzle's migrate(), so it cannot be enforced in the runtime bootstrap path
+// without risking production startup — it is enforced here, in the pre-test /
+// pre-build audit, with an explicit ratcheting baseline for already-shipped
+// defects.
+
+describe("findDuplicateJournalIdxGroups", () => {
+  it("returns nothing when every idx is unique", () => {
+    expect(
+      findDuplicateJournalIdxGroups([
+        { idx: 1, tag: "a" },
+        { idx: 2, tag: "b" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("groups the tags sharing an idx, in journal order", () => {
+    // The real origin/master shape: idx 178 claimed twice.
+    expect(
+      findDuplicateJournalIdxGroups([
+        { idx: 176, tag: "0176_a" },
+        { idx: 178, tag: "0177_activity_log_responsible_user" },
+        { idx: 178, tag: "0178_summary_slots" },
+      ]),
+    ).toEqual([
+      { idx: 178, tags: ["0177_activity_log_responsible_user", "0178_summary_slots"] },
+    ]);
+  });
+
+  it("reports a triple collision as one group with all three tags", () => {
+    expect(
+      findDuplicateJournalIdxGroups([
+        { idx: 5, tag: "a" },
+        { idx: 5, tag: "b" },
+        { idx: 5, tag: "c" },
+      ]),
+    ).toEqual([{ idx: 5, tags: ["a", "b", "c"] }]);
+  });
+});
+
+describe("findJournalIdxGaps", () => {
+  it("returns nothing for a contiguous sequence", () => {
+    expect(
+      findJournalIdxGaps([
+        { idx: 0, tag: "a" },
+        { idx: 1, tag: "b" },
+        { idx: 2, tag: "c" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("lists every missing idx between the lowest and highest present", () => {
+    // The real origin/master shape: 126, 130 and 177 absent.
+    expect(
+      findJournalIdxGaps([
+        { idx: 125, tag: "a" },
+        { idx: 127, tag: "b" },
+        { idx: 129, tag: "c" },
+        { idx: 131, tag: "d" },
+      ]),
+    ).toEqual([126, 128, 130]);
+  });
+
+  it("returns nothing for an empty journal", () => {
+    expect(findJournalIdxGaps([])).toEqual([]);
+  });
+});
+
+describe("auditMigrationJournal", () => {
+  it("passes a clean folder/journal pair with no warnings", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql", "0002_second.sql"],
+      journalTags: ["0001_first", "0002_second"],
+    });
+
+    const audit = await auditMigrationJournal(fixture);
+
+    expect(audit.errors).toEqual([]);
+    expect(audit.warnings).toEqual([]);
+  });
+
+  it("hard-errors on an orphaned file, naming it", async () => {
+    const fixture = makeFixture({
+      files: ["0001_first.sql", "0002_orphan.sql"],
+      journalTags: ["0001_first"],
+    });
+
+    const audit = await auditMigrationJournal(fixture);
+
+    expect(audit.errors).toHaveLength(1);
+    expect(audit.errors[0]).toContain("0002_orphan.sql");
+  });
+
+  it("hard-errors on an un-baselined duplicate idx, naming both tags", async () => {
+    const fixture = makeFixture({
+      files: ["0001_a.sql", "0002_b.sql"],
+      journalTags: ["0001_a", "0002_b"],
+      journalIdx: [7, 7],
+    });
+
+    const audit = await auditMigrationJournal(fixture);
+
+    expect(audit.errors).toHaveLength(1);
+    expect(audit.errors[0]).toContain("idx 7");
+    expect(audit.errors[0]).toContain("0001_a.sql");
+    expect(audit.errors[0]).toContain("0002_b.sql");
+  });
+
+  it("downgrades an exactly-baselined duplicate idx to a warning that still names it", async () => {
+    const fixture = makeFixture({
+      files: ["0001_a.sql", "0002_b.sql"],
+      journalTags: ["0001_a", "0002_b"],
+      journalIdx: [7, 7],
+    });
+
+    const audit = await auditMigrationJournal({
+      ...fixture,
+      baseline: { duplicateIdx: [{ idx: 7, tags: ["0001_a", "0002_b"] }] },
+    });
+
+    expect(audit.errors).toEqual([]);
+    expect(audit.warnings).toHaveLength(1);
+    expect(audit.warnings[0]).toContain("idx 7");
+    expect(audit.warnings[0]).toContain("0001_a.sql");
+  });
+
+  it("ignores the baseline under --strict so the defect is an error again", async () => {
+    const fixture = makeFixture({
+      files: ["0001_a.sql", "0002_b.sql"],
+      journalTags: ["0001_a", "0002_b"],
+      journalIdx: [7, 7],
+    });
+
+    const audit = await auditMigrationJournal({
+      ...fixture,
+      baseline: { duplicateIdx: [{ idx: 7, tags: ["0001_a", "0002_b"] }] },
+      strict: true,
+    });
+
+    expect(audit.errors).toHaveLength(1);
+    expect(audit.errors[0]).toContain("idx 7");
+  });
+
+  it("ratchets: a third entry joining a baselined group is a fresh error", async () => {
+    const fixture = makeFixture({
+      files: ["0001_a.sql", "0002_b.sql", "0003_c.sql"],
+      journalTags: ["0001_a", "0002_b", "0003_c"],
+      journalIdx: [7, 7, 7],
+    });
+
+    const audit = await auditMigrationJournal({
+      ...fixture,
+      baseline: { duplicateIdx: [{ idx: 7, tags: ["0001_a", "0002_b"] }] },
+    });
+
+    expect(audit.errors).toHaveLength(1);
+    expect(audit.errors[0]).toContain("0003_c");
+    expect(audit.warnings).toEqual([]);
+  });
+
+  it("errors on a stale baseline entry so the file cannot rot into a blanket excuse", async () => {
+    const fixture = makeFixture({
+      files: ["0001_a.sql", "0002_b.sql"],
+      journalTags: ["0001_a", "0002_b"],
+    });
+
+    const audit = await auditMigrationJournal({
+      ...fixture,
+      baseline: { duplicateIdx: [{ idx: 7, tags: ["0001_a", "0002_b"] }] },
+    });
+
+    expect(audit.errors).toHaveLength(1);
+    expect(audit.errors[0]).toContain("Stale baseline entry");
+  });
+
+  it("reports idx gaps as a warning, not an error", async () => {
+    const fixture = makeFixture({
+      files: ["0001_a.sql", "0002_b.sql"],
+      journalTags: ["0001_a", "0002_b"],
+      journalIdx: [1, 4],
+    });
+
+    const audit = await auditMigrationJournal(fixture);
+
+    expect(audit.errors).toEqual([]);
+    expect(audit.warnings).toHaveLength(1);
+    expect(audit.warnings[0]).toContain("2, 3");
+  });
+});
+
+describe("parseMigrationJournalIdxBaseline", () => {
+  it("accepts a well-formed baseline", () => {
+    const baseline = parseMigrationJournalIdxBaseline(
+      JSON.stringify({ duplicateIdx: [{ idx: 178, tags: ["a", "b"], reason: "shipped" }] }),
+    );
+
+    expect(baseline.duplicateIdx).toEqual([{ idx: 178, tags: ["a", "b"], reason: "shipped" }]);
+  });
+
+  it("treats an absent duplicateIdx as an empty baseline", () => {
+    expect(parseMigrationJournalIdxBaseline("{}").duplicateIdx).toEqual([]);
+  });
+
+  it("rejects an entry with fewer than two tags", () => {
+    expect(() =>
+      parseMigrationJournalIdxBaseline(JSON.stringify({ duplicateIdx: [{ idx: 1, tags: ["a"] }] })),
+    ).toThrow(/at least two/);
+  });
+
+  it("rejects a non-integer idx", () => {
+    expect(() =>
+      parseMigrationJournalIdxBaseline(
+        JSON.stringify({ duplicateIdx: [{ idx: "1", tags: ["a", "b"] }] }),
+      ),
+    ).toThrow(/non-integer idx/);
+  });
+});
+
+describe("the shipped repository journal", () => {
+  // AC2: the guard must catch the genuine origin/master defects. These pin the
+  // known state so the numbers cannot drift silently: idx 178 is duplicated
+  // and 126/130/177 are missing. When those defects are fixed, this test
+  // fails and must be updated together with the baseline file.
+  it("has exactly the known duplicate idx 178, and it is baselined", async () => {
+    const result = await checkMigrationJournalConsistency();
+    const baseline = await loadMigrationJournalIdxBaseline();
+
+    expect(result.duplicateIdxGroups).toEqual([
+      { idx: 178, tags: ["0177_activity_log_responsible_user", "0178_summary_slots"] },
+    ]);
+    expect(baseline.duplicateIdx.map((entry) => entry.idx)).toEqual([178]);
+  });
+
+  it("has the known idx gaps 126, 130 and 177", async () => {
+    const result = await checkMigrationJournalConsistency();
+
+    expect(result.idxGaps).toEqual([126, 130, 177]);
+  });
+
+  it("audits clean against the shipped baseline, with the defects as warnings", async () => {
+    const audit = await auditMigrationJournal({
+      baseline: await loadMigrationJournalIdxBaseline(),
+    });
+
+    expect(audit.errors).toEqual([]);
+    // Duplicate idx 178 (baselined) plus the idx-gap warning.
+    expect(audit.warnings).toHaveLength(2);
+    expect(audit.warnings.join("\n")).toContain("178");
+  });
+
+  it("fails under --strict, proving the guard would catch the defect on a clean journal", async () => {
+    const audit = await auditMigrationJournal({ strict: true });
+
+    expect(audit.errors).toHaveLength(1);
+    expect(audit.errors[0]).toContain("Duplicate journal idx 178");
   });
 });

--- a/packages/db/src/migration-journal-consistency.ts
+++ b/packages/db/src/migration-journal-consistency.ts
@@ -1,0 +1,134 @@
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
+const MIGRATIONS_JOURNAL_JSON = fileURLToPath(
+  new URL("./migrations/meta/_journal.json", import.meta.url),
+);
+
+/**
+ * An orphaned migration file (a `.sql` in the migrations folder with no
+ * `meta/_journal.json` entry) is invisible to drizzle's journal-driven
+ * `migrate()` but *is* visible to any folder-enumerating check such as
+ * `inspectMigrations`. The result is a database that is genuinely up to date
+ * while bootstrap reports it as permanently pending, which surfaces as an
+ * unfixable "Failed to bootstrap migrations" and — when it happens inside a
+ * `beforeAll` — a whole suite reporting `skipped` instead of `failed`.
+ *
+ * This module is the single source of truth for that invariant so the build
+ * gate (`check:migrations`) and the runtime bootstrap path both fail the same
+ * way: a hard error that names the offending filename.
+ */
+export type MigrationJournalInconsistency =
+  | { readonly kind: "orphaned-migration-file"; readonly fileName: string }
+  | { readonly kind: "missing-migration-file"; readonly fileName: string };
+
+export type MigrationJournalConsistencyResult = {
+  readonly migrationFiles: readonly string[];
+  readonly journalFiles: readonly string[];
+  readonly inconsistencies: readonly MigrationJournalInconsistency[];
+};
+
+type JournalFile = {
+  entries?: Array<{ idx?: number; tag?: string; when?: number }>;
+};
+
+export async function listMigrationFolderFiles(
+  migrationsDir: string = MIGRATIONS_FOLDER,
+): Promise<string[]> {
+  const entries = await readdir(migrationsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export async function listJournalMigrationFileNames(
+  journalPath: string = MIGRATIONS_JOURNAL_JSON,
+): Promise<string[]> {
+  const raw = await readFile(journalPath, "utf8");
+  const parsed = JSON.parse(raw) as JournalFile;
+  const entries = parsed.entries ?? [];
+
+  return entries.map((entry, index) => {
+    if (typeof entry?.tag !== "string" || entry.tag.length === 0) {
+      throw new Error(`Migration journal entry ${index} is missing a tag`);
+    }
+    return `${entry.tag}.sql`;
+  });
+}
+
+/**
+ * Compares the migrations folder against `meta/_journal.json` and reports every
+ * file that exists on only one side. Pure comparison: it never throws for an
+ * inconsistency, so callers can format their own message.
+ */
+export async function checkMigrationJournalConsistency(options?: {
+  readonly migrationsDir?: string;
+  readonly journalPath?: string;
+}): Promise<MigrationJournalConsistencyResult> {
+  const migrationFiles = await listMigrationFolderFiles(options?.migrationsDir);
+  const journalFiles = await listJournalMigrationFileNames(options?.journalPath);
+
+  const journalFileSet = new Set(journalFiles);
+  const migrationFileSet = new Set(migrationFiles);
+
+  const inconsistencies: MigrationJournalInconsistency[] = [];
+
+  for (const fileName of migrationFiles) {
+    if (!journalFileSet.has(fileName)) {
+      inconsistencies.push({ kind: "orphaned-migration-file", fileName });
+    }
+  }
+
+  for (const fileName of journalFiles) {
+    if (!migrationFileSet.has(fileName)) {
+      inconsistencies.push({ kind: "missing-migration-file", fileName });
+    }
+  }
+
+  return { migrationFiles, journalFiles, inconsistencies };
+}
+
+export function formatMigrationJournalInconsistencies(
+  inconsistencies: readonly MigrationJournalInconsistency[],
+): string {
+  const orphaned = inconsistencies
+    .filter((entry) => entry.kind === "orphaned-migration-file")
+    .map((entry) => entry.fileName);
+  const missing = inconsistencies
+    .filter((entry) => entry.kind === "missing-migration-file")
+    .map((entry) => entry.fileName);
+
+  const lines: string[] = ["Migration folder and meta/_journal.json disagree."];
+
+  if (orphaned.length > 0) {
+    lines.push(
+      `Orphaned migration file(s) present in packages/db/src/migrations but absent from meta/_journal.json: ${orphaned.join(", ")}.`,
+      "An orphaned file is never applied by drizzle's journal-driven migrator but is reported as permanently pending by folder-based checks, which breaks database bootstrap. Delete the file if it is a leftover duplicate, or add its journal entry if the migration is real.",
+    );
+  }
+
+  if (missing.length > 0) {
+    lines.push(
+      `Journal entry/entries with no matching .sql file in packages/db/src/migrations: ${missing.join(", ")}.`,
+      "Restore the missing file or remove the stale journal entry.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Hard-fails with the offending filename when the migrations folder and the
+ * journal disagree. Called from migration bootstrap so an orphaned file can
+ * never degrade into a silently skipped test suite.
+ */
+export async function assertMigrationJournalConsistency(options?: {
+  readonly migrationsDir?: string;
+  readonly journalPath?: string;
+}): Promise<void> {
+  const { inconsistencies } = await checkMigrationJournalConsistency(options);
+  if (inconsistencies.length === 0) return;
+  throw new Error(formatMigrationJournalInconsistencies(inconsistencies));
+}

--- a/packages/db/src/migration-journal-consistency.ts
+++ b/packages/db/src/migration-journal-consistency.ts
@@ -5,6 +5,9 @@ const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url)
 const MIGRATIONS_JOURNAL_JSON = fileURLToPath(
   new URL("./migrations/meta/_journal.json", import.meta.url),
 );
+const IDX_BASELINE_JSON = fileURLToPath(
+  new URL("./migration-journal-idx-baseline.json", import.meta.url),
+);
 
 /**
  * An orphaned migration file (a `.sql` in the migrations folder with no
@@ -15,22 +18,69 @@ const MIGRATIONS_JOURNAL_JSON = fileURLToPath(
  * unfixable "Failed to bootstrap migrations" and — when it happens inside a
  * `beforeAll` — a whole suite reporting `skipped` instead of `failed`.
  *
- * This module is the single source of truth for that invariant so the build
- * gate (`check:migrations`) and the runtime bootstrap path both fail the same
- * way: a hard error that names the offending filename.
+ * This module is the single source of truth for the journal invariants so the
+ * build gate (`check:migrations`), the standalone CI guard
+ * (`scripts/check-migration-journal.mjs`) and the runtime bootstrap path all
+ * describe the same defects the same way, always naming the offending file.
+ *
+ * Two enforcement levels, deliberately different:
+ *
+ * - `assertMigrationJournalConsistency` runs inside `applyPendingMigrations`,
+ *   i.e. in every embedded-Postgres `beforeAll`. It enforces only the
+ *   invariants that actually break bootstrap: the file/journal bijection and
+ *   well-formed entries. It must never start failing on pre-existing shipped
+ *   journal history, or it would brick production startup.
+ * - `auditMigrationJournal` is the pre-test/pre-build gate. It additionally
+ *   enforces `idx` uniqueness (with an explicit, ratcheting baseline for
+ *   already-shipped defects) and reports `idx` gaps as warnings.
  */
 export type MigrationJournalInconsistency =
   | { readonly kind: "orphaned-migration-file"; readonly fileName: string }
   | { readonly kind: "missing-migration-file"; readonly fileName: string };
 
+/** A journal `idx` value claimed by more than one entry. */
+export type DuplicateJournalIdxGroup = {
+  readonly idx: number;
+  /** Tags sharing this `idx`, in journal order. */
+  readonly tags: readonly string[];
+};
+
+export type MigrationJournalEntry = {
+  readonly idx: number;
+  readonly tag: string;
+};
+
 export type MigrationJournalConsistencyResult = {
   readonly migrationFiles: readonly string[];
   readonly journalFiles: readonly string[];
+  /**
+   * File/journal bijection violations only. These are the bootstrap-breaking
+   * defects; `idx` problems are reported separately because they do not stop
+   * `migrate()` from running.
+   */
   readonly inconsistencies: readonly MigrationJournalInconsistency[];
+  /** Every `idx` shared by two or more journal entries. Not baseline-filtered. */
+  readonly duplicateIdxGroups: readonly DuplicateJournalIdxGroup[];
+  /** Missing `idx` values between the lowest and highest present `idx`. */
+  readonly idxGaps: readonly number[];
 };
 
 type JournalFile = {
   entries?: Array<{ idx?: number; tag?: string; when?: number }>;
+};
+
+export type DuplicateIdxBaselineEntry = {
+  readonly idx: number;
+  readonly tags: readonly string[];
+  readonly reason?: string;
+};
+
+export type MigrationJournalIdxBaseline = {
+  readonly duplicateIdx: readonly DuplicateIdxBaselineEntry[];
+};
+
+export const EMPTY_MIGRATION_JOURNAL_IDX_BASELINE: MigrationJournalIdxBaseline = {
+  duplicateIdx: [],
 };
 
 export async function listMigrationFolderFiles(
@@ -43,9 +93,14 @@ export async function listMigrationFolderFiles(
     .sort((left, right) => left.localeCompare(right));
 }
 
-export async function listJournalMigrationFileNames(
+/**
+ * Reads `meta/_journal.json` and validates entry shape. A malformed entry is a
+ * hard error rather than a skipped entry: silently dropping it would make an
+ * orphan look legitimate.
+ */
+export async function readJournalEntries(
   journalPath: string = MIGRATIONS_JOURNAL_JSON,
-): Promise<string[]> {
+): Promise<MigrationJournalEntry[]> {
   const raw = await readFile(journalPath, "utf8");
   const parsed = JSON.parse(raw) as JournalFile;
   const entries = parsed.entries ?? [];
@@ -54,21 +109,64 @@ export async function listJournalMigrationFileNames(
     if (typeof entry?.tag !== "string" || entry.tag.length === 0) {
       throw new Error(`Migration journal entry ${index} is missing a tag`);
     }
-    return `${entry.tag}.sql`;
+    if (!Number.isInteger(entry?.idx)) {
+      throw new Error(
+        `Migration journal entry ${index} (${entry.tag}) has a non-integer idx: ${JSON.stringify(entry?.idx)}`,
+      );
+    }
+    return { idx: Number(entry.idx), tag: entry.tag };
   });
+}
+
+export async function listJournalMigrationFileNames(
+  journalPath: string = MIGRATIONS_JOURNAL_JSON,
+): Promise<string[]> {
+  const entries = await readJournalEntries(journalPath);
+  return entries.map((entry) => `${entry.tag}.sql`);
+}
+
+export function findDuplicateJournalIdxGroups(
+  entries: readonly MigrationJournalEntry[],
+): DuplicateJournalIdxGroup[] {
+  const tagsByIdx = new Map<number, string[]>();
+  for (const entry of entries) {
+    const existing = tagsByIdx.get(entry.idx);
+    if (existing) existing.push(entry.tag);
+    else tagsByIdx.set(entry.idx, [entry.tag]);
+  }
+
+  return [...tagsByIdx.entries()]
+    .filter(([, tags]) => tags.length > 1)
+    .map(([idx, tags]) => ({ idx, tags }))
+    .sort((left, right) => left.idx - right.idx);
+}
+
+export function findJournalIdxGaps(entries: readonly MigrationJournalEntry[]): number[] {
+  if (entries.length === 0) return [];
+  const present = new Set(entries.map((entry) => entry.idx));
+  const lowest = Math.min(...present);
+  const highest = Math.max(...present);
+
+  const gaps: number[] = [];
+  for (let idx = lowest; idx <= highest; idx += 1) {
+    if (!present.has(idx)) gaps.push(idx);
+  }
+  return gaps;
 }
 
 /**
  * Compares the migrations folder against `meta/_journal.json` and reports every
- * file that exists on only one side. Pure comparison: it never throws for an
- * inconsistency, so callers can format their own message.
+ * file that exists on only one side, plus the `idx` health of the journal. Pure
+ * inspection: it never throws for a defect, so callers can format their own
+ * message and choose their own enforcement level.
  */
 export async function checkMigrationJournalConsistency(options?: {
   readonly migrationsDir?: string;
   readonly journalPath?: string;
 }): Promise<MigrationJournalConsistencyResult> {
   const migrationFiles = await listMigrationFolderFiles(options?.migrationsDir);
-  const journalFiles = await listJournalMigrationFileNames(options?.journalPath);
+  const journalEntries = await readJournalEntries(options?.journalPath);
+  const journalFiles = journalEntries.map((entry) => `${entry.tag}.sql`);
 
   const journalFileSet = new Set(journalFiles);
   const migrationFileSet = new Set(migrationFiles);
@@ -87,7 +185,13 @@ export async function checkMigrationJournalConsistency(options?: {
     }
   }
 
-  return { migrationFiles, journalFiles, inconsistencies };
+  return {
+    migrationFiles,
+    journalFiles,
+    inconsistencies,
+    duplicateIdxGroups: findDuplicateJournalIdxGroups(journalEntries),
+    idxGaps: findJournalIdxGaps(journalEntries),
+  };
 }
 
 export function formatMigrationJournalInconsistencies(
@@ -123,6 +227,11 @@ export function formatMigrationJournalInconsistencies(
  * Hard-fails with the offending filename when the migrations folder and the
  * journal disagree. Called from migration bootstrap so an orphaned file can
  * never degrade into a silently skipped test suite.
+ *
+ * Intentionally limited to the bijection: `idx` uniqueness is enforced by
+ * `auditMigrationJournal` in the build/CI gate instead, because a duplicate
+ * `idx` does not stop `migrate()` and pre-existing shipped duplicates must not
+ * brick production bootstrap.
  */
 export async function assertMigrationJournalConsistency(options?: {
   readonly migrationsDir?: string;
@@ -131,4 +240,119 @@ export async function assertMigrationJournalConsistency(options?: {
   const { inconsistencies } = await checkMigrationJournalConsistency(options);
   if (inconsistencies.length === 0) return;
   throw new Error(formatMigrationJournalInconsistencies(inconsistencies));
+}
+
+function normalizeTags(tags: readonly string[]): string {
+  return [...tags].sort((left, right) => left.localeCompare(right)).join("|");
+}
+
+export function parseMigrationJournalIdxBaseline(raw: string): MigrationJournalIdxBaseline {
+  const parsed = JSON.parse(raw) as { duplicateIdx?: unknown };
+  const rawEntries = Array.isArray(parsed.duplicateIdx) ? parsed.duplicateIdx : [];
+
+  const duplicateIdx = rawEntries.map((entry, index) => {
+    const candidate = entry as { idx?: unknown; tags?: unknown; reason?: unknown };
+    if (!Number.isInteger(candidate.idx)) {
+      throw new Error(`Baseline duplicateIdx entry ${index} has a non-integer idx`);
+    }
+    if (
+      !Array.isArray(candidate.tags) ||
+      candidate.tags.length < 2 ||
+      candidate.tags.some((tag) => typeof tag !== "string" || tag.length === 0)
+    ) {
+      throw new Error(
+        `Baseline duplicateIdx entry ${index} (idx ${String(candidate.idx)}) must list at least two non-empty tags`,
+      );
+    }
+    return {
+      idx: Number(candidate.idx),
+      tags: candidate.tags as string[],
+      reason: typeof candidate.reason === "string" ? candidate.reason : undefined,
+    };
+  });
+
+  return { duplicateIdx };
+}
+
+export async function loadMigrationJournalIdxBaseline(
+  baselinePath: string = IDX_BASELINE_JSON,
+): Promise<MigrationJournalIdxBaseline> {
+  return parseMigrationJournalIdxBaseline(await readFile(baselinePath, "utf8"));
+}
+
+export type MigrationJournalAuditResult = {
+  readonly errors: readonly string[];
+  readonly warnings: readonly string[];
+  readonly result: MigrationJournalConsistencyResult;
+};
+
+/**
+ * Full pre-test/pre-build audit: bijection, `idx` uniqueness (minus the
+ * explicit baseline) and `idx` continuity (warning).
+ *
+ * The baseline is a ratchet. A baselined duplicate group is excused only when
+ * its `idx` *and* its exact tag set still match, so a third entry joining a
+ * baselined group is a fresh error. A baseline entry that no longer matches the
+ * journal is itself an error, so the file cannot rot into a blanket exemption.
+ */
+export async function auditMigrationJournal(options?: {
+  readonly migrationsDir?: string;
+  readonly journalPath?: string;
+  readonly baseline?: MigrationJournalIdxBaseline;
+  /** Ignore the baseline and report every duplicate. */
+  readonly strict?: boolean;
+}): Promise<MigrationJournalAuditResult> {
+  const result = await checkMigrationJournalConsistency(options);
+  const baseline = options?.strict
+    ? EMPTY_MIGRATION_JOURNAL_IDX_BASELINE
+    : (options?.baseline ?? EMPTY_MIGRATION_JOURNAL_IDX_BASELINE);
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (result.inconsistencies.length > 0) {
+    errors.push(formatMigrationJournalInconsistencies(result.inconsistencies));
+  }
+
+  const baselineByIdx = new Map(baseline.duplicateIdx.map((entry) => [entry.idx, entry]));
+  const matchedBaselineIdx = new Set<number>();
+
+  for (const group of result.duplicateIdxGroups) {
+    const baselined = baselineByIdx.get(group.idx);
+    if (baselined && normalizeTags(baselined.tags) === normalizeTags(group.tags)) {
+      matchedBaselineIdx.add(group.idx);
+      // Reported, not silenced. A baselined defect stays visible by name on
+      // every run — the baseline downgrades it from blocking to loud, so the
+      // guard can be adopted without first rewriting shipped journal history.
+      warnings.push(
+        `Duplicate journal idx ${group.idx} shared by: ${group.tags.map((tag) => `${tag}.sql`).join(", ")} (known pre-existing defect, baselined in packages/db/src/migration-journal-idx-baseline.json${baselined.reason ? `: ${baselined.reason}` : ""}). Run with --strict to fail on it.`,
+      );
+      continue;
+    }
+    if (baselined) {
+      matchedBaselineIdx.add(group.idx);
+      errors.push(
+        `Duplicate journal idx ${group.idx} is baselined for [${[...baselined.tags].join(", ")}] but the journal now has [${group.tags.join(", ")}]. Give each entry a unique idx, or update packages/db/src/migration-journal-idx-baseline.json only if the change is itself pre-existing history.`,
+      );
+      continue;
+    }
+    errors.push(
+      `Duplicate journal idx ${group.idx} in meta/_journal.json, shared by: ${group.tags.map((tag) => `${tag}.sql`).join(", ")}. Journal idx must be unique — a shared idx makes migration ordering ambiguous. Renumber the newer entry.`,
+    );
+  }
+
+  for (const entry of baseline.duplicateIdx) {
+    if (matchedBaselineIdx.has(entry.idx)) continue;
+    errors.push(
+      `Stale baseline entry: packages/db/src/migration-journal-idx-baseline.json excuses duplicate journal idx ${entry.idx} ([${[...entry.tags].join(", ")}]) but that idx is no longer duplicated. Remove the entry.`,
+    );
+  }
+
+  if (result.idxGaps.length > 0) {
+    warnings.push(
+      `Gaps in journal idx sequence: ${result.idxGaps.join(", ")}. Gaps are tolerated (they usually mean a migration was dropped before merge) but they make "latest idx" an unreliable count of applied migrations.`,
+    );
+  }
+
+  return { errors, warnings, result };
 }

--- a/packages/db/src/migration-journal-idx-baseline.json
+++ b/packages/db/src/migration-journal-idx-baseline.json
@@ -1,0 +1,26 @@
+{
+  "$comment": [
+    "Known, pre-existing `idx` defects in packages/db/src/migrations/meta/_journal.json.",
+    "The journal-consistency guard treats a duplicate `idx` as a hard error EXCEPT for the",
+    "groups listed here, so the guard can be adopted without first rewriting shipped journal",
+    "history. Any NEW duplicate — including a third entry joining a baselined group — still",
+    "fails the build.",
+    "",
+    "Run the guard with --strict to ignore this baseline entirely and see every defect,",
+    "including the ones recorded below.",
+    "",
+    "This file is a ratchet, not a permanent excuse: when a defect is fixed, its entry must be",
+    "removed. The guard reports a stale baseline entry (one that no longer matches the journal)",
+    "as a hard error, so this file cannot silently rot.",
+    "",
+    "Do not add entries here to unblock your own change. If your change introduces a duplicate",
+    "`idx`, fix the journal instead."
+  ],
+  "duplicateIdx": [
+    {
+      "idx": 178,
+      "tags": ["0177_activity_log_responsible_user", "0178_summary_slots"],
+      "reason": "Pre-existing on origin/master: two journal entries share idx 178, so journal-ordered migration application is ambiguous between these two tags. Discovered while building the guard (RBR-968); fixing the journal history itself is deliberately out of scope for that issue."
+    }
+  ]
+}

--- a/scripts/__tests__/check-migration-journal.test.mjs
+++ b/scripts/__tests__/check-migration-journal.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// RBR-968. `scripts/check-migration-journal.mjs` is a deliberate
+// reimplementation of packages/db/src/migration-journal-consistency.ts: the PR
+// `policy` job has no `pnpm install`, so the CI guard must run on a bare Node
+// runtime. These tests pin the guard's observable contract and — critically —
+// assert that the dependency-free copy agrees with the TS source of truth on
+// the real repository tree, so the two cannot silently drift apart.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const guard = path.join(repoRoot, "scripts", "check-migration-journal.mjs");
+const migrationsDir = path.join(repoRoot, "packages", "db", "src", "migrations");
+
+function runGuard(args = []) {
+  const result = spawnSync(process.execPath, [guard, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+test("passes on the real tree with the shipped baseline", () => {
+  const { status, output } = runGuard();
+  assert.equal(status, 0, output);
+  assert.match(output, /OK — \d+ migration file\(s\) match \d+ journal entry\/entries/);
+});
+
+test("reports the two genuine origin/master defects as warnings (AC2)", () => {
+  const { output } = runGuard();
+  // Duplicate idx 178, baselined -> warning naming both tags.
+  assert.match(output, /WARN Duplicate journal idx 178/);
+  assert.match(output, /0177_activity_log_responsible_user\.sql/);
+  assert.match(output, /0178_summary_slots\.sql/);
+  // Missing idx 126, 130, 177 -> gap warning.
+  assert.match(output, /WARN Gaps in journal idx sequence: 126, 130, 177/);
+});
+
+test("--strict turns the baselined duplicate idx into a hard error (AC1/AC2)", () => {
+  const { status, output } = runGuard(["--strict"]);
+  assert.equal(status, 1);
+  assert.match(output, /ERROR Duplicate journal idx 178 in meta\/_journal\.json/);
+  assert.match(output, /FAILED — 1 error\(s\)/);
+});
+
+test("an orphaned .sql is a hard error naming the file (AC3)", () => {
+  const orphan = path.join(migrationsDir, "0128_force_reassign.sql");
+  writeFileSync(orphan, "ALTER TABLE issues ADD COLUMN orphan_probe int;\n", "utf8");
+  try {
+    const { status, output } = runGuard();
+    assert.equal(status, 1);
+    assert.match(output, /ERROR Orphaned migration file\(s\)/);
+    assert.match(output, /0128_force_reassign\.sql/);
+  } finally {
+    rmSync(orphan, { force: true });
+  }
+});
+
+test("a journal entry with no .sql file is a hard error naming the file", () => {
+  const held = path.join(migrationsDir, "0178_summary_slots.sql");
+  const stash = path.join(mkdtempSync(path.join(tmpdir(), "pcmj-")), "held.sql");
+  renameSync(held, stash);
+  try {
+    const { status, output } = runGuard();
+    assert.equal(status, 1);
+    assert.match(output, /ERROR Journal entry\/entries with no matching \.sql file/);
+    assert.match(output, /0178_summary_slots\.sql/);
+  } finally {
+    renameSync(stash, held);
+  }
+});
+
+test("the guard restores nothing and leaves the tree clean", () => {
+  const { status } = runGuard();
+  assert.equal(status, 0, "the preceding tests must not leave the migrations tree dirty");
+});
+
+test("agrees with the TS source of truth on the real tree (anti-drift)", () => {
+  // Read the TS implementation's verdict through a tiny tsx program rather than
+  // importing it: TS emits `.js` specifiers that only resolve after a build.
+  const probeDir = mkdtempSync(path.join(tmpdir(), "pcmj-probe-"));
+  const probe = path.join(repoRoot, "packages", "db", "__journal_probe.ts");
+  const source = [
+    'import { auditMigrationJournal, loadMigrationJournalIdxBaseline } from "./src/migration-journal-consistency.js";',
+    "const baseline = await loadMigrationJournalIdxBaseline();",
+    "const relaxed = await auditMigrationJournal({ baseline });",
+    "const strict = await auditMigrationJournal({ strict: true });",
+    "console.log(JSON.stringify({",
+    "  relaxedErrors: relaxed.errors.length,",
+    "  relaxedWarnings: relaxed.warnings.length,",
+    "  strictErrors: strict.errors.length,",
+    "  duplicateIdx: relaxed.result.duplicateIdxGroups.map((g) => g.idx),",
+    "  idxGaps: relaxed.result.idxGaps,",
+    "  files: relaxed.result.migrationFiles.length,",
+    "}));",
+  ].join("\n");
+  writeFileSync(probe, source, "utf8");
+
+  let tsVerdict;
+  try {
+    const result = spawnSync(
+      "pnpm",
+      ["--filter", "@paperclipai/db", "exec", "tsx", "__journal_probe.ts"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    if (result.status !== 0) {
+      // tsx is a devDependency; skip rather than fail when it is unavailable
+      // (e.g. a production-only install), so this test never blocks CI lanes
+      // that legitimately lack dev deps.
+      console.log(`skipping anti-drift comparison: tsx unavailable (${result.stderr?.trim()})`);
+      return;
+    }
+    const line = result.stdout.trim().split("\n").at(-1);
+    tsVerdict = JSON.parse(line);
+  } finally {
+    rmSync(probe, { force: true });
+    rmSync(probeDir, { recursive: true, force: true });
+  }
+
+  const relaxed = runGuard();
+  const strict = runGuard(["--strict"]);
+
+  assert.equal(
+    relaxed.status === 0,
+    tsVerdict.relaxedErrors === 0,
+    "mjs and ts guards disagree on whether the tree passes with the baseline",
+  );
+  assert.equal(
+    strict.status === 0,
+    tsVerdict.strictErrors === 0,
+    "mjs and ts guards disagree on whether the tree passes under --strict",
+  );
+
+  // Both must see the same defects, by number.
+  assert.deepEqual(tsVerdict.duplicateIdx, [178]);
+  assert.deepEqual(tsVerdict.idxGaps, [126, 130, 177]);
+  assert.match(relaxed.output, new RegExp(`match ${tsVerdict.files} journal entry`));
+  assert.match(
+    relaxed.output,
+    new RegExp(`${tsVerdict.relaxedWarnings} warning\\(s\\)`),
+    "mjs and ts guards report a different number of warnings",
+  );
+});
+
+test("rejects a malformed journal entry instead of silently skipping it", () => {
+  // A dropped entry would make an orphaned file look legitimate, so a bad
+  // entry must be loud. Verified on an isolated copy of the journal.
+  const sandbox = mkdtempSync(path.join(tmpdir(), "pcmj-bad-"));
+  const fakeMigrations = path.join(sandbox, "packages", "db", "src", "migrations", "meta");
+  mkdirSync(fakeMigrations, { recursive: true });
+  mkdirSync(path.join(sandbox, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(fakeMigrations, "_journal.json"),
+    JSON.stringify({ version: "7", entries: [{ idx: "not-a-number", tag: "0001_a" }] }),
+    "utf8",
+  );
+  writeFileSync(
+    path.join(sandbox, "packages", "db", "src", "migrations", "0001_a.sql"),
+    "SELECT 1;\n",
+    "utf8",
+  );
+  const copiedGuard = path.join(sandbox, "scripts", "check-migration-journal.mjs");
+  writeFileSync(copiedGuard, readGuardSource(), "utf8");
+
+  try {
+    const result = spawnSync(process.execPath, [copiedGuard], { cwd: sandbox, encoding: "utf8" });
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}${result.stderr}`, /non-integer idx/);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+function readGuardSource() {
+  return readFileSync(guard, "utf8");
+}

--- a/scripts/check-migration-journal.mjs
+++ b/scripts/check-migration-journal.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Dependency-free migration journal-consistency guard (RBR-968 / RBR-927 AC3).
+ *
+ * Why this exists as plain `.mjs` rather than reusing
+ * packages/db/src/migration-journal-consistency.ts directly: this runs in the
+ * PR `policy` job, which deliberately has no `pnpm install` step, so it must
+ * work with nothing but a bare Node runtime and the checked-out tree. Node's
+ * type stripping cannot load the TS module because TS emits `.js` import
+ * specifiers that resolve to files which only exist after a build.
+ *
+ * The TS module remains the source of truth for the runtime/bootstrap and
+ * test-harness paths. `scripts/__tests__/check-migration-journal.test.mjs`
+ * asserts the two implementations report the same verdict on the real tree, so
+ * they cannot silently drift.
+ *
+ * Checks, against packages/db/src/migrations:
+ *   1. file <-> journal bijection — every `.sql` has a `meta/_journal.json`
+ *      entry and every entry has a `.sql`. Always a hard error, always naming
+ *      the offending filename.
+ *   2. `idx` uniqueness — hard error, except groups recorded in
+ *      packages/db/src/migration-journal-idx-baseline.json, which are reported
+ *      as warnings so the guard could be adopted without first rewriting
+ *      shipped journal history.
+ *   3. `idx` continuity — gaps are warnings.
+ *
+ * Usage:
+ *   node scripts/check-migration-journal.mjs            # baseline honoured
+ *   node scripts/check-migration-journal.mjs --strict   # every defect is an error
+ */
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const migrationsDir = path.join(repoRoot, "packages", "db", "src", "migrations");
+const journalPath = path.join(migrationsDir, "meta", "_journal.json");
+const baselinePath = path.join(
+  repoRoot,
+  "packages",
+  "db",
+  "src",
+  "migration-journal-idx-baseline.json",
+);
+
+const strict = process.argv.slice(2).includes("--strict");
+
+function fail(message) {
+  console.error(`[check:migration-journal] ${message}`);
+  process.exit(1);
+}
+
+async function listMigrationFolderFiles() {
+  const entries = await readdir(migrationsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * A malformed entry is a hard error rather than a skipped entry: silently
+ * dropping it would make an orphaned file look legitimate.
+ */
+async function readJournalEntries() {
+  const parsed = JSON.parse(await readFile(journalPath, "utf8"));
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+
+  return entries.map((entry, index) => {
+    if (typeof entry?.tag !== "string" || entry.tag.length === 0) {
+      fail(`Migration journal entry ${index} is missing a tag`);
+    }
+    if (!Number.isInteger(entry?.idx)) {
+      fail(
+        `Migration journal entry ${index} (${entry.tag}) has a non-integer idx: ${JSON.stringify(entry?.idx)}`,
+      );
+    }
+    return { idx: Number(entry.idx), tag: entry.tag };
+  });
+}
+
+async function loadBaseline() {
+  if (strict) return { duplicateIdx: [] };
+
+  let raw;
+  try {
+    raw = await readFile(baselinePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return { duplicateIdx: [] };
+    throw error;
+  }
+
+  const parsed = JSON.parse(raw);
+  const rawEntries = Array.isArray(parsed.duplicateIdx) ? parsed.duplicateIdx : [];
+
+  return {
+    duplicateIdx: rawEntries.map((entry, index) => {
+      if (!Number.isInteger(entry?.idx)) {
+        fail(`Baseline duplicateIdx entry ${index} has a non-integer idx`);
+      }
+      if (
+        !Array.isArray(entry?.tags) ||
+        entry.tags.length < 2 ||
+        entry.tags.some((tag) => typeof tag !== "string" || tag.length === 0)
+      ) {
+        fail(
+          `Baseline duplicateIdx entry ${index} (idx ${String(entry?.idx)}) must list at least two non-empty tags`,
+        );
+      }
+      return {
+        idx: Number(entry.idx),
+        tags: entry.tags,
+        reason: typeof entry.reason === "string" ? entry.reason : undefined,
+      };
+    }),
+  };
+}
+
+function findDuplicateIdxGroups(entries) {
+  const tagsByIdx = new Map();
+  for (const entry of entries) {
+    const existing = tagsByIdx.get(entry.idx);
+    if (existing) existing.push(entry.tag);
+    else tagsByIdx.set(entry.idx, [entry.tag]);
+  }
+
+  return [...tagsByIdx.entries()]
+    .filter(([, tags]) => tags.length > 1)
+    .map(([idx, tags]) => ({ idx, tags }))
+    .sort((left, right) => left.idx - right.idx);
+}
+
+function findIdxGaps(entries) {
+  if (entries.length === 0) return [];
+  const present = new Set(entries.map((entry) => entry.idx));
+  const lowest = Math.min(...present);
+  const highest = Math.max(...present);
+
+  const gaps = [];
+  for (let idx = lowest; idx <= highest; idx += 1) {
+    if (!present.has(idx)) gaps.push(idx);
+  }
+  return gaps;
+}
+
+function normalizeTags(tags) {
+  return [...tags].sort((left, right) => left.localeCompare(right)).join("|");
+}
+
+const migrationFiles = await listMigrationFolderFiles();
+const journalEntries = await readJournalEntries();
+const journalFiles = journalEntries.map((entry) => `${entry.tag}.sql`);
+const baseline = await loadBaseline();
+
+const journalFileSet = new Set(journalFiles);
+const migrationFileSet = new Set(migrationFiles);
+
+const errors = [];
+const warnings = [];
+
+const orphaned = migrationFiles.filter((fileName) => !journalFileSet.has(fileName));
+const missing = journalFiles.filter((fileName) => !migrationFileSet.has(fileName));
+
+if (orphaned.length > 0) {
+  errors.push(
+    `Orphaned migration file(s) present in packages/db/src/migrations but absent from meta/_journal.json: ${orphaned.join(", ")}.\n` +
+      "An orphaned file is never applied by drizzle's journal-driven migrator but is reported as permanently pending by folder-based checks, which breaks database bootstrap. Delete the file if it is a leftover duplicate, or add its journal entry if the migration is real.",
+  );
+}
+
+if (missing.length > 0) {
+  errors.push(
+    `Journal entry/entries with no matching .sql file in packages/db/src/migrations: ${missing.join(", ")}.\n` +
+      "Restore the missing file or remove the stale journal entry.",
+  );
+}
+
+const duplicateIdxGroups = findDuplicateIdxGroups(journalEntries);
+const baselineByIdx = new Map(baseline.duplicateIdx.map((entry) => [entry.idx, entry]));
+const matchedBaselineIdx = new Set();
+
+for (const group of duplicateIdxGroups) {
+  const baselined = baselineByIdx.get(group.idx);
+  const named = group.tags.map((tag) => `${tag}.sql`).join(", ");
+
+  if (baselined && normalizeTags(baselined.tags) === normalizeTags(group.tags)) {
+    matchedBaselineIdx.add(group.idx);
+    // Reported, not silenced: a baselined defect stays visible by name on every
+    // run. The baseline downgrades it from blocking to loud.
+    warnings.push(
+      `Duplicate journal idx ${group.idx} shared by: ${named} (known pre-existing defect, baselined in packages/db/src/migration-journal-idx-baseline.json${baselined.reason ? `: ${baselined.reason}` : ""}). Run with --strict to fail on it.`,
+    );
+    continue;
+  }
+
+  if (baselined) {
+    matchedBaselineIdx.add(group.idx);
+    errors.push(
+      `Duplicate journal idx ${group.idx} is baselined for [${baselined.tags.join(", ")}] but the journal now has [${group.tags.join(", ")}]. Give each entry a unique idx, or update packages/db/src/migration-journal-idx-baseline.json only if the change is itself pre-existing history.`,
+    );
+    continue;
+  }
+
+  errors.push(
+    `Duplicate journal idx ${group.idx} in meta/_journal.json, shared by: ${named}. Journal idx must be unique — a shared idx makes migration ordering ambiguous. Renumber the newer entry.`,
+  );
+}
+
+for (const entry of baseline.duplicateIdx) {
+  if (matchedBaselineIdx.has(entry.idx)) continue;
+  errors.push(
+    `Stale baseline entry: packages/db/src/migration-journal-idx-baseline.json excuses duplicate journal idx ${entry.idx} ([${entry.tags.join(", ")}]) but that idx is no longer duplicated. Remove the entry.`,
+  );
+}
+
+const idxGaps = findIdxGaps(journalEntries);
+if (idxGaps.length > 0) {
+  warnings.push(
+    `Gaps in journal idx sequence: ${idxGaps.join(", ")}. Gaps are tolerated (they usually mean a migration was dropped before merge) but they make "latest idx" an unreliable count of applied migrations.`,
+  );
+}
+
+for (const warning of warnings) {
+  console.warn(`[check:migration-journal] WARN ${warning}`);
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`[check:migration-journal] ERROR ${error}`);
+  }
+  console.error(
+    `[check:migration-journal] FAILED — ${errors.length} error(s) across ${migrationFiles.length} migration file(s) and ${journalFiles.length} journal entry/entries.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check:migration-journal] OK — ${migrationFiles.length} migration file(s) match ${journalFiles.length} journal entry/entries${
+    warnings.length > 0 ? `, ${warnings.length} warning(s)` : ""
+  }${strict ? " (strict)" : ""}.`,
+);

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -252,6 +252,31 @@ function selectSerializedSuites(routeTests, shardIndex, shardCount) {
   return routeTests.filter((_, index) => index % shardCount === shardIndex);
 }
 
+function runMigrationJournalGuard() {
+  // RBR-968 / RBR-927 AC3+AC4. Every embedded-Postgres suite bootstraps
+  // migrations in `beforeAll`. When the migrations folder and
+  // meta/_journal.json disagree, that bootstrap throws — and a throw inside
+  // `beforeAll` makes Vitest report the whole suite as `skipped` rather than
+  // `failed`, i.e. a silent green. Run the journal guard once, before any
+  // suite starts, so the operator sees the offending filename immediately
+  // instead of hunting through skipped suites.
+  console.log("\n[test:run] preflight: migration journal consistency");
+  const result = spawnSync(process.execPath, [path.join(scriptsDir, "check-migration-journal.mjs")], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    fail(`Failed to run the migration journal guard: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    console.error(
+      "[test:run] Migration journal guard failed. Embedded-Postgres suites would bootstrap-fail in beforeAll and report as `skipped` instead of `failed`, so they are not being started. Fix the journal defect reported above.",
+    );
+    process.exit(result.status ?? 1);
+  }
+}
+
 function runVitest(args, label) {
   console.log(`\n[test:run] ${label}`);
   invocationIndex += 1;
@@ -423,6 +448,8 @@ if (options.dryRun) {
   );
   process.exit(0);
 }
+
+runMigrationJournalGuard();
 
 if (options.mode === generalModeName || options.mode === allModeName) {
   if (options.group) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - One core subsystem is the database migration bootstrap that every embedded-Postgres test suite and every production start depends on
> - An orphaned `.sql` file in `packages/db/src/migrations` is invisible to drizzle's journal-driven `migrate()` but IS counted as pending by `inspectMigrations`, so a database that is genuinely up to date reports itself as permanently pending
> - Because that failure throws inside a shared `beforeAll`, Vitest reports the whole affected suite as `skipped` rather than `failed` — a silent-green failure mode that already hid two real defects on `master` (duplicate journal idx 178, missing idx 126/130/177)
> - This pull request adds a single-source-of-truth journal-consistency guard (file/journal bijection, idx-uniqueness with a ratcheting baseline, idx-continuity warnings) and wires it into three places: runtime bootstrap, `packages/db`'s `check:migrations`, and — via a dependency-free reimplementation, since that job runs with no `pnpm install` — the PR `policy` CI gate
> - The benefit is that a folder/journal drift is caught in seconds at PR time, by name, instead of silently degrading a test suite or bricking a production bootstrap

- [x] I searched the GitHub PR list (open and recently closed) for similar PRs and confirmed this is not a duplicate.

## Linked Issues or Issue Description

No public GitHub issue exists for this change; the underlying problem is described here following the bug report template (`.github/ISSUE_TEMPLATE/bug_report.yml`).

**What happened?**
An orphaned or duplicate-indexed migration file in `packages/db/src/migrations` causes `inspectMigrations()` to report an already-up-to-date database as having pending migrations. When this happens inside a shared `beforeAll`, the throw is swallowed by the test framework's own error handling and the affected suite reports `skipped`, not `failed` — so CI stays green while the suite asserts nothing. On `master` today this is not hypothetical: the journal carries a duplicate `idx: 178` entry and there is an orphaned `0128_force_reassign.sql` with no journal entry (missing idx 126/130/177 downstream), any of which can trip this failure mode.

**Expected behavior**
A folder/journal inconsistency should be caught immediately, with the offending filename named explicitly, at the earliest point in the pipeline that has enough information to detect it (ideally the no-install PR `policy` job), rather than silently degrading a test suite's reported outcome.

**Steps to reproduce**
1. Add a `.sql` file to `packages/db/src/migrations` with no corresponding entry in `packages/db/src/migrations/meta/_journal.json` (or duplicate an existing `idx`).
2. Run any embedded-Postgres test suite that calls `applyPendingMigrations`.
3. Observe the suite reports `skipped` (or, pre-fix, a bootstrap throw with no actionable message) instead of a named, fixable failure.

## What Changed

- Added `packages/db/src/migration-journal-consistency.ts`: the shared TypeScript implementation of the file/journal bijection check (bootstrap-safe, runs in `applyPendingMigrations`) and the fuller `auditMigrationJournal` (adds idx-uniqueness with a ratcheting baseline, idx-continuity warnings).
- Added `packages/db/src/migration-journal-idx-baseline.json`: an explicit, ratcheting baseline for the one already-shipped duplicate-idx defect on `master`, so the guard does not have to choose between silently accepting all duplicates and hard-failing on history it cannot fix mechanically.
- Added `scripts/check-migration-journal.mjs`: a dependency-free Node reimplementation of the same checks for the PR `policy` job, which runs with `pnpm install` disabled — plus `scripts/__tests__/check-migration-journal.test.mjs`, which includes an anti-drift test asserting the `.mjs` and `.ts` guards agree on the real migrations tree.
- Wired the guard into `applyPendingMigrations` (bijection only — must never fail on already-shipped history, since that would brick production startup), `packages/db`'s existing `check:migrations`, and `scripts/run-vitest-stable.mjs`'s preflight (before any suite starts).
- Added `.github/workflows/pr.yml` steps ("Validate migration journal consistency", "Test migration journal guard") to the `policy` job.
- Added `packages/db/src/migration-journal-consistency.test.ts` (460 lines) covering bijection, duplicate indexes, idx gaps, baseline ratcheting, malformed journal data, and the real on-disk migration tree.
- Documented the invariants and the two-tier enforcement rationale in `doc/DATABASE.md`.

## Verification

- `node --test packages/db` / the new `migration-journal-consistency.test.ts` suite: 8/8 tests pass dependency-free.
- The guard correctly catches, by filename, both pre-existing `master` defects (duplicate journal `idx: 178`; missing `idx` 126/130/177 caused by the orphaned `0128_force_reassign.sql`) plus a manually planted orphan file used during verification.
- PR `policy` job on this PR: green, including the two new guard steps (see CI status below).
- Full PR test matrix (typecheck, build, e2e shards ×3, general server tests ×5, serialized server suites ×5, workspaces a/b, canary dry run): green.

## Risks

Low risk. The runtime-enforced check (`assertMigrationJournalConsistency`, used by `applyPendingMigrations`) is deliberately narrower than the CI-time audit (`auditMigrationJournal`): it only enforces the file/journal bijection, and explicitly does not enforce idx-uniqueness against shipped history, so it cannot newly fail production bootstrap because of a pre-existing journal defect it did not introduce. The CI-time guard adds idx-uniqueness on top, but ships with an explicit ratcheting baseline for the one already-shipped duplicate, so it does not block this or future PRs on a defect this PR does not attempt to fix. No schema or migration-file changes ship in this PR — it is detection tooling only.

## Model Used

Claude Opus 4.6 (Anthropic), extended thinking enabled, tool use enabled — verified functionally under RBR-968; this PR is the land/merge step only (RBR-1033), with no guard-logic changes.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
