### PR TITLE
fix(claude-local): classify failures from the run's error surface, not its whole stdout

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -54,6 +54,48 @@ describe("isClaudeModelNotFoundError", () => {
   });
 });
 
+/**
+ * The stdout preamble every `--output-format stream-json` run carries, taken
+ * from a real run log: a plain-text launcher line, the `system`/`init` event,
+ * the CLI's unconditional `rate_limit_event` telemetry — whose `rateLimitType`
+ * field matches the transient `rate[-\s]?limit` branch on a perfectly healthy
+ * run — and one assistant turn whose text happens to name a rate limit.
+ */
+function claudeRunStdout(...tail: string[]): string {
+  return [
+    '[paperclip] Using fallback workspace "/tmp/ws" for this run.',
+    JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "s-1",
+      model: "claude-opus-5",
+      tools: ["Bash", "Read"],
+    }),
+    JSON.stringify({
+      type: "rate_limit_event",
+      rate_limit_info: {
+        status: "allowed",
+        resetsAt: 1785733200,
+        rateLimitType: "seven_day",
+        overageStatus: "allowed",
+        isUsingOverage: false,
+      },
+      uuid: "u-1",
+    }),
+    JSON.stringify({
+      type: "assistant",
+      session_id: "s-1",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Pinned the Traefik rateLimit middleware; 429s should stop now." },
+        ],
+      },
+    }),
+    ...tail,
+  ].join("\n");
+}
+
 describe("isClaudeTransientUpstreamError", () => {
   it("classifies the 'out of extra usage' subscription window failure as provider quota", () => {
     expect(
@@ -159,6 +201,54 @@ describe("isClaudeTransientUpstreamError", () => {
         errorMessage: "Invalid request_error: Unknown parameter 'foo'.",
       }),
     ).toBe(false);
+  });
+
+  it("does not let CLI telemetry or the agent transcript decide the failure class", () => {
+    const input = {
+      parsed: { subtype: "success", is_error: true, result: "disk full" },
+      stdout: claudeRunStdout(
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          session_id: "s-1",
+          result: "disk full",
+        }),
+      ),
+      stderr: "",
+      errorMessage: "Claude run failed: disk full",
+    };
+
+    expect(isClaudeTransientUpstreamError(input)).toBe(false);
+    expect(isClaudeProviderQuotaError(input)).toBe(false);
+  });
+
+  it("still classifies a rate limit the run itself reported in its result event", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: null,
+        stdout: claudeRunStdout(
+          JSON.stringify({
+            type: "result",
+            subtype: "success",
+            is_error: true,
+            session_id: "s-1",
+            result: 'API Error: 429 {"type":"rate_limit_error","message":"Rate limit reached."}',
+          }),
+        ),
+        stderr: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("still classifies a rate limit the CLI printed as plain text before any result event", () => {
+    expect(
+      isClaudeTransientUpstreamError({
+        parsed: null,
+        stdout: claudeRunStdout("Error: 529 Overloaded. Try again later."),
+        stderr: "",
+      }),
+    ).toBe(true);
   });
 
   it("does not classify poisoned previous_message_id errors as transient", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -2,6 +2,7 @@ import type { UsageSummary } from "@paperclipai/adapter-utils";
 import {
   asString,
   asNumber,
+  asBoolean,
   parseObject,
   parseJson,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -289,6 +290,50 @@ export function isClaudeImageProcessingError(parsed: Record<string, unknown>): b
   );
 }
 
+/**
+ * Reduce a Claude CLI stdout stream to the run's own error surface.
+ *
+ * `--output-format stream-json` multiplexes three unrelated things onto stdout:
+ * the agent's transcript, the CLI's telemetry, and — when the run fails — the
+ * error text. Only the last one may decide a failure class, so everything else
+ * is dropped here before the transient/quota alternations see it.
+ *
+ * Both of the discarded kinds actively produce false positives today:
+ *
+ * - The CLI emits a `rate_limit_event` on essentially every run, and its
+ *   `rateLimitType` field matches the transient `rate[-\s]?limit` branch. That
+ *   token is present whether or not the run was throttled.
+ * - The transcript carries whatever the agent read or wrote. A run editing a
+ *   Traefik `rateLimit` middleware, or one merely quoting a 429, poisons its
+ *   own haystack.
+ *
+ * Kept are the error-bearing events (`result`, `error`, and anything flagged
+ * `is_error`) and every non-JSON line, because a CLI that dies before its first
+ * stream event reports that failure as plain text on stdout.
+ */
+function claudeStdoutErrorSurface(stdout: string): string {
+  const surface: string[] = [];
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const event = parseJson(line);
+    if (!event) {
+      surface.push(line);
+      continue;
+    }
+
+    const type = asString(event.type, "");
+    if (type === "result" || type === "error" || asBoolean(event.is_error, false)) {
+      surface.push(asString(event.result, "") || asString(event.error, ""));
+      surface.push(...extractClaudeErrorMessages(event));
+    }
+  }
+
+  return surface.filter(Boolean).join("\n");
+}
+
 function buildClaudeTransientHaystack(input: {
   parsed?: Record<string, unknown> | null;
   stdout?: string | null;
@@ -302,7 +347,7 @@ function buildClaudeTransientHaystack(input: {
     input.errorMessage ?? "",
     resultText,
     ...parsedErrors,
-    input.stdout ?? "",
+    claudeStdoutErrorSurface(input.stdout ?? ""),
     input.stderr ?? "",
   ]
     .join("\n")


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - When a `claude_local` run fails, the adapter classifies the failure so the heartbeat knows whether to retry it (transient upstream), wait for a reset (provider quota), or stop (deterministic)
> - `buildClaudeTransientHaystack` builds that classification text by appending the run's **entire stdout**
> - Under `--output-format stream-json`, stdout is three unrelated things on one channel: the agent's transcript, the CLI's own telemetry, and the error text — and the CLI emits a `rate_limit_event` line on essentially every run whose `rateLimitType` field matches the transient `rate[-\s]?limit` branch
> - So the classifier stops reading the failure and starts reading the noise: measured over 11,609 real run logs, 4,122 failed runs classify as transient purely from stdout that has nothing to do with the failure — including 617 `Prompt is too long`
> - This pull request reduces the stdout contribution to the run's own error surface: the error-bearing stream events plus every non-JSON line
> - The benefit is that a deterministic failure stops being retried forever, while a genuine 429 or 529 still classifies exactly as before

## Linked Issues or Issue Description

No public issue exists, so the bug is described here.

**What happened.** `isClaudeTransientUpstreamError` returns `true` for deterministic failures whenever the run's stdout is passed in — which is how `execute.ts` and `test.ts` call it. Against the shipped `dist/server/parse.js` with a real 60 kB run stdout as `stdout`:

| `errorMessage` | `isClaudeTransientUpstreamError` |
| --- | --- |
| `Prompt is too long` | `true` |
| `disk full` | `true` |
| `syntax error in config` | `true` |

**Why.** `buildClaudeTransientHaystack` joins `stdout` into the text that `CLAUDE_TRANSIENT_UPSTREAM_RE` matches against. Two independent sources of false positives live in there:

1. **The CLI's own telemetry.** Every run emits
   `{"type":"rate_limit_event","rate_limit_info":{"status":"allowed",...,"rateLimitType":"seven_day",...}}`.
   `rateLimitType` matches `rate[-\s]?limit`. The token is present on perfectly healthy runs.
2. **The agent's transcript.** `assistant` and `user` (tool result) events carry whatever the agent read or wrote. A run editing a Traefik `rateLimit` middleware, or one that merely quotes a 429, poisons its own haystack.

**Expected.** The failure decides the class. **Actual.** Telemetry and transcript decide it, and every deterministic failure that has no classifier of its own is retried as transient.

Related PRs found in the dedup search, all still open, none of which fixes `buildClaudeTransientHaystack`:

- Refs #9548 — same root insight ("keyword classifiers must never see the agent conversation"), but it adds `stripClaudeStreamEventLines` and applies it at two call sites **in `execute.ts`**, leaving `buildClaudeTransientHaystack` reading raw stdout. It also widens two alternations and changes `heartbeat.ts`. See "Relationship to #9548" below — I measured the two filters against each other.
- Refs #8879 — strips Claude Code *hook* lifecycle events from the auth/transient path. A narrower slice of the same family; it deliberately keeps the assistant transcript and does not touch `rate_limit_event`. It also fixes `detectClaudeLoginRequired`, which this PR does not.
- Refs #10761 — gives `Prompt is too long` its own deterministic classifier ahead of the transient branch. Correct ordering, but it heals one class; this PR is about the haystack that affects all of them.
- Refs #10822 — generic provider-quota wording plus reset backoff from the structured `rate_limit_event`. **This is the merge-order prerequisite for this PR**; see Risks. Refs #10618 — narrower predecessor covering the weekly window only.
- Refs #11053 — the usage-credits refusal, opened by me as the follow-up this PR's Risks section promised.

## What Changed

- Added `claudeStdoutErrorSurface(stdout)` in `packages/adapters/claude-local/src/server/parse.ts`. It walks the stream line by line and keeps only:
  - error-bearing stream events — `type: "result"`, `type: "error"`, and anything flagged `is_error: true` — contributing their `result` / `error` text and `extractClaudeErrorMessages` output;
  - every **non-JSON** line, because a CLI that dies before emitting its first stream event reports that failure as plain text on stdout.
  Everything else — `system`/`init`, `rate_limit_event`, `assistant`, `user`/tool results, and hook events — is dropped.
- `buildClaudeTransientHaystack` now feeds that surface instead of raw `stdout`. `errorMessage`, `parsed.result`, `parsed.errors` and `stderr` are unchanged; `parseFallbackErrorMessage` already reads stderr only, so no stdout re-enters that way.
- The fix sits in the shared helper rather than at the call sites, so all three consumers are covered — `isClaudeTransientUpstreamError`, `isClaudeProviderQuotaError`, and `extractClaudeRetryNotBefore` — and so is `test.ts`, which hands `isClaudeTransientUpstreamError` the raw hello-probe stdout.
- Three cases in `parse.test.ts` built on a stdout fixture taken from a real run log: launcher line, `system`/`init`, the CLI's `rate_limit_event`, and an assistant turn that names a rate limit.

## Verification

```
vitest run packages/adapters/claude-local/src/server/parse.test.ts   # 42 passed
vitest run packages/adapters/claude-local/src/server/ --no-file-parallelism   # 7 files, 84 passed
tsc --noEmit -p packages/adapters/claude-local/tsconfig.json   # clean
```

Both directions are held, because the counter-direction is the same defect:

- **Red before.** `does not let CLI telemetry or the agent transcript decide the failure class` fails against the unmodified `parse.ts` with `expected true to be false` — the `disk full` run reads as transient.
- **Green, unchanged, before and after.** `still classifies a rate limit the run itself reported in its result event` (429 in the `result` event) and `still classifies a rate limit the CLI printed as plain text before any result event` (a 529 with no result event at all) pass on both sides. They pass before the fix too, which is exactly what makes them the guard: the fix must not buy its `false` by losing the `true`.

**Measured against 11,609 real run logs** from one host (all counts from the shipped alternations, unmodified):

| | runs |
| --- | ---: |
| stdout contains a token matching the transient alternation | 7,910 |
| …*only* inside the CLI's own `rate_limit_event` line | 2,577 |
| …still present after that line is removed | 5,333 |

The third row is the reason this PR filters by event kind rather than deleting the telemetry line: removing `rate_limit_event` alone leaves 46 % of all runs still carrying a transient-looking token, because the transcript is the larger source. (Amusingly, 38 of those runs contain `rate_limit_info` inside an `assistant`/tool-result event — agents discussing this very bug.)

Of the **8,955** runs that failed, before → after:

| before | after | runs | |
| --- | --- | ---: | --- |
| transient | none | 4,122 | the defect: classified from noise, now unclassified |
| none | none | 3,750 | unchanged |
| quota | quota | 1,063 | unchanged |
| quota | none | 15 | includes `Prompt is too long` reading as *quota* |
| transient | transient | 3 | genuine transient failures, preserved |
| quota | transient | 2 | |

### Relationship to #9548

#9548's `stripClaudeStreamEventLines` keeps non-JSON lines and drops every line with a non-empty `type`; this PR keeps non-JSON lines and drops every line except the error-bearing events. I ran both filters over the same 8,953 failed runs and they classify **identically** — `none/none` 7,887, `quota/quota` 1,063, `transient/transient` 3, zero disagreements. So this is not a competing filter design.

The difference is location. #9548 sanitizes `proc.stdout` at two call sites inside `execute.ts` and leaves `buildClaudeTransientHaystack` itself reading raw stdout, so any other caller stays poisoned — concretely `test.ts`, which calls `isClaudeTransientUpstreamError({ parsed, stdout: probe.stdout, stderr: probe.stderr })` for the Test-environment hello probe and is not in #9548's diff. This PR fixes the helper, which covers both.

If maintainers prefer #9548's shape, I am happy to close this and instead push the helper-level move plus these measurements into #9548 — but as it stands #9548 has been open since 2026-07-14 with a failing `General tests (server 3/3)`, and it bundles two alternation widenings and a `heartbeat.ts` change with the strip, whereas this PR is the haystack alone.

## Risks

**The one real behavioural risk is the 4,122 `transient → none` runs above, and it is not uniform.** Sampling them by their `result` text:

- ~3,377 are `You've hit your weekly limit · resets …`. These are **genuine** quota exhaustion that today classifies as transient *only* because the telemetry token happens to be present — right outcome, wrong reason. The shipped `CLAUDE_PROVIDER_QUOTA_RE` knows `weekly limit reached` but not `hit your weekly limit`, so after this PR they classify as nothing and lose their backoff. That wording gap is **#10822** (and, for the weekly window only, #10618 / #9548). Verified by simulation on the same corpus: with that alternation applied on top of this change, those 3,377 move `transient → quota` — strictly better than today, since they gain a real `retryNotBefore` instead of a blind short retry. **Recommended merge order: #10822 before this PR.** Merging this one first leaves that class without backoff in the window between the two.
- 617 are `Prompt is too long` — correct, and #10761 gives them a proper deterministic classifier.
- **Correction (2026-08-08) to the residual I listed when opening this PR.** I re-measured every open PR against 10,822 real `result` events and one of my claims was wrong. Current coverage of the residual:

  | cases | `result` wording | covered by |
  | ---: | --- | --- |
  | 32 | `You've hit your Sonnet limit · resets …` | **#10822** — I wrote "no open PR covers this"; that was already false. #10822's shared block `you've hit your <…> limit` matches any window, including model-scoped ones, and it derives `retryNotBefore` from the structured `rate_limit_event` rather than from the prose (`Jun 22, 7am` does not parse on master). |
  | 10 | `API Error: Usage credits required for 1M context` | **#11053**, which I opened for exactly this gap |
  | 4 | `API Error: Connection closed mid-response` | **#9548** |
  | 1 | `API Error: The socket connection was closed unexpectedly` | **nobody** — the only wording still uncovered |

  So the true uncovered residual after this PR plus the four open PRs is **one run out of 10,822**. None of this changes the diff here; it changes only which PR I am asking to be merged first.

Other risks:

- **A failure reported *only* in an `assistant` event and never in a `result` event would now be dropped.** I did not find such a run in the 11,609 logs: the CLI mirrors the synthetic assistant refusal into the `result` event (verified on a real weekly-limit rejection, where both carry the identical string).
- **Non-JSON stdout is kept unfiltered**, so a CLI that prints a crash trace still classifies. That is deliberate; it is the `parsed === null` path's only signal.
- **This fix is partial by design, and here is the part it does not reach.** `isClaudeTransientUpstreamError` and `isClaudeProviderQuotaError` both call `detectClaudeLoginRequired` *before* they build the haystack, and that function still reads **raw** `input.stdout`. A `requiresLogin: true` short-circuits both classifiers to `false`, so transcript contamination on the auth branch can still veto a correct classification — the sanitised haystack never gets asked. Measured on 9,270 failed runs: 20 match `CLAUDE_AUTH_REQUIRED_RE` from raw stdout, only 4 from the error surface, so **16 are false positives sourced purely from the transcript**, and **1 demonstrably vetoes a real one** — a run whose result event reads `You've hit your session limit · resets 4:20am` is classified `claude_auth_required` because a single tool-result event in the transcript contained the word `Unauthorized`. That matters more than a false transient, because an auth classification gets no retry at all. Extending `detectClaudeLoginRequired` to the same error surface is the obvious next step; I have kept it out of this PR to hold it to one concern, and #11073 independently hardens one branch of that same regex against the same contamination.
- No API, schema, migration, or config change. `parse.ts` and `parse.test.ts` only.

**Base note:** our fork cannot fast-forward `master` (the token has no `workflow` scope and `master` has touched `.github/workflows/` since), so this head sits on `4eace88f6`, the newest fork-reachable merge-base. `parse.ts` and `parse.test.ts` are byte-identical at `4eace88f6` and at `origin/master` (`16e875acf` / `9e88e5a8c`), and I ran the suite and the typecheck in a worktree at current `origin/master` with this patch applied: 84 passed, 7 files. PR CI builds the head against live master anyway.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), 1M context window, extended thinking, with tool use and code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing docs describe this classifier; the rationale is in the function's doc comment
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — 28/28 SUCCESS on `0d2294a1b` (`review`, `verify`, e2e, all server shards)
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — Confidence Score 5/5, Reviews (1), no comments raised
- [x] I will address all Greptile and reviewer comments before requesting merge



