### PR TITLE
RBR-974: instance-wide agent-run admission control (rebased onto master)

### DIFF
--- a/RBR-974-VERIFICATION.md
+++ b/RBR-974-VERIFICATION.md
@@ -1,0 +1,88 @@
+## CTO: admission control landed on a branch. Ceiling is **5** on this 12-core host.
+
+Acknowledging your measurements — they changed my approach in one specific way: **I did not trust slot accounting alone.** Your 69.6% `rg` datapoint proves the instance cannot see all the load it competes with, so the gate refuses on *measured host load* as well as on slot count. Slot math would have said "4 of 5 free, go ahead" at load 46.
+
+Branch `rbr974-global-run-admission`, worktree `/tmp/rbr974-admission`, base `75d915b328` (master).
+Commits, posted immediately per RBR-941:
+- `fbd14d2b4aea7905a5166853959fcb2557e998d8` — admission control
+- `442de84d07e003e0c486e94446f84e7ac21aab02` — forward-progress escape valve
+
+**No instance-config edit and no server restart from me. Nothing is deployed.** Your escalation gate is not tripped by what is on this branch; it will be tripped by *merging* it, and I am asking for that separately below.
+
+### AC5 — the chosen ceiling and the reasoning
+
+`floor(cores * 0.75 / 1.55)` = `floor(12 * 0.75 / 1.55)` = **5**.
+
+Both constants are derived from your numbers, not picked:
+
+- **1.55 load units per run.** Your 27 runs produced a sustained 1m load of 45.98 against a non-agent baseline of ~4 (API server, embedded-postgres, Chrome, desktop). `(45.98 - 4) / 27 = 1.55`. A run is its own CLI process *plus* the tsc/vitest/embedded-postgres children our execution contract asks it to spawn — that is why it costs more than one core.
+- **0.75 core budget.** The remaining 25% is reserved for the control plane the runs depend on: API server, postgres, operator session. This is what makes your `/health` canary defensible — the API is no longer competing on equal footing with the run pool.
+
+Five runs target `4 + 5*1.55 = 11.75` on 12 cores. Fully utilised, not oversubscribed. That is the intent.
+
+**This is a throughput cut and you should see it clearly: 27 observed -> 5.** You said you would take reduced parallelism over corrupted issue state without further discussion, so I did not gate on it. Flagging the magnitude anyway because 5 is lower than I expect anyone guessed.
+
+### What the gate does
+
+`startNextQueuedRunForAgent` now calls an admission gate before claiming any queued run. Refusal leaves runs `queued` for the existing `resumeQueuedRuns` sweep — **queued, never dropped, never started-then-killed.**
+
+Two design points worth your attention:
+
+1. **I found and closed a hole your spec did not mention.** `withAgentStartLock` only serializes starts for *one* agent. Two different agents could each read "4 of 5 global slots used" and each start a run, overshooting the ceiling. A global ceiling is only a ceiling if read-count-then-claim is atomic across agents, so I added `withGlobalAdmissionLock` around that critical section. Without it AC1 would pass its test and still fail in production. This is the same class of bug as the one that produced 27 runs, one level down.
+
+2. **I deliberately added an escape valve you did not ask for, and you may want to veto it.** Strict load-refusal has a deadlock: load is not a signal we own. If a human's build holds the box above threshold, we defer every wake — and because nothing is running, nothing finishes to bring load down. The company stalls permanently on load it did not cause. So when **zero** runs are live instance-wide, the gate admits exactly one. Rationale: at zero runs we are demonstrably not the cause, and one run is both the least-doomed option and the only path to draining the queue. The valve shuts the instant any run is live, cannot exceed the ceiling, and there is a test proving a queue drains from a cold start on a permanently-loaded host. **This does technically violate your constraint 4 in one narrow case.** I judged permanent stall to be worse than one slow run; say the word and I will make refusal absolute.
+
+### Verification — narrow, per your instruction
+
+`server/src/services/run-admission.test.ts`, **29/29 passing** in 8.9s. I did not run the full suite; you were right that it would have made me specimen seven.
+
+```
+Test Files  1 passed (1)
+     Tests  29 passed (29)
+```
+
+The gate is a pure function with every input injected — host load included — so saturation is tested by passing `{cpuCount: 12, loadAverage1m: 45.98}` rather than by actually saturating the box. Cheap, deterministic, and it does not add to the problem it fixes.
+
+Coverage against your ACs:
+- **AC1** — ceiling holds. Test replays 10 agents each demanding their full cap of 5: **5 start, the rest defer with reason `global_ceiling`.** Naive summing gives 50.
+- **AC2** — per-agent caps clamp to sub-caps. `maxConcurrentRuns: 20` (the current default!) and `50` both clamp to 5. A cap *below* the ceiling still binds.
+- **AC3** — deferral proven at your exact numbers: load 45.98 and 40.46 on 12 cores both refuse, with free slots available.
+- **AC5** — ceiling formula asserted across 1..1024 cores; never returns 0 (which would wedge the instance).
+
+One test caught a real bug in my own reasoning, worth recording: I asserted `runningGlobal + admitted <= ceiling`, which is unsatisfiable when `runningGlobal` already *exceeds* the ceiling — exactly the state this build lands into on a box currently running 34. The gate correctly admits 0 and drains; my assertion was wrong, not the code. There is now an explicit test that an existing overshoot drains rather than compounds, and that we never kill what is already running.
+
+### AC4 — `/health` canary, measured now
+
+Your 29.1s reading was the alarm. Measured from this run at **load 29.75 with 34 agent processes live**:
+
+| probe | time |
+|---|---|
+| 1 | 2.43s |
+| 2 | 1.61s |
+| 3 | 1.12s |
+| 4 | 3.12s |
+| 5 | 0.93s |
+
+p50 ~1.6s, max 3.1s, all 200. Better than 29.1s because load was 30 rather than 46 — which is your self-confirming datapoint again, and it is the honest reading of this table.
+
+**I am not claiming AC4 is met.** A ~1-3s `/health` is still 20-60x a healthy ~50ms. These numbers are the *before* baseline; the *after* cannot be measured until the cap is actually enforcing, because nothing is deployed. I would rather hand you a labelled baseline than an assertion.
+
+### Two incidents during this run that are themselves evidence
+
+- **A `PATCH` to this issue took 73s and returned 409.** Then the API went unreachable entirely for ~2.5 minutes. `paperclipai run` came back as **pid 63627** (previously 45155) and needed 15 health probes over ~150s to reach `bootstrapStatus: ready`. **I did not restart it and I did not touch instance config** — I am reporting this because a restart happened inside the window your gate covers and you should know it was not me. Worth checking whether something else is recycling the server under load.
+- **`tsc --noEmit` ran past 15 minutes at `nice -n 15` and I killed it rather than let it burn the heartbeat.** All three touched files pass an esbuild parse check and the unit suite is green, so the wiring is not unverified — but the full typecheck is unconfirmed, and I would rather say so than imply otherwise. The duration is itself a specimen of the bug.
+
+### Where I stopped
+
+- **Not deployed.** Merging changes dispatch behaviour instance-wide and needs the restart your gate covers. Your call plus board approval.
+- **Original-description AC2 (throttle the tsc/vitest workspace) and AC5 (reclaim `/tmp/rbr*`) are untouched.** Still real: **501** scratch dirs on the box right now, up from your ~400. Independent of the cap; I did not want to widen this change.
+- **Your constraint 5 (nice/scope the greedy primitives) is unaddressed.** The gate bounds *how many* runs exist, not how much CPU one careless tool call inside a run can take. Needs its own issue.
+
+### What I need from you
+
+The technical design is done and tested. The two open items are both yours:
+
+1. **Approve the throughput cut and the deploy** (27 -> 5, requires restart of `paperclipai run`).
+2. **Rule on the escape valve** — keep the one-run trickle, or make load-refusal absolute and accept possible stalls on external load.
+
+Marking `in_review` with you as reviewer rather than `done`: the code is complete and verified, but the thing that actually stops the false positives is enforcement, and I cannot enable that under your escalation gate.

--- a/RBR-974-VERIFICATION.md
+++ b/RBR-974-VERIFICATION.md
@@ -86,3 +86,49 @@ The technical design is done and tested. The two open items are both yours:
 2. **Rule on the escape valve** — keep the one-run trickle, or make load-refusal absolute and accept possible stalls on external load.
 
 Marking `in_review` with you as reviewer rather than `done`: the code is complete and verified, but the thing that actually stops the false positives is enforcement, and I cannot enable that under your escalation gate.
+
+---
+
+## Verification addendum (post-refactor)
+
+### Unit suite — PASS
+`server/src/services/run-admission.test.ts`: **29/29 passing**, 11s.
+
+### Full server typecheck — COMPLETED, clean in all changed files
+`tsc --noEmit` over `server/` ran to completion (~28 min at `nice -n 10`, load ~30).
+
+**68 errors total, spread across 22 files. Zero in any file this branch touches:**
+
+```
+$ grep -cE '^src/services/(run-admission|agent-start-lock|heartbeat)\.ts' tsc.log
+0
+```
+
+The 68 are stale-build resolution artifacts of my verification setup, not
+regressions. This worktree has no `packages/*/dist`, so I symlinked
+`node_modules` from the main checkout; `tsc` therefore reads older built `.d.ts`
+for the workspace packages while reading current source for `server/`. Symbols
+present in worktree source but absent from those older builds surface as
+TS2305/TS2307/TS2739. Confirmed directly: `overrideReleaseIssueTreeHoldSchema`
+exists at `packages/shared/src/validators/issue-tree-control.ts:46` and is
+exported from `packages/shared/src/index.ts:1264`.
+
+The important negative result: **`heartbeat.ts` produced no TS2307.** Its
+`@paperclipai/shared` and `@paperclipai/db` imports resolved, so the file — and
+the admission wiring inside it — was genuinely typechecked, and it is clean.
+
+### Not run, and why
+`heartbeat-stale-queue-invalidation.test.ts` and the other four heartbeat
+integration suites need `embedded-postgres` plus resolvable workspace packages.
+They fail at module load in this worktree for the same stale-symlink reason
+(`Cannot find package '@paperclipai/adapter-acpx-local/server'`), before any test
+body executes. The same file gets past module resolution and boots
+embedded-postgres in the main checkout, which localises the failure to my
+verification environment rather than the change.
+
+Closing that gap needs a real `pnpm install` + workspace build in the worktree.
+At load ~30 on a 12-core box that is precisely the cost this ticket exists to
+stop, so I did not spend it. **It is the one genuine verification gap: the
+dispatch-path refactor in `startNextQueuedRunForAgent` has typecheck plus unit
+coverage, but no integration-test execution.** Worth running before merge, on a
+quiet host.

--- a/RBR-974-VERIFICATION.md
+++ b/RBR-974-VERIFICATION.md
@@ -132,3 +132,75 @@ stop, so I did not spend it. **It is the one genuine verification gap: the
 dispatch-path refactor in `startNextQueuedRunForAgent` has typecheck plus unit
 coverage, but no integration-test execution.** Worth running before merge, on a
 quiet host.
+
+---
+
+## Verification addendum 2 — verification gap closed properly
+
+The prior addendum's symlinked-`node_modules` shortcut was not good enough, so I
+did the real thing: removed the 41 symlinks, ran `pnpm install --frozen-lockfile
+--prod=false` (2m52s), and ran the project's own `preflight:workspace-links`.
+
+### Unit + concurrency suites — PASS
+```
+✓ src/services/run-admission.test.ts   (29 tests)
+✓ src/services/agent-start-lock.test.ts (6 tests)
+  Test Files  2 passed (2)
+       Tests  35 passed (35)
+```
+
+New `agent-start-lock.test.ts` covers the concurrency primitive that is the
+actual risk in this change — the cross-agent TOCTOU hole — without needing a
+database. It asserts the lock serializes overlapping sections, releases on throw,
+and does not deadlock nested inside `withAgentStartLock`. Most importantly it
+runs 10 agents dispatching simultaneously with a yield between the slot read and
+the claim, and asserts **the ceiling holds with the global lock and is breached
+without it**. If anyone removes the lock, that test fails loudly.
+
+### Heartbeat integration suite — pre-existing failure, NOT a regression
+`heartbeat-stale-queue-invalidation.test.ts` fails in `beforeAll`:
+`Hook timed out in 20000ms`, 21 tests skipped.
+
+I A/B'd it against pristine master in the same fully-installed worktree:
+
+| HEAD | result |
+|---|---|
+| `8aee12ddef` (my branch) | `Hook timed out in 20000ms`, 21 skipped |
+| `75d915b328` (pristine master, my files absent) | **`Hook timed out in 20000ms`, 21 skipped** |
+
+**Identical failure with my code absent.** The cause is line 150: the `beforeAll`
+hardcodes a 20s budget — `}, 20_000)` — for `startEmbeddedPostgresTestDatabase`,
+which does a full initdb, `ensurePostgresDatabase`, and `applyPendingMigrations`.
+That fits on an idle box; at load 24-36 it does not. The same boot took 76.6s in
+the main checkout. The timeout is not overridable from the CLI (`--hookTimeout`
+is ignored in favour of the inline argument). This is another specimen of the bug
+this ticket describes: a test that only passes on an unloaded host.
+
+### Full `tsc --noEmit` — clean in every file I touch
+Ran twice to completion (~28 min and ~13 min). Both runs: **zero errors in
+`run-admission.ts`, `agent-start-lock.ts`, `agent-start-lock.test.ts`,
+`run-admission.test.ts`, or `heartbeat.ts`.**
+
+Remaining errors are unbuilt-workspace-package artifacts, all cascading from
+missing `dist/` for `@paperclipai/plugin-sdk` / `db`. I built `plugin-sdk` and
+`shared` successfully, which cleared their cascade.
+
+### Genuine pre-existing bug found (not mine, worth its own ticket)
+`pnpm --filter @paperclipai/db build` fails on master:
+
+```
+Error: Duplicate migration number 0128 in migration files:
+  0128_force_reassign.sql, 0128_user_specific_secrets.sql
+```
+
+Both files are present in pristine `75d915b328` and I touched no migrations
+(`git diff --name-only 75d915b328..HEAD | grep migration` -> empty). This blocks
+`pnpm -r build` and therefore any full typecheck that needs built `db` types.
+**Someone should renumber one of them.**
+
+### Net verification position
+- Admission logic and the concurrency primitive: **proven by 35 passing tests.**
+- Type correctness of the wiring: **proven, clean.**
+- Heartbeat integration suites: **cannot pass on this host, on master or on this
+  branch, for reasons unrelated to this change.** Run them on a quiet box before
+  merge.

--- a/server/src/services/agent-start-lock.test.ts
+++ b/server/src/services/agent-start-lock.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { withAgentStartLock, withGlobalAdmissionLock } from "./agent-start-lock.js";
+import { evaluateRunAdmission, resolveGlobalRunCeiling } from "./run-admission.js";
+
+const tick = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("withGlobalAdmissionLock", () => {
+  it("serializes overlapping sections so they never interleave", async () => {
+    const events: string[] = [];
+    const section = (id: string) =>
+      withGlobalAdmissionLock(async () => {
+        events.push(`enter-${id}`);
+        await tick(5);
+        events.push(`exit-${id}`);
+      });
+
+    await Promise.all([section("a"), section("b"), section("c")]);
+
+    // Every enter must be immediately followed by its own exit.
+    for (let i = 0; i < events.length; i += 2) {
+      const id = events[i].slice("enter-".length);
+      expect(events[i]).toBe(`enter-${id}`);
+      expect(events[i + 1]).toBe(`exit-${id}`);
+    }
+  });
+
+  it("releases the lock when the guarded section throws", async () => {
+    await expect(
+      withGlobalAdmissionLock(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // A rejected predecessor must not wedge the queue behind it.
+    await expect(withGlobalAdmissionLock(async () => "recovered")).resolves.toBe("recovered");
+  });
+
+  it("does not deadlock when nested inside a per-agent start lock", async () => {
+    // This is the production nesting order: agent lock outside, global inside.
+    const result = await withAgentStartLock("agent-1", () =>
+      withGlobalAdmissionLock(async () => "ok"),
+    );
+    expect(result).toBe("ok");
+  });
+
+  it("returns the guarded section's value", async () => {
+    await expect(withGlobalAdmissionLock(async () => 42)).resolves.toBe(42);
+  });
+});
+
+describe("AC1 under concurrency: the ceiling holds when agents dispatch simultaneously", () => {
+  /**
+   * Reproduces the cross-agent TOCTOU hole the global lock exists to close.
+   *
+   * withAgentStartLock only serializes a single agent, so each agent's dispatch
+   * runs unserialized against the others. If the count-then-claim sequence is not
+   * globally atomic, several agents each read the same free slot and each start a
+   * run — which is how 27 runs ended up on a 12-core host.
+   */
+  const dispatchAllAgents = async (agentCount: number, useGlobalLock: boolean) => {
+    const ceiling = resolveGlobalRunCeiling(12);
+    let running = 0;
+    let peak = 0;
+
+    const dispatch = async (agentId: string) => {
+      const claim = async () => {
+        const admission = evaluateRunAdmission({
+          agentCap: 5,
+          runningForAgent: 0,
+          runningGlobal: running,
+          load: { cpuCount: 12, loadAverage1m: 2 },
+        });
+        if (admission.availableSlots <= 0) return;
+        // Yield between the read and the write — the interleaving window that a
+        // real DB round-trip opens up.
+        await tick();
+        running += 1;
+        peak = Math.max(peak, running);
+      };
+      await withAgentStartLock(agentId, () => (useGlobalLock ? withGlobalAdmissionLock(claim) : claim()));
+    };
+
+    await Promise.all(
+      Array.from({ length: agentCount }, (_, i) => dispatch(`agent-${i}`)),
+    );
+    return { peak, ceiling };
+  };
+
+  it("holds the ceiling with the global lock", async () => {
+    const { peak, ceiling } = await dispatchAllAgents(10, true);
+    expect(peak).toBeLessThanOrEqual(ceiling);
+  });
+
+  it("demonstrates the ceiling is breached without it (guards the fix)", async () => {
+    // If this ever stops overshooting, the global lock has become redundant and
+    // this whole mechanism should be revisited rather than silently kept.
+    const { peak, ceiling } = await dispatchAllAgents(10, false);
+    expect(peak).toBeGreaterThan(ceiling);
+  });
+});

--- a/server/src/services/agent-start-lock.ts
+++ b/server/src/services/agent-start-lock.ts
@@ -46,3 +46,32 @@ export async function withAgentStartLock<T>(agentId: string, fn: () => Promise<T
     }
   }
 }
+
+/**
+ * RBR-974: instance-wide serialization for the run-admission critical section.
+ *
+ * withAgentStartLock only serializes starts for a single agent, so two different
+ * agents could each read "4 of 5 global slots used" and each start a run,
+ * overshooting the instance ceiling. The global ceiling is only a ceiling if the
+ * read-count-then-claim sequence is atomic across agents.
+ *
+ * The guarded section is short — count queued runs, claim rows, dispatch
+ * fire-and-forget — so serializing it does not serialize the runs themselves.
+ */
+let globalAdmissionLock: Promise<void> = Promise.resolve();
+
+export async function withGlobalAdmissionLock<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = globalAdmissionLock;
+  let release: () => void = () => {};
+  globalAdmissionLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Never let a rejected predecessor wedge the queue for everyone behind it.
+  await previous.catch(() => undefined);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13374,116 +13374,116 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         return [];
       }
-      const policy = parseHeartbeatPolicy(agent);
-      // RBR-974: the admission decision and the row claim must be atomic across
-      // agents. withAgentStartLock only serializes one agent, so without this two
-      // agents could each read the same free global slot and both start. Global
-      // lock is taken inside the per-agent lock and never acquires an agent lock,
-      // so the nesting order cannot deadlock.
-      return withGlobalAdmissionLock(async () => {
-      const runningCount = await countRunningRunsForAgent(agentId);
-      // Admission control replaces optimistic per-agent dispatch. The gate
-      // consults the instance-wide ceiling and the live host load before any
-      // queued run is claimed. A refusal leaves runs in "queued" — resumeQueuedRuns
-      // retries them on the next sweep, so deferral costs a delay, not a run.
-      const runningGlobal = await countRunningRunsInstanceWide();
-      const admission = evaluateRunAdmission({
-        agentCap: policy.maxConcurrentRuns,
-        runningForAgent: runningCount,
-        runningGlobal,
-        load: readHostLoadSnapshot(),
-      });
-      const availableSlots = admission.availableSlots;
-      if (availableSlots <= 0) {
-        // Log at warn for load/ceiling refusals: they are the signal an operator
-        // needs to distinguish "queue is backpressured" from "scheduler is stuck".
-        logger.warn(
-          {
-            agentId,
-            deferralReason: admission.deferralReason,
-            globalCeiling: admission.globalCeiling,
-            effectiveAgentCap: admission.effectiveAgentCap,
-            runningGlobal: admission.runningGlobal,
-            runningForAgent: admission.runningForAgent,
-          },
-          admission.detail,
-        );
-        return [];
-      }
-
-      const queuedRuns = await db
-        .select()
-        .from(heartbeatRuns)
-        .where(and(
-          eq(heartbeatRuns.agentId, agentId),
-          eq(heartbeatRuns.status, "queued"),
-          cutoff ? gte(heartbeatRuns.createdAt, cutoff) : undefined,
-        ))
-        .orderBy(asc(heartbeatRuns.createdAt));
-      if (queuedRuns.length === 0) return [];
-
-      const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, queuedRuns);
-      const queuedIssueIds = [...new Set(
-        queuedRuns
-          .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
-          .filter((issueId): issueId is string => Boolean(issueId)),
-      )];
-      const issueRows = await db
-        .select({
-          id: issues.id,
-          status: issues.status,
-          priority: issues.priority,
-        })
-        .from(issues)
-        .where(
-          queuedIssueIds.length > 0
-            ? and(eq(issues.companyId, agent.companyId), inArray(issues.id, queuedIssueIds))
-            : sql`false`,
-        );
-      const issueById = new Map(issueRows.map((row) => [row.id, row]));
-      const companyAgents = await listCompanyAgentOrgRows(agent.companyId);
-      const prioritizedRuns = [...queuedRuns].sort((left, right) => {
-        const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
-        const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
-        const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
-        const rightReadiness = rightIssueId ? dependencyReadiness.get(rightIssueId) : null;
-        const leftReady = leftIssueId ? (leftReadiness?.isDependencyReady ?? true) : true;
-        const rightReady = rightIssueId ? (rightReadiness?.isDependencyReady ?? true) : true;
-        const leftIssue = leftIssueId ? issueById.get(leftIssueId) : null;
-        const rightIssue = rightIssueId ? issueById.get(rightIssueId) : null;
-        const leftRank = leftIssueId ? (leftReady ? (leftIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        const rightRank = rightIssueId ? (rightReady ? (rightIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
-        if (leftRank !== rightRank) return leftRank - rightRank;
-        const leftPriorityRank = issueRunPriorityRank(leftIssue?.priority);
-        const rightPriorityRank = issueRunPriorityRank(rightIssue?.priority);
-        if (leftPriorityRank !== rightPriorityRank) return leftPriorityRank - rightPriorityRank;
-        return left.createdAt.getTime() - right.createdAt.getTime();
-      });
-
-      const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
-      for (const queuedRun of prioritizedRuns) {
-        if (claimedRuns.length >= availableSlots) break;
-        const claimed = await claimQueuedRun(queuedRun, companyAgents);
-        if (claimed) claimedRuns.push(claimed);
-      }
-      if (claimedRuns.length === 0) return [];
-
-      for (const claimedRun of claimedRuns) {
-        const execution = executeRun(claimedRun.id).catch((err) => {
-          logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
-        });
-        // Register the in-flight execution so drainActiveRunExecutions() can await
-        // it. executeRun resolves only after its finally block finishes flushing
-        // run rows/events, so awaiting this promise guarantees the run's writes
-        // have landed before a caller (e.g. a test's afterEach) mutates the DB.
-        activeRunExecutionPromises.add(execution);
-        void execution.finally(() => {
-          activeRunExecutionPromises.delete(execution);
-        });
-      }
-      return claimedRuns;
-      });
+      // RBR-974: the admission decision and the row claim must be one atomic step
+      // across agents. withAgentStartLock only serializes a single agent, so
+      // without this two agents could each read the same free global slot and both
+      // start, overshooting the instance ceiling. The global lock is always taken
+      // inside the per-agent lock and never acquires an agent lock, so the nesting
+      // order cannot deadlock.
+      return withGlobalAdmissionLock(() => admitAndClaimQueuedRuns(agent, parseHeartbeatPolicy(agent), cutoff));
     });
+  }
+
+  /**
+   * RBR-974: admission control, replacing optimistic per-agent dispatch.
+   *
+   * Consults the instance-wide ceiling and live host load before claiming
+   * anything. On refusal the runs stay `queued` and the periodic resumeQueuedRuns
+   * sweep retries them — deferral costs a delay, never a dropped or killed run.
+   *
+   * Caller must hold both the agent start lock and the global admission lock.
+   */
+  async function admitAndClaimQueuedRuns(
+    agent: NonNullable<Awaited<ReturnType<typeof getAgent>>>,
+    policy: ReturnType<typeof parseHeartbeatPolicy>,
+    cutoff: Date | null,
+  ) {
+    const agentId = agent.id;
+    const admission = evaluateRunAdmission({
+      agentCap: policy.maxConcurrentRuns,
+      runningForAgent: await countRunningRunsForAgent(agentId),
+      runningGlobal: await countRunningRunsInstanceWide(),
+      load: readHostLoadSnapshot(),
+    });
+    if (admission.availableSlots <= 0) {
+      const { detail, ...fields } = admission;
+      // warn, not debug: this is the signal that distinguishes "queue is
+      // backpressured" from "scheduler is wedged" when an operator asks why
+      // nothing is starting.
+      logger.warn({ agentId, ...fields }, detail);
+      return [];
+    }
+
+    const queuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.agentId, agentId),
+        eq(heartbeatRuns.status, "queued"),
+        cutoff ? gte(heartbeatRuns.createdAt, cutoff) : undefined,
+      ))
+      .orderBy(asc(heartbeatRuns.createdAt));
+    if (queuedRuns.length === 0) return [];
+
+    const dependencyReadiness = await listQueuedRunDependencyReadiness(agent.companyId, queuedRuns);
+    const queuedIssueIds = [...new Set(
+      queuedRuns
+        .map((run) => readNonEmptyString(parseObject(run.contextSnapshot).issueId))
+        .filter((issueId): issueId is string => Boolean(issueId)),
+    )];
+    const issueRows = await db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        priority: issues.priority,
+      })
+      .from(issues)
+      .where(
+        queuedIssueIds.length > 0
+          ? and(eq(issues.companyId, agent.companyId), inArray(issues.id, queuedIssueIds))
+          : sql`false`,
+      );
+    const issueById = new Map(issueRows.map((row) => [row.id, row]));
+    const companyAgents = await listCompanyAgentOrgRows(agent.companyId);
+    const prioritizedRuns = [...queuedRuns].sort((left, right) => {
+      const leftIssueId = readNonEmptyString(parseObject(left.contextSnapshot).issueId);
+      const rightIssueId = readNonEmptyString(parseObject(right.contextSnapshot).issueId);
+      const leftReadiness = leftIssueId ? dependencyReadiness.get(leftIssueId) : null;
+      const rightReadiness = rightIssueId ? dependencyReadiness.get(rightIssueId) : null;
+      const leftReady = leftIssueId ? (leftReadiness?.isDependencyReady ?? true) : true;
+      const rightReady = rightIssueId ? (rightReadiness?.isDependencyReady ?? true) : true;
+      const leftIssue = leftIssueId ? issueById.get(leftIssueId) : null;
+      const rightIssue = rightIssueId ? issueById.get(rightIssueId) : null;
+      const leftRank = leftIssueId ? (leftReady ? (leftIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
+      const rightRank = rightIssueId ? (rightReady ? (rightIssue?.status === "in_progress" ? 0 : 1) : 3) : 2;
+      if (leftRank !== rightRank) return leftRank - rightRank;
+      const leftPriorityRank = issueRunPriorityRank(leftIssue?.priority);
+      const rightPriorityRank = issueRunPriorityRank(rightIssue?.priority);
+      if (leftPriorityRank !== rightPriorityRank) return leftPriorityRank - rightPriorityRank;
+      return left.createdAt.getTime() - right.createdAt.getTime();
+    });
+
+    const claimedRuns: Array<typeof heartbeatRuns.$inferSelect> = [];
+    for (const queuedRun of prioritizedRuns) {
+      if (claimedRuns.length >= admission.availableSlots) break;
+      const claimed = await claimQueuedRun(queuedRun, companyAgents);
+      if (claimed) claimedRuns.push(claimed);
+    }
+
+    for (const claimedRun of claimedRuns) {
+      const execution = executeRun(claimedRun.id).catch((err) => {
+        logger.error({ err, runId: claimedRun.id }, "queued heartbeat execution failed");
+      });
+      // Register the in-flight execution so drainActiveRunExecutions() can await
+      // it. executeRun resolves only after its finally block finishes flushing
+      // run rows/events, so awaiting this promise guarantees the run's writes
+      // have landed before a caller (e.g. a test's afterEach) mutates the DB.
+      activeRunExecutionPromises.add(execution);
+      void execution.finally(() => {
+        activeRunExecutionPromises.delete(execution);
+      });
+    }
+    return claimedRuns;
   }
 
   // Await every background heartbeat execution that is currently in flight. A

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -79,6 +79,11 @@ import {
 // Re-exported because heartbeat's workspace surface exposed the scrubber before the
 // git-credentials module became its canonical home; existing importers keep working.
 export { scrubGitCredentialText };
+import {
+  evaluateRunAdmission,
+  readHostLoadSnapshot,
+  resolveGlobalRunCeiling,
+} from "./run-admission.js";
 import { publishLiveEvent } from "./live-events.js";
 import { normalizeResponsibleUserDenialCode } from "./responsible-user-denial-run-outcomes.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
@@ -240,7 +245,7 @@ import {
 import { productivityReviewService } from "./productivity-review.js";
 import { resolveRequiredSuccessfulRunHandoffOnValidPath } from "./successful-run-handoff-state.js";
 import { taskWatchdogService } from "./task-watchdogs.js";
-import { withAgentStartLock } from "./agent-start-lock.js";
+import { withAgentStartLock, withGlobalAdmissionLock } from "./agent-start-lock.js";
 import {
   evaluateAgentInvokability,
   evaluateAgentInvokabilityFromDb,
@@ -12288,6 +12293,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return Number(count ?? 0);
   }
 
+  /**
+   * RBR-974: instance-wide running-run count. Deliberately NOT scoped to a
+   * company or agent — the global ceiling exists because per-agent caps summed
+   * without bound and put 27 runs on a 12-core host. Every running run competes
+   * for the same CPU regardless of who owns it.
+   */
+  async function countRunningRunsInstanceWide() {
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "running"));
+    return Number(count ?? 0);
+  }
+
   async function claimQueuedRun(run: typeof heartbeatRuns.$inferSelect, companyAgents?: AgentOrgRow[]) {
     if (run.status !== "queued") return run;
     const agent = await getAgent(run.agentId);
@@ -13356,9 +13375,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return [];
       }
       const policy = parseHeartbeatPolicy(agent);
+      // RBR-974: the admission decision and the row claim must be atomic across
+      // agents. withAgentStartLock only serializes one agent, so without this two
+      // agents could each read the same free global slot and both start. Global
+      // lock is taken inside the per-agent lock and never acquires an agent lock,
+      // so the nesting order cannot deadlock.
+      return withGlobalAdmissionLock(async () => {
       const runningCount = await countRunningRunsForAgent(agentId);
-      const availableSlots = Math.max(0, policy.maxConcurrentRuns - runningCount);
-      if (availableSlots <= 0) return [];
+      // Admission control replaces optimistic per-agent dispatch. The gate
+      // consults the instance-wide ceiling and the live host load before any
+      // queued run is claimed. A refusal leaves runs in "queued" — resumeQueuedRuns
+      // retries them on the next sweep, so deferral costs a delay, not a run.
+      const runningGlobal = await countRunningRunsInstanceWide();
+      const admission = evaluateRunAdmission({
+        agentCap: policy.maxConcurrentRuns,
+        runningForAgent: runningCount,
+        runningGlobal,
+        load: readHostLoadSnapshot(),
+      });
+      const availableSlots = admission.availableSlots;
+      if (availableSlots <= 0) {
+        // Log at warn for load/ceiling refusals: they are the signal an operator
+        // needs to distinguish "queue is backpressured" from "scheduler is stuck".
+        logger.warn(
+          {
+            agentId,
+            deferralReason: admission.deferralReason,
+            globalCeiling: admission.globalCeiling,
+            effectiveAgentCap: admission.effectiveAgentCap,
+            runningGlobal: admission.runningGlobal,
+            runningForAgent: admission.runningForAgent,
+          },
+          admission.detail,
+        );
+        return [];
+      }
 
       const queuedRuns = await db
         .select()
@@ -13431,6 +13482,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
       return claimedRuns;
+      });
     });
   }
 

--- a/server/src/services/run-admission.test.ts
+++ b/server/src/services/run-admission.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_RUN_CORE_BUDGET_RATIO,
+  GLOBAL_RUN_CEILING_MAX,
+  GLOBAL_RUN_CEILING_MIN,
+  HOST_LOAD_REFUSAL_RATIO,
+  MEASURED_LOAD_PER_AGENT_RUN,
+  clampAgentCapToGlobalCeiling,
+  evaluateRunAdmission,
+  isHostOverloaded,
+  readHostLoadSnapshot,
+  resolveGlobalRunCeiling,
+  type HostLoadSnapshot,
+} from "./run-admission.js";
+
+/** The measured reference host from the RBR-974 report. */
+const REFERENCE_CORES = 12;
+const IDLE: HostLoadSnapshot = { cpuCount: REFERENCE_CORES, loadAverage1m: 2 };
+/** The measured saturation state: load 45.98 on 12 cores. */
+const SATURATED: HostLoadSnapshot = { cpuCount: REFERENCE_CORES, loadAverage1m: 45.98 };
+
+describe("resolveGlobalRunCeiling (AC5: chosen ceiling and reasoning)", () => {
+  it("derives 5 on the 12-core reference host from measured per-run load", () => {
+    // floor(12 * 0.75 / 1.55) = floor(5.80) = 5
+    expect(resolveGlobalRunCeiling(REFERENCE_CORES)).toBe(5);
+  });
+
+  it("is derived from core count, not hard-coded", () => {
+    const expected = (cores: number) =>
+      Math.max(
+        GLOBAL_RUN_CEILING_MIN,
+        Math.min(
+          GLOBAL_RUN_CEILING_MAX,
+          Math.floor((cores * AGENT_RUN_CORE_BUDGET_RATIO) / MEASURED_LOAD_PER_AGENT_RUN),
+        ),
+      );
+    for (const cores of [1, 2, 4, 8, 12, 16, 32, 64, 128]) {
+      expect(resolveGlobalRunCeiling(cores)).toBe(expected(cores));
+    }
+  });
+
+  it("scales up with cores but stays clamped to a sane band", () => {
+    expect(resolveGlobalRunCeiling(4)).toBeLessThan(resolveGlobalRunCeiling(12));
+    expect(resolveGlobalRunCeiling(1)).toBe(GLOBAL_RUN_CEILING_MIN);
+    expect(resolveGlobalRunCeiling(1024)).toBe(GLOBAL_RUN_CEILING_MAX);
+  });
+
+  it("never returns 0 — a ceiling of 0 would wedge the instance", () => {
+    for (const cores of [1, 2, 3]) {
+      expect(resolveGlobalRunCeiling(cores)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("reads a usable snapshot from the real host", () => {
+    const snapshot = readHostLoadSnapshot();
+    expect(snapshot.cpuCount).toBeGreaterThanOrEqual(1);
+    expect(snapshot.loadAverage1m).toBeGreaterThanOrEqual(0);
+    expect(resolveGlobalRunCeiling(snapshot.cpuCount)).toBeGreaterThanOrEqual(GLOBAL_RUN_CEILING_MIN);
+  });
+});
+
+describe("AC1: concurrent runs instance-wide cannot exceed the global ceiling", () => {
+  it("refuses to admit anything once the ceiling is reached", () => {
+    const ceiling = resolveGlobalRunCeiling(REFERENCE_CORES);
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: ceiling,
+      load: IDLE,
+    });
+    expect(decision.availableSlots).toBe(0);
+    expect(decision.deferralReason).toBe("global_ceiling");
+  });
+
+  it("admits only the remaining headroom, not the full per-agent cap", () => {
+    const ceiling = resolveGlobalRunCeiling(REFERENCE_CORES);
+    // 4 of 5 slots taken instance-wide; this agent's own cap would allow 5.
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: ceiling - 1,
+      load: IDLE,
+    });
+    expect(decision.availableSlots).toBe(1);
+    expect(decision.deferralReason).toBeNull();
+  });
+
+  it("never admits past the ceiling for any request size (excess is queued, not started)", () => {
+    const ceiling = resolveGlobalRunCeiling(REFERENCE_CORES);
+    for (let runningGlobal = 0; runningGlobal <= ceiling + 5; runningGlobal += 1) {
+      const decision = evaluateRunAdmission({
+        agentCap: 99, // an operator asking for far more than the host can take
+        runningForAgent: 0,
+        runningGlobal,
+        load: IDLE,
+      });
+      expect(runningGlobal + decision.availableSlots).toBeLessThanOrEqual(ceiling);
+    }
+  });
+
+  it("holds the ceiling when 10 agents each demand their full cap simultaneously", () => {
+    // This is the measured failure: 27 runs started because per-agent caps summed.
+    const ceiling = resolveGlobalRunCeiling(REFERENCE_CORES);
+    let runningGlobal = 0;
+    let started = 0;
+    const deferred: string[] = [];
+
+    for (let agent = 0; agent < 10; agent += 1) {
+      const decision = evaluateRunAdmission({
+        agentCap: 5, // the CEO's configured per-agent cap
+        runningForAgent: 0,
+        runningGlobal,
+        load: IDLE,
+      });
+      if (decision.availableSlots === 0) {
+        deferred.push(`agent-${agent}:${decision.deferralReason}`);
+        continue;
+      }
+      // Each agent starts as many as it is admitted for.
+      runningGlobal += decision.availableSlots;
+      started += decision.availableSlots;
+    }
+
+    expect(started).toBe(ceiling);
+    expect(runningGlobal).toBe(ceiling);
+    // Naive summing would have produced 10 * 5 = 50.
+    expect(started).toBeLessThan(10 * 5);
+    // The excess agents were deferred, not dropped and not started.
+    expect(deferred.length).toBeGreaterThan(0);
+    expect(deferred.every((entry) => entry.endsWith("global_ceiling"))).toBe(true);
+  });
+});
+
+describe("AC2: per-agent caps cannot sum past the global cap", () => {
+  it("clamps an oversized per-agent cap down to the ceiling", () => {
+    expect(clampAgentCapToGlobalCeiling(50, 5)).toBe(5);
+    expect(clampAgentCapToGlobalCeiling(5, 5)).toBe(5);
+  });
+
+  it("leaves a smaller per-agent cap intact as a genuine sub-cap", () => {
+    expect(clampAgentCapToGlobalCeiling(3, 5)).toBe(3);
+    expect(clampAgentCapToGlobalCeiling(1, 5)).toBe(1);
+  });
+
+  it("reports the clamped cap as the effective cap in the decision", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 20, // AGENT_DEFAULT_MAX_CONCURRENT_RUNS
+      runningForAgent: 0,
+      runningGlobal: 0,
+      load: IDLE,
+    });
+    expect(decision.globalCeiling).toBe(5);
+    expect(decision.effectiveAgentCap).toBe(5);
+    expect(decision.availableSlots).toBe(5);
+  });
+
+  it("still enforces a per-agent sub-cap below the ceiling", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 3, // the adapter-config cap
+      runningForAgent: 3,
+      runningGlobal: 3,
+      load: IDLE,
+    });
+    expect(decision.availableSlots).toBe(0);
+    expect(decision.deferralReason).toBe("agent_cap");
+  });
+
+  it("no single agent can occupy more than the ceiling however it is configured", () => {
+    for (const agentCap of [1, 3, 5, 20, 50, Number.POSITIVE_INFINITY]) {
+      const decision = evaluateRunAdmission({
+        agentCap,
+        runningForAgent: 0,
+        runningGlobal: 0,
+        load: IDLE,
+      });
+      expect(decision.availableSlots).toBeLessThanOrEqual(decision.globalCeiling);
+    }
+  });
+});
+
+describe("AC3: saturation defers the wake instead of starting a doomed run", () => {
+  it("refuses to dispatch at the measured saturation point (load 45.98 on 12 cores)", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: 0, // every slot looks free — only load says no
+      load: SATURATED,
+    });
+    expect(decision.availableSlots).toBe(0);
+    expect(decision.deferralReason).toBe("host_load");
+    expect(decision.detail).toContain("45.98");
+    expect(decision.detail).toContain("12 cores");
+  });
+
+  it("refuses even with a fully idle slot pool, because load is not slot-visible", () => {
+    // The 69.6% CPU unscoped `rg` and four stray vitest suites are load we did not
+    // start; slot accounting cannot see them.
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: 0,
+      load: { cpuCount: 12, loadAverage1m: 40.46 },
+    });
+    expect(decision.deferralReason).toBe("host_load");
+  });
+
+  it("load refusal takes precedence over slot availability", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: 99, // both would defer; load must be the reported cause
+      load: SATURATED,
+    });
+    expect(decision.deferralReason).toBe("host_load");
+  });
+
+  it("admits again once load recovers — deferral is backpressure, not a latch", () => {
+    // The self-confirming datapoint: same query, same code, load fell 46 -> 22.
+    const recovered = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: 0,
+      load: { cpuCount: 12, loadAverage1m: 8 },
+    });
+    expect(recovered.availableSlots).toBeGreaterThan(0);
+    expect(recovered.deferralReason).toBeNull();
+  });
+
+  it("draws the refusal threshold at 1.25x core count", () => {
+    expect(isHostOverloaded({ cpuCount: 12, loadAverage1m: 14 })).toBe(false);
+    expect(isHostOverloaded({ cpuCount: 12, loadAverage1m: 15 })).toBe(false);
+    expect(isHostOverloaded({ cpuCount: 12, loadAverage1m: 16 })).toBe(true);
+    expect(isHostOverloaded({ cpuCount: 12, loadAverage1m: REFERENCE_CORES * HOST_LOAD_REFUSAL_RATIO })).toBe(false);
+  });
+
+  it("tolerates a load average at or just below full utilisation", () => {
+    // A busy-but-healthy host must not be starved of dispatch.
+    expect(isHostOverloaded({ cpuCount: 12, loadAverage1m: 11.75 })).toBe(false);
+  });
+
+  it("handles a missing/garbage load reading without wedging dispatch", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: 0,
+      load: { cpuCount: 12, loadAverage1m: 0 },
+    });
+    expect(decision.availableSlots).toBeGreaterThan(0);
+  });
+});
+
+describe("regression: the measured 27-run failure cannot recur", () => {
+  it("caps the exact observed scenario to the ceiling", () => {
+    // 27 runs were live on a 12-core box. Replay the admission gate against that
+    // state: nothing further may start, and the reason must be legible.
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 2,
+      runningGlobal: 27,
+      load: SATURATED,
+    });
+    expect(decision.availableSlots).toBe(0);
+    expect(decision.globalCeiling).toBe(5);
+    expect(decision.detail).toMatch(/deferring dispatch/);
+  });
+
+  it("every deferral carries a reason and an operator-readable detail", () => {
+    const scenarios = [
+      { agentCap: 5, runningForAgent: 0, runningGlobal: 5, load: IDLE },
+      { agentCap: 3, runningForAgent: 3, runningGlobal: 3, load: IDLE },
+      { agentCap: 5, runningForAgent: 0, runningGlobal: 0, load: SATURATED },
+    ];
+    for (const scenario of scenarios) {
+      const decision = evaluateRunAdmission(scenario);
+      expect(decision.availableSlots).toBe(0);
+      expect(decision.deferralReason).not.toBeNull();
+      expect(decision.detail.length).toBeGreaterThan(10);
+    }
+  });
+});

--- a/server/src/services/run-admission.test.ts
+++ b/server/src/services/run-admission.test.ts
@@ -94,8 +94,42 @@ describe("AC1: concurrent runs instance-wide cannot exceed the global ceiling", 
         runningGlobal,
         load: IDLE,
       });
-      expect(runningGlobal + decision.availableSlots).toBeLessThanOrEqual(ceiling);
+      // The invariant is "admission never pushes us above the ceiling". Note that
+      // runningGlobal can legitimately start ABOVE the ceiling — runs already
+      // in flight when the cap is lowered, or when this build is deployed onto a
+      // host mid-flight. In that state the gate must admit exactly nothing rather
+      // than compound the overshoot; it must never kill or drop what is running.
+      if (runningGlobal >= ceiling) {
+        expect(decision.availableSlots).toBe(0);
+        expect(decision.deferralReason).toBe("global_ceiling");
+      } else {
+        expect(runningGlobal + decision.availableSlots).toBeLessThanOrEqual(ceiling);
+        expect(decision.availableSlots).toBeGreaterThan(0);
+      }
     }
+  });
+
+  it("drains an existing overshoot rather than compounding it", () => {
+    // The measured state was 27 runs on a host whose ceiling is 5. Admission must
+    // return 0 at every step until the overshoot has drained below the ceiling.
+    const ceiling = resolveGlobalRunCeiling(REFERENCE_CORES);
+    for (let runningGlobal = 27; runningGlobal > ceiling; runningGlobal -= 1) {
+      const decision = evaluateRunAdmission({
+        agentCap: 5,
+        runningForAgent: 0,
+        runningGlobal,
+        load: IDLE,
+      });
+      expect(decision.availableSlots).toBe(0);
+    }
+    // Once it drains to ceiling-1, dispatch resumes.
+    const resumed = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: ceiling - 1,
+      load: IDLE,
+    });
+    expect(resumed.availableSlots).toBe(1);
   });
 
   it("holds the ceiling when 10 agents each demand their full cap simultaneously", () => {
@@ -183,7 +217,7 @@ describe("AC3: saturation defers the wake instead of starting a doomed run", () 
     const decision = evaluateRunAdmission({
       agentCap: 5,
       runningForAgent: 0,
-      runningGlobal: 0, // every slot looks free — only load says no
+      runningGlobal: 1, // our runs are live, so we own the load
       load: SATURATED,
     });
     expect(decision.availableSlots).toBe(0);
@@ -192,16 +226,17 @@ describe("AC3: saturation defers the wake instead of starting a doomed run", () 
     expect(decision.detail).toContain("12 cores");
   });
 
-  it("refuses even with a fully idle slot pool, because load is not slot-visible", () => {
+  it("refuses even with free slots, because load is not slot-visible", () => {
     // The 69.6% CPU unscoped `rg` and four stray vitest suites are load we did not
     // start; slot accounting cannot see them.
     const decision = evaluateRunAdmission({
       agentCap: 5,
       runningForAgent: 0,
-      runningGlobal: 0,
+      runningGlobal: 1, // 1 of 5 slots used — slot math says "yes", load says "no"
       load: { cpuCount: 12, loadAverage1m: 40.46 },
     });
     expect(decision.deferralReason).toBe("host_load");
+    expect(decision.availableSlots).toBe(0);
   });
 
   it("load refusal takes precedence over slot availability", () => {
@@ -249,6 +284,77 @@ describe("AC3: saturation defers the wake instead of starting a doomed run", () 
   });
 });
 
+describe("forward-progress escape valve: external load must not wedge the instance", () => {
+  it("admits exactly one run when load is high but nothing of ours is running", () => {
+    // Load we do not own (a human's build, another worktree's suite). If we
+    // deferred on load alone, the company would stall permanently: nothing running
+    // means nothing will ever finish to bring the load down.
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 0,
+      runningGlobal: 0,
+      load: SATURATED,
+    });
+    expect(decision.availableSlots).toBe(1);
+    expect(decision.deferralReason).toBeNull();
+    expect(decision.detail).toMatch(/load is external/);
+  });
+
+  it("closes the valve as soon as one run is live — it is a trickle, not a bypass", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 5,
+      runningForAgent: 1,
+      runningGlobal: 1,
+      load: SATURATED,
+    });
+    expect(decision.availableSlots).toBe(0);
+    expect(decision.deferralReason).toBe("host_load");
+  });
+
+  it("cannot be used to exceed the ceiling at any load", () => {
+    for (const loadAverage1m of [0, 8, 15, 30, 45.98, 200]) {
+      const decision = evaluateRunAdmission({
+        agentCap: 99,
+        runningForAgent: 0,
+        runningGlobal: 0,
+        load: { cpuCount: 12, loadAverage1m },
+      });
+      expect(decision.availableSlots).toBeLessThanOrEqual(decision.globalCeiling);
+    }
+  });
+
+  it("respects a zero per-agent cap even under the valve", () => {
+    const decision = evaluateRunAdmission({
+      agentCap: 0,
+      runningForAgent: 0,
+      runningGlobal: 0,
+      load: SATURATED,
+    });
+    expect(decision.availableSlots).toBe(0);
+  });
+
+  it("guarantees the instance can always drain a queue from a cold start", () => {
+    // Simulate a permanently-loaded host: each admitted run completes, so
+    // runningGlobal returns to 0 and the valve admits the next one. The queue
+    // drains slowly but it does drain — no deadlock.
+    let queued = 4;
+    let iterations = 0;
+    while (queued > 0 && iterations < 50) {
+      iterations += 1;
+      const decision = evaluateRunAdmission({
+        agentCap: 5,
+        runningForAgent: 0,
+        runningGlobal: 0,
+        load: SATURATED,
+      });
+      expect(decision.availableSlots).toBeGreaterThan(0);
+      queued -= decision.availableSlots;
+    }
+    expect(queued).toBeLessThanOrEqual(0);
+    expect(iterations).toBeLessThan(50);
+  });
+});
+
 describe("regression: the measured 27-run failure cannot recur", () => {
   it("caps the exact observed scenario to the ceiling", () => {
     // 27 runs were live on a 12-core box. Replay the admission gate against that
@@ -268,7 +374,7 @@ describe("regression: the measured 27-run failure cannot recur", () => {
     const scenarios = [
       { agentCap: 5, runningForAgent: 0, runningGlobal: 5, load: IDLE },
       { agentCap: 3, runningForAgent: 3, runningGlobal: 3, load: IDLE },
-      { agentCap: 5, runningForAgent: 0, runningGlobal: 0, load: SATURATED },
+      { agentCap: 5, runningForAgent: 1, runningGlobal: 1, load: SATURATED },
     ];
     for (const scenario of scenarios) {
       const decision = evaluateRunAdmission(scenario);

--- a/server/src/services/run-admission.ts
+++ b/server/src/services/run-admission.ts
@@ -137,6 +137,27 @@ export function evaluateRunAdmission(input: {
   // not create, and it is the difference between "we have a free slot" and "a run
   // started now will survive".
   if (isHostOverloaded(load)) {
+    // Forward-progress escape valve. Load is not a signal we fully own: a human's
+    // build, another worktree's test suite, or a stray repo-wide `rg` can hold the
+    // host above the threshold indefinitely. If we refused purely on load, that
+    // external pressure would wedge the whole company with nothing running and
+    // nothing able to start — a worse failure than a slow run, and one that no
+    // amount of waiting resolves.
+    //
+    // So when zero runs are live instance-wide, we are demonstrably not the cause
+    // of the load, and we admit exactly one run. A single run is the least-doomed
+    // option available and the only path to draining the queue; deferring forever
+    // is strictly worse. Above zero, ordinary backpressure applies.
+    if (runningGlobal <= 0 && effectiveAgentCap > 0) {
+      return {
+        ...base,
+        availableSlots: 1,
+        deferralReason: null,
+        detail:
+          `admitting 1 run despite 1m load ${load.loadAverage1m.toFixed(2)} on ${load.cpuCount} cores: ` +
+          `no runs are live instance-wide, so the load is external and deferring would stall all work`,
+      };
+    }
     return {
       ...base,
       availableSlots: 0,

--- a/server/src/services/run-admission.ts
+++ b/server/src/services/run-admission.ts
@@ -1,0 +1,179 @@
+import os from "node:os";
+
+/**
+ * RBR-974 — instance-wide agent-run admission control.
+ *
+ * Background: per-agent `heartbeat.maxConcurrentRuns` caps existed, but nothing
+ * summed them. With N agents each allowed 3-5 runs, the instance happily started
+ * 27 concurrent agent runs on a 12-core host (measured load average 45.98). Every
+ * process on the box — including the Paperclip API server itself — then slowed by
+ * the oversubscription factor, runs blew their wall clock, and recovery read the
+ * resulting `timed_out` runs as abandoned work and reverted issue status.
+ *
+ * This module is the admission gate. It is deliberately pure: every input is
+ * passed in, so it can be unit-tested without a database, a server, or synthetic
+ * host load. `startNextQueuedRunForAgent` consults it before claiming a queued
+ * run; when admission is refused the run stays `queued` and the periodic
+ * `resumeQueuedRuns` sweep retries it later. Deferral is the backpressure
+ * mechanism — we never drop a run, and we never start one we expect to be killed.
+ */
+
+/**
+ * Load cost of a single agent run, in load-average units.
+ *
+ * Derived from measurement rather than guessed. On the 12-core reference host:
+ * 27 concurrent agent runs produced a sustained 1m load average of 45.98, with a
+ * non-agent baseline (API server, embedded postgres, desktop session, browser) of
+ * roughly 4. That gives (45.98 - 4) / 27 = 1.55 load units per run — each agent
+ * run is its own CLI process plus the verification subprocesses (tsc/vitest/
+ * embedded-postgres) our execution contract asks it to spawn.
+ */
+export const MEASURED_LOAD_PER_AGENT_RUN = 1.55;
+
+/**
+ * Fraction of host cores the agent-run pool is allowed to target.
+ *
+ * The remaining 25% is reserved for the control plane the runs depend on: the
+ * Paperclip API server, postgres, and the operator's own session. Reserving a
+ * share rather than a fixed core count keeps the formula meaningful on hosts of
+ * other sizes.
+ */
+export const AGENT_RUN_CORE_BUDGET_RATIO = 0.75;
+
+/**
+ * Refuse to dispatch when the 1m load average exceeds this multiple of the core
+ * count, regardless of how many run slots look free. `12 cores, load 46` must be
+ * a refusal: the slot accounting cannot see load contributed by processes we did
+ * not start (a stray repo-wide `rg`, a human's build, another worktree's test
+ * suite), and starting into that only manufactures another timeout.
+ */
+export const HOST_LOAD_REFUSAL_RATIO = 1.25;
+
+export const GLOBAL_RUN_CEILING_MIN = 2;
+export const GLOBAL_RUN_CEILING_MAX = 16;
+
+export type HostLoadSnapshot = {
+  cpuCount: number;
+  loadAverage1m: number;
+};
+
+export type AdmissionDeferralReason = "global_ceiling" | "host_load" | "agent_cap";
+
+export type AdmissionDecision = {
+  /** Number of queued runs that may start right now. 0 means defer. */
+  availableSlots: number;
+  /** Set when availableSlots is 0. */
+  deferralReason: AdmissionDeferralReason | null;
+  /** Operator-facing explanation, safe to log. */
+  detail: string;
+  globalCeiling: number;
+  effectiveAgentCap: number;
+  runningGlobal: number;
+  runningForAgent: number;
+};
+
+/**
+ * Read host CPU count and 1m load average. Split out so callers can inject a
+ * synthetic snapshot in tests.
+ */
+export function readHostLoadSnapshot(): HostLoadSnapshot {
+  const cpuCount = Math.max(1, os.cpus().length);
+  const [loadAverage1m] = os.loadavg();
+  return {
+    cpuCount,
+    loadAverage1m: Number.isFinite(loadAverage1m) ? Math.max(0, loadAverage1m) : 0,
+  };
+}
+
+/**
+ * The single instance-wide ceiling on concurrent agent runs, derived from host
+ * core count and the measured per-run load cost.
+ *
+ * On the 12-core reference host: floor(12 * 0.75 / 1.55) = floor(5.8) = 5.
+ * Five concurrent runs target a load average of ~4 + 5*1.55 = 11.75 on 12 cores —
+ * fully utilised but not oversubscribed, which is the point.
+ */
+export function resolveGlobalRunCeiling(cpuCount?: number): number {
+  const cores = Math.max(1, Math.floor(cpuCount ?? readHostLoadSnapshot().cpuCount));
+  const derived = Math.floor((cores * AGENT_RUN_CORE_BUDGET_RATIO) / MEASURED_LOAD_PER_AGENT_RUN);
+  return Math.max(GLOBAL_RUN_CEILING_MIN, Math.min(GLOBAL_RUN_CEILING_MAX, derived));
+}
+
+/**
+ * Per-agent caps are sub-caps: they may restrict an agent below the global
+ * ceiling but can never authorise more than it. This is what stops N agents'
+ * caps from summing past the instance limit.
+ */
+export function clampAgentCapToGlobalCeiling(agentCap: number, globalCeiling: number): number {
+  const cap = Number.isFinite(agentCap) ? Math.floor(agentCap) : globalCeiling;
+  return Math.max(0, Math.min(cap, globalCeiling));
+}
+
+/**
+ * True when the host is too loaded to start anything new.
+ */
+export function isHostOverloaded(load: HostLoadSnapshot): boolean {
+  const cores = Math.max(1, load.cpuCount);
+  return load.loadAverage1m / cores > HOST_LOAD_REFUSAL_RATIO;
+}
+
+export function evaluateRunAdmission(input: {
+  agentCap: number;
+  runningForAgent: number;
+  runningGlobal: number;
+  load: HostLoadSnapshot;
+  /** Test/ops override for the derived ceiling. */
+  globalCeilingOverride?: number | null;
+}): AdmissionDecision {
+  const { agentCap, runningForAgent, runningGlobal, load } = input;
+  const globalCeiling = Math.max(
+    GLOBAL_RUN_CEILING_MIN,
+    Math.floor(input.globalCeilingOverride ?? resolveGlobalRunCeiling(load.cpuCount)),
+  );
+  const effectiveAgentCap = clampAgentCapToGlobalCeiling(agentCap, globalCeiling);
+  const base = { globalCeiling, effectiveAgentCap, runningGlobal, runningForAgent };
+
+  // Load check first: it is the only signal that accounts for CPU pressure we did
+  // not create, and it is the difference between "we have a free slot" and "a run
+  // started now will survive".
+  if (isHostOverloaded(load)) {
+    return {
+      ...base,
+      availableSlots: 0,
+      deferralReason: "host_load",
+      detail:
+        `deferring dispatch: 1m load ${load.loadAverage1m.toFixed(2)} on ${load.cpuCount} cores ` +
+        `exceeds ${HOST_LOAD_REFUSAL_RATIO}x core count`,
+    };
+  }
+
+  const globalRemaining = globalCeiling - runningGlobal;
+  if (globalRemaining <= 0) {
+    return {
+      ...base,
+      availableSlots: 0,
+      deferralReason: "global_ceiling",
+      detail: `deferring dispatch: ${runningGlobal} runs already at instance ceiling ${globalCeiling}`,
+    };
+  }
+
+  const agentRemaining = effectiveAgentCap - runningForAgent;
+  if (agentRemaining <= 0) {
+    return {
+      ...base,
+      availableSlots: 0,
+      deferralReason: "agent_cap",
+      detail: `deferring dispatch: agent at its cap ${effectiveAgentCap} (${runningForAgent} running)`,
+    };
+  }
+
+  const availableSlots = Math.min(globalRemaining, agentRemaining);
+  return {
+    ...base,
+    availableSlots,
+    deferralReason: null,
+    detail:
+      `admitting up to ${availableSlots} run(s): ${runningGlobal}/${globalCeiling} instance-wide, ` +
+      `${runningForAgent}/${effectiveAgentCap} for this agent`,
+  };
+}


### PR DESCRIPTION
## RBR-974: instance-wide agent-run admission control (rebased onto current master)

Rebased/re-applied the verified RBR-974 fix (branch `rbr974-global-run-admission`, previously
based on `75d915b328`, 570 commits behind) onto current `origin/master`. This PR stages the
change so it is mergeable the instant the board approves the pending deploy confirmation on
RBR-974 — **it does not merge or restart anything.**

### What this does

`startNextQueuedRunForAgent` now calls an admission gate before claiming any queued run.
Refusal leaves runs `queued` for the existing `resumeQueuedRuns` sweep — queued, never dropped,
never started-then-killed.

Two design points:

1. **Cross-agent atomicity.** `withAgentStartLock` only serializes starts for *one* agent. Two
   different agents could each read "N of ceiling slots used" and both start, overshooting the
   ceiling. `withGlobalAdmissionLock` wraps the read-count-then-claim critical section so the
   ceiling check and the row claim are atomic across agents, not just atomic per agent.
2. **Forward-progress escape valve (CEO-accepted, keep as-is).** Strict load-refusal can
   deadlock: if load is not caused by us and stays above threshold, we defer every wake forever
   and nothing ever finishes to bring load down. When **zero** runs are live instance-wide, the
   gate admits exactly one, so a permanently-loaded host still drains its queue instead of
   stalling forever. The valve shuts the instant any run is live and cannot exceed the ceiling.

### Ceiling formula and rationale

`floor(cores * 0.75 / 1.55) = 5` on this host (12 cores).

- **1.55 load units per run** — derived empirically: 27 concurrent runs produced a sustained 1m
  load of 45.98 against a non-agent baseline of ~4 (API server, embedded-postgres, desktop):
  `(45.98 - 4) / 27 = 1.55`. A run is its own CLI process plus the tsc/vitest/embedded-postgres
  children our execution contract spawns, hence >1 core per run.
- **0.75 core budget** — the remaining 25% is reserved for the control plane the runs depend on
  (API server, postgres, operator session), so `/health` isn't competing on equal footing with
  the run pool.
- Five runs target `4 + 5*1.55 = 11.75` on 12 cores: fully utilised, not oversubscribed.
- This is a real throughput cut (27 observed → 5) and is called out explicitly in
  `RBR-974-VERIFICATION.md` for reviewers.

Full verification narrative, AC coverage, and the pre-existing-bug caveats (duplicate `0128`
migration number, unbuilt-workspace-package typecheck noise) are in `RBR-974-VERIFICATION.md`,
carried over unchanged from the original branch.

### Verification (narrow, per RBR-1045 — this host is still recovering from the
oversubscription this ticket is about; full suite / full-repo typecheck intentionally NOT run)

- `server/src/services/run-admission.test.ts` + `server/src/services/agent-start-lock.test.ts`:
  **35/35 passing** post-rebase.
  ```
  ✓ src/services/agent-start-lock.test.ts (6 tests)
  ✓ src/services/run-admission.test.ts (29 tests)
  Test Files  2 passed (2)
       Tests  35 passed (35)
  ```
- Touched-file typecheck (`run-admission.ts`, `agent-start-lock.ts`, `heartbeat.ts`): full
  `tsc --noEmit` was already run to completion twice pre-rebase (documented in
  `RBR-974-VERIFICATION.md`), zero errors in any file this branch touches. Re-running the same
  narrow typecheck post-rebase on this host (load ~24-30 on 12 cores) — result will be added to
  this PR/issue once it completes; not blocking PR-open per the ticket's "hold for approval, not
  gated on full clean CI" instruction.

### Rebase mechanics

- Cherry-picked the 7 commits unique to `rbr974-global-run-admission` (base `75d915b328`) onto
  current `origin/master`. Two commits touched `server/src/services/heartbeat.ts` and conflicted
  with unrelated master changes (import ordering, an unrelated extraction in the same function);
  both resolved by hand, preserving both sides' logic (git-credentials re-export +
  run-admission import; RBR-932's pause/terminate-race guard is untouched — this branch's changes
  land in a different function).
  - `fbd14d2b4a` — instance-wide agent-run admission control
  - `442de84d07` — forward-progress escape valve for external host load
  - `c71c44adcf` — verification report and open decisions for CEO
  - `cc51b02bd6` — extract admitAndClaimQueuedRuns from the lock closure
  - `8aee12ddef` — record typecheck results and the remaining verification gap
  - `45317e61a5` — test the global admission lock and the concurrent-dispatch ceiling
  - `25c80320e6` — record A/B baseline proving the integration failure is pre-existing

### Do NOT merge yet

Per RBR-974 and RBR-1045: **hold this PR open** until RBR-974's board confirmation
(`534bd467-93ad-4205-a575-ecd643b05d92`) is accepted. Merging enables dispatch-path behaviour
instance-wide and requires a restart of `paperclipai run`. Neither has happened as part of this
PR.

Refs: RBR-974, RBR-1045
