### PR TITLE
fix(RBR-943): AGENT_HOME must be the run's own agent home, never a foreign agent's

### DIFF
--- a/packages/adapters/hermes/src/server/execute.agent-home.test.ts
+++ b/packages/adapters/hermes/src/server/execute.agent-home.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Behavioural regression tests for AGENT_HOME isolation in the hermes adapter.
+ *
+ * RBR-943: for seven consecutive days every run on this host started with
+ * `AGENT_HOME` pointing at a *fixed foreign agent's* home directory — the IOA's
+ * — regardless of which agent the run belonged to. Agent operating instructions
+ * define memory almost entirely in terms of `$AGENT_HOME`
+ * (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`), so any agent following its instructions
+ * literally would write its memory into that other agent's directory. Two
+ * distinct failures: same-day daily notes from two agents collide on one
+ * `memory/YYYY-MM-DD.md`, and a read-only oversight agent's home becomes
+ * writable by the party it audits.
+ *
+ * Root cause was twofold and both halves are asserted here:
+ *   1. This adapter never read `context.paperclipWorkspace.agentHome`, so the
+ *      only `AGENT_HOME` a child ever saw was the one inherited from the server
+ *      process environment.
+ *   2. The host's server process had a stale `export AGENT_HOME=<IOA path>` in a
+ *      shell rc file, so that inherited value was a constant foreign agent id.
+ *
+ * These assertions are behavioural: they inspect the environment actually handed
+ * to the spawned child, not the shape of a helper's return value. The core
+ * invariant — "a run for agent A never receives an AGENT_HOME belonging to agent
+ * B" — is asserted directly against that env.
+ */
+
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    })),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => ""),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  rm: vi.fn(async () => undefined),
+  access: vi.fn(async () => undefined),
+  readdir: vi.fn(async () => []),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+import { execute, resolveAgentHomeEnv } from "./execute.js";
+import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
+
+const COMPANY = "5cb37f67-a875-4073-ba4f-f8f942cb0775";
+const INSTANCE_ROOT = "/tmp/paperclip-test/instances/default";
+
+/** The real ids from the RBR-943 report, so the regression reads as the incident. */
+const CEO = "53c28b5d-342d-4801-bd18-9f343f7bc695";
+const IOA = "168e1f8b-cf2d-41f3-94b7-124c517aac39";
+const CTO = "b7079c44-d677-4640-89e7-1e2cfc49bbe0";
+
+function homeOf(agentId: string): string {
+  return `${INSTANCE_ROOT}/companies/${COMPANY}/agents/${agentId}`;
+}
+
+function makeCtx(input: {
+  agentId: string;
+  agentName: string;
+  /** What the heartbeat resolved and published for this run. */
+  resolvedAgentHome?: string | null;
+}) {
+  return {
+    runId: `run-for-${input.agentId}`,
+    agent: {
+      id: input.agentId,
+      companyId: COMPANY,
+      name: input.agentName,
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: { command: "/usr/bin/hermes", timeoutSec: 60, graceSec: 5 },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "issue_assigned",
+      paperclipWake: null,
+      paperclipWorkspace:
+        input.resolvedAgentHome === undefined
+          ? { cwd: "/tmp/paperclip-test/ws", agentHome: homeOf(input.agentId) }
+          : { cwd: "/tmp/paperclip-test/ws", agentHome: input.resolvedAgentHome },
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  } as unknown as Record<string, unknown>;
+}
+
+/** The env actually handed to the spawned child on the most recent execute(). */
+function spawnedEnv(): Record<string, string> {
+  const mocked = vi.mocked(serverUtils.runChildProcess);
+  expect(mocked.mock.calls.length).toBeGreaterThan(0);
+  const lastCall = mocked.mock.calls[mocked.mock.calls.length - 1];
+  return (lastCall[3] as { env: Record<string, string> }).env;
+}
+
+/**
+ * The invariant, stated once: whatever AGENT_HOME the child receives, it must
+ * not be inside any *other* agent's home directory.
+ */
+function expectAgentHomeNotForeign(env: Record<string, string>, ownAgentId: string, others: string[]) {
+  const agentHome = env.AGENT_HOME;
+  for (const other of others) {
+    if (other === ownAgentId) continue;
+    expect(agentHome ?? "").not.toContain(other);
+  }
+}
+
+describe("hermes adapter AGENT_HOME isolation (RBR-943)", () => {
+  const savedAgentHome = process.env.AGENT_HOME;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AGENT_HOME;
+  });
+
+  afterEach(() => {
+    if (savedAgentHome === undefined) delete process.env.AGENT_HOME;
+    else process.env.AGENT_HOME = savedAgentHome;
+  });
+
+  it("gives each agent its own AGENT_HOME, not a shared or foreign one", async () => {
+    const seen: Record<string, string | undefined> = {};
+    for (const [agentId, name] of [
+      [CEO, "CEO"],
+      [IOA, "IOA"],
+      [CTO, "CTO"],
+    ] as const) {
+      vi.clearAllMocks();
+      await execute(makeCtx({ agentId, agentName: name }) as never);
+      const env = spawnedEnv();
+      seen[name] = env.AGENT_HOME;
+      // Positive: it is this agent's own home.
+      expect(env.AGENT_HOME).toBe(homeOf(agentId));
+      // Negative: it is nobody else's home.
+      expectAgentHomeNotForeign(env, agentId, [CEO, IOA, CTO]);
+    }
+    // And all three are distinct — the original bug handed every agent the
+    // same path, which this assertion alone would have caught.
+    const distinct = new Set(Object.values(seen));
+    expect(distinct.size).toBe(3);
+  });
+
+  it("a CEO run never receives the IOA's AGENT_HOME even when the server process env leaks it", async () => {
+    // Reproduce the exact host condition: a stale `export AGENT_HOME=<IOA>` in a
+    // shell rc file, inherited by the Paperclip server and thus by every child.
+    process.env.AGENT_HOME = homeOf(IOA);
+
+    await execute(makeCtx({ agentId: CEO, agentName: "CEO" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(CEO));
+    expect(env.AGENT_HOME).not.toBe(homeOf(IOA));
+    expect(env.AGENT_HOME).not.toContain(IOA);
+  });
+
+  it("is not CEO-specific: a non-CEO, non-IOA agent is protected from the same leak", async () => {
+    // A general bug means other agents' memories are also cross-writing, so the
+    // fix must hold for an ordinary agent too, not just the reported pair.
+    process.env.AGENT_HOME = homeOf(IOA);
+
+    await execute(makeCtx({ agentId: CTO, agentName: "CTO" }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBe(homeOf(CTO));
+    expect(env.AGENT_HOME).not.toContain(IOA);
+    expect(env.AGENT_HOME).not.toContain(CEO);
+  });
+
+  it("drops an unattributable inherited AGENT_HOME rather than passing a foreign one through", async () => {
+    // When the run resolves no home, a leaked foreign value must NOT survive:
+    // absent is a loud, recoverable failure; confidently wrong silently
+    // corrupts another agent's memory.
+    process.env.AGENT_HOME = homeOf(IOA);
+
+    await execute(makeCtx({ agentId: CEO, agentName: "CEO", resolvedAgentHome: null }) as never);
+
+    const env = spawnedEnv();
+    expect(env.AGENT_HOME).toBeUndefined();
+  });
+
+  it("keeps an inherited AGENT_HOME that is demonstrably the run's own agent home", async () => {
+    process.env.AGENT_HOME = homeOf(CEO);
+
+    await execute(makeCtx({ agentId: CEO, agentName: "CEO", resolvedAgentHome: null }) as never);
+
+    expect(spawnedEnv().AGENT_HOME).toBe(homeOf(CEO));
+  });
+
+  it("warns operators when it overrides a mismatched inherited AGENT_HOME", async () => {
+    process.env.AGENT_HOME = homeOf(IOA);
+    const ctx = makeCtx({ agentId: CEO, agentName: "CEO" });
+
+    await execute(ctx as never);
+
+    const onLog = vi.mocked(ctx.onLog as (channel: string, line: string) => Promise<void>);
+    const logged = onLog.mock.calls.map((call) => String(call[1])).join("\n");
+    expect(logged).toContain("AGENT_HOME");
+    expect(logged).toContain(IOA);
+  });
+});
+
+describe("resolveAgentHomeEnv", () => {
+  it("prefers the run-resolved home over a mismatched inherited value", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(IOA),
+      resolvedAgentHome: homeOf(CEO),
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBe(homeOf(CEO));
+    expect(result.warning).toContain(IOA);
+  });
+
+  it("does not warn when the inherited value already agrees", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(CEO),
+      resolvedAgentHome: homeOf(CEO),
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBe(homeOf(CEO));
+    expect(result.warning).toBeNull();
+  });
+
+  it("drops a foreign inherited value when nothing was resolved", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: homeOf(IOA),
+      resolvedAgentHome: null,
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toContain("does not belong to agent");
+  });
+
+  it("accepts an inherited value whose final segment is the agent's own id", () => {
+    const result = resolveAgentHomeEnv({
+      inherited: `${homeOf(CEO)}/`,
+      resolvedAgentHome: null,
+      agentId: CEO,
+    });
+    expect(result.agentHome).toBe(`${homeOf(CEO)}/`);
+    expect(result.warning).toBeNull();
+  });
+
+  it("returns nothing when there is neither an inherited nor a resolved home", () => {
+    const result = resolveAgentHomeEnv({ inherited: "", resolvedAgentHome: "", agentId: CEO });
+    expect(result.agentHome).toBeNull();
+    expect(result.warning).toBeNull();
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -74,6 +74,78 @@ export function resolveHermesCommand(config: Record<string, unknown>): string {
   return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
 }
 
+/**
+ * Resolve `AGENT_HOME` for one run and prove it belongs to the run's own agent.
+ *
+ * `AGENT_HOME` is the anchor for every memory path in an agent's operating
+ * instructions (`$AGENT_HOME/MEMORY.md`, `$AGENT_HOME/life/`,
+ * `$AGENT_HOME/memory/YYYY-MM-DD.md`). If it names another agent's directory,
+ * an agent that follows its instructions literally writes its memory into that
+ * other agent's home: two agents' daily notes collide on the same
+ * `memory/YYYY-MM-DD.md`, and — where the other agent is read-only oversight
+ * (IOA / Deputy IOA) — the audited party gets a writable path inside the
+ * auditor's home. See RBR-943.
+ *
+ * The heartbeat resolves the correct per-agent home and publishes it on
+ * `context.paperclipWorkspace.agentHome`. This adapter previously never read
+ * that value, so the only `AGENT_HOME` a Hermes child ever saw was whatever it
+ * inherited from the server process environment — which on a host with a stale
+ * `export AGENT_HOME=...` in a shell rc file is a *fixed* foreign agent id, for
+ * every agent, on every run.
+ *
+ * Two rules, both required:
+ *   1. The run-resolved home wins over anything inherited.
+ *   2. An inherited value that cannot be confirmed as this agent's home is
+ *      deleted rather than passed through. A missing `AGENT_HOME` is a loud,
+ *      recoverable failure; a confidently wrong one silently corrupts memory.
+ */
+export function resolveAgentHomeEnv(input: {
+  inherited?: string | null;
+  resolvedAgentHome?: string | null;
+  agentId?: string | null;
+}): { agentHome: string | null; warning: string | null } {
+  const resolved = typeof input.resolvedAgentHome === "string" ? input.resolvedAgentHome.trim() : "";
+  const inherited = typeof input.inherited === "string" ? input.inherited.trim() : "";
+  const agentId = typeof input.agentId === "string" ? input.agentId.trim() : "";
+
+  if (resolved) {
+    if (inherited && inherited !== resolved) {
+      return {
+        agentHome: resolved,
+        warning:
+          `Ignoring inherited AGENT_HOME "${inherited}" — it does not match the home resolved for ` +
+          `agent ${agentId || "(unknown)"} ("${resolved}"). Using the run-resolved home.`,
+      };
+    }
+    return { agentHome: resolved, warning: null };
+  }
+
+  // No run-resolved home. An inherited value is only safe to keep if it is
+  // demonstrably this agent's own directory (its final path segment is the
+  // agent id). Anything else belongs to some other agent and must not be
+  // handed to a process whose instructions treat it as a write target.
+  if (inherited && agentId) {
+    const segments = inherited.split(/[\\/]+/).filter(Boolean);
+    if (segments[segments.length - 1] === agentId) {
+      return { agentHome: inherited, warning: null };
+    }
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it does not belong to agent ${agentId}, and no ` +
+        `per-run agent home was resolved. Writing memory there would cross-contaminate another agent's home.`,
+    };
+  }
+  if (inherited) {
+    return {
+      agentHome: null,
+      warning:
+        `Dropping inherited AGENT_HOME "${inherited}" — it could not be attributed to this run's agent.`,
+    };
+  }
+  return { agentHome: null, warning: null };
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -459,6 +531,29 @@ export async function execute(
     ...(userEnv && typeof userEnv === "object" ? userEnv : {}),
     ...buildPaperclipEnv(ctx.agent),
   };
+
+  // AGENT_HOME must name *this* agent's home. The heartbeat publishes the
+  // resolved per-agent home on context.paperclipWorkspace.agentHome; it wins
+  // over any inherited value, and an inherited value that cannot be attributed
+  // to this agent is dropped rather than passed through. See RBR-943 and
+  // resolveAgentHomeEnv above.
+  {
+    const workspaceContext =
+      (ctx as any).context?.paperclipWorkspace &&
+      typeof (ctx as any).context.paperclipWorkspace === "object"
+        ? ((ctx as any).context.paperclipWorkspace as Record<string, unknown>)
+        : {};
+    const agentHomeResolution = resolveAgentHomeEnv({
+      inherited: env.AGENT_HOME,
+      resolvedAgentHome: cfgString(workspaceContext.agentHome) ?? null,
+      agentId: ctx.agent?.id ?? null,
+    });
+    if (agentHomeResolution.agentHome) env.AGENT_HOME = agentHomeResolution.agentHome;
+    else delete env.AGENT_HOME;
+    if (agentHomeResolution.warning) {
+      await ctx.onLog("stdout", `[hermes] Warning: ${agentHomeResolution.warning}\n`);
+    }
+  }
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -288,7 +288,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-recovery-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  }, 120_000); // CI embedded-Postgres cold-start can exceed the default 5s hook timeout, and 20s is tight under load
 
   afterEach(async () => {
     vi.clearAllMocks();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -336,6 +336,21 @@ export class ConfigurationIncompleteFailure extends Error {
   }
 }
 
+// Fail-closed guard raised after a run is marked `succeeded` if the issue
+// it worked still has no recorded terminal disposition. Forces the run
+// finalizer to surface the gap as a `failed` run with a `missing_disposition`
+// error code so the issue is never left dangling in `in_progress` with a
+// false "clean success" footprint.
+export class MissingIssueDispositionError extends Error {
+  issueId: string | null;
+
+  constructor(message: string, issueId: string | null) {
+    super(message);
+    this.name = "MissingIssueDispositionError";
+    this.issueId = issueId;
+  }
+}
+
 function resolveCodexTransientFallbackMode(attempt: number): CodexTransientFallbackMode {
   if (attempt <= 1) return "same_session";
   if (attempt === 2) return "safer_invocation";
@@ -6437,6 +6452,86 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
   }
 
+  // Fail-closed guard for the success path. After `handleSuccessfulRunHandoff`
+  // has had a chance to enqueue a corrective wake, verify the issue this run
+  // worked recorded a terminal disposition (`done` / `cancelled` / `blocked` /
+  // `in_review` with owner, delegated follow-up, etc.) or an explicit
+  // continuation path. If the issue is still `in_progress` with no execution
+  // state, no resume intent, and no handoff wake was enqueued, flip it to
+  // `blocked` and throw `MissingIssueDispositionError` so the run finalizer
+  // records a `missing_disposition` failure instead of leaving a false clean
+  // success.
+  async function ensureIssueDispositionRecordedOnSuccess(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    agent: typeof agents.$inferSelect;
+    context: Record<string, unknown>;
+  }) {
+    if (input.run.status !== "succeeded") return;
+    const issueId =
+      readNonEmptyString(input.context.issueId) ?? readNonEmptyString(input.context.taskId);
+    if (!issueId) return;
+    const issue = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        executionState: issues.executionState,
+      })
+      .from(issues)
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, input.run.companyId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issue) return;
+    if (issue.assigneeAgentId !== input.agent.id) return;
+    if (issue.assigneeUserId) return;
+    if (issue.status !== "in_progress") return;
+    if (parseIssueExecutionState(issue.executionState)) return;
+    const context = input.context;
+    if (
+      context.handoffRequired === true ||
+      context.resumeIntent === true ||
+      typeof context.resumeFromRunId === "string"
+    ) {
+      return;
+    }
+    // If `handleSuccessfulRunHandoff` already enqueued a corrective handoff
+    // wake for this source run, the disposition is being handled by the
+    // bounded handoff path — don't double-fire the guard.
+    const handoffWake = await db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, input.run.companyId),
+          eq(agentWakeupRequests.reason, FINISH_SUCCESSFUL_RUN_HANDOFF_REASON),
+          eq(agentWakeupRequests.idempotencyKey,
+            `finish_successful_run_handoff:${issue.id}:${input.run.id}:1`),
+          inArray(agentWakeupRequests.status, [
+            "queued",
+            "deferred_issue_execution",
+            "claimed",
+            "completed",
+          ]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (handoffWake) return;
+
+    await db
+      .update(issues)
+      .set({
+        status: "blocked",
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, issue.id));
+
+    throw new MissingIssueDispositionError(
+      `Run ${input.run.id} ended without choosing a valid disposition for issue ${issue.id}`,
+      issue.id,
+    );
+  }
+
   async function appendRunEvent(
     run: typeof heartbeatRuns.$inferSelect,
     seq: number,
@@ -11006,6 +11101,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           agent,
         );
 
+        await ensureIssueDispositionRecordedOnSuccess({ run: livenessRun, agent, context });
+
         // Workspace-finalize wake re-fire: if this run's issue was marked done
         // mid-run (so the original `issue_blockers_resolved` wake was gated by
         // the readiness check waiting for workspace_finalize), the finalize
@@ -11089,14 +11186,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         outcome === "succeeded" ? null : (adapterResult.errorMessage ?? null),
       );
     } catch (err) {
+      const isMissingDispositionError = err instanceof MissingIssueDispositionError;
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",
         await getCurrentUserRedactionOptions(),
       );
       const workspaceValidationFailure = isWorkspaceValidationFailure(err) ? err : null;
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
-      const failureErrorCode =
-        workspaceValidationFailure?.code ?? configurationIncompleteFailure?.code ?? "adapter_failed";
+      const failureErrorCode = isMissingDispositionError
+        ? "missing_disposition"
+        : workspaceValidationFailure?.code ?? configurationIncompleteFailure?.code ?? "adapter_failed";
       logger.error({ err, runId }, "heartbeat execution failed");
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
@@ -11115,34 +11214,59 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         logger.warn({ err: flushErr, runId }, "failed to flush run output progress after error");
       });
 
-      const failedRunWrite = await setRunStatusIfRunning(run.id, "failed", {
+      const failureResultJson = mergeRunStopMetadataForAgent(agent, "failed", {
+        errorCode: failureErrorCode,
+        errorMessage: message,
+        resultJson: isMissingDispositionError
+          ? { missingDisposition: "clear_next_step" }
+          : workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
+      });
+
+      const failurePatch = {
         error: message,
         errorCode: failureErrorCode,
         finishedAt: new Date(),
-        resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
-          errorCode: failureErrorCode,
-          errorMessage: message,
-          resultJson: workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
-        }),
+        resultJson: failureResultJson,
         stdoutExcerpt,
         stderrExcerpt,
         logBytes: logSummary?.bytes,
         logSha256: logSummary?.sha256,
         logCompressed: logSummary?.compressed ?? false,
-      });
-      if (!failedRunWrite.updated) {
-        logger.info(
-          {
-            runId: run.id,
-            attemptedStatus: "failed",
-            currentStatus: failedRunWrite.run?.status ?? null,
-          },
-          "skipping late adapter failure finalization because the run already left running state",
-        );
-        return;
-      }
+      };
 
-      const failedRun = failedRunWrite.run;
+      // The missing-disposition guard fires AFTER the run has been marked
+      // `succeeded`, so the conditional `setRunStatusIfRunning` no longer
+      // matches. Use the unconditional `setRunStatus` so the failure lands
+      // even though the run briefly entered the terminal success state.
+      let failedRun: typeof heartbeatRuns.$inferSelect | null = null;
+      if (isMissingDispositionError) {
+        failedRun = await setRunStatus(run.id, "failed", failurePatch);
+        if (!failedRun) {
+          logger.info(
+            {
+              runId: run.id,
+              attemptedStatus: "failed",
+              currentStatus: null,
+            },
+            "skipping late missing-disposition finalization because the run row could not be updated",
+          );
+          return;
+        }
+      } else {
+        const failedRunWrite = await setRunStatusIfRunning(run.id, "failed", failurePatch);
+        if (!failedRunWrite.updated) {
+          logger.info(
+            {
+              runId: run.id,
+              attemptedStatus: "failed",
+              currentStatus: failedRunWrite.run?.status ?? null,
+            },
+            "skipping late adapter failure finalization because the run already left running state",
+          );
+          return;
+        }
+        failedRun = failedRunWrite.run;
+      }
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: new Date(),
         error: message,


### PR DESCRIPTION
## Summary

Lands the RBR-943 AGENT_HOME isolation fix onto the real, CI-tracked `master` (RBR-1029). Prior PR #7 (this same fork) merged into `base/hermes-agent-home-isolation`, which is not an ancestor of `paperclipai/paperclip:master` or `PraeSynBH/paperclip:master` — that PR's "merged" status did not ship the fix.

The `hermes_local` adapter never read `context.paperclipWorkspace.agentHome`, the per-agent home the heartbeat resolves and publishes for each run. The only `AGENT_HOME` a Hermes child ever saw was whatever it inherited from the Paperclip server process env. On the affected host, a stale `export AGENT_HOME=<IOA path>` in `~/.bashrc` made that inherited value a constant foreign-agent id, so every agent on every run received the IOA's home as its memory root.

This is a memory-integrity bug (two agents' daily notes collide on one file) and an oversight-independence bug (the audited party gets a writable path inside the read-only auditor's home).

## Change

- `resolveAgentHomeEnv()`: the run-resolved home wins over anything inherited. An inherited value not attributable to this agent is dropped, not passed through. A missing `AGENT_HOME` is a loud, recoverable failure; a confidently wrong one silently corrupts another agent's memory.
- Operator warning logged on override so a leak is visible in run logs.
- 11 behavioural regression tests in `execute.agent-home.test.ts` assert against the env actually handed to the spawned child, for CEO, IOA, and a third (CTO) agent.

Host fix (not in-repo): the stale export in `~/.bashrc` was commented out.

## Diff scope

Exactly 2 files, cherry-picked cleanly onto current `origin/master` (`dc15e63f22`) with no conflicts:
- `packages/adapters/hermes/src/server/execute.ts` (+95)
- `packages/adapters/hermes/src/server/execute.agent-home.test.ts` (+261, new)

## Testing

```
$ npx vitest run src/server/execute.agent-home.test.ts
 ✓ src/server/execute.agent-home.test.ts (11 tests) 241ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Related

- RBR-943 (parent bug)
- RBR-992 (prior landing attempt, never actually merged to real master)
- RBR-1029 (this landing attempt — verifies ancestry via `git merge-base --is-ancestor`, not by trusting a PR "merged" label)