### PR TITLE
fix(adapter-utils): bind /usr before merged-/usr symlink targets

### DIFF
--- a/packages/adapter-utils/src/local-process-sandbox.test.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.test.ts
@@ -96,6 +96,35 @@ describe("local process sandbox", () => {
     expect(target.args.slice(-3)).toEqual([process.execPath, "-e", "console.log('ok')"]);
   });
 
+  it("binds /usr before the merged-/usr symlink targets", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-usrmerge-"));
+    cleanup.push(root);
+    const workspace = path.join(root, "workspace");
+    await fs.mkdir(workspace);
+
+    const target = await buildLocalProcessSandboxSpawnTarget({
+      executable: process.execPath,
+      args: ["-e", "console.log('ok')"],
+      cwd: workspace,
+      options: { workspaceDir: workspace, filesystemScope: "workspace" },
+    });
+
+    const bindIndex = (candidate: string): number => {
+      for (let index = 0; index < target.args.length - 1; index += 1) {
+        if (target.args[index] === "--ro-bind" && target.args[index + 1] === candidate) return index;
+      }
+      return -1;
+    };
+
+    const usrIndex = bindIndex("/usr");
+    expect(usrIndex).toBeGreaterThanOrEqual(0);
+    for (const merged of ["/bin", "/sbin", "/lib", "/lib64"]) {
+      const mergedIndex = bindIndex(merged);
+      if (mergedIndex < 0) continue;
+      expect(mergedIndex).toBeGreaterThan(usrIndex);
+    }
+  });
+
   it("binds a confined absolute alias to the synchronized workspace", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fs-alias-"));
     cleanup.push(root);

--- a/packages/adapter-utils/src/local-process-sandbox.ts
+++ b/packages/adapter-utils/src/local-process-sandbox.ts
@@ -48,10 +48,17 @@ interface NetworkAllowlistProxy {
   close: () => Promise<void>;
 }
 
+// "/usr" must be bound before "/bin", "/sbin", "/lib" and "/lib64". On merged-/usr
+// hosts (Debian, Ubuntu, Fedora, Arch) those four are symlinks into usr/, and the
+// sandbox recreates them as symlinks in the new root via --symlink before binding.
+// Binding "/bin" first makes bwrap resolve /newroot/bin -> /newroot/usr/bin, which
+// does not exist until "/usr" itself is bound, and bwrap aborts. Ordering "/usr"
+// first keeps the symlink destinations resolvable, and is harmless on split-/usr
+// hosts. See #10684.
 const SYSTEM_READ_PATHS = [
+  "/usr",
   "/bin",
   "/sbin",
-  "/usr",
   "/lib",
   "/lib64",
   "/etc/ca-certificates",


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The local process sandbox (`filesystemScope: "workspace"`) confines each agent run with bubblewrap
> - On merged-/usr Linux distributions (Debian, Ubuntu, Fedora, Arch), `/bin`, `/sbin`, `/lib`, `/lib64` are symlinks into `/usr`, and the sandbox builder mounted them before `/usr` itself was bound
> - This left bwrap unable to resolve the symlink target, so it aborted with `Can't bind mount /oldroot/usr/bin on /newroot/bin: No such file or directory`
> - Every agent configured with `filesystemScope: "workspace"` failed to start on these distributions, making filesystem confinement effectively unusable on the most common Linux hosts
> - This pull request reorders `SYSTEM_READ_PATHS` so `/usr` is bound first, before the merged-/usr symlink targets that depend on it
> - The benefit is that workspace-confined agents start correctly on merged-/usr hosts, with no change in behavior on split-/usr hosts

## Linked Issues or Issue Description

Fixes: #10684

## What Changed

- Moved `/usr` to the front of `SYSTEM_READ_PATHS` in `packages/adapter-utils/src/local-process-sandbox.ts` so its read-only bind happens before the merged-/usr symlink targets (`/bin`, `/sbin`, `/lib`, `/lib64`) are bound.
- Added a regression test in `local-process-sandbox.test.ts` asserting that `/usr` is bound before all four merged-/usr symlink targets, using the `--ro-bind` argument index emitted by `buildLocalProcessSandboxSpawnTarget`.
- No change to split-/usr hosts: those paths are independent bind mounts, only their relative order changed.

## Verification

- Ran `buildLocalProcessSandboxSpawnTarget` directly and inspected the emitted `argv` before and after the change (indices of `--ro-bind /usr` vs `--ro-bind /bin`, `/sbin`, `/lib`, `/lib64`), confirming `/usr` now precedes all four.
- Ran the new test in `local-process-sandbox.test.ts`; it fails on `master` and passes with this change.
- Verified end-to-end on Ubuntu (kernel 7.0, bubblewrap 0.11.1): with the patch, `filesystemScope: "workspace"` agents start and run confined, with `--tmpfs /` and only the workspace, Claude config directory, and managed prompt bundle mounted. Without the patch, every run aborts with the bind-mount error above.

## Risks

- Low risk. The change is a reorder of entries in a fixed-order list, not a logic change — no new paths are mounted and no existing mount is removed.
- Split-/usr hosts (no `/bin`, `/sbin`, `/lib`, `/lib64` symlinks) are unaffected: those bind mounts are independent of `/usr` and were already order-independent.
- Worst case if this reorder were wrong: sandboxed agents would fail to start, the same failure mode this PR fixes — so a regression here is immediately visible, not silent.

## Model Used

Claude (Anthropic), claude-opus-5, via Claude Code CLI with standard tool use (file read/edit, local process execution to run and inspect `buildLocalProcessSandboxSpawnTarget` output and the test suite). No extended/chain-of-thought thinking mode used beyond the model's default reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
