### PR TITLE
fix(heartbeat): hard-stop scheduled_retry on billing_402/auth failures

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -39,7 +39,18 @@ export type {
   StdoutLineParser,
   CLIAdapterModule,
   CreateConfigValues,
+  AdapterExecutionErrorFamily,
 } from "./types.js";
+export {
+  TERMINAL_ADAPTER_FAILURE_FAMILIES,
+  classifyTerminalAdapterFailure,
+  isTerminalAdapterFailureFamily,
+} from "./terminal-adapter-failure.js";
+export type {
+  TerminalAdapterFailureFamily,
+  TerminalAdapterFailureClassification,
+  TerminalAdapterFailureClassifierInput,
+} from "./terminal-adapter-failure.js";
 export type {
   SessionCompactionPolicy,
   NativeContextManagement,

--- a/packages/adapter-utils/src/terminal-adapter-failure.test.ts
+++ b/packages/adapter-utils/src/terminal-adapter-failure.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyTerminalAdapterFailure,
+  isTerminalAdapterFailureFamily,
+} from "./terminal-adapter-failure.js";
+
+describe("classifyTerminalAdapterFailure", () => {
+  it("classifies HTTP 402 Insufficient Balance as billing_402", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "HTTP 402: Insufficient Balance — payment required",
+      }),
+    ).toEqual({ family: "billing_402", errorCode: "billing_402" });
+  });
+
+  it("classifies wallet/credit exhaustion as billing_402", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "Provider wallet exhausted; out of credits",
+      })?.family,
+    ).toBe("billing_402");
+  });
+
+  it("does not treat usage-limit / session-cap cues as billing_402", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorCode: "adapter_failed",
+        errorMessage: "You've hit your usage limit for GPT-5. Try again at 4:30 PM.",
+      }),
+    ).toBeNull();
+    expect(
+      classifyTerminalAdapterFailure({
+        errorFamily: "provider_quota",
+        errorMessage: "You've hit your session limit - resets at 4pm (America/Chicago).",
+      }),
+    ).toBeNull();
+  });
+
+  it("prefers billing_402 over provider_quota when both cues appear", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorFamily: "provider_quota",
+        errorCode: "provider_quota",
+        errorMessage: "HTTP 402 Insufficient Balance while checking quota",
+      }),
+    ).toEqual({ family: "billing_402", errorCode: "billing_402" });
+  });
+
+  it("classifies explicit errorFamily auth_key", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorFamily: "auth_key",
+        errorMessage: "anything",
+      }),
+    ).toEqual({ family: "auth_key", errorCode: "auth_key" });
+  });
+
+  it("classifies invalid/expired API key cues as auth_key", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "invalid API key for provider",
+      })?.family,
+    ).toBe("auth_key");
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "missing required env OPENAI_API_KEY",
+      })?.family,
+    ).toBe("auth_key");
+  });
+
+  it("classifies EACCES on credential paths as auth_eacces", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "EACCES: permission denied, open '/home/agent/.config/opencode/credentials.json'",
+      }),
+    ).toEqual({ family: "auth_eacces", errorCode: "auth_eacces" });
+  });
+
+  it("does not treat generic spawn ENOENT as terminal auth", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "spawn opencode ENOENT",
+      }),
+    ).toBeNull();
+  });
+
+  it("reads cues from resultJson stderr/stdout snippets", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorCode: "adapter_failed",
+        resultJson: {
+          stderr: "Error: HTTP 402 Payment Required",
+          stdout: "",
+        },
+      })?.family,
+    ).toBe("billing_402");
+  });
+
+  it("precedence: billing_402 > auth_eacces > auth_key", () => {
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "HTTP 402 Insufficient Balance; also EACCES on api key file; invalid API key",
+      })?.family,
+    ).toBe("billing_402");
+    expect(
+      classifyTerminalAdapterFailure({
+        errorMessage: "EACCES permission denied reading API key credentials; invalid API key",
+      })?.family,
+    ).toBe("auth_eacces");
+  });
+});
+
+describe("isTerminalAdapterFailureFamily", () => {
+  it("accepts only the terminal set", () => {
+    expect(isTerminalAdapterFailureFamily("billing_402")).toBe(true);
+    expect(isTerminalAdapterFailureFamily("auth_key")).toBe(true);
+    expect(isTerminalAdapterFailureFamily("auth_eacces")).toBe(true);
+    expect(isTerminalAdapterFailureFamily("provider_quota")).toBe(false);
+    expect(isTerminalAdapterFailureFamily(null)).toBe(false);
+  });
+});

--- a/packages/adapter-utils/src/terminal-adapter-failure.ts
+++ b/packages/adapter-utils/src/terminal-adapter-failure.ts
@@ -1,0 +1,119 @@
+/**
+ * Terminal adapter failure classes that must never enqueue scheduled_retry /
+ * transient_failure_retry / provider_quota_recovery.
+ *
+ * Precedence: billing_402 > auth_eacces > auth_key.
+ * Billing (HTTP 402 / insufficient balance) must never classify as provider_quota.
+ */
+
+export type TerminalAdapterFailureFamily = "billing_402" | "auth_key" | "auth_eacces";
+
+export const TERMINAL_ADAPTER_FAILURE_FAMILIES = [
+  "billing_402",
+  "auth_key",
+  "auth_eacces",
+] as const satisfies readonly TerminalAdapterFailureFamily[];
+
+const TERMINAL_FAMILY_SET = new Set<string>(TERMINAL_ADAPTER_FAILURE_FAMILIES);
+
+/** HTTP 402 / payment / balance — not usage-limit or session-cap (provider_quota). */
+const BILLING_402_RE =
+  /(?:\bHTTP[/ ]?402\b|\bstatus(?:Code)?[:\s]*402\b|\b402\b(?:\s*[-:])?\s*(?:Payment Required|Insufficient)|Insufficient Balance|payment required|credits?(?:\s+are|\s+have been)?\s+(?:exhausted|depleted|insufficient)|wallet (?:balance )?(?:exhausted|empty|depleted|insufficient)|insufficient (?:credits?|balance|funds)|billing (?:error|failure)|out of credits)/i;
+
+/** EACCES / permission denied on credential or auth-related paths. */
+const AUTH_EACCES_RE =
+  /(?:\bEACCES\b|permission denied)(?:[^.\n]{0,120})(?:credential|\.env\b|api[_ -]?key|auth(?:entication|orization)?|token|secret|\.ssh\b|\/(?:\.config|\.local)\/|key(?:file|ring)?)/i;
+
+const AUTH_EACCES_REVERSE_RE =
+  /(?:credential|\.env\b|api[_ -]?key|auth(?:entication|orization)?|token|secret|\.ssh\b)(?:[^.\n]{0,80})(?:\bEACCES\b|permission denied)/i;
+
+/** Invalid / expired / missing provider API key (env *names* only — never values). */
+const AUTH_KEY_RE =
+  /(?:invalid (?:api[_ -]?|provider )?key|expired (?:api[_ -]?|provider )?key|unauthorized (?:api[_ -]?|provider )?key|api[_ -]?key (?:is )?(?:invalid|expired|revoked|unauthorized)|(?:missing|required) (?:env(?:ironment)? )?(?:var(?:iable)? )?[`'"]?[A-Z][A-Z0-9_]*(?:_API_KEY|_TOKEN|_SECRET|API_KEY)|(?:API[_ -]?KEY|provider key) (?:not (?:set|configured|found)|missing|unset))/i;
+
+export type TerminalAdapterFailureClassification = {
+  family: TerminalAdapterFailureFamily;
+  errorCode?: string;
+};
+
+export type TerminalAdapterFailureClassifierInput = {
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  errorFamily?: string | null;
+  resultJson?: unknown;
+  stderr?: string | null;
+  stdout?: string | null;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function collectClassifierText(input: TerminalAdapterFailureClassifierInput): string {
+  const result = asRecord(input.resultJson);
+  const parts = [
+    input.errorCode,
+    input.errorFamily,
+    input.errorMessage,
+    input.stderr,
+    input.stdout,
+    result ? readNonEmptyString(result.errorMessage) : null,
+    result ? readNonEmptyString(result.message) : null,
+    result ? readNonEmptyString(result.error) : null,
+    result ? readNonEmptyString(result.stderr) : null,
+    result ? readNonEmptyString(result.stdout) : null,
+    result ? JSON.stringify(result) : null,
+  ];
+  return parts.filter((part): part is string => typeof part === "string" && part.length > 0).join("\n");
+}
+
+export function isTerminalAdapterFailureFamily(
+  family: string | null | undefined,
+): family is TerminalAdapterFailureFamily {
+  return typeof family === "string" && TERMINAL_FAMILY_SET.has(family);
+}
+
+/**
+ * Classify terminal adapter failures from sanitized error cues.
+ * Returns null when the failure is retryable or unrecognized as terminal.
+ */
+export function classifyTerminalAdapterFailure(
+  input: TerminalAdapterFailureClassifierInput,
+): TerminalAdapterFailureClassification | null {
+  const text = collectClassifierText(input);
+
+  // Billing cues always win — including over mis-tagged provider_quota / other families.
+  if (text && BILLING_402_RE.test(text)) {
+    return { family: "billing_402", errorCode: "billing_402" };
+  }
+
+  const explicitFamily =
+    readNonEmptyString(input.errorFamily) ??
+    readNonEmptyString(asRecord(input.resultJson)?.errorFamily) ??
+    null;
+  if (isTerminalAdapterFailureFamily(explicitFamily)) {
+    return { family: explicitFamily, errorCode: explicitFamily };
+  }
+
+  const explicitCode = readNonEmptyString(input.errorCode);
+  if (isTerminalAdapterFailureFamily(explicitCode)) {
+    return { family: explicitCode, errorCode: explicitCode };
+  }
+
+  if (!text) return null;
+
+  if (AUTH_EACCES_RE.test(text) || AUTH_EACCES_REVERSE_RE.test(text)) {
+    return { family: "auth_eacces", errorCode: "auth_eacces" };
+  }
+  if (AUTH_KEY_RE.test(text)) {
+    return { family: "auth_key", errorCode: "auth_key" };
+  }
+  return null;
+}

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -68,6 +68,9 @@ export interface AdapterRuntimeServiceReport {
 export type AdapterExecutionErrorFamily =
   | "transient_upstream"
   | "provider_quota"
+  | "billing_402"
+  | "auth_key"
+  | "auth_eacces"
   | "model_refusal"
   | "refresh_token_reused"
   | "refresh_token_expired"

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, classifyTerminalAdapterFailure, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -661,12 +661,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderrLine ||
         `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
       const modelId = model || null;
+      const terminalFailure =
+        (synthesizedExitCode ?? 0) === 0
+          ? null
+          : classifyTerminalAdapterFailure({
+              errorMessage: fallbackErrorMessage,
+              stderr: attempt.proc.stderr,
+              stdout: attempt.proc.stdout,
+            });
 
       return {
         exitCode: synthesizedExitCode,
         signal: attempt.proc.signal,
         timedOut: false,
         errorMessage: (synthesizedExitCode ?? 0) === 0 ? null : fallbackErrorMessage,
+        errorCode: terminalFailure?.errorCode ?? null,
+        errorFamily: terminalFailure?.family ?? null,
         usage: {
           inputTokens: attempt.parsed.usage.inputTokens,
           outputTokens: attempt.parsed.usage.outputTokens,
@@ -683,6 +693,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         resultJson: {
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
+          ...(terminalFailure ? { errorFamily: terminalFailure.family } : {}),
         },
         summary: attempt.parsed.summary,
         clearSession: Boolean(clearSessionOnMissingSession && !attempt.parsed.sessionId),

--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -150,7 +150,8 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     agentId: string;
     now: Date;
     errorCode: string;
-    errorFamily?: "transient_upstream" | "provider_quota" | null;
+    error?: string;
+    errorFamily?: "transient_upstream" | "provider_quota" | "billing_402" | "auth_key" | "auth_eacces" | null;
     retryNotBefore?: string | null;
     scheduledRetryAttempt?: number;
     resultJson?: Record<string, unknown> | null;
@@ -190,7 +191,7 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       agentId: input.agentId,
       invocationSource: "assignment",
       status: "failed",
-      error: "upstream overload",
+      error: input.error ?? "upstream overload",
       errorCode: input.errorCode,
       finishedAt: input.now,
       scheduledRetryAttempt: input.scheduledRetryAttempt ?? 0,
@@ -2305,5 +2306,138 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     expect((wakeupRequest?.payload as Record<string, unknown> | null)?.transientRetryNotBefore).toBe(
       retryNotBefore.toISOString(),
     );
+  });
+
+  it("hard-stops scheduled_retry for HTTP 402 Insufficient Balance even when mis-tagged provider_quota", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-08-07T12:00:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "provider_quota",
+      error: "HTTP 402: Insufficient Balance — payment required",
+      errorFamily: "provider_quota",
+      retryNotBefore: "2030-04-22T21:00:00.000Z",
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled).toMatchObject({
+      outcome: "not_scheduled",
+      errorCode: "terminal_adapter_failure",
+    });
+
+    const retryChildren = await db
+      .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId));
+    expect(retryChildren).toEqual([]);
+
+    const suppressedEvent = await db
+      .select({
+        message: heartbeatRunEvents.message,
+        payload: heartbeatRunEvents.payload,
+      })
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId))
+      .orderBy(sql`${heartbeatRunEvents.id} desc`)
+      .then((rows) => rows[0] ?? null);
+    expect(suppressedEvent?.payload).toMatchObject({
+      event: "retry_suppressed_terminal_adapter_failure",
+      failureClass: "billing_402",
+    });
+  });
+
+  it("hard-stops scheduled_retry for explicit auth_key family", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-08-07T12:05:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "adapter_failed",
+      error: "provider rejected credentials",
+      errorFamily: "auth_key",
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, { now, random: () => 0.5 });
+    expect(scheduled).toMatchObject({
+      outcome: "not_scheduled",
+      errorCode: "terminal_adapter_failure",
+    });
+    const retryChildren = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId));
+    expect(retryChildren).toEqual([]);
+  });
+
+  it("hard-stops scheduled_retry for auth_eacces / EACCES credential path cues", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-08-07T12:10:00.000Z");
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "adapter_failed",
+      error: "EACCES: permission denied, open '/home/agent/.config/opencode/credentials.json'",
+      resultJson: {
+        stderr: "EACCES: permission denied, open '/home/agent/.config/opencode/credentials.json'",
+      },
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, { now, random: () => 0.5 });
+    expect(scheduled).toMatchObject({
+      outcome: "not_scheduled",
+      errorCode: "terminal_adapter_failure",
+    });
+    const retryChildren = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.retryOfRunId, runId));
+    expect(retryChildren).toEqual([]);
+  });
+
+  it("still schedules provider_quota retries with a reset time (regression)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const now = new Date("2026-08-07T12:15:00.000Z");
+    const retryNotBefore = "2030-04-22T21:00:00.000Z";
+
+    await seedRetryFixture({
+      runId,
+      companyId,
+      agentId,
+      now,
+      errorCode: "provider_quota",
+      error: "You've hit your session limit - resets at 4pm (America/Chicago).",
+      errorFamily: "provider_quota",
+      retryNotBefore,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(runId, { now, random: () => 0.5 });
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    expect(scheduled.run.status).toBe("scheduled_retry");
+    expect(scheduled.run.scheduledRetryReason).toBe("transient_failure");
+    expect(scheduled.run.scheduledRetryAt?.toISOString()).toBe(retryNotBefore);
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -260,10 +260,12 @@ import {
 import { redactEventPayload, redactSensitiveText } from "../redaction.js";
 import { createRunSecretRedactionRegistry } from "./run-secret-redaction.js";
 import {
+  classifyTerminalAdapterFailure,
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
   type RuntimeStatusUpdate,
   type SessionCompactionPolicy,
+  type TerminalAdapterFailureFamily,
 } from "@paperclipai/adapter-utils";
 import {
   readPaperclipSkillSyncPreference,
@@ -559,6 +561,22 @@ function readHeartbeatRunErrorFamily(
   return null;
 }
 
+function detectTerminalAdapterFailureFromRun(
+  run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode" | "resultJson">,
+): TerminalAdapterFailureFamily | null {
+  const resultJson = parseObject(run.resultJson);
+  return (
+    classifyTerminalAdapterFailure({
+      errorCode: run.errorCode,
+      errorMessage: run.error,
+      errorFamily: readNonEmptyString(resultJson.errorFamily),
+      resultJson,
+      stderr: readNonEmptyString(resultJson.stderr),
+      stdout: readNonEmptyString(resultJson.stdout),
+    })?.family ?? null
+  );
+}
+
 function isMaxTurnExhaustionRun(
   run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode" | "resultJson">,
 ) {
@@ -580,8 +598,11 @@ function readTransientRetryNotBeforeFromRun(run: Pick<typeof heartbeatRuns.$infe
 }
 
 function readTransientRecoveryContractFromRun(
-  run: Pick<typeof heartbeatRuns.$inferSelect, "errorCode" | "resultJson">,
+  run: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode" | "resultJson">,
 ) {
+  // Terminal auth/billing classes must never become scheduled_retry (defense if mis-tagged).
+  if (detectTerminalAdapterFailureFromRun(run)) return null;
+
   const errorFamily = readHeartbeatRunErrorFamily(run);
   return errorFamily === "transient_upstream" || errorFamily === "provider_quota"
     ? {
@@ -10978,6 +10999,28 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const retryReason = opts?.retryReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON;
     const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
     const maxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
+    const contextSnapshot = parseObject(run.contextSnapshot);
+    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const terminalFailureClass = detectTerminalAdapterFailureFromRun(run);
+    if (terminalFailureClass) {
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "warn",
+        message: `Scheduled retry suppressed for terminal adapter failure (${terminalFailureClass})`,
+        payload: {
+          event: "retry_suppressed_terminal_adapter_failure",
+          failureClass: terminalFailureClass,
+          retryReason,
+        },
+      });
+      return {
+        outcome: "not_scheduled" as const,
+        reason: `Scheduled retry suppressed for terminal adapter failure (${terminalFailureClass})`,
+        errorCode: "terminal_adapter_failure" as const,
+        issueId,
+      };
+    }
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
     const computedBaseSchedule = opts?.delayMs != null
       ? nextAttempt <= maxAttempts
@@ -11002,8 +11045,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ? resolveCodexTransientFallbackMode(nextAttempt)
         : null;
     const transientRetryNotBefore = transientRecovery?.retryNotBefore ?? null;
-    const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
 
     if (!baseSchedule) {
       await appendRunEvent(run, await nextRunEventSeq(run.id), {

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -77,6 +77,27 @@ describe("classifyAdapterFailureForRecovery", () => {
     })).toEqual({ kind: "configuration_incomplete" });
   });
 
+  it("classifies HTTP 402 Insufficient Balance as billing_402, not provider_quota", () => {
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "HTTP 402: Insufficient Balance — payment required",
+      resultJson: { errorFamily: "provider_quota" },
+    })).toEqual({ kind: "billing_402" });
+  });
+
+  it("classifies explicit auth_key / auth_eacces as terminal (no provider_quota recovery)", () => {
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "provider rejected credentials",
+      resultJson: { errorFamily: "auth_key" },
+    })).toEqual({ kind: "auth_key" });
+    expect(classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "EACCES: permission denied, open '/home/agent/.config/opencode/credentials.json'",
+      resultJson: null,
+    })).toEqual({ kind: "auth_eacces" });
+  });
+
   it("ignores quota-like text from non-adapter failures", () => {
     expect(classifyAdapterFailureForRecovery({
       errorCode: "timeout",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -10,6 +10,7 @@ import {
   type IssueGraphLivenessAutoRecoveryPreview,
   type IssueGraphLivenessAutoRecoveryPreviewItem,
 } from "@paperclipai/shared";
+import { classifyTerminalAdapterFailure } from "@paperclipai/adapter-utils";
 import {
   agents,
   agentWakeupRequests,
@@ -161,6 +162,9 @@ type StrandedRecoveryCause =
   | "codex_output_inactivity_monitor"
   | "workspace_validation_failed"
   | "configuration_incomplete"
+  | "billing_402"
+  | "auth_key"
+  | "auth_eacces"
   | "execution_review_participant_recovery"
   | typeof SUCCESSFUL_RUN_MISSING_STATE_REASON;
 
@@ -250,9 +254,18 @@ function readRecoveryRunErrorFamily(latestRun: LatestIssueRun) {
 }
 
 function isProviderQuotaRecovery(latestRun: LatestIssueRun) {
-  if (latestRun?.errorCode === "provider_quota") return true;
+  if (!latestRun) return false;
+  if (classifyTerminalAdapterFailure({
+    errorCode: latestRun.errorCode,
+    errorMessage: latestRun.error,
+    errorFamily: readRecoveryRunErrorFamily(latestRun),
+    resultJson: latestRun.resultJson,
+  })) {
+    return false;
+  }
+  if (latestRun.errorCode === "provider_quota") return true;
   if (readRecoveryRunErrorFamily(latestRun) === "provider_quota") return true;
-  if (latestRun?.errorCode !== "adapter_failed") return false;
+  if (latestRun.errorCode !== "adapter_failed") return false;
   return /(?:usage|rate|quota) limit|quota (?:exceeded|reset)|try again after/i.test(latestRun.error ?? "");
 }
 
@@ -389,7 +402,29 @@ const CONFIGURATION_INCOMPLETE_ERROR_RE =
 export type AdapterFailureRecoveryClassification =
   | { kind: "provider_quota"; retryAt: Date; parsedResetTime: boolean }
   | { kind: "configuration_incomplete" }
+  | { kind: "billing_402" }
+  | { kind: "auth_key" }
+  | { kind: "auth_eacces" }
   | null;
+
+function classifyTerminalAdapterFailureForRecovery(
+  latestRun: Pick<NonNullable<LatestIssueRun>, "error" | "errorCode" | "resultJson">,
+): Extract<
+  NonNullable<AdapterFailureRecoveryClassification>,
+  { kind: "billing_402" | "auth_key" | "auth_eacces" }
+> | null {
+  const resultJson = parseObject(latestRun.resultJson);
+  const terminal = classifyTerminalAdapterFailure({
+    errorCode: latestRun.errorCode,
+    errorMessage: latestRun.error,
+    errorFamily: readNonEmptyString(resultJson.errorFamily),
+    resultJson,
+    stderr: readNonEmptyString(resultJson.stderr),
+    stdout: readNonEmptyString(resultJson.stdout),
+  });
+  if (!terminal) return null;
+  return { kind: terminal.family };
+}
 
 function parseProviderQuotaClockReset(error: string, now: Date) {
   const match = error.match(
@@ -466,15 +501,28 @@ export function classifyAdapterFailureForRecovery(
   if (
     latestRun.errorCode !== "adapter_failed" &&
     latestRun.errorCode !== "provider_quota" &&
-    latestRun.errorCode !== "configuration_incomplete"
+    latestRun.errorCode !== "configuration_incomplete" &&
+    latestRun.errorCode !== "billing_402" &&
+    latestRun.errorCode !== "auth_key" &&
+    latestRun.errorCode !== "auth_eacces"
   ) {
     return null;
   }
+
   const resultJson = parseObject(latestRun.resultJson);
   const error = [latestRun.errorCode ?? "", latestRun.error ?? "", JSON.stringify(resultJson)].join("\n");
+  const terminal = classifyTerminalAdapterFailureForRecovery(latestRun);
+
+  // Billing hard-stop always wins over provider_quota (and other retryable classes).
+  if (terminal?.kind === "billing_402") return terminal;
+
   if (latestRun.errorCode === "configuration_incomplete" || CONFIGURATION_INCOMPLETE_ERROR_RE.test(error)) {
     return { kind: "configuration_incomplete" };
   }
+
+  // Auth terminal classes escalate/park blocked — never provider_quota_recovery.
+  if (terminal) return terminal;
+
   if (latestRun.errorCode !== "provider_quota" && !PROVIDER_QUOTA_ERROR_RE.test(error)) return null;
 
   const persistedRetryAt = readNonEmptyString(resultJson.retryNotBefore) ??
@@ -3538,7 +3586,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           transientRetryNotBefore: classification.retryAt.toISOString(),
           providerQuotaRetryNotBefore: classification.retryAt.toISOString(),
         }
-      : { errorFamily: "configuration_incomplete" };
+      : { errorFamily: classification.kind };
     const errorCode = classification.kind;
 
     return {
@@ -3780,14 +3828,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           result.skipped += 1;
           continue;
         } else {
+          const recoveryCause = adapterFailureClassification.kind;
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: issue.status as StrandedPreviousStatus,
             latestRun,
-            recoveryCause: "configuration_incomplete",
+            recoveryCause,
             comment:
-              "Paperclip classified the latest adapter failure as `configuration_incomplete`. " +
-              "Moving the issue to `blocked` with the configuration fix recorded instead of creating a recovery takeover.",
+              `Paperclip classified the latest adapter failure as \`${recoveryCause}\`. ` +
+              "Moving the issue to `blocked` with the configuration/auth/billing fix recorded instead of creating a recovery takeover.",
           });
           if (updated) {
             latestRun = await persistAdapterFailureRecoveryClassification(latestRun, adapterFailureClassification);
@@ -3944,16 +3993,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           }
           continue;
         }
-        if (participantAdapterFailureClassification?.kind === "configuration_incomplete") {
+        if (
+          participantAdapterFailureClassification?.kind === "configuration_incomplete" ||
+          participantAdapterFailureClassification?.kind === "billing_402" ||
+          participantAdapterFailureClassification?.kind === "auth_key" ||
+          participantAdapterFailureClassification?.kind === "auth_eacces"
+        ) {
+          const recoveryCause = participantAdapterFailureClassification.kind;
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "in_review",
             latestRun: participantLatestRun,
-            recoveryCause: "configuration_incomplete",
+            recoveryCause,
             recoveryOwnerAgentId: participantAgentId,
             comment:
-              "Paperclip classified the active review participant's latest adapter failure as " +
-              "`configuration_incomplete`. Moving the issue to `blocked` with the configuration fix " +
+              `Paperclip classified the active review participant's latest adapter failure as ` +
+              `\`${recoveryCause}\`. Moving the issue to \`blocked\` with the configuration/auth/billing fix ` +
               "recorded instead of repeatedly requeueing the reviewer.",
           });
           if (updated) {


### PR DESCRIPTION
## Summary
- Terminal adapter failure families (`billing_402`, `auth_key`, `auth_eacces`) must never enqueue `scheduled_retry`, `transient_failure_retry`, or `provider_quota_recovery`.
- Shared classifier prefers billing cues over mis-tagged `provider_quota`.
- Heartbeat + recovery paths honor the hard-stop.

## Context
NewLeaf / Paperclip control-plane burn from auto-retry on terminal adapter auth/billing failures (NEW-862 / NEW-857).

## Test plan
- [x] Unit: `packages/adapter-utils` terminal-adapter-failure classifier
- [x] Unit: heartbeat retry scheduling hard-stop
- [x] Unit: recovery provider-failure classification
- [ ] CI green on this PR

Commit: `81464cfe32163dae510e6a217ae9a96bbef6f3e2`

Made with [Cursor](https://cursor.com)