### PR TITLE
fix(workspaces): skip workspace provision command when reusing existing workspace (#8484)

### DIFF
--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -158,6 +158,7 @@ function makeRealizeInput(overrides: {
   environment?: Environment;
   lease?: EnvironmentLease;
   persistedExecutionWorkspace?: ExecutionWorkspace | null;
+  executionWorkspace?: RealizedExecutionWorkspace;
 } = {}): Parameters<ReturnType<typeof environmentRunOrchestrator>["realizeForRun"]>[0] {
   return {
     environment: overrides.environment ?? makeEnvironment("local"),
@@ -166,7 +167,7 @@ function makeRealizeInput(overrides: {
     companyId: "company-1",
     issueId: null,
     heartbeatRunId: "run-1",
-    executionWorkspace: makeExecutionWorkspace(),
+    executionWorkspace: overrides.executionWorkspace ?? makeExecutionWorkspace(),
     effectiveExecutionWorkspaceMode: null,
     persistedExecutionWorkspace: overrides.persistedExecutionWorkspace !== undefined
       ? overrides.persistedExecutionWorkspace
@@ -554,7 +555,74 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledOnce();
   });
 
-  it("skips remote provision command when reusing an existing workspace", async () => {
+  it("skips remote provision command when reusing an existing isolated worktree workspace", async () => {
+    mockBuildWorkspaceRealizationRequest.mockReturnValue({
+      version: 1,
+      adapterType: "claude_local",
+      companyId: "company-1",
+      environmentId: "env-1",
+      executionWorkspaceId: null,
+      issueId: null,
+      heartbeatRunId: "run-1",
+      requestedMode: null,
+      source: {
+        kind: "task_session",
+        localPath: "/workspace/worktrees/issue-1",
+        projectId: null,
+        projectWorkspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        strategy: "git_worktree",
+        branchName: "issue-1",
+        worktreePath: "/workspace/worktrees/issue-1",
+      },
+      runtimeOverlay: {
+        provisionCommand: "npm install -g @anthropic-ai/claude-code",
+      },
+    });
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      remoteCwd: "/remote/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        cwd: "/remote/workspace",
+        metadata: {
+          workspaceRealization: {
+            version: 1,
+            transport: "sandbox",
+            remote: { path: "/remote/workspace" },
+            isNew: false,
+          },
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(makeRealizeInput({
+      environment: makeEnvironment("sandbox"),
+      executionWorkspace: makeExecutionWorkspace("/workspace/worktrees/issue-1", {
+        strategy: "git_worktree",
+        branchName: "issue-1",
+        worktreePath: "/workspace/worktrees/issue-1",
+        created: false,
+      }),
+    }));
+
+    expect(runtime.execute).not.toHaveBeenCalled();
+  });
+
+  it("still runs the remote provision command for a shared project_primary workspace even though its local directory is never reported as freshly \"created\"", async () => {
+    // `project_primary` (shared workspace) realizations always report `created: false` for the
+    // local directory (see workspace-runtime.ts) because it is the project's long-lived primary
+    // checkout rather than something freshly created per run. The reuse-skip gate must not key off
+    // that flag for this strategy, or shared-workspace remote/sandbox provisioning would silently
+    // never run again — not even on the very first run.
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,
       adapterType: "claude_local",
@@ -596,7 +664,6 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
             version: 1,
             transport: "sandbox",
             remote: { path: "/remote/workspace" },
-            isNew: false,
           },
         },
       }),
@@ -605,10 +672,13 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
 
     await orchestrator.realizeForRun(makeRealizeInput({
       environment: makeEnvironment("sandbox"),
-      executionWorkspace: makeExecutionWorkspace("/workspace/project", { created: false }),
+      executionWorkspace: makeExecutionWorkspace("/workspace/project", {
+        strategy: "project_primary",
+        created: false,
+      }),
     }));
 
-    expect(runtime.execute).not.toHaveBeenCalled();
+    expect(runtime.execute).toHaveBeenCalledOnce();
   });
 
   it("surfaces remote provision command failures before resolving the adapter target", async () => {

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -617,6 +617,73 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(runtime.execute).not.toHaveBeenCalled();
   });
 
+  it("still runs the remote provision command when a reused local worktree gets a fresh ephemeral remote lease", async () => {
+    // A reused local git worktree and a freshly acquired remote lease are independent
+    // facts. Built-in realization records carry no per-run isNew/created field for the
+    // remote side (unlike the plugin-sandbox test above, which reports `isNew: false`
+    // explicitly), so the gate must fall back to the lease policy: an "ephemeral" lease
+    // is fresh by construction and must not be skipped just because the local worktree
+    // was reused, or the sandbox/SSH target starts without required setup.
+    mockBuildWorkspaceRealizationRequest.mockReturnValue({
+      version: 1,
+      adapterType: "claude_local",
+      companyId: "company-1",
+      environmentId: "env-1",
+      executionWorkspaceId: null,
+      issueId: null,
+      heartbeatRunId: "run-1",
+      requestedMode: null,
+      source: {
+        kind: "task_session",
+        localPath: "/workspace/worktrees/issue-1",
+        projectId: null,
+        projectWorkspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        strategy: "git_worktree",
+        branchName: "issue-1",
+        worktreePath: "/workspace/worktrees/issue-1",
+      },
+      runtimeOverlay: {
+        provisionCommand: "npm install -g @anthropic-ai/claude-code",
+      },
+    });
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "ssh",
+      remoteCwd: "/remote/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        cwd: "/remote/workspace",
+        metadata: {
+          workspaceRealization: {
+            version: 1,
+            transport: "ssh",
+            remote: { path: "/remote/workspace" },
+          },
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(makeRealizeInput({
+      environment: makeEnvironment("ssh"),
+      lease: makeLease({ leasePolicy: "ephemeral" }),
+      executionWorkspace: makeExecutionWorkspace("/workspace/worktrees/issue-1", {
+        strategy: "git_worktree",
+        branchName: "issue-1",
+        worktreePath: "/workspace/worktrees/issue-1",
+        created: false,
+      }),
+    }));
+
+    expect(runtime.execute).toHaveBeenCalledOnce();
+  });
+
   it("still runs the remote provision command for a shared project_primary workspace even though its local directory is never reported as freshly \"created\"", async () => {
     // `project_primary` (shared workspace) realizations always report `created: false` for the
     // local directory (see workspace-runtime.ts) because it is the project's long-lived primary

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -684,6 +684,81 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(runtime.execute).toHaveBeenCalledOnce();
   });
 
+  it("still runs the remote provision command on a reusable sandbox's very first lease, even though the policy is already reuse_by_environment", async () => {
+    // A `reuseLease: true` sandbox environment's very first-ever lease has
+    // `leasePolicy: "reuse_by_environment"` from the moment it's acquired —
+    // that's a config-level setting, not a fact about this specific lease.
+    // The driver only sets `metadata.wasResumed` when it actually resumed an
+    // existing provider-side lease (environment-runtime.ts); a lease with no
+    // such flag was freshly acquired and must still be provisioned, or the
+    // adapter starts without required tools/dependencies (regression caught
+    // by Greptile on the prior fix for this gate).
+    mockBuildWorkspaceRealizationRequest.mockReturnValue({
+      version: 1,
+      adapterType: "claude_local",
+      companyId: "company-1",
+      environmentId: "env-1",
+      executionWorkspaceId: null,
+      issueId: null,
+      heartbeatRunId: "run-1",
+      requestedMode: null,
+      source: {
+        kind: "task_session",
+        localPath: "/workspace/worktrees/issue-1",
+        projectId: null,
+        projectWorkspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        strategy: "git_worktree",
+        branchName: "issue-1",
+        worktreePath: "/workspace/worktrees/issue-1",
+      },
+      runtimeOverlay: {
+        provisionCommand: "npm install -g @anthropic-ai/claude-code",
+      },
+    });
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      remoteCwd: "/remote/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        cwd: "/remote/workspace",
+        metadata: {
+          workspaceRealization: {
+            version: 1,
+            transport: "sandbox",
+            remote: { path: "/remote/workspace" },
+            // No isNew/created freshness flag — matches built-in realization records.
+          },
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(makeRealizeInput({
+      environment: makeEnvironment("sandbox"),
+      // Policy is already reuse_by_environment (the environment is configured
+      // with reuseLease: true), but this specific lease was freshly acquired —
+      // metadata carries no wasResumed flag, since the sandbox driver only sets
+      // it to true when it actually resumed an existing provider lease.
+      lease: makeLease({ leasePolicy: "reuse_by_environment", metadata: { wasResumed: false } }),
+      executionWorkspace: makeExecutionWorkspace("/workspace/worktrees/issue-1", {
+        strategy: "git_worktree",
+        branchName: "issue-1",
+        worktreePath: "/workspace/worktrees/issue-1",
+        created: false,
+      }),
+    }));
+
+    expect(runtime.execute).toHaveBeenCalledOnce();
+  });
+
   it("still runs the remote provision command for a shared project_primary workspace even though its local directory is never reported as freshly \"created\"", async () => {
     // `project_primary` (shared workspace) realizations always report `created: false` for the
     // local directory (see workspace-runtime.ts) because it is the project's long-lived primary

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -100,7 +100,10 @@ function makeLease(overrides: Partial<EnvironmentLease> = {}): EnvironmentLease 
   };
 }
 
-function makeExecutionWorkspace(cwd: string = "/workspace/project"): RealizedExecutionWorkspace {
+function makeExecutionWorkspace(
+  cwd: string = "/workspace/project",
+  overrides: Partial<RealizedExecutionWorkspace> = {},
+): RealizedExecutionWorkspace {
   return {
     baseCwd: "/workspace",
     source: "project_primary",
@@ -113,7 +116,8 @@ function makeExecutionWorkspace(cwd: string = "/workspace/project"): RealizedExe
     branchName: null,
     worktreePath: null,
     warnings: [],
-    created: false,
+    created: true,
+    ...overrides,
   };
 }
 
@@ -548,6 +552,63 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
       args: ["-lc", "npm install -g @google/gemini-cli"],
     }));
     expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledOnce();
+  });
+
+  it("skips remote provision command when reusing an existing workspace", async () => {
+    mockBuildWorkspaceRealizationRequest.mockReturnValue({
+      version: 1,
+      adapterType: "claude_local",
+      companyId: "company-1",
+      environmentId: "env-1",
+      executionWorkspaceId: null,
+      issueId: null,
+      heartbeatRunId: "run-1",
+      requestedMode: null,
+      source: {
+        kind: "project_primary",
+        localPath: "/workspace/project",
+        projectId: null,
+        projectWorkspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+        strategy: "project_primary",
+        branchName: null,
+        worktreePath: null,
+      },
+      runtimeOverlay: {
+        provisionCommand: "npm install -g @anthropic-ai/claude-code",
+      },
+    });
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "e2b",
+      remoteCwd: "/remote/workspace",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        cwd: "/remote/workspace",
+        metadata: {
+          workspaceRealization: {
+            version: 1,
+            transport: "sandbox",
+            remote: { path: "/remote/workspace" },
+            isNew: false,
+          },
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.realizeForRun(makeRealizeInput({
+      environment: makeEnvironment("sandbox"),
+      executionWorkspace: makeExecutionWorkspace("/workspace/project", { created: false }),
+    }));
+
+    expect(runtime.execute).not.toHaveBeenCalled();
   });
 
   it("surfaces remote provision command failures before resolving the adapter target", async () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -3045,7 +3045,7 @@ describe("realizeExecutionWorkspace", () => {
     expect(restored).toBeNull();
   });
 
-  it("reprovisions an existing persisted git worktree before manual control starts it", async () => {
+  it("does not reprovision an existing persisted git worktree that is reused before manual control starts it", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
     await fs.writeFile(
@@ -3126,7 +3126,7 @@ describe("realizeExecutionWorkspace", () => {
       },
     });
 
-    await expect(fs.readFile(path.join(initial.cwd, ".paperclip-restored-state"), "utf8")).resolves.toBe("reprovisioned\n");
+    await expect(fs.access(path.join(initial.cwd, ".paperclip-restored-state"))).rejects.toThrow();
   }, 15_000);
 
   it("auto-detects the default branch when baseRef is not configured", async () => {

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1204,6 +1204,8 @@ describe("realizeExecutionWorkspace", () => {
       "true\n",
     );
 
+    await fs.rm(path.join(workspace.cwd, ".paperclip-provision-created"));
+
     const reused = await realizeExecutionWorkspace({
       base: {
         baseCwd: repoRoot,
@@ -1232,10 +1234,11 @@ describe("realizeExecutionWorkspace", () => {
       },
     });
 
-    await expect(fs.readFile(path.join(reused.cwd, ".paperclip-provision-created"), "utf8")).resolves.toBe("false\n");
+    expect(reused.created).toBe(false);
+    await expect(fs.access(path.join(reused.cwd, ".paperclip-provision-created"))).rejects.toThrow();
   });
 
-  it("uses the latest repo-managed provision script when reusing an existing worktree", async () => {
+  it("skips running the provision script when reusing an existing worktree", async () => {
     const repoRoot = await createTempRepo();
     await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
     await fs.writeFile(
@@ -1292,8 +1295,6 @@ describe("realizeExecutionWorkspace", () => {
     await runGit(repoRoot, ["add", "scripts/provision.sh"]);
     await runGit(repoRoot, ["commit", "-m", "Update provision script"]);
 
-    await expect(fs.readFile(path.join(initial.cwd, "scripts", "provision.sh"), "utf8")).resolves.toContain("v1");
-
     const reused = await realizeExecutionWorkspace({
       base: {
         baseCwd: repoRoot,
@@ -1322,7 +1323,8 @@ describe("realizeExecutionWorkspace", () => {
       },
     });
 
-    await expect(fs.readFile(path.join(reused.cwd, ".paperclip-provision-version"), "utf8")).resolves.toBe("v2\n");
+    expect(reused.created).toBe(false);
+    await expect(fs.readFile(path.join(reused.cwd, ".paperclip-provision-version"), "utf8")).resolves.toBe("v1\n");
   }, 30_000);
 
   it("writes an isolated repo-local Paperclip config and worktree branding when provisioning", async () => {

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -420,7 +420,17 @@ export function environmentRunOrchestrator(
       (typeof lease.metadata?.remoteCwd === "string" && lease.metadata.remoteCwd.trim().length > 0
         ? lease.metadata.remoteCwd.trim()
         : executionWorkspace.cwd);
+    // `executionWorkspace.created` only carries a meaningful reuse signal for the
+    // `git_worktree` strategy (isolated per-issue worktrees, which are explicitly
+    // created or reused). For `project_primary` (shared workspace) realizations the
+    // local directory always reports `created: false` — it is the project's
+    // long-lived primary checkout, not something freshly created per run — so gating
+    // on that flag would silently skip provisioning forever for every shared-workspace
+    // remote/sandbox environment, including the very first run. Treat non-worktree
+    // strategies as always requiring provisioning, matching prior behavior for that
+    // strategy, and only apply the reuse skip where "created" is well-defined.
     const isNew =
+      executionWorkspace.strategy !== "git_worktree" ||
       executionWorkspace.created === true ||
       workspaceRealization.isNew === true ||
       workspaceRealization.created === true;
@@ -458,6 +468,19 @@ export function environmentRunOrchestrator(
           },
         );
       }
+    }
+
+    // Record the provisioning decision on the realization metadata so operators viewing
+    // run/workspace details can tell whether a workspace was freshly provisioned or reused
+    // without the provision command re-running.
+    if (provisionCommand && environment.driver !== "local") {
+      workspaceRealization = {
+        ...workspaceRealization,
+        provisioning: {
+          ran: isNew,
+          reason: isNew ? "new_workspace" : "reused_existing_workspace",
+        },
+      };
     }
 
     // Step 3: Persist realization metadata on lease and execution workspace

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -420,7 +420,11 @@ export function environmentRunOrchestrator(
       (typeof lease.metadata?.remoteCwd === "string" && lease.metadata.remoteCwd.trim().length > 0
         ? lease.metadata.remoteCwd.trim()
         : executionWorkspace.cwd);
-    if (provisionCommand && environment.driver !== "local") {
+    const isNew =
+      executionWorkspace.created === true ||
+      workspaceRealization.isNew === true ||
+      workspaceRealization.created === true;
+    if (provisionCommand && environment.driver !== "local" && isNew) {
       try {
         const provisionResult = await environmentRuntime.execute({
           environment,

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -436,17 +436,24 @@ export function environmentRunOrchestrator(
     // unless that lease is explicitly using a reuse policy; "ephemeral" leases in
     // particular are fresh every time by construction. When the driver's own
     // realization result reports an explicit `isNew`/`created` flag for the
-    // remote side, trust it. Built-in realization records carry no such field,
-    // so fall back to `lease.leasePolicy`: only a reuse-style policy can mean the
-    // remote side might already be provisioned; anything else fails safe toward
-    // re-provisioning rather than silently skipping it.
+    // remote side, trust it.
+    //
+    // Built-in realization records carry no such field, so fall back to a
+    // genuine per-lease signal: `lease.metadata.wasResumed`, set by the sandbox
+    // driver only when it actually resumed an existing provider-side lease
+    // (environment-runtime.ts). `lease.leasePolicy` is a config-level setting —
+    // "does this environment's config say to reuse a lease when one exists" —
+    // not a fact about whether THIS lease was actually just created or is truly
+    // being reused. A brand new sandbox with `reuseLease: true` has policy
+    // `reuse_by_environment` on its very first, never-provisioned lease, so
+    // policy alone must never stand in for freshness. Anything without an
+    // explicit `wasResumed: true` fails safe toward re-provisioning.
     const hasRemoteFreshnessSignal =
       typeof workspaceRealization.isNew === "boolean" || typeof workspaceRealization.created === "boolean";
-    const isReusableLeasePolicy =
-      lease.leasePolicy === "reuse_by_environment" || lease.leasePolicy === "reuse_by_execution_workspace";
+    const leaseWasResumed = lease.metadata?.wasResumed === true;
     const remoteRealizationIsFresh = hasRemoteFreshnessSignal
       ? workspaceRealization.isNew === true || workspaceRealization.created === true
-      : !isReusableLeasePolicy;
+      : !leaseWasResumed;
     const isNew =
       executionWorkspace.strategy !== "git_worktree" ||
       executionWorkspace.created === true ||

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -429,11 +429,28 @@ export function environmentRunOrchestrator(
     // remote/sandbox environment, including the very first run. Treat non-worktree
     // strategies as always requiring provisioning, matching prior behavior for that
     // strategy, and only apply the reuse skip where "created" is well-defined.
+    //
+    // A reused local worktree says nothing about the remote environment/lease —
+    // those are independent facts. Non-local drivers acquire a brand new remote
+    // lease (and typically a brand new backing sandbox/SSH target) on every run
+    // unless that lease is explicitly using a reuse policy; "ephemeral" leases in
+    // particular are fresh every time by construction. When the driver's own
+    // realization result reports an explicit `isNew`/`created` flag for the
+    // remote side, trust it. Built-in realization records carry no such field,
+    // so fall back to `lease.leasePolicy`: only a reuse-style policy can mean the
+    // remote side might already be provisioned; anything else fails safe toward
+    // re-provisioning rather than silently skipping it.
+    const hasRemoteFreshnessSignal =
+      typeof workspaceRealization.isNew === "boolean" || typeof workspaceRealization.created === "boolean";
+    const isReusableLeasePolicy =
+      lease.leasePolicy === "reuse_by_environment" || lease.leasePolicy === "reuse_by_execution_workspace";
+    const remoteRealizationIsFresh = hasRemoteFreshnessSignal
+      ? workspaceRealization.isNew === true || workspaceRealization.created === true
+      : !isReusableLeasePolicy;
     const isNew =
       executionWorkspace.strategy !== "git_worktree" ||
       executionWorkspace.created === true ||
-      workspaceRealization.isNew === true ||
-      workspaceRealization.created === true;
+      remoteRealizationIsFresh;
     if (provisionCommand && environment.driver !== "local" && isNew) {
       try {
         const provisionResult = await environmentRuntime.execute({

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -985,6 +985,11 @@ function createSandboxEnvironmentDriver(
             });
           }
         }
+        // `providerLease` is non-null here only when the resume call above
+        // actually returned an existing provider-side lease. That is the real
+        // per-lease freshness signal, independent of `resolvedLeasePolicy`
+        // below (a config-level setting, not a fact about this lease).
+        const wasResumed = providerLease !== null;
         const acquiredLease = providerLease ?? await pluginWorkerManager.call(
           pluginProvider.resolved.plugin.id,
           "environmentAcquireLease",
@@ -1057,6 +1062,7 @@ function createSandboxEnvironmentDriver(
             ...sandboxConfigForLeaseMetadata(storedConfig),
             ...sanitizedProviderMetadata,
             ...(reusableScope ? { reusableSandboxLease: reusableScope } : {}),
+            wasResumed,
           },
         });
       }
@@ -1165,6 +1171,14 @@ function createSandboxEnvironmentDriver(
         });
       }
 
+      // The real per-lease freshness signal: the provider lease id only
+      // matches the candidate reusable lease's id when `acquireSandboxProviderLease`
+      // actually resumed that existing provider-side lease above. Any mismatch
+      // (or no candidate at all) means a brand new provider lease was acquired,
+      // regardless of `resolvedLeasePolicy` below (a config-level setting, not
+      // a fact about this specific lease).
+      const wasResumed = Boolean(reusableLease) && providerLease.providerLeaseId === reusableLease.providerLeaseId;
+
       // Same ephemeral-policy-for-tests guard as the plugin-backed path:
       // ad-hoc test leases must not be publishable for reuse.
       const resolvedLeasePolicy = supportsReusableLeases && parsed.config.reuseLease && input.heartbeatRunId !== null
@@ -1199,6 +1213,7 @@ function createSandboxEnvironmentDriver(
           executionWorkspaceMode: input.executionWorkspaceMode,
           ...providerLease.metadata,
           ...(reusableScope ? { reusableSandboxLease: reusableScope } : {}),
+          wasResumed,
         },
       });
     },

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -1177,7 +1177,7 @@ function createSandboxEnvironmentDriver(
       // (or no candidate at all) means a brand new provider lease was acquired,
       // regardless of `resolvedLeasePolicy` below (a config-level setting, not
       // a fact about this specific lease).
-      const wasResumed = Boolean(reusableLease) && providerLease.providerLeaseId === reusableLease.providerLeaseId;
+      const wasResumed = reusableLease != null && providerLease.providerLeaseId === reusableLease.providerLeaseId;
 
       // Same ephemeral-policy-for-tests guard as the plugin-backed path:
       // ad-hoc test leases must not be publishable for reuse.

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -2638,6 +2638,7 @@ async function provisionExecutionWorktree(input: {
   created: boolean;
   recorder?: WorkspaceOperationRecorder | null;
 }) {
+  if (!input.created) return;
   const provisionCommand = asString(input.strategy.provisionCommand, "").trim();
   if (!provisionCommand) return;
   const resolvedProvisionCommand = resolveRepoManagedWorkspaceCommand(provisionCommand, input.repoRoot);
@@ -3135,7 +3136,7 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
     : [];
   const restoreCurrentBaseRefSha = restoreBaseRef ? await resolveBaseRefSha(repoRoot, restoreBaseRef) : null;
 
-  let created = false;
+  let created = true;
   try {
     await recordGitOperation(input.recorder, {
       phase: "worktree_prepare",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The workspace runtime is the subsystem that provisions and reuses per-issue git worktrees and shared project checkouts before an agent runs
> - The workspace `provisionCommand` was executed on every run, even when the workspace already existed and was only being reused (`isNew`/`created` false)
> - This wastes time and resources on every reused run and re-runs setup steps that are only meant to happen once, per issue #8484
> - This pull request adds an explicit reuse guard so `provisionCommand` only executes when the workspace is freshly created, both for local worktree provisioning and for remote/sandbox environment provisioning, while preserving provisioning for shared `project_primary` workspaces where "created" is not a meaningful signal
> - The benefit is agents no longer waste time/resources re-running provision steps on workspace reuse, matching the documented expected behavior in #8484

## Linked Issues or Issue Description

Fixes: #8484

## What Changed

- `server/src/services/workspace-runtime.ts`: Added a guard `if (!input.created) return;` at the top of `provisionExecutionWorktree` so the local `provisionCommand` only runs when the workspace was actually freshly created (`created === true`), not on reuse. Also fixed `ensurePersistedExecutionWorkspaceAvailable` to correctly report `created = true` when a missing worktree has to be recreated via `git worktree add`.
- `server/src/services/environment-run-orchestrator.ts`: Gated the remote/sandbox `provisionCommand` execution behind an `isNew` check (`executionWorkspace.created === true || workspaceRealization.isNew === true || workspaceRealization.created === true`), but only for the `git_worktree` strategy — `project_primary` (shared workspace) realizations always report `created: false` for their local directory since it's a long-lived checkout, so provisioning still always runs for that strategy to avoid silently never provisioning shared workspaces. The provisioning decision (`ran`/`reason`) is now also recorded on `workspaceRealization.provisioning` metadata so it is visible in run details.
- `server/src/__tests__/workspace-runtime.test.ts`: Updated existing tests and added coverage asserting the provision script/command does not re-run on worktree reuse (including for persisted worktrees restored before manual control starts them).
- `server/src/__tests__/environment-run-orchestrator.test.ts`: Added a test that remote provisioning is skipped when reusing an existing isolated `git_worktree` workspace, and a test that remote provisioning still always runs for a shared `project_primary` workspace even though it never reports `created: true`.

## Verification

- `npm test -- workspace-runtime.test.ts` — covers local provision script skip-on-reuse behavior, including the persisted-worktree-restore case.
- `npm test -- environment-run-orchestrator.test.ts` — covers remote/sandbox provision-command skip-on-reuse for `git_worktree`, and confirms `project_primary` workspaces are unaffected (provisioning still runs every time for that strategy).
- Manual repro steps from #8484: enable isolated workspaces, configure a "Provision command", create an issue (new workspace, provision runs), then have an agent do more work on the same issue (reused workspace, provision no longer runs) — confirmed via the added automated tests exercising the same code paths.

## Risks

- Low-to-moderate risk: this changes when `provisionCommand` executes, which existing setups may currently (unintentionally) rely on running every time. Anyone depending on the previous "always re-run provision" behavior for shared/project_primary workspaces is unaffected, since that strategy still always provisions; only `git_worktree` reuse behavior changes, matching the documented expected behavior in #8484.
- The `created` flag semantics differ by strategy (`git_worktree` vs `project_primary`), so the fix intentionally scopes the new gate to `git_worktree` only, to avoid regressing shared-workspace provisioning.

## Model Used

Claude (Anthropic), Sonnet 5 (claude-sonnet-5), standard reasoning mode, with tool use (file edits, test execution) via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (no exact duplicate found for the provision-on-reuse behavior; related workspace/worktree PRs reviewed: #9540, #7504, #8063, #8963)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
