### PR TITLE
fix(test): contain Vitest processes and clean temp roots

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -247,6 +247,79 @@ pnpm test
 pnpm test:watch
 ```
 
+### Stable Vitest containment and cleanup
+
+`pnpm test` and the `test:run:*` shard commands run every Vitest child inside an
+invocation-owned boundary. On Linux the runner first attempts a delegated cgroup
+v2 child; installations without delegated cgroup access fall back to a new POSIX
+process group plus an inherited, random invocation tag. The tag lets teardown
+find detached grandchildren through `/proc` without matching command lines or
+signalling another concurrent Paperclip test. Windows uses the process-tree
+termination path available through `taskkill`; a native Job Object is not yet
+used. On non-Linux POSIX hosts, descendants that deliberately create a new
+session cannot be rediscovered after their direct parent exits, so process-group
+containment is the documented portable limit.
+
+Cleanup always stops new work, sends TERM to the complete owned boundary, waits
+for the configured grace period, sends KILL to verified survivors, confirms that
+the boundary is empty, checks every visible `/proc/*/cwd` and fd for references
+to the invocation root, and only then removes the root. PID start times are
+revalidated immediately before individual or process-group signalling so PID
+reuse fails closed. A failed post-suite invariant makes the command fail and
+leaves the root intact for safe operator inspection instead of deleting files
+still in use.
+
+On Linux, each invocation also starts a credential-free cleanup guardian outside
+the tagged boundary. If the stable-runner PID disappears through uncatchable
+`SIGKILL` or OOM, the guardian performs the same tag-scoped TERM/KILL, identity,
+root-reference, and deletion checks, then exits. Killing an entire service or
+container cgroup can also kill that guardian; in that case the outer service or
+container manager owns process cleanup, and an uncatchable whole-cgroup kill
+cannot promise filesystem cleanup from code that is no longer running.
+
+Configuration:
+
+- `PAPERCLIP_TEST_TMPDIR`: preferred parent for compact `pcvt-*` roots. Set this
+  to a directory on a dedicated data volume (for example a site-specific path
+  below `/srv`) without baking that host path into Paperclip. An absolute,
+  writable `TMPDIR` is the next choice; `os.tmpdir()` is the explicit fallback.
+- `PAPERCLIP_TEST_HOST_CAP` (default `2`): maximum stable runners across all
+  shards for the current OS user. Atomic host slots prevent independently
+  launched shards from bypassing this limit.
+- `PAPERCLIP_TEST_HOST_WAIT_MS` (default `1800000`): bounded wait for a host slot.
+- `PAPERCLIP_TEST_PROCESS_BUDGET` (default `256`): maximum live processes in one
+  invocation. Exceeding it fails with the invocation id, suite label, count, and
+  redacted process-family summary.
+- `PAPERCLIP_TEST_MAX_POSTGRES` (default `16`), `PAPERCLIP_TEST_MAX_SSH`
+  (default `16`), and `PAPERCLIP_TEST_MAX_MODEL_ADAPTERS` (default `64`):
+  per-invocation family caps within the total process budget.
+- `PAPERCLIP_TEST_GRACE_MS` (default `5000`): TERM grace before KILL.
+- `PAPERCLIP_TEST_TIMEOUT_MS`: optional per-Vitest-child timeout.
+- `PAPERCLIP_TEST_CONTROL_DIR`: optional location for the tiny host-slot records.
+
+Failed roots are deleted by default. Artifact retention is explicit and bounded:
+pass `--retain-failed` (or set `PAPERCLIP_TEST_RETAIN_FAILED=1`) and optionally
+`--retained-limit=N` / `PAPERCLIP_TEST_RETAIN_LIMIT=N` (default `3`). Retention
+only happens after owned processes are dead and root-reference guards pass.
+
+Inspect live invocation records without exposing command arguments, environment
+values, adapter tokens, or MCP headers:
+
+```sh
+pnpm test:diagnose
+```
+
+The report lists invocation ids, suite labels, containment modes, process-family
+counts, root-reference counts, and deleted-CWD indicators. Start, cleanup, and
+stop records use structured JSON and include peak descendants, cleanup duration,
+TERM/KILL counts, and any retained-artifact reason.
+
+After an outer service/container kill that also killed the Linux guardian, an
+operator may safely reclaim only reported stale, empty, unreferenced roots with
+`node scripts/run-vitest-stable.mjs --diagnose --reap-stale`. The command refuses
+roots with a live tagged process, any visible cwd/fd reference, a live original
+runner identity, or a path outside the selected temp parent.
+
 Browser suites stay separate:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:run": "pnpm run preflight:workspace-links && node scripts/run-vitest-stable.mjs",
     "test:run:general": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode general",
     "test:run:serialized": "pnpm run preflight:workspace-links && pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && node scripts/run-vitest-stable.mjs --mode serialized",
+    "test:diagnose": "node scripts/run-vitest-stable.mjs --diagnose",
     "db:generate": "pnpm --filter @paperclipai/db generate",
     "db:migrate": "pnpm --filter @paperclipai/db migrate",
     "issue-references:backfill": "pnpm run preflight:workspace-links && tsx scripts/backfill-issue-reference-mentions.ts",

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1123,6 +1123,31 @@ async function isSshEnvLabFixtureProcess(state: Pick<SshEnvLabFixtureState, "pid
   return command.includes(state.sshdConfigPath);
 }
 
+async function stopOwnedSshEnvLabFixtureProcess(
+  state: Pick<SshEnvLabFixtureState, "pid" | "sshdConfigPath">,
+): Promise<void> {
+  if (!(await isSshEnvLabFixtureProcess(state))) return;
+  process.kill(state.pid, "SIGTERM");
+  try {
+    await waitForCondition(async () => {
+      if (await isSshEnvLabFixtureProcess(state)) {
+        throw new Error("SSH fixture process is still running.");
+      }
+    }, { timeoutMs: 5_000, intervalMs: 100 });
+    return;
+  } catch {
+    // Revalidate the command identity before escalation so PID reuse fails closed.
+    if (!(await isSshEnvLabFixtureProcess(state))) return;
+  }
+
+  process.kill(state.pid, "SIGKILL");
+  await waitForCondition(async () => {
+    if (await isSshEnvLabFixtureProcess(state)) {
+      throw new Error("SSH fixture process is still running after SIGKILL.");
+    }
+  }, { timeoutMs: 2_000, intervalMs: 50 });
+}
+
 export async function getSshEnvLabSupport(): Promise<SshEnvLabSupport> {
   if (process.platform === "darwin" && process.env.PAPERCLIP_ENABLE_DARWIN_SSH_ENV_LAB !== "1") {
     return {
@@ -1685,14 +1710,7 @@ export async function stopSshEnvLabFixture(statePath: string): Promise<boolean> 
   const state = await readSshEnvLabFixtureState(statePath);
   if (!state) return false;
 
-  if (await isSshEnvLabFixtureProcess(state)) {
-    process.kill(state.pid, "SIGTERM");
-    await waitForCondition(async () => {
-      if (await isSshEnvLabFixtureProcess(state)) {
-        throw new Error("SSH fixture process is still running.");
-      }
-    }, { timeoutMs: 5_000, intervalMs: 100 });
-  }
+  await stopOwnedSshEnvLabFixtureProcess(state);
 
   await fs.rm(state.rootDir, { recursive: true, force: true }).catch(() => undefined);
   return true;
@@ -1823,9 +1841,7 @@ export async function startSshEnvLabFixture(input: {
     await fs.writeFile(input.statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
     return state;
   } catch (error) {
-    if (await isPidRunning(state.pid)) {
-      process.kill(state.pid, "SIGTERM");
-    }
+    await stopOwnedSshEnvLabFixtureProcess(state);
     await fs.rm(rootDir, { recursive: true, force: true }).catch(() => undefined);
     throw error;
   }

--- a/packages/adapter-utils/src/test-support/fixture-supervisor.test.ts
+++ b/packages/adapter-utils/src/test-support/fixture-supervisor.test.ts
@@ -1,0 +1,46 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { FixtureSupervisor, withFixtureSupervisor } from "./fixture-supervisor.js";
+
+describe("FixtureSupervisor", () => {
+  it("cleans partial setup in process-before-root order and remains idempotent", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-fixture-supervisor-"));
+    const root = path.join(parent, "root");
+    await fs.mkdir(root);
+    let childPid: number | undefined;
+
+    await expect(
+      withFixtureSupervisor({ owner: "partial-setup" }, async (fixtures) => {
+        fixtures.registerRoot(root);
+        const child = spawn(process.execPath, ["-e", "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)"], {
+          cwd: root,
+          detached: process.platform !== "win32",
+          stdio: "ignore",
+        });
+        childPid = child.pid;
+        fixtures.registerProcess(child, {
+          label: "partial child",
+          processGroupId: process.platform === "win32" ? null : child.pid,
+        });
+        throw new Error("setup failed");
+      }),
+    ).rejects.toThrow("setup failed");
+
+    await expect(fs.access(root)).rejects.toThrow();
+    const stoppedPid = childPid;
+    if (stoppedPid) expect(() => process.kill(stoppedPid, 0)).toThrow();
+    await fs.rm(parent, { recursive: true, force: true });
+  });
+
+  it("enforces a per-fixture process budget", () => {
+    const fixtures = new FixtureSupervisor({ owner: "budgeted", maxProcesses: 1 });
+    const fakeChild = { exitCode: 0, signalCode: null } as never;
+    fixtures.registerProcess(fakeChild, { label: "first" });
+    expect(() => fixtures.registerProcess(fakeChild, { label: "second" })).toThrow(
+      /Fixture process budget exceeded for budgeted: 2\/1/,
+    );
+  });
+});

--- a/packages/adapter-utils/src/test-support/fixture-supervisor.ts
+++ b/packages/adapter-utils/src/test-support/fixture-supervisor.ts
@@ -1,0 +1,157 @@
+import type { ChildProcess } from "node:child_process";
+import { promises as fs } from "node:fs";
+
+type FixtureProcess = {
+  child: ChildProcess;
+  label: string;
+  processGroupId: number | null;
+  graceMs: number;
+};
+
+export type FixtureSupervisorOptions = {
+  owner: string;
+  maxProcesses?: number;
+};
+
+function isRunning(child: ChildProcess): boolean {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+function signalFixtureProcess(record: FixtureProcess, signal: NodeJS.Signals): void {
+  if (!isRunning(record.child)) return;
+  if (process.platform !== "win32" && record.processGroupId && record.processGroupId > 0) {
+    try {
+      process.kill(-record.processGroupId, signal);
+      return;
+    } catch {
+      // The direct ChildProcess handle remains the safe portable fallback.
+    }
+  }
+  record.child.kill(signal);
+}
+
+async function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (!isRunning(child)) return true;
+  return await new Promise<boolean>((resolve) => {
+    const onClose = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      child.removeListener("close", onClose);
+      resolve(false);
+    }, timeoutMs);
+    timer.unref?.();
+    child.once("close", onClose);
+    if (!isRunning(child)) {
+      child.removeListener("close", onClose);
+      clearTimeout(timer);
+      resolve(true);
+    }
+  });
+}
+
+/**
+ * Idempotent teardown registry for process-heavy tests.
+ *
+ * Register roots as soon as they are created and processes as soon as spawn
+ * succeeds. Teardown always drains processes before removing roots, including
+ * when setup throws part way through. The stable Vitest invocation supervisor
+ * remains the outer crash/timeout boundary when Vitest hooks cannot run.
+ */
+export class FixtureSupervisor {
+  readonly owner: string;
+  readonly maxProcesses: number;
+  readonly processes: FixtureProcess[] = [];
+  readonly roots = new Set<string>();
+  readonly cleanups: Array<() => Promise<void> | void> = [];
+  private teardownPromise: Promise<void> | null = null;
+
+  constructor(options: FixtureSupervisorOptions) {
+    this.owner = options.owner;
+    this.maxProcesses = options.maxProcesses ?? 16;
+  }
+
+  registerRoot(root: string): string {
+    this.roots.add(root);
+    return root;
+  }
+
+  registerProcess(
+    child: ChildProcess,
+    options: { label: string; processGroupId?: number | null; graceMs?: number },
+  ): ChildProcess {
+    if (this.processes.length >= this.maxProcesses) {
+      signalFixtureProcess(
+        {
+          child,
+          label: options.label,
+          processGroupId: options.processGroupId ?? null,
+          graceMs: options.graceMs ?? 2_000,
+        },
+        "SIGKILL",
+      );
+      throw new Error(
+        `Fixture process budget exceeded for ${this.owner}: ` +
+          `${this.processes.length + 1}/${this.maxProcesses} while registering ${options.label}.`,
+      );
+    }
+    this.processes.push({
+      child,
+      label: options.label,
+      processGroupId: options.processGroupId ?? null,
+      graceMs: options.graceMs ?? 2_000,
+    });
+    return child;
+  }
+
+  registerCleanup(cleanup: () => Promise<void> | void): void {
+    this.cleanups.push(cleanup);
+  }
+
+  async teardown(): Promise<void> {
+    if (this.teardownPromise) return this.teardownPromise;
+    this.teardownPromise = this.teardownOnce();
+    return this.teardownPromise;
+  }
+
+  private async teardownOnce(): Promise<void> {
+    const failures: string[] = [];
+    for (const record of [...this.processes].reverse()) {
+      if (!isRunning(record.child)) continue;
+      signalFixtureProcess(record, "SIGTERM");
+      if (!(await waitForExit(record.child, record.graceMs))) {
+        signalFixtureProcess(record, "SIGKILL");
+        if (!(await waitForExit(record.child, Math.max(1_000, Math.floor(record.graceMs / 2))))) {
+          failures.push(`${record.label} did not exit after SIGKILL`);
+        }
+      }
+    }
+    for (const cleanup of [...this.cleanups].reverse()) {
+      try {
+        await cleanup();
+      } catch (error) {
+        failures.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(`Fixture teardown failed for ${this.owner}: ${failures.join("; ")}`);
+    }
+    for (const root of [...this.roots].reverse()) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }
+}
+
+export async function withFixtureSupervisor<T>(
+  options: FixtureSupervisorOptions,
+  setup: (supervisor: FixtureSupervisor) => Promise<T>,
+): Promise<T> {
+  const supervisor = new FixtureSupervisor(options);
+  try {
+    return await setup(supervisor);
+  } catch (error) {
+    await supervisor.teardown();
+    throw error;
+  }
+}

--- a/packages/adapters/claude-local/src/server/acp.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AdapterExecutionContext, AdapterInvocationMeta } from "@paperclipai/adapter-utils";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import { FixtureSupervisor } from "@paperclipai/adapter-utils/test-support/fixture-supervisor";
 import {
   buildClaudeAcpConfig,
   createClaudeAcpExecutor,
@@ -63,7 +64,7 @@ type FakeRuntimeTurn = {
   closeStream: () => Promise<void>;
 };
 
-const tempRoots: string[] = [];
+let fixtures: FixtureSupervisor;
 const originalNodeVersion = process.version;
 const originalEnv: Record<string, string | undefined> = {
   PAPERCLIP_HOME: process.env.PAPERCLIP_HOME,
@@ -79,13 +80,17 @@ function setNodeVersion(version: string): void {
   });
 }
 
+beforeEach(() => {
+  fixtures = new FixtureSupervisor({ owner: "Claude ACP tests" });
+});
+
 afterEach(async () => {
   setNodeVersion(originalNodeVersion);
   for (const [key, value] of Object.entries(originalEnv)) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
-  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  await fixtures.teardown();
 });
 
 class FakeRuntime {
@@ -178,7 +183,7 @@ class FakeRuntime {
 
 async function makeTempRoot(prefix: string) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempRoots.push(root);
+  fixtures.registerRoot(root);
   return root;
 }
 

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AdapterExecutionContext, AdapterInvocationMeta } from "@paperclipai/adapter-utils";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import { FixtureSupervisor } from "@paperclipai/adapter-utils/test-support/fixture-supervisor";
 import {
   buildCodexAcpConfig,
   createCodexAcpExecutor,
@@ -63,7 +64,7 @@ type FakeRuntimeTurn = {
   closeStream: () => Promise<void>;
 };
 
-const tempRoots: string[] = [];
+let fixtures: FixtureSupervisor;
 const originalNodeVersion = process.version;
 const originalPaperclipHome = process.env.PAPERCLIP_HOME;
 const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
@@ -111,6 +112,10 @@ function setNodeVersion(version: string): void {
   });
 }
 
+beforeEach(() => {
+  fixtures = new FixtureSupervisor({ owner: "codex ACP tests" });
+});
+
 afterEach(async () => {
   setNodeVersion(originalNodeVersion);
   if (originalPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
@@ -121,7 +126,7 @@ afterEach(async () => {
   else process.env.CODEX_HOME = originalCodexHome;
   if (originalOpenAiApiKey === undefined) delete process.env.OPENAI_API_KEY;
   else process.env.OPENAI_API_KEY = originalOpenAiApiKey;
-  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  await fixtures.teardown();
 });
 
 class FakeRuntime {
@@ -214,7 +219,7 @@ class FakeRuntime {
 
 async function makeTempRoot(prefix: string) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempRoots.push(root);
+  fixtures.registerRoot(root);
   process.env.PAPERCLIP_HOME = path.join(root, "paperclip-home");
   process.env.PAPERCLIP_INSTANCE_ID = "test";
   return root;

--- a/packages/adapters/gemini-local/src/server/acp.test.ts
+++ b/packages/adapters/gemini-local/src/server/acp.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AdapterExecutionContext, AdapterInvocationMeta } from "@paperclipai/adapter-utils";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import { FixtureSupervisor } from "@paperclipai/adapter-utils/test-support/fixture-supervisor";
 import {
   buildGeminiAcpConfig,
   createGeminiAcpExecutor,
@@ -62,7 +63,7 @@ type FakeRuntimeTurn = {
   closeStream: () => Promise<void>;
 };
 
-const tempRoots: string[] = [];
+let fixtures: FixtureSupervisor;
 const originalNodeVersion = process.version;
 const originalPath = process.env.PATH;
 const originalHome = process.env.HOME;
@@ -76,6 +77,10 @@ function setNodeVersion(version: string): void {
   });
 }
 
+beforeEach(() => {
+  fixtures = new FixtureSupervisor({ owner: "Gemini ACP tests" });
+});
+
 afterEach(async () => {
   setNodeVersion(originalNodeVersion);
   if (originalPath === undefined) delete process.env.PATH;
@@ -84,7 +89,7 @@ afterEach(async () => {
   else process.env.HOME = originalHome;
   if (originalGeminiApiKey === undefined) delete process.env.GEMINI_API_KEY;
   else process.env.GEMINI_API_KEY = originalGeminiApiKey;
-  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+  await fixtures.teardown();
 });
 
 class FakeRuntime {
@@ -177,7 +182,7 @@ class FakeRuntime {
 
 async function makeTempRoot(prefix: string) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempRoots.push(root);
+  fixtures.registerRoot(root);
   return root;
 }
 

--- a/packages/adapters/hermes/src/server/paperclip-task-bridge.test.ts
+++ b/packages/adapters/hermes/src/server/paperclip-task-bridge.test.ts
@@ -3,10 +3,12 @@ import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FixtureSupervisor } from "@paperclipai/adapter-utils/test-support/fixture-supervisor";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const helperPath = path.resolve(__dirname, "../../skills/paperclip-task-bridge/paperclip-task.mjs");
 const apiKey = "pc_test_secret_should_not_print";
+let fixtures: FixtureSupervisor;
 
 type RequestRecord = {
   method: string;
@@ -24,6 +26,7 @@ function runHelper(args: string[], env: Record<string, string>) {
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
+    fixtures.registerProcess(child, { label: "Hermes task bridge helper" });
     let stdout = "";
     let stderr = "";
     child.stdout.setEncoding("utf8");
@@ -45,6 +48,7 @@ describe("paperclip-task-bridge helper", () => {
   let requests: RequestRecord[];
 
   beforeEach(async () => {
+    fixtures = new FixtureSupervisor({ owner: "Hermes task bridge tests" });
     requests = [];
     server = http.createServer(async (req, res) => {
       let raw = "";
@@ -126,6 +130,7 @@ describe("paperclip-task-bridge helper", () => {
   });
 
   afterEach(async () => {
+    await fixtures.teardown();
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
     });

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -202,10 +202,12 @@ test("active cwd guard prevents premature root deletion", { skip: process.platfo
   });
   t.after(() => holder.kill("SIGKILL"));
   await waitFor(async () => (await findRootReferences(run.root)).some((reference) => reference.pid === holder.pid));
-  await assert.rejects(run.cleanup(), /active_root_reference/);
+  await assert.rejects(run.cleanup({ retainReason: "test_failure" }), /active_root_reference/);
+  assert.equal(run.root.startsWith(path.join(parent, "pcvt-retained-")), false);
   holder.kill("SIGKILL");
   await new Promise((resolve) => holder.once("close", resolve));
-  await run.stopGuardian();
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.removed, true);
 });
 
 test("host-wide slots enforce the configured cap", async (t) => {
@@ -219,6 +221,50 @@ test("host-wide slots enforce the configured cap", async (t) => {
   await first.release();
   const second = await acquireHostSlot({ invocationId: "slot-second", env, cap: 1, waitMs: 1_000 });
   await second.release();
+});
+
+test("concurrent stale-slot reapers cannot remove a replacement owner", async (t) => {
+  const parent = await withTempParent(t);
+  const control = path.join(parent, "control");
+  const slot = path.join(control, "slot-0");
+  await fs.mkdir(slot, { recursive: true });
+  await fs.writeFile(
+    path.join(slot, "owner.json"),
+    `${JSON.stringify({ invocationId: "stale", pid: 2_000_000_000, startTime: "missing" })}\n`,
+  );
+  const env = { PAPERCLIP_TEST_CONTROL_DIR: control };
+  const attempts = await Promise.allSettled([
+    acquireHostSlot({ invocationId: "replacement-first", env, cap: 1, waitMs: 300 }),
+    acquireHostSlot({ invocationId: "replacement-second", env, cap: 1, waitMs: 300 }),
+  ]);
+  const acquired = attempts.filter((attempt) => attempt.status === "fulfilled");
+  const rejected = attempts.filter((attempt) => attempt.status === "rejected");
+  assert.equal(acquired.length, 1);
+  assert.equal(rejected.length, 1);
+  assert.match(rejected[0].reason.message, /host slot/);
+  await acquired[0].value.release();
+});
+
+test("an existing stale-slot reaper lock fails closed", async (t) => {
+  const parent = await withTempParent(t);
+  const control = path.join(parent, "control");
+  const slot = path.join(control, "slot-0");
+  await fs.mkdir(slot, { recursive: true });
+  await fs.writeFile(
+    path.join(slot, "owner.json"),
+    `${JSON.stringify({ invocationId: "stale", pid: 2_000_000_000, startTime: "missing" })}\n`,
+  );
+  await fs.mkdir(path.join(control, ".slot-0-reaper"));
+  await assert.rejects(
+    acquireHostSlot({
+      invocationId: "replacement",
+      env: { PAPERCLIP_TEST_CONTROL_DIR: control },
+      cap: 1,
+      waitMs: 150,
+    }),
+    /host slot/,
+  );
+  assert.equal(JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8")).invocationId, "stale");
 });
 
 test("stale-root recovery only reaps an empty unreferenced dead-runner record", { skip: process.platform !== "linux" }, async (t) => {

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -210,6 +210,21 @@ test("active cwd guard prevents premature root deletion", { skip: process.platfo
   assert.equal(cleanup.removed, true);
 });
 
+test("cleanup waits for transient root references to drain", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const run = supervisor(parent, "transient-cwd-reference", { graceMs: 1_000 });
+  await run.initialize();
+  const holder = spawn(process.execPath, ["-e", "setTimeout(()=>process.exit(0),150)"], {
+    cwd: run.root,
+    stdio: "ignore",
+  });
+  t.after(() => holder.kill("SIGKILL"));
+  await waitFor(async () => (await findRootReferences(run.root)).some((reference) => reference.pid === holder.pid));
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.removed, true);
+  assert.deepEqual(cleanup.references, []);
+});
+
 test("host-wide slots enforce the configured cap", async (t) => {
   const parent = await withTempParent(t);
   const env = { PAPERCLIP_TEST_CONTROL_DIR: path.join(parent, "control") };

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  VitestInvocationSupervisor,
+  acquireHostSlot,
+  diagnoseStableInvocations,
+  findRootReferences,
+  listTaggedProcesses,
+  readLinuxProcessIdentity,
+  reapStaleStableInvocations,
+  resolveTestTempParent,
+  signalProcessIdentity,
+} from "../vitest-supervisor.mjs";
+
+const scratchParent = process.env.PAPERCLIP_RUN_SCRATCH_DIR || os.tmpdir();
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const stableRunner = path.join(repoRoot, "scripts", "run-vitest-stable.mjs");
+
+async function withTempParent(t) {
+  const parent = await fs.mkdtemp(path.join(scratchParent, "pcvt-supervisor-test-"));
+  t.after(() => fs.rm(parent, { recursive: true, force: true }));
+  return parent;
+}
+
+function supervisor(parent, label, overrides = {}) {
+  return new VitestInvocationSupervisor({
+    label,
+    tempParent: parent,
+    graceMs: 300,
+    disableCgroup: true,
+    ...overrides,
+  });
+}
+
+async function waitFor(predicate, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`condition not met within ${timeoutMs}ms`);
+}
+
+test("configured PAPERCLIP_TEST_TMPDIR is preferred and created", async (t) => {
+  const parent = await withTempParent(t);
+  const configured = path.join(parent, "configured");
+  const resolved = await resolveTestTempParent({ PAPERCLIP_TEST_TMPDIR: configured, TMPDIR: "/unused" });
+  assert.equal(resolved.parent, configured);
+  assert.equal(resolved.source, "PAPERCLIP_TEST_TMPDIR");
+});
+
+test("an unsafe configured temp parent falls back to an absolute TMPDIR", async (t) => {
+  const parent = await withTempParent(t);
+  const resolved = await resolveTestTempParent({ PAPERCLIP_TEST_TMPDIR: "relative/path", TMPDIR: parent });
+  assert.equal(resolved.parent, parent);
+  assert.equal(resolved.source, "TMPDIR");
+});
+
+test("successful and nonzero children both leave no root", async (t) => {
+  const parent = await withTempParent(t);
+  for (const exitCode of [0, 7]) {
+    const run = supervisor(parent, `exit-${exitCode}`);
+    const result = await run.run(process.execPath, ["-e", `process.exit(${exitCode})`]);
+    assert.equal(result.code, exitCode);
+    const root = run.root;
+    const cleanup = await run.cleanup();
+    assert.equal(cleanup.removed, true);
+    assert.equal(run.containmentMode, "posix-process-group+tagged-proc");
+    await assert.rejects(fs.access(root));
+  }
+});
+
+test("child spawn errors still clean the invocation root", async (t) => {
+  const parent = await withTempParent(t);
+  const run = supervisor(parent, "spawn-error");
+  await assert.rejects(run.run(path.join(parent, "missing-command"), []), /ENOENT/);
+  const root = run.root;
+  await run.cleanup();
+  await assert.rejects(fs.access(root));
+});
+
+test("explicit failed-artifact retention stays bounded", async (t) => {
+  const parent = await withTempParent(t);
+  for (let index = 0; index < 2; index += 1) {
+    const run = supervisor(parent, `retained-${index}`);
+    await run.run(process.execPath, ["-e", "process.exit(1)"]);
+    const cleanup = await run.cleanup({ retainReason: "test_failure", retainedLimit: 1 });
+    assert.equal(cleanup.removed, false);
+  }
+  const retained = (await fs.readdir(parent)).filter((entry) => entry.startsWith("pcvt-retained-"));
+  assert.equal(retained.length, 1);
+});
+
+test("timeout drains a cooperative detached descendant with TERM only", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{detached:true,stdio:'ignore'})`,
+    "child.unref()",
+    "process.on('SIGTERM',()=>process.exit(0))",
+    "setInterval(()=>{},1000)",
+  ].join(";");
+  const run = supervisor(parent, "cooperative-timeout", { timeoutMs: 120, graceMs: 1_000 });
+  const result = await run.run(process.execPath, ["-e", parentCode]);
+  assert.equal(result.stopReason, "timeout_after_120ms");
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+  assert.equal(run.killCount, 0);
+});
+
+test("SIGTERM-ignoring detached descendants are force-killed", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{detached:true,stdio:'ignore'})`,
+    "child.unref()",
+    "process.on('SIGTERM',()=>{})",
+    "setInterval(()=>{},1000)",
+  ].join(";");
+  const run = supervisor(parent, "forced-timeout", { timeoutMs: 120, graceMs: 150 });
+  const result = await run.run(process.execPath, ["-e", parentCode]);
+  assert.equal(result.stopReason, "timeout_after_120ms");
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+  assert.ok(run.killCount >= 1);
+});
+
+test("a descendant process budget breach fails with scoped diagnostics", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{detached:true,stdio:'ignore'})`,
+    "child.unref()",
+    "setInterval(()=>{},1000)",
+  ].join(";");
+  const run = supervisor(parent, "budget-owner.test.ts", { processBudget: 1, graceMs: 200 });
+  await assert.rejects(
+    run.run(process.execPath, ["-e", parentCode]),
+    new RegExp(`Process budget exceeded for invocation ${run.invocationId} \\(budget-owner\\.test\\.ts\\)`),
+  );
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+});
+
+test("a detached grandchild is reaped after its direct parent exits", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{detached:true,stdio:'ignore'})`,
+    "child.unref()",
+  ].join(";");
+  const run = supervisor(parent, "detached-grandchild");
+  const result = await run.run(process.execPath, ["-e", parentCode]);
+  assert.equal(result.code, 0);
+  assert.ok((await run.ownedProcesses()).length >= 1);
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+});
+
+test("concurrent invocation boundaries cannot signal one another", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const code = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";
+  const first = supervisor(parent, "concurrent-first");
+  const second = supervisor(parent, "concurrent-second");
+  const firstRun = first.run(process.execPath, ["-e", code]);
+  const secondRun = second.run(process.execPath, ["-e", code]);
+  await waitFor(() => first.child?.pid && second.child?.pid);
+  first.requestStop("test_stop_first");
+  await firstRun;
+  await first.cleanup();
+  assert.ok((await second.ownedProcesses()).length >= 1);
+  second.requestStop("test_stop_second");
+  await secondRun;
+  await second.cleanup();
+});
+
+test("PID identity mismatch fails closed", { skip: process.platform !== "linux" }, async () => {
+  const identity = await readLinuxProcessIdentity(process.pid);
+  assert.ok(identity);
+  const outcome = await signalProcessIdentity({ ...identity, startTime: `${identity.startTime}-reused` }, "SIGTERM");
+  assert.equal(outcome, "identity_mismatch");
+});
+
+test("active cwd guard prevents premature root deletion", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const run = supervisor(parent, "cwd-guard");
+  await run.initialize();
+  const holder = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
+    cwd: run.root,
+    stdio: "ignore",
+  });
+  t.after(() => holder.kill("SIGKILL"));
+  await waitFor(async () => (await findRootReferences(run.root)).some((reference) => reference.pid === holder.pid));
+  await assert.rejects(run.cleanup(), /active_root_reference/);
+  holder.kill("SIGKILL");
+  await new Promise((resolve) => holder.once("close", resolve));
+  await run.stopGuardian();
+});
+
+test("host-wide slots enforce the configured cap", async (t) => {
+  const parent = await withTempParent(t);
+  const env = { PAPERCLIP_TEST_CONTROL_DIR: path.join(parent, "control") };
+  const first = await acquireHostSlot({ invocationId: "slot-first", env, cap: 1, waitMs: 1_000 });
+  await assert.rejects(
+    acquireHostSlot({ invocationId: "slot-second", env, cap: 1, waitMs: 150 }),
+    /host slot/,
+  );
+  await first.release();
+  const second = await acquireHostSlot({ invocationId: "slot-second", env, cap: 1, waitMs: 1_000 });
+  await second.release();
+});
+
+test("stale-root recovery only reaps an empty unreferenced dead-runner record", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const run = supervisor(parent, "stale-recovery");
+  await run.initialize();
+  await run.stopGuardian();
+  const record = JSON.parse(await fs.readFile(run.registryPath, "utf8"));
+  await fs.writeFile(
+    run.registryPath,
+    `${JSON.stringify({ ...record, runnerPid: 2_000_000_000, runnerStartTime: "missing" })}\n`,
+  );
+  const report = await reapStaleStableInvocations({ env: { PAPERCLIP_TEST_TMPDIR: parent } });
+  assert.deepEqual(report.reaped, [run.invocationId]);
+  assert.deepEqual(report.refused, []);
+  await assert.rejects(fs.access(run.root));
+});
+
+test("diagnostics redact secret-bearing command arguments", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const secret = "super-secret-token-value";
+  const run = supervisor(parent, "redaction-check");
+  const running = run.run(process.execPath, ["-e", "setInterval(()=>{},1000)", "--", "--token", secret]);
+  await waitFor(() => run.child?.pid);
+  const report = await diagnoseStableInvocations({ env: { PAPERCLIP_TEST_TMPDIR: parent } });
+  assert.equal(JSON.stringify(report).includes(secret), false);
+  run.requestStop("redaction_test_done");
+  await running;
+  await run.cleanup();
+});
+
+test("parent SIGTERM drains the active boundary and does not launch the next suite", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const child = spawn(
+    process.execPath,
+    [stableRunner, "--mode", "serialized", "--shard-index", "0", "--shard-count", "64"],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PAPERCLIP_TEST_TMPDIR: parent,
+        PAPERCLIP_TEST_CONTROL_DIR: path.join(parent, "control"),
+        PAPERCLIP_TEST_HOST_CAP: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  let sentSignal = false;
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+    if (!sentSignal && stdout.includes('"event":"vitest_invocation_start"')) {
+      sentSignal = true;
+      child.kill("SIGTERM");
+    }
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  const exit = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  assert.deepEqual(exit, { code: 143, signal: null }, stderr);
+  assert.equal((stdout.match(/"event":"vitest_invocation_start"/g) ?? []).length, 1, stdout);
+  assert.equal((stdout.match(/"event":"vitest_invocation_cleanup"/g) ?? []).length, 1, stdout);
+  assert.match(stdout, /"rootRemoved":true/);
+  const roots = (await fs.readdir(parent)).filter((entry) => entry.startsWith("pcvt-") && !entry.startsWith("pcvt-retained-"));
+  assert.deepEqual(roots, []);
+});
+
+test("the guardian cleans descendants and roots after uncatchable parent SIGKILL", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const child = spawn(
+    process.execPath,
+    [stableRunner, "--mode", "serialized", "--shard-index", "0", "--shard-count", "64"],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PAPERCLIP_TEST_TMPDIR: parent,
+        PAPERCLIP_TEST_CONTROL_DIR: path.join(parent, "control"),
+        PAPERCLIP_TEST_HOST_CAP: "1",
+        PAPERCLIP_TEST_GRACE_MS: "500",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let invocationId = null;
+  let tempRoot = null;
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+    const line = stdout.split("\n").find((candidate) => candidate.includes('"event":"vitest_invocation_start"'));
+    if (!line || invocationId) return;
+    const record = JSON.parse(line.slice(line.indexOf("{")));
+    invocationId = record.invocationId;
+    tempRoot = record.tempRoot;
+    child.kill("SIGKILL");
+  });
+  const exit = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  assert.deepEqual(exit, { code: null, signal: "SIGKILL" });
+  assert.ok(invocationId && tempRoot, stdout);
+  await waitFor(async () => {
+    const rootGone = await fs.access(tempRoot).then(() => false, () => true);
+    return rootGone && (await listTaggedProcesses(invocationId)).length === 0;
+  }, 10_000);
+  await assert.rejects(fs.access(tempRoot));
+});
+
+test("twenty repeated contained runs return roots to baseline", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  for (let index = 0; index < 20; index += 1) {
+    const run = supervisor(parent, `stress-${index}`);
+    const result = await run.run(process.execPath, ["-e", "process.exit(0)"]);
+    assert.equal(result.code, 0);
+    await run.cleanup();
+  }
+  const roots = (await fs.readdir(parent)).filter((entry) => entry.startsWith("pcvt-"));
+  assert.deepEqual(roots, []);
+});

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -228,6 +228,28 @@ test("active cwd guard prevents premature root deletion", { skip: process.platfo
   assert.equal(cleanup.removed, true);
 });
 
+test("an invariant failure without a guardian keeps its recovery record", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const run = supervisor(parent, "unguarded-cwd-reference");
+  await run.initialize();
+  await run.stopGuardian();
+  const holder = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
+    cwd: run.root,
+    stdio: "ignore",
+  });
+  t.after(() => holder.kill("SIGKILL"));
+  await waitFor(async () => (await findRootReferences(run.root)).some((reference) => reference.pid === holder.pid));
+  await assert.rejects(run.cleanup(), /active_root_reference/);
+  await fs.access(run.registryPath);
+  const report = await diagnoseStableInvocations({ env: { PAPERCLIP_TEST_TMPDIR: parent } });
+  assert.ok(report.invocations.some((invocation) => invocation.invocationId === run.invocationId));
+  holder.kill("SIGKILL");
+  await new Promise((resolve) => holder.once("close", resolve));
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.removed, true);
+  await assert.rejects(fs.access(run.registryPath));
+});
+
 test("cleanup waits for transient root references to drain", { skip: process.platform !== "linux" }, async (t) => {
   const parent = await withTempParent(t);
   const run = supervisor(parent, "transient-cwd-reference", { graceMs: 1_000 });

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -186,6 +186,44 @@ test("an untagged process-group descendant is reaped after its parent exits", { 
   assert.equal(cleanup.survivors.length, 0);
 });
 
+test("an observed detached descendant is reaped after losing its parent and tag", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{detached:true,env:{},stdio:'ignore'})`,
+    "child.unref()",
+    "setTimeout(()=>process.exit(0),500)",
+  ].join(";");
+  const run = supervisor(parent, "observed-detached-descendant");
+  const result = await run.run(process.execPath, ["-e", parentCode]);
+  assert.equal(result.code, 0);
+  const owned = await run.ownedProcesses();
+  assert.equal(owned.length, 1);
+  assert.notEqual(owned[0].processGroupId, run.processGroupId);
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+});
+
+test("a root-scoped detached descendant is reaped without an invocation tag", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{detached:true,env:{TMPDIR:process.env.TMPDIR},stdio:'ignore'})`,
+    "child.unref()",
+  ].join(";");
+  const run = supervisor(parent, "root-scoped-detached-descendant");
+  const result = await run.run(process.execPath, ["-e", parentCode]);
+  assert.equal(result.code, 0);
+  const owned = await run.ownedProcesses();
+  assert.equal(owned.length, 1);
+  assert.notEqual(owned[0].processGroupId, run.processGroupId);
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+  assert.equal(cleanup.removed, true);
+});
+
 test("concurrent invocation boundaries cannot signal one another", { skip: process.platform !== "linux" }, async (t) => {
   const parent = await withTempParent(t);
   const code = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -260,7 +260,7 @@ test("concurrent stale-slot reapers cannot remove a replacement owner", async (t
   await acquired[0].value.release();
 });
 
-test("an existing stale-slot reaper lock fails closed", async (t) => {
+test("a reaper lock with an owner write in flight fails closed", async (t) => {
   const parent = await withTempParent(t);
   const control = path.join(parent, "control");
   const slot = path.join(control, "slot-0");
@@ -280,6 +280,71 @@ test("an existing stale-slot reaper lock fails closed", async (t) => {
     /host slot/,
   );
   assert.equal(JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8")).invocationId, "stale");
+});
+
+test("an abandoned reaper lock is quarantined before capacity is recovered", async (t) => {
+  const parent = await withTempParent(t);
+  const control = path.join(parent, "control");
+  const slot = path.join(control, "slot-0");
+  const reaperLock = path.join(control, ".slot-0-reaper");
+  await fs.mkdir(slot, { recursive: true });
+  await fs.writeFile(
+    path.join(slot, "owner.json"),
+    `${JSON.stringify({ invocationId: "stale", pid: 2_000_000_000, startTime: "missing" })}\n`,
+  );
+  await fs.mkdir(reaperLock);
+  await fs.writeFile(
+    path.join(reaperLock, "owner.json"),
+    `${JSON.stringify({
+      token: "abandoned-token",
+      pid: 2_000_000_000,
+      startTime: "missing",
+    })}\n`,
+  );
+  const replacement = await acquireHostSlot({
+    invocationId: "replacement",
+    env: { PAPERCLIP_TEST_CONTROL_DIR: control },
+    cap: 1,
+    waitMs: 1_000,
+  });
+  assert.equal(
+    JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8")).invocationId,
+    "replacement",
+  );
+  assert.equal(
+    JSON.parse(
+      await fs.readFile(path.join(`${reaperLock}-abandoned-abandoned-token`, "owner.json"), "utf8"),
+    ).token,
+    "abandoned-token",
+  );
+  await replacement.release();
+});
+
+test("an abandoned incomplete reaper lock is recovered after its write window", async (t) => {
+  const parent = await withTempParent(t);
+  const control = path.join(parent, "control");
+  const slot = path.join(control, "slot-0");
+  const reaperLock = path.join(control, ".slot-0-reaper");
+  await fs.mkdir(slot, { recursive: true });
+  await fs.writeFile(
+    path.join(slot, "owner.json"),
+    `${JSON.stringify({ invocationId: "stale", pid: 2_000_000_000, startTime: "missing" })}\n`,
+  );
+  await fs.mkdir(reaperLock);
+  const old = new Date(Date.now() - 10_000);
+  await fs.utimes(reaperLock, old, old);
+  const replacement = await acquireHostSlot({
+    invocationId: "replacement",
+    env: { PAPERCLIP_TEST_CONTROL_DIR: control },
+    cap: 1,
+    waitMs: 1_000,
+  });
+  const tombstone = (await fs.readdir(control)).find((entry) =>
+    entry.startsWith(".slot-0-reaper-abandoned-"),
+  );
+  assert.ok(tombstone);
+  assert.match(await fs.readFile(path.join(control, tombstone, "tombstone"), "utf8"), /\S/);
+  await replacement.release();
 });
 
 test("stale-root recovery only reaps an empty unreferenced dead-runner record", { skip: process.platform !== "linux" }, async (t) => {

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -168,6 +168,24 @@ test("a detached grandchild is reaped after its direct parent exits", { skip: pr
   assert.equal(cleanup.survivors.length, 0);
 });
 
+test("an untagged process-group descendant is reaped after its parent exits", { skip: process.platform !== "linux" }, async (t) => {
+  const parent = await withTempParent(t);
+  const childCode = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";
+  const parentCode = [
+    "const {spawn}=require('node:child_process')",
+    `const child=spawn(process.execPath,['-e',${JSON.stringify(childCode)}],{env:{},stdio:'ignore'})`,
+    "child.unref()",
+  ].join(";");
+  const run = supervisor(parent, "untagged-process-group-descendant");
+  const result = await run.run(process.execPath, ["-e", parentCode]);
+  assert.equal(result.code, 0);
+  const owned = await run.ownedProcesses();
+  assert.equal(owned.length, 1);
+  assert.equal(owned[0].processGroupId, run.processGroupId);
+  const cleanup = await run.cleanup();
+  assert.equal(cleanup.survivors.length, 0);
+});
+
 test("concurrent invocation boundaries cannot signal one another", { skip: process.platform !== "linux" }, async (t) => {
   const parent = await withTempParent(t);
   const code = "process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000)";

--- a/scripts/__tests__/vitest-supervisor.test.mjs
+++ b/scripts/__tests__/vitest-supervisor.test.mjs
@@ -242,12 +242,15 @@ test("diagnostics redact secret-bearing command arguments", { skip: process.plat
   const secret = "super-secret-token-value";
   const run = supervisor(parent, "redaction-check");
   const running = run.run(process.execPath, ["-e", "setInterval(()=>{},1000)", "--", "--token", secret]);
-  await waitFor(() => run.child?.pid);
-  const report = await diagnoseStableInvocations({ env: { PAPERCLIP_TEST_TMPDIR: parent } });
-  assert.equal(JSON.stringify(report).includes(secret), false);
-  run.requestStop("redaction_test_done");
-  await running;
-  await run.cleanup();
+  try {
+    await waitFor(() => run.child?.pid);
+    const report = await diagnoseStableInvocations({ env: { PAPERCLIP_TEST_TMPDIR: parent } });
+    assert.equal(JSON.stringify(report).includes(secret), false);
+  } finally {
+    run.requestStop("redaction_test_done");
+    await running;
+    await run.cleanup();
+  }
 });
 
 test("parent SIGTERM drains the active boundary and does not launch the next suite", { skip: process.platform !== "linux" }, async (t) => {

--- a/scripts/run-vitest-stable.mjs
+++ b/scripts/run-vitest-stable.mjs
@@ -1,10 +1,16 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readdirSync, statSync } from "node:fs";
-import os from "node:os";
+import { randomUUID } from "node:crypto";
+import { readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadShardDurations, selectGeneralServerShard } from "./general-server-shard.mjs";
+import {
+  VitestInvocationSupervisor,
+  acquireHostSlot,
+  diagnoseStableInvocations,
+  reapStaleStableInvocations,
+  resolveTestTempParent,
+} from "./vitest-supervisor.mjs";
 
 const repoRoot = process.cwd();
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
@@ -55,7 +61,11 @@ const additionalSerializedServerTests = new Set([
   "server/src/__tests__/redaction.test.ts",
   "server/src/__tests__/routines-e2e.test.ts",
 ]);
-let invocationIndex = 0;
+let executionOptions = null;
+let activeSupervisor = null;
+let requestedExitCode = null;
+let fatalError = null;
+const cancellation = new AbortController();
 const serializedModeName = "serialized";
 const generalModeName = "general";
 const allModeName = "all";
@@ -139,6 +149,13 @@ function parseCliOptions(argv) {
   let shardCount = null;
   let group = null;
   let dryRun = false;
+  let diagnose = false;
+  let reapStale = false;
+  let retainFailed = process.env.PAPERCLIP_TEST_RETAIN_FAILED === "1";
+  let retainedLimit = parsePositiveInteger(
+    process.env.PAPERCLIP_TEST_RETAIN_LIMIT ?? "3",
+    "PAPERCLIP_TEST_RETAIN_LIMIT",
+  );
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -181,6 +198,33 @@ function parseCliOptions(argv) {
 
     if (arg === "--dry-run") {
       dryRun = true;
+      continue;
+    }
+
+    if (arg === "--diagnose") {
+      diagnose = true;
+      continue;
+    }
+
+    if (arg === "--reap-stale") {
+      diagnose = true;
+      reapStale = true;
+      continue;
+    }
+
+    if (arg === "--retain-failed") {
+      retainFailed = true;
+      continue;
+    }
+
+    if (arg === "--retained-limit") {
+      retainedLimit = parsePositiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--retained-limit=")) {
+      retainedLimit = parsePositiveInteger(arg.slice("--retained-limit=".length), "--retained-limit");
       continue;
     }
 
@@ -236,6 +280,10 @@ function parseCliOptions(argv) {
       shardCount: shardCount ?? 1,
       group: null,
       dryRun,
+      diagnose,
+      reapStale,
+      retainFailed,
+      retainedLimit,
     };
   }
 
@@ -245,6 +293,10 @@ function parseCliOptions(argv) {
     shardCount,
     group,
     dryRun,
+    diagnose,
+    reapStale,
+    retainFailed,
+    retainedLimit,
   };
 }
 
@@ -252,48 +304,71 @@ function selectSerializedSuites(routeTests, shardIndex, shardCount) {
   return routeTests.filter((_, index) => index % shardCount === shardIndex);
 }
 
-function runVitest(args, label) {
+async function runVitest(args, label) {
+  if (cancellation.signal.aborted) {
+    throw cancellation.signal.reason ?? new Error("Stable test run cancelled.");
+  }
   console.log(`\n[test:run] ${label}`);
-  invocationIndex += 1;
-  const tempRootParent = process.platform === "win32" ? os.tmpdir() : "/tmp";
-  const testRoot = mkdtempSync(path.join(tempRootParent, `pcvt-${process.pid}-${invocationIndex}-`));
-  // Keep per-run paths compact so Unix socket fixtures stay under macOS path limits.
-  const env = {
-    ...process.env,
-    NODE_ENV: "test",
-    PAPERCLIP_HOME: path.join(testRoot, "h"),
-    PAPERCLIP_INSTANCE_ID: `vt-${process.pid}-${invocationIndex}`,
-    TMPDIR: path.join(testRoot, "t"),
-  };
-  mkdirSync(env.PAPERCLIP_HOME, { recursive: true });
-  mkdirSync(env.TMPDIR, { recursive: true });
-  const result = spawnSync("pnpm", ["exec", "vitest", "run", ...args], {
-    cwd: repoRoot,
-    env,
-    stdio: "inherit",
+  const temp = await resolveTestTempParent();
+  const supervisor = new VitestInvocationSupervisor({
+    invocationId: randomUUID(),
+    label,
+    tempParent: temp.parent,
+    tempSource: temp.source,
   });
+  activeSupervisor = supervisor;
+  let result = null;
+  let runError = null;
+  try {
+    result = await supervisor.run("pnpm", ["exec", "vitest", "run", ...args], { cwd: repoRoot });
+  } catch (error) {
+    runError = error;
+  } finally {
+    const failed = Boolean(runError || requestedExitCode !== null || result?.code !== 0 || result?.signal);
+    const retainReason = executionOptions.retainFailed && failed
+      ? runError
+        ? "runner_error"
+        : result?.signal
+          ? `child_signal_${result.signal}`
+          : `child_exit_${result?.code ?? "unknown"}`
+      : null;
+    try {
+      await supervisor.cleanup({ retainReason, retainedLimit: executionOptions.retainedLimit });
+    } catch (cleanupError) {
+      runError = cleanupError;
+    }
+    activeSupervisor = null;
+  }
+  if (runError) throw runError;
+  if (fatalError) throw fatalError;
+  if (requestedExitCode !== null) {
+    const error = new Error(`Stable test run cancelled (exit ${requestedExitCode}).`);
+    error.exitCode = requestedExitCode;
+    throw error;
+  }
   if (result.error) {
-    console.error(`[test:run] Failed to start Vitest: ${result.error.message}`);
-    process.exit(1);
+    throw new Error(`Failed to start Vitest: ${result.error.message}`);
   }
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+  if (result.code !== 0) {
+    const error = new Error(`Vitest exited with status ${result.code ?? 1}${result.signal ? ` (${result.signal})` : ""}.`);
+    error.exitCode = result.code ?? 1;
+    throw error;
   }
 }
 
-function runGeneralSuites(routeTests) {
+async function runGeneralSuites(routeTests) {
   for (const groupName of generalGroupNames) {
-    runGeneralGroup(routeTests, groupName);
+    await runGeneralGroup(routeTests, groupName);
   }
 }
 
-function runProjectGroup(projects, groupName) {
+async function runProjectGroup(projects, groupName) {
   for (const project of projects) {
-    runVitest(["--project", project], `${groupName} project ${project}`);
+    await runVitest(["--project", project], `${groupName} project ${project}`);
   }
 }
 
-function runGeneralGroup(routeTests, groupName, shardIndex = null, shardCount = null) {
+async function runGeneralGroup(routeTests, groupName, shardIndex = null, shardCount = null) {
   if (groupName === generalServerGroupName) {
     if (shardCount !== null && shardCount > 1) {
       const shardFiles = selectGeneralServerShard(
@@ -309,7 +384,7 @@ function runGeneralGroup(routeTests, groupName, shardIndex = null, shardCount = 
         return;
       }
 
-      runVitest(
+      await runVitest(
         [
           "--project",
           "@paperclipai/server",
@@ -322,7 +397,7 @@ function runGeneralGroup(routeTests, groupName, shardIndex = null, shardCount = 
     }
 
     const excludeRouteArgs = routeTests.flatMap((file) => ["--exclude", file.serverPath]);
-    runVitest(
+    await runVitest(
       [
         "--project",
         "@paperclipai/server",
@@ -335,26 +410,26 @@ function runGeneralGroup(routeTests, groupName, shardIndex = null, shardCount = 
   }
 
   if (groupName === generalWorkspacesAGroupName) {
-    runProjectGroup(generalWorkspacesAProjects, groupName);
+    await runProjectGroup(generalWorkspacesAProjects, groupName);
     return;
   }
 
   if (groupName === generalWorkspacesBGroupName) {
-    runProjectGroup(generalWorkspacesBProjects, groupName);
+    await runProjectGroup(generalWorkspacesBProjects, groupName);
     return;
   }
 
   fail(`Unknown group "${groupName}".`);
 }
 
-function runSerializedSuites(routeTests, shardIndex, shardCount) {
+async function runSerializedSuites(routeTests, shardIndex, shardCount) {
   const shardTests = selectSerializedSuites(routeTests, shardIndex, shardCount);
   console.log(
     `\n[test:run] serialized shard ${shardIndex + 1}/${shardCount} running ${shardTests.length} of ${routeTests.length} suites`,
   );
 
   for (const routeTest of shardTests) {
-    runVitest(
+    await runVitest(
       [
         "--project",
         "@paperclipai/server",
@@ -388,31 +463,31 @@ const generalServerTestFiles = walk(serverSrcDir)
   .filter((repoPath) => !isRouteOrAuthzTest(repoPath))
   .sort((a, b) => a.localeCompare(b));
 
-const options = parseCliOptions(process.argv.slice(2));
-if (options.dryRun) {
+executionOptions = parseCliOptions(process.argv.slice(2));
+if (executionOptions.dryRun) {
   const serializedSuites =
-    options.mode === serializedModeName
-      ? selectSerializedSuites(routeTests, options.shardIndex, options.shardCount)
+    executionOptions.mode === serializedModeName
+      ? selectSerializedSuites(routeTests, executionOptions.shardIndex, executionOptions.shardCount)
       : routeTests;
   console.log(
     JSON.stringify(
       {
-        mode: options.mode,
-        shardIndex: options.shardIndex,
-        shardCount: options.shardCount,
-        group: options.group,
+        mode: executionOptions.mode,
+        shardIndex: executionOptions.shardIndex,
+        shardCount: executionOptions.shardCount,
+        group: executionOptions.group,
         availableGeneralGroups: generalGroupNames,
         serializedSuiteCount: routeTests.length,
         selectedSerializedSuites: serializedSuites.map((routeTest) => routeTest.repoPath),
         generalServerSuiteCount: generalServerTestFiles.length,
         selectedGeneralServerSuites:
-          options.mode === generalModeName &&
-          options.group === generalServerGroupName &&
-          options.shardCount !== null
+          executionOptions.mode === generalModeName &&
+          executionOptions.group === generalServerGroupName &&
+          executionOptions.shardCount !== null
             ? selectGeneralServerShard(
                 generalServerTestFiles,
-                options.shardIndex,
-                options.shardCount,
+                executionOptions.shardIndex,
+                executionOptions.shardCount,
                 generalServerShardDurations,
               )
             : null,
@@ -424,14 +499,93 @@ if (options.dryRun) {
   process.exit(0);
 }
 
-if (options.mode === generalModeName || options.mode === allModeName) {
-  if (options.group) {
-    runGeneralGroup(routeTests, options.group, options.shardIndex, options.shardCount);
-  } else {
-    runGeneralSuites(routeTests);
-  }
+if (executionOptions.diagnose) {
+  console.log(
+    JSON.stringify(
+      executionOptions.reapStale
+        ? await reapStaleStableInvocations()
+        : await diagnoseStableInvocations(),
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
 }
 
-if (options.mode === serializedModeName || options.mode === allModeName) {
-  runSerializedSuites(routeTests, options.shardIndex ?? 0, options.shardCount ?? 1);
+function requestCancellation(reason, exitCode, error = null) {
+  requestedExitCode ??= exitCode;
+  fatalError ??= error;
+  if (!cancellation.signal.aborted) cancellation.abort(error ?? new Error(reason));
+  activeSupervisor?.requestStop(reason);
+}
+
+const signalHandlers = new Map([
+  ["SIGINT", () => requestCancellation("parent_SIGINT", 130)],
+  ["SIGTERM", () => requestCancellation("parent_SIGTERM", 143)],
+]);
+for (const [signal, handler] of signalHandlers) process.once(signal, handler);
+const uncaughtHandler = (error) => requestCancellation("uncaught_exception", 1, error);
+const rejectionHandler = (reason) => requestCancellation(
+  "unhandled_rejection",
+  1,
+  reason instanceof Error ? reason : new Error(String(reason)),
+);
+process.once("uncaughtException", uncaughtHandler);
+process.once("unhandledRejection", rejectionHandler);
+
+let hostSlot = null;
+try {
+  const stableRunId = randomUUID();
+  hostSlot = await acquireHostSlot({ invocationId: stableRunId, signal: cancellation.signal });
+  console.log(
+    `[test:run] ${JSON.stringify({
+      event: "vitest_stable_run_start",
+      stableRunId,
+      runnerPid: process.pid,
+      hostSlot: hostSlot.index,
+    })}`,
+  );
+  if (executionOptions.mode === generalModeName || executionOptions.mode === allModeName) {
+    if (executionOptions.group) {
+      await runGeneralGroup(
+        routeTests,
+        executionOptions.group,
+        executionOptions.shardIndex,
+        executionOptions.shardCount,
+      );
+    } else {
+      await runGeneralSuites(routeTests);
+    }
+  }
+
+  if (executionOptions.mode === serializedModeName || executionOptions.mode === allModeName) {
+    await runSerializedSuites(
+      routeTests,
+      executionOptions.shardIndex ?? 0,
+      executionOptions.shardCount ?? 1,
+    );
+  }
+} catch (error) {
+  console.error(`[test:run] ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = error?.exitCode ?? requestedExitCode ?? 1;
+} finally {
+  if (activeSupervisor) {
+    try {
+      await activeSupervisor.cleanup();
+    } catch (error) {
+      console.error(`[test:run] ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+    }
+  }
+  if (hostSlot) {
+    try {
+      await hostSlot.release();
+    } catch (error) {
+      console.error(`[test:run] Failed to release host slot: ${error instanceof Error ? error.message : String(error)}`);
+      process.exitCode = 1;
+    }
+  }
+  for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
+  process.removeListener("uncaughtException", uncaughtHandler);
+  process.removeListener("unhandledRejection", rejectionHandler);
 }

--- a/scripts/vitest-cleanup-guardian.mjs
+++ b/scripts/vitest-cleanup-guardian.mjs
@@ -2,7 +2,7 @@
 import { promises as fs } from "node:fs";
 import {
   findRootReferences,
-  listTaggedProcesses,
+  listInvocationProcesses,
   readLinuxProcessIdentity,
   signalProcessIdentity,
 } from "./vitest-supervisor.mjs";
@@ -31,16 +31,16 @@ async function ownerIsAlive() {
 
 async function waitForEmpty(waitMs) {
   const deadline = Date.now() + waitMs;
-  let processes = await listTaggedProcesses(invocationId);
+  let processes = await listInvocationProcesses(invocationId, root);
   while (processes.length > 0 && Date.now() < deadline) {
     await delay(100);
-    processes = await listTaggedProcesses(invocationId);
+    processes = await listInvocationProcesses(invocationId, root);
   }
   return processes;
 }
 
 async function signalAll(signal) {
-  const processes = await listTaggedProcesses(invocationId);
+  const processes = await listInvocationProcesses(invocationId, root);
   for (const identity of processes) await signalProcessIdentity(identity, signal);
 }
 
@@ -50,7 +50,8 @@ while (await ownerIsAlive()) {
 }
 
 // The owner disappeared without disarming us (including SIGKILL/OOM). Drain
-// only processes carrying this invocation's random inherited tag.
+// only processes carrying this invocation's random inherited tag or one of
+// its private root paths in the environment.
 await signalAll("SIGTERM");
 let survivors = await waitForEmpty(graceMs);
 if (survivors.length > 0) {

--- a/scripts/vitest-cleanup-guardian.mjs
+++ b/scripts/vitest-cleanup-guardian.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { promises as fs } from "node:fs";
+import {
+  findRootReferences,
+  listTaggedProcesses,
+  readLinuxProcessIdentity,
+  signalProcessIdentity,
+} from "./vitest-supervisor.mjs";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1] : null;
+  if (!value) throw new Error(`Missing ${name}.`);
+  return value;
+}
+
+const ownerPid = Number(argument("--owner-pid"));
+const ownerStartTime = argument("--owner-start-time");
+const invocationId = argument("--invocation-id");
+const root = argument("--root");
+const registryPath = argument("--registry");
+const stopPath = argument("--stop-file");
+const graceMs = Number(argument("--grace-ms"));
+
+async function ownerIsAlive() {
+  const identity = await readLinuxProcessIdentity(ownerPid);
+  return identity?.startTime === ownerStartTime;
+}
+
+async function waitForEmpty(waitMs) {
+  const deadline = Date.now() + waitMs;
+  let processes = await listTaggedProcesses(invocationId);
+  while (processes.length > 0 && Date.now() < deadline) {
+    await delay(100);
+    processes = await listTaggedProcesses(invocationId);
+  }
+  return processes;
+}
+
+async function signalAll(signal) {
+  const processes = await listTaggedProcesses(invocationId);
+  for (const identity of processes) await signalProcessIdentity(identity, signal);
+}
+
+while (await ownerIsAlive()) {
+  if (await fs.access(stopPath).then(() => true, () => false)) process.exit(0);
+  await delay(250);
+}
+
+// The owner disappeared without disarming us (including SIGKILL/OOM). Drain
+// only processes carrying this invocation's random inherited tag.
+await signalAll("SIGTERM");
+let survivors = await waitForEmpty(graceMs);
+if (survivors.length > 0) {
+  await signalAll("SIGKILL");
+  survivors = await waitForEmpty(Math.max(2_000, Math.floor(graceMs / 2)));
+}
+const references = await findRootReferences(root, invocationId);
+if (survivors.length === 0 && references.length === 0) {
+  const current = JSON.parse(await fs.readFile(registryPath, "utf8").catch(() => "{}"));
+  await fs.rm(root, { recursive: true, force: true });
+  if (current.cgroupPath) await fs.rmdir(current.cgroupPath).catch(() => undefined);
+  await fs.rm(registryPath, { force: true });
+} else {
+  const current = JSON.parse(await fs.readFile(registryPath, "utf8").catch(() => "{}"));
+  await fs.writeFile(
+    registryPath,
+    `${JSON.stringify({
+      ...current,
+      status: "guardian_invariant_failure",
+      survivorCount: survivors.length,
+      rootReferenceCount: references.length,
+      updatedAt: new Date().toISOString(),
+    }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  process.exitCode = 1;
+}

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -1,0 +1,814 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants, promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const deletedSuffix = " (deleted)";
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const guardianScript = path.join(scriptsDir, "vitest-cleanup-guardian.mjs");
+
+export const DEFAULT_HOST_CAP = 2;
+export const DEFAULT_PROCESS_BUDGET = 256;
+export const DEFAULT_GRACE_MS = 5_000;
+export const DEFAULT_HOST_SLOT_WAIT_MS = 30 * 60_000;
+
+function positiveInteger(value, fallback, name) {
+  if (value === undefined || value === null || String(value).trim() === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer; received ${JSON.stringify(value)}.`);
+  }
+  return parsed;
+}
+
+function underRoot(candidate, root) {
+  const normalized = candidate.endsWith(deletedSuffix)
+    ? candidate.slice(0, -deletedSuffix.length)
+    : candidate;
+  return normalized === root || normalized.startsWith(`${root}${path.sep}`);
+}
+
+async function ensurePrivateDirectory(candidate) {
+  await fs.mkdir(candidate, { recursive: true, mode: 0o700 });
+  const stats = await fs.lstat(candidate);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`Test temp parent is not a real directory: ${candidate}`);
+  }
+  await fs.access(candidate, fsConstants.R_OK | fsConstants.W_OK | fsConstants.X_OK);
+  return path.resolve(candidate);
+}
+
+export async function resolveTestTempParent(env = process.env) {
+  const candidates = [
+    ["PAPERCLIP_TEST_TMPDIR", env.PAPERCLIP_TEST_TMPDIR],
+    ["TMPDIR", env.TMPDIR],
+    ["os.tmpdir()", os.tmpdir()],
+  ];
+  const errors = [];
+  for (const [source, raw] of candidates) {
+    if (!raw || !path.isAbsolute(raw)) {
+      if (raw) errors.push(`${source} was not absolute`);
+      continue;
+    }
+    try {
+      return { parent: await ensurePrivateDirectory(raw), source };
+    } catch (error) {
+      errors.push(`${source}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  throw new Error(`No safe test temp parent is available (${errors.join("; ")}).`);
+}
+
+export async function readLinuxProcessIdentity(pid) {
+  if (process.platform !== "linux" || !Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    const raw = await fs.readFile(`/proc/${pid}/stat`, "utf8");
+    const close = raw.lastIndexOf(")");
+    if (close < 0) return null;
+    const comm = raw.slice(raw.indexOf("(") + 1, close);
+    const fields = raw.slice(close + 2).trim().split(/\s+/);
+    const state = fields[0];
+    if (state === "Z" || state === "X") return null;
+    return {
+      pid,
+      ppid: Number(fields[1]),
+      processGroupId: Number(fields[2]),
+      startTime: fields[19],
+      comm,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readProcessEnvironment(pid) {
+  if (process.platform !== "linux") return new Map();
+  try {
+    const raw = await fs.readFile(`/proc/${pid}/environ`);
+    return new Map(
+      raw
+        .toString("utf8")
+        .split("\0")
+        .filter(Boolean)
+        .map((entry) => {
+          const split = entry.indexOf("=");
+          return split < 0 ? [entry, ""] : [entry.slice(0, split), entry.slice(split + 1)];
+        }),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+async function readProcessCommandTokens(pid) {
+  if (process.platform !== "linux") return [];
+  try {
+    const raw = await fs.readFile(`/proc/${pid}/cmdline`);
+    return raw.toString("utf8").split("\0").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function classifyFamily(identity, commandTokens) {
+  const names = [identity.comm, ...commandTokens.slice(0, 3).map((token) => path.basename(token))]
+    .join(" ")
+    .toLowerCase();
+  if (/postgres|postmaster/.test(names)) return "embedded-postgres";
+  if (/(^|\s)sshd?(\s|$)/.test(names)) return "ssh";
+  if (/acpx|acp-relay/.test(names)) return "acp-relay";
+  if (/codex|claude|gemini|hermes|opencode|cursor/.test(names)) return "model-adapter";
+  if (/vitest/.test(names)) return "vitest";
+  if (/node/.test(names)) return "node";
+  return identity.comm || "unknown";
+}
+
+export async function listTaggedProcesses(invocationId) {
+  if (process.platform !== "linux") return [];
+  const entries = await fs.readdir("/proc", { withFileTypes: true }).catch(() => []);
+  const matches = [];
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+      .map(async (entry) => {
+        const pid = Number(entry.name);
+        const env = await readProcessEnvironment(pid);
+        if (env.get("PAPERCLIP_TEST_INVOCATION_ID") !== invocationId) return;
+        const identity = await readLinuxProcessIdentity(pid);
+        if (!identity) return;
+        const commandTokens = await readProcessCommandTokens(pid);
+        matches.push({ ...identity, family: classifyFamily(identity, commandTokens) });
+      }),
+  );
+  return matches.sort((a, b) => a.pid - b.pid);
+}
+
+async function listCgroupProcesses(cgroupPath) {
+  if (!cgroupPath) return [];
+  const raw = await fs.readFile(path.join(cgroupPath, "cgroup.procs"), "utf8").catch(() => "");
+  const results = [];
+  for (const value of raw.split(/\s+/).filter(Boolean)) {
+    const identity = await readLinuxProcessIdentity(Number(value));
+    if (!identity) continue;
+    const commandTokens = await readProcessCommandTokens(identity.pid);
+    results.push({ ...identity, family: classifyFamily(identity, commandTokens) });
+  }
+  return results;
+}
+
+export async function findRootReferences(root, invocationId = null) {
+  if (process.platform !== "linux") return [];
+  const entries = await fs.readdir("/proc", { withFileTypes: true }).catch(() => []);
+  const references = [];
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+      .map(async (entry) => {
+        const pid = Number(entry.name);
+        const identity = await readLinuxProcessIdentity(pid);
+        if (!identity) return;
+        const cwd = await fs.readlink(`/proc/${pid}/cwd`).catch(() => null);
+        if (cwd && underRoot(cwd, root)) {
+          references.push({
+            pid,
+            startTime: identity.startTime,
+            kind: "cwd",
+            deleted: cwd.endsWith(deletedSuffix),
+            family: identity.comm,
+          });
+          return;
+        }
+        if (invocationId) {
+          const env = await readProcessEnvironment(pid);
+          if (env.get("PAPERCLIP_TEST_INVOCATION_ID") !== invocationId) return;
+        }
+        const fds = await fs.readdir(`/proc/${pid}/fd`).catch(() => []);
+        for (const fd of fds) {
+          const target = await fs.readlink(`/proc/${pid}/fd/${fd}`).catch(() => null);
+          if (target && underRoot(target, root)) {
+            references.push({
+              pid,
+              startTime: identity.startTime,
+              kind: "fd",
+              deleted: target.endsWith(deletedSuffix),
+              family: identity.comm,
+            });
+            return;
+          }
+        }
+      }),
+  );
+  return references.sort((a, b) => a.pid - b.pid);
+}
+
+export async function signalProcessIdentity(identity, signal) {
+  if (!identity || !Number.isInteger(identity.pid) || identity.pid <= 0) return "gone";
+  if (process.platform === "linux") {
+    const current = await readLinuxProcessIdentity(identity.pid);
+    if (!current) return "gone";
+    if (current.startTime !== identity.startTime) return "identity_mismatch";
+  }
+  try {
+    process.kill(identity.pid, signal);
+    return "signaled";
+  } catch (error) {
+    if (error?.code === "ESRCH") return "gone";
+    throw error;
+  }
+}
+
+function controlDirectory(env = process.env) {
+  const configured = env.PAPERCLIP_TEST_CONTROL_DIR;
+  if (configured && path.isAbsolute(configured)) return path.resolve(configured);
+  const runtime = env.XDG_RUNTIME_DIR;
+  if (runtime && path.isAbsolute(runtime)) return path.join(runtime, "paperclip-vitest");
+  const uid = typeof process.getuid === "function" ? process.getuid() : "user";
+  return path.join(os.tmpdir(), `paperclip-vitest-${uid}`);
+}
+
+async function slotOwnerIsAlive(owner) {
+  if (!owner || !Number.isInteger(owner.pid) || owner.pid <= 0) return false;
+  if (process.platform === "linux") {
+    const current = await readLinuxProcessIdentity(owner.pid);
+    return Boolean(current && current.startTime === owner.startTime);
+  }
+  try {
+    process.kill(owner.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function acquireHostSlot({
+  invocationId,
+  env = process.env,
+  cap = positiveInteger(env.PAPERCLIP_TEST_HOST_CAP, DEFAULT_HOST_CAP, "PAPERCLIP_TEST_HOST_CAP"),
+  waitMs = positiveInteger(
+    env.PAPERCLIP_TEST_HOST_WAIT_MS,
+    DEFAULT_HOST_SLOT_WAIT_MS,
+    "PAPERCLIP_TEST_HOST_WAIT_MS",
+  ),
+  signal,
+} = {}) {
+  const dir = await ensurePrivateDirectory(controlDirectory(env));
+  const selfIdentity = await readLinuxProcessIdentity(process.pid);
+  const owner = {
+    invocationId,
+    pid: process.pid,
+    startTime: selfIdentity?.startTime ?? null,
+    acquiredAt: new Date().toISOString(),
+  };
+  const deadline = Date.now() + waitMs;
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw signal.reason ?? new Error("Stable test invocation cancelled while waiting for a host slot.");
+    for (let index = 0; index < cap; index += 1) {
+      const slot = path.join(dir, `slot-${index}`);
+      try {
+        await fs.mkdir(slot, { mode: 0o700 });
+        await fs.writeFile(path.join(slot, "owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+        return {
+          index,
+          path: slot,
+          async release() {
+            const stored = JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8").catch(() => "null"));
+            if (stored?.invocationId !== invocationId) {
+              throw new Error(`Host slot ${index} ownership changed; refusing to remove it.`);
+            }
+            await fs.rm(slot, { recursive: true, force: true });
+          },
+        };
+      } catch (error) {
+        if (error?.code !== "EEXIST") throw error;
+        const stored = JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8").catch(() => "null"));
+        const stats = stored ? null : await fs.stat(slot).catch(() => null);
+        const ownerWriteMayBeInFlight = stats && Date.now() - stats.mtimeMs < 5_000;
+        if (!ownerWriteMayBeInFlight && !(await slotOwnerIsAlive(stored))) {
+          await fs.rm(slot, { recursive: true, force: true });
+        }
+      }
+    }
+    await delay(200);
+  }
+  throw new Error(`Timed out after ${waitMs}ms waiting for a stable-test host slot (cap=${cap}).`);
+}
+
+async function createDelegatedCgroup(invocationId) {
+  if (process.platform !== "linux") return null;
+  try {
+    const membership = await fs.readFile("/proc/self/cgroup", "utf8");
+    const unified = membership.split("\n").find((line) => line.startsWith("0::"));
+    if (!unified) return null;
+    const relative = unified.slice(3).replace(/^\/+/, "");
+    const parent = path.join("/sys/fs/cgroup", relative);
+    const candidate = path.join(parent, `pcvt-${invocationId.slice(0, 12)}`);
+    await fs.mkdir(candidate);
+    await fs.access(path.join(candidate, "cgroup.procs"), fsConstants.W_OK);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+function summarizeFamilies(processes) {
+  const counts = new Map();
+  for (const processInfo of processes) {
+    counts.set(processInfo.family, (counts.get(processInfo.family) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 8)
+    .map(([family, count]) => ({ family, count }));
+}
+
+function structuredRecord(record) {
+  console.log(`[test:run] ${JSON.stringify(record)}`);
+}
+
+async function retainWithinLimit(parent, limit) {
+  const entries = await fs.readdir(parent, { withFileTypes: true }).catch(() => []);
+  const retained = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("pcvt-retained-")) continue;
+    const absolute = path.join(parent, entry.name);
+    const stats = await fs.stat(absolute).catch(() => null);
+    if (stats) retained.push({ absolute, mtimeMs: stats.mtimeMs });
+  }
+  retained.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const stale of retained.slice(limit)) {
+    if ((await findRootReferences(stale.absolute)).length === 0) {
+      await fs.rm(stale.absolute, { recursive: true, force: true });
+    }
+  }
+}
+
+export class VitestInvocationSupervisor {
+  constructor({
+    invocationId = randomUUID(),
+    label,
+    tempParent,
+    tempSource = "explicit",
+    env = process.env,
+    graceMs = positiveInteger(env.PAPERCLIP_TEST_GRACE_MS, DEFAULT_GRACE_MS, "PAPERCLIP_TEST_GRACE_MS"),
+    processBudget = positiveInteger(
+      env.PAPERCLIP_TEST_PROCESS_BUDGET,
+      DEFAULT_PROCESS_BUDGET,
+      "PAPERCLIP_TEST_PROCESS_BUDGET",
+    ),
+    familyBudgets = {
+      "embedded-postgres": positiveInteger(env.PAPERCLIP_TEST_MAX_POSTGRES, 16, "PAPERCLIP_TEST_MAX_POSTGRES"),
+      ssh: positiveInteger(env.PAPERCLIP_TEST_MAX_SSH, 16, "PAPERCLIP_TEST_MAX_SSH"),
+      "model-adapter": positiveInteger(
+        env.PAPERCLIP_TEST_MAX_MODEL_ADAPTERS,
+        64,
+        "PAPERCLIP_TEST_MAX_MODEL_ADAPTERS",
+      ),
+    },
+    timeoutMs = env.PAPERCLIP_TEST_TIMEOUT_MS
+      ? positiveInteger(env.PAPERCLIP_TEST_TIMEOUT_MS, null, "PAPERCLIP_TEST_TIMEOUT_MS")
+      : null,
+    disableCgroup = false,
+  }) {
+    this.invocationId = invocationId;
+    this.label = label;
+    this.tempParent = tempParent;
+    this.tempSource = tempSource;
+    this.baseEnv = env;
+    this.graceMs = graceMs;
+    this.processBudget = processBudget;
+    this.familyBudgets = familyBudgets;
+    this.timeoutMs = timeoutMs;
+    this.disableCgroup = disableCgroup;
+    this.root = null;
+    this.child = null;
+    this.childIdentity = null;
+    this.processGroupId = null;
+    this.cgroupPath = null;
+    this.containmentMode = process.platform === "win32" ? "windows-process-tree" : "posix-process-group+tagged-proc";
+    this.stopReason = null;
+    this.peakDescendants = 0;
+    this.termCount = 0;
+    this.killCount = 0;
+    this.identityMismatches = [];
+    this.cleanupPromise = null;
+    this.guardian = null;
+    this.runnerIdentity = null;
+    this.startedAt = Date.now();
+  }
+
+  async initialize() {
+    if (this.root) return;
+    this.root = await fs.mkdtemp(path.join(this.tempParent, `pcvt-${process.pid}-`));
+    this.runnerIdentity = await readLinuxProcessIdentity(process.pid);
+    await fs.mkdir(path.join(this.root, "h"), { recursive: true });
+    await fs.mkdir(path.join(this.root, "t"), { recursive: true });
+    if (!this.disableCgroup) {
+      this.cgroupPath = await createDelegatedCgroup(this.invocationId);
+      if (this.cgroupPath) this.containmentMode = "cgroup-v2";
+    }
+    await this.writeRegistry("starting");
+    await this.startGuardian();
+  }
+
+  get childEnv() {
+    if (!this.root) throw new Error("Supervisor is not initialized.");
+    return {
+      ...this.baseEnv,
+      NODE_ENV: "test",
+      PAPERCLIP_HOME: path.join(this.root, "h"),
+      PAPERCLIP_INSTANCE_ID: `vt-${this.invocationId.replaceAll("-", "").slice(0, 16)}`,
+      PAPERCLIP_TEST_INVOCATION_ID: this.invocationId,
+      PAPERCLIP_TEST_FILE: this.label,
+      TMPDIR: path.join(this.root, "t"),
+    };
+  }
+
+  get registryPath() {
+    return path.join(this.tempParent, ".pcvt-invocations", `${this.invocationId}.json`);
+  }
+
+  get guardianStopPath() {
+    return path.join(path.dirname(this.registryPath), `${this.invocationId}.guardian-stop`);
+  }
+
+  async startGuardian() {
+    if (process.platform !== "linux" || this.guardian) return;
+    const ownerIdentity = this.runnerIdentity ?? await readLinuxProcessIdentity(process.pid);
+    if (!ownerIdentity) return;
+    this.guardian = spawn(
+      process.execPath,
+      [
+        guardianScript,
+        "--owner-pid", String(process.pid),
+        "--owner-start-time", ownerIdentity.startTime,
+        "--invocation-id", this.invocationId,
+        "--root", this.root,
+        "--registry", this.registryPath,
+        "--stop-file", this.guardianStopPath,
+        "--grace-ms", String(this.graceMs),
+      ],
+      {
+        cwd: process.cwd(),
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+        env: {
+          PATH: process.env.PATH,
+          NODE_ENV: "test",
+        },
+      },
+    );
+    this.guardian.once("error", () => {
+      this.guardian = null;
+    });
+    this.guardian.unref();
+  }
+
+  async stopGuardian() {
+    if (!this.guardian) return;
+    await fs.writeFile(this.guardianStopPath, "stop\n", { mode: 0o600 });
+    if (this.guardian.exitCode === null && this.guardian.signalCode === null) {
+      this.guardian.ref();
+      await Promise.race([
+        new Promise((resolve) => this.guardian.once("close", resolve)),
+        delay(2_000),
+      ]);
+    }
+    if (this.guardian.exitCode === null && this.guardian.signalCode === null) {
+      this.guardian.kill("SIGKILL");
+    }
+    await fs.rm(this.guardianStopPath, { force: true });
+    this.guardian = null;
+  }
+
+  async writeRegistry(status) {
+    await fs.mkdir(path.dirname(this.registryPath), { recursive: true, mode: 0o700 });
+    const record = {
+      invocationId: this.invocationId,
+      label: this.label,
+      runnerPid: process.pid,
+      runnerStartTime: this.runnerIdentity?.startTime ?? null,
+      childPid: this.child?.pid ?? null,
+      childStartTime: this.childIdentity?.startTime ?? null,
+      processGroupId: this.processGroupId,
+      cgroupPath: this.cgroupPath,
+      tempRoot: this.root,
+      tempSource: this.tempSource,
+      containmentMode: this.containmentMode,
+      peakDescendants: this.peakDescendants,
+      status,
+      startedAt: new Date(this.startedAt).toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await fs.writeFile(this.registryPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  }
+
+  async ownedProcesses() {
+    const [tagged, cgroup] = await Promise.all([
+      listTaggedProcesses(this.invocationId),
+      listCgroupProcesses(this.cgroupPath),
+    ]);
+    const byIdentity = new Map();
+    for (const processInfo of [...tagged, ...cgroup]) {
+      byIdentity.set(`${processInfo.pid}:${processInfo.startTime}`, processInfo);
+    }
+    return [...byIdentity.values()].filter((processInfo) => processInfo.pid !== process.pid);
+  }
+
+  async attachContainment() {
+    if (!this.child?.pid) return;
+    this.childIdentity = await readLinuxProcessIdentity(this.child.pid);
+    this.processGroupId = process.platform === "win32" ? null : this.child.pid;
+    if (this.cgroupPath) {
+      try {
+        await fs.writeFile(path.join(this.cgroupPath, "cgroup.procs"), `${this.child.pid}\n`);
+      } catch {
+        await fs.rmdir(this.cgroupPath).catch(() => undefined);
+        this.cgroupPath = null;
+        this.containmentMode = "posix-process-group+tagged-proc";
+      }
+    }
+    await this.writeRegistry("running");
+  }
+
+  async run(command, args, { cwd = process.cwd(), timeoutMs = this.timeoutMs } = {}) {
+    await this.initialize();
+    const child = spawn(command, args, {
+      cwd,
+      env: this.childEnv,
+      stdio: "inherit",
+      detached: process.platform !== "win32",
+      windowsHide: true,
+    });
+    this.child = child;
+    await new Promise((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+    await this.attachContainment();
+    structuredRecord({
+      event: "vitest_invocation_start",
+      invocationId: this.invocationId,
+      label: this.label,
+      tempRoot: this.root,
+      childPid: child.pid ?? null,
+      childStartTime: this.childIdentity?.startTime ?? null,
+      processGroupId: this.processGroupId,
+      containmentMode: this.containmentMode,
+      processBudget: this.processBudget,
+      familyBudgets: this.familyBudgets,
+    });
+
+    let monitorStopped = false;
+    let budgetError = null;
+    const monitor = (async () => {
+      while (!monitorStopped) {
+        const owned = await this.ownedProcesses();
+        this.peakDescendants = Math.max(this.peakDescendants, owned.length);
+        const families = summarizeFamilies(owned);
+        const familyViolation = families.find(
+          ({ family, count }) => this.familyBudgets[family] && count > this.familyBudgets[family],
+        );
+        if ((owned.length > this.processBudget || familyViolation) && !budgetError) {
+          const violation = familyViolation
+            ? `${familyViolation.family} ${familyViolation.count}/${this.familyBudgets[familyViolation.family]}`
+            : `total ${owned.length}/${this.processBudget}`;
+          budgetError = new Error(
+            `Process budget exceeded for invocation ${this.invocationId} (${this.label}): ${violation}; ` +
+              `total=${owned.length}/${this.processBudget}; largest families=${JSON.stringify(families)}.`,
+          );
+          this.requestStop("process_budget_exceeded");
+        }
+        await delay(200);
+      }
+    })();
+    let timeout;
+    if (timeoutMs) {
+      timeout = setTimeout(() => this.requestStop(`timeout_after_${timeoutMs}ms`), timeoutMs);
+      timeout.unref?.();
+    }
+
+    const result = await new Promise((resolve) => {
+      let spawnError = null;
+      child.once("error", (error) => {
+        spawnError = error;
+      });
+      child.once("close", (code, signal) => resolve({ code, signal, error: spawnError }));
+    });
+    if (timeout) clearTimeout(timeout);
+    monitorStopped = true;
+    await monitor;
+    if (budgetError) throw budgetError;
+    return { ...result, stopReason: this.stopReason };
+  }
+
+  requestStop(reason) {
+    this.stopReason ??= reason;
+    void this.terminateBoundary();
+  }
+
+  async signalOwned(signal) {
+    const owned = await this.ownedProcesses();
+    let count = 0;
+    if (
+      process.platform !== "win32" &&
+      this.processGroupId &&
+      this.child &&
+      this.child.exitCode === null &&
+      this.child.signalCode === null
+    ) {
+      let groupIdentityMatches = true;
+      if (process.platform === "linux" && this.childIdentity) {
+        const current = await readLinuxProcessIdentity(this.processGroupId);
+        groupIdentityMatches = current?.startTime === this.childIdentity.startTime;
+      }
+      if (groupIdentityMatches) {
+        try {
+          process.kill(-this.processGroupId, signal);
+          count += 1;
+        } catch (error) {
+          if (error?.code !== "ESRCH") throw error;
+        }
+      } else {
+        this.identityMismatches.push(this.processGroupId);
+      }
+    }
+    for (const identity of owned) {
+      const outcome = await signalProcessIdentity(identity, signal);
+      if (outcome === "signaled") count += 1;
+      if (outcome === "identity_mismatch") this.identityMismatches.push(identity.pid);
+    }
+    if (process.platform === "win32" && this.child?.pid) {
+      spawnSync("taskkill", ["/PID", String(this.child.pid), "/T", ...(signal === "SIGKILL" ? ["/F"] : [])], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    }
+    return count;
+  }
+
+  async waitForEmpty(waitMs) {
+    const deadline = Date.now() + waitMs;
+    let current = await this.ownedProcesses();
+    while (current.length > 0 && Date.now() < deadline) {
+      await delay(100);
+      current = await this.ownedProcesses();
+    }
+    return current;
+  }
+
+  async terminateBoundary() {
+    if (this.cleanupPromise) return this.cleanupPromise;
+    this.cleanupPromise = (async () => {
+      const before = await this.ownedProcesses();
+      if (before.length > 0) {
+        this.termCount += await this.signalOwned("SIGTERM");
+      }
+      let survivors = await this.waitForEmpty(this.graceMs);
+      if (survivors.length > 0) {
+        this.killCount += await this.signalOwned("SIGKILL");
+        survivors = await this.waitForEmpty(Math.max(2_000, Math.floor(this.graceMs / 2)));
+      }
+      structuredRecord({
+        event: "vitest_invocation_stop",
+        invocationId: this.invocationId,
+        label: this.label,
+        reason: this.stopReason ?? "child_exited",
+        containmentMode: this.containmentMode,
+        peakDescendants: this.peakDescendants,
+        termCount: this.termCount,
+        killCount: this.killCount,
+        survivorCount: survivors.length,
+      });
+      return survivors;
+    })();
+    return this.cleanupPromise;
+  }
+
+  async cleanup({ retainReason = null, retainedLimit = 3 } = {}) {
+    const cleanupStarted = Date.now();
+    const survivors = await this.terminateBoundary();
+    const references = this.root ? await findRootReferences(this.root, this.invocationId) : [];
+    let retainedArtifactReason = retainReason;
+    let removed = false;
+    if (this.identityMismatches.length > 0) {
+      retainedArtifactReason ??= `pid_identity_mismatch:${this.identityMismatches.join(",")}`;
+    }
+    if (survivors.length > 0) retainedArtifactReason ??= "containment_not_empty";
+    if (references.length > 0) retainedArtifactReason ??= "active_root_reference";
+    const guardianArmed = Boolean(retainedArtifactReason && !retainReason && this.guardian);
+    if (!guardianArmed) await this.stopGuardian();
+
+    if (this.root && retainedArtifactReason && retainReason) {
+      const retained = path.join(
+        this.tempParent,
+        `pcvt-retained-${new Date().toISOString().replaceAll(/[:.]/g, "-")}-${this.invocationId.slice(0, 8)}`,
+      );
+      await fs.rename(this.root, retained);
+      this.root = retained;
+      await retainWithinLimit(this.tempParent, retainedLimit);
+    } else if (this.root && !retainedArtifactReason) {
+      await fs.rm(this.root, { recursive: true, force: true });
+      removed = true;
+    }
+
+    if (this.cgroupPath) {
+      await fs.rmdir(this.cgroupPath).catch(() => undefined);
+    }
+    if (!guardianArmed) await fs.rm(this.registryPath, { force: true });
+    const cleanupDurationMs = Date.now() - cleanupStarted;
+    structuredRecord({
+      event: "vitest_invocation_cleanup",
+      invocationId: this.invocationId,
+      label: this.label,
+      containmentMode: this.containmentMode,
+      peakDescendants: this.peakDescendants,
+      cleanupDurationMs,
+      termCount: this.termCount,
+      killCount: this.killCount,
+      survivorCount: survivors.length,
+      rootReferenceCount: references.length,
+      rootRemoved: removed,
+      retainedArtifactReason,
+      guardianArmed,
+    });
+    if (retainedArtifactReason && !retainReason) {
+      throw new Error(
+        `Post-suite invariants failed for ${this.invocationId}: ${retainedArtifactReason}; ` +
+          `survivors=${survivors.length}, rootReferences=${references.length}. Root was not deleted.`,
+      );
+    }
+    return { survivors, references, removed, retainedArtifactReason, cleanupDurationMs };
+  }
+}
+
+export async function diagnoseStableInvocations({ env = process.env } = {}) {
+  const { parent, source } = await resolveTestTempParent(env);
+  const registryDir = path.join(parent, ".pcvt-invocations");
+  const entries = await fs.readdir(registryDir).catch(() => []);
+  const invocations = [];
+  for (const entry of entries.filter((name) => name.endsWith(".json")).sort()) {
+    const record = JSON.parse(await fs.readFile(path.join(registryDir, entry), "utf8").catch(() => "null"));
+    if (!record?.invocationId) continue;
+    const processes = await listTaggedProcesses(record.invocationId);
+    const rootReferences = record.tempRoot
+      ? await findRootReferences(record.tempRoot, record.invocationId)
+      : [];
+    const runnerIdentity = await readLinuxProcessIdentity(record.runnerPid);
+    const runnerAlive = process.platform === "linux"
+      ? Boolean(runnerIdentity && runnerIdentity.startTime === record.runnerStartTime)
+      : null;
+    invocations.push({
+      invocationId: record.invocationId,
+      label: record.label,
+      runnerPid: record.runnerPid,
+      childPid: record.childPid,
+      containmentMode: record.containmentMode,
+      tempRoot: record.tempRoot,
+      processCount: processes.length,
+      processFamilies: summarizeFamilies(processes),
+      rootReferenceCount: rootReferences.length,
+      deletedCwdCount: rootReferences.filter((reference) => reference.kind === "cwd" && reference.deleted).length,
+      runnerAlive,
+      stale: runnerAlive === false && processes.length > 0,
+      status: record.status,
+      updatedAt: record.updatedAt,
+    });
+  }
+  return { tempParent: parent, tempSource: source, invocationCount: invocations.length, invocations };
+}
+
+export async function reapStaleStableInvocations({ env = process.env } = {}) {
+  const report = await diagnoseStableInvocations({ env });
+  const reaped = [];
+  const refused = [];
+  for (const invocation of report.invocations) {
+    if (invocation.runnerAlive !== false) continue;
+    if (invocation.processCount > 0 || invocation.rootReferenceCount > 0) {
+      refused.push({
+        invocationId: invocation.invocationId,
+        reason: "live_process_or_root_reference",
+        processCount: invocation.processCount,
+        rootReferenceCount: invocation.rootReferenceCount,
+      });
+      continue;
+    }
+    const resolvedRoot = path.resolve(invocation.tempRoot);
+    if (
+      path.dirname(resolvedRoot) !== report.tempParent ||
+      !path.basename(resolvedRoot).startsWith("pcvt-")
+    ) {
+      refused.push({ invocationId: invocation.invocationId, reason: "unsafe_root_path" });
+      continue;
+    }
+    await fs.rm(resolvedRoot, { recursive: true, force: true });
+    await fs.rm(path.join(report.tempParent, ".pcvt-invocations", `${invocation.invocationId}.json`), {
+      force: true,
+    });
+    reaped.push(invocation.invocationId);
+  }
+  return { ...report, reaped, refused };
+}

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -692,6 +692,17 @@ export class VitestInvocationSupervisor {
     return current;
   }
 
+  async waitForRootReferences(waitMs) {
+    if (!this.root) return [];
+    const deadline = Date.now() + waitMs;
+    let current = await findRootReferences(this.root, this.invocationId);
+    while (current.length > 0 && Date.now() < deadline) {
+      await delay(100);
+      current = await findRootReferences(this.root, this.invocationId);
+    }
+    return current;
+  }
+
   async terminateBoundary() {
     if (this.cleanupPromise) return this.cleanupPromise;
     this.cleanupPromise = (async () => {
@@ -723,7 +734,7 @@ export class VitestInvocationSupervisor {
   async cleanup({ retainReason = null, retainedLimit = 3 } = {}) {
     const cleanupStarted = Date.now();
     const survivors = await this.terminateBoundary();
-    const references = this.root ? await findRootReferences(this.root, this.invocationId) : [];
+    const references = await this.waitForRootReferences(this.graceMs);
     let invariantFailureReason = null;
     let removed = false;
     if (this.identityMismatches.length > 0) {

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -328,6 +328,22 @@ function structuredRecord(record) {
   console.log(`[test:run] ${JSON.stringify(record)}`);
 }
 
+async function writeJsonAtomically(destination, value) {
+  const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+    try {
+      await fs.rename(temporary, destination);
+    } catch (error) {
+      if (process.platform !== "win32" || !["EEXIST", "EPERM"].includes(error?.code)) throw error;
+      await fs.rm(destination, { force: true });
+      await fs.rename(temporary, destination);
+    }
+  } finally {
+    await fs.rm(temporary, { force: true });
+  }
+}
+
 async function retainWithinLimit(parent, limit) {
   const entries = await fs.readdir(parent, { withFileTypes: true }).catch(() => []);
   const retained = [];
@@ -503,7 +519,7 @@ export class VitestInvocationSupervisor {
       startedAt: new Date(this.startedAt).toISOString(),
       updatedAt: new Date().toISOString(),
     };
-    await fs.writeFile(this.registryPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+    await writeJsonAtomically(this.registryPath, record);
   }
 
   async ownedProcesses() {
@@ -751,7 +767,14 @@ export async function diagnoseStableInvocations({ env = process.env } = {}) {
   const entries = await fs.readdir(registryDir).catch(() => []);
   const invocations = [];
   for (const entry of entries.filter((name) => name.endsWith(".json")).sort()) {
-    const record = JSON.parse(await fs.readFile(path.join(registryDir, entry), "utf8").catch(() => "null"));
+    const raw = await fs.readFile(path.join(registryDir, entry), "utf8").catch(() => "null");
+    let record = null;
+    try {
+      record = JSON.parse(raw);
+    } catch {
+      // Ignore records created by older/non-atomic writers while they are incomplete.
+      continue;
+    }
     if (!record?.invocationId) continue;
     const processes = await listTaggedProcesses(record.invocationId);
     const rootReferences = record.tempRoot

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -159,6 +159,23 @@ async function listCgroupProcesses(cgroupPath) {
   return results;
 }
 
+async function listProcessGroupProcesses(processGroupId) {
+  if (process.platform !== "linux" || !Number.isInteger(processGroupId) || processGroupId <= 0) return [];
+  const entries = await fs.readdir("/proc", { withFileTypes: true }).catch(() => []);
+  const matches = [];
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+      .map(async (entry) => {
+        const identity = await readLinuxProcessIdentity(Number(entry.name));
+        if (!identity || identity.processGroupId !== processGroupId) return;
+        const commandTokens = await readProcessCommandTokens(identity.pid);
+        matches.push({ ...identity, family: classifyFamily(identity, commandTokens) });
+      }),
+  );
+  return matches.sort((a, b) => a.pid - b.pid);
+}
+
 export async function findRootReferences(root, invocationId = null) {
   if (process.platform !== "linux") return [];
   const entries = await fs.readdir("/proc", { withFileTypes: true }).catch(() => []);
@@ -574,12 +591,13 @@ export class VitestInvocationSupervisor {
   }
 
   async ownedProcesses() {
-    const [tagged, cgroup] = await Promise.all([
+    const [tagged, cgroup, processGroup] = await Promise.all([
       listTaggedProcesses(this.invocationId),
       listCgroupProcesses(this.cgroupPath),
+      listProcessGroupProcesses(this.processGroupId),
     ]);
     const byIdentity = new Map();
-    for (const processInfo of [...tagged, ...cgroup]) {
+    for (const processInfo of [...tagged, ...cgroup, ...processGroup]) {
       byIdentity.set(`${processInfo.pid}:${processInfo.startTime}`, processInfo);
     }
     return [...byIdentity.values()].filter((processInfo) => processInfo.pid !== process.pid);
@@ -680,6 +698,7 @@ export class VitestInvocationSupervisor {
   async signalOwned(signal) {
     const owned = await this.ownedProcesses();
     let count = 0;
+    let groupSignaled = false;
     if (
       process.platform !== "win32" &&
       this.processGroupId &&
@@ -690,12 +709,18 @@ export class VitestInvocationSupervisor {
       let groupIdentityMatches = true;
       if (process.platform === "linux" && this.childIdentity) {
         const current = await readLinuxProcessIdentity(this.processGroupId);
-        groupIdentityMatches = current?.startTime === this.childIdentity.startTime;
+        const groupStillOwned = owned.some(
+          (processInfo) => processInfo.processGroupId === this.processGroupId,
+        );
+        groupIdentityMatches =
+          current?.startTime === this.childIdentity.startTime ||
+          (!current && groupStillOwned);
       }
       if (groupIdentityMatches) {
         try {
           process.kill(-this.processGroupId, signal);
           count += 1;
+          groupSignaled = true;
         } catch (error) {
           if (error?.code !== "ESRCH") throw error;
         }
@@ -704,6 +729,7 @@ export class VitestInvocationSupervisor {
       }
     }
     for (const identity of owned) {
+      if (groupSignaled && identity.processGroupId === this.processGroupId) continue;
       const outcome = await signalProcessIdentity(identity, signal);
       if (outcome === "signaled") count += 1;
       if (outcome === "identity_mismatch") this.identityMismatches.push(identity.pid);

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -243,6 +243,26 @@ async function slotOwnerIsAlive(owner) {
   }
 }
 
+async function reapStaleHostSlot(slot, reaperLock) {
+  try {
+    await fs.mkdir(reaperLock, { mode: 0o700 });
+  } catch (error) {
+    if (error?.code === "EEXIST") return false;
+    throw error;
+  }
+
+  try {
+    const stored = JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8").catch(() => "null"));
+    const stats = stored ? null : await fs.stat(slot).catch(() => null);
+    const ownerWriteMayBeInFlight = stats && Date.now() - stats.mtimeMs < 5_000;
+    if (ownerWriteMayBeInFlight || (await slotOwnerIsAlive(stored))) return false;
+    await fs.rm(slot, { recursive: true, force: true });
+    return true;
+  } finally {
+    await fs.rm(reaperLock, { recursive: true, force: true });
+  }
+}
+
 export async function acquireHostSlot({
   invocationId,
   env = process.env,
@@ -267,6 +287,7 @@ export async function acquireHostSlot({
     if (signal?.aborted) throw signal.reason ?? new Error("Stable test invocation cancelled while waiting for a host slot.");
     for (let index = 0; index < cap; index += 1) {
       const slot = path.join(dir, `slot-${index}`);
+      const reaperLock = path.join(dir, `.slot-${index}-reaper`);
       try {
         await fs.mkdir(slot, { mode: 0o700 });
         await fs.writeFile(path.join(slot, "owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
@@ -283,12 +304,7 @@ export async function acquireHostSlot({
         };
       } catch (error) {
         if (error?.code !== "EEXIST") throw error;
-        const stored = JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8").catch(() => "null"));
-        const stats = stored ? null : await fs.stat(slot).catch(() => null);
-        const ownerWriteMayBeInFlight = stats && Date.now() - stats.mtimeMs < 5_000;
-        if (!ownerWriteMayBeInFlight && !(await slotOwnerIsAlive(stored))) {
-          await fs.rm(slot, { recursive: true, force: true });
-        }
+        await reapStaleHostSlot(slot, reaperLock);
       }
     }
     await delay(200);
@@ -708,17 +724,18 @@ export class VitestInvocationSupervisor {
     const cleanupStarted = Date.now();
     const survivors = await this.terminateBoundary();
     const references = this.root ? await findRootReferences(this.root, this.invocationId) : [];
-    let retainedArtifactReason = retainReason;
+    let invariantFailureReason = null;
     let removed = false;
     if (this.identityMismatches.length > 0) {
-      retainedArtifactReason ??= `pid_identity_mismatch:${this.identityMismatches.join(",")}`;
+      invariantFailureReason = `pid_identity_mismatch:${this.identityMismatches.join(",")}`;
     }
-    if (survivors.length > 0) retainedArtifactReason ??= "containment_not_empty";
-    if (references.length > 0) retainedArtifactReason ??= "active_root_reference";
-    const guardianArmed = Boolean(retainedArtifactReason && !retainReason && this.guardian);
+    if (survivors.length > 0) invariantFailureReason ??= "containment_not_empty";
+    if (references.length > 0) invariantFailureReason ??= "active_root_reference";
+    const retainedArtifactReason = invariantFailureReason ?? retainReason;
+    const guardianArmed = Boolean(invariantFailureReason && this.guardian);
     if (!guardianArmed) await this.stopGuardian();
 
-    if (this.root && retainedArtifactReason && retainReason) {
+    if (this.root && retainReason && !invariantFailureReason) {
       const retained = path.join(
         this.tempParent,
         `pcvt-retained-${new Date().toISOString().replaceAll(/[:.]/g, "-")}-${this.invocationId.slice(0, 8)}`,
@@ -751,9 +768,9 @@ export class VitestInvocationSupervisor {
       retainedArtifactReason,
       guardianArmed,
     });
-    if (retainedArtifactReason && !retainReason) {
+    if (invariantFailureReason) {
       throw new Error(
-        `Post-suite invariants failed for ${this.invocationId}: ${retainedArtifactReason}; ` +
+        `Post-suite invariants failed for ${this.invocationId}: ${invariantFailureReason}; ` +
           `survivors=${survivors.length}, rootReferences=${references.length}. Root was not deleted.`,
       );
     }

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -823,7 +823,9 @@ export class VitestInvocationSupervisor {
     if (this.cgroupPath) {
       await fs.rmdir(this.cgroupPath).catch(() => undefined);
     }
-    if (!guardianArmed) await fs.rm(this.registryPath, { force: true });
+    if (!guardianArmed && !invariantFailureReason) {
+      await fs.rm(this.registryPath, { force: true });
+    }
     const cleanupDurationMs = Date.now() - cleanupStarted;
     structuredRecord({
       event: "vitest_invocation_cleanup",

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -146,6 +146,39 @@ export async function listTaggedProcesses(invocationId) {
   return matches.sort((a, b) => a.pid - b.pid);
 }
 
+export async function listRootScopedProcesses(root) {
+  if (process.platform !== "linux" || !root) return [];
+  const entries = await fs.readdir("/proc", { withFileTypes: true }).catch(() => []);
+  const matches = [];
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+      .map(async (entry) => {
+        const pid = Number(entry.name);
+        const env = await readProcessEnvironment(pid);
+        const scopedPaths = [env.get("PAPERCLIP_HOME"), env.get("TMPDIR")].filter(Boolean);
+        if (!scopedPaths.some((candidate) => underRoot(candidate, root))) return;
+        const identity = await readLinuxProcessIdentity(pid);
+        if (!identity) return;
+        const commandTokens = await readProcessCommandTokens(pid);
+        matches.push({ ...identity, family: classifyFamily(identity, commandTokens) });
+      }),
+  );
+  return matches.sort((a, b) => a.pid - b.pid);
+}
+
+export async function listInvocationProcesses(invocationId, root) {
+  const [tagged, rootScoped] = await Promise.all([
+    listTaggedProcesses(invocationId),
+    listRootScopedProcesses(root),
+  ]);
+  const processes = new Map();
+  for (const processInfo of [...tagged, ...rootScoped]) {
+    processes.set(`${processInfo.pid}:${processInfo.startTime}`, processInfo);
+  }
+  return [...processes.values()].sort((a, b) => a.pid - b.pid);
+}
+
 async function listCgroupProcesses(cgroupPath) {
   if (!cgroupPath) return [];
   const raw = await fs.readFile(path.join(cgroupPath, "cgroup.procs"), "utf8").catch(() => "");
@@ -174,6 +207,36 @@ async function listProcessGroupProcesses(processGroupId) {
       }),
   );
   return matches.sort((a, b) => a.pid - b.pid);
+}
+
+async function listProcessDescendants(ancestorPid) {
+  if (process.platform !== "linux" || !Number.isInteger(ancestorPid) || ancestorPid <= 0) return [];
+  const entries = await fs.readdir("/proc", { withFileTypes: true }).catch(() => []);
+  const identities = (
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+        .map((entry) => readLinuxProcessIdentity(Number(entry.name))),
+    )
+  ).filter(Boolean);
+  const descendantPids = new Set([ancestorPid]);
+  const descendants = [];
+  let foundMore = true;
+  while (foundMore) {
+    foundMore = false;
+    for (const identity of identities) {
+      if (descendantPids.has(identity.pid) || !descendantPids.has(identity.ppid)) continue;
+      descendantPids.add(identity.pid);
+      descendants.push(identity);
+      foundMore = true;
+    }
+  }
+  return Promise.all(
+    descendants.map(async (identity) => {
+      const commandTokens = await readProcessCommandTokens(identity.pid);
+      return { ...identity, family: classifyFamily(identity, commandTokens) };
+    }),
+  );
 }
 
 export async function findRootReferences(root, invocationId = null) {
@@ -443,8 +506,8 @@ export class VitestInvocationSupervisor {
       "PAPERCLIP_TEST_PROCESS_BUDGET",
     ),
     familyBudgets = {
-      "embedded-postgres": positiveInteger(env.PAPERCLIP_TEST_MAX_POSTGRES, 16, "PAPERCLIP_TEST_MAX_POSTGRES"),
-      ssh: positiveInteger(env.PAPERCLIP_TEST_MAX_SSH, 16, "PAPERCLIP_TEST_MAX_SSH"),
+      "embedded-postgres": positiveInteger(env.PAPERCLIP_TEST_MAX_POSTGRES, 128, "PAPERCLIP_TEST_MAX_POSTGRES"),
+      ssh: positiveInteger(env.PAPERCLIP_TEST_MAX_SSH, 64, "PAPERCLIP_TEST_MAX_SSH"),
       "model-adapter": positiveInteger(
         env.PAPERCLIP_TEST_MAX_MODEL_ADAPTERS,
         64,
@@ -477,6 +540,7 @@ export class VitestInvocationSupervisor {
     this.termCount = 0;
     this.killCount = 0;
     this.identityMismatches = [];
+    this.observedProcesses = new Map();
     this.cleanupPromise = null;
     this.guardian = null;
     this.runnerIdentity = null;
@@ -591,16 +655,53 @@ export class VitestInvocationSupervisor {
   }
 
   async ownedProcesses() {
-    const [tagged, cgroup, processGroup] = await Promise.all([
-      listTaggedProcesses(this.invocationId),
+    const [invocationProcesses, cgroup, processGroup, descendants] = await Promise.all([
+      listInvocationProcesses(this.invocationId, this.root),
       listCgroupProcesses(this.cgroupPath),
       listProcessGroupProcesses(this.processGroupId),
+      listProcessDescendants(this.child?.pid),
     ]);
     const byIdentity = new Map();
-    for (const processInfo of [...tagged, ...cgroup, ...processGroup]) {
-      byIdentity.set(`${processInfo.pid}:${processInfo.startTime}`, processInfo);
+    for (const processInfo of [...invocationProcesses, ...cgroup, ...processGroup, ...descendants]) {
+      const key = `${processInfo.pid}:${processInfo.startTime}`;
+      byIdentity.set(key, processInfo);
+      this.observedProcesses.set(key, processInfo);
+    }
+    for (const [key, processInfo] of this.observedProcesses) {
+      if (byIdentity.has(key)) continue;
+      const current = await readLinuxProcessIdentity(processInfo.pid);
+      if (current?.startTime === processInfo.startTime) {
+        byIdentity.set(key, { ...processInfo, ...current });
+      } else {
+        this.observedProcesses.delete(key);
+      }
     }
     return [...byIdentity.values()].filter((processInfo) => processInfo.pid !== process.pid);
+  }
+
+  async observeDescendants() {
+    const descendants = await listProcessDescendants(this.child?.pid);
+    const childIdentity = await readLinuxProcessIdentity(this.child?.pid);
+    if (childIdentity) {
+      const commandTokens = await readProcessCommandTokens(childIdentity.pid);
+      descendants.push({
+        ...childIdentity,
+        family: classifyFamily(childIdentity, commandTokens),
+      });
+    }
+    for (const processInfo of descendants) {
+      this.observedProcesses.set(`${processInfo.pid}:${processInfo.startTime}`, processInfo);
+    }
+    const observed = [];
+    for (const [key, processInfo] of this.observedProcesses) {
+      const current = await readLinuxProcessIdentity(processInfo.pid);
+      if (current?.startTime === processInfo.startTime) {
+        observed.push({ ...processInfo, ...current });
+      } else {
+        this.observedProcesses.delete(key);
+      }
+    }
+    return observed;
   }
 
   async attachContainment() {
@@ -651,7 +752,9 @@ export class VitestInvocationSupervisor {
     let budgetError = null;
     const monitor = (async () => {
       while (!monitorStopped) {
-        const owned = await this.ownedProcesses();
+        const owned = process.platform === "linux"
+          ? await this.observeDescendants()
+          : await this.ownedProcesses();
         this.peakDescendants = Math.max(this.peakDescendants, owned.length);
         const families = summarizeFamilies(owned);
         const familyViolation = families.find(

--- a/scripts/vitest-supervisor.mjs
+++ b/scripts/vitest-supervisor.mjs
@@ -243,14 +243,49 @@ async function slotOwnerIsAlive(owner) {
   }
 }
 
-async function reapStaleHostSlot(slot, reaperLock) {
-  try {
-    await fs.mkdir(reaperLock, { mode: 0o700 });
-  } catch (error) {
-    if (error?.code === "EEXIST") return false;
-    throw error;
-  }
+async function acquireReaperLock(reaperLock) {
+  const identity = await readLinuxProcessIdentity(process.pid);
+  const owner = {
+    token: randomUUID(),
+    pid: process.pid,
+    startTime: identity?.startTime ?? null,
+    acquiredAt: new Date().toISOString(),
+  };
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await fs.mkdir(reaperLock, { mode: 0o700 });
+      try {
+        await fs.writeFile(path.join(reaperLock, "owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+      } catch (error) {
+        await fs.rm(reaperLock, { recursive: true, force: true });
+        throw error;
+      }
+      return true;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
 
+    const stored = JSON.parse(
+      await fs.readFile(path.join(reaperLock, "owner.json"), "utf8").catch(() => "null"),
+    );
+    const stats = await fs.stat(reaperLock).catch(() => null);
+    const ownerWriteMayBeInFlight = !stored && stats && Date.now() - stats.mtimeMs < 5_000;
+    if (!stats || ownerWriteMayBeInFlight || (await slotOwnerIsAlive(stored))) return false;
+    const generation = stored?.token ?? `${stats.dev}-${stats.ino}`;
+    const abandoned = `${reaperLock}-abandoned-${generation}`;
+    try {
+      await fs.rename(reaperLock, abandoned);
+      await fs.writeFile(path.join(abandoned, "tombstone"), `${generation}\n`, { mode: 0o600 });
+    } catch (error) {
+      if (["EEXIST", "ENOTEMPTY", "ENOENT"].includes(error?.code)) return false;
+      throw error;
+    }
+  }
+  return false;
+}
+
+async function reapStaleHostSlot(slot, reaperLock) {
+  if (!(await acquireReaperLock(reaperLock))) return false;
   try {
     const stored = JSON.parse(await fs.readFile(path.join(slot, "owner.json"), "utf8").catch(() => "null"));
     const stats = stored ? null : await fs.stat(slot).catch(() => null);

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { and, eq, or, inArray, sql } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FixtureSupervisor } from "@paperclipai/adapter-utils/test-support/fixture-supervisor";
 import {
   activityLog,
   agents,
@@ -299,7 +300,7 @@ async function spawnOrphanedProcessGroup() {
 describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
-  const childProcesses = new Set<ChildProcess>();
+  let childProcesses: FixtureSupervisor;
   const cleanupPids = new Set<number>();
 
   beforeAll(async () => {
@@ -315,6 +316,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       updatedAt: now,
     });
   }, 20_000);
+
+  beforeEach(() => {
+    childProcesses = new FixtureSupervisor({ owner: "heartbeat process recovery tests", maxProcesses: 32 });
+  });
 
   afterEach(async () => {
     vi.clearAllMocks();
@@ -332,10 +337,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       model: "test-model",
     }));
     runningProcesses.clear();
-    for (const child of childProcesses) {
-      child.kill("SIGKILL");
-    }
-    childProcesses.clear();
+    await childProcesses.teardown();
     for (const pid of cleanupPids) {
       try {
         process.kill(pid, "SIGKILL");
@@ -453,10 +455,6 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   });
 
   afterAll(async () => {
-    for (const child of childProcesses) {
-      child.kill("SIGKILL");
-    }
-    childProcesses.clear();
     for (const pid of cleanupPids) {
       try {
         process.kill(pid, "SIGKILL");
@@ -1198,7 +1196,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("keeps a local run active when the recorded pid is still alive", async () => {
     const child = spawnAliveProcess();
-    childProcesses.add(child);
+    childProcesses.registerProcess(child, { label: "live recorded heartbeat" });
     expect(child.pid).toBeTypeOf("number");
 
     const { runId, wakeupRequestId } = await seedRunFixture({
@@ -1442,7 +1440,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("captures a hot-restart shutdown snapshot without interrupting running runs", async () => {
     const child = spawnAliveProcess();
-    childProcesses.add(child);
+    childProcesses.registerProcess(child, { label: "heartbeat recovery child" });
     expect(child.pid).toBeGreaterThan(0);
     const { runId, wakeupRequestId } = await seedRunFixture({
       agentStatus: "running",
@@ -1506,7 +1504,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("snapshots and drains a server-stdio ACP run before embedded database shutdown", async () => {
     const child = spawnAliveProcess();
-    childProcesses.add(child);
+    childProcesses.registerProcess(child, { label: "heartbeat recovery child" });
     expect(child.pid).toBeGreaterThan(0);
     const { agentId, runId } = await seedRunFixture({
       agentStatus: "running",
@@ -1594,7 +1592,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("reports a selectively drained ACP run as lost when terminal persistence fails", async () => {
     const child = spawnAliveProcess();
-    childProcesses.add(child);
+    childProcesses.registerProcess(child, { label: "heartbeat recovery child" });
     expect(child.pid).toBeGreaterThan(0);
     const { runId } = await seedRunFixture({
       agentStatus: "running",
@@ -1650,8 +1648,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   it("drains only server-stdio runs and preserves detached CLI adoption in a mixed restart", async () => {
     const acpChild = spawnAliveProcess();
     const cliChild = spawnAliveProcess();
-    childProcesses.add(acpChild);
-    childProcesses.add(cliChild);
+    childProcesses.registerProcess(acpChild, { label: "ACP heartbeat child" });
+    childProcesses.registerProcess(cliChild, { label: "CLI heartbeat child" });
     expect(acpChild.pid).toBeGreaterThan(0);
     expect(cliChild.pid).toBeGreaterThan(0);
 
@@ -1746,7 +1744,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("adopts an old-server legacy snapshot written for a new instance-scoped marker", async () => {
     const child = spawnAliveProcess();
-    childProcesses.add(child);
+    childProcesses.registerProcess(child, { label: "heartbeat recovery child" });
     expect(child.pid).toBeGreaterThan(0);
     const { companyId, agentId, issueId, runId } = await seedRunFixture({
       agentStatus: "running",
@@ -1900,7 +1898,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
         };
         const child = spawnAliveProcess();
-        childProcesses.add(child);
+        childProcesses.registerProcess(child, { label: "adapter execution child" });
         if (!child.pid) throw new Error("Test codex_local child did not expose a pid");
         spawnedPid = child.pid;
         await input.onSpawn?.({
@@ -2009,7 +2007,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
   it("reports adopted hot-restart runs before startup reap can mark them process_lost", async () => {
     const child = spawnAliveProcess();
-    childProcesses.add(child);
+    childProcesses.registerProcess(child, { label: "heartbeat recovery child" });
     expect(child.pid).toBeGreaterThan(0);
     const { runId } = await seedRunFixture({
       agentStatus: "running",

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -373,6 +373,7 @@ describe("sanitizeRuntimeServiceBaseEnv", () => {
       DATABASE_URL: "postgres://example.test/paperclip",
       PAPERCLIP_HOME: "/tmp/paperclip-home",
       PAPERCLIP_INSTANCE_ID: "runtime-instance",
+      PAPERCLIP_TEST_INVOCATION_ID: "test-invocation",
       npm_config_tailscale_auth: "true",
       npm_config_authenticated_private: "true",
       HOST: "0.0.0.0",
@@ -380,6 +381,7 @@ describe("sanitizeRuntimeServiceBaseEnv", () => {
 
     expect(sanitized.PAPERCLIP_HOME).toBeUndefined();
     expect(sanitized.PAPERCLIP_INSTANCE_ID).toBeUndefined();
+    expect(sanitized.PAPERCLIP_TEST_INVOCATION_ID).toBe("test-invocation");
     expect(sanitized.DATABASE_URL).toBeUndefined();
     expect(sanitized.npm_config_tailscale_auth).toBeUndefined();
     expect(sanitized.npm_config_authenticated_private).toBeUndefined();

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -8,7 +8,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { parse as parseEnvContents } from "dotenv";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { FixtureSupervisor } from "@paperclipai/adapter-utils/test-support/fixture-supervisor";
 import {
   activityLog,
   agents,
@@ -107,6 +108,7 @@ function workspaceBranchIncoherenceFingerprintForTest(input: {
 }
 
 const leasedRunIds = new Set<string>();
+let processFixtures: FixtureSupervisor;
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 
@@ -344,7 +346,12 @@ function createWorkspaceOperationRecorderDouble() {
   return { recorder, operations };
 }
 
+beforeEach(() => {
+  processFixtures = new FixtureSupervisor({ owner: "workspace runtime tests" });
+});
+
 afterEach(async () => {
+  await processFixtures.teardown();
   await Promise.all(
     Array.from(leasedRunIds).map(async (runId) => {
       await releaseRuntimeServicesForRun(runId);
@@ -4635,6 +4642,7 @@ describe("readLocalServicePortOwner", () => {
       ],
       { cwd: ownerWorkspace, stdio: ["ignore", "pipe", "inherit"] },
     );
+    processFixtures.registerProcess(child, { label: "cross-workspace listener" });
     const port = await new Promise<number>((resolve, reject) => {
       let output = "";
       child.stdout?.on("data", (chunk) => {
@@ -5769,6 +5777,10 @@ describeEmbeddedPostgres("workspace runtime startup reconciliation", () => {
       },
       detached: process.platform !== "win32",
       stdio: "ignore",
+    });
+    processFixtures.registerProcess(staleProcess, {
+      label: "stale runtime service",
+      processGroupId: process.platform === "win32" ? null : staleProcess.pid,
     });
     staleProcess.unref();
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -352,7 +352,7 @@ export async function ensureServerWorkspaceLinksCurrent(
 export function sanitizeRuntimeServiceBaseEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   for (const key of Object.keys(env)) {
-    if (key.startsWith("PAPERCLIP_")) {
+    if (key.startsWith("PAPERCLIP_") && key !== "PAPERCLIP_TEST_INVOCATION_ID") {
       delete env[key];
     }
   }


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip uses Vitest to verify the server, UI, adapters, and shared packages
> - Some test fixtures start PostgreSQL, SSH, and model-adapter process trees
> - An interrupted test run could leave those processes alive and keep its temporary root in use
> - Independent shards could also exceed the host process capacity because each shard controlled only its own workers
> - This pull request gives each Vitest invocation an owned process boundary, a bounded host slot, and verified cleanup
> - The benefit is deterministic test cleanup and a bounded load on developer and CI hosts

## Linked Issues or Issue Description

No public GitHub issue exists for this specific test-runner bug.

Related work: Refs #10624 and #11035. Those pull requests cover other process-lifecycle and timeout paths. They do not add Vitest invocation containment or temp-root cleanup.

**What happened?**

Vitest runs could leave PostgreSQL, SSH, and model-adapter fixture processes alive after an interrupt or failed teardown. The stable runner could then delete or retain a temporary root without one ownership boundary for every descendant. Independent shards could also start too many process-heavy suites on one host.

**Expected behavior**

Each Vitest invocation must own its complete process tree. Cleanup must stop verified descendants before it removes the invocation root. Concurrent shards must share one bounded host capacity.

**Steps to reproduce**

1. Start a process-heavy stable Vitest run.
2. Interrupt the runner while a fixture process is active.
3. Inspect the process tree and the invocation temporary root.
4. Start several independent shards and observe that their combined process count has no host-wide cap.

**Paperclip version or commit**

The bug was present on `master` before this change.

**Deployment mode**

Local development and CI test execution from source.

## What Changed

- Added invocation-owned temporary roots and process containment to the stable Vitest runner.
- Added Linux cgroup v2 support with a process-group and random invocation-tag fallback.
- Added a Linux cleanup guardian for runner crashes, verified TERM/KILL cleanup, root-reference checks, and bounded failed-artifact retention.
- Added atomic host-wide slots, a total process budget, and PostgreSQL, SSH, and model-adapter family limits.
- Added safe diagnostics and stale-root recovery through `pnpm test:diagnose`.
- Added a shared fixture supervisor and used it in process-heavy adapter and server tests.
- Preserved the test invocation tag when runtime services sanitize inherited Paperclip variables, so detached service fixtures stay inside the test boundary.
- Added integration tests for containment, cleanup, diagnostics redaction, stale-slot recovery, budgets, and fixture teardown.
- Made invocation-registry writes atomic so concurrent diagnostics cannot read a partial JSON record.
- Documented the containment modes, limits, cleanup invariants, configuration, and platform limits.

## Verification

- `node --test scripts/__tests__/vitest-supervisor.test.mjs` passes 18 tests.
- `pnpm exec vitest run packages/adapter-utils/src/test-support/fixture-supervisor.test.ts` passes 2 tests.
- The affected server process-recovery and workspace-runtime suites pass 207 tests.
- The affected Claude, Codex, and Gemini ACP suites pass 58 tests.
- The affected Hermes task-bridge suite passes 3 tests.
- A focused supervised workspace-runtime regression passes 3 tests, terminates the escaped fixture tree, finds zero root references, and removes the invocation root.
- `pnpm --filter @paperclipai/adapter-utils typecheck` passes.
- `pnpm -r typecheck` passes.
- The stable general-server lane passes 318 files and 3,490 tests.
- The UI lane passes 438 files and 3,679 tests.
- The CLI lane passes 54 files and 335 tests with host AWS credential variables removed from the test environment.
- The remaining package matrix passes 94 files and 983 tests with one worker on the busy local host.
- `pnpm test:run:serialized` passes all 128 serialized server suites.
- Two database migration tests reached their existing five-second timeout only during a parallel local run. Both tests pass in isolation, and the complete package matrix passes with one worker.
- `pnpm build` passes.
- `pnpm test:diagnose` reports no active invocation after cleanup.
- The latest GitHub Actions matrix passes, including `General tests (workspaces-b)` with the root-scoped detached-process regression.
- The latest Greptile review reports 5/5 with no unresolved review threads.

## Risks

- The process-control path is platform-specific. Linux has the strongest descendant discovery through cgroup v2 or `/proc` tags.
- Windows uses `taskkill` for tree termination. A native Job Object is not part of this change.
- A non-Linux POSIX child that creates a new session cannot be rediscovered after its parent exits.
- The default host cap is two stable runners. This can make many independent local shards wait. Operators can change the cap with `PAPERCLIP_TEST_HOST_CAP`.
- Cleanup fails closed when process identity or root safety cannot be verified. This can retain a root for operator inspection.
- The execution contract requires the existing source branch name. The branch therefore keeps its assigned name even though the public branch guide normally requires a descriptive name without an internal identifier.
- This change has no database migration, API contract change, or production runtime change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex based on GPT-5. The exact deployment ID and context-window size are not exposed. The model used reasoning, repository tools, command execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have reviewed the branch-name rule. The execution contract requires the existing branch name.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
