### PR TITLE
Simplify the onboarding company name label

### DIFF
--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { COMPANY_NAME_FIELD_LABEL } from "./OnboardingWizard";
+
+describe("OnboardingWizard", () => {
+  it("uses the concise company name field label", () => {
+    expect(COMPANY_NAME_FIELD_LABEL).toBe("Name");
+  });
+});

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -988,7 +988,7 @@ export function OnboardingWizard() {
                           : "text-muted-foreground group-focus-within:text-foreground"
                       )}
                     >
-                      Company name
+                      Name
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -66,6 +66,8 @@ type Step = 0 | 1 | 2 | 3 | 4 | 5;
 // wizard's registry-driven approach rather than a fixed union.
 type AdapterType = string;
 
+export const COMPANY_NAME_FIELD_LABEL = "Name";
+
 const MISSION_PROMPT_CHIPS = [
   "Build a SaaS product",
   "Scale a content business",
@@ -988,7 +990,7 @@ export function OnboardingWizard() {
                           : "text-muted-foreground group-focus-within:text-foreground"
                       )}
                     >
-                      Name
+                      {COMPANY_NAME_FIELD_LABEL}
                     </label>
                     <input
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The onboarding wizard helps a user create the first company
> - The first form currently labels the company field as "Company name"
> - The surrounding context already makes the field purpose clear
> - A shorter label reduces repeated wording on the first screen
> - This pull request changes the field label to "Name"
> - The benefit is a simpler and more direct onboarding form

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The first screen of the onboarding wizard uses a longer label for the company name field.

**Subsystem affected**

`ui/` — React and Vite board UI.

**Current behavior**

The field label reads "Company name".

**Proposed behavior**

The field label reads "Name".

**Reason and benefit**

The screen already provides company context. The shorter label removes repeated wording and keeps the form concise.

**Breaking changes**

None. This change only updates visible copy.

The GitHub search found no duplicate or closely related open issue or pull request.

## What Changed

- Changed the first onboarding company field label from "Company name" to "Name".
- Added a focused regression test for the exact field label.

## Verification

- `pnpm check:token-gates` — all three token gates are clean.
- `pnpm typecheck` — passed for all workspace packages.
- `pnpm --filter @paperclipai/ui exec vitest run src/components/OnboardingWizard.test.tsx` — 1 test passed.
- Open the first onboarding screen and confirm that the company field label reads "Name".
- Snapshot baselines were intentionally not updated. The decision sheet marks per-change snapshot verification as dormant in "Per-change snapshot verification demoted to dormant (Jul 13 2026)".

## Risks

- Low risk. The change only updates one visible label and does not change form state or submission behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The context window size is not exposed. Agentic reasoning and tool use were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
