### PR TITLE
fix(ui): add goal owner picker and delete action to Goals UI (#8822)

### DIFF
--- a/ui/src/components/GoalProperties.interactions.test.tsx
+++ b/ui/src/components/GoalProperties.interactions.test.tsx
@@ -1,0 +1,317 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Agent, Goal } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GoalProperties } from "./GoalProperties";
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+const mockAgentsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+const mockGoalsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock("../api/agents", () => ({
+  agentsApi: mockAgentsApi,
+}));
+
+vi.mock("../api/goals", () => ({
+  goalsApi: mockGoalsApi,
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/ui/separator", () => ({
+  Separator: () => <hr />,
+}));
+
+// Bypass Radix popover open/close mechanics: always render trigger + content.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("./AgentIconPicker", () => ({
+  AgentIcon: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function waitForAssertion(assertion: () => void, attempts = 20) {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flush();
+    }
+  }
+
+  throw lastError;
+}
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: "goal-1",
+    companyId: "company-1",
+    title: "Test Goal",
+    description: "Goal description",
+    level: "task",
+    status: "planned",
+    parentId: null,
+    ownerAgentId: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Alpha Agent",
+    urlKey: "alpha",
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "active",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function findButtonByText(root: HTMLElement, text: string): HTMLButtonElement | undefined {
+  return Array.from(root.querySelectorAll("button")).find((b) => b.textContent?.trim() === text);
+}
+
+describe("GoalProperties interactions", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | null;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockAgentsApi.list.mockResolvedValue([
+      makeAgent({ id: "agent-1", name: "Alpha Agent" }),
+      makeAgent({ id: "agent-2", name: "Beta Agent" }),
+    ]);
+    mockGoalsApi.list.mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    const currentRoot = root;
+    if (currentRoot) {
+      await act(async () => {
+        currentRoot.unmount();
+      });
+    }
+    queryClient.clear();
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  function render(props: Partial<Parameters<typeof GoalProperties>[0]> & { goal: Goal }) {
+    root = createRoot(container);
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <GoalProperties {...props} />
+      </QueryClientProvider>,
+    );
+  }
+
+  describe("delete confirmation flow", () => {
+    it("requires a confirmation step before calling onDelete", async () => {
+      const onDelete = vi.fn();
+      render({ goal: makeGoal(), onUpdate: () => {}, onDelete });
+      await flush();
+
+      expect(container.textContent).not.toContain("This action cannot be undone");
+      expect(onDelete).not.toHaveBeenCalled();
+
+      const deleteTrigger = findButtonByText(container, "Delete Goal");
+      expect(deleteTrigger).toBeTruthy();
+      await act(async () => {
+        deleteTrigger?.click();
+      });
+      await flush();
+
+      expect(container.textContent).toContain("This action cannot be undone");
+      expect(onDelete).not.toHaveBeenCalled();
+
+      const confirmButton = findButtonByText(container, "Confirm Delete");
+      await act(async () => {
+        confirmButton?.click();
+      });
+      await flush();
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels out of the confirmation step without calling onDelete", async () => {
+      const onDelete = vi.fn();
+      render({ goal: makeGoal(), onUpdate: () => {}, onDelete });
+      await flush();
+
+      await act(async () => {
+        findButtonByText(container, "Delete Goal")?.click();
+      });
+      await flush();
+      expect(container.textContent).toContain("This action cannot be undone");
+
+      await act(async () => {
+        findButtonByText(container, "Cancel")?.click();
+      });
+      await flush();
+
+      expect(container.textContent).not.toContain("This action cannot be undone");
+      expect(onDelete).not.toHaveBeenCalled();
+    });
+
+    it("disables confirm/cancel buttons and shows pending state while deleting", async () => {
+      const onDelete = vi.fn();
+      render({ goal: makeGoal(), onUpdate: () => {}, onDelete, deletePending: true });
+      await flush();
+
+      await act(async () => {
+        findButtonByText(container, "Delete Goal")?.click();
+      });
+      await flush();
+
+      const deletingButton = findButtonByText(container, "Deleting...");
+      expect(deletingButton).toBeTruthy();
+      expect(deletingButton?.disabled).toBe(true);
+    });
+
+    it("surfaces a delete error message inside the confirmation panel", async () => {
+      const onDelete = vi.fn();
+      render({
+        goal: makeGoal(),
+        onUpdate: () => {},
+        onDelete,
+        deleteError: "Cannot delete a goal with linked issues",
+      });
+      await flush();
+
+      await act(async () => {
+        findButtonByText(container, "Delete Goal")?.click();
+      });
+      await flush();
+
+      expect(container.textContent).toContain("Cannot delete a goal with linked issues");
+      const alert = container.querySelector('[role="alert"]');
+      expect(alert?.textContent).toContain("Cannot delete a goal with linked issues");
+    });
+
+    it("does not render the delete action when onDelete is not provided", async () => {
+      render({ goal: makeGoal(), onUpdate: () => {} });
+      await flush();
+
+      expect(findButtonByText(container, "Delete Goal")).toBeUndefined();
+    });
+  });
+
+  describe("owner reassignment", () => {
+    it("calls onUpdate with the selected agent id when an owner is chosen", async () => {
+      const onUpdate = vi.fn();
+      render({ goal: makeGoal({ ownerAgentId: null }), onUpdate });
+      await flush();
+
+      let betaOption: HTMLButtonElement | undefined;
+      await waitForAssertion(() => {
+        betaOption = findButtonByText(container, "Beta Agent");
+        expect(betaOption).toBeTruthy();
+      });
+
+      await act(async () => {
+        betaOption?.click();
+      });
+      await flush();
+
+      expect(onUpdate).toHaveBeenCalledWith({ ownerAgentId: "agent-2" });
+    });
+
+    it("calls onUpdate with null when the owner is cleared", async () => {
+      const onUpdate = vi.fn();
+      render({ goal: makeGoal({ ownerAgentId: "agent-1" }), onUpdate });
+      await flush();
+
+      // Wait for the agents list to resolve so the trigger reflects the
+      // current owner ("Alpha Agent") rather than the "None" loading
+      // fallback — otherwise both the trigger and the clear option would
+      // read "None" and the wrong button could be targeted.
+      await waitForAssertion(() => {
+        expect(container.textContent).toContain("Alpha Agent");
+      });
+
+      const noneOption = findButtonByText(container, "None");
+      expect(noneOption).toBeTruthy();
+
+      await act(async () => {
+        noneOption?.click();
+      });
+      await flush();
+
+      expect(onUpdate).toHaveBeenCalledWith({ ownerAgentId: null });
+    });
+
+    it("renders the owner as a read-only link when onUpdate is not provided", async () => {
+      render({ goal: makeGoal({ ownerAgentId: "agent-1" }) });
+      await flush();
+
+      await waitForAssertion(() => {
+        expect(container.querySelector("a[href]")).toBeTruthy();
+        expect(container.textContent).toContain("Alpha Agent");
+      });
+    });
+  });
+});

--- a/ui/src/components/GoalProperties.test.tsx
+++ b/ui/src/components/GoalProperties.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment node
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { Goal } from "@paperclipai/shared";
+import { GoalProperties } from "./GoalProperties";
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] }),
+}));
+
+const sampleGoal: Goal = {
+  id: "goal-1",
+  companyId: "company-1",
+  title: "Test Goal",
+  description: "Goal description",
+  level: "task",
+  status: "planned",
+  parentId: null,
+  ownerAgentId: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+describe("GoalProperties", () => {
+  it("renders owner section and delete action when onUpdate and onDelete are provided", () => {
+    const html = renderToStaticMarkup(
+      <GoalProperties
+        goal={sampleGoal}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+      />
+    );
+
+    expect(html).toContain("Owner");
+    expect(html).toContain("Delete Goal");
+  });
+
+  it("renders read-only owner when onUpdate is not provided", () => {
+    const html = renderToStaticMarkup(<GoalProperties goal={sampleGoal} />);
+    expect(html).toContain("Owner");
+    expect(html).toContain("None");
+    expect(html).not.toContain("Delete Goal");
+  });
+});

--- a/ui/src/components/GoalProperties.tsx
+++ b/ui/src/components/GoalProperties.tsx
@@ -20,6 +20,7 @@ interface GoalPropertiesProps {
   onUpdate?: (data: Record<string, unknown>) => void;
   onDelete?: () => void;
   deletePending?: boolean;
+  deleteError?: string | null;
 }
 
 function PropertyRow({ label, children }: { label: string; children: React.ReactNode }) {
@@ -147,7 +148,7 @@ function AgentOwnerPicker({
   );
 }
 
-export function GoalProperties({ goal, onUpdate, onDelete, deletePending }: GoalPropertiesProps) {
+export function GoalProperties({ goal, onUpdate, onDelete, deletePending, deleteError }: GoalPropertiesProps) {
   const { selectedCompanyId } = useCompany();
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
@@ -253,6 +254,11 @@ export function GoalProperties({ goal, onUpdate, onDelete, deletePending }: Goal
                 <p className="text-xs text-destructive font-medium">
                   Delete this goal? This action cannot be undone.
                 </p>
+                {deleteError && (
+                  <p className="text-xs text-destructive" role="alert">
+                    {deleteError}
+                  </p>
+                )}
                 <div className="flex items-center gap-2">
                   <Button
                     size="xs"

--- a/ui/src/components/GoalProperties.tsx
+++ b/ui/src/components/GoalProperties.tsx
@@ -139,7 +139,7 @@ function AgentOwnerPicker({
             <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             <span className="truncate">{agent.name}</span>
             {agent.status === "terminated" && (
-              <span className="text-muted-foreground text-[10px] ml-auto shrink-0">(terminated)</span>
+              <span className="text-muted-foreground text-xs ml-auto shrink-0">(terminated)</span>
             )}
           </Button>
         ))}

--- a/ui/src/components/GoalProperties.tsx
+++ b/ui/src/components/GoalProperties.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link } from "@/lib/router";
 import { useQuery } from "@tanstack/react-query";
-import type { Goal } from "@paperclipai/shared";
+import type { Agent, Goal } from "@paperclipai/shared";
 import { GOAL_STATUSES, GOAL_LEVELS } from "@paperclipai/shared";
 import { agentsApi } from "../api/agents";
 import { goalsApi } from "../api/goals";
@@ -12,10 +12,14 @@ import { formatDate, cn, agentUrl } from "../lib/utils";
 import { Separator } from "@/components/ui/separator";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { AgentIcon } from "./AgentIconPicker";
+import { Trash2 } from "lucide-react";
 
 interface GoalPropertiesProps {
   goal: Goal;
   onUpdate?: (data: Record<string, unknown>) => void;
+  onDelete?: () => void;
+  deletePending?: boolean;
 }
 
 function PropertyRow({ label, children }: { label: string; children: React.ReactNode }) {
@@ -70,8 +74,82 @@ function PickerButton({
   );
 }
 
-export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
+function AgentOwnerPicker({
+  currentAgentId,
+  agents,
+  onChange,
+}: {
+  currentAgentId: string | null;
+  agents: Agent[];
+  onChange: (value: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const currentAgent = currentAgentId
+    ? agents.find((a) => a.id === currentAgentId)
+    : null;
+
+  const selectableAgents = agents.filter(
+    (a) => a.status !== "terminated" || a.id === currentAgentId,
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="cursor-pointer hover:opacity-80 transition-opacity flex items-center gap-1.5 min-w-0"
+        >
+          {currentAgent ? (
+            <>
+              <AgentIcon icon={currentAgent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="text-sm truncate">{currentAgent.name}</span>
+            </>
+          ) : (
+            <span className="text-sm text-muted-foreground">None</span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-48 p-1" align="end">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn("w-full justify-start text-xs", !currentAgentId && "bg-accent")}
+          onClick={() => {
+            onChange(null);
+            setOpen(false);
+          }}
+        >
+          <span className="text-muted-foreground">None</span>
+        </Button>
+        {selectableAgents.map((agent) => (
+          <Button
+            key={agent.id}
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "w-full justify-start gap-2 text-xs truncate",
+              agent.id === currentAgentId && "bg-accent",
+            )}
+            onClick={() => {
+              onChange(agent.id);
+              setOpen(false);
+            }}
+          >
+            <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate">{agent.name}</span>
+            {agent.status === "terminated" && (
+              <span className="text-muted-foreground text-[10px] ml-auto shrink-0">(terminated)</span>
+            )}
+          </Button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function GoalProperties({ goal, onUpdate, onDelete, deletePending }: GoalPropertiesProps) {
   const { selectedCompanyId } = useCompany();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -125,7 +203,13 @@ export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
         </PropertyRow>
 
         <PropertyRow label="Owner">
-          {ownerAgent ? (
+          {onUpdate ? (
+            <AgentOwnerPicker
+              currentAgentId={goal.ownerAgentId}
+              agents={agents ?? []}
+              onChange={(ownerAgentId) => onUpdate({ ownerAgentId })}
+            />
+          ) : ownerAgent ? (
             <Link
               to={agentUrl(ownerAgent)}
               className="text-sm hover:underline"
@@ -159,6 +243,50 @@ export function GoalProperties({ goal, onUpdate }: GoalPropertiesProps) {
           <span className="text-sm">{formatDate(goal.updatedAt)}</span>
         </PropertyRow>
       </div>
+
+      {onDelete && (
+        <>
+          <Separator />
+          <div className="pt-1">
+            {confirmingDelete ? (
+              <div className="space-y-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+                <p className="text-xs text-destructive font-medium">
+                  Delete this goal? This action cannot be undone.
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="xs"
+                    variant="destructive"
+                    disabled={deletePending}
+                    onClick={onDelete}
+                  >
+                    {deletePending ? "Deleting..." : "Confirm Delete"}
+                  </Button>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    disabled={deletePending}
+                    onClick={() => setConfirmingDelete(false)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                size="xs"
+                variant="outline"
+                className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => setConfirmingDelete(true)}
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                Delete Goal
+              </Button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }
+

--- a/ui/src/components/GoalTree.test.tsx
+++ b/ui/src/components/GoalTree.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import type { ReactNode } from "react";
+import type { Goal } from "@paperclipai/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GoalTree } from "./GoalTree";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function act(callback: () => void) {
+  flushSync(callback);
+}
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: "goal-1",
+    companyId: "company-1",
+    title: "Ship the thing",
+    description: null,
+    level: "task",
+    status: "planned",
+    parentId: null,
+    ownerAgentId: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("GoalTree delete control", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | null;
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    container.remove();
+    root = null;
+  });
+
+  function render(props: Partial<Parameters<typeof GoalTree>[0]> = {}) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const goal = makeGoal();
+    act(() => {
+      root?.render(
+        <GoalTree
+          goals={[goal]}
+          goalLink={(g) => `/goals/${g.id}`}
+          onDelete={() => {}}
+          {...props}
+        />,
+      );
+    });
+    return { goal };
+  }
+
+  it("does not nest the delete button inside the row link", () => {
+    render();
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete goal \\"Ship the thing\\""]',
+    );
+    expect(deleteButton).toBeTruthy();
+
+    // A button must never be a descendant of an anchor: nested interactive
+    // elements are invalid HTML with undefined keyboard activation behavior.
+    expect(deleteButton?.closest("a")).toBeNull();
+
+    const rowLink = container.querySelector("a");
+    expect(rowLink).toBeTruthy();
+    expect(rowLink?.contains(deleteButton)).toBe(false);
+  });
+
+  it("reveals the delete button on keyboard focus, not only on hover", () => {
+    render();
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete goal \\"Ship the thing\\""]',
+    );
+    expect(deleteButton).toBeTruthy();
+
+    const classList = deleteButton?.className ?? "";
+    expect(classList).toMatch(/group-hover:opacity-100/);
+    expect(classList).toMatch(/group-focus-within:opacity-100/);
+  });
+
+  it("is independently clickable/focusable as a sibling control of the row link", () => {
+    const onDelete = vi.fn();
+    const { goal } = render({ onDelete });
+
+    const deleteButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete goal \\"Ship the thing\\""]',
+    );
+    expect(deleteButton).toBeTruthy();
+
+    act(() => {
+      deleteButton?.focus();
+    });
+    expect(document.activeElement).toBe(deleteButton);
+
+    act(() => {
+      deleteButton?.click();
+    });
+    expect(onDelete).toHaveBeenCalledWith(goal);
+  });
+
+  it("does not render a delete button when onDelete is not provided", () => {
+    render({ onDelete: undefined });
+    expect(container.querySelector("button[aria-label^='Delete goal']")).toBeNull();
+  });
+});

--- a/ui/src/components/GoalTree.tsx
+++ b/ui/src/components/GoalTree.tsx
@@ -61,6 +61,7 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect, onDelet
             onDelete(goal);
           }}
           title="Delete goal"
+          aria-label={`Delete goal "${goal.title}"`}
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>

--- a/ui/src/components/GoalTree.tsx
+++ b/ui/src/components/GoalTree.tsx
@@ -1,7 +1,7 @@
 import type { Goal } from "@paperclipai/shared";
 import { Link } from "@/lib/router";
 import { StatusBadge } from "./StatusBadge";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Trash2 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { useState } from "react";
 
@@ -9,6 +9,7 @@ interface GoalTreeProps {
   goals: Goal[];
   goalLink?: (goal: Goal) => string;
   onSelect?: (goal: Goal) => void;
+  onDelete?: (goal: Goal) => void;
 }
 
 interface GoalNodeProps {
@@ -18,9 +19,10 @@ interface GoalNodeProps {
   depth: number;
   goalLink?: (goal: Goal) => string;
   onSelect?: (goal: Goal) => void;
+  onDelete?: (goal: Goal) => void;
 }
 
-function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalNodeProps) {
+function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect, onDelete }: GoalNodeProps) {
   const [expanded, setExpanded] = useState(true);
   const hasChildren = children.length > 0;
   const link = goalLink?.(goal);
@@ -29,6 +31,7 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
     <>
       {hasChildren ? (
         <button
+          type="button"
           className="p-0.5"
           onClick={(e) => {
             e.preventDefault();
@@ -48,11 +51,25 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
       <span className="text-xs text-muted-foreground capitalize">{goal.level}</span>
       <span className="flex-1 truncate">{goal.title}</span>
       <StatusBadge status={goal.status} />
+      {onDelete && (
+        <button
+          type="button"
+          className="p-1 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onDelete(goal);
+          }}
+          title="Delete goal"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
     </>
   );
 
   const classes = cn(
-    "flex items-center gap-2 px-3 py-1.5 text-sm transition-colors cursor-pointer hover:bg-accent/50",
+    "group flex items-center gap-2 px-3 py-1.5 text-sm transition-colors cursor-pointer hover:bg-accent/50",
   );
 
   return (
@@ -85,6 +102,7 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
               depth={depth + 1}
               goalLink={goalLink}
               onSelect={onSelect}
+              onDelete={onDelete}
             />
           ))}
         </div>
@@ -93,7 +111,7 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect }: GoalN
   );
 }
 
-export function GoalTree({ goals, goalLink, onSelect }: GoalTreeProps) {
+export function GoalTree({ goals, goalLink, onSelect, onDelete }: GoalTreeProps) {
   const goalIds = new Set(goals.map((g) => g.id));
   const roots = goals.filter((g) => !g.parentId || !goalIds.has(g.parentId));
 
@@ -112,8 +130,10 @@ export function GoalTree({ goals, goalLink, onSelect }: GoalTreeProps) {
           depth={0}
           goalLink={goalLink}
           onSelect={onSelect}
+          onDelete={onDelete}
         />
       ))}
     </div>
   );
 }
+

--- a/ui/src/components/GoalTree.tsx
+++ b/ui/src/components/GoalTree.tsx
@@ -51,47 +51,43 @@ function GoalNode({ goal, children, allGoals, depth, goalLink, onSelect, onDelet
       <span className="text-xs text-muted-foreground capitalize">{goal.level}</span>
       <span className="flex-1 truncate">{goal.title}</span>
       <StatusBadge status={goal.status} />
-      {onDelete && (
-        <button
-          type="button"
-          className="p-1 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onDelete(goal);
-          }}
-          title="Delete goal"
-          aria-label={`Delete goal "${goal.title}"`}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
-      )}
     </>
   );
 
+  const innerClasses = "flex items-center gap-2 min-w-0 flex-1";
+
   const classes = cn(
-    "group flex items-center gap-2 px-3 py-1.5 text-sm transition-colors cursor-pointer hover:bg-accent/50",
+    "group flex items-center gap-2 px-3 py-1.5 text-sm transition-colors hover:bg-accent/50",
   );
 
   return (
     <div>
-      {link ? (
-        <Link
-          to={link}
-          className={cn(classes, "no-underline text-inherit")}
-          style={{ paddingLeft: `${depth * 16 + 12}px` }}
-        >
-          {inner}
-        </Link>
-      ) : (
-        <div
-          className={classes}
-          style={{ paddingLeft: `${depth * 16 + 12}px` }}
-          onClick={() => onSelect?.(goal)}
-        >
-          {inner}
-        </div>
-      )}
+      <div className={classes} style={{ paddingLeft: `${depth * 16 + 12}px` }}>
+        {link ? (
+          <Link to={link} className={cn(innerClasses, "no-underline text-inherit cursor-pointer")}>
+            {inner}
+          </Link>
+        ) : (
+          <div className={cn(innerClasses, "cursor-pointer")} onClick={() => onSelect?.(goal)}>
+            {inner}
+          </div>
+        )}
+        {onDelete && (
+          <button
+            type="button"
+            className="p-1 text-muted-foreground hover:text-destructive opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onDelete(goal);
+            }}
+            title="Delete goal"
+            aria-label={`Delete goal "${goal.title}"`}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
       {hasChildren && expanded && (
         <div>
           {children.map((child) => (

--- a/ui/src/components/NewGoalDialog.tsx
+++ b/ui/src/components/NewGoalDialog.tsx
@@ -4,6 +4,7 @@ import { GOAL_STATUSES, GOAL_LEVELS } from "@paperclipai/shared";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { goalsApi } from "../api/goals";
+import { agentsApi } from "../api/agents";
 import { assetsApi } from "../api/assets";
 import { queryKeys } from "../lib/queryKeys";
 import {
@@ -21,10 +22,12 @@ import {
   Minimize2,
   Target,
   Layers,
+  User,
 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { MarkdownEditor, type MarkdownEditorRef } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
+import { AgentIcon } from "./AgentIconPicker";
 
 const levelLabels: Record<string, string> = {
   company: "Company",
@@ -42,11 +45,13 @@ export function NewGoalDialog() {
   const [status, setStatus] = useState("planned");
   const [level, setLevel] = useState("task");
   const [parentId, setParentId] = useState("");
+  const [ownerAgentId, setOwnerAgentId] = useState("");
   const [expanded, setExpanded] = useState(false);
 
   const [statusOpen, setStatusOpen] = useState(false);
   const [levelOpen, setLevelOpen] = useState(false);
   const [parentOpen, setParentOpen] = useState(false);
+  const [ownerOpen, setOwnerOpen] = useState(false);
   const descriptionEditorRef = useRef<MarkdownEditorRef>(null);
 
   // Apply defaults when dialog opens
@@ -55,6 +60,12 @@ export function NewGoalDialog() {
   const { data: goals } = useQuery({
     queryKey: queryKeys.goals.list(selectedCompanyId!),
     queryFn: () => goalsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId && newGoalOpen,
+  });
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId && newGoalOpen,
   });
 
@@ -81,6 +92,7 @@ export function NewGoalDialog() {
     setStatus("planned");
     setLevel("task");
     setParentId("");
+    setOwnerAgentId("");
     setExpanded(false);
   }
 
@@ -92,6 +104,7 @@ export function NewGoalDialog() {
       status,
       level,
       ...(appliedParentId ? { parentId: appliedParentId } : {}),
+      ...(ownerAgentId ? { ownerAgentId } : {}),
     });
   }
 
@@ -103,6 +116,7 @@ export function NewGoalDialog() {
   }
 
   const currentParent = (goals ?? []).find((g) => g.id === appliedParentId);
+  const currentOwner = (agents ?? []).find((a) => a.id === ownerAgentId);
 
   return (
     <Dialog
@@ -232,6 +246,44 @@ export function NewGoalDialog() {
             </PopoverContent>
           </Popover>
 
+          {/* Owner Agent */}
+          <Popover open={ownerOpen} onOpenChange={setOwnerOpen}>
+            <PopoverTrigger asChild>
+              <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent/50 transition-colors">
+                {currentOwner ? (
+                  <AgentIcon icon={currentOwner.icon} className="h-3 w-3 text-muted-foreground" />
+                ) : (
+                  <User className="h-3 w-3 text-muted-foreground" />
+                )}
+                {currentOwner ? currentOwner.name : "Owner"}
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-48 p-1" align="start">
+              <button
+                className={cn(
+                  "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50",
+                  !ownerAgentId && "bg-accent"
+                )}
+                onClick={() => { setOwnerAgentId(""); setOwnerOpen(false); }}
+              >
+                No owner
+              </button>
+              {(agents ?? []).filter((a) => a.status !== "terminated").map((a) => (
+                <button
+                  key={a.id}
+                  className={cn(
+                    "flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50 truncate",
+                    a.id === ownerAgentId && "bg-accent"
+                  )}
+                  onClick={() => { setOwnerAgentId(a.id); setOwnerOpen(false); }}
+                >
+                  <AgentIcon icon={a.icon} className="h-3 w-3 shrink-0 text-muted-foreground" />
+                  <span className="truncate">{a.name}</span>
+                </button>
+              ))}
+            </PopoverContent>
+          </Popover>
+
           {/* Parent goal */}
           <Popover open={parentOpen} onOpenChange={setParentOpen}>
             <PopoverTrigger asChild>
@@ -280,3 +332,4 @@ export function NewGoalDialog() {
     </Dialog>
   );
 }
+

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useParams } from "@/lib/router";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "@/lib/router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { goalsApi } from "../api/goals";
 import { projectsApi } from "../api/projects";
@@ -18,7 +18,7 @@ import { PageSkeleton } from "../components/PageSkeleton";
 import { cn, projectUrl } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus, SlidersHorizontal } from "lucide-react";
+import { Plus, SlidersHorizontal, Trash2 } from "lucide-react";
 import type { Goal, Project } from "@paperclipai/shared";
 
 interface GoalPropertiesToggleButtonProps {
@@ -48,11 +48,13 @@ export function GoalPropertiesToggleButton({
 
 export function GoalDetail() {
   const { goalId } = useParams<{ goalId: string }>();
+  const navigate = useNavigate();
   const { selectedCompanyId, setSelectedCompanyId } = useCompany();
   const { openNewGoal } = useDialogActions();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+  const [confirmingDeleteHeader, setConfirmingDeleteHeader] = useState(false);
 
   const {
     data: goal,
@@ -97,6 +99,22 @@ export function GoalDetail() {
     }
   });
 
+  const deleteGoal = useMutation({
+    mutationFn: () => goalsApi.remove(goalId!),
+    onSuccess: () => {
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.goals.list(resolvedCompanyId),
+        });
+      }
+      queryClient.removeQueries({
+        queryKey: queryKeys.goals.detail(goalId!),
+      });
+      closePanel();
+      navigate("/goals");
+    },
+  });
+
   const uploadImage = useMutation({
     mutationFn: async (file: File) => {
       if (!resolvedCompanyId) throw new Error("No company selected");
@@ -129,11 +147,13 @@ export function GoalDetail() {
         <GoalProperties
           goal={goal}
           onUpdate={(data) => updateGoal.mutate(data)}
+          onDelete={() => deleteGoal.mutate()}
+          deletePending={deleteGoal.isPending}
         />
       );
     }
     return () => closePanel();
-  }, [goal]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [goal, deleteGoal.isPending]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isLoading) return <PageSkeleton variant="detail" />;
   if (error) return <p className="text-sm text-destructive">{error.message}</p>;
@@ -147,7 +167,38 @@ export function GoalDetail() {
             {goal.level}
           </span>
           <StatusBadge status={goal.status} />
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-2">
+            {confirmingDeleteHeader ? (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-destructive font-medium">Delete?</span>
+                <Button
+                  size="xs"
+                  variant="destructive"
+                  disabled={deleteGoal.isPending}
+                  onClick={() => deleteGoal.mutate()}
+                >
+                  {deleteGoal.isPending ? "Deleting..." : "Confirm"}
+                </Button>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  disabled={deleteGoal.isPending}
+                  onClick={() => setConfirmingDeleteHeader(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button
+                variant="outline"
+                size="xs"
+                className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => setConfirmingDeleteHeader(true)}
+              >
+                <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                Delete
+              </Button>
+            )}
             <GoalPropertiesToggleButton
               panelVisible={panelVisible}
               onShowProperties={() => setPanelVisible(true)}

--- a/ui/src/pages/GoalDetail.tsx
+++ b/ui/src/pages/GoalDetail.tsx
@@ -55,6 +55,8 @@ export function GoalDetail() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const [confirmingDeleteHeader, setConfirmingDeleteHeader] = useState(false);
+  const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null);
+  const [updateErrorMessage, setUpdateErrorMessage] = useState<string | null>(null);
 
   const {
     data: goal,
@@ -88,6 +90,7 @@ export function GoalDetail() {
     mutationFn: (data: Record<string, unknown>) =>
       goalsApi.update(goalId!, data),
     onSuccess: () => {
+      setUpdateErrorMessage(null);
       queryClient.invalidateQueries({
         queryKey: queryKeys.goals.detail(goalId!)
       });
@@ -96,12 +99,16 @@ export function GoalDetail() {
           queryKey: queryKeys.goals.list(resolvedCompanyId)
         });
       }
+    },
+    onError: (err) => {
+      setUpdateErrorMessage(err instanceof Error ? err.message : "Failed to update goal");
     }
   });
 
   const deleteGoal = useMutation({
     mutationFn: () => goalsApi.remove(goalId!),
     onSuccess: () => {
+      setDeleteErrorMessage(null);
       if (resolvedCompanyId) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.goals.list(resolvedCompanyId),
@@ -112,6 +119,9 @@ export function GoalDetail() {
       });
       closePanel();
       navigate("/goals");
+    },
+    onError: (err) => {
+      setDeleteErrorMessage(err instanceof Error ? err.message : "Failed to delete goal");
     },
   });
 
@@ -149,11 +159,12 @@ export function GoalDetail() {
           onUpdate={(data) => updateGoal.mutate(data)}
           onDelete={() => deleteGoal.mutate()}
           deletePending={deleteGoal.isPending}
+          deleteError={deleteErrorMessage}
         />
       );
     }
     return () => closePanel();
-  }, [goal, deleteGoal.isPending]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [goal, deleteGoal.isPending, deleteErrorMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isLoading) return <PageSkeleton variant="detail" />;
   if (error) return <p className="text-sm text-destructive">{error.message}</p>;
@@ -171,6 +182,11 @@ export function GoalDetail() {
             {confirmingDeleteHeader ? (
               <div className="flex items-center gap-1.5">
                 <span className="text-xs text-destructive font-medium">Delete?</span>
+                {deleteErrorMessage && (
+                  <span className="text-xs text-destructive" role="alert">
+                    {deleteErrorMessage}
+                  </span>
+                )}
                 <Button
                   size="xs"
                   variant="destructive"
@@ -183,7 +199,10 @@ export function GoalDetail() {
                   size="xs"
                   variant="outline"
                   disabled={deleteGoal.isPending}
-                  onClick={() => setConfirmingDeleteHeader(false)}
+                  onClick={() => {
+                    setConfirmingDeleteHeader(false);
+                    setDeleteErrorMessage(null);
+                  }}
                 >
                   Cancel
                 </Button>
@@ -193,7 +212,10 @@ export function GoalDetail() {
                 variant="outline"
                 size="xs"
                 className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                onClick={() => setConfirmingDeleteHeader(true)}
+                onClick={() => {
+                  setDeleteErrorMessage(null);
+                  setConfirmingDeleteHeader(true);
+                }}
               >
                 <Trash2 className="h-3.5 w-3.5 mr-1.5" />
                 Delete
@@ -205,6 +227,12 @@ export function GoalDetail() {
             />
           </div>
         </div>
+
+        {updateErrorMessage && (
+          <p className="text-sm text-destructive" role="alert">
+            {updateErrorMessage}
+          </p>
+        )}
 
         <InlineEditor
           value={goal.title}

--- a/ui/src/pages/Goals.test.tsx
+++ b/ui/src/pages/Goals.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Goal } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Goals } from "./Goals";
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("../context/DialogContext", () => ({
+  useDialogActions: () => ({ openNewGoal: vi.fn() }),
+}));
+
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: vi.fn() }),
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ children, to, ...props }: { children: ReactNode; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+const mockGoalsApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../api/goals", () => ({
+  goalsApi: mockGoalsApi,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function waitForAssertion(assertion: () => void, attempts = 20) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flush();
+    }
+  }
+  throw lastError;
+}
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: "goal-1",
+    companyId: "company-1",
+    title: "Ship the thing",
+    description: null,
+    level: "task",
+    status: "planned",
+    parentId: null,
+    ownerAgentId: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("Goals page delete flow", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot> | null;
+  let queryClient: QueryClient;
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockGoalsApi.list.mockResolvedValue([makeGoal()]);
+    confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  afterEach(async () => {
+    const currentRoot = root;
+    if (currentRoot) {
+      await act(async () => {
+        currentRoot.unmount();
+      });
+    }
+    queryClient.clear();
+    container.remove();
+    document.body.innerHTML = "";
+    confirmSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function render() {
+    root = createRoot(container);
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <Goals />
+      </QueryClientProvider>,
+    );
+  }
+
+  it("asks for confirmation before deleting a goal from the list", async () => {
+    mockGoalsApi.remove.mockResolvedValue(makeGoal());
+    render();
+
+    let deleteButton: HTMLButtonElement | null = null;
+    await waitForAssertion(() => {
+      deleteButton = container.querySelector('button[aria-label="Delete goal \\"Ship the thing\\""]');
+      expect(deleteButton).toBeTruthy();
+    });
+
+    await act(async () => {
+      deleteButton?.click();
+    });
+    await flush();
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete goal "Ship the thing"?');
+    expect(mockGoalsApi.remove).toHaveBeenCalledWith("goal-1");
+  });
+
+  it("does not delete when the confirmation is declined", async () => {
+    confirmSpy.mockReturnValue(false);
+    mockGoalsApi.remove.mockResolvedValue(makeGoal());
+    render();
+
+    let deleteButton: HTMLButtonElement | null = null;
+    await waitForAssertion(() => {
+      deleteButton = container.querySelector('button[aria-label="Delete goal \\"Ship the thing\\""]');
+      expect(deleteButton).toBeTruthy();
+    });
+
+    await act(async () => {
+      deleteButton?.click();
+    });
+    await flush();
+
+    expect(mockGoalsApi.remove).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error message when deletion fails", async () => {
+    mockGoalsApi.remove.mockRejectedValue(new Error("Cannot delete a goal with linked issues"));
+    render();
+
+    let deleteButton: HTMLButtonElement | null = null;
+    await waitForAssertion(() => {
+      deleteButton = container.querySelector('button[aria-label="Delete goal \\"Ship the thing\\""]');
+      expect(deleteButton).toBeTruthy();
+    });
+
+    await act(async () => {
+      deleteButton?.click();
+    });
+    await flush();
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain("Cannot delete a goal with linked issues");
+    });
+  });
+});

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { goalsApi } from "../api/goals";
 import { useCompany } from "../context/CompanyContext";
@@ -16,6 +16,7 @@ export function Goals() {
   const { openNewGoal } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+  const [deleteErrorMessage, setDeleteErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Goals" }]);
@@ -30,11 +31,15 @@ export function Goals() {
   const deleteGoal = useMutation({
     mutationFn: (id: string) => goalsApi.remove(id),
     onSuccess: () => {
+      setDeleteErrorMessage(null);
       if (selectedCompanyId) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.goals.list(selectedCompanyId),
         });
       }
+    },
+    onError: (err) => {
+      setDeleteErrorMessage(err instanceof Error ? err.message : "Failed to delete goal");
     },
   });
 
@@ -49,6 +54,11 @@ export function Goals() {
   return (
     <div className="space-y-4">
       {error && <p className="text-sm text-destructive">{error.message}</p>}
+      {deleteErrorMessage && (
+        <p className="text-sm text-destructive" role="alert">
+          {deleteErrorMessage}
+        </p>
+      )}
 
       {goals && goals.length === 0 && (
         <EmptyState

--- a/ui/src/pages/Goals.tsx
+++ b/ui/src/pages/Goals.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { goalsApi } from "../api/goals";
 import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
@@ -15,6 +15,7 @@ export function Goals() {
   const { selectedCompanyId } = useCompany();
   const { openNewGoal } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     setBreadcrumbs([{ label: "Goals" }]);
@@ -24,6 +25,17 @@ export function Goals() {
     queryKey: queryKeys.goals.list(selectedCompanyId!),
     queryFn: () => goalsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
+  });
+
+  const deleteGoal = useMutation({
+    mutationFn: (id: string) => goalsApi.remove(id),
+    onSuccess: () => {
+      if (selectedCompanyId) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.goals.list(selectedCompanyId),
+        });
+      }
+    },
   });
 
   if (!selectedCompanyId) {
@@ -55,9 +67,18 @@ export function Goals() {
               New Goal
             </Button>
           </div>
-          <GoalTree goals={goals} goalLink={(goal) => `/goals/${goal.id}`} />
+          <GoalTree
+            goals={goals}
+            goalLink={(goal) => `/goals/${goal.id}`}
+            onDelete={(goal) => {
+              if (window.confirm(`Delete goal "${goal.title}"?`)) {
+                deleteGoal.mutate(goal.id);
+              }
+            }}
+          />
         </>
       )}
     </div>
   );
 }
+


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Goals UI lets a user view and organize goals for a company, but it only exposes read-only owner display and no delete control
> - The REST API already supports `PATCH /api/goals/:id` (set `ownerAgentId`) and `DELETE /api/goals/:id`, so the backend can do both operations the UI cannot trigger
> - Without an owner picker or delete action, a user must call the API directly to reassign or remove a goal, which is not usable for a UI-first product
> - This pull request adds an agent owner picker to the Goal Properties panel and the New Goal dialog, and adds delete actions to the Goal Properties panel, Goal Detail header, and Goal Tree hover controls
> - The benefit is that goal ownership and deletion, already supported server-side, become reachable from the UI without any backend change

## Linked Issues or Issue Description

Fixes: #8822

## What Changed

- `ui/src/components/GoalProperties.tsx`: added `AgentOwnerPicker` to set/clear a goal's owner agent, and an inline confirm-then-delete control.
- `ui/src/pages/GoalDetail.tsx`: wired the `DELETE /api/goals/:id` mutation and a confirmation delete button in the page header; redirects to `/goals` after deletion.
- `ui/src/components/GoalTree.tsx` and `ui/src/pages/Goals.tsx`: added a hover delete action on tree nodes so goals can be removed directly from the goals hierarchy.
- `ui/src/components/NewGoalDialog.tsx`: added an owner agent selector chip so an owner can be assigned at goal-creation time.
- Tests: `ui/src/components/GoalProperties.test.tsx`, `ui/src/components/GoalProperties.interactions.test.tsx`, `ui/src/pages/Goals.test.tsx` cover the owner picker and delete flows.

## Verification

- Added/updated unit tests exercise the new owner-picker and delete interactions:
  - `ui/src/components/GoalProperties.test.tsx`
  - `ui/src/components/GoalProperties.interactions.test.tsx`
  - `ui/src/pages/Goals.test.tsx`
- Manual check: open a company → Goals → a goal; set/clear the owner via the picker and confirm it persists via `PATCH /api/goals/:id`; delete the goal from the properties panel, the detail header, and the tree hover control and confirm it redirects/removes the node and calls `DELETE /api/goals/:id`.
- Run `npm test` (or the project's UI test command) under `ui/` to execute the new and existing Goals-related test files.

## Risks

- Delete is destructive and irreversible from the UI; mitigated with an inline confirm step before the `DELETE` call fires.
- Owner reassignment only affects the `ownerAgentId` field via the existing `PATCH` endpoint; no schema or backend change, so risk is scoped to the UI layer.
- Low risk overall — additive UI controls on top of already-supported API operations, no changes to data model or existing read paths.

## Model Used

Claude, Sonnet 5 (claude-sonnet-5), agentic coding mode with tool use (file edits, diff review). No extended thinking used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
