### PR TITLE
fix(server): preserve non-plain values during run redaction

### DIFF
--- a/server/src/__tests__/run-secret-redaction.test.ts
+++ b/server/src/__tests__/run-secret-redaction.test.ts
@@ -75,4 +75,22 @@ describe("registered run secret redaction", () => {
     expect(result.createdAt).toBeInstanceOf(Date);
     expect(result.createdAt.toISOString()).toBe("2026-08-06T12:00:00.000Z");
   });
+
+  it("preserves non-plain objects instead of rebuilding them as records", () => {
+    const pattern = /secret/;
+    const metadata = new Map([["token", secret]]);
+    const result = redactRegisteredSecretValues({
+      nested: {
+        pattern,
+        metadata,
+      },
+      plain: {
+        body: secret,
+      },
+    }, [secret]);
+
+    expect(result.nested.pattern).toBe(pattern);
+    expect(result.nested.metadata).toBe(metadata);
+    expect(result.plain.body).toBe(REDACTED_EVENT_VALUE);
+  });
 });

--- a/server/src/services/run-secret-redaction.ts
+++ b/server/src/services/run-secret-redaction.ts
@@ -14,7 +14,11 @@ type RegistryEntry = {
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null
     ? value as Record<string, unknown>
     : null;
 }
@@ -42,9 +46,6 @@ function redactText(input: string, values: string[]) {
 export function redactRegisteredSecretValues<T>(input: T, values: string[]): T {
   if (typeof input === "string") return redactText(input, values) as T;
   if (Array.isArray(input)) return input.map((value) => redactRegisteredSecretValues(value, values)) as T;
-  // Dates carry no redactable text; rebuilding them via Object.entries would
-  // collapse them to `{}` and break every timestamp in redacted responses.
-  if (input instanceof Date) return input;
   const record = asRecord(input);
   if (!record) return input;
   return Object.fromEntries(


### PR DESCRIPTION
## What changed

- Tightened run secret redaction so it only recursively rebuilds plain JSON objects.
- Preserves non-plain runtime values such as `Date`, `Map`, and `RegExp` instead of converting them to `{}` or enumerable-entry objects.
- Added regression coverage alongside the existing heartbeat timestamp tests.

## Why

Issue #10964 was caused by redaction rebuilding `Date` instances as empty objects, which made heartbeat run timestamps serialize as `{}` and render as `Invalid Date` in the browser. `Date` is already covered on `master`; this hardens the same boundary for the broader non-plain-object class called out in the issue analysis.

## Validation

- `pnpm exec vitest run server/src/__tests__/run-secret-redaction.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- Browser validation with Playwright + installed Chrome: redacted heartbeat-run payload JSON serializes dates as ISO strings and Chromium formats them without `Invalid Date`.