### PR TITLE
fix(secrets): store openclaw_gateway credentials as secret refs

### DIFF
--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -262,6 +262,77 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     expect(JSON.stringify(persistedConfig)).not.toContain(literalApiKey);
   });
 
+  it("converts OpenClaw gateway credential strings into persisted secret refs", async () => {
+    const companyId = await seedCompany();
+    const literalAuthToken = `openclaw-token-${randomUUID()}`;
+    const literalPassword = `openclaw-password-${randomUUID()}`;
+    const literalPrivateKeyPem = [
+      "-----BEGIN PRIVATE KEY-----",
+      `openclaw-device-key-${randomUUID()}`,
+      "-----END PRIVATE KEY-----",
+    ].join("\n");
+
+    const created = await agentService(db).create(companyId, {
+      name: "OpenClaw Gateway",
+      role: "engineer",
+      status: "idle",
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "ws://127.0.0.1:18789",
+        authToken: literalAuthToken,
+        password: literalPassword,
+        devicePrivateKeyPem: literalPrivateKeyPem,
+      },
+      runtimeConfig: {},
+      spentMonthlyCents: 0,
+      lastHeartbeatAt: null,
+    });
+
+    const persistedRows = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.id, created.id));
+    const persistedConfig = persistedRows[0]?.adapterConfig as Record<string, unknown>;
+    const serializedConfig = JSON.stringify(persistedConfig);
+    expect(serializedConfig).not.toContain(literalAuthToken);
+    expect(serializedConfig).not.toContain(literalPassword);
+    expect(serializedConfig).not.toContain(literalPrivateKeyPem);
+    for (const key of ["authToken", "password", "devicePrivateKeyPem"]) {
+      expect(persistedConfig[key]).toMatchObject({
+        type: "secret_ref",
+        version: "latest",
+      });
+    }
+    expect(persistedConfig.url).toBe("ws://127.0.0.1:18789");
+
+    const bindings = await db
+      .select()
+      .from(companySecretBindings)
+      .where(and(
+        eq(companySecretBindings.companyId, companyId),
+        eq(companySecretBindings.targetType, "agent"),
+        eq(companySecretBindings.targetId, created.id),
+      ));
+    expect(bindings.map((binding) => binding.configPath).sort()).toEqual([
+      "authToken",
+      "devicePrivateKeyPem",
+      "password",
+    ]);
+
+    const resolved = await secretService(db).resolveAdapterConfigForRuntime(
+      companyId,
+      persistedConfig,
+      {
+        consumerType: "agent",
+        consumerId: created.id,
+      },
+      { adapterType: "openclaw_gateway" },
+    );
+    expect(resolved.config.authToken).toBe(literalAuthToken);
+    expect(resolved.config.password).toBe(literalPassword);
+    expect(resolved.config.devicePrivateKeyPem).toBe(literalPrivateKeyPem);
+  });
+
   it("replaces agent secret bindings when adapterConfig env changes", async () => {
     const companyId = await seedCompany();
     const secrets = secretService(db);

--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -266,6 +266,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     const companyId = await seedCompany();
     const literalAuthToken = `openclaw-token-${randomUUID()}`;
     const literalPassword = `openclaw-password-${randomUUID()}`;
+    const literalDeviceToken = `openclaw-device-token-${randomUUID()}`;
     const literalPrivateKeyPem = [
       "-----BEGIN PRIVATE KEY-----",
       `openclaw-device-key-${randomUUID()}`,
@@ -281,6 +282,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
         url: "ws://127.0.0.1:18789",
         authToken: literalAuthToken,
         password: literalPassword,
+        deviceToken: literalDeviceToken,
         devicePrivateKeyPem: literalPrivateKeyPem,
       },
       runtimeConfig: {},
@@ -296,8 +298,9 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     const serializedConfig = JSON.stringify(persistedConfig);
     expect(serializedConfig).not.toContain(literalAuthToken);
     expect(serializedConfig).not.toContain(literalPassword);
+    expect(serializedConfig).not.toContain(literalDeviceToken);
     expect(serializedConfig).not.toContain(literalPrivateKeyPem);
-    for (const key of ["authToken", "password", "devicePrivateKeyPem"]) {
+    for (const key of ["authToken", "password", "deviceToken", "devicePrivateKeyPem"]) {
       expect(persistedConfig[key]).toMatchObject({
         type: "secret_ref",
         version: "latest",
@@ -316,6 +319,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     expect(bindings.map((binding) => binding.configPath).sort()).toEqual([
       "authToken",
       "devicePrivateKeyPem",
+      "deviceToken",
       "password",
     ]);
 
@@ -330,6 +334,7 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     );
     expect(resolved.config.authToken).toBe(literalAuthToken);
     expect(resolved.config.password).toBe(literalPassword);
+    expect(resolved.config.deviceToken).toBe(literalDeviceToken);
     expect(resolved.config.devicePrivateKeyPem).toBe(literalPrivateKeyPem);
   });
 

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -77,7 +77,7 @@ const COMING_SOON_SECRET_PROVIDERS: ReadonlySet<SecretProvider> = new Set([
 ]);
 const FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS: Readonly<Record<string, readonly string[]>> = {
   hermes_gateway: ["apiKey"],
-  openclaw_gateway: ["authToken", "token", "password", "devicePrivateKeyPem"],
+  openclaw_gateway: ["authToken", "token", "deviceToken", "password", "devicePrivateKeyPem"],
 };
 const USER_SECRET_DEFINITION_KEY_UNIQUE_CONSTRAINT = "user_secret_definitions_company_key_uq";
 const USER_SECRET_VALUE_UNIQUE_CONSTRAINT = "company_secrets_user_definition_owner_uq";

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -77,6 +77,7 @@ const COMING_SOON_SECRET_PROVIDERS: ReadonlySet<SecretProvider> = new Set([
 ]);
 const FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS: Readonly<Record<string, readonly string[]>> = {
   hermes_gateway: ["apiKey"],
+  openclaw_gateway: ["authToken", "token", "password", "devicePrivateKeyPem"],
 };
 const USER_SECRET_DEFINITION_KEY_UNIQUE_CONSTRAINT = "user_secret_definitions_company_key_uq";
 const USER_SECRET_VALUE_UNIQUE_CONSTRAINT = "company_secrets_user_definition_owner_uq";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents are configured per adapter, and `adapterConfig` regularly carries credentials; the secrets service is responsible for turning those literals into secret refs on write (`normalizeAdapterConfigForPersistence`)
> - Which fields get that treatment comes from `listAdapterSchemaSecretFieldKeys()`: the adapter's `getConfigSchema()` fields marked `meta.secret === true`, unioned with a hardcoded `FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS` map
> - The `openclaw_gateway` adapter exports only `execute` and `testEnvironment` — it has no `config-schema.ts` and no `getConfigSchema()` — so the schema branch is skipped entirely and only the fallback map applies
> - The fallback map had a single entry, `hermes_gateway: ["apiKey"]`, so **no** `openclaw_gateway` field was ever normalized, and its gateway credentials were persisted verbatim into `agents.adapter_config`
> - This pull request adds the `openclaw_gateway` credential fields to that fallback map so they become secret refs on write, matching `hermes_gateway`
> - The benefit is that OpenClaw gateway shared tokens, passwords, and device private keys stop living as plaintext in the agents table, and inherit the existing binding/audit/rotation machinery

## Linked Issues or Issue Description

No issue exists for this specific gap, so describing it here per `CONTRIBUTING.md` (bug report shape):

**What happened** — Creating or updating an agent with `adapterType: "openclaw_gateway"` and credential values in `adapterConfig` (`authToken`, `password`, `devicePrivateKeyPem`) stores those values as plaintext strings in `agents.adapter_config`. No `company_secret_bindings` rows are created, so the values are outside the secrets manager: not encrypted at rest in the agents table, not rotatable, not covered by per-agent secret access, and not audited on resolution.

**Expected behavior** — Same as `hermes_gateway`: literal credential strings passed to the agent create/update APIs are converted into `secret_ref` values with backing `company_secret_bindings`, and rehydrated only at runtime by `resolveAdapterConfigForRuntime()`.

**Steps to reproduce**
1. `POST /api/companies/{companyId}/agents` with `adapterType: "openclaw_gateway"` and `adapterConfig: { url: "ws://…", authToken: "<literal>", devicePrivateKeyPem: "-----BEGIN PRIVATE KEY-----…" }`
2. Read the persisted row: `select adapter_config from agents where id = …`
3. Both literals are present verbatim; `select * from company_secret_bindings where target_id = …` returns zero rows
4. Doing the same with `adapterType: "hermes_gateway"` and `apiKey` yields `{"type":"secret_ref",…}` plus a binding row

**Version/commit** — reproduced on `master` (`4683f26`). **Deployment mode** — self-hosted server, `pnpm dev`.

**Related PRs** (read-side redaction; complementary to this change, not duplicates — they hide already-stored plaintext on `GET`, this stops it being stored in the first place):
- Refs #9823 — `fix(security): redact adapterConfig secrets on all agent read endpoints`
- Refs #4763 — `fix(server): redact adapter_config secrets in agent detail responses`
- Refs #10284 — `Security: Add redaction of sensitive fields in Paperclip config-read API responses`
- Refs #1818 — `SECURITY BREACH WARNING: GET /api/companies/{id}/agents leaks plaintext secrets from agent adapter env vars` (adjacent: that issue is about `adapterConfig.env`, which is already normalized; this PR covers the top-level `openclaw_gateway` credential fields, which were not)

I searched open and closed PRs for `openclaw`, `adapter secret`, `devicePrivateKeyPem`, and `openclaw secret ref`, and code-searched `FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS`. Nothing in flight touches this map.

## What Changed

- `server/src/services/secrets.ts`: added an `openclaw_gateway` entry to `FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS` listing `authToken`, `token`, `password`, `devicePrivateKeyPem`.
  - `authToken` / `token`: both are read as the shared gateway token by `resolveAuthToken()` in the adapter (`nonEmpty(config.authToken) ?? nonEmpty(config.token)`), so both are covered.
  - `password`: read at `execute.ts` and `test.ts` as the gateway shared password.
  - `devicePrivateKeyPem`: read by `resolveDeviceIdentity()` and fed to `crypto.createPrivateKey()`.
- `server/src/__tests__/agents-service-secret-bindings.test.ts`: added a regression test mirroring the existing Hermes gateway case — asserts the three UI-settable credential fields persist as `secret_ref`, that the literals do not appear anywhere in the persisted config, that exactly the expected `company_secret_bindings` config paths are created, that non-secret fields (`url`) are untouched, and that `resolveAdapterConfigForRuntime()` returns the original plaintext.

No adapter-side change is needed: `resolveAdapterConfigForRuntime()` rehydrates the plaintext before `execute()` is called.

## Verification

Automated, from `server/`:

```
vitest run src/__tests__/agents-service-secret-bindings.test.ts
#  Test Files  1 passed (1)
#  Tests  10 passed (10)
#  ✓ converts OpenClaw gateway credential strings into persisted secret refs

vitest run src/__tests__/secrets-service.test.ts src/__tests__/adapter-registry.test.ts src/__tests__/company-portability.test.ts
#  Test Files  3 passed (3)
#  Tests  141 passed (141)

tsc --noEmit -p tsconfig.json    # clean
```

The new test runs against embedded Postgres (`getEmbeddedPostgresTestSupport`), so it exercises real persistence and real binding rows rather than mocks.

Manual, on a self-hosted instance with a live `openclaw_gateway` agent:

1. Confirmed the stored `adapter_config` contained a literal gateway token and a full `-----BEGIN PRIVATE KEY-----` PEM, and that both were returned in the agents read response.
2. Applied this patch and restarted the server.
3. `PATCH`ed the same agent with identical `adapterConfig` values; both fields flipped to `{"type":"secret_ref","version":"latest",…}`.
4. Re-read the agents endpoint: zero occurrences of the token string or `BEGIN PRIVATE KEY`.
5. Triggered a real heartbeat wake against the OpenClaw gateway afterwards — the connection authenticated and the run completed, confirming runtime resolution still hands the adapter plaintext.

## Risks

Low risk, but two things worth calling out:

- **Migration of existing rows is not automatic.** Agents configured before this change keep their plaintext values until the config is written again (any agent update re-runs normalization). This PR deliberately does not add a backfill migration; that would be a separate, larger change. Combined with the read-side redaction PRs linked above, already-stored values also stop being served over the API.
- **`token` is undocumented.** `agentConfigurationDoc` lists `authToken` and `password` but not `token`; `token` only exists as an alias inside `resolveAuthToken()`. It is included here so the alias cannot be used to smuggle a credential past normalization. If a maintainer would rather keep the map strictly to documented fields, dropping `token` is a one-word change.
- Behaviour for every other adapter type is unchanged — the map is keyed by adapter type and nothing else was touched.

Longer term the cleaner fix is for the `openclaw_gateway` adapter to ship a `config-schema.ts` with `meta: { secret: true }` on these fields, like `packages/adapters/hermes/src/gateway/server/config-schema.ts` does, which would also drive the config UI. That is a bigger change with UI implications (the adapter currently has a hand-written `src/ui`), so this PR takes the minimal path that the fallback map already exists for. Happy to follow up with the schema version if maintainers prefer it.

## Model Used

- Claude Opus 5 (`claude-opus-5`), Anthropic, via Claude Code CLI
- Extended thinking enabled; tool use (filesystem, shell, test execution)
- The change, the test, and this description were produced with model assistance and reviewed and executed locally by a human-supervised session; all test and typecheck output quoted above is real output from this machine, not reproduced from memory

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs describe this normalization map; `agentConfigurationDoc` field descriptions are unchanged by this PR
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — will confirm once CI reports
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — will address on review
- [x] I will address all Greptile and reviewer comments before requesting merge
