### PR TITLE
fix(interactions): refuse to resolve a card whose issue is already closed

### DIFF
--- a/server/src/services/issue-thread-interactions.test.ts
+++ b/server/src/services/issue-thread-interactions.test.ts
@@ -11,18 +11,22 @@ vi.mock("./issues.js", () => ({
 
 type SelectRow = Record<string, unknown>;
 
+function createWhereChain(rows: SelectRow[]) {
+  return {
+    where() {
+      return {
+        then(callback: (rows: SelectRow[]) => unknown) {
+          return Promise.resolve(callback(rows));
+        },
+      };
+    },
+  };
+}
+
 function createSelectChain(rows: SelectRow[]) {
   return {
     from() {
-      return {
-        where() {
-          return {
-            then(callback: (rows: SelectRow[]) => unknown) {
-              return Promise.resolve(callback(rows));
-            },
-          };
-        },
-      };
+      return createWhereChain(rows);
     },
   };
 }
@@ -30,6 +34,12 @@ function createSelectChain(rows: SelectRow[]) {
 function createFakeDb(args: {
   interactionRow: Record<string, unknown>;
   parentRows?: SelectRow[];
+  /**
+   * Rows the `issues` table answers with. Only consulted when set, so the
+   * call-ordered defaults above stay untouched for the tests that do not care
+   * about the issue's status.
+   */
+  issueRows?: SelectRow[];
 }) {
   let interactionRow = { ...args.interactionRow };
   const issueTouches: Array<Record<string, unknown>> = [];
@@ -38,10 +48,15 @@ function createFakeDb(args: {
   let selectCallCount = 0;
 
   const db: any = {
-    select: vi.fn(() => {
-      selectCallCount += 1;
-      return createSelectChain(selectCallCount === 1 ? [interactionRow] : (args.parentRows ?? []));
-    }),
+    select: vi.fn(() => ({
+      from(table: unknown) {
+        if (args.issueRows && getTableName(table as never) === "issues") {
+          return createWhereChain(args.issueRows);
+        }
+        selectCallCount += 1;
+        return createWhereChain(selectCallCount === 1 ? [interactionRow] : (args.parentRows ?? []));
+      },
+    })),
     update: vi.fn((table: unknown) => ({
       set(values: Record<string, unknown>) {
         return {
@@ -326,5 +341,113 @@ describe("issueThreadInteractionService", () => {
     expect(expired[0]?.result).toMatchObject({ version: 1, outcome: "issue_closed" });
     expect(state.toolActionRequestUpdates).toHaveLength(1);
     expect(state.toolActionRequestUpdates[0]).toMatchObject({ status: "expired", resolvedByUserId: "local-board" });
+  });
+
+  describe("resolving a card whose issue is already closed", () => {
+    const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+
+    function confirmationRow(overrides: Record<string, unknown> = {}) {
+      return {
+        id: "interaction-closed-carrier", companyId: "company-1", issueId: ISSUE_ID,
+        kind: "request_confirmation", status: "pending", continuationPolicy: "wake_assignee",
+        sourceCommentId: null, sourceRunId: null, title: null, summary: null,
+        createdByAgentId: "agent-1", createdByUserId: null, resolvedByAgentId: null, resolvedByUserId: null,
+        payload: { version: 1, prompt: "Proceed?" }, result: null, resolvedAt: null,
+        createdAt: new Date("2026-07-25T10:00:00.000Z"), updatedAt: new Date("2026-07-25T10:00:00.000Z"),
+        ...overrides,
+      };
+    }
+
+    function questionsRow() {
+      return confirmationRow({
+        id: "interaction-closed-questions",
+        kind: "ask_user_questions",
+        payload: {
+          version: 1,
+          questions: [{
+            id: "scope", prompt: "Pick one", selectionMode: "single",
+            options: [{ id: "a", label: "A" }],
+          }],
+        },
+      });
+    }
+
+    for (const issueStatus of ["done", "cancelled"] as const) {
+      it(`refuses to accept a confirmation on a ${issueStatus} issue`, async () => {
+        const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+        const state = createFakeDb({ interactionRow: confirmationRow(), issueRows: [{ status: issueStatus }] });
+        const svc = issueThreadInteractionService(state.db as never);
+
+        await expect(svc.acceptInteraction(
+          { id: ISSUE_ID, companyId: "company-1", projectId: null, goalId: null },
+          "interaction-closed-carrier",
+          {},
+          { userId: "local-board" },
+        )).rejects.toMatchObject({ status: 409 });
+        // The silent failure this guards against is exactly a card that flips to
+        // "accepted" while no continuation wakeup fires, so the card must not move.
+        expect(state.interactionUpdates).toHaveLength(0);
+        expect(state.getInteractionRow().status).toBe("pending");
+      });
+    }
+
+    it("refuses to reject a confirmation on a closed issue", async () => {
+      const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+      const state = createFakeDb({ interactionRow: confirmationRow(), issueRows: [{ status: "done" }] });
+      const svc = issueThreadInteractionService(state.db as never);
+
+      await expect(svc.rejectInteraction(
+        { id: ISSUE_ID, companyId: "company-1" },
+        "interaction-closed-carrier",
+        { reason: "No" },
+        { userId: "local-board" },
+      )).rejects.toMatchObject({ status: 409 });
+      expect(state.interactionUpdates).toHaveLength(0);
+    });
+
+    it("refuses to answer questions on a closed issue", async () => {
+      const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+      const state = createFakeDb({ interactionRow: questionsRow(), issueRows: [{ status: "cancelled" }] });
+      const svc = issueThreadInteractionService(state.db as never);
+
+      await expect(svc.answerQuestions(
+        { id: ISSUE_ID, companyId: "company-1" },
+        "interaction-closed-questions",
+        { answers: [{ questionId: "scope", optionIds: ["a"] }] },
+        { userId: "local-board" },
+      )).rejects.toMatchObject({ status: 409 });
+      expect(state.interactionUpdates).toHaveLength(0);
+    });
+
+    it("still lets the creator withdraw a card whose issue is closed", async () => {
+      const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+      const state = createFakeDb({ interactionRow: confirmationRow(), issueRows: [{ status: "done" }] });
+      const svc = issueThreadInteractionService(state.db as never);
+
+      const withdrawn = await svc.withdrawInteraction(
+        { id: ISSUE_ID, companyId: "company-1" },
+        "interaction-closed-carrier",
+        { reason: "Superseded" },
+        { agentId: "agent-1" },
+      );
+
+      expect(withdrawn.status).toBe("cancelled");
+    });
+
+    it("keeps reporting an already-resolved card as resolved rather than as a closed issue", async () => {
+      const { issueThreadInteractionService } = await import("./issue-thread-interactions.js");
+      const state = createFakeDb({
+        interactionRow: confirmationRow({ status: "expired" }),
+        issueRows: [{ status: "done" }],
+      });
+      const svc = issueThreadInteractionService(state.db as never);
+
+      await expect(svc.acceptInteraction(
+        { id: ISSUE_ID, companyId: "company-1", projectId: null, goalId: null },
+        "interaction-closed-carrier",
+        {},
+        { userId: "local-board" },
+      )).rejects.toMatchObject({ status: 409, message: "Interaction has already been resolved" });
+    });
   });
 });

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -78,6 +78,7 @@ type ResolvedInteractionResult = {
 
 type IssueThreadInteractionRow = typeof issueThreadInteractions.$inferSelect;
 type IssueTouchDb = Pick<Db, "update">;
+type IssueStatusReadDb = Pick<Db, "select">;
 
 type IssueResolutionContext = {
   id: string;
@@ -238,6 +239,40 @@ async function touchIssue(db: IssueTouchDb, issueId: string) {
 
 function isTerminalIssueStatus(status: string) {
   return status === "done" || status === "cancelled";
+}
+
+/**
+ * A resolution on a closed issue must not look like it worked.
+ *
+ * `queueResolvedInteractionContinuationWakeup` (`server/src/routes/issues.ts`)
+ * drops the continuation wakeup when the issue is `done`/`cancelled`, so an
+ * accept/reject/answer there sets the card to a resolved status, writes the
+ * activity entry, returns 200 — and wakes nobody. The card reads as answerable
+ * in the UI, someone answers it in good faith, and nothing happens: no error,
+ * no hint.
+ *
+ * Closing an issue expires its pending cards, so in the normal case the
+ * resolution routes already fail on the `status !== "pending"` check. This guard
+ * covers what that leaves: rows filed before auto-expiry-on-close shipped, and
+ * any path that put an issue into a terminal status without going through it.
+ *
+ * Deliberately not applied to the administrative resolutions (withdraw, cancel):
+ * retiring a stale card on a closed issue is exactly the cleanup those exist for.
+ */
+async function assertIssueOpenForInteractionResolution(
+  db: IssueStatusReadDb,
+  issue: { id: string; companyId: string },
+) {
+  const [row] = await db
+    .select({ status: issues.status })
+    .from(issues)
+    .where(and(eq(issues.id, issue.id), eq(issues.companyId, issue.companyId)));
+  if (!row || !isTerminalIssueStatus(row.status)) return;
+  throw conflict(
+    "Cannot resolve an interaction on a closed issue: the answer would not resume any work. "
+      + "Reopen the issue first, or withdraw the interaction.",
+    { issueId: issue.id, issueStatus: row.status },
+  );
 }
 
 function shouldReturnAcceptedConfirmationToCreatorAgent(args: {
@@ -1028,6 +1063,7 @@ export function issueThreadInteractionService(db: Db) {
     if (current.status !== "pending") {
       throw conflict("Interaction has already been resolved");
     }
+    await assertIssueOpenForInteractionResolution(db, args.issue);
     return current;
   }
 
@@ -1591,6 +1627,7 @@ export function issueThreadInteractionService(db: Db) {
           }
           throw conflict("Interaction has already been resolved");
         }
+        await assertIssueOpenForInteractionResolution(tx, issue);
 
         const expired = await expireStaleRequestConfirmationTarget(tx, {
           row: current,
@@ -2129,6 +2166,7 @@ export function issueThreadInteractionService(db: Db) {
       if (current.status !== "pending") {
         throw conflict("Interaction has already been resolved");
       }
+      await assertIssueOpenForInteractionResolution(db, issue);
 
       const interaction = hydrateInteraction(current) as AskUserQuestionsInteraction;
       const normalizedAnswers = normalizeQuestionAnswers({

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -975,7 +975,7 @@ Resolved result (`RequestCheckboxConfirmationResult`):
 Other outcomes match `request_confirmation`:
 
 - `withdrawn` — `{ outcome: "withdrawn", reason }`. Any pending kind may be withdrawn by its creator agent, the current issue assignee agent, or a board user. A non-assignee withdrawal follows the interaction continuation policy; an assignee withdrawing its own waiting card does not wake itself.
-- `issue_closed` — `{ outcome: "issue_closed" }`. Transitioning the issue to `done` or `cancelled` expires all pending interactions without continuation wakes; listing a terminal issue also performs a catch-up sweep for historical residue.
+- `issue_closed` — `{ outcome: "issue_closed" }`. Transitioning the issue to `done` or `cancelled` expires all pending interactions without continuation wakes; listing a terminal issue also performs a catch-up sweep for historical residue. A card that is still `pending` on a closed issue (filed before that expiry shipped) cannot be resolved: `accept`, `reject`, `respond` and `verdicts` return **409** rather than recording an answer that wakes nobody. `withdraw` and `cancel` stay available so a stale card can still be retired.
 
 - `rejected` — `{ outcome: "rejected", reason, commentId }`. `selectedOptionIds` is absent.
 - `superseded_by_comment` — `{ outcome: "superseded_by_comment", commentId }`. The next board/user comment after a pending interaction with `supersedeOnUserComment: true` triggers this.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The board and its humans unblock agents through issue-thread interactions — confirmations, question sets, suggested tasks — and an answered card resumes the agent through a continuation wakeup
> - `queueResolvedInteractionContinuationWakeup` deliberately drops that wakeup when the issue is `done`/`cancelled`, but the `accept`, `reject`, `respond` and `verdicts` routes never checked the issue status, so a resolution there flipped the card, wrote the activity entry and answered 200 — while waking nobody
> - #10251 closed the forward-looking half by expiring pending cards when an issue goes terminal; it does not cover the rows filed before it shipped, which are still `pending` on issues that closed long ago and still render as answerable
> - On the instance this was found on, 154 such cards sit on 145 closed issues; 146 carry `continuationPolicy: wake_assignee`, and three ask the reader in their prompt to reply — every one of them is a trap that costs a person a real answer and gives back silence
> - This pull request makes the resolution paths read the issue status and answer 409 instead of recording an answer that cannot travel, while leaving `withdraw`/`cancel` open so the stale cards can still be retired
> - The benefit is that a resolution which does nothing no longer looks like one that worked

## Linked Issues or Issue Description

Refs #10251 (the auto-expire-on-close hook this backstops), #10920 (open — backfills
the pre-#10251 residue this guard makes visible). No public GitHub issue tracks the
resolution-side hole; describing it inline per the bug template:

**What happened?**
`POST /api/issues/:id/interactions/:interactionId/accept` (and `reject`, `respond`,
`verdicts`) on an interaction that is still `pending` while its issue is `done` or
`cancelled` returns 200, sets the card to `accepted`/`rejected`/`answered` and writes
the activity entry — but `queueResolvedInteractionContinuationWakeup` returns early on
`isClosedIssueStatus(issue.status)`, so no agent is woken. The answer is recorded and
has no effect.

**Expected behavior**
An answer that cannot resume anything should not report success. Either the card is
unanswerable, or answering it does something.

**Steps to reproduce**
1. Create an issue, assign it to an agent.
2. Create a `request_confirmation` on it with `continuationPolicy: "wake_assignee"`.
3. Write the issue to `status: "cancelled"` by a path that predates or bypasses the
   #10251 close hook — or simply hold any interaction filed before #10251 landed,
   which is still `pending` on an issue that closed earlier.
4. `POST .../accept`. Response is 200, the card shows `accepted`, no wakeup is queued
   and no error is surfaced anywhere.

**Paperclip version**
Reproduced against `@paperclipai/server` 2026.609.0 (`dist/routes/issues.js`, the
bundle the live process loads); the code path is unchanged on current `master`.

**Deployment mode**
Self-hosted, local instance.

## What Changed

- `assertIssueOpenForInteractionResolution()` in
  `server/src/services/issue-thread-interactions.ts` reads the issue's status from the
  database and throws 409 (`{ issueId, issueStatus }` in the error details) when it is
  `done`/`cancelled`.
- Wired into the four resolution entry points: `getPendingInteractionForResolution`
  (covers `acceptInteraction` and `rejectInteraction`, and through them the
  suggest-tasks and confirmation branches), `answerQuestions`, and `submitItemVerdicts`
  (inside its existing transaction, on `tx`).
- Placed *after* the existing `status !== "pending"` check, so an already-resolved card
  keeps its more specific "Interaction has already been resolved" message and this
  change only affects the case that is currently silent.
- `withdrawInteraction` and `cancelQuestions` are deliberately untouched: retiring a
  stale card on a closed issue is the cleanup those exist for.
- The status is read from the database rather than taken from the caller's issue
  object, so the plugin host's accept/reject path gets the same guard, not just the
  HTTP routes.
- `skills/paperclip/references/api-reference.md`: documents the 409 next to the
  existing `issue_closed` outcome, including that `withdraw`/`cancel` stay available.

## Verification

```
npx vitest run server/src/services/issue-thread-interactions.test.ts
#   12 passed  (5 new)
npx vitest run server/src/__tests__/issue-thread-interaction-routes.test.ts \
               server/src/__tests__/issue-thread-interactions-service.test.ts \
               server/src/__tests__/issues-service.test.ts \
               server/src/__tests__/tool-gateway-service.test.ts
#   187 passed
npx vitest run server/src/__tests__/issue-thread-interactions-telemetry.test.ts
#   7 passed
npx tsc --noEmit -p server/tsconfig.json     # no diagnostics in the touched file
```

Red before the fix: with the service change reverted and the new tests in place,
the four refusal tests fail (`4 failed | 8 passed`) — they are measuring the guard,
not the harness.

New tests in `server/src/services/issue-thread-interactions.test.ts`:

- accept on a `done` issue and on a `cancelled` issue → 409, and the card must still
  be `pending` afterwards (the silent failure is precisely a card that moves while
  nothing is woken, so "does not throw" alone would not catch a regression)
- reject on a closed issue → 409, no card update
- `respond` (`answerQuestions`) on a closed issue → 409, no card update
- withdraw on a closed issue still succeeds — the administrative path stays open
- an already-`expired` card on a closed issue still reports "Interaction has already
  been resolved", pinning the ordering of the two conflicts

The test double's `select()` grew table awareness for the `issues` table, opt-in via a
new `issueRows` argument, so every existing call-ordered expectation in that file is
unchanged.

## Risks

Low, and deliberately narrow.

- **Behavioral shift:** a resolution that previously returned 200 now returns 409. It
  only fires for a card that is `pending` on a `done`/`cancelled` issue — a state that
  post-#10251 issues do not reach through the close path, and whose 200 was never
  effective. No caller loses a working outcome; a silent no-op becomes a visible one.
- **One extra `SELECT` per resolution**, primary-key lookup on `issues`, on a path that
  already runs several statements.
- **Fails open when the issue row is not found:** the routes resolve the issue before
  calling in, so a missing row means an inconsistency, not a closed issue; refusing
  there would turn a read anomaly into a blocked answer.
- **Race window is unchanged, not widened:** an issue closing between the guard and the
  card update still lands on the close hook's expiry, and the existing
  `WHERE status = 'pending'` guard on the update turns that into the same 409. The
  pre-check is aimed at rows that are *already* pending on an *already* closed issue.
- No migration, no schema change, no change to any resolved-card result shape.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`, 1M context), extended thinking, with tool use
(repository search, local vitest/tsc runs against a throwaway worktree of this base).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related prior PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — 29 checks `SUCCESS`, 1 `SKIPPED` (Storybook visual regression; no UI files in this PR), 0 failures on `9ec5c99d2`
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — reviewed `9ec5c99d2`, confidence 5/5, no inline comments raised
- [x] I will address all Greptile and reviewer comments before requesting merge

> Note on the base: this branch is cut from `4eace88f6` rather than current `master`,
> because the token available here has no `workflow` scope and pushing the intervening
> `.github/workflows/` commits to the fork is rejected. `4eace88f6` already contains
> #10251, and the functions this PR touches are byte-identical between that commit and
> `master`. A maintainer pressing "Update branch" will rebase it cleanly.

