### PR TITLE
fix(server): keep local agent API traffic on loopback

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -1,9 +1,36 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRuntimeApiCandidateUrls,
+  chooseAgentRuntimeApiUrl,
   choosePrimaryRuntimeApiUrl,
   collectReachableInterfaceHosts,
 } from "../runtime-api.js";
+
+describe("chooseAgentRuntimeApiUrl", () => {
+  it("ignores the auth-proxied public base URL for co-located local_trusted agents", () => {
+    expect(
+      chooseAgentRuntimeApiUrl({
+        deploymentMode: "local_trusted",
+        authPublicBaseUrl: "https://paperclip.example.com",
+        allowedHostnames: ["paperclip.example.com"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
+  it("keeps the public base URL for non-local deployment modes", () => {
+    expect(
+      chooseAgentRuntimeApiUrl({
+        deploymentMode: "authenticated",
+        authPublicBaseUrl: "https://paperclip.example.com",
+        allowedHostnames: ["paperclip.example.com"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("https://paperclip.example.com");
+  });
+});
 
 describe("runtime API discovery", () => {
   it("prefers the explicit public base URL for the primary runtime URL", () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -70,7 +70,7 @@ import {
   reconcileAdapterAvailability,
 } from "./services/adapter-registry-bootstrap.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
-import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
+import { buildRuntimeApiCandidateUrls, chooseAgentRuntimeApiUrl, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
@@ -783,13 +783,25 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
-  const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
+  // Public-facing URL for browser login, outbound webhooks and callback
+  // candidates. May resolve to an auth-proxied host (e.g. Cloudflare Access).
+  const publicApiUrl = choosePrimaryRuntimeApiUrl({
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,
     port: listenPort,
   });
-  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
+  // Agent-facing URL. For co-located (local_trusted) deployments this must be
+  // the loopback/bind origin, never the auth-proxied public host, or the
+  // agent's API calls get 302-redirected to the proxy login flow.
+  const runtimeApiUrl = chooseAgentRuntimeApiUrl({
+    deploymentMode: config.deploymentMode,
+    authPublicBaseUrl: config.authPublicBaseUrl ?? null,
+    allowedHostnames: config.allowedHostnames,
+    bindHost: runtimeListenHost,
+    port: listenPort,
+  });
+  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || publicApiUrl;
   const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
     preferredApiUrl: configuredApiUrl,
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -80,6 +80,37 @@ export function choosePrimaryRuntimeApiUrl(input: {
   return formatOrigin("http:", "localhost", input.port);
 }
 
+/**
+ * Chooses the API URL that a **local agent** should use to reach the control
+ * plane. Local agents run on the same host as the server, so for co-located
+ * (`local_trusted`) deployments the agent must reach the API over the
+ * loopback/bind address.
+ *
+ * The public base URL (`authPublicBaseUrl`) is meant for browser login and
+ * outbound webhooks and may sit behind an authenticating proxy (e.g. Cloudflare
+ * Access). If the agent is handed that public host, every service-to-service
+ * call is redirected to the proxy's login flow (a 302) and fails. So for
+ * `local_trusted` we deliberately ignore `authPublicBaseUrl` here and let
+ * {@link choosePrimaryRuntimeApiUrl} derive the loopback/bind origin. Other
+ * deployment modes keep the existing behaviour.
+ */
+export function chooseAgentRuntimeApiUrl(input: {
+  deploymentMode: string;
+  authPublicBaseUrl?: string | null;
+  allowedHostnames: string[];
+  bindHost: string;
+  port: number;
+}): string {
+  const authPublicBaseUrl =
+    input.deploymentMode === "local_trusted" ? null : input.authPublicBaseUrl ?? null;
+  return choosePrimaryRuntimeApiUrl({
+    authPublicBaseUrl,
+    allowedHostnames: input.allowedHostnames,
+    bindHost: input.bindHost,
+    port: input.port,
+  });
+}
+
 export function collectReachableInterfaceHosts(input: {
   networkInterfacesMap?: NodeJS.Dict<os.NetworkInterfaceInfo[]>;
 } = {}): string[] {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that coordinates AI agents.
> - Local agents use `PAPERCLIP_RUNTIME_API_URL` to call the control plane.
> - A `local_trusted` server can also publish a browser URL through an authentication proxy.
> - Paperclip currently gives that public URL to local agents.
> - The proxy redirects local agent calls to its login flow.
> - This pull request selects a loopback URL for local agents and keeps the public URL for browsers and callbacks.
> - The benefit is reliable local agent traffic without deployment-specific patches.

## Linked Issues or Issue Description

Fixes: #9492

This change supersedes the closed attempt in #9187. It preserves Noel Bossart's original commit and authorship.

## What Changed

- Add `chooseAgentRuntimeApiUrl` for agent-facing URL selection.
- Use the bind origin for `local_trusted` agents.
- Keep the public URL for authenticated modes, browser login, webhooks, and callback candidates.
- Add focused unit tests for local and authenticated modes.

## Verification

- `cd server && pnpm exec vitest run src/__tests__/runtime-api.test.ts src/__tests__/paperclip-env.test.ts` — 12 tests passed.
- `cd server && pnpm run typecheck` — passed.
- `git diff --check origin/master...HEAD` — passed.

## Risks

- Low risk. The behavior changes only for the agent-facing URL in `local_trusted` mode.
- Authenticated modes keep the existing public URL behavior.

## Model Used

- OpenAI Codex, GPT-5 family. The exact serving snapshot is not exposed. Tool use and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
