### PR TITLE
docs: minimize plan task graphs

### DIFF
--- a/skills/paperclip-converting-plans-to-tasks/SKILL.md
+++ b/skills/paperclip-converting-plans-to-tasks/SKILL.md
@@ -15,30 +15,42 @@ For the **mechanics** of recording a plan (issue document with key `plan`, comme
 ## When you're asked to plan
 
 - **Plan deeply.** Capture as much real detail as you have: goals, constraints, unknowns, success criteria, risks. A shallow plan becomes rework downstream — assignees can only act on what they can read.
+- **Minimize the issue graph.** Use as few tasks as possible while still completing and verifying the job. Prefer one end-to-end task with one owner over separate tasks for each step, file, component, or phase. Keep those structural details as checklists or acceptance criteria inside the owning task unless a real execution boundary requires another issue.
+- **Split only for a qualifying boundary.** Create a separate subtask only when at least one of these applies:
+  - A different specialist, owner, permission boundary, or external actor must own the work.
+  - A self-contained deliverable can usefully run in parallel with other work.
+  - A hard dependency or handoff needs its own `blockedByIssueIds` lifecycle.
+  - A review, QA pass, or governed approval gate has an independent owner.
+  - Substantial follow-up work needs independent tracking or retry because it cannot safely be completed and verified in the parent.
 - **Know your team.** Before assigning anything, look up the company's agents and their specialties (reporting lines, role descriptions, prior work). Don't default work to yourself when a better-suited agent exists; don't assign to a name you haven't checked.
 - **Assign for specialty.** Hand each piece of work to the agent most relevant to it. If no one fits, call that out — a hire, a tool, an external dependency, a board decision — instead of papering over the gap.
 - **Take responsibility.** Specialty-matching cuts both ways: when _you_ are the best-suited agent for a piece of work, assign it to yourself instead of reflexively delegating. Don't hand off to avoid load.
-- **Use the dependency tree.** Paperclip's executor automatically starts any assigned task with no open blockers. Parent/child issue nesting is structure, not execution blocking. Express every concrete deliverable as an issue, and wire every hard dependency from the plan through `blockedByIssueIds` on the dependent issue (not prose like "blocked by X"). When a blocker reaches `done`, dependents auto-wake.
-- **Order, then parallelize.** Sequence work by real dependencies, not by personal preference. Independent branches of the graph should start in parallel. Unlike humans, most agents allow concurrent runs, so you can assign parallel work to the same agent.
+- **Use the dependency tree.** Paperclip's executor automatically starts any assigned task with no open blockers. Parent/child issue nesting is structure, not execution blocking. Express each qualifying ownership or lifecycle boundary as an issue; keep other concrete deliverables within the responsible issue's description, checklist, or acceptance criteria. Wire every hard dependency between issues through `blockedByIssueIds` on the dependent issue (not prose like "blocked by X"). When a blocker reaches `done`, dependents auto-wake.
+- **Order, then parallelize.** Sequence work by real dependencies, not by personal preference. Create parallel branches only for qualifying, self-contained work, then start those independent branches in parallel. Unlike humans, most agents allow concurrent runs, so you can assign parallel work to the same agent.
 - **Write review tasks for the reviewer's boundary.** A review/QA task must tell the delegate to post findings on **their own review issue** and mark it `done` — the verdict is the deliverable, and adverse findings are still `done`, not `blocked`. Never instruct a delegate to comment on the parent issue (low-trust reviewers are guaranteed a 403 there), and make the description self-contained since the reviewer may not be able to read your issue. Wire the dependent issue's `blockedByIssueIds` to the review issue so the verdict wakes the right owner.
 - **Enough is enough.** Plans exist to unblock execution, not replace it. If the next step is small and clear, just do it or allow the plan to stand on its own. Re-planning a plan, or splitting work that one agent could finish in the time it took to break it up, is procrastination — ship something.
 
 ## When converting an accepted plan into tasks
 
-Before or while creating tasks, write a compact task matrix with each planned task, owner, initial status, and blockers. Any task that can start immediately should say why it has no blockers; otherwise set it to `blocked` and include the prerequisite issue IDs in `blockedByIssueIds`. Do not rely on `parentId`, child ordering, phase labels, or prose to block execution.
+Start from one end-to-end task and add issues only for the qualifying boundaries above. Before creating tasks, write a compact task matrix with each proposed task, owner, initial status, blockers, and the specific qualifying reason it must be separate. Any task that can start immediately should say why it has no blockers; otherwise set it to `blocked` and include the prerequisite issue IDs in `blockedByIssueIds`. Do not rely on `parentId`, child ordering, phase labels, or prose to block execution.
 
-After creating the tasks, re-fetch the created issues or otherwise verify the issue graph before marking the source planning issue done. Confirm that each dependent task has the expected `blockedByIssueIds`, each independent task has an explicit "can start now" reason, and the parent/child hierarchy is only being used for traceability. If expected blockers are missing, report the mismatch and leave the planning issue in `in_review` or `blocked` until the task graph is corrected.
+Run a merge-back pass before publishing or creating the graph. Require every proposed subtask to name at least one qualifying reason from this skill. If it cannot, merge it into its parent or an adjacent task and preserve the work as an internal step, checklist item, or acceptance criterion. Repeat until every remaining issue has a real ownership, scheduling, lifecycle, or governance reason to exist.
+
+After creating the tasks, re-fetch the created issues or otherwise verify the issue graph before marking the source planning issue done. Confirm that every separate issue still has its qualifying reason, each dependent task has the expected `blockedByIssueIds`, each independent task has an explicit "can start now" reason, review tasks respect the reviewer's write boundary, and the parent/child hierarchy is only being used for traceability. If the graph contains an unjustified split or expected blockers are missing, correct it or report the mismatch and leave the planning issue in `in_review` or `blocked` until the graph is fixed.
 
 ## Quick checklist before you publish a plan
 
 - [ ] Enough detail that assignees can act without re-asking.
-- [ ] Every concrete deliverable is an issue (or named as a known follow-up).
+- [ ] The plan uses the fewest tasks that can complete and verify the job, preferring one end-to-end owner over step/file/component/phase splits.
+- [ ] Every concrete deliverable is accounted for inside an issue or, only when a qualifying boundary applies, as its own issue.
+- [ ] Every proposed subtask names a qualifying reason; otherwise it was merged into its parent or an adjacent task.
 - [ ] Each issue has a deliberate, specialty-matched assignee — not the planner by default.
 - [ ] Each issue's real blockers are declared via `blockedByIssueIds`.
-- [ ] A compact task matrix names planned task, owner, initial status, and blockers.
+- [ ] Independently owned review, QA, and governed approval tasks respect the reviewer's boundary.
+- [ ] A compact task matrix names planned task, owner, initial status, blockers, and qualifying reason.
 - [ ] Tasks without blockers have an explicit reason they can start immediately.
 - [ ] Created issues were re-fetched or otherwise verified before closing the source planning issue.
-- [ ] Independent branches can start in parallel.
+- [ ] Qualifying independent branches can start in parallel.
 - [ ] Gaps (missing skills, hires, decisions, external inputs) are surfaced, not hidden.
 
 ## What this skill is not


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Paperclip skills guide agents through repeatable work.
> - The plan-to-task skill guides agents when they create issue graphs from plans.
> - The prior guidance could encourage an issue for every concrete deliverable.
> - That guidance can create unnecessary subtasks for work that one owner can complete end to end.
> - This pull request defines the boundaries that justify a separate task.
> - It also adds a merge-back pass that removes task splits without a qualifying boundary.
> - The benefit is a smaller issue graph with clear ownership, dependencies, and review gates.

## Linked Issues or Issue Description

**Issue type**

Unclear or confusing documentation.

**Where is the issue?**

`skills/paperclip-converting-plans-to-tasks/SKILL.md`

**What's wrong?**

The skill says that each concrete deliverable must become an issue. This can make agents split one end-to-end job into tasks for each step, file, component, or phase. The result is more coordination work without a real execution boundary.

**Suggested fix**

Tell agents to start with one end-to-end task. Permit separate tasks only for ownership, parallel work, dependencies, independent review or approval, or substantial follow-up work. Require a merge-back pass before agents create the issue graph.

## What Changed

- Added a rule to use the fewest tasks that can complete and verify the work.
- Defined the boundaries that qualify work for a separate issue.
- Added a merge-back pass for proposed subtasks without a qualifying reason.
- Updated dependency, parallel work, verification, and checklist guidance to enforce the smaller graph.

## Verification

- Ran `pnpm exec vitest run packages/shared/src/frontmatter.test.ts`.
- Result: 1 test file passed and 21 tests passed.
- Ran `git diff --check public-gh/master...HEAD`.
- Confirmed that the PR changes one skill file and has no lockfile, workflow, image, or migration changes.

## Risks

- Low risk. This change updates skill guidance only.
- Agents might combine work too aggressively. The qualifying boundaries preserve separate ownership, parallel execution, dependencies, review, approval, and substantial follow-up work.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 through Codex. The exact deployment ID and context window are not exposed. The agent used reasoning, repository tools, command execution, and GitHub tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge