### PR TITLE
fix: preserve explicit runtime API URL

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -19,6 +19,7 @@ All environment variables that Paperclip uses for server configuration.
 | `PAPERCLIP_DEPLOYMENT_MODE` | `local_trusted` | Runtime mode override |
 | `PAPERCLIP_DEPLOYMENT_EXPOSURE` | `private` | Exposure policy when deployment mode is `authenticated` |
 | `PAPERCLIP_API_URL` | (auto-derived) | Paperclip API base URL. When set externally (e.g., via Kubernetes ConfigMap, load balancer, or reverse proxy), the server preserves the value instead of deriving it from the listen host and port. Useful for deployments where the public-facing URL differs from the local bind address. |
+| `PAPERCLIP_RUNTIME_API_URL` | (auto-derived) | Internal Paperclip API base URL for managed runtime bridges and agent processes. An explicit value takes precedence over the auto-derived URL. Set this when the server can reach a different URL than users or remote agents. For example, a container can use `http://127.0.0.1:3100` internally while `PAPERCLIP_API_URL` uses a public reverse-proxy URL. |
 
 ## Secrets
 

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -636,6 +636,7 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     loadConfigMock.mockReturnValue(buildTestConfig());
     process.env.BETTER_AUTH_SECRET = "test-secret";
     delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_RUNTIME_API_URL;
   });
 
   afterEach(() => {
@@ -669,6 +670,20 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
       expect.arrayContaining(["http://custom-api:3100"]),
     );
     expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")[0]).toBe("http://custom-api:3100");
+  });
+
+  it("preserves an explicit PAPERCLIP_RUNTIME_API_URL independently of the public API URL", async () => {
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example";
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://127.0.0.1:3210";
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("https://paperclip.example");
+    expect(process.env.PAPERCLIP_API_URL).toBe("https://paperclip.example");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3210");
+    expect(JSON.parse(process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON ?? "[]")[0]).toBe(
+      "http://127.0.0.1:3210",
+    );
   });
 
   it("falls back to host-based URL when PAPERCLIP_API_URL is not set", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -783,15 +783,17 @@ export async function startServer(): Promise<StartedServer> {
   }
   
   const runtimeListenHost = config.host;
-  const runtimeApiUrl = choosePrimaryRuntimeApiUrl({
-    authPublicBaseUrl: config.authPublicBaseUrl ?? null,
-    allowedHostnames: config.allowedHostnames,
-    bindHost: runtimeListenHost,
-    port: listenPort,
-  });
+  const configuredRuntimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL?.trim();
+  const runtimeApiUrl = configuredRuntimeApiUrl ||
+    choosePrimaryRuntimeApiUrl({
+      authPublicBaseUrl: config.authPublicBaseUrl ?? null,
+      allowedHostnames: config.allowedHostnames,
+      bindHost: runtimeListenHost,
+      port: listenPort,
+    });
   const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim() || runtimeApiUrl;
   const runtimeApiCandidates = buildRuntimeApiCandidateUrls({
-    preferredApiUrl: configuredApiUrl,
+    preferredApiUrl: configuredRuntimeApiUrl || configuredApiUrl,
     authPublicBaseUrl: config.authPublicBaseUrl ?? null,
     allowedHostnames: config.allowedHostnames,
     bindHost: runtimeListenHost,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI agents.
> - Managed remote runtimes use a host-side bridge to call the Paperclip API.
> - Public deployments can use a public URL that the server container cannot reach.
> - Paperclip already defines a separate runtime API URL for internal calls.
> - Server startup overwrote an explicit runtime URL with the public URL.
> - This pull request preserves the explicit runtime URL and keeps the public URL separate.
> - The benefit is reliable managed runtime bridges in container and reverse-proxy deployments.

## Linked Issues or Issue Description

**What happened?**

Server startup replaced an explicit `PAPERCLIP_RUNTIME_API_URL` with the auto-derived public authentication URL. A host-side managed runtime bridge then called the public URL. The call failed when the Paperclip server container could not resolve or reach its own public hostname.

**Expected behavior**

Paperclip must preserve an explicit internal runtime URL. `PAPERCLIP_API_URL` must remain available as the separate public URL.

**Steps to reproduce**

1. Configure an authenticated deployment with a public authentication base URL.
2. Set `PAPERCLIP_RUNTIME_API_URL` to an internal URL that the server can reach.
3. Start Paperclip.
4. Observe that server startup replaces the internal value with the public URL.
5. Start a managed remote runtime and observe that its callback bridge cannot reach the API.

**Paperclip version or commit**

`19be4cf9278b70bc151063778a94bf38bfd5c903`

**Deployment mode**

Authenticated self-hosted Docker deployment.

## What Changed

- Preserve an explicit `PAPERCLIP_RUNTIME_API_URL` during server startup.
- Put the explicit runtime URL first in the runtime API candidate list.
- Add a startup regression test for separate public and internal URLs.
- Document the runtime URL and its precedence.

## Verification

- `pnpm exec vitest run server/src/__tests__/server-startup-feedback-export.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- The targeted test file passes all 17 tests.

## Risks

- Low risk. The behavior changes only when an operator explicitly sets `PAPERCLIP_RUNTIME_API_URL`.
- Deployments without the variable keep the current auto-derived behavior.

## Model Used

- OpenAI Codex `gpt-5.6-sol` with medium reasoning, tool use, and code execution.
- Google Gemini `gemini-3-pro-preview` performed an independent code review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
