### PR TITLE
feat(RBR-914): AC4 surface multi-pending-confirmation hazard in the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,5 @@ tests/storybook-visual/playwright-report/
 .superset/
 .superpowers/
 .claude/worktrees/
+.worktrees/
 .herenow

--- a/RBR-875-FINDING.md
+++ b/RBR-875-FINDING.md
@@ -1,0 +1,145 @@
+# RBR-875 — Finding: AC2's escalation trigger is met
+
+Commit under test: `ead66d0336` (`feat(RBR-875): flip supersedeOnUserComment default to false`)
+Branch: `rbr-875-supersede-default`
+Baseline: `1314723854` (tip of RBR-852 work)
+
+## Summary
+
+The flip is implemented and committed. It **cannot be completed without editing RBR-852's AC5
+suite**, which AC2 defines as a stop-and-escalate condition, not a merge conflict to resolve.
+
+AC1 is satisfied. AC3's premise is materially wrong (19 of 22 files are structurally blind to the
+default). AC4 finds no load-bearing production call site. AC2 is violated and blocks the issue.
+
+## The conflict (AC2)
+
+Two tests in the RBR-852 AC5 suite assert the *opposite* of the RBR-875 objective. They are not
+incidental churn — they were authored deliberately by the RBR-852 work
+(`7232b98774`, "AC5 suite ... no-guess comment supersession") and are labelled as intentional.
+
+1. `server/src/__tests__/issue-thread-interactions-supersession.test.ts:203`
+   `case 1b: a single pending ask still expires on a user comment (historical behaviour intact)`
+
+2. `server/src/__tests__/issue-thread-interactions-service.test.ts:3439`
+   `AC5: a user comment still supersedes when it is the only pending ask on the issue`
+
+Both create a `request_confirmation` **without** `supersedeOnUserComment`, then assert
+`expect(expired).toHaveLength(1)`. That assertion only holds if the default is `true`.
+
+### Verified test output
+
+Gate suite at `ead66d0336` (default `false`):
+
+```
+❯ issue-thread-interactions-supersession.test.ts (8 tests | 1 failed)
+  ✓ case 1: a single user comment does not expire the current ask when three are pending
+  × case 1b: a single pending ask still expires on a user comment (historical behaviour intact)
+  ✓ case 2 / case 3 / case 4 / case 5 / case 5b / case 5c
+AssertionError: expected [] to have a length of 1 but got +0
+  at issue-thread-interactions-supersession.test.ts:223:21
+```
+
+Same suite at baseline `1314723854` (default `true`): **8 passed (8)**.
+
+So the single failure is caused by the flip and by nothing else.
+
+## Why this is a genuine disagreement, not churn
+
+RBR-852's design intent is documented in its own source comment
+(`issue-thread-interactions.ts`, `selectCommentSupersededRows`):
+
+> - Exactly one pending supersedable candidate: the comment supersedes it. A comment posted
+>   instead of answering the only open card is a reply to that card. **This is the historical
+>   behaviour and the only one that survives unchanged.**
+
+RBR-852 deliberately *preserved* single-candidate expiry-by-comment and scoped its fix to the
+multi-candidate case. RBR-875 removes single-candidate expiry-by-comment entirely. These are
+incompatible specifications of the same behaviour, written three commits apart.
+
+The two issues disagree on one question:
+
+> When exactly one ask is pending and a human comments instead of answering it, is that comment
+> a reply to the card (RBR-852: expire it) or unrelated (RBR-875: leave it pending)?
+
+RBR-823 — the shared parent — only ever alleged harm in the **multi**-candidate case
+("contradictory irreversible asks coexist"). The single-candidate case is not part of the reported
+defect. RBR-852 already fixed the defect RBR-823 reported.
+
+## AC3's premise is materially wrong — 21 files is an overcount
+
+The issue states "21 server test files exercise ... load-bearing in comment-wakeup, telemetry,
+activity-events, dependency-wakeups and document-restore suites." That evidence does not survive
+inspection. 22 files reference the expiry methods; **19 of them only ever reference them as
+`vi.fn()` mock declarations** and never construct an interaction or observe the default:
+
+```
+MOCK-ONLY  (19)  document-annotation-routes, environment-selection-route-guards,
+                 issue-activity-events-routes, issue-agent-mutation-ownership-routes,
+                 issue-assigned-backlog-contract-routes, issue-assignee-invokability-routes,
+                 issue-attachment-routes, issue-closed-workspace-routes,
+                 issue-comment-cancel-routes, issue-comment-reopen-routes,
+                 issue-dependency-wakeups-routes, issue-document-restore-routes,
+                 issue-execution-policy-routes, issue-feedback-routes,
+                 issue-telemetry-routes, issue-thread-interaction-routes,
+                 issue-update-comment-wakeup-routes, issue-workspace-command-authz,
+                 issues-goal-context-routes
+REAL-SERVICE (3) issue-thread-interactions-service, issue-thread-interactions-supersession,
+                 issue-thread-interactions-telemetry
+```
+
+Named examples, all pure mock stubs returning `[]`:
+`issue-dependency-wakeups-routes.test.ts:77`, `issue-document-restore-routes.test.ts:50`,
+`issue-telemetry-routes.test.ts:101`, `issue-activity-events-routes.test.ts:117`.
+Four of the five suites the ruling calls "load-bearing" (comment-wakeup, activity-events,
+dependency-wakeups, document-restore) mock the service and cannot observe this default at all.
+
+**Consequence: the test churn this issue was separated from RBR-852 to contain does not exist.**
+The real blast radius is ~4 assertions in 2 files. The original reason for splitting RBR-875 out
+of RBR-852 — "a large, mostly-unrelated test rewrite in front of the gate" — was based on a
+grep count of mock declarations.
+
+## AC4 — no load-bearing production call site
+
+`grep -rn "supersedeOnUserComment" server/src packages/` outside the service file and its tests
+returns **no production caller** that sets the flag. Every in-tree producer relied on the default
+implicitly; none passes `true` deliberately. Nothing needs `supersedeOnUserComment: true` added.
+
+There is exactly one default, at `issue-thread-interactions.ts:474`, consumed at four sites in
+`normalizeCreateInteractionInput` (one per supersedable kind). Validators in
+`packages/shared/src/validators/issue.ts` leave the field `.optional()` with no `.default()`, so
+there is no second source of truth to keep in sync.
+
+## Pre-existing infra failure, unrelated to this change
+
+`issue-thread-interactions-telemetry.test.ts` and `issue-thread-interactions-service.test.ts` both
+fail at `beforeAll` with `Hook timed out in 20000ms` — all tests reported `skipped`, so they never
+reach the default. Their inline hook budget is `20_000` ms while embedded Postgres takes ~80-95 s
+to import and start on this machine. The passing supersession suite uses `120_000`. The CLI
+`--hookTimeout=180000` does not override the inline argument.
+
+This is a pre-existing harness defect, present at baseline, not caused by the flip. It is also why
+prior runs on this issue timed out. Worth its own issue; it currently hides ~56 service-suite tests.
+
+## Recommendation
+
+Prefer **Option A**: accept the flip and retire the two contradicting assertions, replacing them
+with the inverse assertion (a lone pending ask survives a user comment unless it opted in), plus a
+new case proving opt-in `supersedeOnUserComment: true` still expires. Rationale: RBR-823's reported
+harm is fully covered by RBR-852's multi-candidate fix; the single-candidate carve-out is the last
+remaining path by which a comment silently retires an irreversible ask nobody answered, and
+`supersedesInteractionIds` is the supported replacement. But AC2 reserves this call for the CEO,
+so it is not mine to make and nothing further is edited until ruled on.
+
+Option B: keep RBR-852's single-candidate behaviour and narrow RBR-875 to "default `false` only
+when 2+ candidates are pending". This weakens RBR-875 to a no-op — `selectCommentSupersededRows`
+already expires nothing in the multi-candidate case, so there would be no change left to make.
+
+## Also found: RBR-877 is a byte-identical duplicate of RBR-875
+
+`RBR-877` (`fd6e4979-83a7-4146-9d52-e0e40cd950c7`, `todo`) and `RBR-875`
+(`48881e42-d52b-4ee0-ba45-eb025e5a5675`, `in_progress`) carry the same title and the same
+description, and both are assigned to the CTO. Neither has any blocker edge
+(`blockerIssueIds: null` on both), so the `blockedBy: [RBR-852]` edge that RBR-877 was created to
+carry does not actually exist on it. Only one should stay open; RBR-875 is the one with the work
+and the commit. Recommend cancelling RBR-877 as the duplicate.

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -245,7 +245,27 @@ POST /api/issues/{issueId}/interactions/{interactionId}/withdraw
 
 Board users can resolve all interactions. Agent resolution requires the immutable effective policy to be `board_or_agents` — for addressed and unaddressed interactions alike — and addressed interactions further restrict agent resolution to their `addresseeAgentId`. Agent resolvers require authenticated run identity and `issue:mutate` scope; they cannot be the creator agent or source run; low-trust and watchdog actors are denied; and confirmations containing `payload.toolAction` are always board-only. Agent resolution records both agent and run attribution and fires the same continuation wakes.
 
-The creator agent or a board user may withdraw a pending interaction. Withdrawal records an optional reason, expires the interaction, and prevents later resolution. Low-trust and task-watchdog agent runs cannot withdraw interactions.
+The creator agent, the current issue assignee, or a board user may withdraw a pending interaction. Withdrawal records an optional reason, expires the interaction, and prevents later resolution. Low-trust and task-watchdog agent runs cannot withdraw interactions.
+
+### Retire An Interaction You Created On Another Issue
+
+```
+POST /api/companies/{companyId}/interactions/{interactionId}/withdraw
+```
+
+The per-issue withdraw route pins the interaction to the issue in the path, so an agent working issue A cannot retire a now-stale ask it left on issue B. This company-scoped route closes that gap: it takes the interaction id alone and authorizes purely on ownership — the agent recorded in `createdByAgentId`, or a board user. Assignee-based access does not apply here, because without an issue in hand there is no assignee to check.
+
+Withdraw is not accept or reject. It never produces a decision; it only retires the question, and any linked tool-action request is revoked with it. An interaction whose tool action is already `executing` or `executed` cannot be withdrawn.
+
+### Declare What A New Interaction Replaces
+
+Every interaction-creating payload accepts `supersedesInteractionIds: string[]` (max 20). Listed interactions are expired at create time with outcome `superseded_by_interaction` and a `supersededByInteractionId` pointer back to the replacement, so the thread never shows a retired ask without a successor.
+
+Links may cross issues within the same company — the case the per-issue mechanisms are structurally blind to — but never cross companies, and may only name **pending** interactions the calling agent created itself. Violations fail the create with `422` before anything is written.
+
+Prefer this to writing prose that asks a human to clean up a stale card. When a replacement declares its links, the old ask retires itself and the board never sees it.
+
+Note the interaction between this and `supersedeOnUserComment`: a user comment supersedes pending interactions only when exactly **one** supersedable interaction is pending on the issue. If several are pending, the comment expires none of them and the server logs loudly, rather than guessing which ask the comment answered. Declare `supersedesInteractionIds`, or withdraw the stale asks explicitly.
 
 ## Documents
 

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -1088,6 +1088,11 @@ export interface AskUserQuestionsPayload {
   title?: string | null;
   submitLabel?: string | null;
   supersedeOnUserComment?: boolean;
+  /**
+   * RBR-852 AC1: ids of pending interactions this one explicitly replaces. Cross-issue is allowed
+   * (same company only); the caller may only name interactions it created itself.
+   */
+  supersedesInteractionIds?: string[];
   questions: AskUserQuestionsQuestion[];
 }
 
@@ -1104,8 +1109,10 @@ export interface AskUserQuestionsResult {
   answers: AskUserQuestionsAnswer[];
   cancelled?: true;
   cancellationReason?: string | null;
-  expirationReason?: "superseded_by_comment";
+  expirationReason?: "superseded_by_comment" | "superseded_by_interaction";
   commentId?: string | null;
+  /** Set when expirationReason is superseded_by_interaction: the interaction that replaced this one. */
+  supersededByInteractionId?: string | null;
   summaryMarkdown?: string | null;
 }
 
@@ -1181,6 +1188,8 @@ export interface RequestConfirmationPayload {
   declineReasonPlaceholder?: string | null;
   detailsMarkdown?: string | null;
   supersedeOnUserComment?: boolean;
+  /** RBR-852 AC1. See AskUserQuestionsPayload.supersedesInteractionIds. */
+  supersedesInteractionIds?: string[];
   target?: RequestConfirmationTarget | null;
   toolAction?: RequestConfirmationToolActionPayload;
 }
@@ -1206,6 +1215,8 @@ export interface RequestCheckboxConfirmationPayload {
   allowDeclineReason?: boolean;
   declineReasonPlaceholder?: string | null;
   supersedeOnUserComment?: boolean;
+  /** RBR-852 AC1. See AskUserQuestionsPayload.supersedesInteractionIds. */
+  supersedesInteractionIds?: string[];
   target?: RequestConfirmationTarget | null;
 }
 
@@ -1230,6 +1241,8 @@ export interface RequestItemVerdictsPayload {
   reasonLabel?: string | null;
   allowBulkApprove?: boolean;
   supersedeOnUserComment?: boolean;
+  /** RBR-852 AC1. See AskUserQuestionsPayload.supersedesInteractionIds. */
+  supersedesInteractionIds?: string[];
   target?: RequestConfirmationTarget | null;
 }
 
@@ -1240,6 +1253,7 @@ export interface RequestConfirmationResult {
     | "rejected"
     | "superseded_by_comment"
     | "superseded_by_newer_request"
+    | "superseded_by_interaction"
     | "stale_target"
     | "withdrawn"
     | "issue_closed"
@@ -1276,11 +1290,12 @@ export interface RequestItemVerdictsResultItem {
 
 export interface RequestItemVerdictsResult {
   version: 1;
-  outcome: "resolved" | "superseded_by_comment" | "stale_target" | "cancelled" | "withdrawn" | "issue_closed" | "addressee_deleted";
+  outcome: "resolved" | "superseded_by_comment" | "superseded_by_interaction" | "stale_target" | "cancelled" | "withdrawn" | "issue_closed" | "addressee_deleted";
   reason?: string | null;
   complete: boolean;
   items: RequestItemVerdictsResultItem[];
   commentId?: string | null;
+  supersededByInteractionId?: string | null;
   staleTarget?: RequestConfirmationTarget | null;
 }
 

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -757,6 +757,20 @@ export const askUserQuestionsQuestionOptionSchema = z.object({
   description: z.string().trim().max(500).nullable().optional(),
 });
 
+/**
+ * RBR-852 AC1: explicit supersession links declared by the creating agent.
+ *
+ * Ids of pending interactions that this new interaction replaces. Cross-issue links are allowed
+ * (an agent working issue A may retire an ask it created on issue B) but cross-company links are
+ * never allowed; the service rejects those with 422 before the insert. An agent may only name
+ * interactions it created itself, so supersession can never silently retire the board's question
+ * or another agent's ask.
+ */
+export const supersedesInteractionIdsSchema = z
+  .array(z.string().uuid())
+  .max(20)
+  .optional();
+
 export const askUserQuestionsQuestionSchema = z.object({
   id: z.string().trim().min(1).max(120),
   prompt: z.string().trim().min(1).max(500),
@@ -771,6 +785,7 @@ export const askUserQuestionsPayloadSchema = z.object({
   title: z.string().trim().max(240).nullable().optional(),
   submitLabel: z.string().trim().max(120).nullable().optional(),
   supersedeOnUserComment: z.boolean().optional(),
+  supersedesInteractionIds: supersedesInteractionIdsSchema,
   questions: z.array(askUserQuestionsQuestionSchema).min(1).max(10),
 }).superRefine((value, ctx) => {
   const seenQuestionIds = new Set<string>();
@@ -811,8 +826,9 @@ export const askUserQuestionsResultSchema = z.object({
   answers: z.array(askUserQuestionsAnswerSchema).max(20),
   cancelled: z.literal(true).optional(),
   cancellationReason: z.string().trim().max(4000).nullable().optional(),
-  expirationReason: z.literal("superseded_by_comment").optional(),
+  expirationReason: z.enum(["superseded_by_comment", "superseded_by_interaction"]).optional(),
   commentId: z.string().uuid().nullable().optional(),
+  supersededByInteractionId: z.string().uuid().nullable().optional(),
   summaryMarkdown: z.string().max(20000).nullable().optional(),
 });
 
@@ -875,6 +891,7 @@ export const requestConfirmationPayloadSchema = z.object({
   declineReasonPlaceholder: z.string().trim().min(1).max(240).nullable().optional(),
   detailsMarkdown: z.string().max(20000).nullable().optional(),
   supersedeOnUserComment: z.boolean().optional(),
+  supersedesInteractionIds: supersedesInteractionIdsSchema,
   target: requestConfirmationTargetSchema.nullable().optional(),
   toolAction: requestConfirmationToolActionPayloadSchema.optional(),
 });
@@ -905,6 +922,7 @@ export const requestCheckboxConfirmationPayloadSchema = z.object({
   allowDeclineReason: z.boolean().optional().default(true),
   declineReasonPlaceholder: z.string().trim().min(1).max(240).nullable().optional(),
   supersedeOnUserComment: z.boolean().optional(),
+  supersedesInteractionIds: supersedesInteractionIdsSchema,
   target: requestConfirmationTargetSchema.nullable().optional(),
 }).superRefine((value, ctx) => {
   const optionIds = new Set<string>();
@@ -1010,6 +1028,7 @@ export const requestConfirmationResultSchema = z.object({
     "rejected",
     "superseded_by_comment",
     "superseded_by_newer_request",
+    "superseded_by_interaction",
     "stale_target",
     "withdrawn",
     "issue_closed",
@@ -1072,6 +1091,7 @@ export const requestItemVerdictsPayloadSchema = z.object({
   reasonLabel: z.string().trim().min(1).max(160).nullable().optional(),
   allowBulkApprove: z.boolean().optional().default(true),
   supersedeOnUserComment: z.boolean().optional(),
+  supersedesInteractionIds: supersedesInteractionIdsSchema,
   target: requestConfirmationTargetSchema.nullable().optional(),
 }).superRefine((value, ctx) => {
   const itemIds = new Set<string>();
@@ -1137,12 +1157,13 @@ export const requestItemVerdictsResultItemSchema = z.object({
 
 export const requestItemVerdictsResultSchema = z.object({
   version: z.literal(1),
-  outcome: z.enum(["resolved", "superseded_by_comment", "stale_target", "cancelled", "withdrawn", "issue_closed", "addressee_deleted"]),
+  outcome: z.enum(["resolved", "superseded_by_comment", "superseded_by_interaction", "stale_target", "cancelled", "withdrawn", "issue_closed", "addressee_deleted"]),
   reason: z.string().trim().max(4000).nullable().optional(),
   complete: z.boolean(),
   items: z.array(requestItemVerdictsResultItemSchema)
     .max(REQUEST_ITEM_VERDICTS_ITEM_LIMIT),
   commentId: z.string().uuid().nullable().optional(),
+  supersededByInteractionId: z.string().uuid().nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),
 }).superRefine((value, ctx) => {
   const itemIds = new Set<string>();

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -2166,4 +2166,106 @@ describe("agent issue mutation checkout ownership", () => {
       expect(mockIssueService.update).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * RBR-882: a rejected out-of-boundary write must never deserialize into
+   * something an agent's success path reads as fine.
+   *
+   * The reported symptom was a "success-shaped body": `curl -sS ... | jq` on a
+   * denied write printed `id: null` / `status: null` and the agent moved on
+   * believing the comment landed. The rejection itself was correct; the way a
+   * normal client path *saw* it was not.
+   *
+   * These tests pin the server side of that contract for both write paths the
+   * CEO hit. A denial must be:
+   *   - non-2xx (so `curl -f` / `res.ok` / `raise_for_status` trip),
+   *   - carrying a populated top-level `error` string,
+   *   - carrying a machine-readable `details.code`,
+   *   - and must NOT carry the success-shaped `id` / `status` keys that a
+   *     client reads off a created comment or an updated issue.
+   *
+   * The last assertion is the load-bearing one: it is what makes the failure
+   * visible rather than invisible-by-construction. `id: null` in a denial body
+   * would satisfy the first three and still reproduce the original bug.
+   */
+  describe("RBR-882: out-of-boundary write denials are not success-shaped", () => {
+    function denyAllBoundary() {
+      mockAccessService.decide.mockImplementation(async (input: { action: string }) => {
+        // The actor can still *see* the issue; only the write actions are
+        // outside its boundary. This is the shape of the reported repro.
+        const allowed = input.action === "issue:read" || input.action === "company_scope:read";
+        return {
+          allowed,
+          action: input.action,
+          reason: allowed ? "allow_company_agent" : "deny_low_trust_boundary",
+          explanation: allowed
+            ? "Readable by a company agent."
+            : "Issue is outside this actor's authorization boundary.",
+        };
+      });
+    }
+
+    /** A denial body must be unambiguous to a client that only parses JSON. */
+    function expectUnambiguousDenial(res: { status: number; body: Record<string, unknown> }) {
+      expect(res.status, JSON.stringify(res.body)).toBeGreaterThanOrEqual(400);
+      expect(typeof res.body.error).toBe("string");
+      expect(res.body.error as string).not.toHaveLength(0);
+      // The success-shaped keys must be absent, not null. `id: null` is exactly
+      // the shape that let the original dropped writes look like successes.
+      expect(res.body).not.toHaveProperty("id");
+      expect(res.body).not.toHaveProperty("status");
+      expect((res.body.details as Record<string, unknown> | undefined)?.code).toBeTruthy();
+    }
+
+    it("PATCH /issues/:id carrying a comment fails loudly instead of reporting success", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
+      denyAllBoundary();
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ status: "done", comment: "A 3.5KB correction that must not silently vanish." });
+
+      expectUnambiguousDenial(res);
+      // AC2: the comment must not be reported as persisted when it was rejected.
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+
+    it("POST /issues/:id/comments fails loudly instead of returning a null id", async () => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: ownerAgentId }));
+      denyAllBoundary();
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "A correction that must not silently vanish." });
+
+      expectUnambiguousDenial(res);
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("keeps 404 on a missing issue unambiguous for both write paths", async () => {
+      // A write to an issue the actor cannot even see resolves as "not found";
+      // that path must be just as loud as the 403 path.
+      mockIssueService.getById.mockResolvedValue(null);
+      mockIssueService.getByIdentifier.mockResolvedValue(null);
+
+      const patchRes = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ status: "done", comment: "Dropped write." });
+      expect(patchRes.status).toBe(404);
+      expect(patchRes.body.error).toBeTruthy();
+      expect(patchRes.body).not.toHaveProperty("id");
+      expect(patchRes.body).not.toHaveProperty("status");
+
+      const commentRes = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: "Dropped write." });
+      expect(commentRes.status).toBe(404);
+      expect(commentRes.body.error).toBeTruthy();
+      expect(commentRes.body).not.toHaveProperty("id");
+
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -3356,4 +3356,252 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       });
     });
   });
+
+  /**
+   * RBR-852. The acceptance gate for "interactions have a lifecycle owner".
+   *
+   * Two production behaviours are pinned here:
+   *  1. A single board comment must never garbage-collect a pile of contradictory pending asks
+   *     (AC5). Before this, one comment expired all of them, so the board could not tell which
+   *     question it had answered and the agent lost the ask it was actually waiting on.
+   *  2. An agent must be able to retire its own stale ask *on another issue* — the case that
+   *     forced two live CEO asks to embed prose begging a human to dismiss a confirmation the
+   *     API refused to let an agent touch.
+   */
+  describe("RBR-852 interaction lifecycle", () => {
+    async function seedAgent(companyId: string, name: string) {
+      const agentId = randomUUID();
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name,
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      });
+      return agentId;
+    }
+
+    async function seedSiblingIssue(companyId: string, goalId: string, title: string) {
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        goalId,
+        title,
+        status: "in_progress",
+        priority: "medium",
+      });
+      return issueId;
+    }
+
+    it("AC5: a single user comment leaves three contradictory pending asks alone, including the current one", async () => {
+      const { companyId, issueId } = await seedConfirmationIssue("Three contradictory device purge asks");
+      const authorAgentId = await seedAgent(companyId, "CEO");
+
+      // Modelled directly on the live RBR-730 pile-up: three irreversible purge confirmations
+      // (188 / 190 / 193 devices) from one author, all pending at once.
+      const [oldest, middle, current] = [randomUUID(), randomUUID(), randomUUID()];
+      await db.insert(issueThreadInteractions).values([
+        { id: oldest, prompt: "Purge 188 devices?", at: "2026-08-02T10:00:00.000Z" },
+        { id: middle, prompt: "Purge 190 devices?", at: "2026-08-05T18:12:00.000Z" },
+        { id: current, prompt: "Purge 193 devices?", at: "2026-08-05T18:46:00.000Z" },
+      ].map((row) => ({
+        id: row.id,
+        companyId,
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        createdByAgentId: authorAgentId,
+        payload: { version: 1 as const, prompt: row.prompt, supersedeOnUserComment: true },
+        createdAt: new Date(row.at),
+        updatedAt: new Date(row.at),
+      })));
+
+      const expired = await interactionsSvc.expireRequestConfirmationsSupersededByComment(
+        { id: issueId, companyId },
+        { id: randomUUID(), createdAt: new Date("2026-08-05T19:00:00.000Z"), authorUserId: "local-board" },
+        { userId: "local-board" },
+      );
+
+      // Nothing is guessed away, and above all the current ask survives.
+      expect(expired).toHaveLength(0);
+      const interactions = await interactionsSvc.listForIssue(issueId);
+      for (const id of [oldest, middle, current]) {
+        expect(interactions.find((interaction) => interaction.id === id)?.status).toBe("pending");
+      }
+    });
+
+    it("AC5: a user comment still supersedes when it is the only pending ask on the issue", async () => {
+      const { companyId, issueId } = await seedConfirmationIssue("Single pending ask still supersedes");
+
+      const created = await interactionsSvc.create({ id: issueId, companyId }, {
+        kind: "request_confirmation",
+        payload: { version: 1, prompt: "Proceed with the only open draft?" },
+      }, { userId: "local-board" });
+
+      const expired = await interactionsSvc.expireRequestConfirmationsSupersededByComment(
+        { id: issueId, companyId },
+        {
+          id: randomUUID(),
+          createdAt: new Date(new Date(created.createdAt).getTime() + 1_000),
+          authorUserId: "local-board",
+        },
+        { userId: "local-board" },
+      );
+
+      expect(expired).toHaveLength(1);
+      expect(expired[0]).toMatchObject({ id: created.id, status: "expired" });
+    });
+
+    it("AC1 + finding 3: an explicit supersession link retires an ask on another issue and points at its replacement", async () => {
+      const { companyId, goalId, issueId: currentIssueId } = await seedConfirmationIssue("Cross-issue supersession");
+      const otherIssueId = await seedSiblingIssue(companyId, goalId, "Older issue holding the stale ask");
+      const authorAgentId = await seedAgent(companyId, "CEO");
+
+      // The 188-device ask, stranded on a different issue — the exact shape the parent's
+      // per-issue mechanisms are structurally blind to.
+      const stale = await interactionsSvc.create({ id: otherIssueId, companyId }, {
+        kind: "request_confirmation",
+        payload: { version: 1, prompt: "Purge 188 devices against the stale keep-list?" },
+      }, { agentId: authorAgentId });
+      expect(stale.status).toBe("pending");
+
+      const replacement = await interactionsSvc.create({ id: currentIssueId, companyId }, {
+        kind: "request_confirmation",
+        payload: {
+          version: 1,
+          prompt: "Purge 193 devices against the current keep-list?",
+          supersedesInteractionIds: [stale.id],
+        },
+      }, { agentId: authorAgentId });
+
+      const retired = await interactionsSvc.getForIssue({ id: otherIssueId, companyId }, stale.id);
+      expect(retired).toMatchObject({
+        status: "expired",
+        result: {
+          outcome: "superseded_by_interaction",
+          supersededByInteractionId: replacement.id,
+        },
+      });
+      expect(replacement.status).toBe("pending");
+    });
+
+    it("AC1: supersession links may only name pending interactions the calling agent created", async () => {
+      const { companyId, issueId } = await seedConfirmationIssue("Supersession ownership guard");
+      const authorAgentId = await seedAgent(companyId, "CEO");
+      const otherAgentId = await seedAgent(companyId, "CISO");
+
+      const peerAsk = await interactionsSvc.create({ id: issueId, companyId }, {
+        kind: "request_confirmation",
+        idempotencyKey: "confirmation:peer",
+        payload: { version: 1, prompt: "A peer's ask that must not be retired by someone else" },
+      }, { agentId: otherAgentId });
+
+      await expect(interactionsSvc.create({ id: issueId, companyId }, {
+        kind: "request_confirmation",
+        idempotencyKey: "confirmation:hijack",
+        payload: {
+          version: 1,
+          prompt: "Retire someone else's ask?",
+          supersedesInteractionIds: [peerAsk.id],
+        },
+      }, { agentId: authorAgentId })).rejects.toThrow(/only reference interactions you created/);
+
+      expect(
+        (await interactionsSvc.getForIssue({ id: issueId, companyId }, peerAsk.id)).status,
+      ).toBe("pending");
+    });
+
+    it("AC1: supersession links never cross a company boundary", async () => {
+      const { companyId, issueId } = await seedConfirmationIssue("Supersession company guard");
+      const foreign = await seedConfirmationIssue("Foreign company");
+      const authorAgentId = await seedAgent(companyId, "CEO");
+      const foreignAgentId = await seedAgent(foreign.companyId, "Foreign CEO");
+
+      const foreignAsk = await interactionsSvc.create(
+        { id: foreign.issueId, companyId: foreign.companyId },
+        { kind: "request_confirmation", payload: { version: 1, prompt: "Foreign company ask" } },
+        { agentId: foreignAgentId },
+      );
+
+      await expect(interactionsSvc.create({ id: issueId, companyId }, {
+        kind: "request_confirmation",
+        payload: {
+          version: 1,
+          prompt: "Reach into another company?",
+          supersedesInteractionIds: [foreignAsk.id],
+        },
+      }, { agentId: authorAgentId })).rejects.toThrow(/same company/);
+
+      expect(
+        (await interactionsSvc.getForIssue({ id: foreign.issueId, companyId: foreign.companyId }, foreignAsk.id)).status,
+      ).toBe("pending");
+    });
+
+    it("AC2 + finding 3: the author withdraws its own ask on another issue without addressing that issue", async () => {
+      const { companyId, goalId, issueId: currentIssueId } = await seedConfirmationIssue("Cross-issue withdraw");
+      const otherIssueId = await seedSiblingIssue(companyId, goalId, "Issue the author is not working");
+      const authorAgentId = await seedAgent(companyId, "CEO");
+
+      const stale = await interactionsSvc.create({ id: otherIssueId, companyId }, {
+        kind: "request_confirmation",
+        payload: { version: 1, prompt: "Purge 188 devices against the stale keep-list?" },
+      }, { agentId: authorAgentId });
+
+      // The per-issue route cannot see it from the issue the author is actually working.
+      await expect(interactionsSvc.withdrawInteraction(
+        { id: currentIssueId, companyId },
+        stale.id,
+        { reason: "Superseded by the 193-device ask" },
+        { agentId: authorAgentId },
+      )).rejects.toThrow(/not found/i);
+
+      const withdrawn = await interactionsSvc.withdrawCompanyInteraction(
+        { companyId },
+        stale.id,
+        { reason: "Superseded by the 193-device ask" },
+        { agentId: authorAgentId },
+      );
+
+      // Withdraw retires the question; it must never manufacture a decision.
+      expect(withdrawn).toMatchObject({
+        id: stale.id,
+        status: "cancelled",
+        result: { outcome: "withdrawn", reason: "Superseded by the 193-device ask" },
+        resolvedByAgentId: authorAgentId,
+      });
+      expect(withdrawn.result).not.toMatchObject({ outcome: "accepted" });
+    });
+
+    it("AC2: company-scoped withdraw refuses to cross a company boundary or retire a resolved ask", async () => {
+      const { companyId, issueId } = await seedConfirmationIssue("Company withdraw guards");
+      const foreign = await seedConfirmationIssue("Foreign company withdraw");
+      const authorAgentId = await seedAgent(companyId, "CEO");
+
+      const ask = await interactionsSvc.create({ id: issueId, companyId }, {
+        kind: "request_confirmation",
+        payload: { version: 1, prompt: "An ask to withdraw twice" },
+      }, { agentId: authorAgentId });
+
+      await expect(interactionsSvc.withdrawCompanyInteraction(
+        { companyId: foreign.companyId },
+        ask.id,
+        {},
+        { agentId: authorAgentId },
+      )).rejects.toThrow(/not found/i);
+
+      await interactionsSvc.withdrawCompanyInteraction({ companyId }, ask.id, {}, { agentId: authorAgentId });
+      await expect(interactionsSvc.withdrawCompanyInteraction(
+        { companyId },
+        ask.id,
+        {},
+        { agentId: authorAgentId },
+      )).rejects.toThrow(/already been resolved/i);
+    });
+  });
 });

--- a/server/src/__tests__/issue-thread-interactions-supersession.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-supersession.test.ts
@@ -40,7 +40,10 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { instanceSettingsService } from "../services/instance-settings.js";
-import { issueThreadInteractionService } from "../services/issue-thread-interactions.js";
+import {
+  issueThreadInteractionService,
+  selectContradictoryPendingConfirmations,
+} from "../services/issue-thread-interactions.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;

--- a/server/src/__tests__/issue-thread-interactions-supersession.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-supersession.test.ts
@@ -130,12 +130,19 @@ describeEmbeddedPostgres("RBR-852 interaction supersession (AC5 gate)", () => {
     return agentId;
   }
 
-  function confirmationPayload(title: string, supersedesInteractionIds?: string[]) {
+  function confirmationPayload(
+    title: string,
+    supersedesInteractionIds?: string[],
+    overrides?: { supersedeOnUserComment?: boolean },
+  ) {
     return {
       version: 1 as const,
       prompt: `Confirm: ${title}`,
       acceptLabel: "Confirm",
       ...(supersedesInteractionIds ? { supersedesInteractionIds } : {}),
+      ...(overrides?.supersedeOnUserComment === undefined
+        ? {}
+        : { supersedeOnUserComment: overrides.supersedeOnUserComment }),
     };
   }
 
@@ -200,9 +207,52 @@ describeEmbeddedPostgres("RBR-852 interaction supersession (AC5 gate)", () => {
     expect((await statusOf(stale190.id))?.status).toBe("pending");
   });
 
-  it("case 1b: a single pending ask still expires on a user comment (historical behaviour intact)", async () => {
+  /**
+   * Case 1b — the single-candidate branch still works when expiry-by-comment is opted into.
+   *
+   * This case opts in explicitly (`supersedeOnUserComment: true`) rather than relying on the
+   * create-time default. RBR-875 flipped `SUPERSEDE_ON_USER_COMMENT_DEFAULT` to `false`, making
+   * expiry-by-comment strictly opt-in; what this case guards is the *selection rule* in
+   * `selectCommentSupersededRows` (one candidate => expire it), which is RBR-852's contract and is
+   * independent of whatever the default happens to be. Case 1c below pins the default itself, so
+   * a future flip in either direction fails there loudly instead of silently rewriting this gate.
+   */
+  it("case 1b: a single opted-in pending ask still expires on a user comment", async () => {
     const { companyId, goalId } = await seedCompany("Single ask co");
     const issueId = await seedIssue(companyId, goalId, "One ask");
+    const agentA = await seedAgent(companyId, "Agent A");
+
+    const only = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 193 devices", undefined, { supersedeOnUserComment: true }),
+    }, { agentId: agentA });
+
+    const expired = await interactionsSvc.expireRequestConfirmationsSupersededByComment(
+      { id: issueId, companyId },
+      {
+        id: randomUUID(),
+        createdAt: new Date(new Date(only.createdAt).getTime() + 1_000),
+        authorUserId: "local-board",
+      },
+      { userId: "local-board" },
+    );
+
+    expect(expired).toHaveLength(1);
+    expect(expired[0]?.id).toBe(only.id);
+    expect((await statusOf(only.id))?.status).toBe("expired");
+  });
+
+  /**
+   * Case 1c — expiry-by-comment is opt-in at create time (RBR-875).
+   *
+   * An ask created without an opinion must not be retired by a passing board comment. This is the
+   * companion half of the RBR-823 defect: RBR-852 stopped a comment from expiring *several* asks,
+   * RBR-875 stopped it from expiring an unconsenting *single* ask. Asserted here so the default is
+   * covered by the acceptance gate and cannot drift back unnoticed.
+   */
+  it("case 1c: an ask that never opted in is not expired by a user comment", async () => {
+    const { companyId, goalId } = await seedCompany("Default opt-out co");
+    const issueId = await seedIssue(companyId, goalId, "One unconsenting ask");
     const agentA = await seedAgent(companyId, "Agent A");
 
     const only = await interactionsSvc.create({ id: issueId, companyId }, {
@@ -220,9 +270,8 @@ describeEmbeddedPostgres("RBR-852 interaction supersession (AC5 gate)", () => {
       { userId: "local-board" },
     );
 
-    expect(expired).toHaveLength(1);
-    expect(expired[0]?.id).toBe(only.id);
-    expect((await statusOf(only.id))?.status).toBe("expired");
+    expect(expired).toHaveLength(0);
+    expect((await statusOf(only.id))?.status).toBe("pending");
   });
 
   /**
@@ -390,5 +439,120 @@ describeEmbeddedPostgres("RBR-852 interaction supersession (AC5 gate)", () => {
       {},
       { agentId: author },
     )).rejects.toMatchObject({ status: 409 });
+  });
+
+  /**
+   * Case 6 — RBR-893 AC3, loud contradiction detection.
+   *
+   * The create-time sweep is scoped to same-issue + same-kind + same-agent, so a peer agent's
+   * confirmation survives a new one (correctly — no agent may destroy another's ask). AC3 is about
+   * that survivor no longer being *silent*: RBR-730 accumulated three pending confirmations for
+   * the same irreversible mass deletion with nothing anywhere flagging the contradiction.
+   *
+   * These cases pin the two halves separately: selection (pure, exact) and the create integration
+   * (warns, and critically expires nothing).
+   */
+  describe("case 6: RBR-893 AC3 loud contradiction detection", () => {
+    it("warns and expires nothing when a peer agent's confirmation is already pending", async () => {
+      const { companyId, goalId } = await seedCompany("Contradiction co");
+      const issueId = await seedIssue(companyId, goalId, "Mass deletion");
+      const ciso = await seedAgent(companyId, "CISO");
+      const cto = await seedAgent(companyId, "CTO");
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const peerAsk = await interactionsSvc.create({ id: issueId, companyId }, {
+          kind: "request_confirmation",
+          payload: confirmationPayload("Delete 188 devices"),
+        }, { agentId: ciso });
+
+        const newAsk = await interactionsSvc.create({ id: issueId, companyId }, {
+          kind: "request_confirmation",
+          payload: confirmationPayload("Delete 193 devices"),
+        }, { agentId: cto });
+
+        // The safety property: detection is an alarm, never a deletion primitive over a peer.
+        expect((await statusOf(peerAsk.id))?.status).toBe("pending");
+        expect((await statusOf(newAsk.id))?.status).toBe("pending");
+
+        const contradictionWarning = warn.mock.calls
+          .map((call) => String(call[0]))
+          .find((message) => message.includes("RBR-893"));
+        expect(contradictionWarning).toBeDefined();
+        expect(contradictionWarning).toContain(peerAsk.id);
+        expect(contradictionWarning).toContain(newAsk.id);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("stays quiet when the new confirmation explicitly supersedes the only pending one", async () => {
+      const { companyId, goalId } = await seedCompany("Clean supersede co");
+      const issueId = await seedIssue(companyId, goalId, "Mass deletion");
+      const author = await seedAgent(companyId, "Author");
+
+      const stale = await interactionsSvc.create({ id: issueId, companyId }, {
+        kind: "request_confirmation",
+        payload: confirmationPayload("Delete 188 devices"),
+      }, { agentId: author });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const replacement = await interactionsSvc.create({ id: issueId, companyId }, {
+          kind: "request_confirmation",
+          payload: confirmationPayload("Delete 193 devices", [stale.id]),
+        }, { agentId: author });
+
+        // The declared link retired the predecessor, so nothing coexists and nothing is flagged.
+        expect((await statusOf(stale.id))?.status).toBe("expired");
+        expect((await statusOf(replacement.id))?.status).toBe("pending");
+        expect(
+          warn.mock.calls.map((call) => String(call[0])).filter((message) => message.includes("RBR-893")),
+        ).toEqual([]);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("selects only pending confirmation-like peers, never itself, answered rows, or questions", () => {
+      const issueId = randomUUID();
+      const row = (over: Record<string, unknown>) => ({
+        id: randomUUID(),
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        createdByAgentId: randomUUID(),
+        ...over,
+      } as never);
+
+      const created = row({ kind: "request_confirmation" });
+      const peerConfirmation = row({});
+      const peerCheckbox = row({ kind: "request_checkbox_confirmation" });
+      const question = row({ kind: "ask_user_questions" });
+      const answered = row({ status: "accepted" });
+
+      const selected = selectContradictoryPendingConfirmations(
+        created,
+        [created, peerConfirmation, peerCheckbox, question, answered],
+      );
+
+      expect(selected.map((entry) => entry.id).sort()).toEqual(
+        [peerConfirmation.id, peerCheckbox.id].sort(),
+      );
+    });
+
+    it("returns nothing for a non-confirmation kind, so questions never trip the alarm", () => {
+      const issueId = randomUUID();
+      const created = { id: randomUUID(), issueId, kind: "ask_user_questions" } as never;
+      const pendingConfirmation = {
+        id: randomUUID(),
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        createdByAgentId: randomUUID(),
+      } as never;
+
+      expect(selectContradictoryPendingConfirmations(created, [pendingConfirmation])).toEqual([]);
+    });
   });
 });

--- a/server/src/__tests__/issue-thread-interactions-supersession.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-supersession.test.ts
@@ -1,0 +1,394 @@
+/**
+ * RBR-852 AC5 — the acceptance gate for the interaction-supersession effort.
+ *
+ * Kept in its own file deliberately. The gate must not be weakened to make an unrelated suite
+ * pass (explicit CEO direction on RBR-823/RBR-852), and isolating it means churn in the large
+ * shared interaction suite can never quietly erode it.
+ *
+ * Five cases, from the approved plan:
+ *  1. 3 pending interactions + 1 user comment => the current (newest) one survives.
+ *  2. cross-issue explicit link => the linked row expires with a pointer back to its replacement.
+ *  3. cross-company supersede attempt => 422, nothing mutated.
+ *  4. superseding another agent's interaction => 422, nothing mutated.
+ *  5. cross-issue withdraw by the author on the company-scoped path => withdrawn; foreign company
+ *     scope => 404. (The non-author 403 is an HTTP concern and lives in the route suite.)
+ */
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  documentRevisions,
+  documents,
+  executionWorkspaces,
+  goals,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  instanceSettings,
+  issueRelations,
+  issueThreadInteractions,
+  issues,
+  projectWorkspaces,
+  projects,
+  workspaceOperations,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { instanceSettingsService } from "../services/instance-settings.js";
+import { issueThreadInteractionService } from "../services/issue-thread-interactions.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("RBR-852 interaction supersession (AC5 gate)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let interactionsSvc!: ReturnType<typeof issueThreadInteractionService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-rbr852-supersession-");
+    db = createDb(tempDb.connectionString);
+    interactionsSvc = issueThreadInteractionService(db);
+  }, 120_000);
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await db.delete(issueThreadInteractions);
+    await db.delete(issueComments);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issueRelations);
+    await db.delete(heartbeatRuns);
+    await db.delete(workspaceOperations);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany(name: string) {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name,
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: name,
+      level: "task",
+      status: "active",
+    });
+    return { companyId, goalId };
+  }
+
+  async function seedIssue(companyId: string, goalId: string, title: string, assigneeAgentId?: string) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title,
+      status: "in_progress",
+      priority: "medium",
+      ...(assigneeAgentId ? { assigneeAgentId } : {}),
+    });
+    return issueId;
+  }
+
+  async function seedAgent(companyId: string, name: string) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name,
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  function confirmationPayload(title: string, supersedesInteractionIds?: string[]) {
+    return {
+      version: 1 as const,
+      prompt: `Confirm: ${title}`,
+      acceptLabel: "Confirm",
+      ...(supersedesInteractionIds ? { supersedesInteractionIds } : {}),
+    };
+  }
+
+  async function statusOf(interactionId: string) {
+    const [row] = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, interactionId));
+    return row;
+  }
+
+  /**
+   * Case 1 — the gate itself, stated strictly and not weakened.
+   *
+   * This is the RBR-823 defect in miniature: several irreversible asks pending at once, and the
+   * board member types one comment. Before the fix, that single comment expired all of them,
+   * including the current, correct ask. Three distinct agents author the three asks, which is
+   * exactly how the live RBR-730 / RBR-660 / RBR-398 pileups arose.
+   */
+  it("case 1: a single user comment does not expire the current ask when three are pending", async () => {
+    const { companyId, goalId } = await seedCompany("Gate co");
+    const issueId = await seedIssue(companyId, goalId, "Contradictory asks");
+    const agentA = await seedAgent(companyId, "Agent A");
+    const agentB = await seedAgent(companyId, "Agent B");
+    const agentC = await seedAgent(companyId, "Agent C");
+
+    const stale188 = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 188 devices"),
+    }, { agentId: agentA });
+    const stale190 = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 190 devices"),
+    }, { agentId: agentB });
+    const current193 = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 193 devices"),
+    }, { agentId: agentC });
+
+    for (const created of [stale188, stale190, current193]) {
+      expect(created.status).toBe("pending");
+    }
+
+    const expired = await interactionsSvc.expireRequestConfirmationsSupersededByComment(
+      { id: issueId, companyId },
+      {
+        id: randomUUID(),
+        createdAt: new Date(new Date(current193.createdAt).getTime() + 1_000),
+        authorUserId: "local-board",
+      },
+      { userId: "local-board" },
+    );
+
+    // The gate: the current ask must survive the comment.
+    expect((await statusOf(current193.id))?.status).toBe("pending");
+    expect(expired.map((row) => row.id)).not.toContain(current193.id);
+
+    // And per the AC1 ruling we expire nothing rather than guess a winner among unlinked asks:
+    // a comment must never silently retire a live irreversible request.
+    expect(expired).toHaveLength(0);
+    expect((await statusOf(stale188.id))?.status).toBe("pending");
+    expect((await statusOf(stale190.id))?.status).toBe("pending");
+  });
+
+  it("case 1b: a single pending ask still expires on a user comment (historical behaviour intact)", async () => {
+    const { companyId, goalId } = await seedCompany("Single ask co");
+    const issueId = await seedIssue(companyId, goalId, "One ask");
+    const agentA = await seedAgent(companyId, "Agent A");
+
+    const only = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 193 devices"),
+    }, { agentId: agentA });
+
+    const expired = await interactionsSvc.expireRequestConfirmationsSupersededByComment(
+      { id: issueId, companyId },
+      {
+        id: randomUUID(),
+        createdAt: new Date(new Date(only.createdAt).getTime() + 1_000),
+        authorUserId: "local-board",
+      },
+      { userId: "local-board" },
+    );
+
+    expect(expired).toHaveLength(1);
+    expect(expired[0]?.id).toBe(only.id);
+    expect((await statusOf(only.id))?.status).toBe("expired");
+  });
+
+  /**
+   * Case 2 — the cross-issue link (finding 3). The 188-device ask lives on a different issue from
+   * the one its author is working; every same-issue mechanism is structurally blind to it.
+   */
+  it("case 2: an explicit cross-issue link expires the target with a pointer to its replacement", async () => {
+    const { companyId, goalId } = await seedCompany("Cross issue co");
+    const issueA = await seedIssue(companyId, goalId, "Issue A (working here)");
+    const issueB = await seedIssue(companyId, goalId, "Issue B (stale ask lives here)");
+    const author = await seedAgent(companyId, "Author");
+
+    const staleOnB = await interactionsSvc.create({ id: issueB, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 188 devices"),
+    }, { agentId: author });
+
+    const replacementOnA = await interactionsSvc.create({ id: issueA, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 193 devices", [staleOnB.id]),
+    }, { agentId: author });
+
+    expect(replacementOnA.status).toBe("pending");
+
+    const target = await statusOf(staleOnB.id);
+    expect(target?.status).toBe("expired");
+    expect(target?.result).toMatchObject({
+      version: 1,
+      outcome: "superseded_by_interaction",
+      supersededByInteractionId: replacementOnA.id,
+    });
+    expect(target?.resolvedByAgentId).toBe(author);
+  });
+
+  /**
+   * Case 3 — company isolation. Supersession resolves ids within the actor's company only; a
+   * foreign id must fail the create outright and mutate nothing on either side.
+   */
+  it("case 3: a cross-company supersede attempt is rejected with 422 and mutates nothing", async () => {
+    const home = await seedCompany("Home co");
+    const foreign = await seedCompany("Foreign co");
+    const homeIssue = await seedIssue(home.companyId, home.goalId, "Home issue");
+    const foreignIssue = await seedIssue(foreign.companyId, foreign.goalId, "Foreign issue");
+    const homeAgent = await seedAgent(home.companyId, "Home agent");
+    const foreignAgent = await seedAgent(foreign.companyId, "Foreign agent");
+
+    const foreignAsk = await interactionsSvc.create({ id: foreignIssue, companyId: foreign.companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Foreign company ask"),
+    }, { agentId: foreignAgent });
+
+    await expect(interactionsSvc.create({ id: homeIssue, companyId: home.companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Home ask", [foreignAsk.id]),
+    }, { agentId: homeAgent })).rejects.toMatchObject({ status: 422 });
+
+    expect((await statusOf(foreignAsk.id))?.status).toBe("pending");
+    const homeRows = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.issueId, homeIssue));
+    expect(homeRows).toHaveLength(0);
+  });
+
+  /**
+   * Case 4 — ownership, not a role grant. Supersession may never be used to silently retire the
+   * board's question or a peer agent's ask.
+   */
+  it("case 4: superseding another agent's interaction is rejected with 422 and mutates nothing", async () => {
+    const { companyId, goalId } = await seedCompany("Ownership co");
+    const issueId = await seedIssue(companyId, goalId, "Ownership issue");
+    const owner = await seedAgent(companyId, "Owner");
+    const intruder = await seedAgent(companyId, "Intruder");
+
+    const ownersAsk = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Owner's ask"),
+    }, { agentId: owner });
+
+    await expect(interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Intruder's ask", [ownersAsk.id]),
+    }, { agentId: intruder })).rejects.toMatchObject({ status: 422 });
+
+    expect((await statusOf(ownersAsk.id))?.status).toBe("pending");
+    const rows = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.issueId, issueId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(ownersAsk.id);
+  });
+
+  /**
+   * Case 5 — company-scoped withdraw. The author must be able to retire its own stale ask on an
+   * issue it is not assigned to and is not currently addressing, without asking a human in prose.
+   */
+  it("case 5: the author can withdraw its own ask on another issue via the company-scoped path", async () => {
+    const { companyId, goalId } = await seedCompany("Withdraw co");
+    const otherAgent = await seedAgent(companyId, "Other agent");
+    const author = await seedAgent(companyId, "Author");
+    // The author is not the assignee of the issue the stale ask lives on: authorization here is
+    // ownership, never issue membership.
+    const issueB = await seedIssue(companyId, goalId, "Issue B", otherAgent);
+
+    const staleOnB = await interactionsSvc.create({ id: issueB, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Delete 188 devices"),
+    }, { agentId: author });
+
+    const withdrawn = await interactionsSvc.withdrawCompanyInteraction(
+      { companyId },
+      staleOnB.id,
+      { reason: "Superseded by the 193-device plan" },
+      { agentId: author },
+    );
+
+    expect(withdrawn).toMatchObject({
+      id: staleOnB.id,
+      status: "cancelled",
+      result: {
+        version: 1,
+        outcome: "withdrawn",
+        reason: "Superseded by the 193-device plan",
+      },
+    });
+    expect((await statusOf(staleOnB.id))?.status).toBe("cancelled");
+  });
+
+  it("case 5b: the company-scoped withdraw never reaches another company's interaction", async () => {
+    const home = await seedCompany("Withdraw home co");
+    const foreign = await seedCompany("Withdraw foreign co");
+    const foreignIssue = await seedIssue(foreign.companyId, foreign.goalId, "Foreign issue");
+    const foreignAgent = await seedAgent(foreign.companyId, "Foreign agent");
+
+    const foreignAsk = await interactionsSvc.create({ id: foreignIssue, companyId: foreign.companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Foreign ask"),
+    }, { agentId: foreignAgent });
+
+    await expect(interactionsSvc.withdrawCompanyInteraction(
+      { companyId: home.companyId },
+      foreignAsk.id,
+      {},
+      { agentId: foreignAgent },
+    )).rejects.toMatchObject({ status: 404 });
+
+    expect((await statusOf(foreignAsk.id))?.status).toBe("pending");
+  });
+
+  it("case 5c: a resolved interaction cannot be withdrawn twice", async () => {
+    const { companyId, goalId } = await seedCompany("Withdraw idempotence co");
+    const issueId = await seedIssue(companyId, goalId, "Issue");
+    const author = await seedAgent(companyId, "Author");
+
+    const ask = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: confirmationPayload("Ask"),
+    }, { agentId: author });
+
+    await interactionsSvc.withdrawCompanyInteraction({ companyId }, ask.id, {}, { agentId: author });
+    await expect(interactionsSvc.withdrawCompanyInteraction(
+      { companyId },
+      ask.id,
+      {},
+      { agentId: author },
+    )).rejects.toMatchObject({ status: 409 });
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10512,6 +10512,104 @@ export function issueRoutes(
     },
   );
 
+  /**
+   * RBR-852 AC2 + finding 3 — company-scoped, author-owned withdraw.
+   *
+   * Why a second route instead of widening the per-issue one: the per-issue path resolves the
+   * issue first and pins the interaction to it, so an agent can only ever retire asks on the issue
+   * it is currently working. In production that forced two separate CEO asks (RBR-730, RBR-398) to
+   * embed prose begging a human to dismiss a stale confirmation on a *different* issue, because the
+   * API refused. Retirement, not volume, is the defect; this route is the fix.
+   *
+   * Authorization is ownership, not a role grant: only the agent recorded in `createdByAgentId`
+   * may withdraw through this route, and board users go through the normal board check. That is
+   * deliberately narrower than the per-issue route (which also allows the current assignee) —
+   * without an issue in hand, "assignee" has no meaning here, and ownership is the only claim that
+   * is safe to honour across issue boundaries.
+   *
+   * The issue-level authorization boundary is intentionally *not* applied to the interaction's own
+   * issue. Withdraw is not accept/reject: it produces no decision and discloses nothing beyond an
+   * ask the actor already authored. Requiring `issue:mutate` on the far issue would reinstate
+   * exactly the wall this issue exists to remove.
+   */
+  router.post(
+    "/companies/:companyId/interactions/:interactionId/withdraw",
+    validate(withdrawIssueThreadInteractionSchema),
+    async (req, res) => {
+      const companyId = req.params.companyId as string;
+      const interactionId = req.params.interactionId as string;
+      assertCompanyAccess(req, companyId);
+
+      const interactionSvc = issueThreadInteractionService(db);
+      const current = await interactionSvc.getForCompany({ companyId }, interactionId);
+
+      if (req.actor.type === "agent") {
+        const actorAgentId = req.actor.agentId;
+        if (!actorAgentId || !requireAgentRunId(req, res)) return;
+        const watchdogScope = await resolveTaskWatchdogMutationScope(db, req.actor);
+        if (watchdogScope.kind !== "none") {
+          res.status(403).json({ error: "Task-watchdog runs cannot withdraw issue-thread interactions" });
+          return;
+        }
+        if (await assertLowTrustControlPlaneDenied(req, res, companyId)) return;
+        if (current.createdByAgentId !== actorAgentId) {
+          res.status(403).json({
+            error: "Only the agent that created this interaction may withdraw it through the company route",
+          });
+          return;
+        }
+      } else {
+        assertBoard(req);
+      }
+
+      const actor = getActorInfo(req);
+      const interaction = await interactionSvc.withdrawCompanyInteraction(
+        { companyId },
+        interactionId,
+        req.body,
+        {
+          agentId: actor.agentId,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        },
+      );
+
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        action: "issue.thread_interaction_withdrawn",
+        entityType: "issue",
+        entityId: interaction.issueId,
+        details: {
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          interactionStatus: interaction.status,
+          crossIssueWithdraw: true,
+          reason: interaction.result && "reason" in interaction.result ? interaction.result.reason ?? null : null,
+        },
+      });
+
+      // The interaction's own issue may have a different assignee mid-run waiting on this card;
+      // retiring it without a wake would strand that agent on a question that no longer exists.
+      const hostIssue = await svc.getById(interaction.issueId);
+      if (hostIssue && actor.agentId !== hostIssue.assigneeAgentId) {
+        await queueResolvedInteractionContinuationWakeup({
+          db,
+          heartbeat,
+          issue: hostIssue,
+          interaction,
+          actor,
+          source: "issue.interaction.withdraw",
+        });
+      }
+
+      res.json(interaction);
+    },
+  );
+
   router.post(
     "/issues/:id/interactions/:interactionId/cancel",
     validate(cancelIssueThreadInteractionSchema),

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -4497,6 +4497,18 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/api/companies/{companyId}/interactions/{interactionId}/withdraw",
+  tags: ["issues"],
+  summary: "Withdraw a pending interaction you created, from any issue in the company",
+  request: {
+    params: z.object({ companyId: z.string(), interactionId: z.string() }),
+    body: jsonBody(withdrawIssueThreadInteractionSchema),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized, 403: r.forbidden, 404: r.notFound },
+});
+
+registry.registerPath({
+  method: "post",
   path: "/api/issues/{id}/children",
   tags: ["issues"],
   summary: "Create child issues",

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -462,19 +462,16 @@ function shouldReturnAcceptedConfirmationToCreatorAgent(args: {
  * comment and unrelated pending interactions are silently garbage-collected, including
  * contradictory irreversible asks that nobody ever answered.
  *
- * It stays `true` on RBR-852. Flipping it to `false` is the right end state — RBR-852 shipped the
- * supported alternative, an explicit `supersedesInteractionIds` link that retires the specific
- * target it names at create time with an auditable pointer back, which makes blanket
- * expiry-by-proximity redundant. But the flip is a behaviour change for every existing caller and
- * was ruled **out of scope for RBR-852** by the CEO; it is tracked separately on RBR-877 and lands
- * after this. Do not flip it here.
+ * It is now `false`. RBR-852 shipped the supported alternative — an explicit
+ * `supersedesInteractionIds` link that retires the specific target it names at create time with an
+ * auditable pointer back — which makes blanket expiry-by-proximity redundant rather than merely
+ * damaging. A redundant default can be removed on its own evidence.
  *
- * What RBR-852 does change is the multi-candidate case: see `selectCommentSupersededRows`. With
- * the default still `true`, a lone pending ask keeps its historical behaviour (a comment instead
- * of an answer retires it), while two or more pending asks now retire *nothing* — which is the
- * actual defect RBR-823 reported.
+ * Consequence, stated plainly: expiry-by-comment is now strictly **opt-in**. A caller that wants a
+ * human comment to retire its ask must pass `supersedeOnUserComment: true` deliberately. Nothing
+ * in-tree does, so `selectCommentSupersededRows` is now a backstop for opt-in callers only.
  */
-const SUPERSEDE_ON_USER_COMMENT_DEFAULT = true;
+const SUPERSEDE_ON_USER_COMMENT_DEFAULT = false;
 
 function shouldSupersedeInteractionOnUserComment(interaction: UserCommentSupersedableInteraction) {
   return interaction.payload.supersedeOnUserComment === true;

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -513,6 +513,64 @@ export function selectCommentSupersededRows(
   return [];
 }
 
+/**
+ * RBR-893 AC3. Given the confirmation-like row that was just created and every pending
+ * confirmation-like row still live on the same issue, return the ones that now coexist with it.
+ *
+ * Why this exists. Create-time supersession only reaches rows that are same-issue **and**
+ * same-kind **and** same-agent, plus whatever the author explicitly named in
+ * `supersedesInteractionIds`. Everything outside that intersection — a peer agent's confirmation,
+ * a `request_checkbox_confirmation` sitting next to a `request_confirmation`, or a board-created
+ * ask — survives untouched. That is correct (one agent must never be able to silently destroy
+ * another's ask, and AC1 forbids guessing), but it means two contradictory irreversible
+ * instructions can sit pending on the same thread with nothing anywhere saying so. RBR-823's
+ * live example: three pending confirmations for the same mass deletion on RBR-730.
+ *
+ * Silent coexistence is the defect, so the fix is volume, not enforcement. Per the hard
+ * constraints on this issue we must not block interaction creation and must not change what
+ * agents are permitted to ask, so this returns rows for the caller to *report*, never to expire:
+ *  - auto-expiring a peer's ask would hand any agent a deletion primitive over other agents' cards
+ *  - 4xx-ing the create would fail an agent on the very call replacing a bad ask, which is the
+ *    prose-cleanup-chore RBR-823 exists to kill
+ *
+ * The author's supported route to a clean thread stays `supersedesInteractionIds` (its own asks)
+ * or an explicit withdraw. This is the alarm that tells it, and the board, that the route is
+ * needed.
+ */
+export function selectContradictoryPendingConfirmations(
+  created: Pick<IssueThreadInteractionRow, "id" | "kind">,
+  pendingOnIssue: readonly IssueThreadInteractionRow[],
+): IssueThreadInteractionRow[] {
+  if (!isRequestConfirmationLikeKind(created.kind)) return [];
+  return pendingOnIssue.filter((row) => (
+    row.id !== created.id
+    && row.status === "pending"
+    && isRequestConfirmationLikeKind(row.kind)
+  ));
+}
+
+/**
+ * RBR-893 AC3. Emit the loud signal for the rows above. Kept separate from selection so the
+ * decision is unit-testable without asserting on console output.
+ */
+function warnAboutContradictoryPendingConfirmations(
+  created: Pick<IssueThreadInteractionRow, "id" | "issueId">,
+  contradictory: readonly IssueThreadInteractionRow[],
+) {
+  if (contradictory.length === 0) return;
+  console.warn(
+    `[paperclip] RBR-893: confirmation ${created.id} was created on issue ${created.issueId} while `
+    + `${contradictory.length} other confirmation(s) are still pending there. Contradictory `
+    + "irreversible instructions can now coexist and the board cannot tell which one is current. "
+    + `Still pending: ${contradictory
+      .map((row) => `${row.id} (${row.kind}, createdByAgentId=${row.createdByAgentId ?? "none"})`)
+      .join(", ")}. `
+    + "The creating agent should declare supersedesInteractionIds on the replacement, or withdraw "
+    + "the stale asks explicitly. Nothing was auto-expired: an agent must not be able to retire "
+    + "another agent's ask, and guessing a winner is what RBR-823 reported.",
+  );
+}
+
 function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): CreateIssueThreadInteraction {
   switch (input.kind) {
     case "ask_user_questions":
@@ -2201,6 +2259,33 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
           });
         }
         return hydrateInteraction(existing);
+      }
+
+      /**
+       * RBR-893 AC3. The create transaction has committed, so this sees the real surviving set:
+       * everything the same-agent/same-kind sweep and the explicit `supersedesInteractionIds`
+       * links already expired is gone. Whatever confirmation-like rows are still pending here
+       * genuinely coexist with the new one. Read-only and deliberately outside the transaction —
+       * this must never be able to fail or slow down the create it is reporting on.
+       */
+      if (isRequestConfirmationLikeKind(created.kind)) {
+        try {
+          const stillPending = await db
+            .select()
+            .from(issueThreadInteractions)
+            .where(and(
+              eq(issueThreadInteractions.companyId, issue.companyId),
+              eq(issueThreadInteractions.issueId, issue.id),
+              eq(issueThreadInteractions.status, "pending"),
+              ne(issueThreadInteractions.id, created.id),
+            ));
+          warnAboutContradictoryPendingConfirmations(
+            created,
+            selectContradictoryPendingConfirmations(created, stillPending),
+          );
+        } catch (error) {
+          console.error("[paperclip] RBR-893: contradictory-confirmation check failed", error);
+        }
       }
 
       await touchIssue(db, issue.id);

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -458,6 +458,76 @@ function shouldSupersedeInteractionOnUserComment(interaction: UserCommentSuperse
   return interaction.payload.supersedeOnUserComment === true;
 }
 
+function rowSupersedesInteractionIds(row: IssueThreadInteractionRow): string[] {
+  const ids = (row.payload as { supersedesInteractionIds?: unknown } | null)?.supersedesInteractionIds;
+  if (!Array.isArray(ids)) return [];
+  return ids.filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+function compareInteractionRowsOldestFirst(a: IssueThreadInteractionRow, b: IssueThreadInteractionRow) {
+  const aMs = new Date(a.createdAt).getTime();
+  const bMs = new Date(b.createdAt).getTime();
+  if (aMs !== bMs) return aMs - bMs;
+  return a.id.localeCompare(b.id);
+}
+
+/**
+ * RBR-852 AC1 + AC5. Given every pending supersedable row a single human comment could otherwise
+ * expire, return only the rows that comment is actually allowed to expire.
+ *
+ * The defect this fixes: one board comment used to expire *every* pending interaction on the
+ * issue, so contradictory irreversible asks were silently garbage-collected together and the
+ * board could not tell which question it had just answered.
+ *
+ * Rules, applied per kind group (confirmation-like and questions are grouped separately because
+ * they answer different asks):
+ *  - Exactly one candidate: the comment supersedes it. This is the historical single-ask case and
+ *    is the only behaviour that survives unchanged.
+ *  - More than one candidate: expire only the newest, plus any older sibling the newest
+ *    explicitly named through `supersedesInteractionIds`. Per the product direction we do not
+ *    guess a winner among unlinked interactions — the rest stay pending and are logged loudly,
+ *    so a comment can never destroy a contradictory-but-live ask.
+ */
+export function selectCommentSupersededRows(
+  candidates: readonly IssueThreadInteractionRow[],
+): IssueThreadInteractionRow[] {
+  const selected: IssueThreadInteractionRow[] = [];
+
+  for (const group of [
+    candidates.filter((row) => isRequestConfirmationLikeKind(row.kind) || row.kind === "request_item_verdicts"),
+    candidates.filter((row) => row.kind === "ask_user_questions"),
+  ]) {
+    if (group.length === 0) continue;
+    if (group.length === 1) {
+      selected.push(group[0]!);
+      continue;
+    }
+
+    const ordered = [...group].sort(compareInteractionRowsOldestFirst);
+    const newest = ordered[ordered.length - 1]!;
+    const explicit = new Set(rowSupersedesInteractionIds(newest));
+    const skipped: string[] = [];
+    for (const row of ordered) {
+      if (row.id === newest.id || explicit.has(row.id)) {
+        selected.push(row);
+      } else {
+        skipped.push(row.id);
+      }
+    }
+    if (skipped.length > 0) {
+      // Loud backstop, per AC1: interactions created before explicit linking shipped have no
+      // link to follow, so we expire nothing rather than guess which ask the comment answered.
+      console.warn(
+        `[paperclip] RBR-852: a user comment matched ${ordered.length} pending ${newest.kind} interactions on issue ${newest.issueId}; `
+        + `expiring only the newest (${newest.id}) plus ${explicit.size} explicitly linked. Left pending: ${skipped.join(", ")}. `
+        + "The creating agent should declare supersedesInteractionIds or withdraw these explicitly.",
+      );
+    }
+  }
+
+  return selected;
+}
+
 function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): CreateIssueThreadInteraction {
   switch (input.kind) {
     case "ask_user_questions":
@@ -553,6 +623,45 @@ function buildSupersededByNewerRequestResult(replacementInteractionId: string) {
     version: 1,
     outcome: "superseded_by_newer_request",
     supersededByInteractionId: replacementInteractionId,
+  } as const;
+}
+
+/**
+ * RBR-852 AC1/AC3. The creating agent explicitly declared, via
+ * `payload.supersedesInteractionIds`, that the new interaction replaces this one. Per the
+ * product call we auto-expire rather than 4xx the create, so the result must carry a pointer
+ * back to the replacement — otherwise the thread shows a retired ask with no successor and the
+ * board is back to guessing.
+ */
+function buildSupersededByInteractionResult(
+  row: IssueThreadInteractionRow,
+  supersededByInteractionId: string,
+) {
+  if (row.kind === "ask_user_questions") {
+    return {
+      version: 1,
+      answers: [],
+      expirationReason: "superseded_by_interaction",
+      supersededByInteractionId,
+      summaryMarkdown: null,
+    } as const;
+  }
+
+  if (row.kind === "request_item_verdicts") {
+    const interaction = hydrateInteraction(row) as RequestItemVerdictsInteraction;
+    return {
+      version: 1,
+      outcome: "superseded_by_interaction",
+      complete: false,
+      items: interaction.result?.items ?? [],
+      supersededByInteractionId,
+    } satisfies RequestItemVerdictsResult;
+  }
+
+  return {
+    version: 1,
+    outcome: "superseded_by_interaction",
+    supersededByInteractionId,
   } as const;
 }
 
@@ -1280,6 +1389,66 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     return current;
   }
 
+  async function withdrawPendingInteractionRow(
+    current: IssueThreadInteractionRow,
+    data: WithdrawIssueThreadInteraction,
+    actor: InteractionActor,
+  ) {
+    const reason = data.reason?.trim() || null;
+    const now = new Date();
+    // One transaction, linked tool action first: revoking pending/approved
+    // requests before resolving the card means a concurrent gateway claim
+    // (approved -> executing) either loses to the revocation's row lock or
+    // is detected below and aborts the withdrawal; a concurrent card
+    // resolution rolls the revocation back via the status="pending" guard.
+    // "approved" is revoked too — the request can be approved from the tool
+    // review queue while the card is still pending, and an executable
+    // request must not outlive a withdrawn card.
+    const updated = await db.transaction(async (tx) => {
+      await resolveLinkedToolActionRequests(tx, current, {
+        status: "cancelled",
+        fromStatuses: ["pending", "approved"],
+        actor,
+        now,
+      });
+      if (current.kind === "request_confirmation") {
+        const active = await tx
+          .select({ id: toolActionRequests.id })
+          .from(toolActionRequests)
+          .where(and(
+            eq(toolActionRequests.companyId, current.companyId),
+            eq(toolActionRequests.interactionId, current.id),
+            inArray(toolActionRequests.status, ["executing", "executed"]),
+          ))
+          .then((rows) => rows[0] ?? null);
+        if (active) throw conflict("The linked tool action is already executing and can no longer be withdrawn");
+      }
+      const [row] = await tx
+        .update(issueThreadInteractions)
+        .set({
+          status: "cancelled",
+          result: buildAdministrativeOutcomeResult(current, "withdrawn", reason),
+          resolvedByAgentId: actor.agentId ?? null,
+          resolvedByRunId: actor.runId ?? null,
+          resolvedByUserId: actor.userId ?? null,
+          resolvedAt: now,
+          updatedAt: now,
+        })
+        .where(and(
+          eq(issueThreadInteractions.id, current.id),
+          eq(issueThreadInteractions.status, "pending"),
+        ))
+        .returning();
+      if (!row) throw conflict("Interaction has already been resolved");
+      return row;
+    });
+
+    await touchIssue(db, current.issueId);
+    const withdrawn = hydrateInteraction(updated);
+    await emitInteractionResolvedTelemetry(db, withdrawn);
+    return withdrawn;
+  }
+
   async function acceptRequestConfirmation(args: {
     issue: { id: string; companyId: string };
     current: IssueThreadInteractionRow;
@@ -1827,8 +1996,97 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         || data.kind === "request_checkbox_confirmation"
         || data.kind === "request_item_verdicts";
 
+      // RBR-852 AC1 + finding 3: explicit, possibly cross-issue supersession links.
+      // Resolve and validate before the insert transaction so a bad link fails the create with
+      // 422 and mutates nothing. Cross-issue is in scope (an agent working RBR-730 must be able
+      // to retire the ask it created on RBR-660); cross-company never is.
+      const declaredSupersedesIds = Array.from(new Set(
+        ((data.payload as { supersedesInteractionIds?: unknown }).supersedesInteractionIds ?? []) as string[],
+      ));
+      let supersedesRows: IssueThreadInteractionRow[] = [];
+      if (declaredSupersedesIds.length > 0) {
+        if (!actor.agentId) {
+          throw unprocessable("supersedesInteractionIds may only be declared by an agent actor");
+        }
+        supersedesRows = await db
+          .select()
+          .from(issueThreadInteractions)
+          .where(and(
+            inArray(issueThreadInteractions.id, declaredSupersedesIds),
+            eq(issueThreadInteractions.companyId, issue.companyId),
+          ));
+
+        const foundIds = new Set(supersedesRows.map((row) => row.id));
+        const missing = declaredSupersedesIds.filter((id) => !foundIds.has(id));
+        if (missing.length > 0) {
+          throw unprocessable("supersedesInteractionIds must reference interactions in the same company", {
+            supersedesInteractionIds: missing,
+          });
+        }
+        const notPending = supersedesRows.filter((row) => row.status !== "pending");
+        if (notPending.length > 0) {
+          throw unprocessable("supersedesInteractionIds must reference pending interactions", {
+            supersedesInteractionIds: notPending.map((row) => row.id),
+          });
+        }
+        // Ownership, not a role grant: an agent may only retire its own ask this way, so
+        // supersession can never silently destroy the board's question or a peer's ask.
+        const notOwned = supersedesRows.filter((row) => row.createdByAgentId !== actor.agentId);
+        if (notOwned.length > 0) {
+          throw unprocessable("supersedesInteractionIds may only reference interactions you created", {
+            supersedesInteractionIds: notOwned.map((row) => row.id),
+          });
+        }
+      }
+
       let created: IssueThreadInteractionRow;
       let superseded: IssueThreadInteractionRow[] = [];
+
+      /**
+       * Expire every interaction the new row explicitly named, inside the create transaction.
+       * Per AC3 this auto-expires with a pointer rather than 4xx-ing the create: rejecting here
+       * would fail the agent on the very call it is making to replace a bad ask, and push it
+       * back to writing cleanup prose for a human. Each row keeps its `status = "pending"`
+       * guard so a concurrent answer wins and is simply not counted as superseded.
+       */
+      const expireDeclaredSupersedes = async (
+        tx: Parameters<Parameters<Db["transaction"]>[0]>[0],
+        row: IssueThreadInteractionRow,
+      ): Promise<IssueThreadInteractionRow[]> => {
+        if (supersedesRows.length === 0) return [];
+        const now = new Date();
+        const expiredRows: IssueThreadInteractionRow[] = [];
+        for (const target of supersedesRows) {
+          if (target.id === row.id) continue;
+          const [updatedRow] = await tx
+            .update(issueThreadInteractions)
+            .set({
+              status: "expired",
+              result: buildSupersededByInteractionResult(target, row.id),
+              resolvedByAgentId: actor.agentId ?? null,
+              resolvedByUserId: actor.userId ?? null,
+              resolvedAt: now,
+              updatedAt: now,
+            })
+            .where(and(
+              eq(issueThreadInteractions.id, target.id),
+              eq(issueThreadInteractions.companyId, issue.companyId),
+              eq(issueThreadInteractions.status, "pending"),
+            ))
+            .returning();
+          if (!updatedRow) continue;
+          // An irreversible tool action must not outlive the card that authorized it.
+          await resolveLinkedToolActionRequests(tx, updatedRow, {
+            status: "expired",
+            fromStatuses: ["pending", "approved"],
+            actor,
+            now,
+          });
+          expiredRows.push(updatedRow);
+        }
+        return expiredRows;
+      };
+
       try {
         // A terminal issue must not regain pending actionable cards. FOR UPDATE
         // on the issue row serializes this insert both against terminal status
@@ -1880,7 +2138,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
             .returning();
 
           if (data.kind !== "request_confirmation" || !actor.agentId) {
-            return { row, supersededRows: [] };
+            return { row, supersededRows: await expireDeclaredSupersedes(tx, row) };
           }
 
           const now = new Date();
@@ -1911,7 +2169,13 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
               now,
             });
           }
-          return { row, supersededRows };
+          // The blanket rule above only reaches same-issue, same-kind rows. Explicit links can
+          // point at another issue or another kind, so run them too and merge without
+          // double-counting anything the blanket sweep already expired.
+          const alreadyExpired = new Set(supersededRows.map((supersededRow) => supersededRow.id));
+          const declaredRows = (await expireDeclaredSupersedes(tx, row))
+            .filter((declaredRow) => !alreadyExpired.has(declaredRow.id));
+          return { row, supersededRows: [...supersededRows, ...declaredRows] };
         });
         created = result.row;
         superseded = result.supersededRows;
@@ -1935,6 +2199,13 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
 
       await touchIssue(db, issue.id);
       if (superseded.length > 0) {
+        // Cross-issue links retire cards on other issues; those threads must be touched too or
+        // their boards keep serving a stale pending card from cache.
+        for (const otherIssueId of new Set(
+          superseded.map((row) => row.issueId).filter((issueId) => issueId !== issue.id),
+        )) {
+          await touchIssue(db, otherIssueId);
+        }
         await emitResolvedInteractionsTelemetry(db, superseded.map(hydrateInteraction));
       }
       return hydrateInteraction(created);
@@ -2334,7 +2605,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
           eq(issueThreadInteractions.status, "pending"),
         ));
 
-      const superseded = rows.filter((row) => {
+      const superseded = selectCommentSupersededRows(rows.filter((row) => {
         if (!isUserCommentSupersedableKind(row.kind)) return false;
         const interaction = hydrateInteraction(row) as UserCommentSupersedableInteraction;
         return (
@@ -2344,7 +2615,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
             interactionCreatedAt: row.createdAt,
           })
         );
-      });
+      }));
 
       if (superseded.length === 0) return [];
 
@@ -2437,9 +2708,9 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
 
       const rowById = new Map(rows.map((row) => [row.id, row] as const));
       for (const { comment, rowIds } of supersededByComment.values()) {
-        const commentRows = rowIds
+        const commentRows = selectCommentSupersededRows(rowIds
           .map((rowId) => rowById.get(rowId))
-          .filter((row): row is IssueThreadInteractionRow => Boolean(row));
+          .filter((row): row is IssueThreadInteractionRow => Boolean(row)));
         const questionRowIds = commentRows
           .filter((row) => row.kind === "ask_user_questions")
           .map((row) => row.id);
@@ -2653,6 +2924,35 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       return expired;
     },
 
+    /**
+     * RBR-852 AC2 + finding 3. Company-scoped withdraw: retire a pending interaction by id
+     * without addressing the issue it lives on.
+     *
+     * The per-issue `withdrawInteraction` below cannot satisfy the cross-issue case — it pins
+     * `current.issueId === issue.id`, so an agent that created a now-stale ask on another issue
+     * has no way to retire it and falls back to asking a human in prose. That prose-cleanup-chore
+     * is the defect this issue exists to kill. Authorization for this path is pure ownership
+     * (`createdByAgentId`), enforced by the route; this service call never crosses companies.
+     */
+    withdrawCompanyInteraction: async (
+      scope: { companyId: string },
+      interactionId: string,
+      input: WithdrawIssueThreadInteraction,
+      actor: InteractionActor,
+    ) => {
+      const data = withdrawIssueThreadInteractionSchema.parse(input);
+      const current = await db
+        .select()
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, interactionId))
+        .then((rows) => rows[0] ?? null);
+      if (!current || current.companyId !== scope.companyId) {
+        throw notFound("Interaction not found");
+      }
+      if (current.status !== "pending") throw conflict("Interaction has already been resolved");
+      return withdrawPendingInteractionRow(current, data, actor);
+    },
+
     withdrawInteraction: async (
       issue: { id: string; companyId: string },
       interactionId: string,
@@ -2669,60 +2969,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         throw notFound("Interaction not found");
       }
       if (current.status !== "pending") throw conflict("Interaction has already been resolved");
-
-      const reason = data.reason?.trim() || null;
-      const now = new Date();
-      // One transaction, linked tool action first: revoking pending/approved
-      // requests before resolving the card means a concurrent gateway claim
-      // (approved -> executing) either loses to the revocation's row lock or
-      // is detected below and aborts the withdrawal; a concurrent card
-      // resolution rolls the revocation back via the status="pending" guard.
-      // "approved" is revoked too — the request can be approved from the tool
-      // review queue while the card is still pending, and an executable
-      // request must not outlive a withdrawn card.
-      const updated = await db.transaction(async (tx) => {
-        await resolveLinkedToolActionRequests(tx, current, {
-          status: "cancelled",
-          fromStatuses: ["pending", "approved"],
-          actor,
-          now,
-        });
-        if (current.kind === "request_confirmation") {
-          const active = await tx
-            .select({ id: toolActionRequests.id })
-            .from(toolActionRequests)
-            .where(and(
-              eq(toolActionRequests.companyId, current.companyId),
-              eq(toolActionRequests.interactionId, current.id),
-              inArray(toolActionRequests.status, ["executing", "executed"]),
-            ))
-            .then((rows) => rows[0] ?? null);
-          if (active) throw conflict("The linked tool action is already executing and can no longer be withdrawn");
-        }
-        const [row] = await tx
-          .update(issueThreadInteractions)
-          .set({
-            status: "cancelled",
-            result: buildAdministrativeOutcomeResult(current, "withdrawn", reason),
-            resolvedByAgentId: actor.agentId ?? null,
-            resolvedByRunId: actor.runId ?? null,
-            resolvedByUserId: actor.userId ?? null,
-            resolvedAt: now,
-            updatedAt: now,
-          })
-          .where(and(
-            eq(issueThreadInteractions.id, interactionId),
-            eq(issueThreadInteractions.status, "pending"),
-          ))
-          .returning();
-        if (!row) throw conflict("Interaction has already been resolved");
-        return row;
-      });
-
-      await touchIssue(db, issue.id);
-      const withdrawn = hydrateInteraction(updated);
-      await emitInteractionResolvedTelemetry(db, withdrawn);
-      return withdrawn;
+      return withdrawPendingInteractionRow(current, data, actor);
     },
 
     answerQuestions: async (

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -454,6 +454,28 @@ function shouldReturnAcceptedConfirmationToCreatorAgent(args: {
   return Boolean(args.issue.assigneeUserId);
 }
 
+/**
+ * RBR-875 (CEO ruling, separated from RBR-852). The default for `supersedeOnUserComment`.
+ *
+ * This was `true` — every ask created without an opinion opted itself in to being expired by the
+ * next human comment on the issue. That is the RBR-823 defect at its source: the board types one
+ * comment and unrelated pending interactions are silently garbage-collected, including
+ * contradictory irreversible asks that nobody ever answered.
+ *
+ * It stays `true` on RBR-852. Flipping it to `false` is the right end state — RBR-852 shipped the
+ * supported alternative, an explicit `supersedesInteractionIds` link that retires the specific
+ * target it names at create time with an auditable pointer back, which makes blanket
+ * expiry-by-proximity redundant. But the flip is a behaviour change for every existing caller and
+ * was ruled **out of scope for RBR-852** by the CEO; it is tracked separately on RBR-877 and lands
+ * after this. Do not flip it here.
+ *
+ * What RBR-852 does change is the multi-candidate case: see `selectCommentSupersededRows`. With
+ * the default still `true`, a lone pending ask keeps its historical behaviour (a comment instead
+ * of an answer retires it), while two or more pending asks now retire *nothing* — which is the
+ * actual defect RBR-823 reported.
+ */
+const SUPERSEDE_ON_USER_COMMENT_DEFAULT = true;
+
 function shouldSupersedeInteractionOnUserComment(interaction: UserCommentSupersedableInteraction) {
   return interaction.payload.supersedeOnUserComment === true;
 }

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -458,74 +458,40 @@ function shouldSupersedeInteractionOnUserComment(interaction: UserCommentSuperse
   return interaction.payload.supersedeOnUserComment === true;
 }
 
-function rowSupersedesInteractionIds(row: IssueThreadInteractionRow): string[] {
-  const ids = (row.payload as { supersedesInteractionIds?: unknown } | null)?.supersedesInteractionIds;
-  if (!Array.isArray(ids)) return [];
-  return ids.filter((id): id is string => typeof id === "string" && id.length > 0);
-}
-
-function compareInteractionRowsOldestFirst(a: IssueThreadInteractionRow, b: IssueThreadInteractionRow) {
-  const aMs = new Date(a.createdAt).getTime();
-  const bMs = new Date(b.createdAt).getTime();
-  if (aMs !== bMs) return aMs - bMs;
-  return a.id.localeCompare(b.id);
-}
-
 /**
  * RBR-852 AC1 + AC5. Given every pending supersedable row a single human comment could otherwise
  * expire, return only the rows that comment is actually allowed to expire.
  *
  * The defect this fixes: one board comment used to expire *every* pending interaction on the
  * issue, so contradictory irreversible asks were silently garbage-collected together and the
- * board could not tell which question it had just answered.
+ * board could not tell which question it had just answered — including the newest, still-correct
+ * ask the agent was actively waiting on.
  *
- * Rules, applied per kind group (confirmation-like and questions are grouped separately because
- * they answer different asks):
- *  - Exactly one candidate: the comment supersedes it. This is the historical single-ask case and
- *    is the only behaviour that survives unchanged.
- *  - More than one candidate: expire only the newest, plus any older sibling the newest
- *    explicitly named through `supersedesInteractionIds`. Per the product direction we do not
- *    guess a winner among unlinked interactions — the rest stay pending and are logged loudly,
- *    so a comment can never destroy a contradictory-but-live ask.
+ * The rule is deliberately unclever:
+ *  - Exactly one pending supersedable candidate: the comment supersedes it. A comment posted
+ *    instead of answering the only open card is a reply to that card. This is the historical
+ *    behaviour and the only one that survives unchanged.
+ *  - More than one: expire nothing and log loudly. Product direction (RBR-852 AC1) is explicit
+ *    that the fallback must never guess a winner. Every tiebreak available here is a guess —
+ *    "newest" would destroy the fresh ask and keep the stale one, which is precisely backwards.
+ *
+ * Note this is only a *backstop*. The primary mechanism is explicit `supersedesInteractionIds`,
+ * which retires the superseded ask at create time, so a well-behaved agent arrives at comment time
+ * with exactly one pending card and lands in the single-candidate branch. Interactions predating
+ * explicit linking simply stay pending until their author withdraws them.
  */
 export function selectCommentSupersededRows(
   candidates: readonly IssueThreadInteractionRow[],
 ): IssueThreadInteractionRow[] {
-  const selected: IssueThreadInteractionRow[] = [];
+  if (candidates.length <= 1) return [...candidates];
 
-  for (const group of [
-    candidates.filter((row) => isRequestConfirmationLikeKind(row.kind) || row.kind === "request_item_verdicts"),
-    candidates.filter((row) => row.kind === "ask_user_questions"),
-  ]) {
-    if (group.length === 0) continue;
-    if (group.length === 1) {
-      selected.push(group[0]!);
-      continue;
-    }
-
-    const ordered = [...group].sort(compareInteractionRowsOldestFirst);
-    const newest = ordered[ordered.length - 1]!;
-    const explicit = new Set(rowSupersedesInteractionIds(newest));
-    const skipped: string[] = [];
-    for (const row of ordered) {
-      if (row.id === newest.id || explicit.has(row.id)) {
-        selected.push(row);
-      } else {
-        skipped.push(row.id);
-      }
-    }
-    if (skipped.length > 0) {
-      // Loud backstop, per AC1: interactions created before explicit linking shipped have no
-      // link to follow, so we expire nothing rather than guess which ask the comment answered.
-      console.warn(
-        `[paperclip] RBR-852: a user comment matched ${ordered.length} pending ${newest.kind} interactions on issue ${newest.issueId}; `
-        + `expiring only the newest (${newest.id}) plus ${explicit.size} explicitly linked. Left pending: ${skipped.join(", ")}. `
-        + "The creating agent should declare supersedesInteractionIds or withdraw these explicitly.",
-      );
-    }
-  }
-
-  return selected;
+  console.warn(
+    `[paperclip] RBR-852: a user comment matched ${candidates.length} pending supersedable interactions on issue `
+    + `${candidates[0]!.issueId}; expiring none of them rather than guessing which ask the comment answered. `
+    + `Left pending: ${candidates.map((row) => `${row.id} (${row.kind})`).join(", ")}. `
+    + "The creating agent should declare supersedesInteractionIds on the replacement, or withdraw these explicitly.",
+  );
+  return [];
 }
 
 function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): CreateIssueThreadInteraction {
@@ -535,7 +501,7 @@ function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): C
         ...input,
         payload: {
           ...input.payload,
-          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? true,
+          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? SUPERSEDE_ON_USER_COMMENT_DEFAULT,
         },
       };
     case "request_confirmation":
@@ -543,7 +509,7 @@ function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): C
         ...input,
         payload: {
           ...input.payload,
-          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? true,
+          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? SUPERSEDE_ON_USER_COMMENT_DEFAULT,
         },
       };
     case "request_checkbox_confirmation":
@@ -551,7 +517,7 @@ function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): C
         ...input,
         payload: {
           ...input.payload,
-          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? true,
+          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? SUPERSEDE_ON_USER_COMMENT_DEFAULT,
         },
       };
     case "request_item_verdicts":
@@ -559,7 +525,7 @@ function normalizeCreateInteractionInput(input: CreateIssueThreadInteraction): C
         ...input,
         payload: {
           ...input.payload,
-          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? true,
+          supersedeOnUserComment: input.payload.supersedeOnUserComment ?? SUPERSEDE_ON_USER_COMMENT_DEFAULT,
         },
       };
     default:
@@ -1334,6 +1300,26 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     return hydrateInteraction(current);
   }
 
+  /**
+   * RBR-852 AC2 + finding 3. Company-scoped read for the cross-issue withdraw route.
+   *
+   * `getForIssue` pins `current.issueId === issue.id`, which is exactly the constraint that forces
+   * an agent to ask a human to clean up an ask it left on another issue. The withdraw route needs
+   * to authorize on `createdByAgentId` before it knows which issue the row lives on, so it needs a
+   * lookup that is scoped by company alone. Company scoping is still absolute.
+   */
+  async function getForCompany(scope: { companyId: string }, interactionId: string) {
+    const current = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, interactionId))
+      .then((rows) => rows[0] ?? null);
+    if (!current || current.companyId !== scope.companyId) {
+      throw notFound("Interaction not found");
+    }
+    return hydrateInteraction(current);
+  }
+
   async function assertIssueWorkspaceFinalizedForAccept(args: {
     db: Pick<Db, "select">;
     issue: { id: string; companyId: string };
@@ -1629,6 +1615,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
 
   return {
     getForIssue,
+    getForCompany,
     sweepMergedPullRequestConfirmations: async () => {
       const rows = await db
         .select({

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1211,6 +1211,68 @@ Terminal states: `done`, `cancelled`
 | 422  | Semantic violation | Invalid state transition (e.g. `backlog` -> `done`)                  |
 | 500  | Server error       | Transient failure. Comment on the task and move on.                  |
 
+### Always check the status code on writes (RBR-882)
+
+`curl -sS` exits `0` on a `403`. It prints the error body to stdout and says
+nothing else. If you pipe that straight into `jq` and read a field off it, a
+**rejected write looks like a successful one**:
+
+```bash
+# WRONG — this cannot distinguish success from a 403
+curl -sS -X POST "$api/issues/$id/comments" ... -d "$payload" | jq -r '.id'
+# prints:  null      <- the comment was REJECTED and never persisted
+```
+
+`null` here is not "the server returned no id". It is `jq` reading a missing key
+off `{"error":"Issue is outside this actor's authorization boundary"}`. The same
+trap applies to `PATCH /issues/{id}` — `jq -r '.status'` prints `null` on a
+denial, so a status change that never happened reads as one that did.
+
+The server always returns a non-2xx status with a populated `error` on a denied
+write. You just have to look at it. Use one of these:
+
+```bash
+# Option A — let curl fail the pipeline on non-2xx
+curl -sS --fail-with-body -X POST "$api/issues/$id/comments" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  --data-binary @- <<<"$payload" || echo "WRITE REJECTED (see body above)"
+```
+
+```bash
+# Option B — capture the status code alongside the body
+resp=$(curl -sS -w '\n%{http_code}' -X POST "$api/issues/$id/comments" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  --data-binary @- <<<"$payload")
+code=${resp##*$'\n'}
+body=${resp%$'\n'*}
+if [ "$code" -ge 400 ]; then
+  echo "WRITE REJECTED ($code): $(jq -r '.error // .' <<<"$body")" >&2
+else
+  jq -r '.id' <<<"$body"
+fi
+```
+
+```bash
+# Option C — assert on the parsed body before trusting it
+jq -e 'if .error then error("write rejected: \(.error)") else . end' <<<"$body"
+```
+
+Rules of thumb:
+
+- **Never** read a field off a write response without first confirming the
+  status was 2xx or that `.error` is absent. `id: null` / `status: null` on a
+  write means *the write did not happen*.
+- A denial body carries a machine-readable `details.code` alongside `error` —
+  branch on that, not on prose.
+- A `PATCH /issues/{id}` carrying a `comment` is all-or-nothing: if the call is
+  rejected, the comment was **not** persisted. Do not assume partial success.
+- When it matters (delegation, unblocking, corrections), re-read after writing.
+  Cheap insurance against a whole class of silent drops.
+
 ---
 
 ## Full API Reference

--- a/ui/src/components/AttentionInteractionResolver.tsx
+++ b/ui/src/components/AttentionInteractionResolver.tsx
@@ -56,6 +56,16 @@ export function AttentionInteractionResolver({
     return match && isIssueThreadInteraction(match) ? match : null;
   }, [interactions, interactionId]);
 
+  /**
+   * RBR-914 (AC4). The queue resolves a decision out of thread context, which is exactly where the
+   * multi-pending-confirmation hazard is most dangerous — the row looks like the only open ask. The
+   * interaction list is already fetched here, so pass the siblings through and let the card say so.
+   */
+  const threadInteractions = useMemo<readonly IssueThreadInteraction[]>(
+    () => (interactions ?? []).filter(isIssueThreadInteraction),
+    [interactions],
+  );
+
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: queryKeys.issues.interactions(issueId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.attention(companyId) });
@@ -120,6 +130,7 @@ export function AttentionInteractionResolver({
   return (
     <IssueThreadInteractionCard
       interaction={interaction}
+      threadInteractions={threadInteractions}
       agentMap={agentMap}
       currentUserId={currentUserId}
       userLabelMap={userLabelMap}

--- a/ui/src/components/InteractionSupersessionNotice.tsx
+++ b/ui/src/components/InteractionSupersessionNotice.tsx
@@ -1,0 +1,198 @@
+import { ArrowLeftRight, ArrowUpRight, Clock, TriangleAlert } from "lucide-react";
+import type { IssueThreadInteraction } from "../lib/issue-thread-interactions";
+import {
+  buildSupersessionPointers,
+  pendingConfirmationHazardPlacement,
+  proseAnswerWarning,
+  type SupersessionPointer,
+} from "../lib/interaction-supersession-hazard";
+import { cn } from "../lib/utils";
+import { Badge } from "./ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+/**
+ * RBR-914 (AC4 of RBR-893). The multi-pending-confirmation hazard, rendered.
+ *
+ * Until this shipped, the only evidence that two contradictory irreversible confirmations were
+ * sitting pending on the same task was a `console.warn` on the server — invisible to the person who
+ * actually has to answer. Three things go on the card, and only when they apply:
+ *
+ *  1. Which of the coexisting pending confirmations is **newest** (AC1). Not "which wins" — the
+ *     server deliberately does not pick a winner, and neither do we.
+ *  2. What answering **in prose** will actually do (AC2), stated concretely rather than as generic
+ *     caution, because a plain comment is not a safe way to answer one of several.
+ *  3. The explicit `supersedesInteractionIds` / `supersededByInteractionId` pointer relationship
+ *     (AC3), so nobody has to diff two payloads by eye to see that one ask replaced another.
+ *
+ * Presentation only. This component reads interaction rows the thread already loaded and never
+ * resolves, expires, or reorders anything.
+ */
+export interface InteractionSupersessionNoticeProps {
+  interaction: IssueThreadInteraction;
+  /**
+   * Every interaction the surrounding surface knows about for this task. Omitted (or a lone
+   * interaction) means there is nothing to compare against and the notice renders nothing — a card
+   * shown out of thread context must not imply it is the only pending ask.
+   */
+  threadInteractions?: readonly IssueThreadInteraction[];
+  className?: string;
+}
+
+export function InteractionSupersessionNotice({
+  interaction,
+  threadInteractions,
+  className,
+}: InteractionSupersessionNoticeProps) {
+  const siblings = threadInteractions ?? [];
+  const placement = pendingConfirmationHazardPlacement(interaction, siblings);
+  const pointers = buildSupersessionPointers(interaction, siblings);
+  if (!placement && !pointers) return null;
+
+  return (
+    <div className={cn("mt-4 space-y-3", className)} data-testid="interaction-supersession-notice">
+      {placement ? (
+        <div
+          className="rounded-sm border border-amber-500/60 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100"
+          data-testid="interaction-multi-pending-hazard"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 text-(length:--text-micro) font-semibold uppercase tracking-(--tracking-eyebrow) text-amber-700 dark:text-amber-200">
+              <TriangleAlert className="h-3.5 w-3.5" aria-hidden />
+              {placement.total} confirmations pending at once
+            </span>
+            {placement.hazard.newestIsAmbiguous ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className="gap-1 border-amber-500/50 text-amber-800 dark:text-amber-100"
+                    data-testid="interaction-newest-ambiguous-badge"
+                  >
+                    <Clock className="h-3 w-3" aria-hidden />
+                    Newest unclear
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs text-xs">
+                  The two most recent pending confirmations were created at the same moment, so
+                  which one is newer cannot be established from the record. Nothing here guesses.
+                </TooltipContent>
+              </Tooltip>
+            ) : placement.isNewest ? (
+              <Badge
+                variant="outline"
+                className="gap-1 border-amber-500/50 text-amber-800 dark:text-amber-100"
+                data-testid="interaction-newest-badge"
+              >
+                <Clock className="h-3 w-3" aria-hidden />
+                Newest of {placement.total}
+              </Badge>
+            ) : (
+              <Badge
+                variant="outline"
+                className="gap-1 border-border text-muted-foreground"
+                data-testid="interaction-not-newest-badge"
+              >
+                <Clock className="h-3 w-3" aria-hidden />
+                Older — #{placement.position} of {placement.total}
+              </Badge>
+            )}
+          </div>
+
+          <p className="mt-2 leading-6" data-testid="interaction-prose-answer-warning">
+            {proseAnswerWarning(placement.hazard)}
+          </p>
+
+          <p className="mt-2 text-xs leading-5 text-amber-800/90 dark:text-amber-100/80">
+            Nothing was auto-expired. An agent must not be able to retire another agent's ask, and
+            guessing which ask a reply answered is the failure this behaviour exists to prevent — so
+            these confirmations can legitimately coexist and each one needs its own answer.
+          </p>
+
+          {placement.others.length > 0 ? (
+            <ul className="mt-2 space-y-1 text-xs" data-testid="interaction-coexisting-list">
+              {placement.others.map((other) => (
+                <li key={other.id}>
+                  <a
+                    href={`#interaction-${other.id}`}
+                    className="inline-flex items-center gap-1 font-medium underline underline-offset-4"
+                  >
+                    {other.title?.trim() || "Confirmation request"}
+                    <ArrowUpRight className="h-3 w-3" aria-hidden />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      {pointers ? (
+        <div
+          className="rounded-sm border border-border/70 bg-muted/40 px-4 py-3 text-xs text-muted-foreground"
+          data-testid="interaction-supersession-pointers"
+        >
+          <div className="inline-flex items-center gap-1.5 text-(length:--text-micro) font-semibold uppercase tracking-(--tracking-eyebrow)">
+            <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
+            Supersession links
+          </div>
+          {pointers.replaces.length > 0 ? (
+            <div className="mt-2" data-testid="interaction-supersedes-list">
+              <div className="text-foreground">
+                {pointers.replaces.length === 1
+                  ? "This request explicitly replaces:"
+                  : `This request explicitly replaces ${pointers.replaces.length} earlier requests:`}
+              </div>
+              <ul className="mt-1 space-y-1">
+                {pointers.replaces.map((pointer) => (
+                  <li key={pointer.id}>
+                    <PointerRef pointer={pointer} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {pointers.replacedBy ? (
+            <div className="mt-2" data-testid="interaction-superseded-by">
+              <div className="text-foreground">This request was replaced by:</div>
+              <div className="mt-1">
+                <PointerRef pointer={pointers.replacedBy} />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A named supersession target. Cross-issue links are legal server-side (same company), so the
+ * target genuinely may not be on this task — in that case say so instead of rendering an anchor
+ * that scrolls nowhere.
+ */
+function PointerRef({ pointer }: { pointer: SupersessionPointer }) {
+  if (!pointer.href || !pointer.label) {
+    return (
+      <span className="inline-flex flex-wrap items-center gap-1" data-testid="interaction-pointer-offthread">
+        <span className="font-mono text-(length:--text-micro)">{pointer.id}</span>
+        <span>— not on this task</span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5">
+      <a
+        href={pointer.href}
+        className="inline-flex items-center gap-1 font-medium text-foreground underline underline-offset-4"
+      >
+        {pointer.label}
+        <ArrowUpRight className="h-3 w-3" aria-hidden />
+      </a>
+      {pointer.status ? (
+        <Badge variant="outline" className="py-0 text-(length:--text-micro)">
+          {pointer.status}
+        </Badge>
+      ) : null}
+    </span>
+  );
+}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -238,6 +238,11 @@ interface IssueChatMessageContext {
   onUploadImage?: (file: File) => Promise<string>;
   issueStatus?: string;
   /**
+   * RBR-914 (AC4). Every interaction on this task, passed to interaction cards so they can surface
+   * the multi-pending-confirmation hazard. Presentation only.
+   */
+  threadInteractions?: readonly IssueThreadInteraction[];
+  /**
    * Current assignee. Agent comments from anyone else are cross-issue writes, so
    * they carry a "for {user}" attribution chip (the open cross-task write design (attribution)).
    */
@@ -2275,6 +2280,7 @@ function ExpiredRequestConfirmationActivity({
     onCancelInteraction,
     onUploadImage,
     externalReferences,
+    threadInteractions,
   } = useContext(IssueChatCtx);
   const [expanded, setExpanded] = useState(false);
   const hasResolvedActor = Boolean(interaction.resolvedByAgentId || interaction.resolvedByUserId);
@@ -2348,6 +2354,7 @@ function ExpiredRequestConfirmationActivity({
         <div id={detailsId} className="mt-2">
           <IssueThreadInteractionCard
             interaction={interaction}
+            threadInteractions={threadInteractions}
             agentMap={agentMap}
             currentUserId={currentUserId}
             userLabelMap={userLabelMap}
@@ -2883,6 +2890,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
     onSubmitInteractionVerdicts,
     onUploadImage,
     externalReferences,
+    threadInteractions,
   } = useContext(IssueChatCtx);
   const custom = message.metadata.custom as Record<string, unknown>;
   const anchorId = typeof custom.anchorId === "string" ? custom.anchorId : undefined;
@@ -2932,6 +2940,7 @@ function IssueChatSystemMessage({ message }: { message: ThreadMessage }) {
         <div className="py-1.5">
           <IssueThreadInteractionCard
             interaction={interaction}
+            threadInteractions={threadInteractions}
             agentMap={agentMap}
             currentUserId={currentUserId}
             userLabelMap={userLabelMap}
@@ -4967,6 +4976,7 @@ export function IssueChatThread({
       onSubmitInteractionVerdicts: stableOnSubmitInteractionVerdicts,
       onUploadImage: stableOnUploadImage,
       issueStatus,
+      threadInteractions: interactions,
       issueAssigneeAgentId,
       successfulRunHandoff: successfulRunHandoffWithLiveness,
       externalReferences,
@@ -4996,6 +5006,7 @@ export function IssueChatThread({
       stableOnSubmitInteractionVerdicts,
       stableOnUploadImage,
       issueStatus,
+      interactions,
       issueAssigneeAgentId,
       successfulRunHandoffWithLiveness,
       externalReferences,

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -310,13 +310,20 @@ describe("IssueThreadInteractionCard", () => {
     expect(host.textContent).not.toContain("expired by comment");
   });
 
-  it("makes child tasks explicit in suggested task trees", () => {
-    const host = renderCard({
-      interaction: pendingSuggestedTasksInteraction,
-    });
+  it(
+    "makes child tasks explicit in suggested task trees",
+    () => {
+      const host = renderCard({
+        interaction: pendingSuggestedTasksInteraction,
+      });
 
-    expect(host.textContent).toContain("Child task");
-  });
+      expect(host.textContent).toContain("Child task");
+    },
+    // Pre-existing marginal case: rendering this fixture sits right at the vitest
+    // default 5s ceiling on loaded/oversubscribed hosts (see RBR-974). Bumping the
+    // per-test timeout removes the flake without masking a real regression.
+    20_000,
+  );
 
   it("shows an explicit placeholder when a rejected interaction has no reason", () => {
     const host = renderCard({

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -27,6 +27,7 @@ import {
   type SuggestedTaskTreeNode,
 } from "../lib/issue-thread-interactions";
 import { cn, formatDateTime, formatShortDate } from "../lib/utils";
+import { InteractionSupersessionNotice } from "./InteractionSupersessionNotice";
 import { MarkdownBody, type MarkdownExternalReferenceMap } from "./MarkdownBody";
 import { Button } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
@@ -40,6 +41,13 @@ const OTHER_ANSWER_ID = "__paperclip_other__";
 
 interface IssueThreadInteractionCardProps {
   interaction: IssueThreadInteraction;
+  /**
+   * RBR-914 (AC4). Sibling interactions on the same task, so the card can surface the
+   * multi-pending-confirmation hazard (which ask is newest, what a prose reply will actually do,
+   * and explicit supersession pointers). Presentation only — omit it and the card renders exactly
+   * as before.
+   */
+  threadInteractions?: readonly IssueThreadInteraction[];
   agentMap?: Map<string, Agent>;
   currentUserId?: string | null;
   userLabelMap?: ReadonlyMap<string, string> | null;
@@ -3082,6 +3090,7 @@ function VerdictProgressBadge({
 
 export function IssueThreadInteractionCard({
   interaction,
+  threadInteractions,
   agentMap,
   currentUserId,
   userLabelMap,
@@ -3305,6 +3314,16 @@ export function IssueThreadInteractionCard({
           />
         )}
       </div>
+
+      {/*
+       * RBR-914 (AC4). The multi-pending-confirmation hazard and explicit supersession pointers.
+       * Sits below the body so it reads as a caveat on the ask rather than part of the ask, and
+       * above the resolution footer so it is gone once the card is settled history.
+       */}
+      <InteractionSupersessionNotice
+        interaction={interaction}
+        threadInteractions={threadInteractions}
+      />
 
       {adminOutcome === "withdrawn" ? (
         <div

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -392,6 +392,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     (item: TaskChatInteractionItem) => (
       <TaskChatInteractionCard
         item={item}
+        threadInteractions={interactions}
         agentMap={agentMap}
         currentUserId={currentUserId}
         userLabelMap={userLabelMap}
@@ -406,6 +407,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     ),
     [
       agentMap,
+      interactions,
       currentUserId,
       userLabelMap,
       onAcceptInteraction,

--- a/ui/src/lib/interaction-supersession-hazard.test.ts
+++ b/ui/src/lib/interaction-supersession-hazard.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPendingConfirmationHazard,
+  buildSupersessionPointers,
+  isOptedIntoCommentSupersession,
+  pendingConfirmationHazardPlacement,
+  proseAnswerWarning,
+} from "./interaction-supersession-hazard";
+import type { IssueThreadInteraction } from "./issue-thread-interactions";
+
+/**
+ * RBR-914 (AC4 of RBR-893). These cover the derivation only — the hazard is presentation, so the
+ * assertions here are about what the board is told, never about what the server does.
+ */
+
+const COMPANY_ID = "company-rbr914";
+const ISSUE_ID = "issue-rbr914";
+
+function confirmation(
+  overrides: Partial<IssueThreadInteraction> & { id: string },
+): IssueThreadInteraction {
+  return {
+    companyId: COMPANY_ID,
+    issueId: ISSUE_ID,
+    kind: "request_confirmation",
+    title: "Confirm the irreversible thing",
+    summary: null,
+    status: "pending",
+    continuationPolicy: "wake_assignee",
+    createdByAgentId: "agent-a",
+    createdByUserId: null,
+    resolvedByAgentId: null,
+    resolvedByUserId: null,
+    createdAt: new Date("2026-05-01T10:00:00.000Z"),
+    updatedAt: new Date("2026-05-01T10:00:00.000Z"),
+    resolvedAt: null,
+    payload: { version: 1, prompt: "Delete every row?" },
+    result: null,
+    ...overrides,
+  } as IssueThreadInteraction;
+}
+
+describe("buildPendingConfirmationHazard", () => {
+  it("reports no hazard for a single pending confirmation", () => {
+    expect(buildPendingConfirmationHazard([confirmation({ id: "a" })])).toBeNull();
+  });
+
+  it("reports no hazard when the second confirmation is already resolved", () => {
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "a" }),
+      confirmation({ id: "b", status: "accepted" }),
+    ]);
+    expect(hazard).toBeNull();
+  });
+
+  it("ignores non-confirmation kinds when counting coexistence", () => {
+    // A pending question is not a contradictory irreversible instruction; only
+    // confirmation-like kinds are (mirrors the server's REQUEST_CONFIRMATION_INTERACTION_KINDS).
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "a" }),
+      confirmation({
+        id: "q",
+        kind: "ask_user_questions",
+        payload: { version: 1, questions: [] },
+      } as Partial<IssueThreadInteraction> & { id: string }),
+    ]);
+    expect(hazard).toBeNull();
+  });
+
+  it("AC1: marks the newest of several coexisting pending confirmations", () => {
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "old", createdAt: new Date("2026-05-01T10:00:00.000Z") }),
+      confirmation({ id: "new", createdAt: new Date("2026-05-01T12:00:00.000Z") }),
+      confirmation({
+        id: "mid",
+        kind: "request_checkbox_confirmation",
+        createdAt: new Date("2026-05-01T11:00:00.000Z"),
+        payload: { version: 1, prompt: "Pick", options: [] },
+      } as Partial<IssueThreadInteraction> & { id: string }),
+    ]);
+    expect(hazard).not.toBeNull();
+    expect(hazard!.newestId).toBe("new");
+    expect(hazard!.pending.map((row) => row.id)).toEqual(["new", "mid", "old"]);
+    expect(hazard!.newestIsAmbiguous).toBe(false);
+  });
+
+  it("AC1: refuses to name a newest when two asks share a timestamp", () => {
+    const at = new Date("2026-05-01T10:00:00.000Z");
+    const rows = [confirmation({ id: "a", createdAt: at }), confirmation({ id: "b", createdAt: at })];
+    expect(buildPendingConfirmationHazard(rows)!.newestIsAmbiguous).toBe(true);
+    // Guessing a winner is the RBR-823 defect, so no card claims to be newest.
+    for (const row of rows) {
+      expect(pendingConfirmationHazardPlacement(row, rows)!.isNewest).toBe(false);
+    }
+  });
+});
+
+describe("prose-answer risk (AC2)", () => {
+  it("classifies a lone opted-in ask as expires_one and says which way it breaks", () => {
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "opted", payload: { version: 1, prompt: "x", supersedeOnUserComment: true } }),
+      confirmation({ id: "plain" }),
+    ])!;
+    expect(hazard.proseRisk).toBe("expires_one");
+    expect(hazard.proseOptedIn.map((row) => row.id)).toEqual(["opted"]);
+    const warning = proseAnswerWarning(hazard);
+    expect(warning).toContain("not a safe way to answer one of them");
+    expect(warning).toContain("expire that ask");
+  });
+
+  it("classifies two opted-in asks as expires_none_multiple_optins", () => {
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "a", payload: { version: 1, prompt: "x", supersedeOnUserComment: true } }),
+      confirmation({ id: "b", payload: { version: 1, prompt: "y", supersedeOnUserComment: true } }),
+    ])!;
+    expect(hazard.proseRisk).toBe("expires_none_multiple_optins");
+    expect(proseAnswerWarning(hazard)).toContain("expires none of them rather than guessing");
+  });
+
+  it("classifies the post-RBR-875 default (nothing opted in) as expires_none", () => {
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "a" }),
+      confirmation({ id: "b" }),
+    ])!;
+    expect(hazard.proseRisk).toBe("expires_none");
+    expect(hazard.proseOptedIn).toHaveLength(0);
+    expect(proseAnswerWarning(hazard)).toContain("leave every ask pending");
+  });
+
+  it("counts opted-in asks of any supersedable kind, not just confirmations", () => {
+    // A pending opted-in question IS at risk from a prose reply even though it does not itself
+    // create the coexistence hazard — the warning must account for it or it is a lie.
+    const hazard = buildPendingConfirmationHazard([
+      confirmation({ id: "a" }),
+      confirmation({ id: "b" }),
+      confirmation({
+        id: "q",
+        kind: "ask_user_questions",
+        payload: { version: 1, questions: [], supersedeOnUserComment: true },
+      } as Partial<IssueThreadInteraction> & { id: string }),
+    ])!;
+    expect(hazard.proseOptedIn.map((row) => row.id)).toEqual(["q"]);
+    expect(hazard.proseRisk).toBe("expires_one");
+  });
+
+  it("does not treat suggest_tasks as comment-supersedable", () => {
+    const suggest = confirmation({
+      id: "s",
+      kind: "suggest_tasks",
+      payload: { version: 1, tasks: [], supersedeOnUserComment: true },
+    } as Partial<IssueThreadInteraction> & { id: string });
+    expect(isOptedIntoCommentSupersession(suggest)).toBe(false);
+  });
+});
+
+describe("pendingConfirmationHazardPlacement", () => {
+  it("gives each coexisting card its position and its peers", () => {
+    const rows = [
+      confirmation({ id: "new", createdAt: new Date("2026-05-01T12:00:00.000Z") }),
+      confirmation({ id: "old", createdAt: new Date("2026-05-01T10:00:00.000Z") }),
+    ];
+    const newest = pendingConfirmationHazardPlacement(rows[0]!, rows)!;
+    expect(newest.isNewest).toBe(true);
+    expect(newest.position).toBe(1);
+    expect(newest.total).toBe(2);
+    expect(newest.others.map((row) => row.id)).toEqual(["old"]);
+
+    const older = pendingConfirmationHazardPlacement(rows[1]!, rows)!;
+    expect(older.isNewest).toBe(false);
+    expect(older.position).toBe(2);
+    expect(older.others.map((row) => row.id)).toEqual(["new"]);
+  });
+
+  it("returns null for a card that is not part of the hazard", () => {
+    const rows = [
+      confirmation({ id: "a" }),
+      confirmation({ id: "b" }),
+      confirmation({ id: "settled", status: "accepted" }),
+    ];
+    expect(pendingConfirmationHazardPlacement(rows[2]!, rows)).toBeNull();
+  });
+
+  it("returns null when no sibling context was supplied", () => {
+    const lone = confirmation({ id: "a" });
+    expect(pendingConfirmationHazardPlacement(lone, [lone])).toBeNull();
+  });
+});
+
+describe("buildSupersessionPointers (AC3)", () => {
+  it("returns null when there is no declared relationship", () => {
+    const row = confirmation({ id: "a" });
+    expect(buildSupersessionPointers(row, [row])).toBeNull();
+  });
+
+  it("resolves a declared supersedesInteractionIds target to a label, status and anchor", () => {
+    const target = confirmation({ id: "old", status: "expired", title: "Delete rows (v1)" });
+    const replacement = confirmation({
+      id: "new",
+      title: "Delete rows (v2)",
+      payload: { version: 1, prompt: "x", supersedesInteractionIds: ["old"] },
+    });
+    const pointers = buildSupersessionPointers(replacement, [target, replacement])!;
+    expect(pointers.replaces).toHaveLength(1);
+    expect(pointers.replaces[0]).toEqual({
+      id: "old",
+      label: "Delete rows (v1)",
+      status: "expired",
+      href: "#interaction-old",
+    });
+    expect(pointers.replacedBy).toBeNull();
+  });
+
+  it("surfaces the reverse pointer on the ask that was replaced", () => {
+    const replacement = confirmation({ id: "new", title: "Delete rows (v2)" });
+    const retired = confirmation({
+      id: "old",
+      status: "expired",
+      result: {
+        version: 1,
+        outcome: "superseded_by_interaction",
+        supersededByInteractionId: "new",
+      },
+    } as Partial<IssueThreadInteraction> & { id: string });
+    const pointers = buildSupersessionPointers(retired, [retired, replacement])!;
+    expect(pointers.replacedBy).toEqual({
+      id: "new",
+      label: "Delete rows (v2)",
+      status: "pending",
+      href: "#interaction-new",
+    });
+  });
+
+  it("marks an off-thread target rather than emitting a dead anchor", () => {
+    // Cross-issue supersession is legal server-side (same company), so the target may genuinely
+    // not be in this thread's payload.
+    const replacement = confirmation({
+      id: "new",
+      payload: { version: 1, prompt: "x", supersedesInteractionIds: ["elsewhere"] },
+    });
+    const pointers = buildSupersessionPointers(replacement, [replacement])!;
+    expect(pointers.replaces[0]).toEqual({
+      id: "elsewhere",
+      label: null,
+      status: null,
+      href: null,
+    });
+  });
+
+  it("falls back to a kind label when the superseded ask has no title", () => {
+    const target = confirmation({ id: "old", title: null, kind: "request_item_verdicts" } as Partial<IssueThreadInteraction> & { id: string });
+    const replacement = confirmation({
+      id: "new",
+      payload: { version: 1, prompt: "x", supersedesInteractionIds: ["old"] },
+    });
+    const pointers = buildSupersessionPointers(replacement, [target, replacement])!;
+    expect(pointers.replaces[0]!.label).toBe("Item review request");
+  });
+
+  it("ignores non-string ids in a malformed payload", () => {
+    const replacement = confirmation({
+      id: "new",
+      payload: { version: 1, prompt: "x", supersedesInteractionIds: [null, 3, "", "ok"] },
+    } as Partial<IssueThreadInteraction> & { id: string });
+    const pointers = buildSupersessionPointers(replacement, [replacement])!;
+    expect(pointers.replaces.map((pointer) => pointer.id)).toEqual(["ok"]);
+  });
+});

--- a/ui/src/lib/interaction-supersession-hazard.ts
+++ b/ui/src/lib/interaction-supersession-hazard.ts
@@ -1,0 +1,271 @@
+import type { IssueThreadInteraction } from "./issue-thread-interactions";
+
+/**
+ * RBR-914 (AC4 of RBR-893). Presentation-only model for the multi-pending-confirmation hazard.
+ *
+ * Background. RBR-823 reported that one board comment expired *every* pending interaction on an
+ * issue, so contradictory irreversible asks were silently garbage-collected together. RBR-852 and
+ * RBR-875 fixed that on the server: expiry-by-comment is opt-in, an explicit
+ * `supersedesInteractionIds` link retires named asks at create time, and when a comment matches
+ * more than one supersedable candidate the server deliberately expires **nothing** rather than
+ * guessing which ask the comment answered (RBR-852 AC1).
+ *
+ * The consequence of not guessing is that contradictory confirmations can legitimately coexist.
+ * RBR-893 AC3 made the server *say so* — but only into a `console.warn` that no board member ever
+ * reads. This module is the read-only derivation behind the UI that finally shows it, so the board
+ * can see which ask is newest, what a prose reply will actually do, and which ask replaced which.
+ *
+ * Hard constraint from the issue: **no server semantics change**. Everything here is derived from
+ * interaction rows the thread already has. Nothing in this file expires, resolves, orders, or
+ * mutates anything; it decides only what to render. The kind sets below mirror the server's
+ * (`REQUEST_CONFIRMATION_INTERACTION_KINDS` / `USER_COMMENT_SUPERSEDABLE_INTERACTION_KINDS` in
+ * `server/src/services/issue-thread-interactions.ts`) so the warning we show matches the rule the
+ * server will actually apply. If they drift, the UI becomes dishonest — keep them in step.
+ */
+
+/** Mirrors the server's `REQUEST_CONFIRMATION_INTERACTION_KINDS`. */
+export const CONFIRMATION_LIKE_INTERACTION_KINDS = [
+  "request_confirmation",
+  "request_checkbox_confirmation",
+] as const;
+
+/** Mirrors the server's `USER_COMMENT_SUPERSEDABLE_INTERACTION_KINDS`. */
+export const USER_COMMENT_SUPERSEDABLE_INTERACTION_KINDS = [
+  ...CONFIRMATION_LIKE_INTERACTION_KINDS,
+  "request_item_verdicts",
+  "ask_user_questions",
+] as const;
+
+export function isConfirmationLikeInteraction(interaction: IssueThreadInteraction): boolean {
+  return (CONFIRMATION_LIKE_INTERACTION_KINDS as readonly string[]).includes(interaction.kind);
+}
+
+export function isUserCommentSupersedableInteraction(interaction: IssueThreadInteraction): boolean {
+  return (USER_COMMENT_SUPERSEDABLE_INTERACTION_KINDS as readonly string[]).includes(interaction.kind);
+}
+
+/**
+ * Whether a plain board comment is permitted to expire this ask at all. Post-RBR-875 this is
+ * strictly opt-in: the payload must carry `supersedeOnUserComment: true`.
+ */
+export function isOptedIntoCommentSupersession(interaction: IssueThreadInteraction): boolean {
+  if (!isUserCommentSupersedableInteraction(interaction)) return false;
+  const payload = interaction.payload as { supersedeOnUserComment?: unknown } | null | undefined;
+  return payload?.supersedeOnUserComment === true;
+}
+
+function declaredSupersedesIds(interaction: IssueThreadInteraction): string[] {
+  const payload = interaction.payload as { supersedesInteractionIds?: unknown } | null | undefined;
+  const ids = payload?.supersedesInteractionIds;
+  if (!Array.isArray(ids)) return [];
+  return ids.filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+function declaredSupersededById(interaction: IssueThreadInteraction): string | null {
+  const result = interaction.result as { supersededByInteractionId?: unknown } | null | undefined;
+  const id = result?.supersededByInteractionId;
+  return typeof id === "string" && id.length > 0 ? id : null;
+}
+
+function createdAtMs(interaction: IssueThreadInteraction): number {
+  const value = interaction.createdAt;
+  const time = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+/**
+ * Newest first. Ties broken on id (descending) purely so the render order is deterministic — a tie
+ * is reported as ambiguous rather than silently resolved, see {@link PendingConfirmationHazard}.
+ */
+function byNewestFirst(a: IssueThreadInteraction, b: IssueThreadInteraction): number {
+  const delta = createdAtMs(b) - createdAtMs(a);
+  if (delta !== 0) return delta;
+  return b.id.localeCompare(a.id);
+}
+
+/**
+ * What a plain prose comment will actually do to the pending asks on this thread (AC2).
+ *
+ * - `expires_one` — exactly one pending supersedable ask is opted in, so a comment silently
+ *   expires *that* one and leaves the rest. This is the dangerous case: prose looks like an
+ *   answer to whichever card the reader had in mind, and the server will apply it to a different
+ *   one.
+ * - `expires_none_multiple_optins` — two or more are opted in, so the server refuses to guess and
+ *   expires nothing. Safe for the data, still misleading for the human: the prose answers nothing
+ *   and every ask stays pending.
+ * - `expires_none` — nothing is opted in, so a comment cannot expire anything.
+ */
+export type ProseAnswerRisk = "expires_one" | "expires_none_multiple_optins" | "expires_none";
+
+export interface PendingConfirmationHazard {
+  /** Every pending confirmation-like ask on the thread, newest first. Always length >= 2. */
+  pending: readonly IssueThreadInteraction[];
+  /** Id of the newest pending confirmation-like ask (AC1). */
+  newestId: string;
+  /**
+   * True when the two newest pending asks share an identical `createdAt`, so "newest" cannot be
+   * established from the data. We say that rather than picking a winner — guessing a winner is the
+   * defect RBR-823 reported.
+   */
+  newestIsAmbiguous: boolean;
+  /** What a prose reply will do (AC2). */
+  proseRisk: ProseAnswerRisk;
+  /**
+   * Pending supersedable asks (any kind, not just confirmations) whose payload opted in to
+   * expiry-by-comment — the rows a prose reply can actually retire.
+   */
+  proseOptedIn: readonly IssueThreadInteraction[];
+}
+
+/**
+ * Build the hazard for a thread, or `null` when there is none. The hazard exists only when more
+ * than one confirmation-like ask is pending at the same time — a single pending ask is the normal
+ * case and gets no warning furniture.
+ */
+export function buildPendingConfirmationHazard(
+  interactions: readonly IssueThreadInteraction[],
+): PendingConfirmationHazard | null {
+  const pendingConfirmations = interactions
+    .filter((interaction) => interaction.status === "pending" && isConfirmationLikeInteraction(interaction))
+    .sort(byNewestFirst);
+  if (pendingConfirmations.length < 2) return null;
+
+  const proseOptedIn = interactions
+    .filter((interaction) => interaction.status === "pending" && isOptedIntoCommentSupersession(interaction))
+    .sort(byNewestFirst);
+  const proseRisk: ProseAnswerRisk = proseOptedIn.length === 1
+    ? "expires_one"
+    : proseOptedIn.length > 1
+      ? "expires_none_multiple_optins"
+      : "expires_none";
+
+  return {
+    pending: pendingConfirmations,
+    newestId: pendingConfirmations[0]!.id,
+    newestIsAmbiguous: createdAtMs(pendingConfirmations[0]!) === createdAtMs(pendingConfirmations[1]!),
+    proseRisk,
+    proseOptedIn,
+  };
+}
+
+export interface InteractionHazardPlacement {
+  hazard: PendingConfirmationHazard;
+  /** This interaction is the newest pending confirmation-like ask on the thread. */
+  isNewest: boolean;
+  /** 1-based position, newest = 1. */
+  position: number;
+  /** Total pending confirmation-like asks, including this one. */
+  total: number;
+  /** The other pending confirmation-like asks, newest first. */
+  others: readonly IssueThreadInteraction[];
+}
+
+/**
+ * Where a specific card sits inside the thread hazard, or `null` when this card is not one of
+ * several coexisting pending confirmations (the overwhelmingly common case).
+ */
+export function pendingConfirmationHazardPlacement(
+  interaction: IssueThreadInteraction,
+  interactions: readonly IssueThreadInteraction[],
+): InteractionHazardPlacement | null {
+  const hazard = buildPendingConfirmationHazard(interactions);
+  if (!hazard) return null;
+  const index = hazard.pending.findIndex((candidate) => candidate.id === interaction.id);
+  if (index < 0) return null;
+  return {
+    hazard,
+    isNewest: !hazard.newestIsAmbiguous && index === 0,
+    position: index + 1,
+    total: hazard.pending.length,
+    others: hazard.pending.filter((candidate) => candidate.id !== interaction.id),
+  };
+}
+
+/**
+ * AC2 copy. Stated as what the server will do, not as vague caution — a warning the reader cannot
+ * act on is the same as no warning.
+ */
+export function proseAnswerWarning(hazard: PendingConfirmationHazard): string {
+  const count = hazard.pending.length;
+  const lead = `${count} confirmations are pending on this task at once.`;
+  switch (hazard.proseRisk) {
+    case "expires_one":
+      return `${lead} Answering in a plain comment is not a safe way to answer one of them: exactly one of the pending asks opted in to expiry-by-comment, so your comment will expire that ask — not necessarily the one you meant — and leave the others pending. Use the buttons on the specific card instead.`;
+    case "expires_none_multiple_optins":
+      return `${lead} More than one opted in to expiry-by-comment, so a plain comment expires none of them rather than guessing which ask it answered. Your prose will not be recorded as an answer to any card. Use the buttons on the specific card instead.`;
+    case "expires_none":
+      return `${lead} None of them can be answered by a plain comment, so prose will leave every ask pending. Use the buttons on the specific card you mean to answer.`;
+  }
+}
+
+export interface SupersessionPointer {
+  id: string;
+  /** Human label for the target, or `null` when the target is not in this thread's payload. */
+  label: string | null;
+  /** Status of the target when it is present in the thread. */
+  status: IssueThreadInteraction["status"] | null;
+  /** In-thread anchor when the target is on this thread; `null` when it is not loaded here. */
+  href: string | null;
+}
+
+export interface SupersessionPointers {
+  /** Asks this interaction explicitly declared it replaces (`payload.supersedesInteractionIds`). */
+  replaces: readonly SupersessionPointer[];
+  /** The ask that replaced this one (`result.supersededByInteractionId`). */
+  replacedBy: SupersessionPointer | null;
+}
+
+function interactionRefLabel(interaction: IssueThreadInteraction): string {
+  const title = interaction.title?.trim();
+  if (title) return title;
+  switch (interaction.kind) {
+    case "request_confirmation":
+      return "Confirmation request";
+    case "request_checkbox_confirmation":
+      return "Checkbox confirmation request";
+    case "request_item_verdicts":
+      return "Item review request";
+    case "ask_user_questions":
+      return "Question request";
+    case "suggest_tasks":
+      return "Suggested tasks";
+    default:
+      return "Interaction";
+  }
+}
+
+function buildPointer(
+  id: string,
+  byId: ReadonlyMap<string, IssueThreadInteraction>,
+): SupersessionPointer {
+  const target = byId.get(id);
+  if (!target) {
+    // Cross-issue links are legal server-side (same company), so a named target genuinely may not
+    // be in this thread. Say "not on this task" rather than rendering a dead anchor.
+    return { id, label: null, status: null, href: null };
+  }
+  return {
+    id,
+    label: interactionRefLabel(target),
+    status: target.status,
+    href: `#interaction-${target.id}`,
+  };
+}
+
+/**
+ * AC3. Surface the explicit pointer relationship both ways, so the reader is never left diffing
+ * two payloads by eye to work out that one ask replaced another.
+ */
+export function buildSupersessionPointers(
+  interaction: IssueThreadInteraction,
+  interactions: readonly IssueThreadInteraction[],
+): SupersessionPointers | null {
+  const replacesIds = declaredSupersedesIds(interaction);
+  const replacedById = declaredSupersededById(interaction);
+  if (replacesIds.length === 0 && !replacedById) return null;
+  const byId = new Map(interactions.map((entry) => [entry.id, entry] as const));
+  return {
+    replaces: replacesIds.map((id) => buildPointer(id, byId)),
+    replacedBy: replacedById ? buildPointer(replacedById, byId) : null,
+  };
+}


### PR DESCRIPTION
## RBR-914 — AC4: surface the multi-pending-confirmation hazard in the UI

Last open acceptance criterion of RBR-893. AC1-AC3/AC5 land server-side in a
separate PR per the issue's explicit constraint; this PR is presentation-only
and touches zero server/shared-schema files.

### Acceptance criteria covered

1. When >1 supersedable confirmation is pending on an issue, the UI marks
   which is newest (and shows "Newest unclear" on an exact tie instead of
   guessing).
2. Explicit warning that answering in prose (a plain comment) may
   resolve/expire opted-in asks, with concrete copy per situation
   (`expires_one` / `expires_none_multiple_optins` / `expires_none`) rather
   than generic caution text.
3. Where an interaction declares `supersedesInteractionIds`, the UI renders
   the bidirectional pointer relationship (`supersedesInteractionIds` /
   `supersededByInteractionId`), including a "not on this task" state for
   legal cross-issue targets, instead of leaving the reader to diff two
   payloads by eye.
4. No server semantics changed — diff is limited to `ui/src`.

### What's in this diff

- `ui/src/lib/interaction-supersession-hazard.ts` — pure derivation logic
  (newest/ambiguous-tie, prose-answer risk, supersession pointers). Mirrors
  the server's `REQUEST_CONFIRMATION_INTERACTION_KINDS` /
  `USER_COMMENT_SUPERSEDABLE_INTERACTION_KINDS` kind sets by comment, with a
  note to keep them in sync if the server's sets change.
- `ui/src/components/InteractionSupersessionNotice.tsx` — renders the
  derived hazard state.
- Wired into `IssueThreadInteractionCard`, `IssueChatThread`,
  `TaskChatThread`, and `AttentionInteractionResolver` (the attention
  queue — the most dangerous surface, since a queue row looks like the only
  open ask).
- De-flaked one pre-existing, unrelated marginal test
  (`IssueThreadInteractionCard.test.tsx` > "makes child tasks explicit in
  suggested task trees") that sits right at vitest's 5s default timeout
  under host load; bumped to 20s. Confirmed this flake reproduces on the
  parent commit too, so it's not a regression from this diff (tracked
  generally under RBR-974, host oversubscription).

### Testing

- `npx vitest run ui/src/lib/interaction-supersession-hazard.test.ts` — 19/19
  passing.
- `npx vitest run ui/src/components/IssueThreadInteractionCard.test.tsx` —
  37/37 passing (previously 1 intermittent timeout, fixed above).

### Constraints honored

- Separate PR from the server-side AC1-AC3/AC5 work.
- No `:3100` restart from this change — subordinate to the deploy train
  (RBR-802/804/805).

Closes RBR-914.