### PR TITLE
fix: skip productivity reviews for paused and zero-run issues

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -482,7 +482,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listProductivityReviews(seeded.companyId)).toHaveLength(4);
   });
 
-  it("creates a long-active review without enabling a continuation hold", async () => {
+  it("does not create a long-active review for a stale zero-run issue", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue({
       status: "in_progress",
@@ -498,11 +498,30 @@ describeEmbeddedPostgres("productivity review service", () => {
       now,
     });
 
-    expect(result.created).toBe(1);
-    const [review] = await listProductivityReviews(seeded.companyId);
-    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
-    expect(review?.priority).toBe("medium");
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
     expect(hold.held).toBe(false);
+  });
+
+  it("does not create a productivity review for a paused assignee", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+    await db.update(agents).set({ status: "paused" }).where(eq(agents.id, seeded.coderId));
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -443,6 +443,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     thresholds: ProductivityReviewThresholds,
     now: Date,
   ): Promise<ProductivityReviewEvidence | null> {
+    // A paused/retired assignee has no actionable productivity signal.
+    if (!isAgentInvokable(sourceAgent)) return null;
+
     const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
     const sixHoursAgo = new Date(now.getTime() - 6 * 60 * 60 * 1000);
 
@@ -458,6 +461,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       )
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
       .limit(MAX_RUNS_FOR_STREAK);
+
+    // A stale in_progress timestamp without any issue-linked run is not an active episode.
+    if (latestRuns.length === 0) return null;
 
     const runIds = latestRuns.map((run) => run.id);
     const commentRunIds = new Set<string>();


### PR DESCRIPTION
## Problem
Paused agents and stale `in_progress` issues without issue-linked runs could still generate Productivity-Review work via the long-active path.

## Änderung
- skippt nicht aufrufbare Agents zentral in `collectEvidence()`
- skippt Quellen ohne issue-gebundenen Heartbeat-Run
- Regressionstests für beide Fälle

## Verifikation
- `pnpm exec vitest run server/src/__tests__/productivity-review-service.test.ts` — 16/16
- `pnpm --filter @paperclipai/server typecheck`

Cherry-picked und lokal gebaut auf Release-Basis `v2026.722.0`.