### PR TITLE
fix(ci): measure the committed lockfile overrides before pr.yml regenerates it

### DIFF
--- a/.github/scripts/check-pr-lockfile.mjs
+++ b/.github/scripts/check-pr-lockfile.mjs
@@ -6,12 +6,19 @@
  */
 import { fileURLToPath } from 'node:url';
 
+// refresh-lockfile.yml opens its heal PR as the commitperclip app, because PRs
+// created with GITHUB_TOKEN never trigger the checks the auto-merge waits on.
+// github-actions[bot] stays accepted so the gate keeps working if that workflow
+// ever falls back to github.token.
+export const REFRESH_BOT_AUTHORS = ['github-actions[bot]', 'commitperclip[bot]'];
+export const REFRESH_BOT_BRANCH = 'chore/refresh-lockfile';
+
 export function checkLockfile(files, prAuthor, prBranch) {
   const lockfileChanged = files.some(f => f.filename === 'pnpm-lock.yaml');
   if (!lockfileChanged) return { passed: true, failures: [] };
 
   const isRefreshBot =
-    prAuthor === 'github-actions[bot]' && prBranch === 'chore/refresh-lockfile';
+    REFRESH_BOT_AUTHORS.includes(prAuthor) && prBranch === REFRESH_BOT_BRANCH;
 
   return {
     passed: isRefreshBot,

--- a/.github/scripts/tests/check-pr-lockfile.test.mjs
+++ b/.github/scripts/tests/check-pr-lockfile.test.mjs
@@ -17,6 +17,26 @@ test('passes when lockfile changed by refresh bot on correct branch', () => {
   assert.equal(result.passed, true);
 });
 
+// refresh-lockfile.yml opens the heal PR as the commitperclip app so its
+// required checks actually trigger; the gate must let that author through.
+test('passes when lockfile changed by commitperclip app on correct branch', () => {
+  const result = checkLockfile(
+    makeFiles(['pnpm-lock.yaml']),
+    'commitperclip[bot]',
+    'chore/refresh-lockfile'
+  );
+  assert.equal(result.passed, true);
+});
+
+test('fails when lockfile changed by commitperclip app on wrong branch', () => {
+  const result = checkLockfile(
+    makeFiles(['pnpm-lock.yaml']),
+    'commitperclip[bot]',
+    'fix/something-else'
+  );
+  assert.equal(result.passed, false);
+});
+
 test('fails when lockfile changed by regular user', () => {
   const result = checkLockfile(makeFiles(['pnpm-lock.yaml']), 'someuser', 'fix/bug');
   assert.equal(result.passed, false);

--- a/scripts/check-lockfile-overrides.mjs
+++ b/scripts/check-lockfile-overrides.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+/**
+ * check-lockfile-overrides.mjs
+ *
+ * Guards the one part of `pnpm-lock.yaml` that the PR pipeline never measures:
+ * the committed lockfile itself.
+ *
+ * `pr.yml` regenerates the lockfile whenever a PR touches a manifest and hands
+ * the regenerated copy to every downstream job as the `pr-lockfile` artifact.
+ * That is deliberate — contributors are not allowed to commit the lockfile — but
+ * it means the manifest-changing PRs (exactly the ones that can break dependency
+ * resolution) run `pnpm install --frozen-lockfile` against a *repaired* lockfile
+ * that is thrown away afterwards. A committed lockfile whose `overrides:` block
+ * contradicts the root manifest therefore merges green and only detonates in the
+ * next, unrelated PR.
+ *
+ * This check compares the `overrides:` mapping of the committed lockfile against
+ * the effective `pnpm.overrides` of the root manifest, before any regeneration
+ * happens. It deliberately carries no `dependabot[bot]` exception — the
+ * `Block manual lockfile edits` step above it does, and dependabot was the
+ * trigger the one time this hole was hit.
+ *
+ * The check is scoped to mismatches *this PR introduces*: a mismatch that
+ * already exists identically on the base commit is reported but not failed, so a
+ * broken base branch does not blame unrelated PRs. Set `BASE_SHA` to enable that
+ * scoping; without it the check compares the working tree strictly, which is the
+ * useful behaviour for a local run.
+ *
+ * Exports: parseYamlScalarBlock, readManifestOverrides, changedKeys,
+ *          checkLockfileOverrides, runCheck
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const LOCKFILE = "pnpm-lock.yaml";
+const MANIFEST = "package.json";
+const WORKSPACE = "pnpm-workspace.yaml";
+
+/**
+ * Unwraps a YAML scalar. pnpm writes override keys and values verbatim, quoting
+ * only when YAML forces it (`'>=4.59.0'`, `'@lexical/react'`), so unquoting is
+ * all that is needed to compare against the JSON manifest.
+ */
+function unquoteYamlScalar(raw) {
+  const value = raw.trim();
+  if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\(["\\])/g, "$1");
+  }
+  return value;
+}
+
+/** Splits `key: value`, honouring a quoted key that may itself contain a colon. */
+function splitEntry(trimmed) {
+  const quote = trimmed[0];
+  if (quote === "'" || quote === '"') {
+    let i = 1;
+    for (; i < trimmed.length; i++) {
+      if (quote === '"' && trimmed[i] === "\\") {
+        i++;
+        continue;
+      }
+      if (trimmed[i] === quote) {
+        if (quote === "'" && trimmed[i + 1] === "'") {
+          i++;
+          continue;
+        }
+        break;
+      }
+    }
+    if (i >= trimmed.length) return null;
+    const rest = trimmed.slice(i + 1).trimStart();
+    if (!rest.startsWith(":")) return null;
+    return { key: unquoteYamlScalar(trimmed.slice(0, i + 1)), value: rest.slice(1) };
+  }
+
+  const idx = trimmed.indexOf(":");
+  if (idx === -1) return null;
+  return { key: trimmed.slice(0, idx).trim(), value: trimmed.slice(idx + 1) };
+}
+
+/**
+ * Reads a top-level block of flat `key: value` scalars (`overrides:`) out of a
+ * YAML document. Returns null when the block is absent, so "no block" stays
+ * distinguishable from "empty block".
+ *
+ * Throws on any shape it cannot represent faithfully — a guard that silently
+ * mis-parses is the very failure mode this file exists to close.
+ */
+export function parseYamlScalarBlock(text, blockName) {
+  const lines = text.split("\n");
+  const header = `${blockName}:`;
+
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trimEnd() === header) {
+      start = i + 1;
+      break;
+    }
+  }
+  if (start === -1) return null;
+
+  const entries = {};
+  let baseIndent = null;
+
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+
+    const indent = line.length - line.trimStart().length;
+    if (indent === 0) break;
+
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) continue;
+
+    if (baseIndent === null) baseIndent = indent;
+    if (indent < baseIndent) break;
+    if (indent > baseIndent) {
+      throw new Error(
+        `${LOCKFILE}: unsupported nested value under \`${blockName}:\` at line ${i + 1}: ${trimmed}`,
+      );
+    }
+
+    const entry = splitEntry(trimmed);
+    if (!entry || entry.value.trim() === "") {
+      throw new Error(
+        `${LOCKFILE}: unsupported entry under \`${blockName}:\` at line ${i + 1}: ${trimmed}`,
+      );
+    }
+    entries[entry.key] = unquoteYamlScalar(entry.value);
+  }
+
+  return entries;
+}
+
+/**
+ * The effective override map of the workspace root. pnpm 9 reads
+ * `pnpm.overrides` from package.json; pnpm 10 moved the field to
+ * pnpm-workspace.yaml. Both are honoured, workspace-level last, so this check
+ * does not silently go blind the day the repo migrates.
+ */
+export function readManifestOverrides({ packageJsonText, workspaceYamlText }) {
+  const fromManifest = JSON.parse(packageJsonText)?.pnpm?.overrides ?? null;
+  const fromWorkspace =
+    workspaceYamlText == null ? null : parseYamlScalarBlock(workspaceYamlText, "overrides");
+
+  const merged = {};
+  for (const [key, value] of Object.entries(fromManifest ?? {})) merged[key] = String(value);
+  for (const [key, value] of Object.entries(fromWorkspace ?? {})) merged[key] = String(value);
+  return merged;
+}
+
+/** Override keys whose value differs between two maps (added and removed included). */
+export function changedKeys(before, after) {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  return [...keys].filter(key => before[key] !== after[key]);
+}
+
+/**
+ * Compares the committed lockfile's overrides against the root manifest's.
+ *
+ * A key is exempt when either
+ *  - the identical mismatch already exists on the base commit (pre-existing
+ *    breakage is reported, not blamed on this PR), or
+ *  - this PR changed the key in the manifest while leaving the lockfile's entry
+ *    for it untouched — the legitimate shape of an override change, since
+ *    contributors must not commit the lockfile and CI regenerates it.
+ */
+export function checkLockfileOverrides({
+  lockOverrides,
+  manifestOverrides,
+  baseLockOverrides = null,
+  baseManifestOverrides = null,
+}) {
+  const hasBase = baseLockOverrides !== null && baseManifestOverrides !== null;
+  const manifestTouched = hasBase ? new Set(changedKeys(baseManifestOverrides, manifestOverrides)) : new Set();
+  const lockTouched = hasBase ? new Set(changedKeys(baseLockOverrides, lockOverrides)) : new Set();
+
+  const keys = [...new Set([...Object.keys(lockOverrides), ...Object.keys(manifestOverrides)])].sort();
+  const problems = [];
+  const preExisting = [];
+
+  for (const key of keys) {
+    const inLock = Object.hasOwn(lockOverrides, key);
+    const inManifest = Object.hasOwn(manifestOverrides, key);
+    if (inLock && inManifest && lockOverrides[key] === manifestOverrides[key]) continue;
+
+    const problem = {
+      key,
+      lock: inLock ? lockOverrides[key] : null,
+      manifest: inManifest ? manifestOverrides[key] : null,
+    };
+
+    // A manifest-only override change with an untouched lockfile entry is the
+    // sanctioned flow: CI owns the lockfile and regenerates it after merge.
+    if (manifestTouched.has(key) && !lockTouched.has(key)) continue;
+
+    // Unchanged on both sides and already broken at the base — not this PR's doing.
+    if (
+      hasBase &&
+      baseLockOverrides[key] === problem.lock &&
+      baseManifestOverrides[key] === problem.manifest
+    ) {
+      preExisting.push(problem);
+      continue;
+    }
+
+    problems.push(problem);
+  }
+
+  return { passed: problems.length === 0, problems, preExisting };
+}
+
+function describe(problem) {
+  const { key, lock, manifest } = problem;
+  if (lock === null) return `  ${key}: missing from ${LOCKFILE}, manifest pins ${manifest}`;
+  if (manifest === null) return `  ${key}: ${LOCKFILE} pins ${lock}, manifest declares no override`;
+  return `  ${key}: ${LOCKFILE} pins ${lock}, manifest pins ${manifest}`;
+}
+
+function readBaseFile(repoRoot, baseSha, file) {
+  return execFileSync("git", ["show", `${baseSha}:${file}`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function runCheck({ repoRoot, baseSha = null, log = console.log, error = console.error }) {
+  const lockfilePath = path.join(repoRoot, LOCKFILE);
+  if (!existsSync(lockfilePath)) {
+    error(`ERROR: ${LOCKFILE} not found at repository root.`);
+    return 1;
+  }
+
+  const workspacePath = path.join(repoRoot, WORKSPACE);
+  const lockOverrides = parseYamlScalarBlock(readFileSync(lockfilePath, "utf8"), "overrides") ?? {};
+  const manifestOverrides = readManifestOverrides({
+    packageJsonText: readFileSync(path.join(repoRoot, MANIFEST), "utf8"),
+    workspaceYamlText: existsSync(workspacePath) ? readFileSync(workspacePath, "utf8") : null,
+  });
+
+  let baseLockOverrides = null;
+  let baseManifestOverrides = null;
+  if (baseSha) {
+    // fetch-depth: 0 is set on the policy job, so a missing base object means a
+    // broken assumption rather than a shallow clone. Fail loudly instead of
+    // quietly downgrading to a comparison that cannot exempt anything.
+    try {
+      baseLockOverrides = parseYamlScalarBlock(readBaseFile(repoRoot, baseSha, LOCKFILE), "overrides") ?? {};
+      baseManifestOverrides = readManifestOverrides({
+        packageJsonText: readBaseFile(repoRoot, baseSha, MANIFEST),
+        workspaceYamlText: (() => {
+          try {
+            return readBaseFile(repoRoot, baseSha, WORKSPACE);
+          } catch {
+            return null;
+          }
+        })(),
+      });
+    } catch (e) {
+      error(`ERROR: could not read ${LOCKFILE}/${MANIFEST} at base commit ${baseSha}: ${e.message}`);
+      return 1;
+    }
+  }
+
+  const { passed, problems, preExisting } = checkLockfileOverrides({
+    lockOverrides,
+    manifestOverrides,
+    baseLockOverrides,
+    baseManifestOverrides,
+  });
+
+  if (preExisting.length > 0) {
+    log(`  !  ${preExisting.length} pre-existing override mismatch(es) on the base commit (not failed here):`);
+    for (const problem of preExisting) log(describe(problem));
+  }
+
+  if (!passed) {
+    error(`ERROR: the committed ${LOCKFILE} contradicts the root manifest's \`pnpm.overrides\`:\n`);
+    for (const problem of problems) error(describe(problem));
+    error(
+      `\nDownstream jobs install from a lockfile that ${
+        baseSha ? "this PR regenerates and then discards" : "CI regenerates and then discards"
+      }, so this mismatch would merge green and break the next unrelated PR at ` +
+        "`pnpm install --frozen-lockfile`.",
+    );
+    error(
+      `\nTo fix: run \`pnpm install --lockfile-only\` and align the root ${MANIFEST} \`pnpm.overrides\` ` +
+        `with the versions the lockfile resolves — the two must agree in the same commit.`,
+    );
+    return 1;
+  }
+
+  const count = Object.keys(manifestOverrides).length;
+  log(
+    preExisting.length > 0
+      ? `  ✓  This PR introduces no override mismatch (${count} checked; see the pre-existing one above).`
+      : `  ✓  Committed ${LOCKFILE} overrides match the root manifest (${count} checked).`,
+  );
+  return 0;
+}
+
+function isMainModule() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (isMainModule()) {
+  process.exit(runCheck({ repoRoot: process.cwd(), baseSha: process.env.BASE_SHA || null }));
+}

--- a/scripts/check-lockfile-overrides.test.mjs
+++ b/scripts/check-lockfile-overrides.test.mjs
@@ -1,0 +1,201 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  changedKeys,
+  checkLockfileOverrides,
+  parseYamlScalarBlock,
+  readManifestOverrides,
+} from "./check-lockfile-overrides.mjs";
+
+// The `overrides:` block as pnpm 9.15.4 actually writes it: quoted only where
+// YAML forces it, followed by an unrelated top-level block.
+const LOCKFILE_TEXT = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+overrides:
+  rollup: '>=4.59.0'
+  react: ^19.2.7
+  lexical: 0.46.0
+  '@lexical/react': 0.46.0
+
+patchedDependencies:
+  acpx@0.12.0:
+    hash: tb5cdbd7kiiblhylbkroxfdcha
+`;
+
+const MANIFEST_TEXT = JSON.stringify({
+  name: "paperclip",
+  pnpm: {
+    overrides: {
+      rollup: ">=4.59.0",
+      react: "^19.2.7",
+      lexical: "0.46.0",
+      "@lexical/react": "0.46.0",
+    },
+  },
+});
+
+test("parses a flat overrides block and stops at the next top-level key", () => {
+  assert.deepEqual(parseYamlScalarBlock(LOCKFILE_TEXT, "overrides"), {
+    rollup: ">=4.59.0",
+    react: "^19.2.7",
+    lexical: "0.46.0",
+    "@lexical/react": "0.46.0",
+  });
+});
+
+test("returns null when the block is absent, {} when it is empty", () => {
+  assert.equal(parseYamlScalarBlock("lockfileVersion: '9.0'\n", "overrides"), null);
+  assert.deepEqual(parseYamlScalarBlock("overrides:\n\nimporters:\n  .:\n", "overrides"), {});
+});
+
+test("skips comments and ignores an `overrides:` key that is not top-level", () => {
+  const text = "overrides:\n  # pinned for CVE-2026-1\n  rollup: '>=4.59.0'\n";
+  assert.deepEqual(parseYamlScalarBlock(text, "overrides"), { rollup: ">=4.59.0" });
+  assert.equal(parseYamlScalarBlock("settings:\n  overrides:\n    react: 1\n", "overrides"), null);
+});
+
+test("throws rather than mis-parsing a nested value", () => {
+  assert.throws(
+    () => parseYamlScalarBlock("overrides:\n  react:\n    version: 19\n", "overrides"),
+    /unsupported/i,
+  );
+});
+
+test("reads overrides from package.json, with pnpm-workspace.yaml taking precedence", () => {
+  assert.deepEqual(
+    readManifestOverrides({ packageJsonText: MANIFEST_TEXT, workspaceYamlText: null }),
+    { rollup: ">=4.59.0", react: "^19.2.7", lexical: "0.46.0", "@lexical/react": "0.46.0" },
+  );
+
+  // pnpm 10 moves the field into pnpm-workspace.yaml; the guard must not go blind.
+  const merged = readManifestOverrides({
+    packageJsonText: JSON.stringify({ pnpm: { overrides: { react: "^18.0.0" } } }),
+    workspaceYamlText: "packages:\n  - server\n\noverrides:\n  react: ^19.2.7\n  lexical: 0.46.0\n",
+  });
+  assert.deepEqual(merged, { react: "^19.2.7", lexical: "0.46.0" });
+});
+
+test("changedKeys reports changed, added and removed keys", () => {
+  assert.deepEqual(changedKeys({ a: "1", b: "1" }, { a: "1", b: "2" }), ["b"]);
+  assert.deepEqual(changedKeys({}, { a: "1" }), ["a"]);
+  assert.deepEqual(changedKeys({ a: "1" }, {}), ["a"]);
+});
+
+test("passes when the committed lockfile agrees with the manifest", () => {
+  const result = checkLockfileOverrides({
+    lockOverrides: parseYamlScalarBlock(LOCKFILE_TEXT, "overrides"),
+    manifestOverrides: readManifestOverrides({ packageJsonText: MANIFEST_TEXT, workspaceYamlText: null }),
+  });
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.problems, []);
+});
+
+// The regression this guard exists for: #10299 bumped lexical in the lockfile
+// and in ui/package.json but left the root override at 0.46.0, and was green in
+// every job because it touched a manifest.
+test("fails on the a90f816c8 shape: lockfile bumped, root override left behind", () => {
+  const base = { rollup: ">=4.59.0", lexical: "0.46.0" };
+  const result = checkLockfileOverrides({
+    lockOverrides: { rollup: ">=4.59.0", lexical: "0.48.0" },
+    manifestOverrides: base,
+    baseLockOverrides: base,
+    baseManifestOverrides: base,
+  });
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.problems, [{ key: "lexical", lock: "0.48.0", manifest: "0.46.0" }]);
+});
+
+// The heal PR (#10391 / 20b98379a) regenerated the lockfile back to 0.46.0.
+test("passes on the 20b98379a shape: refreshed lockfile back in agreement", () => {
+  const base = { rollup: ">=4.59.0", lexical: "0.46.0" };
+  const result = checkLockfileOverrides({
+    lockOverrides: base,
+    manifestOverrides: base,
+    baseLockOverrides: { rollup: ">=4.59.0", lexical: "0.48.0" },
+    baseManifestOverrides: base,
+  });
+  assert.equal(result.passed, true);
+});
+
+test("reports but does not fail a mismatch inherited unchanged from the base commit", () => {
+  const broken = { lexical: "0.48.0" };
+  const manifest = { lexical: "0.46.0" };
+  const result = checkLockfileOverrides({
+    lockOverrides: broken,
+    manifestOverrides: manifest,
+    baseLockOverrides: broken,
+    baseManifestOverrides: manifest,
+  });
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.preExisting, [{ key: "lexical", lock: "0.48.0", manifest: "0.46.0" }]);
+});
+
+test("allows a manifest-only override change, since contributors must not commit the lockfile", () => {
+  const result = checkLockfileOverrides({
+    lockOverrides: { react: "^19.2.7" },
+    manifestOverrides: { react: "^19.3.0" },
+    baseLockOverrides: { react: "^19.2.7" },
+    baseManifestOverrides: { react: "^19.2.7" },
+  });
+  assert.equal(result.passed, true);
+});
+
+test("still fails when a PR moves both sides to versions that disagree", () => {
+  const result = checkLockfileOverrides({
+    lockOverrides: { lexical: "0.48.0" },
+    manifestOverrides: { lexical: "0.47.0" },
+    baseLockOverrides: { lexical: "0.46.0" },
+    baseManifestOverrides: { lexical: "0.46.0" },
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.problems[0].key, "lexical");
+});
+
+test("fails when the lockfile drops an override the manifest still declares", () => {
+  const base = { lexical: "0.46.0" };
+  const result = checkLockfileOverrides({
+    lockOverrides: {},
+    manifestOverrides: base,
+    baseLockOverrides: base,
+    baseManifestOverrides: base,
+  });
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.problems, [{ key: "lexical", lock: null, manifest: "0.46.0" }]);
+});
+
+test("fails when the lockfile gains an override the manifest never declared", () => {
+  const result = checkLockfileOverrides({
+    lockOverrides: { lexical: "0.46.0" },
+    manifestOverrides: {},
+    baseLockOverrides: {},
+    baseManifestOverrides: {},
+  });
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.problems, [{ key: "lexical", lock: "0.46.0", manifest: null }]);
+});
+
+// Adding an override to the manifest without the lockfile is the sanctioned
+// contributor flow — `Block manual lockfile edits` forbids committing the
+// lockfile, and CI regenerates it. The guard must not block that.
+test("allows a newly added manifest override with an untouched lockfile", () => {
+  const result = checkLockfileOverrides({
+    lockOverrides: {},
+    manifestOverrides: { lexical: "0.46.0" },
+    baseLockOverrides: {},
+    baseManifestOverrides: {},
+  });
+  assert.equal(result.passed, true);
+});
+
+test("without a base commit every mismatch is failed", () => {
+  const result = checkLockfileOverrides({
+    lockOverrides: { lexical: "0.48.0" },
+    manifestOverrides: { lexical: "0.46.0" },
+  });
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.preExisting, []);
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Its PR pipeline (`.github/workflows/pr.yml`) gates every contribution behind `pnpm install --frozen-lockfile`, so dependency resolution is a shared, repo-wide invariant
> - The `policy` job regenerates `pnpm-lock.yaml` whenever a PR touches a manifest and publishes the result as the `pr-lockfile` artifact; every downstream job downloads that artifact over the checked-in file before installing
> - That is deliberate — contributors must not commit the lockfile — but it means the manifest-changing PRs, the only ones that can break resolution, are exactly the PRs whose **committed** lockfile is never measured, and the repaired copy is thrown away at the end of the run
> - a90f816c8 (#10299) landed that way: a lockfile pinning `lexical: 0.48.0` against a root manifest pinning `0.46.0`, green in every job because it touched `ui/package.json` — and afterwards every other open PR died in `Install dependencies` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (#10393)
> - `refresh-lockfile.yml` did detect the break and opened the correct one-file fix as #10391 with `gh pr merge --auto --squash`, but it creates that PR with `GITHUB_TOKEN`, and GitHub raises no `pull_request` events for those, so the required checks never arrive and the auto-merge waits forever
> - This pull request adds a cheap, unconditional check that measures the committed lockfile's `overrides:` block against the root manifest before the regeneration step overwrites it, and widens the refresh gate's allowlist so the heal PR can be opened by the app identity whose PRs do trigger checks
> - The benefit is that a lockfile/manifest contradiction fails on the PR that introduces it, instead of on the next, unrelated PR — and that the guard's own remedy can land without a human

## Linked Issues or Issue Description

Refs #10393 — `master` is broken: every PR fails at `Install dependencies` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (fix #10391 is auto-merge deadlocked).

Related history: #10299 (the PR that introduced the mismatch), #10391 (the heal PR that could not merge).

## What Changed

- **New `scripts/check-lockfile-overrides.mjs`** — compares the `overrides:` mapping of the committed `pnpm-lock.yaml` against the root `package.json`'s effective `pnpm.overrides`. No `dependabot[bot]` exception: the `Block manual lockfile edits` step above it already carries one, and dependabot was the trigger the one time this hole was hit. Scoped to mismatches the PR *introduces* — a mismatch that already exists identically on `BASE_SHA` is reported but not failed, so a broken base branch does not blame unrelated PRs. A manifest-only override change stays allowed, because contributors are not permitted to commit the lockfile.
- **New `scripts/check-lockfile-overrides.test.mjs`** — 16 `node --test` cases covering the YAML scalar/quoting edge cases, workspace-level overrides, base-scoping with and without `BASE_SHA`, and the manifest-only-change allowance.
- **`.github/scripts/check-pr-lockfile.mjs`** — the refresh-bot allowlist becomes two exported constants and accepts `commitperclip[bot]` in addition to `github-actions[bot]`, still only on `chore/refresh-lockfile`. This is the prerequisite for the `refresh-lockfile.yml` hunk below: once the heal PR is opened by the app, this gate must not reject the very PR it exists to admit. `github-actions[bot]` stays accepted so the gate keeps working if that workflow falls back to `github.token`.
- **`.github/scripts/tests/check-pr-lockfile.test.mjs`** — 2 new cases for the added author, plus the existing 4 unchanged.

### Not in this diff — two workflow hunks a maintainer must apply

My token has no `workflow` scope, so I cannot push `.github/workflows/*`. Both hunks below **apply cleanly on current `master`** (verified with `git apply --check`). Without the first one, `scripts/check-lockfile-overrides.mjs` ships but is not yet called by CI; without the second, #10391's successor still cannot merge.

<details>
<summary><code>git apply</code>-able diff for <code>.github/workflows/pr.yml</code> and <code>.github/workflows/refresh-lockfile.yml</code></summary>

```diff
diff --git a/.github/workflows/pr.yml b/.github/workflows/pr.yml
index b3fbdaffc..64649e9d6 100644
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,6 +76,20 @@ jobs:
           PAPERCLIP_RELEASE_BOOTSTRAP_BASE_SHA="${{ github.event.pull_request.base.sha }}" \
             node ./scripts/check-release-package-bootstrap.mjs "${changed_paths[@]}"
 
+      # Must run before the regeneration step below: that step overwrites
+      # pnpm-lock.yaml in place, after which the committed state is no longer
+      # observable. Without this check the manifest-changing PRs — the only ones
+      # that can break dependency resolution — are the ones whose committed
+      # lockfile is never measured, because every downstream job installs from
+      # the regenerated artifact instead.
+      - name: Validate committed lockfile overrides
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node ./scripts/check-lockfile-overrides.mjs
+
+      - name: Test lockfile overrides check
+        run: node --test ./scripts/check-lockfile-overrides.test.mjs
+
       - name: Validate dependency resolution when manifests change
         id: regen_lockfile
         run: |
diff --git a/.github/workflows/refresh-lockfile.yml b/.github/workflows/refresh-lockfile.yml
index 06546bbb7..ce7e8e0c4 100644
--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -34,6 +34,25 @@ jobs:
           node-version: 20
           cache: pnpm
 
+      # PRs created with GITHUB_TOKEN do not trigger `pull_request` events, so a
+      # heal PR opened with `github.token` never runs pr.yml or
+      # commitperclip-review.yml: its required checks never arrive and the
+      # auto-merge below waits forever. Opening and pushing it as the
+      # commitperclip app makes the events fire, which is what lets the
+      # already-configured auto-merge actually land the fix.
+      - name: Generate commitperclip token
+        id: token
+        env:
+          COMMITPERCLIP_KEY: ${{ secrets.COMMITPERCLIP_KEY }}
+        run: |
+          if [ -z "${COMMITPERCLIP_KEY:-}" ]; then
+            echo "::warning::COMMITPERCLIP_KEY is not set; falling back to github.token. The heal PR will open but its required checks will not trigger, so auto-merge cannot complete."
+            exit 0
+          fi
+          TOKEN="$(node .github/scripts/get-bot-token.mjs)"
+          echo "::add-mask::$TOKEN"
+          echo "value=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Refresh pnpm lockfile
         run: pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
 
@@ -53,7 +72,7 @@ jobs:
       - name: Create or update pull request
         id: upsert-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.value || github.token }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
           if git diff --quiet -- pnpm-lock.yaml; then
@@ -69,7 +88,12 @@ jobs:
           git checkout -B "$BRANCH"
           git add pnpm-lock.yaml
           git commit -m "chore(lockfile): refresh pnpm-lock.yaml"
-          git push --force origin "$BRANCH"
+          # Push with the same identity that opens the PR: a branch update pushed
+          # with GITHUB_TOKEN does not emit `synchronize`, so a refreshed heal PR
+          # would otherwise sit with stale (or absent) checks.
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/$BRANCH"
 
           # Only reuse an open PR from this repository owner, not a fork with the same branch name.
           pr_url="$(
@@ -91,6 +115,6 @@ jobs:
       - name: Enable auto-merge for lockfile PR
         if: steps.upsert-pr.outputs.pr_url != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.value || github.token }}
         run: |
           gh pr merge --auto --squash --delete-branch "${{ steps.upsert-pr.outputs.pr_url }}"
```

</details>

Placement matters for the first hunk: the new step must run **before** `Validate dependency resolution when manifests change`, because that step overwrites `pnpm-lock.yaml` in place and the committed state is not observable afterwards.

## Verification

- `node --test scripts/check-lockfile-overrides.test.mjs` → 16/16 pass.
- `node --test .github/scripts/tests/check-pr-lockfile.test.mjs` → 6/6 pass.
- Run against the real trees, not against fixtures:
  - `a90f816c8` (#10299, the PR that broke `master`), `BASE_SHA` = its parent → **exit 1**, naming `lexical: pnpm-lock.yaml pins 0.48.0, manifest pins 0.46.0`. It would have stopped #10299 loudly.
  - `20b98379a` (#10391, the heal commit), `BASE_SHA` = its parent → **exit 0**, `13 checked`.
  - current `master` → **exit 0**, `13 checked`.
  - this PR's base → **exit 0**, `13 checked`. The new check introduces no false failure on the existing tree.
- `git apply --check` of the two workflow hunks against current `master` → clean.

## Risks

- Low for the shipped files: the new script is not yet reachable from any workflow until the `pr.yml` hunk is applied, and the `check-pr-lockfile.mjs` change only *widens* an allowlist — no author that passed before is rejected now.
- Once wired, the check adds one `node` invocation (no install, no network) to the `policy` job and can only fail a PR whose committed lockfile contradicts the root manifest — which is precisely the state that breaks every subsequent PR.
- The `refresh-lockfile.yml` hunk depends on `secrets.COMMITPERCLIP_KEY`. It degrades explicitly: if the secret is absent the step emits a `::warning::` and the workflow falls back to `github.token`, i.e. exactly today's behaviour, rather than failing the run.
- This PR is based on `4eace88f6` rather than the tip of `master` — same reason as above, my token cannot send the newer `.github/workflows/` objects. All four touched paths are byte-identical between `4eace88f6` and current `master` (two are new files), so the merge is clean. A maintainer can press **Update branch** if a fresher base is preferred.

## Model Used

Claude Opus 5 (`claude-opus-5`, 1M context), extended thinking, with shell/tool use for the local `node --test` runs and the red/green verification against the real commits.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
