### PR TITLE
fix(claude-local): classify the usage-credits refusal as provider quota

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -129,6 +129,35 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(true);
   });
 
+  it("classifies the usage-credits refusal for the 1M context window as provider quota", () => {
+    // Verbatim wording from a real refused run: the account has no usage credits
+    // enabled for the 1M context window, so the CLI refuses before doing work.
+    const errorMessage =
+      "API Error: Usage credits required for 1M context · turn on usage credits at " +
+      "claude.ai/settings/usage?from=cc_cli_limit_message, or use --model to switch to standard context";
+
+    expect(isClaudeProviderQuotaError({ errorMessage })).toBe(true);
+    expect(isClaudeTransientUpstreamError({ errorMessage })).toBe(false);
+  });
+
+  it("does not widen the quota classifier onto deterministic failures that mention limits", () => {
+    // The alternation must stay anchored on credit/limit wording the CLI only
+    // emits when it refuses a run — not on any error that says "limit".
+    expect(isClaudeProviderQuotaError({ errorMessage: "Prompt is too long" })).toBe(false);
+    expect(
+      isClaudeProviderQuotaError({
+        errorMessage:
+          "API Error: Claude's response exceeded the 32000 output token maximum. To configure " +
+          "this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
+      }),
+    ).toBe(false);
+    expect(
+      isClaudeProviderQuotaError({
+        errorMessage: "Credits required to continue: purchase usage credits.",
+      }),
+    ).toBe(false);
+  });
+
   it("does not classify login/auth failures as transient", () => {
     expect(
       isClaudeTransientUpstreamError({

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -11,8 +11,14 @@ const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+// `usage credits required` / `turn on usage credits` is how the CLI refuses a
+// run whose account has no usage credits enabled for the requested context
+// window ("API Error: Usage credits required for 1M context · turn on usage
+// credits at claude.ai/settings/usage…"). It is a subscription-window refusal
+// like the other wordings here, but it names credits rather than a limit, so it
+// matched no classifier at all and the run failed hard instead of backing off.
 const CLAUDE_PROVIDER_QUOTA_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+  /(?:you(?:'|’)ve\s+hit\s+your\s+session\s+limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception|usage\s+credits\s+required|turn\s+on\s+usage\s+credits)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `claude-local` adapter runs the Claude CLI and classifies each failed run from its output, so the heartbeat knows whether to retry, back off, or stop
> - `parse.ts` holds that classification. `CLAUDE_PROVIDER_QUOTA_RE` matches subscription-window refusals; `CLAUDE_TRANSIENT_UPSTREAM_RE` matches upstream faults
> - The Claude CLI has one refusal wording that matches neither: `API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage…`
> - It is a subscription-window refusal, but it names credits instead of a limit, so the run is classified as nothing and fails hard with no quota backoff
> - This pull request adds the two verbatim wordings the CLI uses for that refusal to `CLAUDE_PROVIDER_QUOTA_RE`
> - The benefit is that a run refused for missing usage credits now gets the same quota handling as a run refused for a session or weekly limit

## Linked Issues or Issue Description

No existing GitHub issue. The problem, in bug-report form:

**What happened**

A Claude CLI run ends with this result event:

```
API Error: Usage credits required for 1M context · turn on usage credits at
claude.ai/settings/usage?from=cc_cli_limit_message, or use --model to switch to
standard context
```

`isClaudeProviderQuotaError` returns `false` and `isClaudeTransientUpstreamError` returns `false`. The run is classified as nothing.

**What I expected**

The run is classified as `provider_quota`. The CLI refused the run because the account has no usage credits enabled for the requested context window. This is the same class of refusal as `You've hit your session limit`, which `CLAUDE_PROVIDER_QUOTA_RE` already matches.

**Steps to reproduce**

```ts
isClaudeProviderQuotaError({
  errorMessage:
    "API Error: Usage credits required for 1M context · turn on usage credits at " +
    "claude.ai/settings/usage?from=cc_cli_limit_message, or use --model to switch to standard context",
});
// => false on master, true with this change
```

**Related pull requests** (searched; none covers this wording)

- Refs #9548 — adds `you've reached your … limit` and the literal `/usage-credits` slash command to the same regex. The wording in this PR has no slash command, so #9548 does not match it. I measured this.
- Refs #10822 — generalises `you've hit your <window> limit`. It does not match this wording either.
- Refs #10618, Refs #11052 — same file, different wordings and a different code path.

## What Changed

- `CLAUDE_PROVIDER_QUOTA_RE` in `packages/adapters/claude-local/src/server/parse.ts` gains two alternatives: `usage\s+credits\s+required` and `turn\s+on\s+usage\s+credits`.
- A comment records which CLI message these two wordings come from.
- Two tests in `parse.test.ts`: one asserts the refusal is `provider_quota` and not transient; one asserts the classifier does not widen onto deterministic failures.

## Verification

```
cd packages/adapters/claude-local && npx vitest run src/server/parse.test.ts
# 41 passed
```

Without the `parse.ts` change, the new positive test fails with `expected false to be true`. The negative-guard test passes both before and after, which is correct for a guard.

I also replayed the change over 10,822 real Claude CLI result events (8,048 with `is_error: true`) from one host, and compared the old regex against the new one:

| | count |
| --- | ---: |
| newly `provider_quota` | 10 (all the usage-credits refusal) |
| classifications lost | 0 |
| successful runs newly matched | 0 |
| `Prompt is too long` runs newly matched | 0 (619 stay unclassified) |

## Risks

Low risk. The change is two alternatives added to one regex. Both are multi-word phrases the CLI emits only when it refuses a run, so they cannot match a deterministic failure that merely contains the word `limit` or the words `usage credits` — the third assertion in the new negative test pins this (`Credits required to continue: purchase usage credits.` stays unclassified).

The behavioural shift is intended: 10 runs per 10,822 move from *unclassified* to `provider_quota`, so they get quota backoff instead of a hard failure.

This regex is also edited by #9548, #10618, #10822 and #11052. Whichever merges first, the other needs a trivial conflict resolution in one line.

## Model Used

- Provider: Anthropic (Claude)
- Model: Claude Opus 5, model id `claude-opus-5[1m]`
- Context window: 1M
- Reasoning mode: extended thinking
- Capabilities used: tool use, file editing, local test execution, and a Node script that replayed the regex over the host's run-log corpus

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — not applicable, no documented behaviour changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — 28 checks green, 1 skipped (Storybook visual regression), 0 red; `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — 5/5 on the first review pass
- [x] I will address all Greptile and reviewer comments before requesting merge
