### PR TITLE
fix: tolerate a concurrent symlink when linking the plugin dev SDK

### DIFF
--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -93,6 +93,15 @@ export function linkSdkInto(packageDir) {
     if (error?.code !== "ENOENT") throw error;
   }
 
-  symlinkSync(relativeSdkDir, linkTarget, "dir");
+  try {
+    symlinkSync(relativeSdkDir, linkTarget, "dir");
+  } catch (err) {
+    if (err.code === "EEXIST") {
+      // Race with another concurrent postinstall created it in between our
+      // lstat/rm/symlink. The target's existence is what we wanted anyway.
+      return true;
+    }
+    throw err;
+  }
   return true;
 }

--- a/scripts/link-plugin-dev-sdk.test.js
+++ b/scripts/link-plugin-dev-sdk.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawn } from "node:child_process";
 import { after, before, test } from "node:test";
 
 import { linkSdkInto, readPluginsUnder } from "./link-plugin-dev-sdk.mjs";
@@ -86,4 +87,51 @@ test("linkSdkInto replaces a symlink that points somewhere else", () => {
   assert.equal(linkSdkInto(pkg), true);
   assert.notEqual(readlinkSync(join(scopeDir, "plugin-sdk")), "../somewhere-else");
   assert.ok(existsSync(scopeDir));
+});
+
+// Regression test for the EEXIST race.
+//
+// linkSdkInto checks for an existing link, removes it, then creates its own.
+// Workspace installs run it for several packages at once, so two runs can
+// interleave between the check and the create. The loser used to fail the whole
+// install with EEXIST.
+//
+// The window only opens under real parallelism, so this uses separate processes.
+// In-process calls cannot interleave, because the underlying fs calls are
+// synchronous. Every worker targets the same package directory and busy-waits to a
+// shared start instant so they collide.
+test("linkSdkInto tolerates a concurrent create of the same link", async () => {
+  const moduleUrl = new URL("./link-plugin-dev-sdk.mjs", import.meta.url).href;
+  const WORKERS = 12;
+  const ROUNDS = 5;
+
+  const runWorker = (pkg, startAt) =>
+    new Promise((resolve) => {
+      const source = [
+        `while (Date.now() < ${startAt}) {}`,
+        `const { linkSdkInto } = await import(${JSON.stringify(moduleUrl)});`,
+        `linkSdkInto(${JSON.stringify(pkg)});`,
+      ].join("\n");
+      const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      let stderr = "";
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.on("close", (code) => resolve({ code, stderr }));
+    });
+
+  for (let round = 0; round < ROUNDS; round += 1) {
+    const pkg = makePackage(join(workDir, `race-${round}`));
+    const startAt = Date.now() + 400;
+    const results = await Promise.all(
+      Array.from({ length: WORKERS }, () => runWorker(pkg, startAt)),
+    );
+
+    const failures = results
+      .filter((result) => result.code !== 0)
+      .map((result) => result.stderr.trim().split("\n").find((line) => line.includes("Error")) ?? "unknown");
+
+    assert.deepEqual(failures, [], `round ${round}: ${failures.length}/${WORKERS} workers failed`);
+    assert.ok(lstatSync(join(pkg, "node_modules", "@paperclipai", "plugin-sdk")).isSymbolicLink());
+  }
 });

--- a/scripts/link-plugin-dev-sdk.test.js
+++ b/scripts/link-plugin-dev-sdk.test.js
@@ -98,18 +98,31 @@ test("linkSdkInto replaces a symlink that points somewhere else", () => {
 //
 // The window only opens under real parallelism, so this uses separate processes.
 // In-process calls cannot interleave, because the underlying fs calls are
-// synchronous. Every worker targets the same package directory and busy-waits to a
-// shared start instant so they collide.
+// synchronous. Every worker targets the same package directory and converges on a
+// shared start instant so they collide. Twelve workers over five rounds is well
+// past what the bug needs — one round already fails 11/12 workers without the fix
+// — and the redundancy covers machines where a given round happens to miss.
+//
+// Cost is small enough not to matter: ~2.2s on a GitHub-hosted runner, inside a
+// job that takes ~4m.
 test("linkSdkInto tolerates a concurrent create of the same link", async () => {
   const moduleUrl = new URL("./link-plugin-dev-sdk.mjs", import.meta.url).href;
   const WORKERS = 12;
   const ROUNDS = 5;
+  // Enough for a worker to boot Node and load the module before the barrier.
+  const STARTUP_BUDGET_MS = 400;
+  // Spin only over the last stretch. Spinning the whole budget would pin every
+  // core on a small CI runner for no extra alignment.
+  const SPIN_MS = 5;
 
   const runWorker = (pkg, startAt) =>
     new Promise((resolve) => {
       const source = [
-        `while (Date.now() < ${startAt}) {}`,
+        // Import before the barrier so module load time is not part of the race
+        // window; every worker arrives at the symlink call already warm.
         `const { linkSdkInto } = await import(${JSON.stringify(moduleUrl)});`,
+        `await new Promise((r) => setTimeout(r, ${startAt} - ${SPIN_MS} - Date.now()));`,
+        `while (Date.now() < ${startAt}) {}`,
         `linkSdkInto(${JSON.stringify(pkg)});`,
       ].join("\n");
       const child = spawn(process.execPath, ["--input-type=module", "-e", source], {
@@ -117,21 +130,28 @@ test("linkSdkInto tolerates a concurrent create of the same link", async () => {
       });
       let stderr = "";
       child.stderr.on("data", (chunk) => { stderr += chunk; });
+      // A spawn that never starts (e.g. EAGAIN under process pressure) emits
+      // "error" and may never emit "close". Without this the promise would not
+      // settle and the run would hang until the CI job timeout.
+      child.on("error", (error) => resolve({ code: -1, stderr: String(error) }));
       child.on("close", (code) => resolve({ code, stderr }));
     });
 
   for (let round = 0; round < ROUNDS; round += 1) {
     const pkg = makePackage(join(workDir, `race-${round}`));
-    const startAt = Date.now() + 400;
+    const startAt = Date.now() + STARTUP_BUDGET_MS;
     const results = await Promise.all(
       Array.from({ length: WORKERS }, () => runWorker(pkg, startAt)),
     );
 
-    const failures = results
-      .filter((result) => result.code !== 0)
-      .map((result) => result.stderr.trim().split("\n").find((line) => line.includes("Error")) ?? "unknown");
+    const failed = results.filter((result) => result.code !== 0);
+    // Workers fail identically, so report the distinct errors rather than one
+    // long line per worker.
+    const failures = [...new Set(
+      failed.map((result) => result.stderr.trim().split("\n").find((line) => line.includes("Error")) ?? "unknown"),
+    )];
 
-    assert.deepEqual(failures, [], `round ${round}: ${failures.length}/${WORKERS} workers failed`);
+    assert.deepEqual(failures, [], `round ${round}: ${failed.length}/${WORKERS} workers failed`);
     assert.ok(lstatSync(join(pkg, "node_modules", "@paperclipai", "plugin-sdk")).isSymbolicLink());
   }
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The repo is a pnpm workspace. A postinstall step links the in-repo plugin SDK into each plugin package
> - `linkSdkInto` checks for an existing link, removes it, then creates its own
> - Workspace installs run that step for several packages at the same time, so two runs can interleave between the check and the create
> - The loser gets EEXIST, and one failed link fails the whole install
> - This pull request treats EEXIST as success, because the link already points where the run intended
> - The benefit is that `pnpm install` stops failing intermittently on a clean checkout

## Linked Issues or Issue Description

No existing issue. Describing it here per CONTRIBUTING.md.

**What happened?**
`pnpm install` fails intermittently with `EEXIST: file already exists, symlink ... @paperclipai/plugin-sdk`. Re-running usually succeeds.

**Expected behavior**
The install completes. The symlink exists and points at the in-repo SDK.

**Steps to reproduce**
Run `pnpm install` on a clean checkout with several plugin packages present. The failure is timing dependent. The test added here reproduces it deterministically: twelve processes link the same package directory at a shared start instant, and eleven fail against the unfixed linker.

**Paperclip version or commit**
master, a388ea1ca.

**Deployment mode**
Not applicable. This is a build step.

**Installation method**
From source, `pnpm install`.

## What Changed

- `linkSdkInto` treats `EEXIST` from `symlinkSync` as success and returns `true`. Any other error still propagates. That is the whole behavior change: one error code on one call.
- Added a concurrency regression test to the existing `scripts/link-plugin-dev-sdk.test.js`, which the `test:release-registry` job already runs. It drives separate processes, because in-process calls cannot interleave when the underlying filesystem calls are synchronous.
- Hardened that test harness in a follow-up commit: handle a worker's `error` event so a spawn failure cannot leave the run hanging until the job timeout, sleep to just before the shared start instant instead of busy-waiting the whole window, import the module before the barrier so module load is not inside the race window, and report distinct worker errors instead of one identical line per worker.

## Verification

`node --test scripts/link-plugin-dev-sdk.test.js` — 8 pass in 2.1s.

The contrast is the actual evidence. Restoring the original `link-plugin-dev-sdk.mjs` from master and re-running fails the new test on round 0 with 11 of 12 workers reporting EEXIST, reproduced 3 for 3.

On CI cost: the race test measured 2102ms on a GitHub-hosted runner (2224ms before the harness change) in the `Typecheck + Release Registry` job, which takes about 4 minutes overall. The harness change cut CPU from roughly 1074% to 107% at the same wall time, so the 60 spawned processes no longer pin every core while they wait. Worker and round counts are left at 12 and 5 — one round already fails 11 of 12 workers without the fix, and the extra rounds are cheap redundancy for machines where a given round happens to miss the window.

## Risks

Low. The change narrows to one error code on one call. The postcondition is unchanged: after either path the link exists and points at the in-repo SDK. A real (non-symlink) install is still left alone, and a stale link pointing elsewhere is still replaced.

Two things worth naming for a reviewer:

- The `security-review` check reports neutral, "Security Review Recommended". The flag is `suspicious-test / shell-exec`: the new test imports `spawn` from `node:child_process`. That is inherent to the test — the race window only opens under real process-level parallelism — and the spawned command is `process.execPath` running a literal source string with paths interpolated through `JSON.stringify`. No network, no shell, no external input.
- Swallowing EEXIST assumes the racing creator is another run of this same script, which computes the same relative target for the same package directory. That holds here, because the target is derived only from the package directory and the repo root. A different writer creating something else at that path would be left in place, which matches what the existing "a real install has already populated it" branch does deliberately.

## Model Used

Claude Opus 4.5 (`claude-opus-4-5`) for the fix and the initial test; Claude Opus 5 (`claude-opus-5`, 1M context) for the test-harness hardening and the CI cost analysis. Extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
